### PR TITLE
Use entity meta model to determine if some properties should be skipped when getting all properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
@@ -588,7 +588,7 @@ public abstract class AbstractEntityTuplizer implements EntityTuplizer {
 	}
 
 	protected boolean shouldGetAllProperties(Object entity) {
-		return !hasUninitializedLazyProperties( entity );
+		return !entityMetamodel.hasLazyProperties();
 	}
 
 	public Object[] getPropertyValues(Object entity) throws HibernateException {


### PR DESCRIPTION
shouldGetAllProperties should not look at the entity's not yet initialized lazy properties, but rather use the meta model to check if there are lazy properties at all. This becomes clear when looking at the callers of this method, who care if a property is lazy or not, but not if it is already initialized.
