### PR TITLE
HHH-5642 Error configuring Hibernate with PostgreSQL JDBC3 8.2.511 driver

### DIFF
--- a/core/src/main/java/org/hibernate/cfg/SettingsFactory.java
+++ b/core/src/main/java/org/hibernate/cfg/SettingsFactory.java
@@ -24,7 +24,6 @@
 package org.hibernate.cfg;
 
 import java.io.Serializable;
-import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -114,6 +113,16 @@ public class SettingsFactory implements Serializable {
 				Connection conn = connections.getConnection();
 				try {
 					DatabaseMetaData meta = conn.getMetaData();
+
+					dialect = DialectFactory.buildDialect( props, conn );
+					jdbcSupport = JdbcSupportLoader.loadJdbcSupport( conn );
+
+					metaSupportsScrollable = meta.supportsResultSetType( ResultSet.TYPE_SCROLL_INSENSITIVE );
+					metaSupportsBatchUpdates = meta.supportsBatchUpdates();
+					metaReportsDDLCausesTxnCommit = meta.dataDefinitionCausesTransactionCommit();
+					metaReportsDDLInTxnSupported = !meta.dataDefinitionIgnoredInTransactions();
+					metaSupportsGetGeneratedKeys = meta.supportsGetGeneratedKeys();
+					
 					log.info( "Database ->\n" +
 							"       name : " + meta.getDatabaseProductName() + '\n' +
 							"    version : " +  meta.getDatabaseProductVersion() + '\n' +
@@ -126,15 +135,6 @@ public class SettingsFactory implements Serializable {
 							"      major : " + meta.getDriverMajorVersion() + '\n' +
 							"      minor : " + meta.getDriverMinorVersion()
 					);
-
-					dialect = DialectFactory.buildDialect( props, conn );
-					jdbcSupport = JdbcSupportLoader.loadJdbcSupport( conn );
-
-					metaSupportsScrollable = meta.supportsResultSetType( ResultSet.TYPE_SCROLL_INSENSITIVE );
-					metaSupportsBatchUpdates = meta.supportsBatchUpdates();
-					metaReportsDDLCausesTxnCommit = meta.dataDefinitionCausesTransactionCommit();
-					metaReportsDDLInTxnSupported = !meta.dataDefinitionIgnoredInTransactions();
-					metaSupportsGetGeneratedKeys = meta.supportsGetGeneratedKeys();
 				}
 				catch ( SQLException sqle ) {
 					log.warn( "Could not obtain connection metadata", sqle );

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -544,6 +544,11 @@
                 <artifactId>h2</artifactId>
                 <version>1.2.145</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.byteman</groupId>
+                <artifactId>byteman</artifactId>
+                <version>${bytemanVersion}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1044,5 +1049,6 @@
     <properties>
         <slf4jVersion>1.6.1</slf4jVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <bytemanVersion>1.5.1</bytemanVersion>
     </properties>
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -109,6 +114,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkMode>once</forkMode>
+                    <argLine>-Dorg.jboss.byteman.verbose=true -javaagent:${settings.localRepository}/org/jboss/byteman/byteman/${bytemanVersion}/byteman-${bytemanVersion}.jar=script:${project.build.testOutputDirectory}/bytemanrules.txt</argLine>
                     <systemProperties>
                         <property>
                             <name>hibernate.test.validatefailureexpected</name>

--- a/testsuite/src/test/java/org/hibernate/test/dialect/detection/DialectDetectWithoutMetadataTest.java
+++ b/testsuite/src/test/java/org/hibernate/test/dialect/detection/DialectDetectWithoutMetadataTest.java
@@ -1,0 +1,62 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.test.dialect.detection;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.test.dialect.function.Product;
+import org.hibernate.testing.junit.functional.FunctionalTestCase;
+
+/**
+ * Verifies the Dialect is detected even if some non critical metadata
+ * is not provided by the JDBC driver.
+ * 
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ */
+public class DialectDetectWithoutMetadataTest extends FunctionalTestCase {
+	
+	public DialectDetectWithoutMetadataTest( String string ) {
+		super( string );
+	}
+
+	public String[] getMappings() {
+		return new String[] { "dialect/function/Product.hbm.xml" };
+	}
+	
+	public void testBasicOperations() {
+		// save and query a single entity:
+		// enough to know the configuration is working.
+		Product product = new Product();
+		product.setLength( 100 );
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		s.save( product );
+		tx.commit();
+		s.clear();
+		
+		tx = s.beginTransaction();
+		Query q = s.createQuery( "from Product p" );
+		q.uniqueResult();
+		tx.commit();
+		s.close();
+	}
+
+}

--- a/testsuite/src/test/resources/bytemanrules.txt
+++ b/testsuite/src/test/resources/bytemanrules.txt
@@ -1,0 +1,45 @@
+########################################################################
+# JBoss, Home of Professional Open Source
+# Copyright 2011, Red Hat and individual contributors
+# by the @authors tag. See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+# @authors Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+#
+# The org.hibernate.test.dialect.detection.DialectDetectWithoutMetadataTest test
+# uses Byteman to verify a database connection is usable even if it's
+# DatabaseMetaData throws an exception when invoking getDatabaseMajorVersion()
+# (Apparently some databases do this)
+
+RULE emulate broken JDBC driver in DialectDetectWithoutMetadataTest
+CLASS org.hibernate.test.dialect.detection.DialectDetectWithoutMetadataTest
+METHOD getMappings
+IF TRUE
+	DO	
+		traceln( "\n *** Byteman rule enabled! Next DatabaseMetaData.getDatabaseMajorVersion() invocation will fail. ***\n" );
+		flag("metadataErrorEnabled")
+ENDRULE
+
+RULE DatabaseMetaData fails getDatabaseMajorVersion()
+INTERFACE ^java.sql.DatabaseMetaData
+METHOD getDatabaseMajorVersion
+IF flagged("metadataErrorEnabled")
+	DO
+		clear("metadataErrorEnabled");
+		throw new java.sql.SQLException("Byteman injected fault: unsupported feature!");
+ENDRULE


### PR DESCRIPTION
The functional test introduces a test dependency to Byteman to simulate broken drivers.
The rules for Byteman are defined in testsuite/src/test/resources/bytemanrules.txt

The used rule does not work on H2 as the method signature doesn't permit it to
throw a SQLException: but as it can't throw it, it can't ever have this bug of course.
So drivers which could actually be affected by this would fail as Byteman forces them
to, and the test will be able to verify Hibernate is still able to boot on those
incomplete driver implementations.

There are several forum posts complaining about the same issue being experienced
with Oracle as well, should I open an additional JIRA for it or shall I rename this one?

This pull contains the fix for branch 3.6 only, I'll make a different one for master as they
are quite different.
