### PR TITLE
Fix for HHH-6883

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -240,4 +240,35 @@ public class InformixDialect extends Dialect {
 	public String getCurrentTimestampSelectString() {
 		return "select distinct current timestamp from informix.systables";
 	}
+
+	/**
+	 * Overrides {@link Dialect#supportsTemporaryTables()} to return
+	 * {@code true} when invoked.
+	 *
+	 * @return {@code true} when invoked
+	 */
+	public boolean supportsTemporaryTables() {
+		return true;
+	}
+
+	/**
+	 * Overrides {@link Dialect#getCreateTemporaryTableString()} to
+	 * return "{@code create temp table}" when invoked.
+	 *
+	 * @return "{@code create temp table}" when invoked
+	 */
+	public String getCreateTemporaryTableString() {
+		return "create temp table";
+	}
+
+	/**
+	 * Overrides {@link Dialect#getCreateTemporaryTablePostfix()} to
+	 * return "{@code with no log}" when invoked.
+	 *
+	 * @return "{@code with no log}" when invoked
+	 */
+	public String getCreateTemporaryTablePostfix() {
+		return "with no log";
+	}
+
 }


### PR DESCRIPTION
Hello; this is my first pull request to the Hibernate project.  Please kindly correct me where I have done something wrong.

I have patched the `InformixDialect.java` file to add support for temporary tables as Informix does, in fact, support them.  This fixes [bug HHH-6883](https://hibernate.onjira.com/browse/HHH-6883).  Thanks as always for Hibernate.

Best,
Laird
