### PR TITLE
type=MyISAM syntax is deprecated in MySQL 5.5

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLMyISAMDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLMyISAMDialect.java
@@ -30,7 +30,7 @@ package org.hibernate.dialect;
 public class MySQLMyISAMDialect extends MySQLDialect {
 
 	public String getTableTypeString() {
-		return " type=MyISAM";
+		return " ENGINE=MyISAM";
 	}
 
 	public boolean dropConstraints() {


### PR DESCRIPTION
type=MyISAM syntax is deprecated in MySQL 5.5, modified the dialect to use ENGINE=MyISAM on a table.
