### PR TITLE
 Persistence units that has exploded packages in "<jar-file>" tag, does not have its entities scanned

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/ejb/packaging/JarVisitorFactory.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/ejb/packaging/JarVisitorFactory.java
@@ -162,7 +162,7 @@ public class JarVisitorFactory {
 		if ( "jar".equals( protocol ) ) {
 			return new JarProtocolVisitor( jarUrl, filters, entry );
 		}
-		else if ( StringHelper.isEmpty( protocol ) || "file".equals( protocol ) ) {
+		else if ( StringHelper.isEmpty( protocol ) || "file".equals( protocol ) || "vfszip".equals( protocol ) || "vfsfile".equals( protocol ) ) {
 			File file;
 			try {
 				final String filePart = jarUrl.getFile();

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/packaging/JarVisitorTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/packaging/JarVisitorTest.java
@@ -23,14 +23,22 @@
  */
 package org.hibernate.ejb.test.packaging;
 
-import javax.persistence.Embeddable;
-import javax.persistence.Entity;
-import javax.persistence.MappedSuperclass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
 import java.util.Set;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.MappedSuperclass;
 
 import org.hibernate.ejb.packaging.ClassFilter;
 import org.hibernate.ejb.packaging.Entry;
@@ -45,15 +53,8 @@ import org.hibernate.ejb.packaging.JarVisitorFactory;
 import org.hibernate.ejb.packaging.PackageFilter;
 import org.hibernate.ejb.test.pack.defaultpar.ApplicationServer;
 import org.hibernate.ejb.test.pack.explodedpar.Carpet;
-
-import org.junit.Test;
-
 import org.hibernate.testing.TestForIssue;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 /**
  * @author Emmanuel Bernard
@@ -219,6 +220,41 @@ public class JarVisitorTest extends PackagingTestCase {
 			assertNotNull( localEntry.getInputStream() );
 			localEntry.getInputStream().close();
 		}
+	}
+	
+	@Test
+	@TestForIssue(jiraKey = "HHH-6806")
+	public void testJarVisitorFactory() throws Exception{
+		
+        //setting URL to accept vfs based protocol
+		URL.setURLStreamHandlerFactory(new URLStreamHandlerFactory() {
+			public URLStreamHandler createURLStreamHandler(String protocol) {
+				if("vfszip".equals(protocol) || "vfsfile".equals(protocol) )
+				return new URLStreamHandler() {
+					protected URLConnection openConnection(URL u)
+							throws IOException {
+						return null;
+					}
+				};
+				return null;
+			}
+		});
+        
+		URL jarUrl  = new URL ("file:./target/packages/defaultpar.par");
+		JarVisitor jarVisitor =  JarVisitorFactory.getVisitor(jarUrl, getFilters(), null);
+		assertEquals(FileZippedJarVisitor.class.getName(), jarVisitor.getClass().getName());
+		
+		jarUrl  = new URL ("file:./target/packages/explodedpar");
+		jarVisitor =  JarVisitorFactory.getVisitor(jarUrl, getFilters(), null);
+		assertEquals(ExplodedJarVisitor.class.getName(), jarVisitor.getClass().getName());
+		
+	    jarUrl  = new URL ("vfszip:./target/packages/defaultpar.par");
+		jarVisitor =  JarVisitorFactory.getVisitor(jarUrl, getFilters(), null);
+		assertEquals(FileZippedJarVisitor.class.getName(), jarVisitor.getClass().getName());
+		
+		jarUrl  = new URL ("vfsfile:./target/packages/explodedpar");
+		jarVisitor =  JarVisitorFactory.getVisitor(jarUrl, getFilters(), null);
+		assertEquals(ExplodedJarVisitor.class.getName(), jarVisitor.getClass().getName());		
 	}
 
 	@Test


### PR DESCRIPTION
HHH-6806: In JBoss, Persistence Units return a vfsfile protocol for exploded packages declared in "<jar-file>" which is not scanned by Hibernate EntityManager. The class JarVisitorFactory returns a wrong implementation of AbstractJarVisitor for vfsfile (it's returning InputStreamZippedJarVisitor). The fix makes JarVisitorFactory returning the correct implementation, ExplodedJarVisitor that is able to scan entities in exploded packages appropriately . 

This was fixed in JBPAPP-7491 and JBPAPP-7488, now it needs fix on upstream.
