### PR TITLE
HHH-8404: Correctly render 'ListIndexExpression'.

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/criteria/expression/ListIndexExpression.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/criteria/expression/ListIndexExpression.java
@@ -60,7 +60,7 @@ public class ListIndexExpression extends ExpressionImpl<Integer> implements Seri
 
 	public String render(RenderingContext renderingContext) {
 		return "index("
-				+ origin.getPathIdentifier() + '.' + getListAttribute().getName()
+				+ origin.getPathIdentifier()
 				+ ")";
 	}
 


### PR DESCRIPTION
A correctly rendered 'index' expression should be "index(foo)" where 'foo' is
the name (or alias) of the list table. Since 'ListAttributeJoin' passes 'this'
as 'origin' when creating a 'ListIndexExpression', "origin.getPathIdentifier()"
will already refer to this list table on the right-hand side of the join.
Appending the list attribute (which is relative to the table on the left-hand
side of the join) does not make sense.
