### PR TITLE
HHH-3434

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IntoClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IntoClause.java
@@ -26,11 +26,16 @@ package org.hibernate.hql.internal.ast.tree;
 
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import org.hibernate.QueryException;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.persister.entity.Queryable;
+import org.hibernate.type.ComponentType;
 import org.hibernate.type.Type;
+
 import antlr.collections.AST;
 
 /**
@@ -49,6 +54,8 @@ public class IntoClause extends HqlSqlWalkerNode implements DisplayableNode {
 	private boolean explicitIdInsertion;
 	private boolean explicitVersionInsertion;
 
+	private Set componentIds;
+	private List explicitComponentIds;
 
 	public void initialize(Queryable persister) {
 		if ( persister.isAbstract() ) {
@@ -165,10 +172,27 @@ public class IntoClause extends HqlSqlWalkerNode implements DisplayableNode {
 			throw new QueryException( "INSERT statements cannot refer to superclass/joined properties [" + name + "]" );
 		}
 
-		if ( name.equals( persister.getIdentifierPropertyName() ) ) {
-			explicitIdInsertion = true;
+		if ( !explicitIdInsertion ) {
+			if ( persister.getIdentifierType() instanceof ComponentType ) {
+				if ( componentIds == null ) {
+					String[] propertyNames = ( (ComponentType) persister.getIdentifierType() ).getPropertyNames();
+					componentIds = new HashSet();
+					for ( int i = 0; i < propertyNames.length; i++ ) {
+						componentIds.add( propertyNames[i] );
+					}
+				}
+				if ( componentIds.contains(name) ) {
+					if ( explicitComponentIds == null ) {
+						explicitComponentIds = new ArrayList( componentIds.size() );
+					}
+					explicitComponentIds.add( name );
+					explicitIdInsertion = explicitComponentIds.size() == componentIds.size();
+				}
+			} else if ( name.equals( persister.getIdentifierPropertyName() ) ) {
+				explicitIdInsertion = true;
+			}
 		}
-
+			
 		if ( persister.isVersioned() ) {
 			if ( name.equals( persister.getPropertyNames()[ persister.getVersionProperty() ] ) ) {
 				explicitVersionInsertion = true;

--- a/hibernate-core/src/matrix/java/org/hibernate/test/hql/BulkManipulationTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/hql/BulkManipulationTest.java
@@ -65,7 +65,8 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 				"legacy/Multi.hbm.xml",
 				"hql/EntityWithCrazyCompositeKey.hbm.xml",
 				"hql/SimpleEntityWithAssociation.hbm.xml",
-				"hql/BooleanLiteralEntity.hbm.xml"
+				"hql/BooleanLiteralEntity.hbm.xml",
+				"hql/CompositeIdEntity.hbm.xml"
 		};
 	}
 
@@ -494,6 +495,18 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 		s.createQuery( "delete TimestampVersioned" ).executeUpdate();
 		t.commit();
 		s.close();
+	}
+
+	@Test
+	public void testInsertWithAssignedCompositeId() {
+		// this just checks that the query parser detects that we are explicitly inserting a composite id
+		Session s = openSession();
+		s.beginTransaction();
+		// intentionally reversing the order of the composite id properties to make sure that is supported too
+		s.createQuery( "insert into CompositeIdEntity (key2, someProperty, key1) select a.key2, 'COPY', a.key1 from CompositeIdEntity a" ).executeUpdate();
+		s.createQuery( "delete from CompositeIdEntity" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();		
 	}
 
 	@Test

--- a/hibernate-core/src/matrix/java/org/hibernate/test/hql/CompositeIdEntity.hbm.xml
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/hql/CompositeIdEntity.hbm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping SYSTEM "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd" >
+
+<hibernate-mapping package="org.hibernate.test.hql">
+
+    <class name="CompositeIdEntity">
+    	<composite-id>
+    		<key-property name="key1" />
+    		<key-property name="key2" />
+    	</composite-id>
+    	
+    	<property name="someProperty" />
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/matrix/java/org/hibernate/test/hql/CompositeIdEntity.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/hql/CompositeIdEntity.java
@@ -1,0 +1,60 @@
+package org.hibernate.test.hql;
+
+import java.io.Serializable;
+
+public class CompositeIdEntity implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Long key1;
+	private String key2;
+	private String someProperty;
+
+	public Long getKey1() {
+		return key1;
+	}
+
+	public void setKey1( Long key1 ) {
+		this.key1 = key1;
+	}
+
+	public String getKey2() {
+		return key2;
+	}
+
+	public void setKey2( String key2 ) {
+		this.key2 = key2;
+	}
+
+	public String getSomeProperty() {
+		return someProperty;
+	}
+
+	public void setSomeProperty( String someProperty ) {
+		this.someProperty = someProperty;
+	}
+
+	@Override
+	public int hashCode() {
+		// not really needed, thus the dumb implementation.
+		return 42;
+	}
+
+	@Override
+	public boolean equals( Object obj ) {
+		if (this == obj) {
+			return true;
+		}
+		if ( !( obj instanceof CompositeIdEntity ) ) {
+			return false; 
+		}
+		CompositeIdEntity other = ( CompositeIdEntity ) obj;
+		if ( key1 == null ? other.key1 != null : !key1.equals( other.key1 ) ) {
+			return false;
+		}
+		if ( key2 == null ? other.key2 != null : !key2.equals( other.key2 ) ) {
+			return false;
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
This is in reply to

http://twitter.com/#!/Hibernate/status/125865622675525633
http://twitter.com/#!/Hibernate/status/125865837105119232

A few comments:
- I still put the key properties in a HashSet. I did not see why it was important to preserve order. The set is only used to lookup up key property names. The order in which the properties appear in the INSERT statement should not matter, right?
- If you are okay with the patch, can we backport it to 3.6? I can make the change and send a separate pull request.

Andrei
