### PR TITLE
HHH-8428 Protect SessionFactoryRegistry.getNamedSessionFactory(String) from NPE…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryRegistry.java
@@ -132,7 +132,11 @@ public class SessionFactoryRegistry {
 	public SessionFactory getNamedSessionFactory(String name) {
         LOG.debugf( "Lookup: name=%s", name );
 		final String uuid = nameUuidXref.get( name );
-		return getSessionFactory( uuid );
+		if ( uuid != null ) {
+			return getSessionFactory( uuid );
+		} else {
+			return null;
+		}
 	}
 
 	public SessionFactory getSessionFactory(String uuid) {


### PR DESCRIPTION
… when the named SessionFactory hasn't been registered.

This problem occurs because ConcurrentHashMap does not support null keys, and throws a NullPointerException.

This can occur from ProviderMBeanRegistration.locateSessionFactory() when it checks to see whether the named SessionFactory is available on a background thread. It expects a null response to indicate that the SessionFactory has not been configured yet.

This same patch applies cleanly to master.
