### PR TITLE
HHH-6952 Allow extensions of InfinispanRegionFactory to override classloader logic

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
@@ -427,7 +427,7 @@ public class InfinispanRegionFactory implements RegionFactory {
       return createCacheWrapper(cache.getAdvancedCache());
    }
 
-   protected ClassLoaderAwareCache createCacheWrapper(AdvancedCache cache) {
+   protected AdvancedCache createCacheWrapper(AdvancedCache cache) {
       return new ClassLoaderAwareCache(cache, Thread.currentThread().getContextClassLoader());
    }
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/timestamp/TimestampsRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/timestamp/TimestampsRegionImplTestCase.java
@@ -141,7 +141,7 @@ public class TimestampsRegionImplTestCase extends AbstractGeneralDataRegionTestC
 //      }
 
       @Override
-      protected ClassLoaderAwareCache createCacheWrapper(AdvancedCache cache) {
+      protected AdvancedCache createCacheWrapper(AdvancedCache cache) {
          return new ClassLoaderAwareCache(cache, Thread.currentThread().getContextClassLoader()) {
             @Override
             public void addListener(Object listener) {


### PR DESCRIPTION
This allows the cache to leverage AS7's classloader handling.
