### PR TITLE
HHH-7066

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
@@ -43,7 +43,7 @@ import org.hibernate.type.descriptor.BinaryStream;
  */
 public class DataHelper {
 
-    private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, DataHelper.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, DataHelper.class.getName() );
 
 	private static Class nClobClass;
 	static {
@@ -52,7 +52,7 @@ public class DataHelper {
 			nClobClass = ReflectHelper.classForName( "java.sql.NClob", DataHelper.class );
 		}
 		catch ( ClassNotFoundException e ) {
-            LOG.unableToLocateNClobClass();
+			LOG.unableToLocateNClobClass();
 		}
 	}
 
@@ -80,7 +80,7 @@ public class DataHelper {
 				stringBuilder.append( buffer, 0, amountRead );
 			}
 		}
-		catch ( IOException ioe) {
+		catch ( IOException ioe ) {
 			throw new HibernateException( "IOException occurred reading text", ioe );
 		}
 		finally {
@@ -88,7 +88,7 @@ public class DataHelper {
 				reader.close();
 			}
 			catch (IOException e) {
-                LOG.unableToCloseStream(e);
+				LOG.unableToCloseStream( e );
 			}
 		}
 		return stringBuilder.toString();
@@ -179,13 +179,13 @@ public class DataHelper {
 				inputStream.close();
 			}
 			catch ( IOException e ) {
-                LOG.unableToCloseInputStream(e);
+				LOG.unableToCloseInputStream( e );
 			}
 			try {
 				outputStream.close();
 			}
 			catch ( IOException e ) {
-                LOG.unableToCloseOutputStream(e);
+				LOG.unableToCloseOutputStream( e );
 			}
 		}
 		return outputStream.toByteArray();


### PR DESCRIPTION
While focusing mainly on [HHH-7066](https://hibernate.onjira.com/browse/HHH-7066), I found some other changes while profiling String allocations in Hibernate Core.

I've also replaced all StringBuffer with StringBuilder, and found some areas in which we could improve on the StringBuilder initial allocation. This makes the patch rather large, but I've kept all commits separated so you can remove those if it's not an appropriate time to do such a change.
