### PR TITLE
OS independent file separator in Gradle script

### DIFF
--- a/release/release.gradle
+++ b/release/release.gradle
@@ -90,9 +90,9 @@ String determinePackageName(SourceDirectorySet sourceDirectorySet, File javaFile
         if ( javaFileAbsolutePath.startsWith( sourceDirectoryAbsolutePath ) ) {
             final String javaFileRelativePath = javaFileAbsolutePath.substring(
                     sourceDirectoryAbsolutePath.length() + 1,
-                    javaFileAbsolutePath.lastIndexOf( '/' )
+                    javaFileAbsolutePath.lastIndexOf( File.separator )
             );
-            return javaFileRelativePath.replace( '/', '.' );
+            return javaFileRelativePath.replace( File.separator, "." );
         }
     }
     throw new RuntimeException( "ugh" );


### PR DESCRIPTION
I am not a Gradle wizard, so please revise. It's just a simple fix, so I hope that creating new JIRA issue was not necessary.

Regards,
Lukasz Antoniak
