### PR TITLE
Fixing HHH-7479 getForUpdateString() of HSQLDialect returns empty string

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -244,7 +244,12 @@ public class HSQLDialect extends Dialect {
 	}
 
 	public String getForUpdateString() {
+		if ( hsqldbVersion >= 20 ) {
+			return " for update";
+		}
+		else {
 		return "";
+		}
 	}
 
 	public boolean supportsUnique() {


### PR DESCRIPTION
The problem here is that HQL Data base didn't support (select for
update) statement in hql version 1.8 but it support it now  (since
version 2.0)
  so i modify  getForUpdate()@HSQLDialect  class and it works now
