### PR TITLE
HHH-3718 better document that proxy id getters trigger proxy initialize if field access is used

### DIFF
--- a/documentation/src/main/docbook/manual/en-US/content/basic_mapping.xml
+++ b/documentation/src/main/docbook/manual/en-US/content/basic_mapping.xml
@@ -2316,7 +2316,7 @@ public class Flight implements Serializable {
       </section>
     </section>
 
-    <section xml:id="mapping-declaration-property" revision="4">
+    <section xml:id="mapping-declaration-property" revision="5">
       <title>Property</title>
 
       <para>You need to decide which property needs to be made persistent in a
@@ -2552,8 +2552,14 @@ public class MonetaryAmount implements Serializable {
           are on a field, then only fields are considered for persistence and
           the state is accessed via the field. If there annotations are on a
           getter, then only the getters are considered for persistence and the
-          state is accessed via the getter/setter. That works well in practice
+          state is accessed via the getter/setter. The latter works well in practice
           and is the recommended approach.<note>
+              <para>The choice of access type has a notable effect on the behavior
+              of proxies. If using the recommended property access approach,
+              the identifier getter method can be called without requiring the
+              proxy to be initialized. On the other hand, when using field access,
+              any method invocation will cause proxy initialization.</para>
+            </note><note>
               <para>The placement of annotations within a class hierarchy has
               to be consistent (either field or on property) to be able to
               determine the default access type. It is recommended to stick to

--- a/documentation/src/main/docbook/manual/en-US/content/performance.xml
+++ b/documentation/src/main/docbook/manual/en-US/content/performance.xml
@@ -3,7 +3,7 @@
 <chapter xml:id="performance" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Improving performance</title>
 
-  <section xml:id="performance-fetching" revision="2">
+  <section xml:id="performance-fetching" revision="3">
     <title>Fetching strategies</title>
 
     <para>Hibernate uses a <emphasis>fetching strategy</emphasis> to retrieve
@@ -72,8 +72,8 @@
 
       <listitem>
         <para><emphasis>Proxy fetching</emphasis>: a single-valued association
-        is fetched when a method other than the identifier getter is invoked
-        upon the associated object.</para>
+        is fetched when any method (except the identifier getter if using property access) 
+        is invoked upon the associated object.</para>
       </listitem>
 
       <listitem>
@@ -216,7 +216,7 @@ Integer accessLevel = (Integer) permissions.get("accounts");  // Error!</program
       use the second-level cache.</para>
     </section>
 
-    <section xml:id="performance-fetching-proxies" revision="2">
+    <section xml:id="performance-fetching-proxies" revision="3">
       <title>Single-ended association proxies</title>
 
       <para>Lazy fetching for collections is implemented using Hibernate's own
@@ -330,7 +330,9 @@ Cat fritz = (Cat) iter.next();</programlisting>
         </listitem>
 
         <listitem>
-          <para>The identifier getter method</para>
+          <para>The identifier getter method, if using property access. 
+          (When using field access, any method invocation will trigger 
+          initialization of the proxy.)</para>
         </listitem>
       </itemizedlist>
 


### PR DESCRIPTION
HHH-3718 Clarify that in order to call the identifier getter method on an uninitialized proxy, you have to choose property access, not field access.
