### PR TITLE
Refactoring the query splitter

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/QuerySplitter.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/QuerySplitter.java
@@ -85,51 +85,38 @@ public final class QuerySplitter {
 		ArrayList placeholders = new ArrayList();
 		ArrayList replacements = new ArrayList();
 		StringBuffer templateQuery = new StringBuffer( 40 );
+
+		int start = getStartingPositionFor(tokens, templateQuery);
 		int count = 0;
-		String last = null;
-		int nextIndex = 0;
 		String next = null;
-		boolean isSelectClause = false;
+		String last = tokens[start - 1].toLowerCase();
 
-		templateQuery.append( tokens[0] );
-		if ( "select".equals( tokens[0].toLowerCase() ) ) isSelectClause = true;
-
-		for ( int i = 1; i < tokens.length; i++ ) {
-
-			//update last non-whitespace token, if necessary
-			if ( !ParserHelper.isWhitespace( tokens[i - 1] ) ) last = tokens[i - 1].toLowerCase();
-
-			// select-range is terminated by declaration of "from"
-			if ( "from".equals( tokens[i].toLowerCase() ) ) isSelectClause = false;
+		for ( int i = start; i < tokens.length; i++ ) {
 
 			String token = tokens[i];
-			if ( !ParserHelper.isWhitespace( token ) || last == null ) {
 
-				//scan for next non-whitespace token
-				if ( nextIndex <= i ) {
-					for ( nextIndex = i + 1; nextIndex < tokens.length; nextIndex++ ) {
-						next = tokens[nextIndex].toLowerCase();
-						if ( !ParserHelper.isWhitespace( next ) ) break;
+			if ( ParserHelper.isWhitespace( token ) ) {
+				templateQuery.append( token );
+				continue;
+			}
+
+			next = nextNonWhite(tokens, i).toLowerCase();
+
+			boolean process = isJavaIdentifier( token ) &&
+					isPossiblyClassName( last, next );
+
+			last = token.toLowerCase();
+
+			if (process) {
+				String importedClassName = getImportedClass( token, factory );
+				if ( importedClassName != null ) {
+					String[] implementors = factory.getImplementors( importedClassName );
+					token = "$clazz" + count++ + "$";
+					if ( implementors != null ) {
+						placeholders.add( token );
+						replacements.add( implementors );
 					}
 				}
-
-				boolean process = !isSelectClause &&
-						isJavaIdentifier( token ) &&
-						isPossiblyClassName( last, next );
-
-				if (process) {
-					String importedClassName = getImportedClass( token, factory );
-					if ( importedClassName != null ) {
-						String[] implementors = factory.getImplementors( importedClassName );
-						String placeholder = "$clazz" + count++ + "$";
-						if ( implementors != null ) {
-							placeholders.add( placeholder );
-							replacements.add( implementors );
-						}
-						token = placeholder; // Note this!!
-					}
-				}
-
 			}
 
 			templateQuery.append( token );
@@ -138,6 +125,25 @@ public final class QuerySplitter {
 		String[] results = StringHelper.multiply( templateQuery.toString(), placeholders.iterator(), replacements.iterator() );
         if (results.length == 0) LOG.noPersistentClassesFound(query);
 		return results;
+	}
+	
+	private static String nextNonWhite(String[] tokens, int start) {
+		for ( int i = start + 1; i < tokens.length; i++ ) {
+			if ( !ParserHelper.isWhitespace( tokens[i] ) ) return tokens[i];
+		}
+		return tokens[tokens.length - 1];
+	}
+	
+	private static int getStartingPositionFor(String[] tokens, StringBuffer templateQuery) {
+		templateQuery.append( tokens[0] );
+		if ( !"select".equals( tokens[0].toLowerCase() ) ) return 1;
+
+		// select-range is terminated by declaration of "from"
+		for (int i = 1; i < tokens.length; i++ ) {
+			if ( "from".equals( tokens[i].toLowerCase() ) ) return i;
+			templateQuery.append( tokens[i] );
+		}
+		return tokens.length;
 	}
 
 	private static boolean isPossiblyClassName(String last, String next) {


### PR DESCRIPTION
The query splitter had some unnecessary logic checks and variables.
I've extracted them step by step (each step is a commit) while keeping tests green.

In the end, the algorithm still runs on (2*tokens length), as it did earlier, but with lesser conditionals.

This refactor also allows to easier understand what goes on inside the method:
- finds the starting position
- simply append whitespaces
- for non whitespaces that might be classes, process, append
- for non whitespaces that are not classes, append

The cyclomatic complexity of the method should be much lower by now because most of the nested complexity was removed: 
- max(nested flow controls) was 5, now is 4.
- there were 5 big nesting branches inside the for loop, now there are 2

Regards
