### PR TITLE
HHH-6381 - handle optional=true joins for SecondaryTables in the JoinedSubclassEntityPersister

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -111,6 +111,10 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	private final String discriminatorSQLString;
 
+	private int coreTableSpan;
+	// only contains values for SecondaryTables ie. not tables part of the "coreTableSpan"
+	private final boolean[] isNullableTable;
+	
 	//INITIALIZATION:
 
 	public JoinedSubclassEntityPersister(
@@ -179,11 +183,16 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 		
 		//Span of the tables directly mapped by this entity and super-classes, if any
-		int coreTableSpan = tables.size();
+		coreTableSpan = tables.size();
 		
+		isNullableTable = new boolean[persistentClass.getJoinClosureSpan()];
+		
+		int tabIndex = 0;
 		Iterator joinIter = persistentClass.getJoinClosureIterator();
 		while ( joinIter.hasNext() ) {
 			Join join = (Join) joinIter.next();
+			
+			isNullableTable[tabIndex++] = join.isOptional();
 			
 			Table tab = join.getTable();
 			 
@@ -492,6 +501,12 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	}
 
+	protected boolean isNullableTable(int j) {
+	    if (j < coreTableSpan)
+		return false;
+	    return isNullableTable[j-coreTableSpan];
+	}
+	
 	protected boolean isSubclassTableSequentialSelect(int j) {
 		return subclassTableSequentialSelect[j] && !isClassOrSuperclassTable[j];
 	}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/JoinedSubclassAndSecondaryTable.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/JoinedSubclassAndSecondaryTable.java
@@ -14,8 +14,25 @@ public class JoinedSubclassAndSecondaryTable extends TestCase {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();
 		SwimmingPool sp = new SwimmingPool();
-		sp.setAddress( "Park Avenue" );
+		//sp.setAddress( "Park Avenue" );
 		s.persist( sp );
+		s.flush();
+		s.clear();
+		
+		SwimmingPool sp2 = (SwimmingPool)s.get(SwimmingPool.class, sp.getId());
+		assertEquals( sp.getAddress(), null);
+		
+		PoolAddress addr = new PoolAddress();
+		addr.setAddress("Park Avenue");
+		sp2.setAddress(addr);
+		
+		s.flush();
+		s.clear();
+		
+		sp2 = (SwimmingPool)s.get(SwimmingPool.class, sp.getId());
+		assertFalse( sp2.getAddress() == null );
+		assertEquals( sp2.getAddress().getAddress(), "Park Avenue");
+		
 		tx.rollback();
 		s.close();
 	}

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/Pool.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/Pool.java
@@ -8,6 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.Embedded;
 
 /**
  * @author Emmanuel Bernard
@@ -15,16 +16,19 @@ import javax.persistence.InheritanceType;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @SecondaryTable(name="POOL_ADDRESS")
+@org.hibernate.annotations.Table(appliesTo="POOL_ADDRESS", optional=true)
 public class Pool {
-	@Id @GeneratedValue private Integer id;
-	@Column(table = "POOL_ADDRESS")
-	private String address;
+	@Id @GeneratedValue 
+	private Integer id;
+	
+	@Embedded
+	private PoolAddress address;
 
-	public String getAddress() {
+	public PoolAddress getAddress() {
 		return address;
 	}
 
-	public void setAddress(String address) {
+	public void setAddress(PoolAddress address) {
 		this.address = address;
 	}
 

--- a/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/PoolAddress.java
+++ b/hibernate-testsuite/src/test/java/org/hibernate/test/annotations/inheritance/joined/PoolAddress.java
@@ -1,0 +1,18 @@
+package org.hibernate.test.annotations.inheritance.joined;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class PoolAddress {
+    @Column(table = "POOL_ADDRESS")
+    private String address;
+    
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}


### PR DESCRIPTION
As requested, here is:

HHH-6381 - handle optional=true joins for SecondaryTables in the JoinedSubclassEntityPersister

against 3.6 branch.

This is a straight backport of the change done on the master (4.0beta) branch.   I didn't attempt to incorporate the "improved" test case, as the method used (getTableRowCount) doesn't seem to be available in 3.6 :-(
