### PR TITLE
Memory leak fix for PersistentMap introduced at 4.1.7.Final

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
@@ -296,6 +296,7 @@ public class PersistentMap extends AbstractPersistentCollection implements Map {
 			for ( Object[] entry : loadingEntries ) {
 				map.put( entry[0], entry[1] );
 			}
+            loadingEntries = null;
 		}
 		return super.endRead();
 	}


### PR DESCRIPTION
Field  "loadingEntries" is not cleared after read what leads to big useless ArrayLists present in memory. Please see https://github.com/hibernate/hibernate-orm/commit/3e2be6a009e6783c30ad6483ff378770d5105f4b, this commit introduces memory leak.
