### PR TITLE
Natural-id : NPE after persisting null String value, if using @NaturalIdCache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
@@ -76,7 +76,7 @@ public class NaturalIdCacheKey implements Serializable {
 			final Type type = propertyTypes[naturalIdPropertyIndexes[i]];
 			final Object value = naturalIdValues[i];
 			
-			result = prime * result + type.getHashCode( value, factory );
+			result = prime * result + (value != null ? type.getHashCode( value, factory ) : 0);
 			
 			disassembledNaturalId[i] = type.disassemble( value, session, null );
 			


### PR DESCRIPTION
See HHH-7236
