### PR TITLE
Propose removing the dependecy of Session on SessionFactoryImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -23,10 +23,13 @@
  */
 package org.hibernate.engine.spi;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.hibernate.EntityNameResolver;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MappingException;
@@ -44,6 +47,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.profile.FetchProfile;
 import org.hibernate.engine.query.spi.QueryPlanCache;
+import org.hibernate.engine.transaction.spi.TransactionEnvironment;
 import org.hibernate.exception.spi.SQLExceptionConverter;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -238,4 +242,21 @@ public interface SessionFactoryImplementor extends Mapping, SessionFactory {
 	public ServiceRegistryImplementor getServiceRegistry();
 
 	public void addObserver(SessionFactoryObserver observer);
+	
+	/**
+	 * Obtain the {@link TransactionEnvironment} associated with this session factory.
+	 *
+	 * @return The transaction environment.
+	 */
+	public TransactionEnvironment getTransactionEnvironment();
+	
+	public Iterable<EntityNameResolver> iterateEntityNameResolvers() ;
+	
+	/**
+	 * Custom serialization hook used during Session serialization.
+	 *
+	 * @param oos The stream to which to write the factory
+	 * @throws IOException Indicates problems writing out the serial data stream
+	 */
+	void serialize(ObjectOutputStream oos) throws IOException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterImpl.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.hibernate.Filter;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.FilterDefinition;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.Type;
 
 /**
@@ -48,7 +49,7 @@ public class FilterImpl implements Filter, Serializable {
 	private String filterName;
 	private Map<String,Object> parameters = new HashMap<String, Object>();
 	
-	void afterDeserialize(SessionFactoryImpl factory) {
+	void afterDeserialize(SessionFactoryImplementor factory) {
 		definition = factory.getFilterDefinition(filterName);
 		validate();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -40,10 +40,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
-
-import org.jboss.logging.Logger;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.Cache;
@@ -139,6 +138,7 @@ import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.type.AssociationType;
 import org.hibernate.type.Type;
 import org.hibernate.type.TypeResolver;
+import org.jboss.logging.Logger;
 
 
 /**
@@ -1616,13 +1616,8 @@ public final class SessionFactoryImpl
 		return typeHelper;
 	}
 
-	/**
-	 * Custom serialization hook used during Session serialization.
-	 *
-	 * @param oos The stream to which to write the factory
-	 * @throws IOException Indicates problems writing out the serial data stream
-	 */
-	void serialize(ObjectOutputStream oos) throws IOException {
+	@Override
+	public void serialize(ObjectOutputStream oos) throws IOException {
 		oos.writeUTF( uuid );
 		oos.writeBoolean( name != null );
 		if ( name != null ) {
@@ -1656,7 +1651,7 @@ public final class SessionFactoryImpl
 	}
 
 	static class SessionBuilderImpl implements SessionBuilder {
-		private final SessionFactoryImpl sessionFactory;
+		private final SessionFactoryImplementor sessionFactory;
 		private Interceptor interceptor;
 		private Connection connection;
 		private ConnectionReleaseMode connectionReleaseMode;
@@ -1665,9 +1660,9 @@ public final class SessionFactoryImpl
 		private boolean flushBeforeCompletion;
 		private String tenantIdentifier;
 
-		SessionBuilderImpl(SessionFactoryImpl sessionFactory) {
+		SessionBuilderImpl(SessionFactoryImplementor sessionFactory) {
 			this.sessionFactory = sessionFactory;
-			final Settings settings = sessionFactory.settings;
+			final Settings settings = sessionFactory.getSettings();
 
 			// set up default builder values...
 			this.interceptor = sessionFactory.getInterceptor();
@@ -1687,7 +1682,7 @@ public final class SessionFactoryImpl
 					sessionFactory,
 					getTransactionCoordinator(),
 					autoJoinTransactions,
-					sessionFactory.settings.getRegionFactory().nextTimestamp(),
+					sessionFactory.getSettings().getRegionFactory().nextTimestamp(),
 					interceptor,
 					flushBeforeCompletion,
 					autoClose,

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -100,7 +100,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 
 	@Override
 	public TransactionEnvironment getTransactionEnvironment() {
-		return factory.getTransactionEnvironment();
+		return getFactory().getTransactionEnvironment();
 	}
 
 	// inserts ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -311,7 +311,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 	}
 
 	public ConnectionReleaseMode getConnectionReleaseMode() {
-		return factory.getSettings().getConnectionReleaseMode();
+		return getFactory().getSettings().getConnectionReleaseMode();
 	}
 
 	@Override
@@ -320,7 +320,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 	}
 
 	public boolean isAutoCloseSessionEnabled() {
-		return factory.getSettings().isAutoCloseSessionEnabled();
+		return getFactory().getSettings().isAutoCloseSessionEnabled();
 	}
 
 	public boolean isFlushBeforeCompletionEnabled() {
@@ -423,10 +423,10 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 			throws HibernateException {
 		errorIfClosed();
 		if ( entityName==null ) {
-			return factory.getEntityPersister( guessEntityName( object ) );
+			return getFactory().getEntityPersister( guessEntityName( object ) );
 		}
 		else {
-			return factory.getEntityPersister( entityName ).getSubclassEntityPersister( object, getFactory() );
+			return getFactory().getEntityPersister( entityName ).getSubclassEntityPersister( object, getFactory() );
 		}
 	}
 
@@ -574,7 +574,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 		String entityName = criteria.getEntityOrClassName();
 		CriteriaLoader loader = new CriteriaLoader(
 				getOuterJoinLoadable( entityName ),
-		        factory,
+		        getFactory(),
 		        criteria,
 		        entityName,
 		        getLoadQueryInfluencers()
@@ -584,14 +584,14 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 
 	public List list(CriteriaImpl criteria) throws HibernateException {
 		errorIfClosed();
-		String[] implementors = factory.getImplementors( criteria.getEntityOrClassName() );
+		String[] implementors = getFactory().getImplementors( criteria.getEntityOrClassName() );
 		int size = implementors.length;
 
 		CriteriaLoader[] loaders = new CriteriaLoader[size];
 		for( int i=0; i <size; i++ ) {
 			loaders[i] = new CriteriaLoader(
 					getOuterJoinLoadable( implementors[i] ),
-			        factory,
+			        getFactory(),
 			        criteria,
 			        implementors[i],
 			        getLoadQueryInfluencers()
@@ -617,7 +617,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 	}
 
 	private OuterJoinLoadable getOuterJoinLoadable(String entityName) throws MappingException {
-		EntityPersister persister = factory.getEntityPersister(entityName);
+		EntityPersister persister = getFactory().getEntityPersister(entityName);
 		if ( !(persister instanceof OuterJoinLoadable) ) {
 			throw new MappingException( "class persister is not OuterJoinLoadable: " + entityName );
 		}


### PR DESCRIPTION
I'm not sure if the appropriate way to begin this discussion is with a pull request, but with some code at least it could be discussed.  This change Modifies AbstractSession and it's decendant classes such that they only rely on SessionFactoryImplementor instead of SessionFactoryImpl.

This change would allow an end user to make a delegate session that can properly conform to the interface.

Ultimately, my goal is to be able to create a threadlocal statistics service, (not necessarily packed with hibernate, but as a client of the library) and this is one step in that direction.

Thanks,
Nathan
