### PR TITLE
HHH-1283 : Join fetched collections using Query.scroll() is correct only for first entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -381,12 +381,21 @@ public abstract class Loader {
 						hydratedObjects,
 						loadedKeys,
 						returnProxies
+				);
+				if ( ! keyToRead.equals( loadedKeys[0] ) ) {
+					throw new AssertionFailure(
+							String.format(
+									"Unexpected key read for row; expected [%s]; actual [%s]",
+									keyToRead,
+									loadedKeys[0] )
 					);
+				}
 				if ( result == null ) {
 					result = loaded;
 				}
 			}
-			while ( keyToRead.equals( loadedKeys[0] ) && resultSet.next() );
+			while ( resultSet.next() &&
+					keyToRead.equals( getKeyFromResultSet( 0, getEntityPersisters()[0], null, resultSet, session ) ) );
 		}
 		catch ( SQLException sqle ) {
 			throw factory.getSQLExceptionHelper().convert(

--- a/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/HQLScrollFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/HQLScrollFetchTest.java
@@ -25,6 +25,7 @@ import org.hibernate.transform.DistinctRootEntityResultTransformer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -84,7 +85,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testIncompleteScrollSecondResult() {
 		try {
 			insertTestData();
@@ -122,7 +123,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testIncompleteScrollSecondResultInTransaction() {
 		try {
 			insertTestData();
@@ -144,7 +145,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283")
+	@TestForIssue( jiraKey = "HHH-1283")
 	public void testIncompleteScroll() {
 		try {
 			insertTestData();
@@ -179,15 +180,8 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 				}
 			}
 			// check that the same second parent is obtained by calling Session.get()
-			assertSame( pOther, s.get( Parent.class, "parent2" ) );
-			assertNotNull( pOther );
-			assertNotNull( cOther );
-			// pOther's collection non-lazy, but only 1 element has been loaded so far;
-			// Should pOther's collection really be initialized???
-			assertTrue( Hibernate.isInitialized( pOther.getChildren() ) );
-			assertTrue( pOther.getChildren().contains( cOther ) );
-			// The following fails because pOther only has 1 element.
-			assertResultFromOneUser( pOther );
+			assertNull( pOther );
+			assertNull( cOther );
 			s.close();
 		}
 		finally {
@@ -196,7 +190,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testIncompleteScrollLast() {
 		try {
 			insertTestData();
@@ -244,7 +238,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testScrollOrderParentAsc() {
 		try {
 			insertTestData();
@@ -263,7 +257,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testScrollOrderParentDesc() {
 		try {
 			insertTestData();
@@ -282,7 +276,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testScrollOrderParentAscChildrenAsc() {
 		try {
 			insertTestData();
@@ -301,7 +295,7 @@ public class HQLScrollFetchTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1283" )
+	@TestForIssue( jiraKey = "HHH-1283" )
 	public void testScrollOrderParentAscChildrenDesc() {
 		try {
 			insertTestData();


### PR DESCRIPTION
This fix to Loader.sequentialLoad() only processes the next row of the result set if the first entity key for that row is the same as the previous.
