### PR TITLE
HHH-7068 - Fix for "Cursor state not valid" error from AS400 on queries with setFirstResult.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1700,7 +1700,7 @@ public abstract class Loader {
 		final boolean canScroll = getFactory().getSettings().isScrollableResultSetsEnabled();
 		final boolean useScrollableResultSetToSkip = hasFirstRow &&
 				!useLimitOffset && canScroll;
-		final ScrollMode scrollMode = getScrollMode( scroll, hasFirstRow, useLimit, queryParameters );
+		final ScrollMode scrollMode = getScrollMode( scroll, hasFirstRow, useLimitOffset, queryParameters );
 //
 //		if(canScroll && ( scroll || useScrollableResultSetToSkip )){
 //			 scrollMode = scroll ? queryParameters.getScrollMode() : ScrollMode.SCROLL_INSENSITIVE;


### PR DESCRIPTION
Fixed typo on org.hibernate.loader.Loader.prepareQueryStatement (line 1703). Wrong variable was being passed to method getScrollMode.
