### PR TITLE
Integer overflows

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
@@ -75,7 +75,7 @@ public class SQLServer2005Dialect extends SQLServerDialect {
 	@Override
 	public int convertToFirstRowValue(int zeroBasedFirstResult) {
 		// Our dialect paginated results aren't zero based. The first row should get the number 1 and so on
-		return zeroBasedFirstResult + 1;
+		return zeroBasedFirstResult == Integer.MAX_VALUE ? Integer.MAX_VALUE : zeroBasedFirstResult + 1;
 	}
 	
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1775,7 +1775,8 @@ public abstract class Loader {
 		final int firstRow = dialect.convertToFirstRowValue( getFirstRow( selection ) );
 		final int lastRow = selection.getMaxRows().intValue();
 		if ( dialect.useMaxForLimit() ) {
-			return lastRow + firstRow;
+			int maxRow = lastRow + firstRow;
+			return maxRow < 0 ? Integer.MAX_VALUE : maxRow;
 		}
 		else {
 			return lastRow;


### PR DESCRIPTION
It happens with large limit/offset values (close to Integer.MAX_VALUE)
After adding it overflows and the result value becomes < 0. As a result, it leads to unexpected behaviour.

hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java:
it overflows at "+ 1" if Integer.MAX_VALUE is given as the offset.
