### PR TITLE
Jira-issue: Hibernate ORM HHH-7508

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
@@ -99,7 +99,7 @@ public class OptimizerFactory {
 				return POOLED_LO;
 			}
 			else {
-				LOG.debugf( "Unknown optimizer key [%s]; returning null assuming Optimizer impl class name" );
+				LOG.debugf( "Unknown optimizer key [%s]; returning null assuming Optimizer impl class name", externalName );
 				return null;
 			}
 		}


### PR DESCRIPTION
In OptimizerFactory.java, the line I have changed used to cause a MissingFormatArgumentException because the s% to be replaced by a String.format in a logger had no arguments.
