### PR TITLE
change the static final variables from private to protected for subclass usage

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
@@ -36,10 +36,10 @@ import org.hibernate.type.StandardBasicTypes;
  * @author Yoryos Valotasios
  */
 public class SQLServer2005Dialect extends SQLServerDialect {
-	private static final String SELECT = "select";
-	private static final String FROM = "from";
-	private static final String DISTINCT = "distinct";
-	private static final int MAX_LENGTH = 8000;
+	protected static final String SELECT = "select";
+	protected static final String FROM = "from";
+	protected static final String DISTINCT = "distinct";
+	protected static final int MAX_LENGTH = 8000;
 
 	/**
 	 * Regular expression for stripping alias


### PR DESCRIPTION
I have a case where I want to extend SQLServer2005Dialect to enable NVARCHAR usage.

like so  

```
registerHibernateType(Types.NVARCHAR, StandardBasicTypes.STRING.getName() );
registerHibernateType(Types.LONGNVARCHAR, StandardBasicTypes.STRING.getName() );
registerHibernateType(Types.NVARCHAR, 8000, StandardBasicTypes.STRING.getName());

registerColumnType(Types.NVARCHAR, "nvarchar(MAX)");
registerColumnType(Types.LONGNVARCHAR, "nvarchar(MAX)");
registerColumnType(Types.NVARCHAR, 8000, "nvarchar($1)");
```

which works. however, SQLServer20005Dialect has a constant MAX_LENGTH that = 8000, it would be nice to just use the MAX_LENGTH constant in my subclass rather then copy-pasting the value.
