### PR TITLE
HHH-7359 Use TRACE level logging for unit tests

### DIFF
--- a/hibernate-core/src/test/resources/log4j.properties
+++ b/hibernate-core/src/test/resources/log4j.properties
@@ -1,19 +1,23 @@
-log4j.rootLogger=TRACE, null
-
-
 log4j.appender.null=org.apache.log4j.varia.NullAppender
 
+# Only records messages at INFO below, used to mimim root level info logging
+log4j.appender.stdout_info=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout_info.Target=System.out
+log4j.appender.stdout_info.Threshold=INFO
+log4j.appender.stdout_info.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout_info.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
+# Used by loggers other than root to log at any level
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.Threshold
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
 
 
-#log4j.rootLogger=info, stdout
+log4j.rootLogger=trace, null, stdout_info
 
-#log4j.logger.org.hibernate.tool.hbm2ddl=trace
-#log4j.logger.org.hibernate.testing.cache=debug
+log4j.logger.org.hibernate.tool.hbm2ddl=trace
+log4j.logger.org.hibernate.testing.cache=debug, stdout
 
 # SQL Logging - HHH-6833
-#log4j.logger.org.hibernate.SQL=debug
+log4j.logger.org.hibernate.SQL=debug, stdout


### PR DESCRIPTION
This isn't a fix for the issue but demonstrates the bug. It enables TRACE level logging to a null appender for the tests in hibernate-core. This is likely a reasonable long-term change for all hibernate tests to make sure all logging code gets exercised.
