### PR TITLE
HHH-6121: Fix for Hibernate statistics should log at DEBUG level instead of INFO

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/stat/ConcurrentStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/ConcurrentStatisticsImpl.java
@@ -316,7 +316,9 @@ public class ConcurrentStatisticsImpl implements Statistics, StatisticsImplement
 
 	@SuppressWarnings({ "UnnecessaryBoxing" })
 	public void queryExecuted(String hql, int rows, long time) {
-		PERF_LOG.info( "HQL: {}, time: {}ms, rows: {}", new Object[] {hql, Long.valueOf( time ), Long.valueOf(rows)} );
+		if (PERF_LOG.isDebugEnabled()) {
+			PERF_LOG.debug( "HQL: {}, time: {}ms, rows: {}", new Object[] {hql, Long.valueOf( time ), Long.valueOf(rows)} );
+		}
 		queryExecutionCount.getAndIncrement();
 		boolean isLongestQuery = false;
 		for ( long old = queryExecutionMaxTime.get();

--- a/hibernate-core/src/main/java/org/hibernate/stat/StatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/StatisticsImpl.java
@@ -296,7 +296,9 @@ public class StatisticsImpl implements Statistics, StatisticsImplementor {
 		if (hql!=null) {
 			QueryStatisticsImpl qs = (QueryStatisticsImpl) getQueryStatistics(hql);
 			qs.executed(rows, time);
-			log.info( "HQL: {}, time: {}ms, rows: {}", new Object[]{hql, new Long( time ), new Long( rows )} );
+			if (log.isDebugEnabled()) {
+				log.debug( "HQL: {}, time: {}ms, rows: {}", new Object[]{hql, new Long( time ), new Long( rows )} );
+			}
 		}
 	}
 	


### PR DESCRIPTION
Fix for https://hibernate.onjira.com/browse/HHH-6121 , production ready logging!

Cheers,

Johno
