### PR TITLE
HHH-5944 - Refresh of an entity should clear its entries in the action queue

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -30,10 +30,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.persister.entity.EntityPersister;
 import org.jboss.logging.Logger;
 
 import org.hibernate.AssertionFailure;
@@ -63,6 +65,7 @@ import org.hibernate.type.Type;
  * until a flush forces them to be executed against the database.
  *
  * @author Steve Ebersole
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 public class ActionQueue {
 
@@ -166,6 +169,30 @@ public class ActionQueue {
 
 	public void registerProcess(BeforeTransactionCompletionProcess process) {
 		beforeTransactionProcesses.register( process );
+	}
+
+	/**
+	 * Removes all actions (insertions, updates, deletions) associated with a given entity instance.
+	 *
+	 * @param persister Entity persister.
+	 * @param id Entity identifier.
+	 */
+	public void removeAllEntityActions(EntityPersister persister, Serializable id) {
+		removeEntityActions( insertions, persister, id );
+		removeEntityActions( updates, persister, id );
+		removeEntityActions( deletions, persister, id );
+	}
+
+	private void removeEntityActions(ArrayList list, EntityPersister persister, Serializable id) {
+		if ( list != null ) {
+			Iterator listIterator = list.iterator();
+			while ( listIterator.hasNext() ) {
+				EntityAction action = (EntityAction) listIterator.next();
+				if ( action.getEntityName().equals( persister.getEntityName() ) && action.getId().equals( id ) ) {
+					listIterator.remove();
+				}
+			}
+		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -123,6 +123,8 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		if ( e != null ) {
 			final EntityKey key = source.generateEntityKey( id, persister );
 			source.getPersistenceContext().removeEntity(key);
+			// If the entity is being refreshed, remove previously scheduled DML operations.
+			source.getActionQueue().removeAllEntityActions( persister, id );
 			if ( persister.hasCollections() ) new EvictVisitor( source ).process(object, persister);
 		}
 

--- a/hibernate-core/src/matrix/java/org/hibernate/test/version/RefreshEntityStateTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/version/RefreshEntityStateTest.java
@@ -1,0 +1,67 @@
+package org.hibernate.test.version;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.hibernate.Session;
+import org.hibernate.StaleObjectStateException;
+import org.hibernate.Transaction;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+/**
+ * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
+ */
+@TestForIssue(jiraKey = "HHH-5944")
+public class RefreshEntityStateTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public String[] getMappings() {
+		return new String[] { "version/PersonThing.hbm.xml" };
+	}
+
+	@Test
+	public void testClearActionQueueAfterEntityRefresh() {
+		Session s1 = openSession();
+		Transaction t1 = s1.beginTransaction();
+		Thing computer = new Thing();
+		computer.setDescription( "Computer" );
+		computer.setDescription( "My Computer" );
+		s1.persist( computer );
+		t1.commit();
+		s1.close();
+
+		s1 = openSession();
+		t1 = s1.beginTransaction();
+		computer = (Thing) s1.get( Thing.class, computer.getDescription() );
+
+		/* Change entity in another session. */
+		Session s2 = openSession();
+		Transaction t2 = s2.beginTransaction();
+		Thing newComputer = (Thing) s2.get( Thing.class, computer.getDescription() );
+		newComputer.setLongDescription( "My New Computer" );
+		s2.update( newComputer );
+		t2.commit();
+		s2.close();
+
+		computer.setLongDescription( "My New Laptop" );
+		s1.update( computer );
+		try {
+			s1.flush();
+			Assert.assertTrue( "StaleObjectStateException expected.", false );
+		}
+		catch ( StaleObjectStateException e ) {
+			s1.refresh( computer );
+			Assert.assertEquals( "My New Computer", computer.getLongDescription() );
+			// All events associated with computer object shall be removed.
+			Assert.assertEquals( 0, ( (EventSource) s1 ).getActionQueue().numberOfUpdates() );
+		}
+		computer.setLongDescription( "My New Laptop" );
+		s1.update( computer );
+		s1.flush();
+		t1.commit();
+		s1.close();
+
+		Assert.assertEquals( "My New Laptop", computer.getLongDescription() );
+	}
+}


### PR DESCRIPTION
Patch and test for HHH-5944 JIRA issue.
Link: http://opensource.atlassian.com/projects/hibernate/browse/HHH-5944

Regards,
Lukasz Antoniak
