### PR TITLE
HHH-7689 Adding Test to illustrate that the batch is still active if it ...

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/IrrelevantEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/IrrelevantEntity.java
@@ -28,6 +28,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.validator.constraints.NotBlank;
 
 /**
  * A testing entity for cases where the entity definition itself is irrelevant (testing JDBC connection semantics, etc).
@@ -50,6 +51,7 @@ public class IrrelevantEntity {
 		this.id = id;
 	}
 
+	@NotBlank
 	public String getName() {
 		return name;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionBatchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionBatchTest.java
@@ -1,0 +1,87 @@
+package org.hibernate.sharedSession;
+
+import junit.framework.Assert;
+import org.hibernate.IrrelevantEntity;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl;
+import org.hibernate.engine.jdbc.batch.internal.BatchingBatch;
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class SessionWithSharedConnectionBatchTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, "20" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { IrrelevantEntity.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-7689" )
+	@FailureExpected( jiraKey = "HHH-7989" )
+	public void testChildSessionAbortsBatchOnFailure() {
+		Session session = openSession();
+		session.getTransaction().begin();
+
+		//open secondary session to insert a valid entity and an invalid entity
+		Session secondSession = session.sessionWithOptions()
+				.connection()
+				.flushBeforeCompletion( true )
+				.autoClose( true )
+				.openSession();
+
+		IrrelevantEntity validIrrelevantEntity = new IrrelevantEntity();
+		validIrrelevantEntity.setName( "valid entity" );
+		secondSession.save( validIrrelevantEntity );
+
+		//name is required
+		IrrelevantEntity invalidIrrelevantEntity = new IrrelevantEntity();
+		secondSession.save( invalidIrrelevantEntity );
+
+		try {
+			secondSession.flush();
+			secondSession.close();
+			Assert.fail( "expected validation failure didn't occur" );
+		}
+		catch (Exception e) {
+			secondSession.close();
+
+			try {
+				//at this point the transaction is still active but the batch should have been aborted (have to use reflection to get at the field)
+				Field field = ( ( SessionImplementor ) session ).getTransactionCoordinator().getJdbcCoordinator().getClass().getDeclaredField( "currentBatch" );
+				field.setAccessible( true );
+				Batch batch = ( Batch ) field.get( ( ( SessionImplementor ) session ).getTransactionCoordinator().getJdbcCoordinator() );
+				if ( batch == null ) {
+					throw new Exception( "Current batch was null" );
+				}
+				else {
+					//make sure it's actually a batching impl
+					Assert.assertEquals( BatchingBatch.class, batch.getClass() );
+					field = AbstractBatchImpl.class.getDeclaredField( "statements" );
+					field.setAccessible( true );
+					//check to see that there aren't any statements queued up (this can be an issue if using SavePoints)
+					Assert.assertEquals( 0, ( ( Map ) field.get( batch ) ).size() );
+				}
+			}
+			catch (Exception fieldException) {
+				Assert.fail( "Couldn't inspect field " + fieldException.getMessage() );
+			}
+		}
+		finally {
+			session.getTransaction().rollback();
+			session.close();
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/sharedSession/SessionWithSharedConnectionTest.java
@@ -27,7 +27,6 @@ import org.hibernate.engine.transaction.internal.TransactionCoordinatorImpl;
 import org.hibernate.engine.transaction.spi.TransactionCoordinator;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.*;
-import org.hibernate.testing.FailureExpected;
 import org.junit.Test;
 
 import org.hibernate.IrrelevantEntity;
@@ -173,7 +172,9 @@ public class SessionWithSharedConnectionTest extends BaseCoreFunctionalTestCase 
 		assertTrue( ((TransactionContext) secondSession).isFlushBeforeCompletionEnabled() );
 
 		// now try it out
-		Integer id = (Integer) secondSession.save( new IrrelevantEntity() );
+		final IrrelevantEntity irrelevantEntity = new IrrelevantEntity();
+		irrelevantEntity.setName("testing flush");
+		Integer id = (Integer) secondSession.save( irrelevantEntity );
 		session.getTransaction().commit();
 		assertFalse( ((SessionImplementor) session).isClosed() );
 		assertTrue( ((SessionImplementor) secondSession).isClosed() );


### PR DESCRIPTION
...encounters a failure.  Modified IrrelevantEntity so that the name is required in order to trigger a validation exception.
