### PR TITLE
HHH-6556 : Bind unsaved value for identifier/version property

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/annotations/attribute/SimpleIdentifierSourceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/annotations/attribute/SimpleIdentifierSourceImpl.java
@@ -64,6 +64,11 @@ public class SimpleIdentifierSourceImpl implements SimpleIdentifierSource {
 	public IdGenerator getIdentifierGeneratorDescriptor() {
 		return attribute.getIdGenerator();
 	}
+
+	@Override
+	public String getUnsavedValue() {
+		return null;
+	}
 }
 
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/annotations/entity/EntityBindingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/annotations/entity/EntityBindingContext.java
@@ -29,14 +29,18 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
 
 import org.hibernate.cfg.NamingStrategy;
+import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.internal.jaxb.Origin;
 import org.hibernate.internal.jaxb.SourceType;
 import org.hibernate.internal.util.Value;
 import org.hibernate.metamodel.spi.domain.Type;
+import org.hibernate.metamodel.spi.source.IdentifierSource;
 import org.hibernate.metamodel.spi.source.LocalBindingContext;
 import org.hibernate.metamodel.spi.source.MappingDefaults;
 import org.hibernate.metamodel.spi.source.MetadataImplementor;
 import org.hibernate.metamodel.internal.source.annotations.AnnotationBindingContext;
+import org.hibernate.metamodel.spi.source.UnsavedValueStrategy;
+import org.hibernate.metamodel.spi.source.VersionAttributeSource;
 import org.hibernate.service.ServiceRegistry;
 
 /**
@@ -47,6 +51,7 @@ import org.hibernate.service.ServiceRegistry;
 public class EntityBindingContext implements LocalBindingContext, AnnotationBindingContext {
 	private final AnnotationBindingContext contextDelegate;
 	private final Origin origin;
+	private final UnsavedValueStrategy unsavedValueStrategy = new UnsavedValueStrategyImpl();
 
 	public EntityBindingContext(AnnotationBindingContext contextDelegate, ConfiguredClass source) {
 		this.contextDelegate = contextDelegate;
@@ -126,5 +131,28 @@ public class EntityBindingContext implements LocalBindingContext, AnnotationBind
 	@Override
 	public ResolvedTypeWithMembers resolveMemberTypes(ResolvedType type) {
 		return contextDelegate.resolveMemberTypes( type );
+	}
+
+	@Override
+	public UnsavedValueStrategy getUnsavedValueStrategy() {
+		return unsavedValueStrategy;
+	}
+
+	private class UnsavedValueStrategyImpl implements UnsavedValueStrategy{
+		@Override
+		public String getIdUnsavedValue(IdentifierSource identifierSource, boolean isIdAssigned) {
+			// TODO: is this correct???
+			if ( identifierSource.getNature() == IdentifierSource.Nature.SIMPLE ) {
+				return isIdAssigned ? "undefined" : null;
+			}
+			else {
+				throw new NotYetImplementedException( identifierSource.getNature().toString() );
+			}
+		}
+
+		@Override
+		public String getVersionUnsavedValue(VersionAttributeSource versionAttributeSource) {
+			return "undefined";
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/hbm/RootEntitySourceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/source/hbm/RootEntitySourceImpl.java
@@ -100,6 +100,11 @@ public class RootEntitySourceImpl extends AbstractEntitySourceImpl implements Ro
 				public Nature getNature() {
 					return Nature.SIMPLE;
 				}
+				
+				@Override
+				public String getUnsavedValue() {
+					return entityElement().getId().getUnsavedValue();
+				}
 			};
 		}
 		return null;  //To change body of implemented methods use File | Settings | File Templates.

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/IdentifierSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/IdentifierSource.java
@@ -64,4 +64,11 @@ public interface IdentifierSource {
 	 * @return The identifier source's nature.
 	 */
 	public Nature getNature();
+
+	/**
+	 * Obtain the value used for an identifier before an entity is persisted.
+	 *
+	 * @return the value used for an identifier before an entity is persisted.
+	 */
+	public String getUnsavedValue();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/LocalBindingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/LocalBindingContext.java
@@ -30,4 +30,6 @@ import org.hibernate.internal.jaxb.Origin;
  */
 public interface LocalBindingContext extends BindingContext {
 	public Origin getOrigin();
+
+	public UnsavedValueStrategy getUnsavedValueStrategy();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/UnsavedValueStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/source/UnsavedValueStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.metamodel.spi.source;
+
+/**
+ * Provides the strategy for "unsaved" identifier and version property values
+ * that indicates an instance is newly instantiated (unsaved), distinguishing
+ * it from detached instances that were saved or loaded in a previous session.
+ *
+ * @author Gail Badner
+ */
+public interface UnsavedValueStrategy {
+
+	/**
+	 * Determines the strategy for an "unsaved" entity identifier value.
+	 *
+	 * @param identifierSource - the entity ID source.
+	 * @param isIdAssigned - true, if the ID is assigned by the application;
+	 *                       false, otherwise.
+	 * @return the strategy for an "unsaved" entity identifier value;
+	 */
+	public String getIdUnsavedValue(IdentifierSource identifierSource, boolean isIdAssigned);
+
+	/**
+	 * Determines the strategy for an "unsaved" version or timestamp value.
+	 *
+	 * @param versionAttributeSource - the version source.
+	 * @return the strategy for an "unsaved" version value.
+	 */
+	public String getVersionUnsavedValue(VersionAttributeSource versionAttributeSource);
+}

--- a/hibernate-core/src/matrix/java/org/hibernate/test/unidir/manytoone/UnidirectionalManyToOneTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/unidir/manytoone/UnidirectionalManyToOneTest.java
@@ -63,10 +63,10 @@ public class UnidirectionalManyToOneTest extends BaseCoreFunctionalTestCase {
 		Child c2 = new Child("Blase");
 		c.setParent( p );
 		c2.setParent( p );
-		s.save( p );
-		s.save(p2);
-		s.save( c );
-		s.save( c2 );
+		s.persist( p );
+		s.persist(p2);
+		s.persist( c );
+		s.persist( c2 );
 		t.commit();
 		s.close();
 

--- a/hibernate-core/src/test/java/org/hibernate/metamodel/internal/source/annotations/entity/VersionBindingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/metamodel/internal/source/annotations/entity/VersionBindingTests.java
@@ -107,6 +107,16 @@ public class VersionBindingTests extends BaseAnnotationBindingTestCase {
 		assertTrue( descriptor.getTypeParameters().isEmpty() );
 	}
 
+	@Test
+	@Resources(annotatedClasses = VersionBindingTests.Item2.class)
+	public void testUnsavedVersionValue() {
+		EntityBinding binding = getEntityBinding( Item2.class );
+		assertEquals(
+				"undefined",
+				binding.getHierarchyDetails().getEntityVersion().getUnsavedValue()
+		);
+	}	
+	
 	@Entity
 	class Item3 {
 		@Id


### PR DESCRIPTION
At the team meeting in Austin, I remember discussion about cases where different "strategies" were needed to process values obtained from annotations and hbm.xml sources. I can't remember if we discussed unsaved values, but it seems to me that this is one case where this is needed.

Please take a look and provide feedback to let me know if I'm on the right track.

Thanks,
Gail
