### PR TITLE
HHH-7984 - Oracle callable statement closing

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -370,14 +370,15 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 	}
 
 	@Override
-	public void register(ResultSet resultSet) {
+	public void register(ResultSet resultSet, Statement statement) {
 		LOG.tracev( "Registering result set [{0}]", resultSet );
-		Statement statement;
-		try {
-			statement = resultSet.getStatement();
-		}
-		catch ( SQLException e ) {
-			throw exceptionHelper.convert( e, "unable to access statement from resultset" );
+		if ( statement == null ) {
+			try {
+				statement = resultSet.getStatement(); // best guess
+			}
+			catch ( SQLException e ) {
+				throw exceptionHelper.convert( e, "unable to access statement from resultset" );
+			}
 		}
 		if ( statement != null ) {
 			if ( LOG.isEnabled( Level.WARN ) && !xref.containsKey( statement ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
@@ -54,7 +54,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 		}
 		try {
 			ResultSet rs = statement.executeQuery();
-			postExtract( rs );
+			postExtract( rs, statement );
 			return rs;
 		}
 		catch ( SQLException e ) {
@@ -68,7 +68,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 			// sql logged by StatementPreparerImpl
 			ResultSet rs = jdbcCoordinator.getLogicalConnection().getJdbcServices()
 					.getDialect().getResultSet( statement );
-			postExtract( rs );
+			postExtract( rs, statement );
 			return rs;
 		}
 		catch ( SQLException e ) {
@@ -82,7 +82,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 				.getSqlStatementLogger().logStatement( sql );
 		try {
 			ResultSet rs = statement.executeQuery( sql );
-			postExtract( rs );
+			postExtract( rs, statement );
 			return rs;
 		}
 		catch ( SQLException e ) {
@@ -100,7 +100,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 				}
 			}
 			ResultSet rs = statement.getResultSet();
-			postExtract( rs );
+			postExtract( rs, statement );
 			return rs;
 		}
 		catch ( SQLException e ) {
@@ -119,7 +119,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 				}
 			}
 			ResultSet rs = statement.getResultSet();
-			postExtract( rs );
+			postExtract( rs, statement );
 			return rs;
 		}
 		catch ( SQLException e ) {
@@ -157,8 +157,8 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 				.getSqlExceptionHelper();
 	}
 
-	private void postExtract(ResultSet rs) {
-		if ( rs != null ) jdbcCoordinator.register( rs );
+	private void postExtract(ResultSet rs, Statement st) {
+		if ( rs != null ) jdbcCoordinator.register( rs, st );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/JdbcCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/JdbcCoordinator.java
@@ -170,10 +170,15 @@ public interface JdbcCoordinator extends Serializable {
 
 	/**
 	 * Register a JDBC result set.
+	 * <p/>
+	 * Implementation note: Second parameter has been introduced to prevent
+	 * multiple registrations of the same statement in case {@link ResultSet#getStatement()}
+	 * does not return original {@link Statement} object.
 	 *
 	 * @param resultSet The result set to register.
+	 * @param statement Statement from which {@link ResultSet} has been generated.
 	 */
-	public void register(ResultSet resultSet);
+	public void register(ResultSet resultSet, Statement statement);
 
 	/**
 	 * Release a previously registered result set.

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
@@ -952,8 +952,9 @@ public class QueryTranslatorImpl extends BasicLoader implements FilterTranslator
 
 		try {
 			final List<AfterLoadAction> afterLoadActions = new ArrayList<AfterLoadAction>();
-			final ResultSet rs = executeQueryStatement( queryParameters, false, afterLoadActions, session );
-			final PreparedStatement st = (PreparedStatement) rs.getStatement();
+			final SqlStatementWrapper wrapper = executeQueryStatement( queryParameters, false, afterLoadActions, session );
+			final ResultSet rs = wrapper.getResultSet();
+			final PreparedStatement st = (PreparedStatement) wrapper.getStatement();
 			HolderInstantiator hi = HolderInstantiator.createClassicHolderInstantiator(holderConstructor, queryParameters.getResultTransformer());
 			Iterator result = new IteratorImpl( rs, st, session, queryParameters.isReadOnly( session ), returnTypes, getColumnNames(), hi );
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/DynamicBatchingCollectionInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/DynamicBatchingCollectionInitializerBuilder.java
@@ -253,8 +253,9 @@ public class DynamicBatchingCollectionInitializerBuilder extends BatchingCollect
 					Integer.MAX_VALUE;
 
 			final List<AfterLoadAction> afterLoadActions = Collections.emptyList();
-			final ResultSet rs = executeQueryStatement( sql, queryParameters, false, afterLoadActions, session );
-			final Statement st = rs.getStatement();
+			final SqlStatementWrapper wrapper = executeQueryStatement( sql, queryParameters, false, afterLoadActions, session );
+			final ResultSet rs = wrapper.getResultSet();
+			final Statement st = wrapper.getStatement();
 			try {
 				processResultSet( rs, queryParameters, session, true, null, maxRows, afterLoadActions );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/DynamicBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/DynamicBatchingEntityLoaderBuilder.java
@@ -255,8 +255,9 @@ public class DynamicBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuil
 					Integer.MAX_VALUE;
 
 			final List<AfterLoadAction> afterLoadActions = new ArrayList<AfterLoadAction>();
-			final ResultSet rs = executeQueryStatement( sql, queryParameters, false, afterLoadActions, session );
-			final Statement st = rs.getStatement();
+			final SqlStatementWrapper wrapper = executeQueryStatement( sql, queryParameters, false, afterLoadActions, session );
+			final ResultSet rs = wrapper.getResultSet();
+			final Statement st = wrapper.getStatement();
 			try {
 				return processResultSet( rs, queryParameters, session, false, null, maxRows, afterLoadActions );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/loader/hql/QueryLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/hql/QueryLoader.java
@@ -510,8 +510,9 @@ public class QueryLoader extends BasicLoader {
 			if ( queryParameters.isCallable() ) {
 				throw new QueryException("iterate() not supported for callable statements");
 			}
-			final ResultSet rs = executeQueryStatement( queryParameters, false, Collections.<AfterLoadAction>emptyList(), session );
-			final PreparedStatement st = (PreparedStatement) rs.getStatement();
+			final SqlStatementWrapper wrapper = executeQueryStatement( queryParameters, false, Collections.<AfterLoadAction>emptyList(), session );
+			final ResultSet rs = wrapper.getResultSet();
+			final PreparedStatement st = (PreparedStatement) wrapper.getStatement();
 			final Iterator result = new IteratorImpl(
 					rs,
 			        st,

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/dataTypes/BasicOperationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/dataTypes/BasicOperationsTest.java
@@ -129,7 +129,7 @@ public class BasicOperationsTest extends BaseCoreFunctionalTestCase {
 			String columnNamePattern = generateFinalNamePattern( meta, columnName );
 
 			ResultSet columnInfo = meta.getColumns( null, null, tableNamePattern, columnNamePattern );
-			s.getTransactionCoordinator().getJdbcCoordinator().register(columnInfo);
+			s.getTransactionCoordinator().getJdbcCoordinator().register(columnInfo, columnInfo.getStatement());
 			assertTrue( columnInfo.next() );
 			int dataType = columnInfo.getInt( "DATA_TYPE" );
 			s.getTransactionCoordinator().getJdbcCoordinator().release( columnInfo );


### PR DESCRIPTION
Patch and test for HHH-7984 JIRA ticket.
Link: https://hibernate.atlassian.net/browse/HHH-7984

Issues:
1. Execution of native PL/SQL function returns OracleCallableStatementWrapper which is registered in JdbcCoordinatorImpl#xref via Loader#prepareQueryStatement(String, QueryParameters, LimitHandler, boolean, SessionImplementor) -> StatementPreparerImpl# prepareQueryStatement(String, boolean, ScrollMode) -> QueryStatementPreparationTempl and so on... ResultSet generated from OracleCallableStatementWrapper is than passed to JdbcCoordinatorImpl#register(ResultSet). In this case ResultSet#getStatement() does not return original OracleCallableStatementWrapper, but T4CStatement. Both objects are not equal and LOG.unregisteredStatement() message is logged. This results in two objects registered in JdbcCoordinatorImpl#xref representing the same PL/SQL call.
2. Loader#doQuery(SessionImplementor, QueryParameters, boolean, ResultTransformer) retrieves statement from ResultSet and closes it by invoking `session.getTransactionCoordinator().getJdbcCoordinator().release( st )` (st points to T4CStatement). This results in unclosed cursor.

Proposed solution:
1. Pass original Statement during ResultSet registration. This way JdbcCoordinatorImpl#xref doesn't contain two object representing the same PL/SQL call.
2. Encapsulate original Statement and ResultSet in SqlStatementWrapper. Closing OracleCallableStatementWrapper (not T4CStatement) releases database cursor.

Regards,
Lukasz Antoniak
