### PR TITLE
 HHH-4699 trim value from database before Enum.valueOf() 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -455,7 +455,10 @@ public class EnumType implements EnhancedUserType, DynamicParameterizedType,Logg
 
 		private Enum fromName(String name) {
 			try {
-				return Enum.valueOf( enumClass, name );
+			    if(name == null) {
+			        return null;
+			    }
+				return Enum.valueOf( enumClass, name.trim() );
 			}
 			catch ( IllegalArgumentException iae ) {
 				throw new IllegalArgumentException(


### PR DESCRIPTION
this change fixes the problem with fixed size columns with enum values
that are right padded.
