### PR TITLE
Fix for HHH-3452

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaLoader.java
@@ -209,5 +209,9 @@ public class CriteriaLoader extends OuterJoinLoader {
 	protected List getResultList(List results, ResultTransformer resultTransformer) {
 		return resolveResultTransformer( resultTransformer ).transformList( results );
 	}
+	
+	protected String getQueryIdentifier() { 
+		return "[CRITERIA] " + getSQLString(); 
+	}
 
 }


### PR DESCRIPTION
Statistics for Criteria Queries

I added the getQueryIdentifier method as described in the comments
