### PR TITLE
HHH-6349 AuditJoinTable rows missing when detached entities with collections are merged into the persistence context (4.0.x)

### DIFF
--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionEntity.java
@@ -1,4 +1,4 @@
-package org.hibernate.envers.test.integration.collection;
+package org.hibernate.envers.test.entities.collection;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionRefEntity1.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionRefEntity1.java
@@ -1,4 +1,4 @@
-package org.hibernate.envers.test.integration.collection;
+package org.hibernate.envers.test.entities.collection;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionRefEntity2.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/MultipleCollectionRefEntity2.java
@@ -1,4 +1,4 @@
-package org.hibernate.envers.test.integration.collection;
+package org.hibernate.envers.test.entities.collection;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
@@ -20,6 +20,9 @@ import org.hibernate.envers.internal.EnversMessageLogger;
 import org.hibernate.envers.test.AbstractEntityTest;
 import org.hibernate.envers.test.EnversTestingJtaBootstrap;
 import org.hibernate.envers.test.Priority;
+import org.hibernate.envers.test.entities.collection.MultipleCollectionEntity;
+import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity1;
+import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity2;
 import org.jboss.logging.Logger;
 import org.junit.Test;
 


### PR DESCRIPTION
This pull request contains a testcase for [HHH-6349](http://opensource.atlassian.com/projects/hibernate/browse/HHH-6349) in the 4.0.x series (master). 

This testcase should pass after [HHH-6361](http://opensource.atlassian.com/projects/hibernate/browse/HHH-6361) has been fixed in the 4.0.x series (master). 
