### PR TITLE
Fixed broken gradle documentation URLs in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Resources
 
 To start with - here is a list of resources to obtain more information about Gradle:
 
-* The Gradle User Guide : http://gradle.org/latest/docs/userguide/userguide_single.html
-* Gradle DSL Guide : http://gradle.org/latest/docs/dsl/index.html
+* The Gradle User Guide : http://gradle.org/docs/current/userguide/userguide_single.html
+* Gradle DSL Guide : http://gradle.org/docs/current/dsl/index.html
 * Additional Hibernate/Gradle information : http://community.jboss.org/wiki/GradleFAQ
 
 Here is the link of how to set up ~/.m2/settings.xml to use JBoss Nexus repo.


### PR DESCRIPTION
My 2 cents :)
