### PR TITLE
HHH-6614 - Envers bad performance without invoking EntityManager.clear()

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/revisioninfo/DefaultRevisionInfoGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/revisioninfo/DefaultRevisionInfoGenerator.java
@@ -29,6 +29,7 @@ import org.hibernate.envers.EntityTrackingRevisionListener;
 import org.hibernate.envers.RevisionListener;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.entities.PropertyData;
+import org.hibernate.envers.synchronization.SessionCacheCleaner;
 import org.hibernate.envers.tools.reflection.ReflectionTools;
 import org.hibernate.property.Setter;
 
@@ -45,6 +46,7 @@ public class DefaultRevisionInfoGenerator implements RevisionInfoGenerator {
     private final Setter revisionTimestampSetter;
     private final boolean timestampAsDate;
     private final Class<?> revisionInfoClass;
+    private final SessionCacheCleaner sessionCacheCleaner;
 
     public DefaultRevisionInfoGenerator(String revisionInfoEntityName, Class<?> revisionInfoClass,
                                        Class<? extends RevisionListener> listenerClass,
@@ -69,10 +71,13 @@ public class DefaultRevisionInfoGenerator implements RevisionInfoGenerator {
             // Default listener - none
             listener = null;
         }
+
+        sessionCacheCleaner = new SessionCacheCleaner();
     }
 
 	public void saveRevisionData(Session session, Object revisionData) {
         session.save(revisionInfoEntityName, revisionData);
+        sessionCacheCleaner.scheduleAuditDataRemoval(session, revisionData);
 	}
 
     public Object generate() {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/synchronization/SessionCacheCleaner.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/synchronization/SessionCacheCleaner.java
@@ -1,0 +1,27 @@
+package org.hibernate.envers.synchronization;
+
+import org.hibernate.Session;
+import org.hibernate.action.spi.AfterTransactionCompletionProcess;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.event.spi.EventSource;
+
+/**
+ * Class responsible for evicting audit data entries that have been stored in the session level cache.
+ * This operation increases Envers performance in case of massive entity updates without clearing persistence context.
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
+ */
+public class SessionCacheCleaner {
+    /**
+     * Schedules audit data removal from session level cache after transaction completion. The operation is performed
+     * regardless of commit success.
+     * @param session Active Hibernate session.
+     * @param data Audit data that shall be evicted (e.g. revision data or entity snapshot)
+     */
+    public void scheduleAuditDataRemoval(final Session session, final Object data) {
+        ((EventSource) session).getActionQueue().registerProcess(new AfterTransactionCompletionProcess() {
+            public void doAfterTransactionCompletion(boolean success, SessionImplementor session) {
+                ((Session) session).evict(data);
+            }
+        });
+    }
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/performance/EvictAuditDataAfterCommitTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/performance/EvictAuditDataAfterCommitTest.java
@@ -1,0 +1,104 @@
+package org.hibernate.envers.test.performance;
+
+import org.hibernate.MappingException;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.test.AbstractSessionTest;
+import org.hibernate.envers.test.entities.StrTestEntity;
+import org.hibernate.envers.test.entities.onetomany.SetRefEdEntity;
+import org.hibernate.envers.test.entities.onetomany.SetRefIngEntity;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
+ */
+public class EvictAuditDataAfterCommitTest extends AbstractSessionTest {
+    @Override
+    protected void initMappings() throws MappingException, URISyntaxException {
+        config.addAnnotatedClass(StrTestEntity.class);
+        config.addAnnotatedClass(SetRefEdEntity.class);
+        config.addAnnotatedClass(SetRefIngEntity.class);
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-6614")
+    public void testSessionCacheClear() {
+        getSession().getTransaction().begin();
+        StrTestEntity ste = new StrTestEntity("data");
+        getSession().persist(ste);
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), "org.hibernate.envers.test.entities.StrTestEntity_AUD");
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-6614")
+    public void testSessionCacheCollectionClear() {
+        final String[] auditEntityNames = new String[] {"org.hibernate.envers.test.entities.onetomany.SetRefEdEntity_AUD",
+                                                        "org.hibernate.envers.test.entities.onetomany.SetRefIngEntity_AUD"};
+
+        SetRefEdEntity ed1 = new SetRefEdEntity(1, "data_ed_1");
+        SetRefEdEntity ed2 = new SetRefEdEntity(2, "data_ed_2");
+        SetRefIngEntity ing1 = new SetRefIngEntity(3, "data_ing_1");
+        SetRefIngEntity ing2 = new SetRefIngEntity(4, "data_ing_2");
+        
+        getSession().getTransaction().begin();
+        getSession().persist(ed1);
+        getSession().persist(ed2);
+        getSession().persist(ing1);
+        getSession().persist(ing2);
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), auditEntityNames);
+
+        getSession().getTransaction().begin();
+        ed1 = (SetRefEdEntity) getSession().load(SetRefEdEntity.class, ed1.getId());
+        ing1.setReference(ed1);
+        ing2.setReference(ed1);
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), auditEntityNames);
+
+        getSession().getTransaction().begin();
+        ed2 = (SetRefEdEntity) getSession().load(SetRefEdEntity.class, ed2.getId());
+        Set<SetRefIngEntity> reffering = new HashSet<SetRefIngEntity>();
+        reffering.add(ing1);
+        reffering.add(ing2);
+        ed2.setReffering(reffering);
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), auditEntityNames);
+
+        getSession().getTransaction().begin();
+        ed2 = (SetRefEdEntity) getSession().load(SetRefEdEntity.class, ed2.getId());
+        ed2.getReffering().remove(ing1);
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), auditEntityNames);
+
+        getSession().getTransaction().begin();
+        ed2 = (SetRefEdEntity) getSession().load(SetRefEdEntity.class, ed2.getId());
+        ed2.getReffering().iterator().next().setData("mod_data_ing_2");
+        getSession().getTransaction().commit();
+        checkEmptyAuditSessionCache(getSession(), auditEntityNames);
+    }
+
+    private void checkEmptyAuditSessionCache(Session session, String ... auditEntityNames) {
+        List<String> entityNames = Arrays.asList(auditEntityNames);
+        PersistenceContext persistenceContext = ((SessionImplementor) session).getPersistenceContext();
+        for (Object entry : persistenceContext.getEntityEntries().values()) {
+            EntityEntry entityEntry = (EntityEntry) entry;
+            if (entityNames.contains(entityEntry.getEntityName())) {
+                assert false : "Audit data shall not be stored in the session level cache. This causes performance issues.";
+            }
+            Assert.assertFalse("Revision entity shall not be stored in the session level cache. This causes performance issues.",
+                               DefaultRevisionEntity.class.getName().equals(entityEntry.getEntityName()));
+        }
+    }
+}


### PR DESCRIPTION
Patch and test for HHH-6614 JIRA issue.
Link: http://opensource.atlassian.com/projects/hibernate/browse/HHH-6614

Test case assigned to JIRA issue demonstrates the grow of Persistence Context caused by generating massive amount of audit data (only one "current" Mailman entity is being updated). Proposed solution evicts audit entities from session cache after committing transaction. In my opinion this operation does not affect any use cases.

Regards,
Lukasz Antoniak
