### PR TITLE
HHH-7308

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -281,17 +281,10 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 
 				@Override
 				public void beforeCompletion(TransactionImplementor transaction) {
-					if ( isOpen() ) {
-						if ( flushBeforeCompletionEnabled ){
-							SessionImpl.this.managedFlush();
-						}
-						getActionQueue().beforeTransactionCompletion();
+					if ( isOpen() && flushBeforeCompletionEnabled ) {
+						SessionImpl.this.managedFlush();
 					}
-					else {
-						if (actionQueue.hasAfterTransactionActions()){
-							LOG.log( Logger.Level.DEBUG, "Session had after transaction actions that were not processed");
-						}
-					}
+					beforeTransactionCompletion( transaction );
 				}
 
 				@Override


### PR DESCRIPTION
Change the beforeCompletion() method of the TransactionObserver() to call the beforeTransactionCompletion() method regardless of whether or not the session is open like the afterCompletion() method does when calling the afterTransactionCompletion() and also cleaned up the log message around session having after transaction events as this sort of logging had been previously moved to the close() method of SessionImpl.
