### PR TITLE
HHH-7431 HHH-7432 Don't pre-calc toString and use Type for equals

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheKey.java
@@ -75,7 +75,11 @@ public class CacheKey implements Serializable {
 
 	@Override
 	public boolean equals(Object other) {
-		if ( !(other instanceof CacheKey) ) {
+		if ( this == other ) {
+			return true;
+		}
+		if ( !(other instanceof CacheKey) || hashCode != other.hashCode() ) {
+			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
 			return false;
 		}
 		CacheKey that = (CacheKey) other;

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
@@ -24,7 +24,6 @@
 package org.hibernate.cache.spi;
 
 import java.io.Serializable;
-import java.util.Arrays;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -39,11 +38,11 @@ import org.hibernate.type.Type;
  * @author Steve Ebersole
  */
 public class NaturalIdCacheKey implements Serializable {
+	private final Type[] naturalIdTypes;
 	private final Serializable[] naturalIdValues;
 	private final String entityName;
 	private final String tenantId;
 	private final int hashCode;
-	private final String toString;
 
 	/**
 	 * Construct a new key for a caching natural identifier resolutions into the second level cache.
@@ -61,8 +60,8 @@ public class NaturalIdCacheKey implements Serializable {
 		this.entityName = persister.getRootEntityName();
 		this.tenantId = session.getTenantIdentifier();
 
-		final Serializable[] disassembledNaturalId = new Serializable[naturalIdValues.length];
-		final StringBuilder toStringBuilder = new StringBuilder( entityName ).append( "##NaturalId[" );
+		this.naturalIdValues = new Serializable[naturalIdValues.length];
+		this.naturalIdTypes = new Type[naturalIdValues.length];
 
 		final SessionFactoryImplementor factory = session.getFactory();
 		final int[] naturalIdPropertyIndexes = persister.getNaturalIdentifierProperties();
@@ -78,18 +77,11 @@ public class NaturalIdCacheKey implements Serializable {
 			
 			result = prime * result + (value != null ? type.getHashCode( value, factory ) : 0);
 			
-			disassembledNaturalId[i] = type.disassemble( value, session, null );
-			
-			toStringBuilder.append( type.toLoggableString( value, factory ) );
-			if (i + 1 < naturalIdValues.length) {
-				toStringBuilder.append( ", " );
-			}
+			this.naturalIdTypes[i] = type;
+			this.naturalIdValues[i] = type.disassemble( value, session, null );
 		}
-		toStringBuilder.append( "]" );
 		
-		this.naturalIdValues = disassembledNaturalId;
 		this.hashCode = result;
-		this.toString = toStringBuilder.toString();
 	}
 
 	@SuppressWarnings( {"UnusedDeclaration"})
@@ -109,7 +101,18 @@ public class NaturalIdCacheKey implements Serializable {
 
 	@Override
 	public String toString() {
-		return this.toString;
+		//Complex toString is needed as naturalIds for entities are not simply based on a single value like primary keys
+		//the only sane way to differentiate the keys is to included the disassembled values in the string.
+		final StringBuilder toStringBuilder = new StringBuilder( entityName ).append( "##NaturalId[" );
+		for ( int i = 0; i < naturalIdValues.length; i++ ) {
+			toStringBuilder.append( naturalIdValues[i] );
+			if (i + 1 < naturalIdValues.length) {
+				toStringBuilder.append( ", " );
+			}
+		}
+		toStringBuilder.append( "]" );
+		
+		return toStringBuilder.toString();
 	}
 	
 	@Override
@@ -122,14 +125,24 @@ public class NaturalIdCacheKey implements Serializable {
 		if ( this == o ) {
 			return true;
 		}
-		if ( o == null || getClass() != o.getClass() ) {
+		if ( !(o instanceof NaturalIdCacheKey) || hashCode != o.hashCode() ) {
+			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
 			return false;
 		}
 
 		final NaturalIdCacheKey other = (NaturalIdCacheKey) o;
-		return entityName.equals( other.entityName )
-				&& EqualsHelper.equals( tenantId, other.tenantId )
-				&& Arrays.equals( naturalIdValues, other.naturalIdValues );
-
+		if ( !entityName.equals( other.entityName )
+				|| !EqualsHelper.equals( tenantId, other.tenantId )
+				|| naturalIdValues.length != other.naturalIdValues.length ) {
+			return false;
+		}
+		
+		for ( int i = 0; i < naturalIdValues.length; i++ ) {
+			if ( !this.naturalIdTypes[i].isEqual( naturalIdValues[i], other.naturalIdValues[i] ) ) {
+				return false;
+			}
+		}
+		
+		return true;
 	}
 }


### PR DESCRIPTION
Remove toString pre-calculation to avoid excess memory usage.

Use Type.isEquals in the equals method for comparing the naturalId values.

Note the org.hibernate.test.cache.infinispan.functional.cluster.NaturalIdInvalidationTestCase test fails but I'm not quite sure why. As soon as the NaturalIdCacheKey retains the Type[] of references the test fails even with no other changes to the NaturalIdCacheKey class. I'm hoping that someone can help me figure out if it is a bug with the test or the class.
