### PR TITLE
Escape ':' in Native SQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
@@ -77,6 +77,10 @@ public class ParameterParser {
 				}
 				recognizer.other( c );
 			}
+			else if ( '\\' == c ) {
+				// skip sending the backslash and instead send then next character, treating is as a literal
+				recognizer.other( sqlString.charAt( ++indx ) );
+			}
 			else if ( '\'' == c ) {
 				inQuote = true;
 				recognizer.other( c );

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueriesTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
+import org.hibernate.QueryException;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -832,6 +833,17 @@ public class NativeSQLQueriesTest extends BaseCoreFunctionalTestCase {
 				.uniqueResult();
 		assertTrue( ArrayHelper.isEquals( photo, photoRead ) );
 		s.delete( holder );
+		t.commit();
+		s.close();
+	}
+	@Test
+	public void testEscapeColonInSQL() throws QueryException {
+		Session s = openSession();
+		Transaction t = s.beginTransaction();
+		SQLQuery query = s.createSQLQuery( "SELECT @row \\:= 1" );
+		List list = query.list();
+		assertTrue( list.get( 0 ).toString().equals( "1" ) );
+		
 		t.commit();
 		s.close();
 	}


### PR DESCRIPTION
Allows Native SQL queries like: 

``` mysql
SELECT @row := 1;
```

to be called without a QueryException: "Space is not allowed after parameter prefix".  See diff of test file NativeSQLQueriesTest.java for full example.

``` java
SQLQuery query = s.createSQLQuery( "SELECT @row \\:= 1" );
```
