### PR TITLE
HHH-6121: Fix for Hibernate statistics should log at DEBUG level instead of INFO

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -396,7 +396,7 @@ public interface CoreMessageLogger extends BasicLogger {
 								  String incrementParam,
 								  int incrementSize);
 
-	@LogMessage(level = INFO)
+	@LogMessage(level = DEBUG)
 	@Message(value = "HQL: %s, time: %sms, rows: %s", id = 117)
 	void hql(String hql,
 			 Long valueOf,


### PR DESCRIPTION
Fix for https://hibernate.onjira.com/browse/HHH-6121 , production ready logging!

Cheers,

Johno
