### PR TITLE
HHH-5845 (partial fix) Lazy Loading of audited entites with revision typ...

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/AuditReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/AuditReader.java
@@ -71,7 +71,26 @@ public interface AuditReader {
 	<T> T find(Class<T> cls, String entityName, Object primaryKey,
 			Number revision) throws IllegalArgumentException,
 			NotAuditedException, IllegalStateException;
-
+    
+    /**
+     * Find an entity by primary key at the given revision with the specified entityName,
+     * possibly including deleted entities in the search.
+     * @param cls Class of the entity.
+     * @param entityName Name of the entity (if can't be guessed basing on the {@code cls}).
+     * @param primaryKey Primary key of the entity.
+     * @param revision Revision in which to get the entity.
+     * @param includeDeletions Whether to include deleted entities in the search.
+     * @return The found entity instance at the given revision (its properties may be partially filled
+     * if not all properties are audited) or null, if an entity with that id didn't exist at that
+     * revision.
+     * @throws IllegalArgumentException If cls or primaryKey is null or revision is less or equal to 0.
+     * @throws NotAuditedException When entities of the given class are not audited.
+     * @throws IllegalStateException If the associated entity manager is closed.
+     */
+	<T> T find(Class<T> cls, String entityName, Object primaryKey,
+			Number revision, boolean includeDeletions) throws IllegalArgumentException,
+			NotAuditedException, IllegalStateException;
+    
     /**
      * Get a list of revision numbers, at which an entity was modified.
      * @param cls Class of the entity.

--- a/hibernate-envers/src/main/java/org/hibernate/envers/entities/mapper/relation/ToOneIdMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/entities/mapper/relation/ToOneIdMapper.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.configuration.AuditConfiguration;
 import org.hibernate.envers.entities.PropertyData;
 import org.hibernate.envers.entities.mapper.id.IdMapper;
@@ -99,7 +100,7 @@ public class ToOneIdMapper extends AbstractToOneMapper {
                 EntityInfo referencedEntity = getEntityInfo(verCfg, referencedEntityName);
                 value = ToOneEntityLoader.createProxyOrLoadImmediate(
                         versionsReader, referencedEntity.getEntityClass(), referencedEntityName,
-                        entityId, revision, verCfg
+                        entityId, revision, RevisionType.DEL.equals( data.get( verCfg.getAuditEntCfg().getRevisionTypePropName() ) ), verCfg
                 );
             }
         }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/entities/mapper/relation/lazy/ToOneDelegateSessionImplementor.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/entities/mapper/relation/lazy/ToOneDelegateSessionImplementor.java
@@ -42,20 +42,22 @@ public class ToOneDelegateSessionImplementor extends AbstractDelegateSessionImpl
     private final Class<?> entityClass;
     private final Object entityId;
     private final Number revision;
+    private final boolean removed;
     private final AuditConfiguration verCfg;
 
 	public ToOneDelegateSessionImplementor(AuditReaderImplementor versionsReader,
-                                           Class<?> entityClass, Object entityId, Number revision,
+                                           Class<?> entityClass, Object entityId, Number revision, boolean removed,
                                            AuditConfiguration verCfg) {
         super(versionsReader.getSessionImplementor());
         this.versionsReader = versionsReader;
         this.entityClass = entityClass;
         this.entityId = entityId;
         this.revision = revision;
+        this.removed = removed;
         this.verCfg = verCfg;
     }
 
     public Object doImmediateLoad(String entityName) throws HibernateException {
-        return ToOneEntityLoader.loadImmediate( versionsReader, entityClass, entityName, entityId, revision, verCfg );
+        return ToOneEntityLoader.loadImmediate( versionsReader, entityClass, entityName, entityId, revision, removed, verCfg );
     }
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditQueryCreator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditQueryCreator.java
@@ -81,6 +81,25 @@ public class AuditQueryCreator {
     }
 
     /**
+     * Creates a query, which will return entities satisfying some conditions (specified later),
+     * at a given revision and a given entityName. Deleted entities may be optionally
+     * included.
+     * @param c Class of the entities for which to query.
+     * @param entityName Name of the entity (if can't be guessed basing on the {@code c}).
+     * @param revision Revision number at which to execute the query.
+     * @param includeDeletions Whether to include deleted entities in the search.
+     * @return A query for entities at a given revision, to which conditions can be added and which
+     * can then be executed. The result of the query will be a list of entities (beans), unless a
+     * projection is added.
+     */
+    public AuditQuery forEntitiesAtRevision(Class<?> c, String entityName, Number revision, boolean includeDeletions) {
+        checkNotNull(revision, "Entity revision");
+        checkPositive(revision, "Entity revision");
+        c = getTargetClassIfProxied(c);
+        return new EntitiesAtRevisionQuery(auditCfg, auditReaderImplementor, c, entityName, revision, includeDeletions);
+    }
+
+    /**
      * Creates a query, which will return entities modified at the specified revision.
      *
      * In comparison, the {@link #forEntitiesAtRevision(Class, String, Number)} query takes into all entities

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/impl/EntitiesAtRevisionQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/impl/EntitiesAtRevisionQuery.java
@@ -45,20 +45,31 @@ import static org.hibernate.envers.entities.mapper.relation.query.QueryConstants
  */
 public class EntitiesAtRevisionQuery extends AbstractAuditQuery {
     private final Number revision;
+    private final boolean includeDeletions;
 
     public EntitiesAtRevisionQuery(AuditConfiguration verCfg,
                                    AuditReaderImplementor versionsReader, Class<?> cls,
                                    Number revision) {
         super(verCfg, versionsReader, cls);
         this.revision = revision;
+        this.includeDeletions = false;
     }
     
 	public EntitiesAtRevisionQuery(AuditConfiguration verCfg,
 			AuditReaderImplementor versionsReader, Class<?> cls, String entityName, Number revision) {
 		super(verCfg, versionsReader, cls, entityName);
 		this.revision = revision;
-	}    
+		this.includeDeletions = false;
+	}
 
+    public EntitiesAtRevisionQuery(AuditConfiguration verCfg,
+                                   AuditReaderImplementor versionsReader, Class<?> cls,
+                                   String entityName, Number revision, boolean includeDeletions) {
+        super(verCfg, versionsReader, cls, entityName);
+        this.revision = revision;
+        this.includeDeletions = includeDeletions;
+    }
+    
     @SuppressWarnings({"unchecked"})
     public List list() {
         /*
@@ -91,8 +102,10 @@ public class EntitiesAtRevisionQuery extends AbstractAuditQuery {
         		verEntCfg.getRevisionEndFieldName(), true, referencedIdData, 
 				revisionPropertyPath, originalIdPropertyName, REFERENCED_ENTITY_ALIAS, REFERENCED_ENTITY_ALIAS_DEF_AUD_STR);
         
-         // e.revision_type != DEL
-         qb.getRootParameters().addWhereWithParam(verEntCfg.getRevisionTypePropName(), "<>", RevisionType.DEL);
+        // e.revision_type != DEL
+        if (!includeDeletions) {
+            qb.getRootParameters().addWhereWithParam(verEntCfg.getRevisionTypePropName(), "<>", RevisionType.DEL);
+        }
 
         // all specified conditions
         for (AuditCriterion criterion : criterions) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/reader/AuditReaderImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/reader/AuditReaderImpl.java
@@ -95,9 +95,15 @@ public class AuditReaderImpl implements AuditReaderImplementor {
     	cls = getTargetClassIfProxied(cls);
     	return this.find(cls, cls.getName(), primaryKey, revision);
     }
-    
+
+    public <T> T find(Class<T> cls, String entityName, Object primaryKey, Number revision)
+            throws IllegalArgumentException, NotAuditedException, IllegalStateException {
+        return this.find(cls, entityName, primaryKey, revision, false);
+    }
+
     @SuppressWarnings({"unchecked"})
-    public <T> T find(Class<T> cls, String entityName, Object primaryKey, Number revision) throws
+    public <T> T find(Class<T> cls, String entityName, Object primaryKey, Number revision,
+        boolean includeDeletions) throws
             IllegalArgumentException, NotAuditedException, IllegalStateException {
         cls = getTargetClassIfProxied(cls);
         checkNotNull(cls, "Entity class");
@@ -118,7 +124,7 @@ public class AuditReaderImpl implements AuditReaderImplementor {
         Object result;
         try {
             // The result is put into the cache by the entity instantiator called from the query
-            result = createQuery().forEntitiesAtRevision(cls, entityName, revision)
+            result = createQuery().forEntitiesAtRevision(cls, entityName, revision, includeDeletions)
                 .add(AuditEntity.id().eq(primaryKey)).getSingleResult();
         } catch (NoResultException e) {
             result = null;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/proxy/RemovedObjectQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/proxy/RemovedObjectQueryTest.java
@@ -1,0 +1,83 @@
+package org.hibernate.envers.test.integration.proxy;
+
+import org.hibernate.Hibernate;
+import org.hibernate.envers.RevisionType;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.query.AuditQuery;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.envers.test.entities.onetomany.SetRefEdEntity;
+import org.hibernate.envers.test.entities.onetomany.SetRefIngEntity;
+import org.hibernate.envers.test.tools.TestTools;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+@TestForIssue(jiraKey = "HHH-5845")
+public class RemovedObjectQueryTest extends BaseEnversJPAFunctionalTestCase {
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void addConfigOptions(Map options) {
+        options.put("org.hibernate.envers.store_data_at_delete", "true");
+    }
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { SetRefEdEntity.class, SetRefIngEntity.class };
+    }
+
+    @Test
+    @Priority(10)
+    public void initData() {
+        EntityManager em = getEntityManager();
+
+        SetRefEdEntity refEdEntity = new SetRefEdEntity(1, "Demo Data");
+        SetRefIngEntity refIngEntity = new SetRefIngEntity(2, "Example Data", refEdEntity);
+
+        em.getTransaction().begin();
+        em.persist(refEdEntity);
+        em.persist(refIngEntity);
+        em.getTransaction().commit();
+
+        em.getTransaction().begin();
+        refIngEntity = em.find(SetRefIngEntity.class, 2);
+        em.remove(refIngEntity);
+        em.remove(refEdEntity);
+        em.getTransaction().commit();
+    }
+
+    @Test
+    public void testFindDeletedReference() {
+        AuditQuery query = getAuditReader().createQuery().forRevisionsOfEntity(SetRefIngEntity.class, false, true)
+                                                         .add(AuditEntity.revisionType().eq(RevisionType.DEL));
+        List queryResult = (List) query.getResultList();
+
+        Object[] objArray = (Object[]) queryResult.get(0);
+        SetRefIngEntity refIngEntity = (SetRefIngEntity) objArray[0];
+        Assert.assertEquals("Example Data", refIngEntity.getData());
+
+        Hibernate.initialize(refIngEntity.getReference());
+        Assert.assertEquals("Demo Data", refIngEntity.getReference().getData());
+    }
+
+    @FailureExpected(jiraKey = "HHH-5845") // TODO: doesn't work until collection queries are fixed
+    @Test
+    public void testFindDeletedReferring() {
+        AuditQuery query = getAuditReader().createQuery().forRevisionsOfEntity(SetRefEdEntity.class, false, true)
+                                                         .add(AuditEntity.revisionType().eq(RevisionType.DEL));
+        List queryResult = (List) query.getResultList();
+
+        Object[] objArray = (Object[]) queryResult.get(0);
+        SetRefEdEntity refEdEntity = (SetRefEdEntity) objArray[0];
+        Assert.assertEquals("Demo Data", refEdEntity.getData());
+
+        Hibernate.initialize(refEdEntity.getReffering());
+        Assert.assertEquals(TestTools.makeSet(new SetRefIngEntity(2, "Example Data")), refEdEntity.getReffering());
+    }
+}


### PR DESCRIPTION
...e 'delete'

Fixed for to-one associations, but not for one-to-many and other collection types.

Based largely on https://github.com/hibernate/hibernate-orm/pull/301.

This is a quick-and-dirty fix that works for me because I don't audit collections.
Fixing collections is more challenging: the RelationQueryGenerator group of
classes don't allow for easy customization of queries based on input data.
