### PR TITLE
HHH-5930 [branch 4.x] - Remove hibernate-tools dependency from runtime scope

### DIFF
--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -4,13 +4,11 @@ dependencies {
     compile( project( ':hibernate-core' ) )
     compile( project( ':hibernate-entitymanager' ) )
     compile( libraries.commons_annotations )
-    compile( [group: 'org.hibernate', name: 'hibernate-tools', version: '3.2.0.ga'] ) {
-        trasitive = false
-    }
+    provided( [group: 'org.hibernate', name: 'hibernate-tools', version: '3.2.0.ga'] )
     compile( libraries.dom4j ) {
         trasitive = false
     }
-    compile( libraries.ant )
+    provided( libraries.ant )
     testCompile( libraries.junit )
     testCompile( project(':hibernate-testing') )
     testCompile( libraries.jpa )


### PR DESCRIPTION
Patch for HHH-5930 JIRA task.
Link: http://opensource.atlassian.com/projects/hibernate/browse/HHH-5930

Regards,
Lukasz Antoniak
