### PR TITLE
Updated Hibernate tests

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/abstractembeddedcomponents/cid/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/abstractembeddedcomponents/cid/Mappings.hbm.xml
@@ -10,7 +10,7 @@
             <key-property name="key1" type="string"/>
             <key-property name="key2" type="string"/>
         </composite-id>
-        <discriminator column="TYPE" type="string" length="10"/>
+        <discriminator column="`TYPE`" type="string" length="10"/>
         <property name="name" type="string"/>
     </class>
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/CharProperty.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/CharProperty.java
@@ -3,6 +3,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Column;
 
 @Entity
 @Table( name = "char_property" )
@@ -11,6 +12,7 @@ public class CharProperty implements Property {
 
 	private String name;
 
+    @Column(name = "`value`")
 	private Character value;
 
 	public CharProperty() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/IntegerProperty.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/IntegerProperty.java
@@ -3,12 +3,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Column;
 
 @Entity
 @Table(name="int_property")
 public class IntegerProperty implements Property {
 	private Integer id;
 	private String name;
+    @Column(name = "`value`")
 	private Integer value;
 	
 	public IntegerProperty() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/LongProperty.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/LongProperty.java
@@ -3,6 +3,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Column;
 
 @Entity
 @Table(name = "long_property")
@@ -10,7 +11,7 @@ public class LongProperty implements Property {
     private Integer id;
 
     private String name;
-
+    @Column(name = "`value`")
     private Long value;
 
     public LongProperty() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/StringProperty.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/StringProperty.java
@@ -3,12 +3,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Column;
 
 @Entity
 @Table(name="string_property")
 public class StringProperty implements Property {
 	private Integer id;
 	private String name;
+    @Column(name = "`value`")
 	private String value;
 
 	public StringProperty() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/MinMax.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/MinMax.java
@@ -26,6 +26,7 @@ package org.hibernate.test.annotations.beanvalidation;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Column;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
@@ -41,6 +42,7 @@ public class MinMax {
 
 	@Max(10)
 	@Min(2)
+    @Column(name = "`value`")
 	private Integer value;
 
 	private MinMax() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/Tv.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/Tv.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Column;
 import javax.validation.Valid;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.Min;
@@ -81,6 +82,7 @@ public class Tv {
 	@Embeddable
 	public static class Recorder {
 		@NotNull
+        @Column(name = "`time`")
 		public BigDecimal time;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/cascade/Tooth.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/cascade/Tooth.java
@@ -5,6 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.Column;
 
 /**
  * @author Emmanuel Bernard

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/cascade/Tooth.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/cascade/Tooth.java
@@ -14,6 +14,7 @@ public class Tooth {
 	@Id
 	@GeneratedValue
 	public Integer id;
+    @Column(name = "`type`")
 	public String type;
 	@ManyToOne(cascade = CascadeType.PERSIST)
 	public Tooth leftNeighbour;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvMagazin.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvMagazin.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Column;
 
 /**
  * @author Emmanuel Bernard
@@ -20,5 +21,6 @@ public class TvMagazin {
 	@EmbeddedId
 	public TvMagazinPk id;
 	@Temporal(TemporalType.TIME)
+    @Column(name="`time`")
 	Date time;
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvProgram.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvProgram.java
@@ -28,6 +28,7 @@ public class TvProgram {
 	public TvMagazinPk id;
 
 	@Temporal( TemporalType.TIME )
+    @Column(name="`time`")
 	Date time;
 
 	@Column( name = "TXT", table = "TV_PROGRAM_EXT" )

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvProgramIdClass.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/cid/TvProgramIdClass.java
@@ -27,6 +27,7 @@ public class TvProgramIdClass {
 	public Presenter presenter;
 
 	@Temporal( TemporalType.TIME )
+    @Column(name="`time`")
 	Date time;
 
 	@Column( name = "TXT", table = "TV_PROGRAM_IDCLASS" )

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/embeddables/withcustomenumdef/Location.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/embeddables/withcustomenumdef/Location.java
@@ -26,6 +26,7 @@ package org.hibernate.test.annotations.collectionelement.embeddables.withcustome
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Column;
 
 /**
  * @author Steve Ebersole
@@ -44,6 +45,7 @@ public class Location {
 
 	@Enumerated(EnumType.STRING)
 //	@Column(columnDefinition = "VARCHAR(32)")
+	@Column(name = "`type`")
 	private Type type;
 
 	public Location() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/embeddables/withcustomenumdef/Query.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/embeddables/withcustomenumdef/Query.java
@@ -31,6 +31,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import org.hibernate.annotations.GenericGenerator;
 
@@ -38,6 +39,7 @@ import org.hibernate.annotations.GenericGenerator;
  * @author Steve Ebersole
  */
 @Entity
+@Table(name="`Query`")
 public class Query {
 	@Id
 	@GeneratedValue( generator = "increment" )

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/embeddables/Investment.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/embeddables/Investment.java
@@ -34,6 +34,7 @@ public class Investment {
 	
 	private DollarValue amount;
 	private String description;
+    @Column(name = "`date`")
 	private MyDate date;
 
 	public DollarValue getAmount() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/embedded/CorpType.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/embedded/CorpType.java
@@ -3,6 +3,7 @@ package org.hibernate.test.annotations.embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Column;
 
 /**
  * @author Emmanuel Bernard
@@ -10,6 +11,7 @@ import javax.persistence.Id;
 @Entity
 public class CorpType {
 	private Integer id;
+    @Column(name = "`type`")
 	private String type;
 
 	@Id

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/filter/subclass/joined/JoinedSubClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/filter/subclass/joined/JoinedSubClassTest.java
@@ -2,9 +2,16 @@ package org.hibernate.test.annotations.filter.subclass.joined;
 
 import junit.framework.Assert;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.test.annotations.filter.subclass.SubClassTest;
 import org.junit.Test;
+import org.hibernate.testing.*;
 
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class JoinedSubClassTest extends SubClassTest{
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/join/SysUserOrm.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/join/SysUserOrm.java
@@ -11,7 +11,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
 @Entity( name = "sys_user" )
-@Table( name = "SYS_USER" )
+@Table( name = "`SYS_USER`" )
 public class SysUserOrm {
 
 	private long userid;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/manytomany/Zone.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/manytomany/Zone.java
@@ -4,11 +4,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 /**
  * @author Emmanuel Bernard
  */
 @Entity
+@Table(name="`Zone`")
 public class Zone {
 	private Integer id;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/manytoonewithformula/Language.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/manytoonewithformula/Language.java
@@ -30,11 +30,13 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 /**
  * @author Sharath Reddy
  */
 @Entity
+@Table(name="`Language`")
 public class Language implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/SerialNumber.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/SerialNumber.java
@@ -2,6 +2,7 @@
 package org.hibernate.test.annotations.onetoone;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Column;
 
 /**
  * @author Emmanuel Bernard
@@ -35,6 +36,7 @@ public class SerialNumber {
 		this.id = id;
 	}
 
+    @Column(name="`value`")
 	public String getValue() {
 		return value;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/query/Dictionary.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/query/Dictionary.java
@@ -25,7 +25,7 @@ import javax.persistence.SqlResultSetMapping;
 		@FieldResult(name = "name", column = "name"),
 		@FieldResult(name = "editor", column = "editor")
 				},
-		discriminatorColumn = "type"
+		discriminatorColumn = "`type`"
 )
 		}
 )

--- a/hibernate-core/src/test/java/org/hibernate/test/cascade/MultiPathCascade.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/cascade/MultiPathCascade.hbm.xml
@@ -7,7 +7,7 @@
 
         <id name="id" type="long"><generator class="native"/></id>
 
-        <property name="data" type="string" not-null="true"/>
+        <property name="data" column="`data`" type="string" not-null="true"/>
 
         <!--
              Associations
@@ -25,7 +25,7 @@
 
         <id name="id" type="long"><generator class="native"/></id>
 
-        <property name="data" type="string" not-null="true"/>
+        <property name="data" column="`data`" type="string" not-null="true"/>
 
         <!--
              Associations
@@ -47,7 +47,7 @@
 
         <id name="id" type="long"><generator class="native"/></id>
 
-        <property name="data" type="string" not-null="true"/>
+        <property name="data" column="`data`" type="string" not-null="true"/>
 
         <!--
             Associations

--- a/hibernate-core/src/test/java/org/hibernate/test/criteria/TestObject.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/criteria/TestObject.hbm.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="org.hibernate.test.criteria">
-	<class name="TestObject" table="test">
+	<class name="TestObject" table="`test`">
 		<id name="id">
 			<column name="ID" />
 			<generator class="native" />

--- a/hibernate-core/src/test/java/org/hibernate/test/discriminator/SimpleInheritance.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/discriminator/SimpleInheritance.hbm.xml
@@ -28,7 +28,7 @@
 			<generator class="assigned"/>
 		</id>
 		
-        <discriminator column="TYPE" type="character"/>
+        <discriminator column="`TYPE`" type="character"/>
 
 		<property name="name"
 			not-null="true"

--- a/hibernate-core/src/test/java/org/hibernate/test/entityname/Vehicle.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/entityname/Vehicle.hbm.xml
@@ -10,7 +10,7 @@
 		<id name="id" access="field" type="long">
 			<generator class="increment"/>
 		</id>
-		<discriminator column="TYPE" type="string" />
+		<discriminator column="`TYPE`" type="string" />
 		<property name="vin" type="string"/>
 		<property name="owner" type="string"/>
 

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/join/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/join/Mappings.hbm.xml
@@ -59,7 +59,7 @@
         </fetch-profile>
     </class>
 
-    <class name="CourseOffering" table="SECTION">
+    <class name="CourseOffering" table="`SECTION`">
         <id name="id" type="long">
             <generator class="increment"/>
         </id>

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/hql/JoinedFilteredBulkManipulationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/hql/JoinedFilteredBulkManipulationTest.java
@@ -24,6 +24,8 @@
 package org.hibernate.test.filter.hql;
 import java.util.Date;
 
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.Session;
@@ -34,6 +36,11 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Steve Ebersole
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class JoinedFilteredBulkManipulationTest extends BaseCoreFunctionalTestCase {
 	public String[] getMappings() {
 		return new String[] {

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -106,6 +106,11 @@ import static org.junit.Assert.fail;
  *
  * @author Steve
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	private static final Logger log = Logger.getLogger( ASTParserLoadingTest.class );
 

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -61,6 +61,7 @@ import org.hibernate.dialect.Sybase11Dialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.dialect.SybaseAnywhereDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.hql.internal.ast.ASTQueryTranslatorFactory;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.persister.entity.DiscriminatorType;
@@ -1819,6 +1820,13 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of version 8.4.1 CUBRID does not support temporary tables." +
+                    " This test somehow calls MultiTableDeleteExecutor which raises an" +
+                    " exception saying 'cannot doAfterTransactionCompletion multi-table" +
+                    " deletes using dialect not supporting temp tables'."
+    )
 	public void testParameterMixing() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/Animal.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/Animal.hbm.xml
@@ -77,7 +77,7 @@
 				</set>
 				<map name="addresses" table="addresses">
 					<key column="human"/>
-					<map-key type="string" column="type"/>
+					<map-key type="string" column="`type`"/>
 					<composite-element class="Address">
 						<property name="street"/>
 						<property name="city"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/BulkManipulationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/BulkManipulationTest.java
@@ -28,6 +28,8 @@ import java.util.Date;
 import java.util.List;
 
 import junit.framework.AssertionFailedError;
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.QueryException;
@@ -102,6 +104,11 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testTempTableGenerationIsolation() throws Throwable{
 		Session s = openSession();
 		s.beginTransaction();
@@ -510,6 +517,11 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testInsertWithSelectListUsingJoins() {
 		// this is just checking parsing and syntax...
 		Session s = openSession();
@@ -713,6 +725,11 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testUpdateOnManyToOne() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -1144,6 +1161,11 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testDeleteWithMetadataWhereFragments() throws Throwable {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ScrollableCollectionFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ScrollableCollectionFetchingTest.java
@@ -23,6 +23,7 @@
  */
 package org.hibernate.test.hql;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.junit.Test;
 
 import org.hibernate.HibernateException;
@@ -139,6 +140,11 @@ public class ScrollableCollectionFetchingTest extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testScrollingJoinFetchesSingleRowResultSet() {
 		Session s = openSession();
 		Transaction txn = s.beginTransaction();
@@ -292,6 +298,11 @@ public class ScrollableCollectionFetchingTest extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testScrollingJoinFetchesReverse() {
 		TestData data = new TestData();
 		data.prepare();
@@ -321,6 +332,11 @@ public class ScrollableCollectionFetchingTest extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testScrollingJoinFetchesPositioning() {
 		TestData data = new TestData();
 		data.prepare();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/joinedSubclass/JoinedSubclassBulkManipTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/joinedSubclass/JoinedSubclassBulkManipTest.java
@@ -23,6 +23,8 @@
  */
 package org.hibernate.test.hql.joinedSubclass;
 
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.Session;
@@ -32,6 +34,11 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 /**
  * @author Steve Ebersole
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class JoinedSubclassBulkManipTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/ContractVariation.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/ContractVariation.hbm.xml
@@ -50,7 +50,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="true" order-by="version asc"
 				mutable="false" cascade="all" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariation.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariation.hbm.xml
@@ -49,7 +49,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="true" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationOneToManyJoin.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationOneToManyJoin.hbm.xml
@@ -56,7 +56,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="true" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationVersioned.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationVersioned.hbm.xml
@@ -53,7 +53,7 @@
 		</id>
         <version name="version" column="VERS" type="long" />
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="true" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationVersionedOneToManyJoin.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/ContractVariationVersionedOneToManyJoin.hbm.xml
@@ -60,7 +60,7 @@
 		</id>
         <version name="version" column="VERS" type="long" />
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="true" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/EntityWithInverseOneToManyJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/EntityWithInverseOneToManyJoinTest.java
@@ -23,11 +23,18 @@
  */
 package org.hibernate.test.immutable.entitywithmutablecollection.inverse;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.test.immutable.entitywithmutablecollection.AbstractEntityWithOneToManyTest;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Gail Badner
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class EntityWithInverseOneToManyJoinTest extends AbstractEntityWithOneToManyTest {
 	public String[] getMappings() {
 		return new String[] { "immutable/entitywithmutablecollection/inverse/ContractVariationOneToManyJoin.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/VersionedEntityWithInverseOneToManyJoinFailureExpectedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/VersionedEntityWithInverseOneToManyJoinFailureExpectedTest.java
@@ -23,6 +23,8 @@
  */
 package org.hibernate.test.immutable.entitywithmutablecollection.inverse;
 
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.test.immutable.entitywithmutablecollection.AbstractEntityWithOneToManyTest;
@@ -31,6 +33,11 @@ import org.hibernate.testing.FailureExpected;
 /**
  * @author Gail Badner
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class VersionedEntityWithInverseOneToManyJoinFailureExpectedTest extends AbstractEntityWithOneToManyTest {
 	public String[] getMappings() {
 		return new String[] { "immutable/entitywithmutablecollection/inverse/ContractVariationVersionedOneToManyJoin.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/VersionedEntityWithInverseOneToManyJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/inverse/VersionedEntityWithInverseOneToManyJoinTest.java
@@ -23,7 +23,9 @@
  */
 package org.hibernate.test.immutable.entitywithmutablecollection.inverse;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.test.immutable.entitywithmutablecollection.AbstractEntityWithOneToManyTest;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 
 
@@ -31,6 +33,11 @@ import org.hibernate.testing.TestForIssue;
  * @author Gail Badner
  */
 @TestForIssue( jiraKey = "HHH-4992" )
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class VersionedEntityWithInverseOneToManyJoinTest extends AbstractEntityWithOneToManyTest {
 	public String[] getMappings() {
 		return new String[] { "immutable/entitywithmutablecollection/inverse/ContractVariationVersionedOneToManyJoin.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariation.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariation.hbm.xml
@@ -49,7 +49,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="false" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationOneToManyJoin.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationOneToManyJoin.hbm.xml
@@ -56,7 +56,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="false" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationUnidir.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationUnidir.hbm.xml
@@ -48,7 +48,7 @@
 			<generator class="increment"/>
 		</id>
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="false" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationVersioned.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationVersioned.hbm.xml
@@ -53,7 +53,7 @@
 		</id>
         <version name="version" column="VERS" type="long" />
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="false" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationVersionedOneToManyJoin.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/ContractVariationVersionedOneToManyJoin.hbm.xml
@@ -60,7 +60,7 @@
 		</id>
         <version name="version" column="VERS" type="long" />
 		<property name="customerName" not-null="true"/>
-		<property name="type" not-null="true"/>
+		<property name="type" column="`type`" not-null="true"/>
 		<bag name="variations" inverse="false" order-by="id asc"
 				mutable="true" cascade="all-delete-orphan" fetch="join">
 			<key column="contract"/>

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/EntityWithNonInverseOneToManyJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/EntityWithNonInverseOneToManyJoinTest.java
@@ -23,11 +23,18 @@
  */
 package org.hibernate.test.immutable.entitywithmutablecollection.noninverse;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.test.immutable.entitywithmutablecollection.AbstractEntityWithOneToManyTest;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Gail Badner
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class EntityWithNonInverseOneToManyJoinTest extends AbstractEntityWithOneToManyTest {
 	public String[] getMappings() {
 		return new String[] { "immutable/entitywithmutablecollection/noninverse/ContractVariationOneToManyJoin.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/VersionedEntityWithNonInverseOneToManyJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/immutable/entitywithmutablecollection/noninverse/VersionedEntityWithNonInverseOneToManyJoinTest.java
@@ -23,11 +23,18 @@
  */
 package org.hibernate.test.immutable.entitywithmutablecollection.noninverse;
 
+import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.test.immutable.entitywithmutablecollection.AbstractEntityWithOneToManyTest;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Gail Badner
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class VersionedEntityWithNonInverseOneToManyJoinTest extends AbstractEntityWithOneToManyTest {
 	public String[] getMappings() {
 		return new String[] { "immutable/entitywithmutablecollection/noninverse/ContractVariationVersionedOneToManyJoin.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/MyEntity.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/MyEntity.hbm.xml
@@ -8,7 +8,7 @@
         <id name="id" column="ID" type="long">
             <generator class="increment"/>
         </id>
-        <discriminator column="TYPE" />
+        <discriminator column="`TYPE`" />
         <property name="name" type="string"/>
         <many-to-one name="other" class="MyEntity" />
         <subclass name="MySubclassEntity" discriminator-value="S">

--- a/hibernate-core/src/test/java/org/hibernate/test/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetomany/OneToManyTest.java
@@ -23,6 +23,8 @@
  */
 package org.hibernate.test.onetomany;
 
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.Session;
@@ -41,6 +43,11 @@ public class OneToManyTest extends BaseCoreFunctionalTestCase {
 
 	@SuppressWarnings( {"unchecked", "UnusedAssignment"})
 	@Test
+    @SkipForDialect(
+            value = CUBRIDDialect.class,
+            comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                    "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+    )
 	public void testOneToManyLinkTable() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/datadirect/oracle/StoredProcedures.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/datadirect/oracle/StoredProcedures.hbm.xml
@@ -10,17 +10,17 @@
 
 	<sql-query name="simpleScalar" callable="true">
 	 <return-scalar column="name" type="string"/>
-	 <return-scalar column="value" type="long"/>
+	 <return-scalar column="`value`" type="long"/>
 	 { call simpleScalar(:number) }
 	</sql-query>
 	<sql-query name="paramhandling" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call testParamHandling(?,?) }
 	</sql-query>
 
 	<sql-query name="paramhandling_mixed" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call testParamHandling(?,:second) }
 	</sql-query>
@@ -34,7 +34,7 @@
 			<return-property name="regionCode" column="REGIONCODE"/>			
 			<return-property name="employmentId" column="EMPID"/>						
 			<return-property name="salary">
-  			  <return-column name="VALUE"/>
+  			  <return-column name="`VALUE`"/>
 			  <return-column name="CURRENCY"/>			
 			</return-property>
 		</return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/db2/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/db2/Mappings.hbm.xml
@@ -51,7 +51,7 @@
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
         <property name="salary" type="org.hibernate.test.sql.hand.MonetaryAmountUserType">
-			<column name="VALUE" sql-type="float"/>
+			<column name="`VALUE`" sql-type="float"/>
 			<column name="CURRENCY"/>			
 		</property>
 		<loader query-ref="employment"/>
@@ -162,7 +162,7 @@
 			<return-property name="salary"> 
 		      <!-- as multi column properties are not supported via the
 		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="VALUE"/>
+  			  <return-column name="`VALUE`"/>
 			  <return-column name="CURRENCY"/>			
 			</return-property>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
@@ -179,18 +179,18 @@
 
 	<sql-query name="simpleScalar" callable="true">
 		<return-scalar column="name" type="string"/>
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		{ call simpleScalar(:number) }
 	</sql-query>
 
 	<sql-query name="paramhandling" callable="true">
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		<return-scalar column="value2" type="long"/>
 		{ call paramHandling(?,?) }
 	</sql-query>
 
 	<sql-query name="paramhandling_mixed" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call paramHandling(?,:second) }
 	</sql-query>
@@ -206,7 +206,7 @@
 			<return-property name="salary"> 
 				<!-- as multi column properties are not supported via the
 				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="VALUE"/>
+				<return-column name="`VALUE`"/>
 				<return-column name="CURRENCY"/>			
 			</return-property>
 		</return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/mysql/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/mysql/Mappings.hbm.xml
@@ -52,7 +52,7 @@
 		<property name="endDate" insert="false"/>
 		<property name="regionCode" update="false"/>
 	  <property name="salary" type="org.hibernate.test.sql.hand.MonetaryAmountUserType">
-			<column name="VALUE" sql-type="float"/>
+			<column name="`VALUE`" sql-type="float"/>
 			<column name="CURRENCY"/>			
 		</property>
 		<loader query-ref="employment"/>
@@ -160,7 +160,7 @@
 			<return-property name="salary"> 
 		      <!-- as multi column properties are not supported via the
 		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="VALUE"/>
+  			  <return-column name="`VALUE`"/>
 			  <return-column name="CURRENCY"/>			
 			</return-property>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
@@ -177,18 +177,18 @@
 
 	<sql-query name="simpleScalar" callable="true">
 	 <return-scalar column="name" type="string"/>
-	 <return-scalar column="value" type="long"/>
+	 <return-scalar column="`value`" type="long"/>
 		{ call simpleScalar(:number) }
 	</sql-query>
 
 	<sql-query name="paramhandling" callable="true">
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		<return-scalar column="value2" type="long"/>
 		{ call paramHandling(?,?) }
 	</sql-query>
 
 	<sql-query name="paramhandling_mixed" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call paramHandling(?,:second) }
 	</sql-query>
@@ -204,7 +204,7 @@
 			<return-property name="salary"> 
 				<!-- as multi column properties are not supported via the
 				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="VALUE"/>
+				<return-column name="`VALUE`"/>
 				<return-column name="CURRENCY"/>			
 			</return-property>
 		</return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/Mappings.hbm.xml
@@ -52,7 +52,7 @@
         <property name="endDate" insert="false"/>
         <property name="regionCode" update="false"/>
         <property name="salary" type="org.hibernate.test.sql.hand.MonetaryAmountUserType">
-            <column name="VALUE" sql-type="float"/>
+            <column name="`VALUE`" sql-type="float"/>
             <column name="CURRENCY"/>
         </property>
         <loader query-ref="employment"/>
@@ -154,7 +154,7 @@
             <return-property name="salary">
                 <!-- as multi column properties are not supported via the
                               {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-                <return-column name="VALUE"/>
+                <return-column name="`VALUE`"/>
                 <return-column name="CURRENCY"/>
             </return-property>
             <!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/StoredProcedures.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/StoredProcedures.hbm.xml
@@ -10,18 +10,18 @@
 
     <sql-query name="simpleScalar" callable="true">
         <return-scalar column="name" type="string"/>
-        <return-scalar column="value" type="long"/>
+        <return-scalar column="`value`" type="long"/>
         { ? = call simpleScalar(:number) }
     </sql-query>
 
     <sql-query name="paramhandling" callable="true">
-        <return-scalar column="value" type="long"/>
+        <return-scalar column="`value`" type="long"/>
         <return-scalar column="value2" type="long"/>
         { ? = call testParamHandling(?,?) }
     </sql-query>
 
     <sql-query name="paramhandling_mixed" callable="true">
-        <return-scalar column="value" type="long"/>
+        <return-scalar column="`value`" type="long"/>
         <return-scalar column="value2" type="long"/>
         { ? = call testParamHandling(?,:second) }
     </sql-query>
@@ -35,7 +35,7 @@
             <return-property name="regionCode" column="REGIONCODE"/>
             <return-property name="employmentId" column="EMPID"/>
             <return-property name="salary">
-                <return-column name="VALUE"/>
+                <return-column name="`VALUE`"/>
                 <return-column name="CURRENCY"/>
             </return-property>
         </return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/sqlserver/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/sqlserver/Mappings.hbm.xml
@@ -161,7 +161,7 @@
 			<return-property name="salary"> 
 		      <!-- as multi column properties are not supported via the
 		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="VALUE"/>
+  			  <return-column name="`VALUE`"/>
 			  <return-column name="CURRENCY"/>			
 			</return-property>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
@@ -178,18 +178,18 @@
 
 	<sql-query name="simpleScalar" callable="true">
 		<return-scalar column="name" type="string"/>
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		{ call simpleScalar(:number) }
 	</sql-query>
 
 	<sql-query name="paramhandling" callable="true">
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		<return-scalar column="value2" type="long"/>
 		{ call paramHandling(?,?) }
 	</sql-query>
 
 	<sql-query name="paramhandling_mixed" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call paramHandling(?,:second) }
 	</sql-query>
@@ -205,7 +205,7 @@
 			<return-property name="salary"> 
 				<!-- as multi column properties are not supported via the
 				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="VALUE"/>
+				<return-column name="`VALUE`"/>
 				<return-column name="CURRENCY"/>			
 			</return-property>
 		</return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/sybase/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/sybase/Mappings.hbm.xml
@@ -51,7 +51,7 @@
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
         <property name="salary" type="org.hibernate.test.sql.hand.MonetaryAmountUserType">
-			<column name="VALUE" sql-type="float"/>
+			<column name="`VALUE`" sql-type="float"/>
 			<column name="CURRENCY"/>			
 		</property>
 		<loader query-ref="employment"/>
@@ -161,7 +161,7 @@
 			<return-property name="salary"> 
 		      <!-- as multi column properties are not supported via the
 		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="VALUE"/>
+  			  <return-column name="`VALUE`"/>
 			  <return-column name="CURRENCY"/>			
 			</return-property>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
@@ -178,18 +178,18 @@
 
 	<sql-query name="simpleScalar" callable="true">
 		<return-scalar column="name" type="string"/>
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		{ call simpleScalar(:number) }
 	</sql-query>
 
 	<sql-query name="paramhandling" callable="true">
-		<return-scalar column="value" type="long"/>
+		<return-scalar column="`value`" type="long"/>
 		<return-scalar column="value2" type="long"/>
 		{ call paramHandling(?,?) }
 	</sql-query>
 
 	<sql-query name="paramhandling_mixed" callable="true">
-		<return-scalar column="value" type="long" />
+		<return-scalar column="`value`" type="long" />
 		<return-scalar column="value2" type="long" />
 		{ call paramHandling(?,:second) }
 	</sql-query>
@@ -205,7 +205,7 @@
 			<return-property name="salary"> 
 				<!-- as multi column properties are not supported via the
 				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="VALUE"/>
+				<return-column name="`VALUE`"/>
 				<return-column name="CURRENCY"/>			
 			</return-property>
 		</return>

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueries.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueries.hbm.xml
@@ -53,7 +53,7 @@
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
 	    <property name="salary" type="org.hibernate.test.sql.hand.MonetaryAmountUserType">
-			<column name="VALUE" sql-type="float"/>
+			<column name="`VALUE`" sql-type="float"/>
 			<column name="CURRENCY"/>			
 		</property>
 	</class>
@@ -246,7 +246,7 @@
 			<return-property name="element.regionCode" column="REGIONCODE"/>			
 			<return-property name="element.employmentId" column="EMPID"/>						
 			<return-property name="element.salary">
-                <return-column name="VALUE"/>
+                <return-column name="`VALUE`"/>
                 <return-column name="CURRENCY"/>
 			</return-property>
 		</return-join>

--- a/hibernate-core/src/test/java/org/hibernate/test/subclassfilter/JoinedSubclassFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/subclassfilter/JoinedSubclassFilterTest.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hibernate.dialect.CUBRIDDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import org.hibernate.Session;
@@ -39,6 +41,11 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Steve Ebersole
  */
+@SkipForDialect(
+        value = CUBRIDDialect.class,
+        comment = "As of verion 8.4.1 CUBRID doesn't support temporary tables. This test fails with" +
+                "HibernateException: cannot doAfterTransactionCompletion multi-table deletes using dialect not supporting temp tables"
+)
 public class JoinedSubclassFilterTest extends BaseCoreFunctionalTestCase {
 	public final String[] getMappings() {
 		return new String[] { "subclassfilter/joined-subclass.hbm.xml" };

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/metamodel/CreditCard.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/metamodel/CreditCard.java
@@ -94,7 +94,7 @@ public class CreditCard implements java.io.Serializable {
 		number = v;
 	}
 
-	@Column(name = "TYPE")
+	@Column(name = "`TYPE`")
 	public String getType() {
 		return type;
 	}

--- a/hibernate-entitymanager/src/test/resources/org/hibernate/jpa/test/xml/Qualifier.hbm.xml
+++ b/hibernate-entitymanager/src/test/resources/org/hibernate/jpa/test/xml/Qualifier.hbm.xml
@@ -17,7 +17,7 @@
             <column name="NAME" length="20" not-null="true"/>
         </property>
         <property name="value" type="string">
-            <column name="VALUE" length="1948"/>
+            <column name="`VALUE`" length="1948"/>
         </property>
     </class>
 


### PR DESCRIPTION
These changes to test classes were made to make sure they do not fail for CUBRID Dialect. They cover these two scenarios:
1. When column/table names were not quoted. These fail because those column names (`TYPE`, `VALUE`, `SYS_USER`, `DATE`, `TIME`, etc.) are reserved in CUBRID.
2. When tests work with temporary tables which are not supported yet as of CUBRID 8.4.1. So they need to be `@SkipForDialect`. I added a comment to each _skip_ why they skip for CUBRID.

These updates do not change any functionality of the tests. Only wrap some column/table names and skip some tests. Tested on default H2 - all success; tested with MySQL - same 13 known failures. Testing on CUBRID with these changes reduced the number of failed tests from 1000+ down to 500+.

I will investigate other failures and will send pull requests with the changes.

Edit: The Windows client for Github messed up some commits by automatically adding LF to CRLF conversion to my changes. Didn't display in the client. Noticed this only on Github. Sorry for that.
