### PR TITLE
HHH-7251 PostgreSQL dialect proper HibernateExceptions for deadlock & lock timeout.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -28,13 +28,18 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.JDBCException;
 import org.hibernate.LockOptions;
+import org.hibernate.PessimisticLockException;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.NoArgSQLFunction;
 import org.hibernate.dialect.function.PositionSubstringFunction;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.function.StandardSQLFunction;
 import org.hibernate.dialect.function.VarArgsSQLFunction;
+import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.internal.SQLStateConversionDelegate;
+import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtracter;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtracter;
 import org.hibernate.id.SequenceGenerator;
@@ -366,6 +371,35 @@ public class PostgreSQL81Dialect extends Dialect {
 			}
 		}
 	};
+	
+	@Override
+	public SQLExceptionConversionDelegate buildSQLExceptionConversionDelegate() {
+		SQLExceptionConversionDelegate delegate = super.buildSQLExceptionConversionDelegate();
+		if (delegate == null) {
+			delegate = new SQLStateConversionDelegate(this) {
+	
+				@Override
+				public JDBCException convert(SQLException sqlException, String message, String sql) {
+					JDBCException exception = super.convert(sqlException, message, sql);
+					
+					if (exception == null) {
+						String sqlState = JdbcExceptionHelper.extractSqlState(sqlException);
+						
+						if ("40P01".equals(sqlState)) { // DEADLOCK DETECTED
+							exception = new LockAcquisitionException(message, sqlException, sql);
+						}
+						
+						if ("55P03".equals(sqlState)) { // LOCK NOT AVAILABLE
+							exception = new PessimisticLockException(message, sqlException, sql);
+						}
+					}
+					
+					return exception;
+				}
+			};
+		}
+		return delegate;
+	}
 	
 	public int registerResultSetOutParameter(CallableStatement statement, int col) throws SQLException {
 		// Register the type of the out param - PostgreSQL uses Types.OTHER


### PR DESCRIPTION
The PostgreSQL error codes for timeout and deadlock were not being handled by the SQLStateConversionDelegate installed by default during initialization. 

This change overrides the buildSQLExceptionConversionDelegate to provide a subclass of the SQLStateConverstionDelegate which properly checks for postgres specific error codes.
