### PR TITLE
HHH-6865 : PessimisticLockException should be thrown when pessimistic read/write locking fail

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
@@ -116,6 +116,14 @@ public class PessimisticReadSelectLockingStrategy extends AbstractSelectLockingS
 			);
 			throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
 		}
+		catch ( JDBCException e ) {
+			if ( ! PessimisticLockException.class.isInstance( e ) ) {
+				throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	protected String generateLockString(int lockTimeout) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
@@ -128,6 +128,14 @@ public class PessimisticReadUpdateLockingStrategy implements LockingStrategy {
 				);
 			throw new PessimisticLockException("could not obtain pessimistic lock", e, object);
 		}
+		catch ( JDBCException e ) {
+			if ( ! PessimisticLockException.class.isInstance( e ) ) {
+				throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	protected String generateLockString() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
@@ -116,6 +116,14 @@ public class PessimisticWriteSelectLockingStrategy extends AbstractSelectLocking
 			);
 			throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
 		}
+		catch ( JDBCException e ) {
+			if ( ! PessimisticLockException.class.isInstance( e ) ) {
+				throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	protected String generateLockString(int lockTimeout) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -128,6 +128,14 @@ public class PessimisticWriteUpdateLockingStrategy implements LockingStrategy {
 				);
 			throw new PessimisticLockException("could not obtain pessimistic lock", e, object);
 		}
+		catch ( JDBCException e ) {
+			if ( ! PessimisticLockException.class.isInstance( e ) ) {
+				throw new PessimisticLockException( "could not obtain pessimistic lock", e, object );
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	protected String generateLockString() {


### PR DESCRIPTION
PessimisticLockException should be thrown when pessimistic read and write locking strategies fail.

See https://hibernate.onjira.com/browse/HHH-6865 for details.
