### PR TITLE
Incorrect Update Timestamp results in a lot of 2L misses

### DIFF
--- a/hibernate-core/pom.xml
+++ b/hibernate-core/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-parent</artifactId>
-        <version>3.6.7.Final</version>
+        <version>3.6.7-2L</version>
         <relativePath>../hibernate-parent/pom.xml</relativePath>
     </parent>
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/ActionQueue.java
@@ -282,7 +282,7 @@ public class ActionQueue {
 		if ( session.getFactory().getSettings().isQueryCacheEnabled() ) {
 			final String[] spaces = (String[]) executable.getPropertySpaces();
 			afterTransactionProcesses.addSpacesToInvalidate( spaces );
-			session.getFactory().getUpdateTimestampsCache().preinvalidate( spaces );
+			session.getFactory().getUpdateTimestampsCache().invalidate( spaces );
 		}
 		afterTransactionProcesses.register( executable.getAfterTransactionCompletionProcess() );
 	}

--- a/hibernate-parent/pom.xml
+++ b/hibernate-parent/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.hibernate</groupId>
     <artifactId>hibernate-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.6.7.Final</version>
+    <version>3.6.7-2L</version>
 
     <name>Hibernate Core Parent POM</name>
     <description>The base POM for all Hibernate Core modules.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-parent</artifactId>
-        <version>3.6.7.Final</version>
+        <version>3.6.7-2L</version>
         <relativePath>hibernate-parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
As indicated in this bug report, there could be an issue with the 2L cache: https://hibernate.onjira.com/browse/HHH-6680
