### PR TITLE
HHH-7520 - Small fix in javadoc for BlobProxy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/BlobProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/BlobProxy.java
@@ -90,8 +90,8 @@ public class BlobProxy implements InvocationHandler {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws UnsupportedOperationException if any methods other than {@link Blob#length()}
-	 * or {@link Blob#getBinaryStream} are invoked.
+	 * @throws UnsupportedOperationException if any methods other than {@link Blob#length}
+	 * , {@link Blob#getBinaryStream}, {@link Blob#getBytes} or {@link Blob#free} are invoked.
 	 */
 	@Override
 	@SuppressWarnings({ "UnnecessaryBoxing" })


### PR DESCRIPTION
Javadoc says that only length() and getBinaryStream() are supported.
Implementation is that getBytes() and free() are also supported.

Did some changes in BlobProxy.java
