### PR TITLE
HHH-6693 Maven fails to resolve maven-jdocbook-style-plugin due to missing plugin repository declaration

### DIFF
--- a/hibernate-parent/pom.xml
+++ b/hibernate-parent/pom.xml
@@ -391,6 +391,14 @@
         </extensions>
     </build>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>JBossPublic</id>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <name>Public JBoss Repository Group</name>
+        </pluginRepository>   
+    </pluginRepositories>
+    
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
HHH-6693 Added missing pluginRepository declaration pointing to Public JBoss Repository Group, so that JBoss maven plugins and their dependencies can be resolved.
