### PR TITLE
HHH-7239

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionCoordinatorImpl.java
@@ -285,6 +285,11 @@ public class TransactionCoordinatorImpl implements TransactionCoordinator {
 	}
 
 	@Override
+	public void removeObserver(TransactionObserver observer) {
+		observers.remove( observer );
+	}
+
+	@Override
 	@SuppressWarnings( {"unchecked"})
 	public boolean isTransactionJoinable() {
 		return transactionFactory().isJoinableJtaTransaction( this, currentHibernateTransaction );
@@ -329,7 +334,7 @@ public class TransactionCoordinatorImpl implements TransactionCoordinator {
 	@Override
 	public void sendAfterTransactionCompletionNotifications(TransactionImplementor hibernateTransaction, int status) {
 		final boolean successful = JtaStatusHelper.isCommitted( status );
-		for ( TransactionObserver observer : observers ) {
+		for ( TransactionObserver observer : new ArrayList<TransactionObserver>( observers ) ) {
 			observer.afterCompletion( successful, hibernateTransaction );
 		}
 		synchronizationRegistry.notifySynchronizationsAfterTransactionCompletion( status );

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionCoordinator.java
@@ -74,6 +74,13 @@ public interface TransactionCoordinator extends Serializable {
 	public void addObserver(TransactionObserver observer);
 
 	/**
+	 * Removed an observer from the coordinator.
+	 *
+	 * @param observer The observer to remove.
+	 */
+	public void removeObserver(TransactionObserver observer);
+	
+	/**
 	 * Can we join to the underlying transaction?
 	 *
 	 * @return {@literal true} if the underlying transaction can be joined or is already joined; {@literal false}

--- a/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionTest.java
@@ -191,7 +191,6 @@ public class SessionWithSharedConnectionTest extends BaseCoreFunctionalTestCase 
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7239" )
-	@FailureExpected(jiraKey = "HHH-7239" )
 	public void testSessionRemovedFromObserversOnClose() throws Exception {
 		Session session = sessionFactory().openSession();
 		session.getTransaction().begin();
@@ -235,7 +234,6 @@ public class SessionWithSharedConnectionTest extends BaseCoreFunctionalTestCase 
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-7239" )
-	@FailureExpected(jiraKey = "HHH-7239" )
 	public void testChildSessionCallsAfterTransactionAction() throws Exception {
 		Session session = openSession();
 
@@ -276,7 +274,6 @@ public class SessionWithSharedConnectionTest extends BaseCoreFunctionalTestCase 
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-7239" )
-	@FailureExpected(jiraKey = "HHH-7239" )
 	public void testChildSessionTwoTransactions() throws Exception {
 		Session session = openSession();
 		


### PR DESCRIPTION
Temporary fix until the SPIs can be reworked. Remove the transaction observer on Session close and added some checks to ensure the session is still open when the listeners fire.
