### PR TITLE
HHH-4412 NativeNamedQuery

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/QueryBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/QueryBinder.java
@@ -158,7 +158,17 @@ public abstract class QueryBinder {
 					.createNamedQueryDefinition();
 		}
 		else {
-			throw new NotYetImplementedException( "Pure native scalar queries are not yet supported" );
+			query = new NamedSQLQueryDefinitionBuilder( queryAnn.name() ).setQuery( queryName )
+					.setQueryReturns( new NativeSQLQueryReturn[0] ).setQuerySpaces( null )
+					.setCacheable( getBoolean( queryName, "org.hibernate.cacheable", hints ) )
+					.setCacheRegion( getString( queryName, "org.hibernate.cacheRegion", hints ) )
+					.setTimeout( getTimeout( queryName, hints ) )
+					.setFetchSize( getInteger( queryName, "org.hibernate.fetchSize", hints ) )
+					.setFlushMode( getFlushMode( queryName, hints ) ).setCacheMode( getCacheMode( queryName, hints ) )
+					.setReadOnly( getBoolean( queryName, "org.hibernate.readOnly", hints ) )
+					.setComment( getString( queryName, "org.hibernate.comment", hints ) ).setParameterTypes( null )
+					.setCallable( getBoolean( queryName, "org.hibernate.callable", hints ) )
+					.createNamedQueryDefinition();
 		}
 		if ( isDefault ) {
 			mappings.addDefaultSQLQuery( query.getName(), query );

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/DestinationEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/DestinationEntity.java
@@ -1,0 +1,79 @@
+package org.hibernate.test.jpa.ql;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.Table;
+
+/**
+ * @author Janario Oliveira
+ */
+@Entity
+@Table(name = "destination_entity")
+@NamedNativeQueries({
+		@NamedNativeQuery(name = "DestinationEntity.insertSelect", query = "insert into destination_entity(id, from_id, fullNameFrom) "
+				+ " select fe.id, fe.id, fe.name||fe.lastName from from_entity fe where fe.id in (:ids)"),
+		@NamedNativeQuery(name = "DestinationEntity.insert", query = "insert into destination_entity(id, from_id, fullNameFrom) "
+				+ "values (:generatedId, :fromId, :fullName)"),
+		@NamedNativeQuery(name = "DestinationEntity.update", query = "update destination_entity set from_id=:idFrom, fullNameFrom=:fullName"
+				+ " where id in (:ids)"),
+		@NamedNativeQuery(name = "DestinationEntity.delete", query = "delete destination_entity where id in (:ids)"),
+		@NamedNativeQuery(name = "DestinationEntity.selectIds", query = "select id, from_id, fullNameFrom from destination_entity where id in (:ids)") })
+public class DestinationEntity {
+
+	@Id
+	@GeneratedValue
+	Integer id;
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "from_id")
+	FromEntity from;
+	@Column(nullable = false)
+	String fullNameFrom;
+
+	public DestinationEntity() {
+	}
+
+	public DestinationEntity(FromEntity from, String fullNameFrom) {
+		this.from = from;
+		this.fullNameFrom = fullNameFrom;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( from == null ) ? 0 : from.hashCode() );
+		result = prime * result + ( ( fullNameFrom == null ) ? 0 : fullNameFrom.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj )
+			return true;
+		if ( obj == null )
+			return false;
+		if ( getClass() != obj.getClass() )
+			return false;
+		DestinationEntity other = (DestinationEntity) obj;
+		if ( from == null ) {
+			if ( other.from != null )
+				return false;
+		}
+		else if ( !from.equals( other.from ) )
+			return false;
+		if ( fullNameFrom == null ) {
+			if ( other.fullNameFrom != null )
+				return false;
+		}
+		else if ( !fullNameFrom.equals( other.fullNameFrom ) )
+			return false;
+		return true;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/FromEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/FromEntity.java
@@ -1,0 +1,57 @@
+package org.hibernate.test.jpa.ql;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author Janario Oliveira
+ */
+@Entity
+@Table(name = "from_entity")
+public class FromEntity {
+
+	@Id
+	@GeneratedValue
+	Integer id;
+	@Column(nullable = false)
+	String name;
+	@Column(nullable = false)
+	String lastName;
+
+	public FromEntity() {
+	}
+
+	public FromEntity(String name, String lastName) {
+		this.name = name;
+		this.lastName = lastName;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 5;
+		hash = 53 * hash + ( this.name != null ? this.name.hashCode() : 0 );
+		hash = 53 * hash + ( this.lastName != null ? this.lastName.hashCode() : 0 );
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		final FromEntity other = (FromEntity) obj;
+		if ( ( this.name == null ) ? ( other.name != null ) : !this.name.equals( other.name ) ) {
+			return false;
+		}
+		if ( ( this.lastName == null ) ? ( other.lastName != null ) : !this.lastName.equals( other.lastName ) ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/NamedNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/NamedNativeQueryTest.java
@@ -1,0 +1,295 @@
+package org.hibernate.test.jpa.ql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Janario Oliveira
+ */
+public class NamedNativeQueryTest extends BaseCoreFunctionalTestCase {
+
+	private FromEntity createFrom(String name, String lastName) {
+		Session session = openSession();
+		session.getTransaction().begin();
+		FromEntity fromEntity = new FromEntity( name, lastName );
+		session.save( fromEntity );
+		session.getTransaction().commit();
+		session.close();
+		return fromEntity;
+	}
+
+	private DestinationEntity createDestination(FromEntity fromEntity, String fullName) {
+		final DestinationEntity destinationEntity = new DestinationEntity( fromEntity, fullName );
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		session.save( destinationEntity );
+		session.getTransaction().commit();
+		session.close();
+		return destinationEntity;
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<DestinationEntity> findDestinationByIds(List<Integer> ids) {
+		Session session = openSession();
+		List<DestinationEntity> list = session
+				.createQuery( "from DestinationEntity de where de.id in (:ids) order by id" )
+				.setParameterList( "ids", ids ).list();
+		session.close();
+		return list;
+	}
+
+	@Test
+	public void testSingleSelect() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final String fullName = name + " " + lastName;
+		final DestinationEntity destination = createDestination( createFrom( name, lastName ), fullName );
+
+		Session session = openSession();
+		Query select = session.getNamedQuery( "DestinationEntity.selectIds" );
+		select.setParameterList( "ids", Collections.singletonList( destination.id ) );
+		Object[] unique = (Object[]) select.uniqueResult();
+		session.close();
+
+		assertEquals( destination.id, unique[0] );
+		assertEquals( destination.from.id, unique[1] );
+		assertEquals( destination.fullNameFrom, unique[2] );
+	}
+
+	@Test
+	public void testMultipleSelect() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final List<Integer> ids = new ArrayList<Integer>();
+		final int quantity = 10;
+		final List<DestinationEntity> destinations = new ArrayList<DestinationEntity>();
+		for ( int i = 0; i < quantity; i++ ) {
+			DestinationEntity createDestination = createDestination( createFrom( name + i, lastName + i ), name + i
+					+ lastName + i );
+			ids.add( createDestination.id );
+			destinations.add( createDestination );
+		}
+
+		Session session = openSession();
+		Query select = session.getNamedQuery( "DestinationEntity.selectIds" );
+		select.setParameterList( "ids", ids );
+		List list = select.list();
+		session.close();
+
+		assertEquals( quantity, list.size() );
+		for ( int i = 0; i < list.size(); i++ ) {
+			Object[] object = (Object[]) list.get( i );
+			DestinationEntity destination = destinations.get( i );
+			assertEquals( destination.id, object[0] );
+			assertEquals( destination.from.id, object[1] );
+			assertEquals( destination.fullNameFrom, object[2] );
+		}
+	}
+
+	@Test
+	public void testInsertSingleValue() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final String fullName = name + " " + lastName;
+		final FromEntity fromEntity = createFrom( name, lastName );
+		final int id = 10000;// id fake
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query insert = session.getNamedQuery( "DestinationEntity.insert" );
+		insert.setParameter( "generatedId", id );
+		insert.setParameter( "fromId", fromEntity.id );
+		insert.setParameter( "fullName", fullName );
+		int executeUpdate = insert.executeUpdate();
+		assertEquals( 1, executeUpdate );
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+		DestinationEntity get = (DestinationEntity) session.get( DestinationEntity.class, id );
+		session.close();
+
+		assertEquals( fromEntity, get.from );
+		assertEquals( fullName, get.fullNameFrom );
+	}
+
+	@Test
+	public void testInsertMultipleValues() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final List<Integer> ids = new ArrayList<Integer>();
+		final int quantity = 10;
+		final List<FromEntity> froms = new ArrayList<FromEntity>();
+		for ( int i = 0; i < quantity; i++ ) {
+			FromEntity fe = createFrom( name + i, lastName + i );
+			froms.add( fe );
+			ids.add( fe.id );
+		}
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query insertSelect = session.getNamedQuery( "DestinationEntity.insertSelect" );
+		insertSelect.setParameterList( "ids", ids );
+		int executeUpdate = insertSelect.executeUpdate();
+		assertEquals( quantity, executeUpdate );
+
+		session.getTransaction().commit();
+		session.close();
+
+		List<DestinationEntity> list = findDestinationByIds( ids );
+		assertEquals( quantity, list.size() );
+
+		for ( int i = 0; i < quantity; i++ ) {
+			DestinationEntity de = (DestinationEntity) list.get( i );
+			FromEntity from = froms.get( i );
+			assertEquals( from, de.from );
+			assertEquals( from.name + from.lastName, de.fullNameFrom );
+		}
+	}
+
+	@Test
+	public void testUpdateSingleValue() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final String fullName = name + " " + lastName;
+
+		final FromEntity fromEntity = createFrom( name, lastName );
+		final DestinationEntity destinationEntity = createDestination( fromEntity, fullName );
+
+		final String inverseFullName = lastName + " " + name;
+		final FromEntity anotherFrom = createFrom( lastName, name );
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query update = session.getNamedQuery( "DestinationEntity.update" );
+		update.setParameter( "idFrom", anotherFrom.id );
+		update.setParameter( "fullName", inverseFullName );
+		update.setParameterList( "ids", Collections.singletonList( destinationEntity.id ) );
+
+		int executeUpdate = update.executeUpdate();
+		assertEquals( 1, executeUpdate );
+
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+		DestinationEntity get = (DestinationEntity) session.get( DestinationEntity.class, destinationEntity.id );
+
+		assertEquals( anotherFrom, get.from );
+		assertEquals( inverseFullName, get.fullNameFrom );
+		session.close();
+	}
+
+	@Test
+	public void testUpdateMultipleValues() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final List<Integer> ids = new ArrayList<Integer>();
+		final int quantity = 10;
+		final List<DestinationEntity> destinations = new ArrayList<DestinationEntity>();
+		for ( int i = 0; i < quantity; i++ ) {
+			FromEntity fe = createFrom( name + i, lastName + i );
+			DestinationEntity destination = createDestination( fe, fe.name + fe.lastName );
+			destinations.add( destination );
+			ids.add( destination.id );
+		}
+
+		final String inverseFullName = lastName + " " + name;
+		final FromEntity anotherFrom = createFrom( lastName, name );
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query update = session.getNamedQuery( "DestinationEntity.update" );
+		update.setParameter( "idFrom", anotherFrom.id );
+		update.setParameter( "fullName", inverseFullName );
+		update.setParameterList( "ids", ids );
+
+		int executeUpdate = update.executeUpdate();
+		assertEquals( quantity, executeUpdate );
+
+		session.getTransaction().commit();
+		session.close();
+
+		List<DestinationEntity> list = findDestinationByIds( ids );
+		assertEquals( quantity, list.size() );
+
+		for ( int i = 0; i < quantity; i++ ) {
+			DestinationEntity updated = (DestinationEntity) list.get( i );
+
+			assertEquals( anotherFrom, updated.from );
+			assertEquals( inverseFullName, updated.fullNameFrom );
+		}
+	}
+
+	@Test
+	public void testDeleteSingleValue() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final String fullName = name + " " + lastName;
+
+		final FromEntity fromEntity = createFrom( name, lastName );
+		final DestinationEntity destinationEntity = createDestination( fromEntity, fullName );
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query delete = session.getNamedQuery( "DestinationEntity.delete" );
+		delete.setParameterList( "ids", Collections.singletonList( destinationEntity.id ) );
+
+		int executeUpdate = delete.executeUpdate();
+		assertEquals( 1, executeUpdate );
+
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+		DestinationEntity get = (DestinationEntity) session.get( DestinationEntity.class, destinationEntity.id );
+		session.close();
+
+		assertNull( get );
+	}
+
+	@Test
+	public void testDeleteMultipleValues() {
+		final String name = "Name";
+		final String lastName = "LastName";
+		final List<Integer> ids = new ArrayList<Integer>();
+		final int quantity = 10;
+		final List<DestinationEntity> destinations = new ArrayList<DestinationEntity>();
+		for ( int i = 0; i < quantity; i++ ) {
+			FromEntity fe = createFrom( name + i, lastName + i );
+			DestinationEntity destination = createDestination( fe, fe.name + fe.lastName );
+			destinations.add( destination );
+			ids.add( destination.id );
+		}
+
+		Session session = openSession();
+		session.getTransaction().begin();
+		Query delete = session.getNamedQuery( "DestinationEntity.delete" );
+		delete.setParameterList( "ids", ids );
+
+		int executeUpdate = delete.executeUpdate();
+		assertEquals( quantity, executeUpdate );
+
+		session.getTransaction().commit();
+		session.close();
+
+		List<DestinationEntity> list = findDestinationByIds( ids );
+		assertTrue( list.isEmpty() );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { FromEntity.class, DestinationEntity.class };
+	}
+}


### PR DESCRIPTION
Allowed to create native named query with bulk operations(insert, update, delete)
Attached a test case, NamedNativeQueryTest, that tests:
-insert/insert select
-updates(single and multiple values)
-deletes(single and multiple values)
-select as array object(single and multiple values)

As I talked in pull request 458 with @sebersole 
I'm sending this pull request to issue HHH-4412 separeted from the others once they need to be sent in other branch
https://github.com/hibernate/hibernate-orm/pull/458

I'm going to see the others.
Thanks.
