### PR TITLE
HHH-5300 for 3.3 branch

### DIFF
--- a/core/src/main/java/org/hibernate/cfg/Environment.java
+++ b/core/src/main/java/org/hibernate/cfg/Environment.java
@@ -43,6 +43,7 @@ import org.hibernate.bytecode.BytecodeProvider;
 import org.hibernate.util.ConfigHelper;
 import org.hibernate.util.PropertiesHelper;
 
+import org.hibernate.util.SoftLimitMRUCache;
 
 /**
  * Provides access to configuration info passed in <tt>Properties</tt> objects.
@@ -166,6 +167,14 @@ import org.hibernate.util.PropertiesHelper;
  *   <td><tt>hibernate.transaction.factory_class</tt></td>
  *   <td>the factory to use for instantiating <tt>Transaction</tt>s.
  *   (Defaults to <tt>JDBCTransactionFactory</tt>.)</td>
+ * </tr>
+ * <tr>
+ *   <td><tt>hibernate.query.plan_cache_max_strong_references</tt></td>
+ *   <td>The maximum number of strong references maintained by {@link SoftLimitMRUCache}. Default is 128.</td>
+ * </tr>
+ * <tr>
+ *   <td><tt>hibernate.query.plan_cache_max_soft_references</tt></td>
+ *   <td>The maximum number of soft references maintained by {@link SoftLimitMRUCache}. Default is 2048.</td>
  * </tr>
  * <tr>
  *   <td><tt>hibernate.query.substitutions</tt></td><td>query language token substitutions</td>
@@ -515,6 +524,16 @@ public final class Environment {
 
 	public static final String JPAQL_STRICT_COMPLIANCE= "hibernate.query.jpaql_strict_compliance";
 
+	/**
+	 * The maximum number of strong references maintained by {@link SoftLimitMRUCache}. Default is 128.
+	 */
+	public static final String QUERY_PLAN_CACHE_MAX_STRONG_REFERENCES = "hibernate.query.plan_cache_max_strong_references";
+
+	/**
+	 * The maximum number of soft references maintained by {@link SoftLimitMRUCache}. Default is 2048.
+	 */
+	public static final String QUERY_PLAN_CACHE_MAX_SOFT_REFERENCES = "hibernate.query.plan_cache_max_soft_references";
+
 	private static final BytecodeProvider BYTECODE_PROVIDER_INSTANCE;
 	private static final boolean ENABLE_BINARY_STREAMS;
 	private static final boolean ENABLE_REFLECTION_OPTIMIZER;
@@ -527,6 +546,7 @@ public final class Environment {
 	private static final HashMap ISOLATION_LEVELS = new HashMap();
 	private static final Map OBSOLETE_PROPERTIES = new HashMap();
 	private static final Map RENAMED_PROPERTIES = new HashMap();
+
 
 	private static final Logger log = LoggerFactory.getLogger(Environment.class);
 

--- a/core/src/main/java/org/hibernate/engine/SessionFactoryImplementor.java
+++ b/core/src/main/java/org/hibernate/engine/SessionFactoryImplementor.java
@@ -25,6 +25,7 @@
 package org.hibernate.engine;
 
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.sql.Connection;
 
@@ -219,5 +220,7 @@ public interface SessionFactoryImplementor extends Mapping, SessionFactory {
 	public EntityNotFoundDelegate getEntityNotFoundDelegate();
 
 	public SQLFunctionRegistry getSqlFunctionRegistry();
+
+	public Properties getProperties();
 		
 }

--- a/core/src/main/java/org/hibernate/impl/SessionFactoryImpl.java
+++ b/core/src/main/java/org/hibernate/impl/SessionFactoryImpl.java
@@ -179,7 +179,7 @@ public final class SessionFactoryImpl implements SessionFactory, SessionFactoryI
 	private final transient SessionFactoryObserver observer;
 	private final transient HashMap entityNameResolvers = new HashMap();
 
-	private final QueryPlanCache queryPlanCache = new QueryPlanCache( this );
+	private final QueryPlanCache queryPlanCache;
 
 	private transient boolean isClosed = false;
 
@@ -219,6 +219,7 @@ public final class SessionFactoryImpl implements SessionFactory, SessionFactoryI
 
 		// Caches
 		settings.getRegionFactory().start( settings, properties );
+		queryPlanCache = new QueryPlanCache( this );
 
 		//Generators:
 
@@ -1153,5 +1154,9 @@ public final class SessionFactoryImpl implements SessionFactory, SessionFactoryI
 
 	public SQLFunctionRegistry getSqlFunctionRegistry() {
 		return sqlFunctionRegistry;
+	}
+
+	public Properties getProperties() {
+		return this.properties;
 	}
 }

