### PR TITLE
HHH-8492: Making the validator factory available via EMF.getProperties()

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -889,6 +889,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 		if ( validationFactory != null ) {
 			BeanValidationIntegrator.validateFactory( validationFactory );
 			serviceRegistryBuilder.applySetting( AvailableSettings.VALIDATION_FACTORY, validationFactory );
+			configurationValues.put( AvailableSettings.VALIDATION_FACTORY, this.validatorFactory );
 		}
 
 		// flush before completion validation


### PR DESCRIPTION
Adding the ValidatorFactory to the configurationValues map to make sure that the ValidatorFactory specified via EntityManagerFactoryBuilderImpl.withValidatorFactory will actually get used.

More details in https://hibernate.atlassian.net/browse/HHH-8492
