### PR TITLE
Custom class loading strategy for cglib and javassist proxies

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/cglib/CGLIBLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/cglib/CGLIBLazyInitializer.java
@@ -158,6 +158,14 @@ public final class CGLIBLazyInitializer extends BasicLazyInitializer implements 
   		e.setCallbackFilter(FINALIZE_FILTER);
   		e.setUseFactory(false);
 		e.setInterceptDuringConstruction( false );
+		e.setClassLoader(new ClassLoader(persistentClass.getClassLoader()) {
+			private final ClassLoader platformClassLoader = getClass().getClassLoader();
+
+			@Override
+			protected Class<?> findClass(String name) throws ClassNotFoundException {
+				return platformClassLoader.loadClass(name);
+			}
+		});
 		return e.createClass();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
@@ -155,7 +155,20 @@ public class JavassistLazyInitializer extends BasicLazyInitializer implements Me
 		// note: interfaces is assumed to already contain HibernateProxy.class
 
 		try {
-			ProxyFactory factory = new ProxyFactory();
+			final ClassLoader platformDelegatingClassLoader = new ClassLoader(persistentClass.getClassLoader()) {
+				private final ClassLoader platformClassLoader = getClass().getClassLoader();
+
+				@Override
+				protected Class<?> findClass(String name) throws ClassNotFoundException {
+					return platformClassLoader.loadClass(name);
+				}
+			};
+			ProxyFactory factory = new ProxyFactory() {
+				@Override
+				protected ClassLoader getClassLoader() {
+					return platformDelegatingClassLoader;
+				}
+			};
 			factory.setSuperclass( interfaces.length == 1 ? persistentClass : null );
 			factory.setInterfaces( interfaces );
 			factory.setFilter( FINALIZE_FILTER );


### PR DESCRIPTION
Fixes https://hibernate.onjira.com/browse/HHH-5962 Issue.
The issue was that Hibernate's classloader uses the classloader of mapped classes to load its own classes (i.e. org.hibernate.\* etc) after creating the proxy. It works well if the classloader of the enhanced classes is the same as the Hibernate's one but it fails if this classloader knows nothing about the hibernate classes (e.g. if the mapped classes are dynamically loaded from another bundle).

I've been testing the patched Hibernate with my OSGi project for a few months and it works pretty well.
