### PR TITLE
HHH-8250 - fix for collection caching, sql query was executed even if collection was found in cache 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -73,8 +73,10 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 					source
 				);
 
-			if ( foundInCache && traceEnabled ) {
-				LOG.trace( "Collection initialized from cache" );
+			if ( foundInCache ) {
+				if ( traceEnabled ) {
+					LOG.trace( "Collection initialized from cache" );
+				}
 			}
 			else {
 				if ( traceEnabled ) {


### PR DESCRIPTION
If trace logging was enabled it worked corectly.
