### PR TITLE
HHH-6353: Support aliases in Criteria SQL projections and restrictions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/CriteriaQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/CriteriaQuery.java
@@ -173,7 +173,17 @@ public interface CriteriaQuery {
 	 * @return The SQL table alias for the given criteria
 	 */
 	public String getSQLAlias(Criteria criteria, String propertyPath);
-	
+
+	/**
+	 * Get the SQL table alias corresponding to a given query alias. This will
+	 * look up the chain to any outer queries if no match was found directly.
+	 *
+	 * @param alias An alias assigned within this criteria or its parents.
+	 *
+	 * @return The matching SQL table alias, if found. Otherwise this will return null.
+	 */
+	public String getSQLAlias( String alias );
+
 	/**
 	 * Get the property name, given a possibly qualified property name
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
@@ -451,7 +451,8 @@ public class Restrictions {
 
 	/**
 	 * Create a restriction expressed in SQL with JDBC parameters.  Any occurrences of <tt>{alias}</tt> will be
-	 * replaced by the table alias.
+	 * replaced by the table alias. Join tables can also use this syntax. For example: writing {myAlias} will be
+	 * replaced with the actual table alias for that join.
 	 *
 	 * @param sql The SQL restriction
 	 * @param values The parameter values

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -28,8 +28,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.util.collections.ArrayHelper;
@@ -37,6 +41,9 @@ import org.hibernate.internal.util.collections.ArrayHelper;
 public final class StringHelper {
 
 	private static final int ALIAS_TRUNCATE_LENGTH = 10;
+	private static final String ALIAS_INTERPOLATE_PREFIX = "{";
+	private static final String ALIAS_INTERPOLATE_SUFFIX = "}";
+	private static final Pattern ALIAS_INTERPOLATE_PATTERN = Pattern.compile( "[{](\\w+)[}]" );
 	public static final String WHITESPACE = " \n\r\f\t";
 
 	private StringHelper() { /* static methods only - hide constructor */
@@ -513,6 +520,43 @@ public final class StringHelper {
 		return generateAliasRoot(description) +
 			Integer.toString(unique) +
 			'_';
+	}
+
+	/**
+	 * Inspect a string for potential interpolation matches (word characters contained within
+	 * curly braces).
+	 *
+	 * @param sql An un-interpolated SQL string.
+	 * @return The set of keys that can be interpolated in this SQL.
+	 */
+	public static Set<String> findInterpolationKeys( String sql ){
+		final Matcher matcher = ALIAS_INTERPOLATE_PATTERN.matcher( sql );
+		// slightly better estimate sizing than default
+		final Set<String> results = new HashSet<String>( 3 );
+		while( matcher.find() ){
+			results.add( matcher.group( 1 ) );
+		}
+		return results;
+	}
+
+	/**
+	 * Allows for a SQL string to be interpolated with a a given alias mapping. The prefix/postfix character
+	 * used to determine where interpolation should be performed are '{' and '}'. Eg. if the value of
+	 * <tt>alias</tt> is 'person', then this will look for instances of the string <tt>{person}</tt> in
+	 * the provided SQL and replace them with <tt>newValue</tt>.
+	 *
+	 * @param sql An un-interpolated SQL string potentially containing the alias that we want to convert.
+	 * @param alias The alias to replace
+	 * @param newValue Replacement value
+	 *
+	 * @return A string with the replaced values.
+	 */
+	public static String interpolateAlias(String sql, String alias, String newValue){
+		final String replaceToken = new StringBuilder( alias.length() + 2 )
+				.append( ALIAS_INTERPOLATE_PREFIX )
+				.append( alias )
+				.append( ALIAS_INTERPOLATE_SUFFIX ).toString();
+		return StringHelper.replace( sql, replaceToken, newValue );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
@@ -644,6 +644,23 @@ public class CriteriaQueryTranslator implements CriteriaQuery {
 		}
 		return getSQLAlias( criteria );
 	}
+
+	public String getSQLAlias( String alias ) {
+
+		final Criteria criteria = getAliasedCriteria( alias );
+		if( criteria != null ) {
+			return getSQLAlias( criteria );
+		}
+		else if( outerQueryTranslator != null ) {
+			// recurse up to find a match
+			return outerQueryTranslator.getSQLAlias( alias );
+		}
+		// no match found. Don't throw an exception to avoid being overly obtrusive
+		// to cases where no match was actually excepted (ie. we incorrectly found something
+		// to interpolate that should be left alone).
+		return null;
+	}
+
 	@Override
 	public String getPropertyName(String propertyName) {
 		if ( propertyName.indexOf( '.' ) > 0 ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/util/StringHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/util/StringHelperTest.java
@@ -28,8 +28,11 @@ import org.junit.Test;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -58,5 +61,25 @@ public class StringHelperTest extends BaseUnitTestCase {
 		assertNull( StringHelper.collapseQualifierBase( null, BASE_PACKAGE ) );
 		assertEquals( STRING_HELPER_NAME, StringHelper.collapseQualifierBase( STRING_HELPER_NAME, BASE_PACKAGE ) );
 		assertEquals( "o.h.internal.util.StringHelper", StringHelper.collapseQualifierBase( STRING_HELPER_FQN, BASE_PACKAGE ) );
+	}
+
+	@Test
+	public void testFindInterpolationKeys() {
+
+		Set<String> results = StringHelper.findInterpolationKeys( "{}" );
+		assertEquals( 0, results.size() );
+
+		results = StringHelper.findInterpolationKeys( "{person}.fname and {person}.lname" );
+		assertEquals( 1, results.size() );
+		assertTrue( results.contains( "person" ) );
+
+		results = StringHelper.findInterpolationKeys( "{person}.fname and {other_123}.fname" );
+		assertEquals( 2, results.size() );
+		assertTrue( results.contains( "person" ) );
+		assertTrue( results.contains( "other_123" ) );
+
+		// should ignore whitespace and non-word characters
+		results = StringHelper.findInterpolationKeys( "{'person'}{ other }{*}{person.fname}" );
+		assertEquals( 0, results.size() );
 	}
 }


### PR DESCRIPTION
This adds support for using named aliases in Criteria SQL-based `Restrictions` and `Projections` using placeholders. This is useful for complex cases such as writing correlated sub-queries that need access to tables other than the root entity. The `{alias}` placeholder has been left around for the purposes of backwards compatibility.

Here is a simple example intended to show the new syntax that this supports:

```
List data = session.createCriteria( Course.class, "c" )
        .add( Subqueries.exists(
                DetachedCriteria.forClass( Enrolment.class, "e" )
                        .setProjection( Projections.id() )
                        .add( Restrictions.sqlRestriction( 
                                "lower({c}.code) = {e}.code" ) ) )
        ).list();   
```

An alternate (simpler) solution for HHH-6353 would simply be to expose alias look-ups on `Criteria`, but that is a less fluid solution IMHO. 

Its my hope that this can lead to a solid solution for HHH-2736. I'd like to be able to re-use this placeholder syntax for writing query hints -- AFAIK Oracle expects table aliases to be provided in hints, and unfortunately I don't see that handled in https://github.com/hibernate/hibernate-orm/pull/160 . 
