### PR TITLE
HHH-6723 : Remove extra join from eager @OneToOne

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/AbstractEntityJoinWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/AbstractEntityJoinWalker.java
@@ -24,6 +24,7 @@
  */
 package org.hibernate.loader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.hibernate.FetchMode;
@@ -183,6 +184,21 @@ public abstract class AbstractEntityJoinWalker extends JoinWalker {
 	}
 
 	public abstract String getComment();
+
+	@Override
+    protected boolean isDuplicateAssociation(
+		final String foreignKeyTable,
+		final String[] foreignKeyColumns
+	) {
+		//disable a join back to this same association
+		final boolean isSameJoin =
+				persister.getTableName().equals( foreignKeyTable ) &&
+						Arrays.equals( foreignKeyColumns, persister.getKeyColumnNames() );
+		return isSameJoin ||
+			super.isDuplicateAssociation(foreignKeyTable, foreignKeyColumns);
+	}
+
+
 
 	protected final Loadable getPersister() {
 		return persister;

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/onetoone/OneToOneTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/onetoone/OneToOneTest.java
@@ -332,7 +332,7 @@ public class OneToOneTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-6723" )
+	@TestForIssue( jiraKey = "HHH-6723" )
 	public void testPkOneToOneSelectStatementDoesNotGenerateExtraJoin() {
 		// This test uses an interceptor to verify that correct number of joins are generated.
 		Session s = openSession(new JoinCounter(1));


### PR DESCRIPTION
I was able to get rid of the extra join by adding AbstractEntityJoinWalker.isDuplicateAssociation() similar to OneToManyJoinWalker.isDuplicateAssociation().

I think this will work, but I'm not sure. Can someone familiar with this code take a look?

Thanks,
Gail
