### PR TITLE
HHH-7952 Typo in Javadoc For TableGenerator/TableHiLoGenerator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/TableGenerator.java
@@ -73,7 +73,7 @@ import org.hibernate.type.Type;
  * @see TableHiLoGenerator
  * @author Gavin King
  * 
- * @deprecate use {@link SequenceStyleGenerator} instead.
+ * @deprecated use {@link SequenceStyleGenerator} instead.
  */
 @Deprecated
 public class TableGenerator implements PersistentIdentifierGenerator, Configurable {

--- a/hibernate-core/src/main/java/org/hibernate/id/TableHiLoGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/TableHiLoGenerator.java
@@ -49,7 +49,7 @@ import org.hibernate.type.Type;
  * @see SequenceHiLoGenerator
  * @author Gavin King
  * 
- * @deprecate use {@link SequenceStyleGenerator} instead.
+ * @deprecated use {@link SequenceStyleGenerator} instead.
  */
 @Deprecated 
 public class TableHiLoGenerator extends TableGenerator {


### PR DESCRIPTION
Jira: https://hibernate.onjira.com/browse/HHH-7952

Typo in TableGenerator/TableHiLoGenerator.
