### PR TITLE
HHH-5280: a partial fix

### DIFF
--- a/core/src/main/java/org/hibernate/engine/StatefulPersistenceContext.java
+++ b/core/src/main/java/org/hibernate/engine/StatefulPersistenceContext.java
@@ -37,16 +37,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.map.ReferenceMap;
+import org.hibernate.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.hibernate.AssertionFailure;
-import org.hibernate.Hibernate;
-import org.hibernate.HibernateException;
-import org.hibernate.LockMode;
-import org.hibernate.MappingException;
-import org.hibernate.NonUniqueObjectException;
-import org.hibernate.PersistentObjectException;
-import org.hibernate.TransientObjectException;
 import org.hibernate.engine.loading.LoadContexts;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.collection.PersistentCollection;
@@ -1143,7 +1136,13 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	    // try cache lookup first
 	    Object parent = parentsByChild.get(childEntity);
 		if (parent != null) {
-	       if (isFoundInParent(propertyName, childEntity, persister, collectionPersister, parent)) {
+           boolean foundInParent = false;
+           try {
+                foundInParent = isFoundInParent(propertyName, childEntity, persister, collectionPersister, parent);
+           } catch (PropertyAccessException e) {
+               // this can happen if an entity has more than one parent - see HHH-5280
+           }
+	       if (foundInParent) {
 		       return getEntry(parent).getId();
 		   }
 		   else {


### PR DESCRIPTION
getOwnerId() has been patched. It will now work correctly (without throwing a nasty exception) but there will be a performance penalty for entities that have multiple parents.

getIndexInOwner() might need patching but I haven't created a test case to break this yet.
