### PR TITLE
Add varargs to Restrictions.and(c1,c2) and Restrictions.or(c1,c2) 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
@@ -246,6 +246,31 @@ public class Restrictions {
 		return new LogicalExpression(lhs, rhs, "or");
 	}
 	/**
+	 * Return the conjunction of an expressions array
+	 * @param ands the criterion array
+	 * @return Criterion
+	 */
+	public static Criterion and(Criterion... ands) {
+		Conjunction conj = conjunction();
+		for ( Criterion and : ands ) {
+			conj.add(and);
+		}
+		return conj;
+	}
+	/**
+	 * Return the disjunction of an expressions array
+	 * @param ors the criterion array
+	 * @return Criterion
+	 */
+	public static Criterion or(Criterion... ors) {
+		Disjunction dis = disjunction();
+		for ( Criterion or : ors ) {
+			dis.add(or);
+		}
+		return dis;
+	}
+	
+	/**
 	 * Return the negation of an expression
 	 *
 	 * @param expression


### PR DESCRIPTION
This becomes more userfriendly to create a large list of AND / OR restrictions, without the pain of instantiating and filling a (con/dis)junction

Note that the old methods are returning LogicalExpression (and not Criterion) and should be kept for retrocompatibility.
As Java uses varargs in last resort in the case of an overload, callind and(c1,c2) will still call the old methods so it doesn't break the compatibility for people that uses the return type as a LogicalExpression and not as a Criterion
