### PR TITLE
HHH-5929 PooledLoOptimizer is not thread-safe (3.6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
@@ -544,7 +544,7 @@ public class OptimizerFactory {
 			}
 		}
 
-		public Serializable generate(AccessCallback callback) {
+		public synchronized Serializable generate(AccessCallback callback) {
 			if ( lastSourceValue == null || ! value.lt( lastSourceValue.copy().add( incrementSize ) ) ) {
 				lastSourceValue = callback.getNextValue();
 				value = lastSourceValue.copy();


### PR DESCRIPTION
All Optimizers in OptimizerFactory are thread safe by having the
 #generate(AccessCallback) method synchronized. The only exception is
PooledLoOptimizer who's #generate(AccessCallback) method is not
synchronized.
- make PooledLoOptimizer#generate(AccessCallback) synchronized
  
  https://hibernate.onjira.com/browse/HHH-5929
  https://hibernate.onjira.com/browse/HHH-6829
