### PR TITLE
HHH-7029 - prependListeners changed to appendListeners in chapter 7.9.1....

### DIFF
--- a/documentation/src/main/docbook/devguide/en-US/chapters/services/extras/register-event-listeners-example.java
+++ b/documentation/src/main/docbook/devguide/en-US/chapters/services/extras/register-event-listeners-example.java
@@ -18,6 +18,6 @@ public class MyIntegrator implements org.hibernate.integrator.spi.Integrator {
         //     2) This form adds the specified listener(s) to the beginning of the listener chain
         eventListenerRegistry.prependListeners( EventType.AUTO_FLUSH, myListenersToBeCalledFirst );
         //     3) This form adds the specified listener(s) to the end of the listener chain
-        eventListenerRegistry.prependListeners( EventType.AUTO_FLUSH, myListenersToBeCalledLast );
+        eventListenerRegistry.appendListeners( EventType.AUTO_FLUSH, myListenersToBeCalledLast );
     }
 }


### PR DESCRIPTION
Title: Javadoc says the opposite as in code example
Link: https://hibernate.onjira.com/browse/HHH-7029

The last line of the example in chapter 7.9.1 (devguide) is wrong. The comment is saying the listener should be added at the end, but the code is adding it at the first. 

I have changed the prependListners to appendListeners in the example.
