### PR TITLE
HHH-7918 - Merging ModWorkUnits ended with incorrect values of modified flags

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/AuditMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/AuditMetadataGenerator.java
@@ -427,7 +427,7 @@ public final class AuditMetadataGenerator {
 			ExtendedPropertyMapper propertyMapper = null;
 			String parentEntityName = null;
 			EntityConfiguration entityCfg = new EntityConfiguration(entityName, pc.getClassName(), idMapper, propertyMapper,
-					parentEntityName, auditingData.isUsingModifiedFlag());
+					parentEntityName);
 			notAuditedEntitiesConfigurations.put(entityName, entityCfg);
 			return;
 		}
@@ -501,7 +501,7 @@ public final class AuditMetadataGenerator {
 
         // Storing the generated configuration
         EntityConfiguration entityCfg = new EntityConfiguration(auditEntityName, pc.getClassName(), idMapper,
-                propertyMapper, parentEntityName, auditingData.isUsingModifiedFlag());
+                propertyMapper, parentEntityName);
         entitiesConfigurations.put(pc.getEntityName(), entityCfg);
     }
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/reader/ClassAuditingData.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/metadata/reader/ClassAuditingData.java
@@ -85,18 +85,6 @@ public class ClassAuditingData implements AuditedPropertiesHolder {
 	public boolean isAudited() {
         return defaultAudited || properties.size() > 0;
     }
-
-	/**
-	 * @return {@code true} if any of the properties has modification flag enabled, {@code false} otherwise.
-	 */
-	public boolean isUsingModifiedFlag() {
-		for ( PropertyAuditingData prop : properties.values() ) {
-			if ( prop.isUsingModifiedFlag() ) {
-				return true;
-			}
-		}
-		return false;
-	}
 	
 	public boolean contains(String propertyName) {
 		return properties.containsKey(propertyName);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/entities/EntityConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/entities/EntityConfiguration.java
@@ -42,16 +42,14 @@ public class EntityConfiguration {
     // Maps from property name
     private Map<String, RelationDescription> relations;
     private String parentEntityName;
-    private boolean usingModifiedFlag;
 
     public EntityConfiguration(String versionsEntityName, String entityClassName, IdMappingData idMappingData,
-                               ExtendedPropertyMapper propertyMapper, String parentEntityName, boolean usingModifiedFlag) {
+                               ExtendedPropertyMapper propertyMapper, String parentEntityName) {
         this.versionsEntityName = versionsEntityName;
         this.entityClassName = entityClassName;
         this.idMappingData = idMappingData;
         this.propertyMapper = propertyMapper;
         this.parentEntityName = parentEntityName;
-        this.usingModifiedFlag = usingModifiedFlag;
 
         this.relations = new HashMap<String, RelationDescription>();
     }
@@ -124,12 +122,5 @@ public class EntityConfiguration {
      */
     public String getEntityClassName() {
 		return entityClassName;
-	}
-
-	/**
-	 * @return {@code true} if the entity or any of its properties use modification flag, {@code false} otherwise.
-	 */
-	public boolean isUsingModifiedFlag() {
-		return usingModifiedFlag;
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/synchronization/work/ModWorkUnit.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/synchronization/work/ModWorkUnit.java
@@ -74,15 +74,12 @@ public class ModWorkUnit extends AbstractAuditWorkUnit implements AuditWorkUnit 
     }
 
     public AuditWorkUnit merge(ModWorkUnit second) {
-        if ( verCfg.getEntCfg().get( getEntityName() ).isUsingModifiedFlag() ) {
-            // In case of multiple subsequent flushes within single transaction, modification flags need to be
-            // recalculated against initial and final state of the given entity.
-            return new ModWorkUnit(
-                    second.sessionImplementor, second.getEntityName(), second.verCfg, second.id,
-                    second.entityPersister, second.newState, this.oldState
-            );
-        }
-        return second;
+        // In case of multiple subsequent flushes within single transaction, modification flags need to be
+        // recalculated against initial and final state of the given entity.
+        return new ModWorkUnit(
+                second.sessionImplementor, second.getEntityName(), second.verCfg, second.id,
+                second.entityPersister, second.newState, this.oldState
+        );
     }
 
     public AuditWorkUnit merge(DelWorkUnit second) {


### PR DESCRIPTION
Patch for HHH-7918 JIRA ticket.
Link: https://hibernate.onjira.com/browse/HHH-7918

@mskowron, @adamw: Please review. I know that we could just alter `data` variable in the second `ModWorkUnit` while merging, but thought that creating new object would be a cleaner way.

Regards,
Lukasz Antoniak
