### PR TITLE
HHH-7603 Changed AbstractPersistentCollection so that it would behave in...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -140,16 +140,22 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 							@Override
 							public Boolean doWork() {
 								CollectionEntry entry = session.getPersistenceContext().getCollectionEntry( AbstractPersistentCollection.this );
-								CollectionPersister persister = entry.getLoadedPersister();
-								if ( persister.isExtraLazy() ) {
-									if ( hasQueuedOperations() ) {
-										session.flush();
+
+								if ( entry != null ) {
+									CollectionPersister persister = entry.getLoadedPersister();
+									if ( persister.isExtraLazy() ) {
+										if ( hasQueuedOperations() ) {
+											session.flush();
+										}
+										cachedSize = persister.getSize( entry.getLoadedKey(), session );
+										return true;
 									}
-									cachedSize = persister.getSize( entry.getLoadedKey(), session );
-									return true;
+									else {
+										read();
+									}
 								}
-								else {
-									read();
+								else{
+									throwLazyInitializationExceptionIfNotConnected();
 								}
 								return false;
 							}


### PR DESCRIPTION
... a similar manner as 4.1.6 when using the default lazy load behavior for collections.  With the changes for HHH-7603 the AbstractPersistentCollection was throwing a NPE instead of a LIE in a very particular case.

Added test that simulates a use case from Hibernate Search 4.1.1 as far as I can tell.