--- a/core/src/main/java/org/hibernate/util/LRUMap.java
+++ b/core/src/main/java/org/hibernate/util/LRUMap.java
@@ -1,0 +1,28 @@
+package org.hibernate.util;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A simple LRU cache that implements the <code>Map</code> interface. Instances
+ * are not thread-safe and should be synchronized externally, for instance by
+ * using {@link Collections#synchronizedMap(Map)}.
+ * 
+ */
+public class LRUMap extends LinkedHashMap implements Serializable {
+
+	private static final long serialVersionUID = -5522608033020688048L;
+
+	private final int maxEntries;
+
+	public LRUMap(int maxEntries) {
+		super(maxEntries, .75f, true);
+		this.maxEntries = maxEntries;
+	}
+
+	protected boolean removeEldestEntry(Map.Entry eldest) {
+		return (size() > maxEntries);
+	}
+}

--- a/core/src/main/java/org/hibernate/util/SimpleMRUCache.java
+++ b/core/src/main/java/org/hibernate/util/SimpleMRUCache.java
@@ -24,8 +24,6 @@
  */
 package org.hibernate.util;
 
-import org.apache.commons.collections.map.LRUMap;
-
 import java.io.Serializable;
 import java.io.IOException;
 

--- a/core/src/main/java/org/hibernate/util/SoftLimitMRUCache.java
+++ b/core/src/main/java/org/hibernate/util/SoftLimitMRUCache.java
@@ -24,14 +24,15 @@
  */
 package org.hibernate.util;
 
-import org.apache.commons.collections.map.ReferenceMap;
-import org.apache.commons.collections.map.LRUMap;
-
-import java.io.Serializable;
 import java.io.IOException;
+import java.io.Serializable;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+
+import org.hibernate.cfg.Environment;
 
 /**
- * Cache following a "Most Recently Used" (MRY) algorithm for maintaining a
+ * Cache following a "Most Recently Used" (MRU) algorithm for maintaining a
  * bounded in-memory size; the "Least Recently Used" (LRU) entry is the first
  * available for removal from the cache.
  * <p/>
@@ -39,69 +40,218 @@ import java.io.IOException;
  * meaning that all cache entries are kept within a completely
  * {@link java.lang.ref.SoftReference}-based map with the most recently utilized
  * entries additionally kept in a hard-reference manner to prevent those cache
- * entries soft references from becoming enqueued by the garbage collector.
- * Thus the actual size of this cache impl can actually grow beyond the stated
- * max size bound as long as GC is not actively seeking soft references for
+ * entries soft references from becoming enqueued by the garbage collector. Thus
+ * the actual size of this cache impl can actually grow beyond the stated max
+ * size bound as long as GC is not actively seeking soft references for
  * enqueuement.
- *
+ * <p/>
+ * The soft-size is bounded and configurable. This allows controlling memory
+ * usage which can grow out of control under some circumstances, especially when
+ * very large heaps are in use. Although memory usage per se should not be a
+ * problem with soft references, which are cleared when necessary, this can
+ * trigger extremely slow stop-the-world GC pauses when nearing full heap usage,
+ * even with CMS concurrent GC (i.e. concurrent mode failure). This is most
+ * evident when ad-hoc HQL queries are produced by the application, leading to
+ * poor soft-cache hit ratios. This can also occur with heavy use of SQL IN
+ * clauses, which will generate multiples SQL queries (even if parameterized),
+ * one for each collection/array size passed to the IN clause. Many slightly
+ * different queries will eventually fill the heap and trigger a full GC to
+ * reclaim space, leading to unacceptable pauses in some cases.
+ * <p/>
+ * <strong>Note:</strong> This class is serializable, however all entries are
+ * discarded on serialization.
+ * 
+ * @see Environment#QUERY_PLAN_CACHE_MAX_STRONG_REFERENCES
+ * @see Environment#QUERY_PLAN_CACHE_MAX_SOFT_REFERENCES
+ * 
  * @author Steve Ebersole
+ * @author Manuel Dominguez Sarmiento
  */
 public class SoftLimitMRUCache implements Serializable {
 
+	// Constants
+
+	/**
+	 * The default strong reference count.
+	 */
 	public static final int DEFAULT_STRONG_REF_COUNT = 128;
 
-	private final int strongReferenceCount;
+	/**
+	 * The default soft reference count.
+	 */
+	public static final int DEFAULT_SOFT_REF_COUNT = 2048;
 
-	// actual cache of the entries.  soft references are used for both the keys and the
-	// values here since the values pertaining to the MRU entries are kept in a
-	// seperate hard reference cache (to avoid their enqueuement/garbage-collection).
-	private transient ReferenceMap softReferenceCache = new ReferenceMap( ReferenceMap.SOFT, ReferenceMap.SOFT );
-	// the MRU cache used to keep hard references to the most recently used query plans;
-	// note : LRU here is a bit of a misnomer, it indicates that LRU entries are removed, the
-	// actual kept entries are the MRU entries
-	private transient LRUMap strongReferenceCache;
+	// Fields
 
+	private final int strongRefCount;
+
+	private final int softRefCount;
+
+	private transient LRUMap strongRefCache;
+
+	private transient LRUMap softRefCache;
+
+	private transient ReferenceQueue referenceQueue;
+
+	// Constructors
+
+	/**
+	 * Constructs a cache with the default settings.
+	 * 
+	 * @see #DEFAULT_STRONG_REF_COUNT
+	 * @see #DEFAULT_SOFT_REF_COUNT
+	 */
 	public SoftLimitMRUCache() {
-		this( DEFAULT_STRONG_REF_COUNT );
+		this(DEFAULT_STRONG_REF_COUNT, DEFAULT_SOFT_REF_COUNT);
 	}
 
-	public SoftLimitMRUCache(int strongRefCount) {
-		this.strongReferenceCount = strongRefCount;
+	/**
+	 * Constructs a cache with the specified settings.
+	 * 
+	 * @param strongRefCount
+	 *            the strong reference count.
+	 * @param softRefCount
+	 *            the soft reference count.
+	 * @throws IllegalArgumentException
+	 *             if either of the arguments is less than one, or if the strong
+	 *             reference count is higher than the soft reference count.
+	 */
+	public SoftLimitMRUCache(int strongRefCount, int softRefCount) {
+
+		if (strongRefCount < 1 || softRefCount < 1) {
+			throw new IllegalArgumentException();
+		}
+
+		if (strongRefCount > softRefCount) {
+			throw new IllegalArgumentException();
+		}
+
+		this.strongRefCount = strongRefCount;
+		this.softRefCount = softRefCount;
 		init();
 	}
 
+	// Cache methods
+
+	/**
+	 * Gets an object from the cache.
+	 * 
+	 * @param key
+	 *            the cache key.
+	 * @return the stored value, or <code>null</code> if no entry exists.
+	 */
 	public synchronized Object get(Object key) {
-		Object result = softReferenceCache.get( key );
-		if ( result != null ) {
-			strongReferenceCache.put( key, result );
+
+		if (key == null) {
+			throw new NullPointerException();
 		}
-		return result;
+
+		clearObsoleteReferences();
+
+		SoftReference ref = (SoftReference) softRefCache.get(key);
+		if (ref != null) {
+			Object refValue = ref.get();
+			if (refValue != null) {
+				// This ensures recently used entries are strongly-reachable
+				strongRefCache.put(key, refValue);
+				return refValue;
+			}
+		}
+
+		return null;
 	}
 
+	/**
+	 * Puts a value in the cache.
+	 * 
+	 * @param key
+	 *            the key.
+	 * @param value
+	 *            the value.
+	 * @return the previous value stored in the cache, if any.
+	 */
 	public synchronized Object put(Object key, Object value) {
-		softReferenceCache.put( key, value );
-		return strongReferenceCache.put( key, value );
+
+		if (key == null || value == null) {
+			throw new NullPointerException();
+		}
+
+		clearObsoleteReferences();
+
+		strongRefCache.put(key, value);
+		SoftReference ref = (SoftReference) softRefCache.put(key,
+				new KeyedSoftReference(key, value, referenceQueue));
+
+		return (ref != null) ? ref.get() : null;
 	}
 
+	/**
+	 * Gets the strong reference cache size.
+	 * 
+	 * @return the strong reference cache size.
+	 */
 	public synchronized int size() {
-		return strongReferenceCache.size();
+		clearObsoleteReferences();
+		return strongRefCache.size();
 	}
 
+	/**
+	 * Gets the soft reference cache size.
+	 * 
+	 * @return the soft reference cache size.
+	 */
 	public synchronized int softSize() {
-		return softReferenceCache.size();
+		clearObsoleteReferences();
+		return softRefCache.size();
 	}
+
+	/**
+	 * Clears the cache.
+	 */
+	public synchronized void clear() {
+		strongRefCache.clear();
+		softRefCache.clear();
+	}
+
+	// Private helper methods
 
 	private void init() {
-		strongReferenceCache = new LRUMap( strongReferenceCount );
+		this.strongRefCache = new LRUMap(strongRefCount);
+		this.softRefCache = new LRUMap(softRefCount);
+		this.referenceQueue = new ReferenceQueue();
 	}
 
-	private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+	private void readObject(java.io.ObjectInputStream in) throws IOException,
+			ClassNotFoundException {
+
 		in.defaultReadObject();
 		init();
 	}
 
-	public synchronized void clear() {
-		strongReferenceCache.clear();
-		softReferenceCache.clear();
+	private void clearObsoleteReferences() {
+
+		// Clear entries for soft references
+		// removed by garbage collector
+		KeyedSoftReference obsoleteRef;
+		while ((obsoleteRef = (KeyedSoftReference) referenceQueue.poll()) != null) {
+			Object key = obsoleteRef.getKey();
+			softRefCache.remove(key);
+		}
+	}
+
+	// Private static class
+
+	private static class KeyedSoftReference extends SoftReference {
+
+		private final Object key;
+
+		private KeyedSoftReference(Object key, Object value, ReferenceQueue q) {
+			super(value, q);
+			this.key = key;
+		}
+
+		private Object getKey() {
+			return key;
+		}
 	}
 }


### PR DESCRIPTION
I've added the HHH-5300 (Configurable QueryPlanCache reference counts) patch to the 3.3 branch.

The patch is based on Manuel Dominguez Sarmiento's attached diff.zip file (at http://opensource.atlassian.com/projects/hibernate/browse/HHH-5300 ), which was added into the 3.5 / 3.6 branch.
