### PR TITLE
Envers bugfix hhh 7682

### DIFF
--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/Simple.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/Simple.java
@@ -24,7 +24,6 @@
 package org.hibernate.envers.test.integration.basic;
 
 import java.util.Arrays;
-import java.util.List;
 import javax.persistence.EntityManager;
 
 import org.hibernate.envers.test.AbstractEntityTest;
@@ -33,8 +32,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import org.hibernate.ejb.Ejb3Configuration;
-
-import static org.testng.Assert.assertEquals;
 
 /**
  * @author Adam Warski (adam at warski dot org)
@@ -73,30 +70,5 @@ public class Simple extends AbstractEntityTest {
 
         assert getAuditReader().find(IntTestEntity.class, id1, 1).equals(ver1);
         assert getAuditReader().find(IntTestEntity.class, id1, 2).equals(ver2);
-    }
-
-    @Test
-    public void testAuditRecordsRollback() {
-        // Given
-        EntityManager em = getEntityManager();
-        em.getTransaction().begin();
-        IntTestEntity iteToRollback = new IntTestEntity(30);
-        em.persist(iteToRollback);
-        Integer rollbackedIteId = iteToRollback.getId();
-        em.getTransaction().rollback();
-
-        // When
-        em.getTransaction().begin();
-        IntTestEntity ite2 = new IntTestEntity(50);
-        em.persist(ite2);
-        Integer ite2Id = ite2.getId();
-        em.getTransaction().commit();
-
-        // Then
-        List<Number> revisionsForSavedClass = getAuditReader().getRevisions(IntTestEntity.class, ite2Id);
-        assertEquals(revisionsForSavedClass.size(), 1, "There should be one revision for inserted entity");
-
-        List<Number> revisionsForRolledbackClass = getAuditReader().getRevisions(IntTestEntity.class, rollbackedIteId);
-        assertEquals(revisionsForRolledbackClass.size(), 0, "There should be no revisions for insert that was rolled back");
     }
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/TransactionRollbackBehaviour.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/TransactionRollbackBehaviour.java
@@ -1,0 +1,46 @@
+package org.hibernate.envers.test.integration.basic;
+
+import org.hibernate.ejb.Ejb3Configuration;
+import org.hibernate.envers.test.AbstractEntityTest;
+import org.hibernate.envers.test.entities.IntTestEntity;
+import org.testng.annotations.Test;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Tomasz Dziurko (tdziurko at gmail dot com)
+ */
+public class TransactionRollbackBehaviour  extends AbstractEntityTest {
+
+    public void configure(Ejb3Configuration cfg) {
+        cfg.addAnnotatedClass(IntTestEntity.class);
+    }
+
+    @Test
+    public void testAuditRecordsRollback() {
+        // Given
+        EntityManager em = getEntityManager();
+        em.getTransaction().begin();
+        IntTestEntity iteToRollback = new IntTestEntity(30);
+        em.persist(iteToRollback);
+        Integer rollbackedIteId = iteToRollback.getId();
+        em.getTransaction().rollback();
+
+        // When
+        em.getTransaction().begin();
+        IntTestEntity ite2 = new IntTestEntity(50);
+        em.persist(ite2);
+        Integer ite2Id = ite2.getId();
+        em.getTransaction().commit();
+
+        // Then
+        List<Number> revisionsForSavedClass = getAuditReader().getRevisions(IntTestEntity.class, ite2Id);
+        assertEquals(revisionsForSavedClass.size(), 1, "There should be one revision for inserted entity");
+
+        List<Number> revisionsForRolledbackClass = getAuditReader().getRevisions(IntTestEntity.class, rollbackedIteId);
+        assertEquals(revisionsForRolledbackClass.size(), 0, "There should be no revisions for insert that was rolled back");
+    }
+}


### PR DESCRIPTION
Issue is described on JIRA: https://hibernate.onjira.com/browse/HHH-7682.

Fix contains small modification how AuditProcessManager behaves when EntityManager is reused to start next transaction after previous one was rolled back.
