### PR TITLE
HHH-6361 - Collection events may contain wrong stored snapshot after merging a detached entity into the persistencecontext  (3.6 branch)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/CollectionEntry.java
@@ -260,6 +260,20 @@ public final class CollectionEntry implements Serializable {
 		return snapshot;
 	}
 
+	/**
+	 * Reset the stored snapshot for both the persistent collection and this collection entry. 
+	 * Used during the merge of detached collections.
+	 * 
+	 * @param collection the persistentcollection to be updated
+	 * @param storedSnapshot the new stored snapshot
+	 */
+	public void resetStoredSnapshot(PersistentCollection collection, Serializable storedSnapshot) {
+		log.debug("Reset storedSnapshot to {} for {}", storedSnapshot, this);
+		
+		snapshot = storedSnapshot;
+		collection.setSnapshot(loadedKey, role, snapshot);
+	}
+
 	private void setLoadedPersister(CollectionPersister persister) {
 		loadedPersister = persister;
 		setRole( persister == null ? null : persister.getRole() );

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/DetachedMultipleCollectionChangeTest.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/DetachedMultipleCollectionChangeTest.java
@@ -1,0 +1,301 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.event.collection.detached;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Test;
+
+import org.hibernate.Session;
+import org.hibernate.event.AbstractCollectionEvent;
+import org.hibernate.event.PostCollectionRecreateEvent;
+import org.hibernate.event.PreCollectionRemoveEvent;
+import org.hibernate.event.PreCollectionUpdateEvent;
+import org.hibernate.test.jpa.AbstractJPATest;
+import org.hibernate.testing.junit.functional.FunctionalTestClassTestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test HHH-6361: Collection events may contain wrong stored snapshot after
+ * merging a detached entity into the persistencecontext.
+ * 
+ * @author Erik-Berndt Scheper
+ */
+public class DetachedMultipleCollectionChangeTest extends AbstractJPATest {
+
+	private final Logger log = LoggerFactory
+			.getLogger(DetachedMultipleCollectionChangeTest.class);
+
+	public DetachedMultipleCollectionChangeTest(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return new FunctionalTestClassTestSuite(
+				DetachedMultipleCollectionChangeTest.class);
+	}
+
+	public String[] getMappings() {
+		return new String[] { "event/collection/detached/MultipleCollectionBagMapping.hbm.xml" };
+	}
+
+	public void testMergeMultipleCollectionChangeEvents() {
+		MultipleCollectionListeners listeners = new MultipleCollectionListeners(
+				getSessions());
+
+		List<MultipleCollectionRefEntity1> oldRefentities1;
+		List<MultipleCollectionRefEntity2> oldRefentities2;
+		int eventCount;
+		Session s;
+
+		oldRefentities1 = new ArrayList<MultipleCollectionRefEntity1>();
+		oldRefentities2 = new ArrayList<MultipleCollectionRefEntity2>();
+
+		listeners.clear();
+		eventCount = 0;
+
+		s = openSession();
+		s.beginTransaction();
+
+		MultipleCollectionEntity mce = new MultipleCollectionEntity();
+		mce.setText("MultipleCollectionEntity-1");
+
+		s.save(mce);
+		s.getTransaction().commit();
+
+		checkListener(listeners, listeners.getPreCollectionRecreateListener(),
+				mce, oldRefentities1, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionRecreateListener(),
+				mce, oldRefentities1, eventCount++);
+		checkListener(listeners, listeners.getPreCollectionRecreateListener(),
+				mce, oldRefentities2, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionRecreateListener(),
+				mce, oldRefentities2, eventCount++);
+		checkEventCount(listeners, eventCount);
+
+		s.close();
+
+		Long mceId1 = mce.getId();
+		assertNotNull(mceId1);
+
+		// add new entities to both collections
+
+		MultipleCollectionEntity prevMce = mce.deepCopy();
+		oldRefentities1 = prevMce.getRefEntities1();
+		oldRefentities2 = prevMce.getRefEntities2();
+
+		listeners.clear();
+		eventCount = 0;
+
+		s = openSession();
+		s.beginTransaction();
+
+		MultipleCollectionRefEntity1 re1_1 = new MultipleCollectionRefEntity1();
+		re1_1.setText("MultipleCollectionRefEntity1-1");
+		re1_1.setMultipleCollectionEntity(mce);
+
+		MultipleCollectionRefEntity1 re1_2 = new MultipleCollectionRefEntity1();
+		re1_2.setText("MultipleCollectionRefEntity1-2");
+		re1_2.setMultipleCollectionEntity(mce);
+
+		mce.addRefEntity1(re1_1);
+		mce.addRefEntity1(re1_2);
+
+		mce = (MultipleCollectionEntity) s.merge(mce);
+
+		s.getTransaction().commit();
+		s.close();
+
+		checkListener(listeners, listeners.getInitializeCollectionListener(),
+				mce, null, eventCount++);
+		checkListener(listeners, listeners.getPreCollectionUpdateListener(),
+				mce, oldRefentities1, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionUpdateListener(),
+				mce, mce.getRefEntities1(), eventCount++);
+
+		s = openSession();
+		s.beginTransaction();
+
+		MultipleCollectionRefEntity2 re2_1 = new MultipleCollectionRefEntity2();
+		re2_1.setText("MultipleCollectionRefEntity2-1");
+		re2_1.setMultipleCollectionEntity(mce);
+
+		MultipleCollectionRefEntity2 re2_2 = new MultipleCollectionRefEntity2();
+		re2_2.setText("MultipleCollectionRefEntity2-2");
+		re2_2.setMultipleCollectionEntity(mce);
+
+		mce.addRefEntity2(re2_1);
+		mce.addRefEntity2(re2_2);
+
+		mce = (MultipleCollectionEntity) s.merge(mce);
+
+		s.getTransaction().commit();
+
+		checkListener(listeners, listeners.getInitializeCollectionListener(),
+				mce, null, eventCount++);
+		checkListener(listeners, listeners.getPreCollectionUpdateListener(),
+				mce, oldRefentities2, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionUpdateListener(),
+				mce, mce.getRefEntities2(), eventCount++);
+		checkEventCount(listeners, eventCount);
+
+		s.close();
+
+		for (MultipleCollectionRefEntity1 refEnt1 : mce.getRefEntities1()) {
+			assertNotNull(refEnt1.getId());
+		}
+		for (MultipleCollectionRefEntity2 refEnt2 : mce.getRefEntities2()) {
+			assertNotNull(refEnt2.getId());
+		}
+
+		// remove and add entities in both collections
+
+		prevMce = mce.deepCopy();
+		oldRefentities1 = prevMce.getRefEntities1();
+		oldRefentities2 = prevMce.getRefEntities2();
+
+		listeners.clear();
+		eventCount = 0;
+
+		s = openSession();
+		s.beginTransaction();
+
+		assertEquals(2, mce.getRefEntities1().size());
+		assertEquals(2, mce.getRefEntities2().size());
+
+		mce.removeRefEntity1(re1_2);
+
+		MultipleCollectionRefEntity1 re1_3 = new MultipleCollectionRefEntity1();
+		re1_3.setText("MultipleCollectionRefEntity1-3");
+		re1_3.setMultipleCollectionEntity(mce);
+		mce.addRefEntity1(re1_3);
+
+		mce = (MultipleCollectionEntity) s.merge(mce);
+
+		s.getTransaction().commit();
+		s.close();
+		
+		checkListener(listeners, listeners.getInitializeCollectionListener(),
+				mce, null, eventCount++);
+		checkListener(listeners, listeners.getPreCollectionUpdateListener(),
+				mce, oldRefentities1, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionUpdateListener(),
+				mce, mce.getRefEntities1(), eventCount++);
+		
+		s = openSession();
+		s.beginTransaction();
+
+		mce.removeRefEntity2(re2_2);
+
+		MultipleCollectionRefEntity2 re2_3 = new MultipleCollectionRefEntity2();
+		re2_3.setText("MultipleCollectionRefEntity2-3");
+		re2_3.setMultipleCollectionEntity(mce);
+		mce.addRefEntity2(re2_3);
+
+		mce = (MultipleCollectionEntity) s.merge(mce);
+
+		// assertEquals(2, mce.getRefEntities1().size());
+		// assertEquals(2, mce.getRefEntities2().size());
+
+		s.getTransaction().commit();
+
+		checkListener(listeners, listeners.getInitializeCollectionListener(),
+				mce, null, eventCount++);
+		checkListener(listeners, listeners.getPreCollectionUpdateListener(),
+				mce, oldRefentities2, eventCount++);
+		checkListener(listeners, listeners.getPostCollectionUpdateListener(),
+				mce, mce.getRefEntities2(), eventCount++);
+
+		checkEventCount(listeners, eventCount);
+
+		s.close();
+
+		// cleanup after test
+		cleanupData();
+	}
+
+	protected void checkListener(
+			MultipleCollectionListeners listeners,
+			MultipleCollectionListeners.Listener listenerExpected,
+			org.hibernate.test.event.collection.Entity ownerExpected,
+			List<? extends org.hibernate.test.event.collection.Entity> expectedCollectionEntrySnapshot,
+			int index) {
+		AbstractCollectionEvent event = (AbstractCollectionEvent) listeners
+				.getEvents().get(index);
+
+		assertSame(listenerExpected, listeners.getListenersCalled().get(index));
+		assertEquals(ownerExpected, event.getAffectedOwnerOrNull());
+		assertEquals(ownerExpected.getId(), event.getAffectedOwnerIdOrNull());
+		assertEquals(ownerExpected.getClass().getName(),
+				event.getAffectedOwnerEntityName());
+
+		if (event instanceof PreCollectionUpdateEvent) {
+			Serializable snapshot = listeners.getSnapshots().get(index);
+			assertEquals(expectedCollectionEntrySnapshot, snapshot);
+		}
+		if (event instanceof PreCollectionRemoveEvent) {
+			Serializable snapshot = listeners.getSnapshots().get(index);
+			assertEquals(expectedCollectionEntrySnapshot, snapshot);
+		}
+		if (event instanceof PostCollectionRecreateEvent) {
+			Serializable snapshot = listeners.getSnapshots().get(index);
+			assertEquals(expectedCollectionEntrySnapshot, snapshot);
+		}
+
+	}
+
+	private void checkEventCount(MultipleCollectionListeners listeners,
+			int nEventsExpected) {
+		assertEquals(nEventsExpected, listeners.getListenersCalled().size());
+		assertEquals(nEventsExpected, listeners.getEvents().size());
+	}
+
+	private void cleanupData() {
+		Session s = null;
+		try {
+			s = openSession();
+			s.beginTransaction();
+			s.createQuery("delete MultipleCollectionRefEntity1")
+					.executeUpdate();
+			s.createQuery("delete MultipleCollectionRefEntity2")
+					.executeUpdate();
+			s.createQuery("delete MultipleCollectionEntity").executeUpdate();
+			s.getTransaction().commit();
+		} catch (Throwable t) {
+			log.warn("unable to cleanup test data [" + fullTestName() + "] : "
+					+ t);
+		} finally {
+			if (s != null) {
+				try {
+					s.close();
+				} catch (Throwable ignore) {
+				}
+			}
+		}
+	}
+
+}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionBagMapping.hbm.xml
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionBagMapping.hbm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<!--
+
+-->
+
+<hibernate-mapping package="org.hibernate.test.event.collection.detached">
+
+    <class name="MultipleCollectionEntity" table="PARENT">
+        <id name="id" column="ID" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="text" column="TEXT" type="string"/>
+        <bag name="refEntities1"
+             inverse="true"
+             cascade="all,delete-orphan">
+            <key column="parent_id"/>
+            <one-to-many class="MultipleCollectionRefEntity1"/>
+        </bag>
+        <bag name="refEntities2"
+             inverse="true"
+             cascade="all,delete-orphan">
+            <key column="parent_id"/>
+            <one-to-many class="MultipleCollectionRefEntity2"/>
+        </bag>
+    </class>
+
+    <class name="MultipleCollectionRefEntity1" table="CHILD1">
+        <id name="id" column="ID" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="text" column="TEXT" type="string"/>
+        <many-to-one name="multipleCollectionEntity" column="MCE_ID" class="MultipleCollectionEntity" cascade="none"/>
+    </class>
+
+    <class name="MultipleCollectionRefEntity2" table="CHILD2">
+        <id name="id" column="ID" type="long">
+            <generator class="native"/>
+        </id>
+        <property name="text" column="TEXT" type="string"/>
+        <many-to-one name="multipleCollectionEntity" column="MCE_ID" class="MultipleCollectionEntity" cascade="none"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionEntity.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionEntity.java
@@ -1,0 +1,168 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.event.collection.detached;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+
+@Entity
+public class MultipleCollectionEntity implements org.hibernate.test.event.collection.Entity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", length = 10)
+	private Long id;
+
+	@Column(name = "TEXT", length = 50, nullable = false)
+	private String text;
+
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "MCE_ID", nullable = false)
+	private List<MultipleCollectionRefEntity1> refEntities1 = new ArrayList<MultipleCollectionRefEntity1>();
+
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "MCE_ID", nullable = false)
+	private List<MultipleCollectionRefEntity2> refEntities2 = new ArrayList<MultipleCollectionRefEntity2>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public List<MultipleCollectionRefEntity1> getRefEntities1() {
+		return refEntities1;
+	}
+
+	public void setRefEntities1(List<MultipleCollectionRefEntity1> refEntities1) {
+		this.refEntities1 = refEntities1;
+	}
+
+	public void addRefEntity1(MultipleCollectionRefEntity1 refEntity1) {
+		refEntities1.add(refEntity1);
+	}
+
+	public void removeRefEntity1(MultipleCollectionRefEntity1 refEntity1) {
+		refEntities1.remove(refEntity1);
+	}
+
+	public List<MultipleCollectionRefEntity2> getRefEntities2() {
+		return refEntities2;
+	}
+
+	public void setRefEntities2(List<MultipleCollectionRefEntity2> refEntities2) {
+		this.refEntities2 = refEntities2;
+	}
+
+	public void addRefEntity2(MultipleCollectionRefEntity2 refEntity2) {
+		refEntities2.add(refEntity2);
+	}
+
+	public void removeRefEntity2(MultipleCollectionRefEntity2 refEntity2) {
+		refEntities2.remove(refEntity2);
+	}
+
+	@Override
+	public String toString() {
+		return "MultipleCollectionEntity [id=" + id + ", text=" + text
+				+ ", refEntities1=" + refEntities1 + ", refEntities2="
+				+ refEntities2 + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((text == null) ? 0 : text.hashCode());
+		result = prime * result
+				+ ((refEntities1 == null) ? 0 : refEntities1.hashCode());
+		result = prime * result
+				+ ((refEntities2 == null) ? 0 : refEntities2.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MultipleCollectionEntity other = (MultipleCollectionEntity) obj;
+		if (text == null) {
+			if (other.text != null)
+				return false;
+		} else if (!text.equals(other.text))
+			return false;
+		if (refEntities1 == null) {
+			if (other.refEntities1 != null)
+				return false;
+		} else if (!refEntities1.equals(other.refEntities1))
+			return false;
+		if (refEntities2 == null) {
+			if (other.refEntities2 != null)
+				return false;
+		} else if (!refEntities2.equals(other.refEntities2))
+			return false;
+		return true;
+	}
+
+	
+	public MultipleCollectionEntity deepCopy() {
+		MultipleCollectionEntity clone = new MultipleCollectionEntity();
+		clone.setText(this.text);
+		clone.setId(this.id);
+		
+		for (MultipleCollectionRefEntity1 refEntity1 : refEntities1) {
+			clone.addRefEntity1(refEntity1.deepCopy(clone));
+		}
+		for (MultipleCollectionRefEntity2 refEntity2 : refEntities2) {
+			clone.addRefEntity2(refEntity2.deepCopy(clone));
+		}
+		return clone;
+	}
+
+
+}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionListeners.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionListeners.java
@@ -1,0 +1,277 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.event.collection.detached;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.CollectionEntry;
+import org.hibernate.event.AbstractCollectionEvent;
+import org.hibernate.event.InitializeCollectionEvent;
+import org.hibernate.event.InitializeCollectionEventListener;
+import org.hibernate.event.PostCollectionRecreateEvent;
+import org.hibernate.event.PostCollectionRecreateEventListener;
+import org.hibernate.event.PostCollectionRemoveEvent;
+import org.hibernate.event.PostCollectionRemoveEventListener;
+import org.hibernate.event.PostCollectionUpdateEvent;
+import org.hibernate.event.PostCollectionUpdateEventListener;
+import org.hibernate.event.PreCollectionRecreateEvent;
+import org.hibernate.event.PreCollectionRecreateEventListener;
+import org.hibernate.event.PreCollectionRemoveEvent;
+import org.hibernate.event.PreCollectionRemoveEventListener;
+import org.hibernate.event.PreCollectionUpdateEvent;
+import org.hibernate.event.PreCollectionUpdateEventListener;
+import org.hibernate.event.def.DefaultInitializeCollectionEventListener;
+import org.hibernate.impl.SessionFactoryImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Support listeners for Test HHH-6361: Collection events may contain wrong
+ * stored snapshot after merging a detached entity into the persistencecontext.
+ * 
+ * @author Erik-Berndt Scheper
+ */
+public class MultipleCollectionListeners {
+
+	private final Logger log = LoggerFactory
+			.getLogger(MultipleCollectionListeners.class);
+
+	public interface Listener extends Serializable {
+		void addEvent(AbstractCollectionEvent event, Listener listener);
+	}
+
+	public static abstract class AbstractListener implements Listener {
+
+		private final MultipleCollectionListeners listeners;
+
+		protected AbstractListener(MultipleCollectionListeners listeners) {
+			this.listeners = listeners;
+		}
+
+		public void addEvent(AbstractCollectionEvent event, Listener listener) {
+			listeners.addEvent(event, listener);
+		}
+	}
+
+	public static class InitializeCollectionListener extends
+			DefaultInitializeCollectionEventListener implements Listener {
+		private final MultipleCollectionListeners listeners;
+
+		private InitializeCollectionListener(
+				MultipleCollectionListeners listeners) {
+			this.listeners = listeners;
+		}
+
+		public void onInitializeCollection(InitializeCollectionEvent event) {
+			super.onInitializeCollection(event);
+			addEvent(event, this);
+		}
+
+		public void addEvent(AbstractCollectionEvent event, Listener listener) {
+			listeners.addEvent(event, listener);
+		}
+	}
+
+	public static class PreCollectionRecreateListener extends AbstractListener
+			implements PreCollectionRecreateEventListener {
+		private PreCollectionRecreateListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPreRecreateCollection(PreCollectionRecreateEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	public static class PostCollectionRecreateListener extends AbstractListener
+			implements PostCollectionRecreateEventListener {
+		private PostCollectionRecreateListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPostRecreateCollection(PostCollectionRecreateEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	public static class PreCollectionRemoveListener extends AbstractListener
+			implements PreCollectionRemoveEventListener {
+		private PreCollectionRemoveListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPreRemoveCollection(PreCollectionRemoveEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	public static class PostCollectionRemoveListener extends AbstractListener
+			implements PostCollectionRemoveEventListener {
+		private PostCollectionRemoveListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPostRemoveCollection(PostCollectionRemoveEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	public static class PreCollectionUpdateListener extends AbstractListener
+			implements PreCollectionUpdateEventListener {
+		private PreCollectionUpdateListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPreUpdateCollection(PreCollectionUpdateEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	public static class PostCollectionUpdateListener extends AbstractListener
+			implements PostCollectionUpdateEventListener {
+		private PostCollectionUpdateListener(
+				MultipleCollectionListeners listeners) {
+			super(listeners);
+		}
+
+		public void onPostUpdateCollection(PostCollectionUpdateEvent event) {
+			addEvent(event, this);
+		}
+	}
+
+	private final PreCollectionRecreateListener preCollectionRecreateListener;
+	private final InitializeCollectionListener initializeCollectionListener;
+	private final PreCollectionRemoveListener preCollectionRemoveListener;
+	private final PreCollectionUpdateListener preCollectionUpdateListener;
+	private final PostCollectionRecreateListener postCollectionRecreateListener;
+	private final PostCollectionRemoveListener postCollectionRemoveListener;
+	private final PostCollectionUpdateListener postCollectionUpdateListener;
+
+	private List<Listener> listenersCalled = new ArrayList<Listener>();
+	private List<AbstractCollectionEvent> events = new ArrayList<AbstractCollectionEvent>();
+	private List<Serializable> snapshots = new ArrayList<Serializable>();
+
+	public MultipleCollectionListeners(SessionFactory sf) {
+		preCollectionRecreateListener = new PreCollectionRecreateListener(this);
+		initializeCollectionListener = new InitializeCollectionListener(this);
+		preCollectionRemoveListener = new PreCollectionRemoveListener(this);
+		preCollectionUpdateListener = new PreCollectionUpdateListener(this);
+		postCollectionRecreateListener = new PostCollectionRecreateListener(
+				this);
+		postCollectionRemoveListener = new PostCollectionRemoveListener(this);
+		postCollectionUpdateListener = new PostCollectionUpdateListener(this);
+		SessionFactoryImpl impl = (SessionFactoryImpl) sf;
+		impl.getEventListeners()
+				.setInitializeCollectionEventListeners(
+						new InitializeCollectionEventListener[] { initializeCollectionListener });
+		impl.getEventListeners()
+				.setPreCollectionRecreateEventListeners(
+						new PreCollectionRecreateEventListener[] { preCollectionRecreateListener });
+		impl.getEventListeners()
+				.setPostCollectionRecreateEventListeners(
+						new PostCollectionRecreateEventListener[] { postCollectionRecreateListener });
+		impl.getEventListeners()
+				.setPreCollectionRemoveEventListeners(
+						new PreCollectionRemoveEventListener[] { preCollectionRemoveListener });
+		impl.getEventListeners()
+				.setPostCollectionRemoveEventListeners(
+						new PostCollectionRemoveEventListener[] { postCollectionRemoveListener });
+		impl.getEventListeners()
+				.setPreCollectionUpdateEventListeners(
+						new PreCollectionUpdateEventListener[] { preCollectionUpdateListener });
+		impl.getEventListeners()
+				.setPostCollectionUpdateEventListeners(
+						new PostCollectionUpdateEventListener[] { postCollectionUpdateListener });
+	}
+
+	public void addEvent(AbstractCollectionEvent event, Listener listener) {
+
+		CollectionEntry collectionEntry = event.getSession()
+				.getPersistenceContext()
+				.getCollectionEntry(event.getCollection());
+
+		Serializable snapshot = collectionEntry.getSnapshot();
+
+		log.debug("add Event: " + event.getClass() + "; listener = "
+				+ listener.getClass() + "; snapshot = " + snapshot);
+
+		listenersCalled.add(listener);
+		events.add(event);
+		snapshots.add(snapshot);
+	}
+
+	public List<Listener> getListenersCalled() {
+		return listenersCalled;
+	}
+
+	public List<AbstractCollectionEvent> getEvents() {
+		return events;
+	}
+
+	public List<Serializable> getSnapshots() {
+		return snapshots;
+	}
+
+	public void clear() {
+		listenersCalled.clear();
+		events.clear();
+		snapshots.clear();
+	}
+
+	public PreCollectionRecreateListener getPreCollectionRecreateListener() {
+		return preCollectionRecreateListener;
+	}
+
+	public InitializeCollectionListener getInitializeCollectionListener() {
+		return initializeCollectionListener;
+	}
+
+	public PreCollectionRemoveListener getPreCollectionRemoveListener() {
+		return preCollectionRemoveListener;
+	}
+
+	public PreCollectionUpdateListener getPreCollectionUpdateListener() {
+		return preCollectionUpdateListener;
+	}
+
+	public PostCollectionRecreateListener getPostCollectionRecreateListener() {
+		return postCollectionRecreateListener;
+	}
+
+	public PostCollectionRemoveListener getPostCollectionRemoveListener() {
+		return postCollectionRemoveListener;
+	}
+
+	public PostCollectionUpdateListener getPostCollectionUpdateListener() {
+		return postCollectionUpdateListener;
+	}
+}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionRefEntity1.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionRefEntity1.java
@@ -1,0 +1,127 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.event.collection.detached;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class MultipleCollectionRefEntity1 implements org.hibernate.test.event.collection.Entity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", length = 10)
+	private Long id;
+
+	@Column(name = "TEXT", length = 50, nullable = false)
+	private String text;
+
+	@ManyToOne
+	@JoinColumn(name = "MCE_ID", nullable = false, insertable = false, updatable = false)
+	@org.hibernate.annotations.ForeignKey(name = "FK_RE1_MCE")
+	private MultipleCollectionEntity multipleCollectionEntity;
+
+	@Column(name = "MCE_ID", insertable = false, updatable = false)
+	private Long multipleCollectionEntityId;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public MultipleCollectionEntity getMultipleCollectionEntity() {
+		return multipleCollectionEntity;
+	}
+
+	public void setMultipleCollectionEntity(
+			MultipleCollectionEntity multipleCollectionEntity) {
+		this.multipleCollectionEntity = multipleCollectionEntity;
+	}
+
+	public Long getMultipleCollectionEntityId() {
+		return multipleCollectionEntityId;
+	}
+
+	public void setMultipleCollectionEntityId(Long multipleCollectionEntityId) {
+		this.multipleCollectionEntityId = multipleCollectionEntityId;
+	}
+
+	@Override
+	public String toString() {
+		return "MultipleCollectionRefEntity1 [id=" + id + ", text=" + text
+				+ ", multipleCollectionEntityId=" + multipleCollectionEntityId
+				+ "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((text == null) ? 0 : text.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MultipleCollectionRefEntity1 other = (MultipleCollectionRefEntity1) obj;
+		if (text == null) {
+			if (other.text != null)
+				return false;
+		} else if (!text.equals(other.text))
+			return false;
+		return true;
+	}
+	
+	public MultipleCollectionRefEntity1 deepCopy(MultipleCollectionEntity newRef) {
+		MultipleCollectionRefEntity1 clone = new MultipleCollectionRefEntity1();
+		clone.setText(this.text);
+		clone.setId(this.id);
+		clone.setMultipleCollectionEntity(newRef);
+		clone.setMultipleCollectionEntityId(newRef.getId());
+		return clone;
+	}
+
+}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionRefEntity2.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/event/collection/detached/MultipleCollectionRefEntity2.java
@@ -1,0 +1,128 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.event.collection.detached;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class MultipleCollectionRefEntity2 implements org.hibernate.test.event.collection.Entity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", length = 10)
+	private Long id;
+
+	@Column(name = "TEXT", length = 50, nullable = false)
+	private String text;
+
+	@ManyToOne
+	@JoinColumn(name = "MCE_ID", nullable = false, insertable = false, updatable = false)
+	@org.hibernate.annotations.ForeignKey(name = "FK_RE2_MCE")
+	private MultipleCollectionEntity multipleCollectionEntity;
+
+	@Column(name = "MCE_ID", insertable = false, updatable = false)
+	private Long multipleCollectionEntityId;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public MultipleCollectionEntity getMultipleCollectionEntity() {
+		return multipleCollectionEntity;
+	}
+
+	public void setMultipleCollectionEntity(
+			MultipleCollectionEntity multipleCollectionEntity) {
+		this.multipleCollectionEntity = multipleCollectionEntity;
+	}
+
+	public Long getMultipleCollectionEntityId() {
+		return multipleCollectionEntityId;
+	}
+
+	public void setMultipleCollectionEntityId(Long multipleCollectionEntityId) {
+		this.multipleCollectionEntityId = multipleCollectionEntityId;
+	}
+
+	@Override
+	public String toString() {
+		return "MultipleCollectionRefEntity2 [id=" + id + ", text=" + text
+				+ ", multipleCollectionEntityId=" + multipleCollectionEntityId
+				+ "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((text == null) ? 0 : text.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MultipleCollectionRefEntity2 other = (MultipleCollectionRefEntity2) obj;
+		if (text == null) {
+			if (other.text != null)
+				return false;
+		} else if (!text.equals(other.text))
+			return false;
+		return true;
+	}
+
+	
+	public MultipleCollectionRefEntity2 deepCopy(MultipleCollectionEntity newRef) {
+		MultipleCollectionRefEntity2 clone = new MultipleCollectionRefEntity2();
+		clone.setText(this.text);
+		clone.setId(this.id);
+		clone.setMultipleCollectionEntity(newRef);
+		clone.setMultipleCollectionEntityId(newRef.getId());
+		return clone;
+	}
+
+}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/manytomanyassociationclass/compositeid/ManyToManyAssociationClassCompositeIdTest.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/manytomanyassociationclass/compositeid/ManyToManyAssociationClassCompositeIdTest.java
@@ -27,7 +27,9 @@ package org.hibernate.test.manytomanyassociationclass.compositeid;
 import junit.framework.Test;
 
 import org.hibernate.test.manytomanyassociationclass.AbstractManyToManyAssociationClassTest;
+import org.hibernate.test.manytomanyassociationclass.Group;
 import org.hibernate.test.manytomanyassociationclass.Membership;
+import org.hibernate.test.manytomanyassociationclass.User;
 import org.hibernate.testing.junit.functional.FunctionalTestClassTestSuite;
 
 /**
@@ -52,4 +54,15 @@ public class ManyToManyAssociationClassCompositeIdTest extends AbstractManyToMan
 	public Membership createMembership( String name ) {
 		return new MembershipWithCompositeId( name );
 	}
+	
+	@Override
+	public void deleteMembership(User u, Group g, Membership ug) {
+		if ( u == null || g == null ) {
+			throw new IllegalArgumentException();
+		}
+		u.getMemberships().remove( ug );
+		g.getMemberships().remove( ug );
+		ug.setId(null);
+	}
+
 }

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/manytomanyassociationclass/compositeid/MembershipWithCompositeId.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/manytomanyassociationclass/compositeid/MembershipWithCompositeId.java
@@ -65,20 +65,36 @@ public class MembershipWithCompositeId extends Membership {
 			this.groupId = groupId;
 		}
 
-		public boolean equals(Object o) {
-			if ( o != null && o instanceof Id ) {
-				Id that = ( Id ) o;
-				return this.userId.equals( that.userId ) &&
-						this.groupId.equals( that.groupId );
-			}
-			else {
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
 				return false;
-			}
+			if (getClass() != obj.getClass())
+				return false;
+			Id other = (Id) obj;
+			if (userId == null) {
+				if (other.userId != null)
+					return false;
+			} else if (!userId.equals(other.userId))
+				return false;
+			if (groupId == null) {
+				if (other.groupId != null)
+					return false;
+			} else if (!groupId.equals(other.groupId))
+				return false;
+			return true;
 		}
 
 		public int hashCode() {
-			return userId.hashCode() + groupId.hashCode();
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+			result = prime * result
+					+ ((groupId == null) ? 0 : groupId.hashCode());
+			return result;
 		}
+
 	}
 
 	public MembershipWithCompositeId() {
@@ -90,12 +106,19 @@ public class MembershipWithCompositeId extends Membership {
 	}
 
 	public void setGroup(Group group) {
+		if (getId() == null) {
+			setId(new Id());
+		}
 		( (Id) getId() ).setGroupId( ( group == null ? null : group.getId() ) );
 		super.setGroup( group );
 	}
 
 	public void setUser(User user) {
+		if (getId() == null) {
+			setId(new Id());
+		}
 		( (Id) getId() ).setUserId( user == null ? null : user.getId() );
 		super.setUser( user );
 	}
+
 }


### PR DESCRIPTION
This pull request contains 3 separate commits to fix [HHH-6361](http://opensource.atlassian.com/projects/hibernate/browse/HHH-6361) in the 3.6 branch. 

The first commit (fbascheper/hibernate-core@2e99c9f7a722ec8cda251cd49f7bf385248a3b8d) is a testcase demonstrating the issue at hand. 

The second commit (fbascheper/hibernate-core@6867b586f8f1df7819b18047fcd92fed7c6d8509) is a patch for this issue (and also for HHH-6349 as demonstrated by its testcase). However, this patch breaks the Hibernate 3.6 build, as ManyToManyAssociationClassCompositeIdTest now crashes with an NPE on the hashCode() method.

The third commit (fbascheper/hibernate-core@a3f8d5aac93ac9d626f722378170dc64ca429f22) fixes both the ManyToManyAssociationClassCompositeIdTest  and the hashCode() and equals() methods of  MembershipWithCompositeId.java to prevent the NPE from occurring. 
