### PR TITLE
HHH-7367

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -6,7 +6,7 @@ slf4jVersion = '1.6.1'
 junitVersion = '4.10'
 h2Version = '1.2.145'
 bytemanVersion = '1.5.2'
-infinispanVersion = '5.1.4.FINAL'
+infinispanVersion = '5.1.6.FINAL'
 jnpVersion = '5.0.6.CR1'
 
 libraries = [


### PR DESCRIPTION
Fixed Infinispan to pass all of Hibernate's tests. Good news is that we didn't waste time: the failing test was legit and actually highlighted a problem in Infinispan.

Note that I'm sending the pull now as I'm offline on Monday, but **the Infinispan team still needs to release the version 5.1.6.FINAL** which is needed to integrate this.

please track https://issues.jboss.org/browse/ISPN-2193 and ping @maniksurtani for the Infinispan release.
