### PR TITLE
HHH-7693 Use SQLServer2008Dialect for SQL Server 2012

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolver.java
@@ -133,6 +133,7 @@ public class StandardDialectResolver extends AbstractDialectResolver {
                 case 9:
                     return new SQLServer2005Dialect();
                 case 10:
+                case 11:
                     return new SQLServer2008Dialect();
                 default:
                     LOG.unknownSqlServerVersion(databaseMajorVersion);

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
@@ -1,0 +1,85 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2008, Red Hat Middleware LLC or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Middleware LLC.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ *
+ */
+package org.hibernate.engine.jdbc.dialect.internal;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServer2005Dialect;
+import org.hibernate.dialect.SQLServer2008Dialect;
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test of the {@link StandardDialectResolver} class.
+ *
+ * @author Bryan Turner
+ */
+public class StandardDialectResolverTest extends BaseUnitTestCase {
+
+    @Test
+    public void testResolveDialectInternalForSQLServer2000() throws SQLException {
+        runSQLServerDialectTest(8, SQLServerDialect.class);
+    }
+
+    @Test
+    public void testResolveDialectInternalForSQLServer2005() throws SQLException {
+        runSQLServerDialectTest(9, SQLServer2005Dialect.class);
+    }
+
+    @Test
+    public void testResolveDialectInternalForSQLServer2008() throws SQLException {
+        runSQLServerDialectTest(10, SQLServer2008Dialect.class);
+    }
+
+    @Test
+    public void testResolveDialectInternalForSQLServer2012() throws SQLException {
+        runSQLServerDialectTest(11, SQLServer2008Dialect.class);
+    }
+
+    @Test
+    public void testResolveDialectInternalForUnknownSQLServerVersion() throws SQLException {
+        runSQLServerDialectTest(7, SQLServerDialect.class);
+    }
+
+    private static void runSQLServerDialectTest(int version, Class<? extends SQLServerDialect> expectedDialect)
+            throws SQLException {
+        DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+        when(metaData.getDatabaseProductName()).thenReturn("Microsoft SQL Server");
+        when(metaData.getDatabaseMajorVersion()).thenReturn(version);
+
+        Dialect dialect = new StandardDialectResolver().resolveDialectInternal(metaData);
+        assertNotNull("Dialect for SQL Server version " + version + " should not be null", dialect);
+        assertTrue("Dialect for SQL Server version " + version + " should be " + expectedDialect.getSimpleName(),
+                expectedDialect.isInstance(dialect));
+    }
+}


### PR DESCRIPTION
- Previously, SQL Server version 11 (SQL Server 2012) was an unknown
  version, resulting in the SQLServerDialect
- Added version 11 to the switch statement so that SQLServer2008Dialect
  is now returned by default, as SQL Server 2012 is much more similar
  to SQL Server 2008 than SQL Server 2000
- Added test cases to verify dialects for several SQL Server versions
