### PR TITLE
Give a better message about where a problem with a mapping could be.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -95,6 +95,7 @@ import org.hibernate.cfg.PropertyHolder;
 import org.hibernate.cfg.PropertyHolderBuilder;
 import org.hibernate.cfg.PropertyInferredData;
 import org.hibernate.cfg.PropertyPreloadedData;
+import org.hibernate.cfg.RecoverableException;
 import org.hibernate.cfg.SecondPass;
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.internal.CoreMessageLogger;
@@ -1411,9 +1412,13 @@ public abstract class CollectionBinder {
 			boolean cascadeDeleteEnabled,
 			XProperty property,
 			Mappings mappings) {
-		BinderHelper.createSyntheticPropertyReference(
-				joinColumns, collValue.getOwner(), collectionEntity, collValue, false, mappings
-		);
+		try {
+			BinderHelper.createSyntheticPropertyReference(
+					joinColumns, collValue.getOwner(), collectionEntity, collValue, false, mappings
+			);
+		} catch(RecoverableException ex) {
+			throw new RecoverableException("Unable to map collection property " + property.getName() + "of class " + collectionEntity.getClassName(), ex);
+		}
 		SimpleValue key = buildCollectionKey( collValue, joinColumns, cascadeDeleteEnabled, property, mappings );
 		if ( property.isAnnotationPresent( ElementCollection.class ) && joinColumns.length > 0 ) {
 			joinColumns[0].setJPA2ElementCollection( true );


### PR DESCRIPTION
When having @JoinColumn in a @CollectionTable that do not point to valid columns, the message can be really confusing. These new lines will actually enrich the exception which is thrown that the problem appeared on a specific property of a specific class.

Please include this, since it is not always clear what the actual problem is with a mapping when an exception occurs.
