### PR TITLE
HHH-8110 Wrong resolving entity name for AnyType#toLoggableString

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.hibernate.CustomEntityDirtinessStrategy;
+import org.hibernate.EntityNameResolver;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MappingException;
@@ -188,6 +189,13 @@ public interface SessionFactoryImplementor extends Mapping, SessionFactory {
 	 * Statistics SPI
 	 */
 	public StatisticsImplementor getStatisticsImplementor();
+	
+	/**
+	 * Get entity-name resolver
+	 * 
+	 * @return entity-name resolver
+	 */
+	public EntityNameResolver getEntityNameResolver();
 
 	public NamedQueryDefinition getNamedQuery(String queryName);
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -191,7 +191,7 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 	private transient StatefulPersistenceContext persistenceContext;
 	private transient TransactionCoordinatorImpl transactionCoordinator;
 	private transient Interceptor interceptor;
-	private transient EntityNameResolver entityNameResolver = new CoordinatingEntityNameResolver();
+	private transient EntityNameResolver entityNameResolver;
 
 	private transient ConnectionReleaseMode connectionReleaseMode;
 	private transient FlushMode flushMode = FlushMode.AUTO;
@@ -241,6 +241,7 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 		this.timestamp = timestamp;
 		this.sessionOwner = sessionOwner;
 		this.interceptor = interceptor == null ? EmptyInterceptor.INSTANCE : interceptor;
+		this.entityNameResolver = interceptor == null ? factory.getEntityNameResolver() : new SessionEntityNameResolver();
 		this.actionQueue = new ActionQueue( this );
 		this.persistenceContext = new StatefulPersistenceContext( this );
 
@@ -2099,8 +2100,6 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 
 		ois.defaultReadObject();
 
-		entityNameResolver = new CoordinatingEntityNameResolver();
-
 		connectionReleaseMode = ConnectionReleaseMode.parse( ( String ) ois.readObject() );
 		autoClear = ois.readBoolean();
 		autoJoinTransactions = ois.readBoolean();
@@ -2119,6 +2118,8 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 		actionQueue = ActionQueue.deserialize( ois, this );
 
 		loadQueryInfluencers = (LoadQueryInfluencers) ois.readObject();
+		
+		entityNameResolver = EmptyInterceptor.class.isInstance(interceptor) ? factory.getEntityNameResolver() : new SessionEntityNameResolver();
 
 		// LoadQueryInfluencers.getEnabledFilters() tries to validate each enabled
 		// filter, which will fail when called before FilterImpl.afterDeserialize( factory );
@@ -2322,28 +2323,16 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 		}
 	}
 
