### PR TITLE
HHH-7265 : ConcurrentModificationException in SynchronizationRegistryImp.l.notifySynchronizationsAfterTransactionCompletion

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/ejb/EntityManagerImpl.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/ejb/EntityManagerImpl.java
@@ -131,28 +131,14 @@ public class EntityManagerImpl extends AbstractEntityManagerImpl {
 		if ( !open ) {
 			throw new IllegalStateException( "EntityManager is closed" );
 		}
-		if ( !discardOnClose && isTransactionInProgress() ) {
-			//delay the closing till the end of the enlisted transaction
-            getSession().getTransaction().registerSynchronization(new Synchronization() {
-                public void beforeCompletion() {
-                    // nothing to do
-                }
-
-				public void afterCompletion( int i ) {
-                    if (session != null) if (session.isOpen()) {
-                        LOG.debugf("Closing entity manager after transaction completion");
-                        session.close();
-                    } else LOG.entityManagerClosedBySomeoneElse(Environment.AUTO_CLOSE_SESSION);
-                    // TODO session == null should not happen
-                }
-            });
-		}
-		else {
+		if ( discardOnClose || !isTransactionInProgress() ) {
 			//close right now
 			if ( session != null ) {
 				session.close();
 			}
 		}
+		// otherwise, the session will be closed at the end of the enlisted transaction
+
 		open = false;
 	}
 


### PR DESCRIPTION
This pull request removes the synchronization that gets registered by EntityManagerImpl.close(). Instead the synchronization will be added by AbstractEntityManagerImpl$AfterCompletionActionImpl.doAction() if the session is still open, but the entity manager is closed. Adding the synchronization here should ensure that it's the last afterCompletion synchronization that closes the session.

It would be tidier if AfterCompletionAction had something like "doAfterAfterCompletionAction" that simply closed the session (rather than relying on a synchronization to do it).

See documentation in the pull request code for more info.
