### PR TITLE
HHH-7825 DataHelper is incompatible with FireBird JDBC

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
@@ -30,6 +30,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.sql.Clob;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 
 import org.jboss.logging.Logger;
 
@@ -275,7 +276,12 @@ public class DataHelper {
 	public static String extractString(final Clob value) {
 		try {
 			Reader characterStream = value.getCharacterStream();
-			long length = value.length();
+			long length;
+                        try {
+                          length = value.length();
+                        } catch (SQLFeatureNotSupportedException unsupEx) {
+                          length = BUFFER_SIZE;
+                        }
 			if ( length > Integer.MAX_VALUE ) {
 				return extractString( characterStream, Integer.MAX_VALUE );
 			}


### PR DESCRIPTION
HHH-7825 org.hibernate.type.descriptor.java.DataHelper is incompatible with FireBird JDBC
