### PR TITLE
HHH-7115 definition of returned class inside SerializableToBlobType

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
@@ -142,8 +142,6 @@ public class SimpleValueBinder {
 			isArray = true;
 		}
 		this.xproperty = property;
-		Properties typeParameters = this.typeParameters;
-		typeParameters.clear();
 		String type = BinderHelper.ANNOTATION_STRING_DEFAULT;
 
 		Type annType = property.getAnnotation( Type.class );
@@ -216,11 +214,6 @@ public class SimpleValueBinder {
 					.toXClass( Serializable.class )
 					.isAssignableFrom( returnedClassOrElement ) ) {
 				type = SerializableToBlobType.class.getName();
-				//typeParameters = new Properties();
-				typeParameters.setProperty(
-						SerializableToBlobType.CLASS_NAME,
-						returnedClassOrElement.getName()
-				);
 			}
 			else {
 				type = "blob";
@@ -245,7 +238,6 @@ public class SimpleValueBinder {
 		}
 
 		defaultType = BinderHelper.isEmptyAnnotationValue( type ) ? returnedClassName : type;
-		this.typeParameters = typeParameters;
 	}
 
 	private TemporalType getTemporalType(XProperty property) {

--- a/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.dom4j.Node;
-
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
@@ -43,14 +42,14 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.SerializationHelper;
-import org.hibernate.usertype.ParameterizedType;
+import org.hibernate.usertype.DynamicParameterizedType;
 
 /**
  * @author Emmanuel Bernard
  */
-public class SerializableToBlobType extends AbstractLobType implements ParameterizedType {
+public class SerializableToBlobType extends AbstractLobType implements DynamicParameterizedType {
 	/**
-	 * class name of the serialisable class
+	 * class name of the serialisable class   
 	 */
 	public static final String CLASS_NAME = "classname";
 	private Class serializableClass;
@@ -138,17 +137,19 @@ public class SerializableToBlobType extends AbstractLobType implements Parameter
 	}
 
 	public void setParameterValues(Properties parameters) {
-		if ( parameters != null ) {
+		ParameterType reader = (ParameterType) parameters.get( PARAMETER_TYPE );
+		if ( reader != null ) {
+			serializableClass = reader.getReturnedClass();
+		}
+		else {
 			String className = parameters.getProperty( CLASS_NAME );
 			if ( className == null ) {
-				throw new MappingException(
-						"No class name defined for type: " + SerializableToBlobType.class.getName()
-				);
+				throw new MappingException( "No class name defined for type: " + SerializableToBlobType.class.getName() );
 			}
 			try {
 				serializableClass = ReflectHelper.classForName( className );
 			}
-			catch (ClassNotFoundException e) {
+			catch ( ClassNotFoundException e ) {
 				throw new MappingException( "Unable to load class from " + CLASS_NAME + " parameter", e );
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/EntitySerialize.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/EntitySerialize.java
@@ -1,0 +1,44 @@
+package org.hibernate.test.annotations.lob;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+/**
+ * @author Janario Oliveira
+ */
+@Entity
+@TypeDefs({ @TypeDef(typeClass = ImplicitSerializableType.class, defaultForType = ImplicitSerializable.class) })
+public class EntitySerialize {
+	@Id
+	@GeneratedValue
+	long id;
+
+	@Lob
+	ExplicitSerializable explicitLob;
+	
+	@Type(type = "org.hibernate.test.annotations.lob.ExplicitSerializableType")
+	ExplicitSerializable explicit;
+
+	ImplicitSerializable implicit;
+
+	@Type(type = "org.hibernate.test.annotations.lob.ExplicitSerializableType")
+	ImplicitSerializable explicitOverridingImplicit;
+
+	/**
+	 * common in ExplicitSerializable and ImplicitSerializable to create same property in both
+	 * This property will not persist it have a default value per type
+	 * 
+	 * @author Janario Oliveira
+	 */
+	public interface CommonSerializable {
+		String getDefaultValue();
+
+		void setDefaultValue(String defaultValue);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ExplicitSerializable.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ExplicitSerializable.java
@@ -1,0 +1,23 @@
+package org.hibernate.test.annotations.lob;
+
+import java.io.Serializable;
+
+import org.hibernate.test.annotations.lob.EntitySerialize.CommonSerializable;
+
+/**
+ * @author Janario Oliveira
+ */
+public class ExplicitSerializable implements Serializable, CommonSerializable {
+	String defaultValue;
+	String value;
+
+	@Override
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	@Override
+	public void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ExplicitSerializableType.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ExplicitSerializableType.java
@@ -1,0 +1,30 @@
+package org.hibernate.test.annotations.lob;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.test.annotations.lob.EntitySerialize.CommonSerializable;
+import org.hibernate.type.SerializableToBlobType;
+
+/**
+ * @author Janario Oliveira
+ */
+public class ExplicitSerializableType extends SerializableToBlobType {
+	@Override
+	public Object get(ResultSet rs, String name) throws SQLException {
+		CommonSerializable deserialize = (CommonSerializable) super.get( rs, name );
+		deserialize.setDefaultValue( "EXPLICIT" );
+		return deserialize;
+	}
+
+	@Override
+	public void set(PreparedStatement st, Object value, int index, SessionImplementor session) throws SQLException {
+		if ( value != null ) {
+			( (CommonSerializable) value ).setDefaultValue( null );
+		}
+		super.set( st, value, index, session );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ImplicitSerializable.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ImplicitSerializable.java
@@ -1,0 +1,23 @@
+package org.hibernate.test.annotations.lob;
+
+import java.io.Serializable;
+
+import org.hibernate.test.annotations.lob.EntitySerialize.CommonSerializable;
+
+/**
+ * @author Janario Oliveira
+ */
+public class ImplicitSerializable implements Serializable, CommonSerializable {
+	String defaultValue;
+	String value;
+
+	@Override
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	@Override
+	public void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ImplicitSerializableType.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/ImplicitSerializableType.java
@@ -1,0 +1,31 @@
+package org.hibernate.test.annotations.lob;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.test.annotations.lob.EntitySerialize.CommonSerializable;
+import org.hibernate.type.SerializableToBlobType;
+
+/**
+ * @author Janario Oliveira
+ */
+public class ImplicitSerializableType extends SerializableToBlobType {
+
+	@Override
+	public Object get(ResultSet rs, String name) throws SQLException {
+		CommonSerializable deserialize = (CommonSerializable) super.get( rs, name );
+		deserialize.setDefaultValue( "IMPLICIT" );
+		return deserialize;
+	}
+
+	@Override
+	public void set(PreparedStatement st, Object value, int index, SessionImplementor session) throws SQLException {
+		if ( value != null ) {
+			( (CommonSerializable) value ).setDefaultValue( null );
+		}
+		super.set( st, value, index, session );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/SerializableToBlobTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/lob/SerializableToBlobTypeTest.java
@@ -1,0 +1,89 @@
+package org.hibernate.test.annotations.lob;
+
+import static org.junit.Assert.assertEquals;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.type.SerializableToBlobType;
+import org.hibernate.type.Type;
+import org.junit.Test;
+
+/**
+ * Test type definition for SerializableToBlobType
+ * 
+ * @author Janario Oliveira
+ */
+public class SerializableToBlobTypeTest extends BaseCoreFunctionalTestCase {
+	@Test
+	public void testTypeDefinition() {
+		Configuration cfg = configuration();
+		PersistentClass pc = cfg.getClassMapping( EntitySerialize.class.getName() );
+
+		// explicitLob of SerializableToBlobType
+		Type explicitLobType = pc.getProperty( "explicitLob" ).getType();
+		assertEquals( ExplicitSerializable.class, explicitLobType.getReturnedClass() );
+		assertEquals( SerializableToBlobType.class.getName(), explicitLobType.getName() );
+
+		// explicit of ExplicitSerializableType
+		Type explicitType = pc.getProperty( "explicit" ).getType();
+		assertEquals( ExplicitSerializable.class, explicitType.getReturnedClass() );
+		assertEquals( ExplicitSerializableType.class.getName(), explicitType.getName() );
+
+		// implicit of ImplicitSerializableType
+		Type implicitType = pc.getProperty( "implicit" ).getType();
+		assertEquals( ImplicitSerializable.class, implicitType.getReturnedClass() );
+		assertEquals( ImplicitSerializableType.class.getName(), implicitType.getName() );
+
+		// explicitOverridingImplicit ExplicitSerializableType overrides ImplicitSerializableType
+		Type overrideType = pc.getProperty( "explicitOverridingImplicit" ).getType();
+		assertEquals( ImplicitSerializable.class, overrideType.getReturnedClass() );
+		assertEquals( ExplicitSerializableType.class.getName(), overrideType.getName() );
+	}
+
+	@Test
+	public void testPersist() {
+		EntitySerialize entitySerialize = new EntitySerialize();
+
+		entitySerialize.explicitLob = new ExplicitSerializable();
+		entitySerialize.explicitLob.value = "explicitLob";
+		entitySerialize.explicitLob.defaultValue = "defaultExplicitLob";
+
+		entitySerialize.explicit = new ExplicitSerializable();
+		entitySerialize.explicit.value = "explicit";
+
+		entitySerialize.implicit = new ImplicitSerializable();
+		entitySerialize.implicit.value = "implicit";
+
+		entitySerialize.explicitOverridingImplicit = new ImplicitSerializable();
+		entitySerialize.explicitOverridingImplicit.value = "explicitOverridingImplicit";
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		session.persist( entitySerialize );
+
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+
+		EntitySerialize persistedSerialize = (EntitySerialize) session.get( EntitySerialize.class, entitySerialize.id );
+		assertEquals( "explicitLob", persistedSerialize.explicitLob.value );
+		assertEquals( "explicit", persistedSerialize.explicit.value );
+		assertEquals( "implicit", persistedSerialize.implicit.value );
+		assertEquals( "explicitOverridingImplicit", persistedSerialize.explicitOverridingImplicit.value );
+
+		assertEquals( "defaultExplicitLob", persistedSerialize.explicitLob.defaultValue );
+		assertEquals( "EXPLICIT", persistedSerialize.explicit.defaultValue );
+		assertEquals( "IMPLICIT", persistedSerialize.implicit.defaultValue );
+		assertEquals( "EXPLICIT", persistedSerialize.explicitOverridingImplicit.defaultValue );
+
+		session.close();
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { EntitySerialize.class };
+	}
+}


### PR DESCRIPTION
HHH-7115 - similar to HHH-7108 
There is a property in SimpleValueBinder class to read the returned class and pass it to SerializableToBlobType. That property can be read inside the type class by implementing DynamicParameterizedType interface.
After that there is no more fixed properties in SimpleValueBinder.setType method.

There is a test case SerializableToBlobTypeTest
Thanks.
