### PR TITLE
HHH-7357 - Constraint violation exception while inserting NULL to not nullable column

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -30,6 +30,7 @@ import org.hibernate.dialect.function.AvgWithArgumentCastFunction;
 import org.hibernate.dialect.function.NoArgSQLFunction;
 import org.hibernate.dialect.function.StandardSQLFunction;
 import org.hibernate.dialect.function.VarArgsSQLFunction;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtracter;
@@ -312,6 +313,12 @@ public class H2Dialect extends Dialect {
                     if (50200 == errorCode) { // LOCK NOT AVAILABLE
                         exception = new PessimisticLockException(message, sqlException, sql);
                     }
+
+					if ( 90006 == errorCode ) {
+						// NULL not allowed for column [90006-145]
+						final String constraintName = getViolatedConstraintNameExtracter().extractConstraintName( sqlException );
+						exception = new ConstraintViolationException( message, sqlException, sql, constraintName );
+					}
 
 					return exception;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -37,6 +37,7 @@ import org.hibernate.dialect.function.NvlFunction;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.function.StandardSQLFunction;
 import org.hibernate.dialect.function.VarArgsSQLFunction;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.LockTimeoutException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
@@ -461,6 +462,14 @@ public class Oracle8iDialect extends Dialect {
 					throw new QueryTimeoutException(  message, sqlException, sql );
 				}
 
+
+				// data integrity violation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+				if ( 1407 == errorCode ) {
+					// ORA-01407: cannot update column to NULL
+					final String constraintName = getViolatedConstraintNameExtracter().extractConstraintName( sqlException );
+					return new ConstraintViolationException( message, sqlException, sql, constraintName );
+				}
 
 				return null;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
@@ -112,7 +112,8 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 
 	@Override
 	public JDBCException convert(SQLException sqlException, String message, String sql) {
-		String sqlState = JdbcExceptionHelper.extractSqlState( sqlException );
+		final String sqlState = JdbcExceptionHelper.extractSqlState( sqlException );
+		final int errorCode = JdbcExceptionHelper.extractErrorCode( sqlException );
 
 		if ( sqlState != null ) {
 			String sqlStateClassCode = JdbcExceptionHelper.determineSqlStateClassCode( sqlState );
@@ -146,8 +147,8 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 
 			// MySQL Query execution was interrupted
 			if ( "70100".equals( sqlState ) ||
-				// Oracle user requested cancel of current operation
-				  "72000".equals( sqlState ) ) {
+					// Oracle user requested cancel of current operation
+					( "72000".equals( sqlState ) && errorCode == 1013 ) ) {
 				throw new QueryTimeoutException(  message, sqlException, sql );
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/exception/User.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/exception/User.hbm.xml
@@ -6,7 +6,7 @@
 		<id name="id" unsaved-value="null" column="user_id" >
 			<generator class="native"/>
 		</id>
-		<property name="username" type="string" column="user_name" />
+		<property name="username" type="string" column="user_name" not-null="true" />
 		<set name="memberships" inverse="false" table="T_MEMBERSHIP" cascade="none">
 			<key column="user_id"/>
 			<many-to-many class="Group" column="group_id"/>


### PR DESCRIPTION
Patch and test for HHH-7357 JIRA ticket.
Link: https://hibernate.atlassian.net/browse/HHH-7357

In my opinion dialect specific exception recognition could be moved from SQLStateConversionDelegate#convert(SQLException, String, String) to Dialect#buildSQLExceptionConversionDelegate(). See detection of MySQL and Oracle query interruption, and Derby lock obtaining timeout - https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java#L142.

Regards,
Lukasz Antoniak
