### PR TITLE
HHH-5920: improve the performance of PersistentClass

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/mapping/PersistentClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/mapping/PersistentClassTest.java
@@ -1,0 +1,48 @@
+package org.hibernate.test.mapping;
+
+import org.hibernate.MappingException;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PersistentClassTest extends BaseUnitTestCase {
+
+	@Test
+	public void testGetMappedClass() {
+		RootClass pc = new RootClass();
+		pc.setClassName(String.class.getName());
+		Assert.assertEquals(String.class.getName(), pc.getClassName());
+		Assert.assertEquals(String.class, pc.getMappedClass());
+		pc.setClassName(Integer.class.getName());
+		Assert.assertEquals(Integer.class, pc.getMappedClass());
+	}
+	
+	@Test
+	public void testGetProxyInterface() {
+		RootClass pc = new RootClass();
+		pc.setProxyInterfaceName(String.class.getName());
+		Assert.assertEquals(String.class.getName(), pc.getProxyInterfaceName());
+		Assert.assertEquals(String.class, pc.getProxyInterface());
+		pc.setProxyInterfaceName(Integer.class.getName());
+		Assert.assertEquals(Integer.class, pc.getProxyInterface());
+	}
+	
+	@Test
+	public void testGetProperty() {
+		RootClass pc = new RootClass();
+		Property p = new Property();
+		p.setName("name");
+		pc.addProperty(p);
+		Assert.assertEquals(p, pc.getProperty("name"));
+		Assert.assertEquals(p, pc.getProperty("name.test"));
+		try {
+			Assert.assertNull(pc.getProperty("test"));
+			Assert.fail("MappingException expected");
+		} catch (MappingException e) {
+			// expected
+		}
+	}
+
+}


### PR DESCRIPTION
This implements most of HHH-5920. Specifically:
- new transient lazily instantiated properties (mappedClass, proxyInterface)
- minor improvement to performance of getProperty(String propertyName, Iterator iterator)
- tests to ensure the methods still behave as expected

The extra complexity to have a no exception version of getProperty(String propertyName, Iterator iterator) was seen as overkill.
