### PR TITLE
Regression test to check if audit records are rolled back properly. 

### DIFF
--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/TransactionRollbackBehaviour.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/TransactionRollbackBehaviour.java
@@ -1,0 +1,45 @@
+package org.hibernate.envers.test.integration.basic;
+
+import org.hibernate.ejb.Ejb3Configuration;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.entities.IntTestEntity;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+/**
+ * @author Tomasz Dziurko (tdziurko at gmail dot com)
+ */
+public class TransactionRollbackBehaviour extends BaseEnversJPAFunctionalTestCase {
+
+    public void configure(Ejb3Configuration cfg) {
+        cfg.addAnnotatedClass(IntTestEntity.class);
+    }
+
+    @Test
+    public void testAuditRecordsRollback() {
+        // Given
+        EntityManager em = getEntityManager();
+        em.getTransaction().begin();
+        IntTestEntity iteToRollback = new IntTestEntity(30);
+        em.persist(iteToRollback);
+        Integer rollbackedIteId = iteToRollback.getId();
+        em.getTransaction().rollback();
+
+        // When
+        em.getTransaction().begin();
+        IntTestEntity ite2 = new IntTestEntity(50);
+        em.persist(ite2);
+        Integer ite2Id = ite2.getId();
+        em.getTransaction().commit();
+
+        // Then
+        List<Number> revisionsForSavedClass = getAuditReader().getRevisions(IntTestEntity.class, ite2Id);
+        Assert.assertEquals("There should be one revision for inserted entity", 1, revisionsForSavedClass.size());
+
+        List<Number> revisionsForRolledbackClass = getAuditReader().getRevisions(IntTestEntity.class, rollbackedIteId);
+        Assert.assertEquals("There should be one revision for inserted entity", 0, revisionsForRolledbackClass.size());
+    }
+}


### PR DESCRIPTION
This pull request is linked with bug https://hibernate.onjira.com/browse/HHH-7682 which was fixed for Hibernate 3.6  by pull request https://github.com/hibernate/hibernate-orm/pull/393 . 

This test checks if audit records are rolled back correctly when transaction is rolled back. I am requesting to have this pull applied on 4.1 but maybe this test case should be added to H5 development branch.
