### PR TITLE
HHH-5848 - Column's table name not processed by naming strategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3Column.java
@@ -443,7 +443,9 @@ public class Ejb3Column {
 					final String sqlType = col.columnDefinition().equals( "" )
 							? null
 							: nameNormalizer.normalizeIdentifierQuoting( col.columnDefinition() );
-					final String tableName = nameNormalizer.normalizeIdentifierQuoting( col.table() );
+					final String tableName = ! StringHelper.isEmpty(col.table())
+                                             ? nameNormalizer.normalizeIdentifierQuoting( mappings.getNamingStrategy().tableName( col.table() ) )
+                                             : "";
 					final String columnName = nameNormalizer.normalizeIdentifierQuoting( col.name() );
 					Ejb3Column column = new Ejb3Column();
 					column.setImplicit( false );

--- a/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/Item.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/Item.java
@@ -1,0 +1,82 @@
+package org.hibernate.test.namingstrategy;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
+ */
+@Entity
+@Table(name = "ITEMS")
+@SecondaryTable(name="ITEMS_SEC")
+public class Item implements Serializable {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "price")
+    private Double price;
+
+    @Column(name = "price", table = "ITEMS_SEC")
+    private Double specialPrice;
+
+    public Item() {
+    }
+
+    public Item(Double price, Double specialPrice) {
+        this.price = price;
+        this.specialPrice = specialPrice;
+    }
+
+    public Item(Long id, Double price, Double specialPrice) {
+        this.id = id;
+        this.price = price;
+        this.specialPrice = specialPrice;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Item item = (Item) o;
+
+        if (id != null ? !id.equals(item.id) : item.id != null) return false;
+        if (price != null ? !price.equals(item.price) : item.price != null) return false;
+        if (specialPrice != null ? !specialPrice.equals(item.specialPrice) : item.specialPrice != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (price != null ? price.hashCode() : 0);
+        result = 31 * result + (specialPrice != null ? specialPrice.hashCode() : 0);
+        return result;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Double getSpecialPrice() {
+        return specialPrice;
+    }
+
+    public void setSpecialPrice(Double specialPrice) {
+        this.specialPrice = specialPrice;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/NamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/NamingStrategyTest.java
@@ -29,12 +29,14 @@ import org.hibernate.mapping.PersistentClass;
 
 import org.junit.Test;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Emmanuel Bernard
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 public class NamingStrategyTest extends BaseCoreFunctionalTestCase {
 	@Override
@@ -42,6 +44,13 @@ public class NamingStrategyTest extends BaseCoreFunctionalTestCase {
 		super.configure( cfg );
 		cfg.setNamingStrategy( new TestNamingStrategy() );
 	}
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] {
+                Item.class
+        };
+    }
 
 	@Override
 	public String[] getMappings() {
@@ -51,10 +60,19 @@ public class NamingStrategyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCorrectDatabase() {
+	public void testDatabaseColumnNames() {
 		PersistentClass classMapping = configuration().getClassMapping( Customers.class.getName() );
 		Column stateColumn = (Column) classMapping.getProperty( "specified_column" ).getColumnIterator().next();
 		assertEquals( "CN_specified_column", stateColumn.getName() );
 	}
 
+    @Test
+    @TestForIssue(jiraKey = "HHH-5848")
+    public void testDatabaseTableNames() {
+        PersistentClass classMapping = configuration().getClassMapping( Item.class.getName() );
+        Column secTabColumn = (Column) classMapping.getProperty( "specialPrice" ).getColumnIterator().next();
+        assertEquals( "TAB_ITEMS_SEC", secTabColumn.getValue().getTable().getName() );
+        Column tabColumn = (Column) classMapping.getProperty( "price" ).getColumnIterator().next();
+        assertEquals( "TAB_ITEMS", tabColumn.getValue().getTable().getName() );
+    }
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/TestNamingStrategy.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/TestNamingStrategy.java
@@ -3,6 +3,7 @@ import org.hibernate.cfg.DefaultNamingStrategy;
 
 /**
  * @author Emmanuel Bernard
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 public class TestNamingStrategy extends DefaultNamingStrategy {
 	public String propertyToColumnName(String propertyName) {
@@ -17,4 +18,9 @@ public class TestNamingStrategy extends DefaultNamingStrategy {
 			propertyName) {
 		return "LCN_" + super.logicalColumnName( columnName, propertyName );
 	}
+
+    @Override
+    public String tableName(String tableName) {
+        return "TAB_" + tableName;
+    }
 }


### PR DESCRIPTION
Patch and test for HHH-5848 JIRA issue.
Link: http://opensource.atlassian.com/projects/hibernate/browse/HHH-5848

BTW, shouldn't the naming strategy be applied to id columns? It would be another JIRA issue.

Regards,
Lukasz Antoniak

P.S. Adam, this time patch concerns hibernate-core module.
