### PR TITLE
HHH-7059 The DerbyDialect deprecation warning should appear no more,

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -56,7 +56,9 @@ public class DerbyDialect extends DB2Dialect {
 
 	public DerbyDialect() {
 		super();
-		LOG.deprecatedDerbyDialect();
+		if (this.getClass() == DerbyDialect.class) {
+			LOG.deprecatedDerbyDialect();
+		}
 		registerFunction( "concat", new DerbyConcatFunction() );
 		registerFunction( "trim", new AnsiTrimFunction() );
         registerColumnType( Types.BLOB, "blob" );


### PR DESCRIPTION
when using one of the version-specific dialects
