### PR TITLE
Unclear ClassCastException message from JavassistLazyInitializer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
@@ -188,7 +188,11 @@ public class JavassistLazyInitializer extends BasicLazyInitializer implements Me
 				try {
 					if ( ReflectHelper.isPublic( persistentClass, thisMethod ) ) {
 						if ( !thisMethod.getDeclaringClass().isInstance( target ) ) {
-							throw new ClassCastException( target.getClass().getName() );
+							throw new ClassCastException(
+									target.getClass().getName()
+									+ " incompatible with "
+									+ thisMethod.getDeclaringClass().getName()
+							);
 						}
 						returnValue = thisMethod.invoke( target, args );
 					}


### PR DESCRIPTION
Debugging the ClassCastException explicitly thrown by the JavassistLazyInitializer would be easier if the message contained the class names of both the target class and the declaring class.
