### PR TITLE
HHH-6974 Redirect naturalId criteria queries to new API

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/NaturalIdentifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/NaturalIdentifier.java
@@ -23,6 +23,9 @@
  *
  */
 package org.hibernate.criterion;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -30,7 +33,6 @@ import org.hibernate.engine.spi.TypedValue;
 
 /**
  * @author Gavin King
- *
  * @see Session#byNaturalId(Class)
  * @see Session#byNaturalId(String)
  * @see Session#bySimpleNaturalId(Class)
@@ -38,7 +40,8 @@ import org.hibernate.engine.spi.TypedValue;
  */
 public class NaturalIdentifier implements Criterion {
 		
-	private Junction conjunction = new Conjunction();
+	private final Junction conjunction = new Conjunction();
+	private final Map<String, Object> naturalIdValues = new HashMap<String, Object>();
 
 	public TypedValue[] getTypedValues(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
 		return conjunction.getTypedValues(criteria, criteriaQuery);
@@ -48,8 +51,13 @@ public class NaturalIdentifier implements Criterion {
 		return conjunction.toSqlString(criteria, criteriaQuery);
 	}
 	
+	public Map<String, Object> getNaturalIdValues() {
+		return naturalIdValues;
+	}
+
 	public NaturalIdentifier set(String property, Object value) {
 		conjunction.add( Restrictions.eq(property, value) );
+		naturalIdValues.put( property, value );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1562,4 +1562,24 @@ public interface CoreMessageLogger extends BasicLogger {
 	void cannotResolveNonNullableTransientDependencies(String transientEntityString,
 													   Set<String> dependentEntityStrings,
 													   Set<String> nonNullableAssociationPaths);
+
+	@LogMessage(level = INFO)
+	@Message(value = "NaturalId cache puts: %s", id = 438)
+	void naturalIdCachePuts(long naturalIdCachePutCount);
+
+	@LogMessage(level = INFO)
+	@Message(value = "NaturalId cache hits: %s", id = 439)
+	void naturalIdCacheHits(long naturalIdCacheHitCount);
+
+	@LogMessage(level = INFO)
+	@Message(value = "NaturalId cache misses: %s", id = 440)
+	void naturalIdCacheMisses(long naturalIdCacheMissCount);
+
+	@LogMessage(level = INFO)
+	@Message(value = "Max NaturalId query time: %sms", id = 441)
+	void naturalIdMaxQueryTime(long naturalIdQueryExecutionMaxTime);
+	
+	@LogMessage(level = INFO)
+	@Message(value = "NaturalId queries executed to database: %s", id = 442)
+	void naturalIdQueriesExecuted(long naturalIdQueriesExecutionCount);
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -36,6 +36,7 @@ import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.NClob;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -78,6 +79,8 @@ import org.hibernate.TypeHelper;
 import org.hibernate.UnknownProfileException;
 import org.hibernate.UnresolvableObjectException;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.criterion.NaturalIdentifier;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.engine.internal.StatefulPersistenceContext;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.query.spi.FilterQueryPlan;
@@ -130,6 +133,7 @@ import org.hibernate.event.spi.ResolveNaturalIdEvent;
 import org.hibernate.event.spi.ResolveNaturalIdEventListener;
 import org.hibernate.event.spi.SaveOrUpdateEvent;
 import org.hibernate.event.spi.SaveOrUpdateEventListener;
+import org.hibernate.internal.CriteriaImpl.CriterionEntry;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.jdbc.ReturningWork;
 import org.hibernate.jdbc.Work;
@@ -1492,8 +1496,71 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 			dontFlushFromFind--;
 		}
 	}
+	
+	/**
+	 * Checks to see if the CriteriaImpl is a naturalId lookup that can be done via
+	 * NaturalIdLoadAccess
+	 * 
+	 * @return A fully configured NaturalIdLoadAccess or null, if null is returned the standard CriteriaImpl execution
+	 *         should be performed
+	 */
+	private NaturalIdLoadAccess tryNaturalIdLoadAccess(CriteriaImpl criteria) {
+		// See if the criteria lookup is by naturalId
+		if ( !criteria.isLookupByNaturalKey() ) {
+			return null;
+		}
+		
+		final String entityName = criteria.getEntityOrClassName();
+		final EntityPersister entityPersister = factory.getEntityPersister( entityName );
+
+		// Verify the entity actually has a natural id, needed for legacy support as NaturalIdentifier criteria
+		// queries did no natural id validation
+		if ( !entityPersister.hasNaturalIdentifier() ) {
+			return null;
+		}
+		
+		// Since isLookupByNaturalKey is true there can be only one CriterionEntry and getCriterion() will 
+		// return an instanceof NaturalIdentifier
+		final CriterionEntry criterionEntry = (CriterionEntry) criteria.iterateExpressionEntries().next();
+		final NaturalIdentifier naturalIdentifier = (NaturalIdentifier) criterionEntry.getCriterion();
+
+		final Map<String, Object> naturalIdValues = naturalIdentifier.getNaturalIdValues();
+		final int[] naturalIdentifierProperties = entityPersister.getNaturalIdentifierProperties();
+
+		// Verify the NaturalIdentifier criterion includes all naturalId properties, first check that the property counts match
+		if ( naturalIdentifierProperties.length != naturalIdValues.size() ) {
+			return null;
+		}
+
+		final String[] propertyNames = entityPersister.getPropertyNames();
+		final NaturalIdLoadAccess naturalIdLoader = this.byNaturalId( entityName );
+
+		// Build NaturalIdLoadAccess and in the process verify all naturalId properties were specified
+		for ( int i = 0; i < naturalIdentifierProperties.length; i++ ) {
+			final String naturalIdProperty = propertyNames[naturalIdentifierProperties[i]];
+			final Object naturalIdValue = naturalIdValues.get( naturalIdProperty );
+
+			if ( naturalIdValue == null ) {
+				// A NaturalId property is missing from the critera query, can't use NaturalIdLoadAccess
+				return null;
+			}
+
+			naturalIdLoader.using( naturalIdProperty, naturalIdValue );
+		}
+
+		// Critera query contains a valid naturalId, use the new API
+		LOG.warn( "Session.byNaturalId(" + entityName
+				+ ") should be used for naturalId queries instead of Restrictions.naturalId() from a Criteria" );
+
+		return naturalIdLoader;
+	}
 
 	public List list(CriteriaImpl criteria) throws HibernateException {
+		final NaturalIdLoadAccess naturalIdLoadAccess = this.tryNaturalIdLoadAccess( criteria );
+		if ( naturalIdLoadAccess != null ) {
+			return Arrays.asList( naturalIdLoadAccess.load() );
+		}
+
 		errorIfClosed();
 		checkTransactionSynchStatus();
 		String[] implementors = factory.getImplementors( criteria.getEntityOrClassName() );

--- a/hibernate-core/src/main/java/org/hibernate/jmx/StatisticsService.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/StatisticsService.java
@@ -244,6 +244,21 @@ public class StatisticsService implements StatisticsServiceMBean {
 	public long getNaturalIdCachePutCount() {
 		return stats.getNaturalIdCachePutCount();
 	}
+	
+	@Override
+	public long getNaturalIdQueryExecutionCount() {
+		return stats.getNaturalIdQueryExecutionCount();
+	}
+
+	@Override
+	public long getNaturalIdQueryExecutionMaxTime() {
+		return stats.getNaturalIdQueryExecutionMaxTime();
+	}
+
+	@Override
+	public String getNaturalIdQueryExecutionMaxTimeRegion() {
+		return stats.getNaturalIdQueryExecutionMaxTimeRegion();
+	}
 
 	/**
 	 * @see StatisticsServiceMBean#getSessionCloseCount()

--- a/hibernate-core/src/main/java/org/hibernate/stat/NaturalIdCacheStatistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/NaturalIdCacheStatistics.java
@@ -39,6 +39,14 @@ public interface NaturalIdCacheStatistics extends Serializable {
 	long getMissCount();
 
 	long getPutCount();
+	
+	long getExecutionCount();
+	
+	long getExecutionAvgTime();
+	
+	long getExecutionMaxTime();
+	
+	long getExecutionMinTime();
 
 	long getElementCountInMemory();
 

--- a/hibernate-core/src/main/java/org/hibernate/stat/Statistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/Statistics.java
@@ -131,6 +131,18 @@ public interface Statistics {
      * Get the global number of cacheable queries put in cache
      */
 	public long getQueryCachePutCount();
+	/**
+	 * Get the global number of naturalId queries executed against the database
+	 */
+	public long getNaturalIdQueryExecutionCount();
+	/**
+	 * Get the global maximum query time for naturalId queries executed against the database
+	 */
+	public long getNaturalIdQueryExecutionMaxTime();
+	/**
+	 * Get the region for the maximum naturalId query time 
+	 */
+	public String getNaturalIdQueryExecutionMaxTimeRegion();
     /**
      * Get the global number of cached naturalId lookups successfully retrieved from cache
      */

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentNaturalIdCacheStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentNaturalIdCacheStatisticsImpl.java
@@ -27,86 +27,175 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.stat.NaturalIdCacheStatistics;
 
 /**
- * Second level cache statistics of a specific region
- *
- * @author Alex Snaps
+ * NaturalId cache statistics of a specific region
+ * 
+ * @author Eric Dalquist
  */
 public class ConcurrentNaturalIdCacheStatisticsImpl extends CategorizedStatistics implements NaturalIdCacheStatistics {
+	private static final long serialVersionUID = 1L;
 	private final transient Region region;
-	private AtomicLong hitCount = new AtomicLong();
-	private AtomicLong missCount = new AtomicLong();
-	private AtomicLong putCount = new AtomicLong();
+	private final AtomicLong hitCount = new AtomicLong();
+	private final AtomicLong missCount = new AtomicLong();
+	private final AtomicLong putCount = new AtomicLong();
+	private final AtomicLong executionCount = new AtomicLong();
+	private final AtomicLong executionMaxTime = new AtomicLong();
+	private final AtomicLong executionMinTime = new AtomicLong( Long.MAX_VALUE );
+	private final AtomicLong totalExecutionTime = new AtomicLong();
+
+	private final Lock readLock;
+	private final Lock writeLock;
+	{
+		final ReadWriteLock lock = new ReentrantReadWriteLock();
+		this.readLock = lock.readLock();
+		this.writeLock = lock.writeLock();
+	}
 
 	ConcurrentNaturalIdCacheStatisticsImpl(Region region) {
 		super( region.getName() );
 		this.region = region;
 	}
 
+	@Override
 	public long getHitCount() {
-		return hitCount.get();
+		return this.hitCount.get();
 	}
 
+	@Override
 	public long getMissCount() {
-		return missCount.get();
+		return this.missCount.get();
 	}
 
+	@Override
 	public long getPutCount() {
-		return putCount.get();
+		return this.putCount.get();
 	}
 
+	/**
+	 * queries executed to the DB
+	 */
+	@Override
+	public long getExecutionCount() {
+		return this.executionCount.get();
+	}
+
+	/**
+	 * average time in ms taken by the excution of this query onto the DB
+	 */
+	@Override
+	public long getExecutionAvgTime() {
+		// We write lock here to be sure that we always calculate the average time
+		// with all updates from the executed applied: executionCount and totalExecutionTime
+		// both used in the calculation
+		this.writeLock.lock();
+		try {
+			long avgExecutionTime = 0;
+			if ( this.executionCount.get() > 0 ) {
+				avgExecutionTime = this.totalExecutionTime.get() / this.executionCount.get();
+			}
+			return avgExecutionTime;
+		}
+		finally {
+			this.writeLock.unlock();
+		}
+	}
+
+	/**
+	 * max time in ms taken by the excution of this query onto the DB
+	 */
+	@Override
+	public long getExecutionMaxTime() {
+		return this.executionMaxTime.get();
+	}
+
+	/**
+	 * min time in ms taken by the excution of this query onto the DB
+	 */
+	@Override
+	public long getExecutionMinTime() {
+		return this.executionMinTime.get();
+	}
+
+	@Override
 	public long getElementCountInMemory() {
-		return region.getElementCountInMemory();
+		return this.region.getElementCountInMemory();
 	}
 
+	@Override
 	public long getElementCountOnDisk() {
-		return region.getElementCountOnDisk();
+		return this.region.getElementCountOnDisk();
 	}
 
+	@Override
 	public long getSizeInMemory() {
-		return region.getSizeInMemory();
+		return this.region.getSizeInMemory();
 	}
 
+	@Override
 	public Map getEntries() {
-		Map map = new HashMap();
-		Iterator iter = region.toMap().entrySet().iterator();
-		while (iter.hasNext()) {
-			Map.Entry me = (Map.Entry) iter.next();
-			map.put(((CacheKey) me.getKey()).getKey(), me.getValue());
+		final Map map = new HashMap();
+		final Iterator iter = this.region.toMap().entrySet().iterator();
+		while ( iter.hasNext() ) {
+			final Map.Entry me = (Map.Entry) iter.next();
+			map.put( ( (CacheKey) me.getKey() ).getKey(), me.getValue() );
 		}
 		return map;
 	}
 
+	@Override
 	public String toString() {
-		StringBuilder buf = new StringBuilder()
-				.append("NaturalIdCacheStatistics")
-				.append("[hitCount=").append(this.hitCount)
-				.append(",missCount=").append(this.missCount)
-				.append(",putCount=").append(this.putCount);
-		//not sure if this would ever be null but wanted to be careful
-		if (region != null) {
-			buf.append(",elementCountInMemory=").append(this.getElementCountInMemory())
-					.append(",elementCountOnDisk=").append(this.getElementCountOnDisk())
-					.append(",sizeInMemory=").append(this.getSizeInMemory());
+		final StringBuilder buf = new StringBuilder()
+			.append( "NaturalIdCacheStatistics" )
+			.append( "[hitCount=" ).append( this.hitCount )
+			.append( ",missCount=" ).append( this.missCount )
+			.append( ",putCount=" ).append( this.putCount )
+			.append( ",executionCount=" ).append( this.executionCount )
+			.append( ",executionAvgTime=" ).append( this.getExecutionAvgTime() )
+			.append( ",executionMinTime=" ).append( this.executionMinTime )
+			.append( ",executionMaxTime=" ).append( this.executionMaxTime );
+		// not sure if this would ever be null but wanted to be careful
+		if ( this.region != null ) {
+			buf.append( ",elementCountInMemory=" ).append( this.getElementCountInMemory() )
+				.append( ",elementCountOnDisk=" ).append( this.getElementCountOnDisk() )
+				.append( ",sizeInMemory=" ).append( this.getSizeInMemory() );
 		}
-		buf.append(']');
+		buf.append( ']' );
 		return buf.toString();
 	}
 
 	void incrementHitCount() {
-		hitCount.getAndIncrement();
+		this.hitCount.getAndIncrement();
 	}
 
 	void incrementMissCount() {
-		missCount.getAndIncrement();
+		this.missCount.getAndIncrement();
 	}
 
 	void incrementPutCount() {
-		putCount.getAndIncrement();
+		this.putCount.getAndIncrement();
+	}
+
+	void queryExecuted(long time) {
+		// read lock is enough, concurrent updates are supported by the underlying type AtomicLong
+		// this only guards executed(long, long) to be called, when another thread is executing getExecutionAvgTime()
+		this.readLock.lock();
+		try {
+			// Less chances for a context switch
+			for ( long old = this.executionMinTime.get(); time < old && !this.executionMinTime.compareAndSet( old, time ); old = this.executionMinTime.get() ) {;}
+			for ( long old = this.executionMaxTime.get(); time > old && !this.executionMaxTime.compareAndSet( old, time ); old = this.executionMaxTime.get() ) {;}
+			this.executionCount.getAndIncrement();
+			this.totalExecutionTime.addAndGet( time );
+		}
+		finally {
+			this.readLock.unlock();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/stat/spi/StatisticsImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/spi/StatisticsImplementor.java
@@ -195,6 +195,14 @@ public interface StatisticsImplementor extends Statistics, Service {
 	public void naturalIdCacheMiss(String regionName);
 
 	/**
+	 * Callback indicating execution of a natural id query
+	 *
+	 * @param regionName The name of the cache region
+	 * @param time execution time
+	 */
+	public void naturalIdQueryExecuted(String regionName, long time);
+
+	/**
 	 * Callback indicating a put into the query cache.
 	 *
 	 * @param hql The query

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/ImmutableNaturalKeyLookupTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/ImmutableNaturalKeyLookupTest.java
@@ -54,20 +54,19 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 		a1.setName( "name1" );
 		s.persist( a1 );
 		newTx.commit();
-
+		
 		newTx = s.beginTransaction();
 		getCriteria( s ).uniqueResult(); // put query-result into cache
 		A a2 = new A();
 		a2.setName( "xxxxxx" );
 		s.persist( a2 );
 		newTx.commit();	  // Invalidates space A in UpdateTimeStamps region
+		
+		//Create new session to avoid the session cache which can't be tracked
+		s.close();
+		s = openSession();
 
 		newTx = s.beginTransaction();
-
-		// please enable
-		// log4j.logger.org.hibernate.cache.StandardQueryCache=DEBUG
-		// log4j.logger.org.hibernate.cache.UpdateTimestampsCache=DEBUG
-		// to see that isUpToDate is called where not appropriated
 
 		Assert.assertTrue( s.getSessionFactory().getStatistics().isStatisticsEnabled() );
 		s.getSessionFactory().getStatistics().clear();
@@ -76,7 +75,7 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 
 		Assert.assertEquals(
 				"query is not considered as isImmutableNaturalKeyLookup, despite fullfilling all conditions",
-				1, s.getSessionFactory().getStatistics().getQueryCacheHitCount()
+				1, s.getSessionFactory().getStatistics().getNaturalIdCacheHitCount()
 		);
 
 		s.createQuery( "delete from A" ).executeUpdate();
@@ -105,11 +104,6 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 		newTx.commit();	  // Invalidates space A in UpdateTimeStamps region
 
 		newTx = s.beginTransaction();
-
-		// please enable
-		// log4j.logger.org.hibernate.cache.StandardQueryCache=DEBUG
-		// log4j.logger.org.hibernate.cache.UpdateTimestampsCache=DEBUG
-		// to see that isUpToDate is called where not appropriated
 
 		Assert.assertTrue( s.getSessionFactory().getStatistics().isStatisticsEnabled() );
 		s.getSessionFactory().getStatistics().clear();
@@ -147,6 +141,10 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 		a2.setName( "xxxxxx" );
 		s.persist( a2 );
 		newTx.commit();	  // Invalidates space A in UpdateTimeStamps region
+		
+		//Create new session to avoid the session cache which can't be tracked
+		s.close();
+		s = openSession();
 
 		newTx = s.beginTransaction();
 
@@ -163,7 +161,7 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 
 		Assert.assertEquals(
 				"query is not considered as isImmutableNaturalKeyLookup, despite fullfilling all conditions",
-				1, s.getSessionFactory().getStatistics().getQueryCacheHitCount()
+				1, s.getSessionFactory().getStatistics().getNaturalIdCacheHitCount()
 		);
 		s.createQuery( "delete from D" ).executeUpdate();
 		s.createQuery( "delete from A" ).executeUpdate();
@@ -196,12 +194,11 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 		s.persist( a2 );
 		newTx.commit();	  // Invalidates space A in UpdateTimeStamps region
 
-		newTx = s.beginTransaction();
+		//Create new session to avoid the session cache which can't be tracked
+		s.close();
+		s = openSession();
 
-		// please enable
-		// log4j.logger.org.hibernate.cache.StandardQueryCache=DEBUG
-		// log4j.logger.org.hibernate.cache.UpdateTimestampsCache=DEBUG
-		// to see that isUpToDate is called where not appropriated
+		newTx = s.beginTransaction();
 
 		Assert.assertTrue( s.getSessionFactory().getStatistics().isStatisticsEnabled() );
 		s.getSessionFactory().getStatistics().clear();
@@ -211,7 +208,7 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 
 		Assert.assertEquals(
 				"query is not considered as isImmutableNaturalKeyLookup, despite fullfilling all conditions",
-				1, s.getSessionFactory().getStatistics().getQueryCacheHitCount()
+				1, s.getSessionFactory().getStatistics().getNaturalIdCacheHitCount()
 		);
 		s.createQuery( "delete from A" ).executeUpdate();
 		s.createQuery( "delete from D" ).executeUpdate();

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/NaturalIdOnManyToOne.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/NaturalIdOnManyToOne.java
@@ -5,8 +5,10 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
 import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
 
 @Entity
+@NaturalIdCache
 /**
  * Test case for NaturalId annotation - ANN-750
  * 

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/NaturalIdOnSingleManyToOneTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/naturalid/NaturalIdOnSingleManyToOneTest.java
@@ -88,7 +88,10 @@ public class NaturalIdOnSingleManyToOneTest extends BaseCoreFunctionalTestCase {
 		s.persist( singleManyToOne );
 		tx.commit();
 		s.close();
-
+		
+		//Clear naturalId cache that was populated when putting the data
+		s.getSessionFactory().getCache().evictNaturalIdRegions();
+		
 		s = openSession();
 		tx = s.beginTransaction();
 		Criteria criteria = s.createCriteria( NaturalIdOnManyToOne.class );
@@ -100,7 +103,7 @@ public class NaturalIdOnSingleManyToOneTest extends BaseCoreFunctionalTestCase {
 		stats.clear();
 		assertEquals(
 				"Cache hits should be empty", 0, stats
-						.getQueryCacheHitCount()
+						.getNaturalIdCacheHitCount()
 		);
 
 		// first query
@@ -108,22 +111,34 @@ public class NaturalIdOnSingleManyToOneTest extends BaseCoreFunctionalTestCase {
 		assertEquals( 1, results.size() );
 		assertEquals(
 				"Cache hits should be empty", 0, stats
-						.getQueryCacheHitCount()
+						.getNaturalIdCacheHitCount()
 		);
 		assertEquals(
 				"First query should be a miss", 1, stats
-						.getQueryCacheMissCount()
+						.getNaturalIdCacheMissCount()
 		);
 		assertEquals(
 				"Query result should be added to cache", 1, stats
-						.getQueryCachePutCount()
+						.getNaturalIdCachePutCount()
+		);
+		assertEquals(
+				"Query count should be one", 1, stats
+						.getNaturalIdQueryExecutionCount()
 		);
 
-		// query a second time - result should be cached
+		// query a second time - result should be in session cache
 		criteria.list();
 		assertEquals(
-				"Cache hits should be empty", 1, stats
-						.getQueryCacheHitCount()
+				"Cache hits should be empty", 0, stats
+						.getNaturalIdCacheHitCount()
+		);
+		assertEquals(
+				"Second query should not be a miss", 1, stats
+						.getNaturalIdCacheMissCount()
+		);
+		assertEquals(
+				"Query count should be one", 1, stats
+						.getNaturalIdQueryExecutionCount()
 		);
 
 		// cleanup

--- a/hibernate-core/src/matrix/java/org/hibernate/test/jpa/naturalid/ImmutableNaturalIdTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/jpa/naturalid/ImmutableNaturalIdTest.java
@@ -155,9 +155,9 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 		assertEquals( 0, sessionFactory().getStatistics().getSecondLevelCacheMissCount() );
 		assertEquals( 0, sessionFactory().getStatistics().getSecondLevelCacheHitCount() );
 		assertEquals( 0, sessionFactory().getStatistics().getSecondLevelCachePutCount() );
-		assertEquals( 0, sessionFactory().getStatistics().getQueryExecutionCount() );
-		assertEquals( 0, sessionFactory().getStatistics().getQueryCacheHitCount() );
-		assertEquals( 0, sessionFactory().getStatistics().getQueryCachePutCount() );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() );
 
 		s = openSession();
 		s.beginTransaction();
@@ -173,13 +173,13 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 		u = (User) s.byNaturalId( User.class ).using( "userName", "steve" ).load();
 		assertNotNull( u );
 		assertEquals( 1, sessionFactory().getStatistics().getEntityLoadCount() );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
 		u = (User) s.byNaturalId( User.class ).using( "userName", "steve" ).load();
 		assertNotNull( u );
 		assertEquals( 1, sessionFactory().getStatistics().getEntityLoadCount() );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
 		s.getTransaction().commit();
 		s.close();
 
@@ -211,9 +211,9 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 		s.getTransaction().commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() );//1: no stats since hbm.xml can't enable NaturalId caching
 
 		s = openSession();
 		s.beginTransaction();
@@ -231,15 +231,15 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );//0: no stats since hbm.xml can't enable NaturalId caching
 		u = ( User ) s.createCriteria( User.class )
 				.add( Restrictions.naturalId().set( "userName", "steve" ) )
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 2 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );//0: no stats since hbm.xml can't enable NaturalId caching
 		s.getTransaction().commit();
 		s.close();
 
@@ -271,9 +271,9 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 		s.getTransaction().commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() );//0: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 
@@ -284,8 +284,8 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );//1: incorrect stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 
@@ -324,9 +324,9 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 				.uniqueResult();
 		assertNotNull( u );
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() );//1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 		s.getTransaction().commit();
@@ -338,8 +338,8 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );//0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );//1: incorrect stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 

--- a/hibernate-core/src/matrix/java/org/hibernate/test/naturalid/immutable/ImmutableNaturalIdTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/naturalid/immutable/ImmutableNaturalIdTest.java
@@ -123,9 +123,9 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		s.getTransaction().commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //0: no stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s = openSession();
 		s.beginTransaction();
@@ -143,15 +143,15 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 		u = ( User ) s.createCriteria( User.class )
 				.add( Restrictions.naturalId().set( "userName", "steve" ) )
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 2 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //2: no stats since hbm.xml can't enable NaturalId caching
 		s.getTransaction().commit();
 		s.close();
 
@@ -183,9 +183,9 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		s.getTransaction().commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 
@@ -196,8 +196,8 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 
@@ -236,9 +236,9 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.uniqueResult();
 		assertNotNull( u );
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 		s.getTransaction().commit();
@@ -249,8 +249,8 @@ public class ImmutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 

--- a/hibernate-core/src/matrix/java/org/hibernate/test/naturalid/mutable/MutableNaturalIdTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/naturalid/mutable/MutableNaturalIdTest.java
@@ -115,9 +115,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		t.commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 0 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount(), 1 );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount(), 0 );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount(), 0 );
 
 		s = openSession();
 		t = s.beginTransaction();
@@ -146,9 +146,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		t.commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 
@@ -167,8 +167,8 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		t.commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 
@@ -188,9 +188,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		t.commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 0 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() );
 	}
 
 	@Test
@@ -217,9 +217,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		t.commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s = openSession();
 		t = s.beginTransaction();
@@ -240,8 +240,8 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull(u);
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
 
 		u = ( User ) s.createCriteria( User.class )
 				.add( Restrictions.naturalId()
@@ -251,8 +251,8 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull(u);
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		t.commit();
 		s.close();
@@ -288,9 +288,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 		s.getTransaction().commit();
 		s.close();
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 
@@ -304,8 +304,8 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 
@@ -350,9 +350,9 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.uniqueResult();
 		assertNotNull( u );
 
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 1 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCachePutCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCachePutCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		sessionFactory().getStatistics().clear();
 		s.getTransaction().commit();
@@ -368,8 +368,8 @@ public class MutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 				.setCacheable( true )
 				.uniqueResult();
 		assertNotNull( u );
-		assertEquals( sessionFactory().getStatistics().getQueryExecutionCount(), 0 );
-		assertEquals( sessionFactory().getStatistics().getQueryCacheHitCount(), 1 );
+		assertEquals( 1, sessionFactory().getStatistics().getNaturalIdQueryExecutionCount() ); //0: incorrect stats since hbm.xml can't enable NaturalId caching
+		assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() ); //1: no stats since hbm.xml can't enable NaturalId caching
 
 		s.delete( u );
 


### PR DESCRIPTION
Add a check in SessionImpl for critera queries that use the NaturalIdentifier criterion and
redirect the call to NaturalIdLoadAccess

Add NaturalId query execution tracking into the statisticsHHH-6974 Redirect naturalId criteria queries to new API
