### PR TITLE
HHH-4084 @UniqueConstraint(columnNames="") causes StringIndexOutOfBoundsException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -1541,8 +1541,7 @@ public class Configuration implements Serializable {
 		Set<Column> unboundNoLogical = new HashSet<Column>();
 		for ( int index = 0; index < size; index++ ) {
 			String column = columnNames[index];
-			boolean columnNameValid = !StringHelper.isEmpty(column);
-			final String logicalColumnName = columnNameValid ? normalizer.normalizeIdentifierQuoting( column ) : "";
+			final String logicalColumnName = StringHelper.isNotEmpty( column ) ? normalizer.normalizeIdentifierQuoting( column ) : "";
 			try {
 				final String columnName = createMappings().getPhysicalColumnName( logicalColumnName, table );
 				columns[index] = new Column( columnName );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -84,7 +84,7 @@ public class Column implements Selectable, Serializable, Cloneable {
 	}
 	public void setName(String name) {
 		if (
-			!name.isEmpty() &&
+			StringHelper.isNotEmpty( name ) &&
 			Dialect.QUOTE.indexOf( name.charAt(0) ) > -1 //TODO: deprecated, remove eventually
 		) {
 			quoted=true;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintValidationTest.java
@@ -15,6 +15,10 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
 
+/**
+ * @author Nikolay Shestakov
+ *
+ */
 public class UniqueConstraintValidationTest extends BaseUnitTestCase {
 
 	@Test(expected = AnnotationException.class)


### PR DESCRIPTION
new version of https://github.com/hibernate/hibernate-orm/pull/447

if column name is empty than throw AnnotationException (likewise column isn't exists).
