### PR TITLE
HHH-6895 : Easier annotation definition of increment generator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -2123,6 +2123,20 @@ public final class AnnotationBinder {
 		if ( isComponent ) {
 			generatorType = "assigned";
 		} //a component must not have any generator
+		else if ( generatedValue != null ) {
+			// add "increment" generator to localGenerators only when type
+			// is AUTO and there is no generator in mappings or localGenerators
+			// named "increment".
+			final String incrementGeneratorName = "increment";
+			if ( incrementGeneratorName.equals( generatorName ) &&
+					generatedValue.strategy() == GenerationType.AUTO &&
+					mappings.getGenerator( incrementGeneratorName, localGenerators ) == null ) {
+				IdGenerator incrementGenerator = new IdGenerator();
+				incrementGenerator.setIdentifierGeneratorStrategy( incrementGeneratorName );
+				incrementGenerator.setName( incrementGeneratorName );
+				localGenerators.put( incrementGeneratorName, incrementGenerator );
+			}
+		}
 		BinderHelper.makeIdGenerator( idValue, generatorType, generatorName, mappings, localGenerators );
 
 		if ( LOG.isTraceEnabled() ) {

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/id/generationmappings/IncrementEntity.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/id/generationmappings/IncrementEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.id.generationmappings;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * TODO : javadoc
+ *
+ * @author Gail Badner
+ */
+@Entity
+public class IncrementEntity {
+	private Long id;
+
+	@Id
+	@GeneratedValue( generator = "increment" )
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long long1) {
+		id = long1;
+	}
+}

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/id/generationmappings/NewGeneratorMappingsTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/id/generationmappings/NewGeneratorMappingsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.id.IdentifierGenerator;
+import org.hibernate.id.IncrementGenerator;
 import org.hibernate.id.enhanced.OptimizerFactory;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.id.enhanced.TableGenerator;
@@ -51,7 +52,8 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 				MinimalSequenceEntity.class,
 				CompleteSequenceEntity.class,
 				AutoEntity.class,
-				MinimalTableEntity.class
+				MinimalTableEntity.class,
+				IncrementEntity.class
 		};
 	}
 
@@ -118,5 +120,12 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 		// 50 is the annotation default
 		assertEquals( 50, tabGenerator.getIncrementSize() );
 		assertTrue( OptimizerFactory.PooledOptimizer.class.isInstance( tabGenerator.getOptimizer() ) );
+	}
+
+	@Test
+	public void testIncrementEntity() {
+		final EntityPersister persister = sessionFactory().getEntityPersister( IncrementEntity.class.getName() );
+		IdentifierGenerator generator = persister.getIdentifierGenerator();
+		assertTrue( IncrementGenerator.class.isInstance( generator ) );
 	}
 }


### PR DESCRIPTION
This commit is a fix so that it is possible to do:

@Id 
@GeneratedValue( generator="increment" )
public Long getId() { .. }

instead of:
@Id 
@GeneratedValue( generator="increment" )
@org.hibernate.annotations.GenericGenerator( name = "increment", strategy = "increment" )
public Long getId() { .. }
