### PR TITLE
HHH-5580 - Moving query API

### DIFF
--- a/documentation/src/main/docbook/devguide/en-US/Envers.xml
+++ b/documentation/src/main/docbook/devguide/en-US/Envers.xml
@@ -800,9 +800,9 @@ query.add(AuditEntity.relatedId("address").eq(relatedEntityId));]]></programlist
                 The basic query allows retrieving entity names and corresponding Java classes changed in a specified revision:
             </para>
             <programlisting><![CDATA[Set<Pair<String, Class>> modifiedEntityTypes = getAuditReader()
-    .getEntitiesChangedInRevisionManager().findEntityTypes(revisionNumber);]]></programlisting>
+    .getCrossTypeRevisionChangesReader().findEntityTypes(revisionNumber);]]></programlisting>
             <para>
-                Other queries (also accessible from <interfacename>org.hibernate.envers.EntitiesChangedInRevisionManager</interfacename>):
+                Other queries (also accessible from <interfacename>org.hibernate.envers.CrossTypeRevisionChangesReader</interfacename>):
             </para>
             <orderedlist>
                 <listitem>

--- a/hibernate-envers/src/main/java/org/hibernate/envers/AuditReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/AuditReader.java
@@ -211,7 +211,7 @@ public interface AuditReader {
 			throws HibernateException;
 
     /**
-     * @return Basic implementation of {@link EntitiesChangedInRevisionManager} interface. Raises an exception if the default
+     * @return Basic implementation of {@link CrossTypeRevisionChangesReader} interface. Raises an exception if the default
      *         mechanism of tracking entity names modified during revisions has not been enabled. 
      * @throws AuditException If none of the following conditions is satisfied:
      *                        <ul>
@@ -223,5 +223,5 @@ public interface AuditReader {
      *                            marked with {@link ModifiedEntityNames} interface.</li>
      *                        </ul>
      */
-    public EntitiesChangedInRevisionManager getEntitiesChangedInRevisionManager() throws AuditException;
+    public CrossTypeRevisionChangesReader getCrossTypeRevisionChangesReader() throws AuditException;
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/CrossTypeRevisionChangesReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/CrossTypeRevisionChangesReader.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * is enabled.
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
-public interface EntitiesChangedInRevisionManager {
+public interface CrossTypeRevisionChangesReader {
     /**
      * Find all entities changed (added, updated and removed) in a given revision. Executes <i>n+1</i> SQL queries,
      * where <i>n</i> is a number of different entity classes modified within specified revision.

--- a/hibernate-envers/src/main/java/org/hibernate/envers/reader/AuditReaderImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/reader/AuditReaderImpl.java
@@ -37,7 +37,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.NonUniqueResultException;
 import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.envers.EntitiesChangedInRevisionManager;
+import org.hibernate.envers.CrossTypeRevisionChangesReader;
 import org.hibernate.envers.configuration.AuditConfiguration;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.exception.NotAuditedException;
@@ -58,7 +58,7 @@ public class AuditReaderImpl implements AuditReaderImplementor {
     private final SessionImplementor sessionImplementor;
     private final Session session;
     private final FirstLevelCache firstLevelCache;
-    private final EntitiesChangedInRevisionManager entitiesChangedInRevisionManager;
+    private final CrossTypeRevisionChangesReader crossTypeRevisionChangesReader;
 
     public AuditReaderImpl(AuditConfiguration verCfg, Session session,
                               SessionImplementor sessionImplementor) {
@@ -67,7 +67,7 @@ public class AuditReaderImpl implements AuditReaderImplementor {
         this.session = session;
 
         firstLevelCache = new FirstLevelCache();
-        entitiesChangedInRevisionManager = new EntitiesChangedInRevisionManagerImpl(this, verCfg);
+        crossTypeRevisionChangesReader = new CrossTypeRevisionChangesReaderImpl(this, verCfg);
     }
 
     private void checkSession() {
@@ -244,13 +244,13 @@ public class AuditReaderImpl implements AuditReaderImplementor {
         }
     }
 
-    public EntitiesChangedInRevisionManager getEntitiesChangedInRevisionManager() throws AuditException {
+    public CrossTypeRevisionChangesReader getCrossTypeRevisionChangesReader() throws AuditException {
         if (!verCfg.getGlobalCfg().isTrackEntitiesChangedInRevisionEnabled()) {
             throw new AuditException("This API is designed for Envers default mechanism of tracking entities modified in a given revision."
                                      + " Extend DefaultTrackingModifiedEntitiesRevisionEntity, utilize @ModifiedEntityNames annotation or set "
                                      + "'org.hibernate.envers.track_entities_changed_in_revision' parameter to true.");
         }
-        return entitiesChangedInRevisionManager;
+        return crossTypeRevisionChangesReader;
     }
 
 	@SuppressWarnings({"unchecked"})

--- a/hibernate-envers/src/main/java/org/hibernate/envers/reader/CrossTypeRevisionChangesReaderImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/reader/CrossTypeRevisionChangesReaderImpl.java
@@ -3,7 +3,7 @@ package org.hibernate.envers.reader;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.envers.EntitiesChangedInRevisionManager;
+import org.hibernate.envers.CrossTypeRevisionChangesReader;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.configuration.AuditConfiguration;
 import org.hibernate.envers.query.criteria.RevisionTypeAuditExpression;
@@ -18,11 +18,11 @@ import static org.hibernate.envers.tools.ArgumentsTools.checkPositive;
 /**
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
-public class EntitiesChangedInRevisionManagerImpl implements EntitiesChangedInRevisionManager {
+public class CrossTypeRevisionChangesReaderImpl implements CrossTypeRevisionChangesReader {
     private final AuditReaderImplementor auditReaderImplementor;
     private final AuditConfiguration verCfg;
 
-    public EntitiesChangedInRevisionManagerImpl(AuditReaderImplementor auditReaderImplementor, AuditConfiguration verCfg) {
+    public CrossTypeRevisionChangesReaderImpl(AuditReaderImplementor auditReaderImplementor, AuditConfiguration verCfg) {
         this.auditReaderImplementor = auditReaderImplementor;
         this.verCfg = verCfg;
     }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/CustomTrackingEntitiesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/CustomTrackingEntitiesTest.java
@@ -100,6 +100,6 @@ public class CustomTrackingEntitiesTest extends AbstractEntityTest {
 
     @Test(expected = AuditException.class)
     public void testFindEntitiesChangedInRevisionException() {
-        getAuditReader().getEntitiesChangedInRevisionManager();
+        getAuditReader().getCrossTypeRevisionChangesReader();
     }
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/DefaultTrackingEntitiesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/DefaultTrackingEntitiesTest.java
@@ -1,7 +1,7 @@
 package org.hibernate.envers.test.integration.reventity.trackmodifiedentities;
 
 import org.hibernate.ejb.Ejb3Configuration;
-import org.hibernate.envers.EntitiesChangedInRevisionManager;
+import org.hibernate.envers.CrossTypeRevisionChangesReader;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.test.AbstractEntityTest;
 import org.hibernate.envers.test.Priority;
@@ -85,14 +85,14 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity("x", steId);
         StrIntTestEntity site = new StrIntTestEntity("y", 1, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(1), ste, site);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(1), ste, site);
     }
 
     @Test
     public void testTrackModifiedEntities() {
         StrIntTestEntity site = new StrIntTestEntity("y", 2, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(2), site);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(2), site);
     }
 
     @Test
@@ -100,12 +100,12 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity(null, steId);
         StrIntTestEntity site = new StrIntTestEntity(null, null, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(3), site, ste);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(3), site, ste);
     }
 
     @Test
     public void testFindChangesInInvalidRevision() {
-        assert getEntitiesChangedInRevisionManager().findEntities(4).isEmpty();
+        assert getCrossTypeRevisionChangesReader().findEntities(4).isEmpty();
     }
 
     @Test
@@ -113,7 +113,7 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity("x", steId);
         StrIntTestEntity site = new StrIntTestEntity("y", 1, siteId);
 
-        Map<RevisionType, List<Object>> result = getEntitiesChangedInRevisionManager().findEntitiesGroupByRevisionType(1);
+        Map<RevisionType, List<Object>> result = getCrossTypeRevisionChangesReader().findEntitiesGroupByRevisionType(1);
         assert TestTools.checkList(result.get(RevisionType.ADD), site, ste);
         assert TestTools.checkList(result.get(RevisionType.MOD));
         assert TestTools.checkList(result.get(RevisionType.DEL));
@@ -123,7 +123,7 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
     public void testTrackModifiedEntitiesGroupByRevisionType() {
         StrIntTestEntity site = new StrIntTestEntity("y", 2, siteId);
 
-        Map<RevisionType, List<Object>> result = getEntitiesChangedInRevisionManager().findEntitiesGroupByRevisionType(2);
+        Map<RevisionType, List<Object>> result = getCrossTypeRevisionChangesReader().findEntitiesGroupByRevisionType(2);
         assert TestTools.checkList(result.get(RevisionType.ADD));
         assert TestTools.checkList(result.get(RevisionType.MOD), site);
         assert TestTools.checkList(result.get(RevisionType.DEL));
@@ -134,7 +134,7 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity(null, steId);
         StrIntTestEntity site = new StrIntTestEntity(null, null, siteId);
 
-        Map<RevisionType, List<Object>> result = getEntitiesChangedInRevisionManager().findEntitiesGroupByRevisionType(3);
+        Map<RevisionType, List<Object>> result = getCrossTypeRevisionChangesReader().findEntitiesGroupByRevisionType(3);
         assert TestTools.checkList(result.get(RevisionType.ADD));
         assert TestTools.checkList(result.get(RevisionType.MOD));
         assert TestTools.checkList(result.get(RevisionType.DEL), site, ste);
@@ -145,14 +145,14 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity("x", steId);
         StrIntTestEntity site = new StrIntTestEntity("y", 1, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(1, RevisionType.ADD), ste, site);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(1, RevisionType.ADD), ste, site);
     }
 
     @Test
     public void testFindChangedEntitiesByRevisionTypeMOD() {
         StrIntTestEntity site = new StrIntTestEntity("y", 2, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(2, RevisionType.MOD), site);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(2, RevisionType.MOD), site);
     }
 
     @Test
@@ -160,24 +160,24 @@ public class DefaultTrackingEntitiesTest extends AbstractEntityTest {
         StrTestEntity ste = new StrTestEntity(null, steId);
         StrIntTestEntity site = new StrIntTestEntity(null, null, siteId);
 
-        assert TestTools.checkList(getEntitiesChangedInRevisionManager().findEntities(3, RevisionType.DEL), ste, site);
+        assert TestTools.checkList(getCrossTypeRevisionChangesReader().findEntities(3, RevisionType.DEL), ste, site);
     }
 
     @Test
     public void testFindEntityTypesChangedInRevision() {
         assert TestTools.makeSet(Pair.make(StrTestEntity.class.getName(), StrTestEntity.class),
                                  Pair.make(StrIntTestEntity.class.getName(), StrIntTestEntity.class))
-                        .equals(getEntitiesChangedInRevisionManager().findEntityTypes(1));
+                        .equals(getCrossTypeRevisionChangesReader().findEntityTypes(1));
 
         assert TestTools.makeSet(Pair.make(StrIntTestEntity.class.getName(), StrIntTestEntity.class))
-                        .equals(getEntitiesChangedInRevisionManager().findEntityTypes(2));
+                        .equals(getCrossTypeRevisionChangesReader().findEntityTypes(2));
         
         assert TestTools.makeSet(Pair.make(StrTestEntity.class.getName(), StrTestEntity.class),
                                  Pair.make(StrIntTestEntity.class.getName(), StrIntTestEntity.class))
-                        .equals(getEntitiesChangedInRevisionManager().findEntityTypes(3));
+                        .equals(getCrossTypeRevisionChangesReader().findEntityTypes(3));
     }
 
-    private EntitiesChangedInRevisionManager getEntitiesChangedInRevisionManager() {
-        return getAuditReader().getEntitiesChangedInRevisionManager();
+    private CrossTypeRevisionChangesReader getCrossTypeRevisionChangesReader() {
+        return getAuditReader().getCrossTypeRevisionChangesReader();
     }
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/EntityNamesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/EntityNamesTest.java
@@ -64,9 +64,9 @@ public class EntityNamesTest extends AbstractSessionTest {
     public void testModifiedEntityTypes() {
         assert TestTools.makeSet(Pair.make(Car.class.getName(), Car.class),
                                  Pair.make("Personaje", Person.class))
-                        .equals(getAuditReader().getEntitiesChangedInRevisionManager().findEntityTypes(1));
+                        .equals(getAuditReader().getCrossTypeRevisionChangesReader().findEntityTypes(1));
         assert TestTools.makeSet(Pair.make(Car.class.getName(), Car.class),
                                  Pair.make("Personaje", Person.class))
-                        .equals(getAuditReader().getEntitiesChangedInRevisionManager().findEntityTypes(2));
+                        .equals(getAuditReader().getCrossTypeRevisionChangesReader().findEntityTypes(2));
     }
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/TrackingEntitiesMultipleChangesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/trackmodifiedentities/TrackingEntitiesMultipleChangesTest.java
@@ -1,7 +1,7 @@
 package org.hibernate.envers.test.integration.reventity.trackmodifiedentities;
 
 import org.hibernate.ejb.Ejb3Configuration;
-import org.hibernate.envers.EntitiesChangedInRevisionManager;
+import org.hibernate.envers.CrossTypeRevisionChangesReader;
 import org.hibernate.envers.test.AbstractEntityTest;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.StrTestEntity;
@@ -60,7 +60,7 @@ public class TrackingEntitiesMultipleChangesTest extends AbstractEntityTest {
         StrTestEntity ste1 = new StrTestEntity("x", steId1);
         StrTestEntity ste2 = new StrTestEntity("y", steId2);
 
-        assert Arrays.asList(ste1, ste2).equals(getEntitiesChangedInRevisionManager().findEntities(1));
+        assert Arrays.asList(ste1, ste2).equals(getCrossTypeRevisionChangesReader().findEntities(1));
     }
 
     @Test
@@ -68,17 +68,17 @@ public class TrackingEntitiesMultipleChangesTest extends AbstractEntityTest {
         StrTestEntity ste1 = new StrTestEntity("z", steId1);
         StrTestEntity ste2 = new StrTestEntity(null, steId2);
 
-        assert Arrays.asList(ste1, ste2).equals(getEntitiesChangedInRevisionManager().findEntities(2));
+        assert Arrays.asList(ste1, ste2).equals(getCrossTypeRevisionChangesReader().findEntities(2));
     }
 
     @Test
     public void testTrackUpdateAndRemoveTheSameEntity() {
         StrTestEntity ste1 = new StrTestEntity(null, steId1);
 
-        assert Arrays.asList(ste1).equals(getEntitiesChangedInRevisionManager().findEntities(3));
+        assert Arrays.asList(ste1).equals(getCrossTypeRevisionChangesReader().findEntities(3));
     }
 
-    private EntitiesChangedInRevisionManager getEntitiesChangedInRevisionManager() {
-        return getAuditReader().getEntitiesChangedInRevisionManager();
+    private CrossTypeRevisionChangesReader getCrossTypeRevisionChangesReader() {
+        return getAuditReader().getCrossTypeRevisionChangesReader();
     }
 }


### PR DESCRIPTION
Moving queries from AuditReader to EntitiesChangedInRevisionManager.

Regards,
Lukasz Antoniak
