### PR TITLE
Ehcache dependency upgrade

### DIFF
--- a/hibernate-ehcache/pom.xml
+++ b/hibernate-ehcache/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.4.1</version>
+            <version>2.4.2</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Hey,
I've upgraded the hibernate-ehcache pom to depend on the latest 2.4.2 that has fixes wrt Hibernate's 2LC
Alex
