### PR TITLE
HHH-7292 - Changed the EntityEntry to check the CustomDirtynessStrategy first

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityEntry.java
@@ -288,22 +288,26 @@ public final class EntityEntry implements Serializable {
 	 */
 	public boolean requiresDirtyCheck(Object entity) {
 		return isModifiableEntity()
-				&& ( getPersister().hasMutableProperties() || ! isUnequivocallyNonDirty( entity ) );
+				&& ( ! isUnequivocallyNonDirty( entity ) );
 	}
 
 	@SuppressWarnings( {"SimplifiableIfStatement"})
 	private boolean isUnequivocallyNonDirty(Object entity) {
-		if ( getPersister().getInstrumentationMetadata().isInstrumented() ) {
-			// the entity must be instrumented (otherwise we cant check dirty flag) and the dirty flag is false
-			return ! getPersister().getInstrumentationMetadata().extractInterceptor( entity ).isDirty();
-		}
-
 		final CustomEntityDirtinessStrategy customEntityDirtinessStrategy =
 				persistenceContext.getSession().getFactory().getCustomEntityDirtinessStrategy();
 		if ( customEntityDirtinessStrategy.canDirtyCheck( entity, getPersister(), (Session) persistenceContext.getSession() ) ) {
 			return ! customEntityDirtinessStrategy.isDirty( entity, getPersister(), (Session) persistenceContext.getSession() );
 		}
-
+		
+		if ( getPersister().hasMutableProperties() ) {
+			return false;
+		}
+		
+		if ( getPersister().getInstrumentationMetadata().isInstrumented() ) {
+			// the entity must be instrumented (otherwise we cant check dirty flag) and the dirty flag is false
+			return ! getPersister().getInstrumentationMetadata().extractInterceptor( entity ).isDirty();
+		}
+		
 		return false;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/dirtiness/Thing.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dirtiness/Thing.java
@@ -23,8 +23,7 @@
  */
 package org.hibernate.test.dirtiness;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -43,6 +42,7 @@ public class Thing {
 	private Long id;
 
 	private String name;
+	private Date mutableProperty;
 
 	public Thing() {
 	}
@@ -62,11 +62,19 @@ public class Thing {
 	public String getName() {
 		return name;
 	}
-
+	
 	public void setName(String name) {
 		// intentionally simple dirty tracking (i.e. no checking against previous state)
 		changedValues.put( "name", this.name );
 		this.name = name;
+	}
+
+	public Date getMutableProperty() {
+		return mutableProperty;
+	}
+
+	public void setMutableProperty(Date mutableProperty) {
+		this.mutableProperty = mutableProperty;
 	}
 
 	@Transient


### PR DESCRIPTION
Changed the EntityEntry to check the CustomDirtynessStrategy first to determine if the entity needs to continue with the dirty check.  Previously if the entity had mutable properties then it would bypass the custom dirty check.

To maintain legacy functionality still checking the mutable properties before checking the instrumented dirtyFlg (if applicable)

Added a Date property to the "Thing" test entity to verify that with mutable properties that the CustomDirtynessStrategy is still called.
