### PR TITLE
HHH-5930 [branch 3.x] - Remove hibernate-tools dependency from runtime scope

### DIFF
--- a/hibernate-envers/pom.xml
+++ b/hibernate-envers/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-tools</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>ant</groupId>


### PR DESCRIPTION
Patch for HHH-5930 JIRA task.
Link: http://opensource.atlassian.com/projects/hibernate/browse/HHH-5930

Regards,
Lukasz Antoniak
