### PR TITLE
HHH-6694 Maven fails to resolve commons-logging due to missing repository declaration

### DIFF
--- a/hibernate-parent/pom.xml
+++ b/hibernate-parent/pom.xml
@@ -557,6 +557,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+	
+	<repositories>
+	    <repository>
+		    <id>JBossPublic</id>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <name>Public JBoss Repository Group</name>
+		</repository>
+	</repositories>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
HH6694 Added missing repository declaration pointing to Public JBoss Repository Group, so that dependencies can be resolved.
