### PR TITLE
HHH-6914: Improve LIMIT/OFFSET handling in SQL Server

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
@@ -57,9 +57,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		String input = "select distinct f1 as f53245 from table849752 order by f234, f67 desc";
 
 		assertEquals(
-				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __hibernate_row_nr__ from ( " +
-						"select distinct top(?) f1 as f53245 from table849752 order by f234, f67 desc ) inner_query )" +
-						" select f53245 from query where __hibernate_row_nr__ >= ? and __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by f234, f67 desc) as __hibernate_row_nr__ from ( " +
+						"select distinct f1 as f53245 from table849752  ) inner_query )" +
+						" select f53245 from query where __hibernate_row_nr__ >= ? and __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( input, toRowSelection( 10, 15 ) ).getProcessedSql().toLowerCase()
 		);
 	}
@@ -74,9 +74,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"where persistent0_.customerid=?";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY current_timestamp) as __hibernate_row_nr__ FROM ( " +
 						fromColumnNameSQL + " ) inner_query ) " +
-						"SELECT rid1688_, deviati16_1688_, sortindex1688_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"SELECT rid1688_, deviati16_1688_, sortindex1688_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?" +
+						" order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( fromColumnNameSQL, toRowSelection( 1, 10 ) ).getProcessedSql()
 		);
 	}
@@ -87,9 +88,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String notAliasedSQL = "select column1, column2, column3, column4 from table1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY current_timestamp) as __hibernate_row_nr__ FROM ( " +
 						"select column1 as page0_, column2 as page1_, column3 as page2_, column4 as page3_ from table1 ) inner_query ) " +
-						"SELECT page0_, page1_, page2_, page3_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"SELECT page0_, page1_, page2_, page3_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?" +
+						" order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( notAliasedSQL, toRowSelection( 3, 5 ) ).getProcessedSql()
 		);
 	}
@@ -105,9 +107,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"where persistent0_.type='v'";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY current_timestamp) as __hibernate_row_nr__ FROM ( " +
 						subselectInSelectClauseSQL + " ) inner_query ) " +
-						"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?" +
+						" order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( subselectInSelectClauseSQL, toRowSelection( 2, 5 ) ).getProcessedSql()
 		);
 	}
@@ -122,11 +125,13 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"order by persistent0_.Order";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY mpialias0_) as __hibernate_row_nr__ FROM ( " +
 						"select TOP(?) persistent0_.id as page0_, persistent0_.uid AS tmp1, " +
 						"(select case when persistent0_.name = 'Smith' then 'Neo' else persistent0_.id end) as page1_ " +
+						", persistent0_.Order AS mpialias0_ " +
 						"from C_Customer persistent0_ where persistent0_.type='Va' order by persistent0_.Order ) " +
-						"inner_query ) SELECT page0_, tmp1, page1_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"inner_query ) SELECT page0_, tmp1, page1_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?" +
+						" order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( caseSensitiveSQL, toRowSelection( 1, 2 ) ).getProcessedSql()
 		);
 	}
@@ -137,9 +142,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String distinctInAggregateSQL = "select aggregate_function(distinct p.n) as f1 from table849752 p order by f1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY f1) as __hibernate_row_nr__ FROM ( " +
 						"select TOP(?) aggregate_function(distinct p.n) as f1 from table849752 p order by f1 ) inner_query ) " +
-						"SELECT f1 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"SELECT f1 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( distinctInAggregateSQL, toRowSelection( 2, 5 ) ).getProcessedSql()
 		);
 	}
@@ -173,10 +178,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY col_1_0_ DESC) as __hibernate_row_nr__ FROM ( " +
 					"select TOP(?) cast(lc302_doku6_.redniBrojStavke as varchar(255)) as col_0_0_, lc302_doku6_.dokumentiID as col_1_0_ " +
 					"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC ) inner_query ) " +
-					"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+					"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( query, toRowSelection( 1, 3 ) ).getProcessedSql()
 		);
 	}
@@ -187,9 +192,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String query = "select t1.*, t2.* from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) t1.*, t2.* from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
-						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY mpialias0_ desc) as __hibernate_row_nr__ FROM ( " +
+						"select TOP(?) t1.*, t2.* , t1.id AS mpialias0_ from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
+						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( query, toRowSelection( 1, 3 ) ).getProcessedSql()
 		);
 	}
@@ -200,11 +205,27 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String query = "select * from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) * from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
-						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY mpialias0_ desc) as __hibernate_row_nr__ FROM ( " +
+						"select TOP(?) * , t1.id AS mpialias0_ from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
+						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
 				dialect.buildLimitHandler( query, toRowSelection( 1, 3 ) ).getProcessedSql()
 		);
+	}
+
+	/**
+	 * HHH-6914: use ROW_NUMBER() OVER when query contains order by with multiple expressioms
+	 * 
+	 * @author Piotr Findeisen <piotr.findeisen@gmail.com>
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HHH-6914")
+	public void testGetLimitStringWithOrderByOverMultiple() {
+		final String query = "select t1.id as t1Id from tab1 t1 order by t1.id, t1Id";
+
+		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY t1Id, t1Id) as __hibernate_row_nr__ FROM ( "
+				+ "select t1.id as t1Id from tab1 t1  ) inner_query ) "
+				+ "SELECT t1Id FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ? order by __hibernate_row_nr__",
+				dialect.buildLimitHandler( query, toRowSelection( 0, 3 ) ).getProcessedSql() );
 	}
 
 	private RowSelection toRowSelection(int firstRow, int maxRows) {


### PR DESCRIPTION
- ROW_NUMBER() OVER should use original ORDER BY if it exists
- use ROW_NUMBER() OVER when original ORDER BY has multiple clause to avoid
  SQLServerException: A column has been specified more than once in the order
  by list. Columns in the order by list must be unique.
