### PR TITLE
[HHH-6442] In the case a URL cannot be reconstructed due to MalformedURLE

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/ejb/packaging/JarVisitorFactory.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/ejb/packaging/JarVisitorFactory.java
@@ -85,7 +85,15 @@ public class JarVisitorFactory {
 				}
 			}
 			else {
-				jarUrl = new URL( protocol, url.getHost(), url.getPort(), file );
+				try {
+                    jarUrl = new URL( protocol, url.getHost(), url.getPort(), file );
+                }
+                // HHH-6442
+                catch(final MalformedURLException murle) {
+                    // Just use the provided URL as-is, likely it has a URLStreamHandler
+                    // associated w/ the instance
+                    jarUrl = url;
+                }
 			}
 		}
 		catch (MalformedURLException e) {


### PR DESCRIPTION
[HHH-6442] In the case a URL cannot be reconstructed due to MalformedURLException, use the one passed in (which will already have a URLStreamHandler association)
