### PR TITLE
Fix for running hibernate-core matrix tests offline

### DIFF
--- a/hibernate-core/src/matrix/java/org/hibernate/test/propertyref/cachedcollections/Mappings.hbm.xml
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/propertyref/cachedcollections/Mappings.hbm.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Hibernate, Relational Persistence for Idiomatic Java
   ~
@@ -24,7 +25,7 @@
 
 <!DOCTYPE hibernate-mapping PUBLIC
     "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-    "http://hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="org.hibernate.test.propertyref.cachedcollections">
 


### PR DESCRIPTION
fixed hibernate-core matrix test to work offline by correcting test mapping xml doctype for CachedPropertyRefCollectionTest.
