### PR TITLE
HHH-7541: When using HSQLDB, inserting any CLOB value larger than 16Mb always fails with an exception

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -123,8 +123,8 @@ public class HSQLDialect extends Dialect {
 			registerColumnType( Types.CLOB, "longvarchar" );
 		}
 		else {
-			registerColumnType( Types.BLOB, "blob" );
-			registerColumnType( Types.CLOB, "clob" );
+			registerColumnType( Types.BLOB, "blob($l)" );
+			registerColumnType( Types.CLOB, "clob($l)" );
 		}
 
 		// aggregate functions


### PR DESCRIPTION
Fixed.
