### PR TITLE
HHH-7532 Override getForUpdateString in Db2400Dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
@@ -71,4 +71,7 @@ public class DB2400Dialect extends DB2Dialect {
 				.toString();
 	}
 
+	public String getForUpdateString() {
+		return " for update with rs";
+	}
 }


### PR DESCRIPTION
Fix for HHH-7532 - SQLGrammarException generating Id's with DB2400Dialect, caused by fix for HHH-1512
