### PR TITLE
HHH-6384 : hibernate.hbm2ddl.auto=create does not drop tables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
@@ -270,7 +270,8 @@ public class SchemaExport {
 	}
 
 	/**
-	 * Run the schema creation script.
+	 * Run the schema creation script; drop script is automatically
+	 * executed before running the creation script.
 	 *
 	 * @param script print the DDL to the console
 	 * @param export export the script to the database
@@ -279,8 +280,15 @@ public class SchemaExport {
 		create( Target.interpret( script, export ) );
 	}
 
+	/**
+	 * Run the schema creation script; drop script is automatically
+	 * executed before running the creation script.
+	 *
+	 * @param output the target of the script.
+	 */
 	public void create(Target output) {
-		execute( output, Type.CREATE );
+		// need to drop tables before creating so need to specify Type.BOTH
+		execute( output, Type.BOTH );
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaexport/mapping.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaexport/mapping.hbm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC 
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.test.schemaupdate">
+
+	<class name="Version">
+		<id name="id">
+			<generator class="org.hibernate.id.TableHiLoGenerator">
+                <param name="table">uid_table</param>
+                <param name="column">next_hi_value_column</param>
+        	</generator>
+		</id>
+		<property name="description"/>	
+	</class>
+
+</hibernate-mapping>
+


### PR DESCRIPTION
Restores 3.6 behaviour where SchemaExport.create() automatically executes the drop script before executing the create script.
