### PR TITLE
HHH-4962: Taking @OneToMany(mappedBy) Into Account

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/reader/AuditedPropertiesReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/reader/AuditedPropertiesReader.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKey;
+import javax.persistence.OneToMany;
 import javax.persistence.Version;
 
 import org.hibernate.MappingException;
@@ -333,6 +334,12 @@ public class AuditedPropertiesReader {
 	}
 
     private void setPropertyAuditMappedBy(XProperty property, PropertyAuditingData propertyData) {
+        OneToMany oneToMany = property.getAnnotation(OneToMany.class);
+        if (oneToMany != null) {
+            if(!"".equals(oneToMany.mappedBy())) {
+                propertyData.setAuditMappedBy(oneToMany.mappedBy());
+            }
+        }
         AuditMappedBy auditMappedBy = property.getAnnotation(AuditMappedBy.class);
         if (auditMappedBy != null) {
 		    propertyData.setAuditMappedBy(auditMappedBy.mappedBy());


### PR DESCRIPTION
@AuditMappedBy can already be used to define an inverse mapping for envers.
Being unable to see any reason why standard annotations may not be taken
into account mappedBy from @OneToMany is used for an inverse @ManyToOne
mapping and can be overridden by @AuditMappedBy.
