### PR TITLE
HHH-7101 Sanity check (to return NONE) prevents NullPointerException during initialization.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
@@ -49,6 +49,10 @@ public enum CacheConcurrencyStrategy {
 	}
 
 	public static CacheConcurrencyStrategy fromAccessType(AccessType accessType) {
+		if (null == accessType) {
+			return NONE;
+		}
+		
 		switch ( accessType ) {
 			case READ_ONLY: {
 				return READ_ONLY;


### PR DESCRIPTION
https://hibernate.onjira.com/browse/HHH-7101
