### PR TITLE
HHH-8364 exclude-unlisted-classes parsing handles content incorrectly

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/PersistenceXmlParser.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/PersistenceXmlParser.java
@@ -217,7 +217,7 @@ public class PersistenceXmlParser {
 					persistenceUnit.addJarFileUrl( ArchiveHelper.getURLFromPath( extractContent( element ) ) );
 				}
 				else if ( tag.equals( "exclude-unlisted-classes" ) ) {
-					persistenceUnit.setExcludeUnlistedClasses( true );
+					persistenceUnit.setExcludeUnlistedClasses( extractBooleanContent(element, true) );
 				}
 				else if ( tag.equals( "delimited-identifiers" ) ) {
 					persistenceUnit.setUseQuotedIdentifiers( true );
@@ -268,6 +268,14 @@ public class PersistenceXmlParser {
 			}
 		}
 		return result.toString().trim();
+	}
+
+	private static boolean extractBooleanContent(Element element, boolean defaultBool) {
+		String content = extractContent( element );
+		if (content != null && content.length() > 0) {
+			return Boolean.valueOf(content);
+		}
+		return defaultBool;
 	}
 
 	private static PersistenceUnitTransactionType parseTransactionType(String value) {


### PR DESCRIPTION
Parsing for `exclude-unlisted-classes` handles content within the element incorrectly. The value correctly defaults to `false`. `<exclude-unlisted-classes />` and `<exclude-unlisted-classes>true</exclude-unlisted-classes>` are correctly parsed as `true`. However, `<exclude-unlisted-classes>false</exclude-unlisted-classes>` is incorrectly also parsed as `true`. This commit fixes that.