-	private class CoordinatingEntityNameResolver implements EntityNameResolver {
-		public String resolveEntityName(Object entity) {
-			String entityName = interceptor.getEntityName( entity );
-			if ( entityName != null ) {
-				return entityName;
-			}
+    private class SessionEntityNameResolver implements EntityNameResolver {
+        public String resolveEntityName(Object entity) {
+            String entityName = interceptor.getEntityName( entity );
+            if ( entityName != null ) {
+                return entityName;
+            }
+            return factory.getEntityNameResolver().resolveEntityName(entity);
+        }
+    }
 
-			for ( EntityNameResolver resolver : factory.iterateEntityNameResolvers() ) {
-				entityName = resolver.resolveEntityName( entity );
-				if ( entityName != null ) {
-					break;
-				}
-			}
-
-			if ( entityName != null ) {
-				return entityName;
-			}
-
-			// the old-time stand-by...
-			return entity.getClass().getName();
-		}
-	}
 
 	private class LockRequestImpl implements LockRequest {
 		private final LockOptions lockOptions;

--- a/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
@@ -198,12 +198,11 @@ public class AnyType extends AbstractType implements CompositeType, AssociationT
 
 	public String toLoggableString(Object value, SessionFactoryImplementor factory) 
 	throws HibernateException {
-		//TODO: terrible implementation!
-		return value == null
-				? "null"
-				: factory.getTypeHelper()
-						.entity( HibernateProxyHelper.getClassWithoutInitializingProxy( value ) )
-						.toLoggableString( value, factory );
+	    if (value == null) {
+	        return "null";
+	    }
+	    String entityName = factory.getEntityNameResolver().resolveEntityName(value);
+	    return factory.getTypeHelper().entity(entityName).toLoggableString(value, factory);
 	}
 
 	public Object fromXMLNode(Node xml, Mapping factory) throws HibernateException {

--- a/hibernate-core/src/test/java/org/hibernate/test/any/AnyTypeEntityNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/any/AnyTypeEntityNameTest.java
@@ -1,0 +1,93 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.any;
+
+import junit.framework.Assert;
+
+import org.hibernate.Session;
+import org.hibernate.internal.util.EntityPrinter;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Nikolay Shestakov
+ */
+public class AnyTypeEntityNameTest extends BaseCoreFunctionalTestCase {
+    @Override
+    public String[] getMappings() {
+        return new String[] { "any/DBObject.hbm.xml" };
+    }
+
+    @Override
+    public String getCacheConcurrencyStrategy() {
+        // having second level cache causes a condition whereby the original test case would not fail...
+        return null;
+    }
+
+    @Test
+    public void testToLoggableString() {
+        Session session = openSession();
+        session.beginTransaction();
+        DBObject obj1 = new DBObject("dbobject1");
+        DBObjectReference ref = new DBObjectReference();
+        ref.setRef(obj1);
+        session.saveOrUpdate("dbobject1", obj1);
+        session.saveOrUpdate(ref);
+        session.getTransaction().commit();
+        session.close();
+
+        session = openSession();
+        session.beginTransaction();
+        ref = (DBObjectReference) session.load(DBObjectReference.class, ref.getId());
+        String str = new EntityPrinter(sessionFactory()).toString(DBObjectReference.class.getName(), ref);
+        Assert.assertEquals("org.hibernate.test.any.DBObjectReference{id=1, ref=dbobject1#1}", str);
+        session.getTransaction().commit();
+        session.close();
+
+        session = openSession();
+        session.beginTransaction();
+        ref = (DBObjectReference) session.load(DBObjectReference.class, ref.getId());
+        DBObject obj2 = new DBObject("dbobject2");
+        ref.setRef(obj2);
+        session.saveOrUpdate("dbobject2", obj2);
+        session.getTransaction().commit();
+        session.close();
+
+        session = openSession();
+        session.beginTransaction();
+        ref = (DBObjectReference) session.load(DBObjectReference.class, ref.getId());
+        str = new EntityPrinter(sessionFactory()).toString(DBObjectReference.class.getName(), ref);
+        Assert.assertEquals("org.hibernate.test.any.DBObjectReference{id=1, ref=dbobject2#1}", str);
+        session.getTransaction().commit();
+        session.close();
+
+        session = openSession();
+        session.beginTransaction();
+        session.delete(ref);
+        session.delete("dbobject1", obj1);
+        session.delete("dbobject2", obj2);
+        session.getTransaction().commit();
+        session.close();
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/any/DBObject.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/any/DBObject.hbm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+      "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+          "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.test.any">
+
+    <class entity-name="dbobject1" name="DBObject" table="T_ANY_DBOBJECT1" >
+        <tuplizer class="org.hibernate.test.any.DBObjectTuplizer"/>
+        <id name="id" column="ID_">
+            <generator class="increment" />
+        </id>
+        <property name="entityName" formula="'dbobject1'" />
+    </class>
+
+    <class entity-name="dbobject2" name="DBObject" table="T_ANY_DBOBJECT2" >
+        <tuplizer class="org.hibernate.test.any.DBObjectTuplizer"/>
+        <id name="id" column="ID_">
+            <generator class="increment" />
+        </id>
+        <property name="entityName" formula="'dbobject2'" />
+    </class>
+    
+    <class name="DBObjectReference" table="T_ANY_DBOBJECTREFERENCE">
+        <id name="id" column="ID_">
+            <generator class="increment" />
+        </id>
+        <any name="ref" id-type="long" cascade="none">
+            <meta-value value="1" class="dbobject1"/>
+            <meta-value value="2" class="dbobject2"/>
+            <column name="DATATYPE_"/>
+            <column name="DATAID_"/>
+        </any>
+    </class>
+
+ </hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/test/any/DBObject.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/any/DBObject.java
@@ -1,0 +1,34 @@
+package org.hibernate.test.any;
+
+/**
+ * Java-class mapped as two entity
+ * 
+ * @author Nikolay Shestakov
+ */
+public class DBObject {
+    private Long   id;
+    private String entityName;
+
+    public DBObject() {
+    }
+
+    public DBObject(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/any/DBObjectReference.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/any/DBObjectReference.java
@@ -1,0 +1,27 @@
+package org.hibernate.test.any;
+
+/**
+ * Entity with any to java class mapped as two entity 
+ * 
+ * @author Nikolay Shestakov
+ */
+public class DBObjectReference {
+    private Long     id;
+    private DBObject ref;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public DBObject getRef() {
+        return ref;
+    }
+
+    public void setRef(DBObject ref) {
+        this.ref = ref;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/any/DBObjectTuplizer.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/any/DBObjectTuplizer.java
@@ -1,0 +1,38 @@
+package org.hibernate.test.any;
+
+import org.hibernate.EntityNameResolver;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.metamodel.binding.EntityBinding;
+import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.tuple.entity.PojoEntityTuplizer;
+
+/**
+ * Tuplizer for {@link DBObject}
+ * 
+ * @author Nikolay Shestakov
+ */
+public class DBObjectTuplizer extends PojoEntityTuplizer {
+
+    private static class DBObjectEntityNameResolver implements EntityNameResolver {
+        @Override
+        public String resolveEntityName(Object entity) {
+            if (entity instanceof DBObject) {
+                return ((DBObject) entity).getEntityName();
+            }
+            return null;
+        }
+    }
+
+    public DBObjectTuplizer(EntityMetamodel entityMetamodel, EntityBinding mappedEntity) {
+        super(entityMetamodel, mappedEntity);
+    }
+
+    public DBObjectTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
+        super(entityMetamodel, mappedEntity);
+    }
+
+    @Override
+    public EntityNameResolver[] getEntityNameResolvers() {
+        return new EntityNameResolver[] { new DBObjectEntityNameResolver() };
+    }
+}


### PR DESCRIPTION
If many entities mapped to one java class then AnyType#toLoggableString is throws NPE

I append SessionFactoryImplimentator#getEntityNameResolver and i move CoordinatingEntityNameResolver from SessionImpl to SessionFactoryImpl. If session have own interceptor then SessionImpl#guessEntityName resolv entity-name use interceptor first and SessionFactoryImplimentator#getEntityNameResolver after.
