### PR TITLE
HHH-7630 Add identifier columns names to search

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -830,15 +830,13 @@ public abstract class CollectionBinder {
 		PersistentClass associatedClass = (PersistentClass) persistentClasses.get( assocClass );
 		if ( jpaOrderBy != null ) {
 			final String jpaOrderByFragment = jpaOrderBy.value();
-			if ( StringHelper.isNotEmpty( jpaOrderByFragment ) ) {
-				final String orderByFragment = buildOrderByClauseFromHql(
-						jpaOrderBy.value(),
-						associatedClass,
-						collection.getRole()
-				);
-				if ( StringHelper.isNotEmpty( orderByFragment ) ) {
-					collection.setOrderBy( orderByFragment );
-				}
+			final String orderByFragment = buildOrderByClauseFromHql(
+					jpaOrderBy.value(),
+					associatedClass,
+					collection.getRole()
+			);
+			if (StringHelper.isNotEmpty(orderByFragment)) {
+				collection.setOrderBy(orderByFragment);
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -851,6 +851,15 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 				}
 			}
 		}
+
+		// if the column is not located in normal column names,
+		// then search though the identifier column names
+		for ( String identifier : this.getIdentifierColumnNames() ) {
+			if ( identifier.equals(columnName) ) {
+				return 0;
+			}
+		}
+
 		throw new HibernateException( "Could not locate table which owns column [" + columnName + "] referenced in order-by mapping" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Asset.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Asset.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.io.Serializable;
+
+/**
+ *
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Asset implements Serializable {
+	/** */
+	@Id
+	@Column(name = "id_asset")
+	private final Integer idAsset;
+	@Id
+	@Column(name = "id_test")
+	private final Integer test;
+	/** */
+	@ManyToOne(cascade = {CascadeType.ALL})
+	@JoinColumn(nullable = false)
+	private Employee employee;
+
+	public Asset() {
+		this.idAsset = 0;
+		this.test = 1;
+	}
+
+	/**
+	 * @param idAsset
+	 */
+	public Asset(Integer idAsset) {
+		this.idAsset = idAsset;
+		this.test = 1;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getIdAsset() {
+		return idAsset;
+	}
+
+	/**
+	 * @return the employee
+	 */
+	public Employee getEmployee() {
+		return employee;
+	}
+
+	/**
+	 * @param employee the employee to set
+	 */
+	public void setEmployee(Employee employee) {
+		this.employee = employee;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Asset2.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Asset2.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ *
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Asset2 implements Serializable {
+	/** */
+	@Id
+	@Column(name = "id_asset")
+	private final Integer idAsset;
+	@Id
+	@Column(name = "id_test")
+	private final Integer test;
+	/** */
+	@ManyToOne(cascade = {CascadeType.ALL})
+	@JoinColumn(nullable = false)
+	private Employee2 employee;
+
+	public Asset2() {
+		this.idAsset = 0;
+		this.test = 1;
+	}
+
+	/**
+	 * @param idAsset
+	 */
+	public Asset2(Integer idAsset) {
+		this.idAsset = idAsset;
+		this.test = 1;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getIdAsset() {
+		return idAsset;
+	}
+
+	/**
+	 * @return the employee
+	 */
+	public Employee2 getEmployee() {
+		return employee;
+	}
+
+	/**
+	 * @param employee the employee to set
+	 */
+	public void setEmployee(Employee2 employee) {
+		this.employee = employee;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Computer.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Computer.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.Entity;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.PrimaryKeyJoinColumns;
+
+/**
+ *
+ */
+@Entity
+@PrimaryKeyJoinColumns({
+		@PrimaryKeyJoinColumn(name = "id_asset"),
+		@PrimaryKeyJoinColumn(name = "id_test")
+})
+public class Computer
+		extends Asset {
+	/** */
+	private String computerName;
+
+	public Computer() {
+
+	}
+
+	/**
+	 * @param id
+	 */
+	public Computer(Integer id) {
+		super(id);
+	}
+
+	/**
+	 * @return the computerName
+	 */
+	public String getComputerName() {
+		return computerName;
+	}
+
+	/**
+	 * @param computerName the computerName to set
+	 */
+	public void setComputerName(String computerName) {
+		this.computerName = computerName;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Computer2.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Computer2.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.Entity;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.PrimaryKeyJoinColumns;
+
+/**
+ *
+ */
+@Entity
+@PrimaryKeyJoinColumns({
+		@PrimaryKeyJoinColumn(name = "id_asset"),
+		@PrimaryKeyJoinColumn(name = "id_test")
+})
+public class Computer2
+		extends Asset2 {
+	/** */
+	private String computerName;
+
+	public Computer2() {
+
+	}
+
+	/**
+	 * @param id
+	 */
+	public Computer2(Integer id) {
+		super(id);
+	}
+
+	/**
+	 * @return the computerName
+	 */
+	public String getComputerName() {
+		return computerName;
+	}
+
+	/**
+	 * @param computerName the computerName to set
+	 */
+	public void setComputerName(String computerName) {
+		this.computerName = computerName;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Employee.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Employee.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.*;
+
+/**
+ *
+ */
+@Entity
+public class Employee {
+	/** */
+	@OneToMany(cascade = CascadeType.ALL, mappedBy = "employee", orphanRemoval = true)
+	@OrderBy("idAsset asc")
+	private final List<Asset> assets = new ArrayList<Asset>();
+	/** */
+	@Id
+	@Column(name = "id")
+	private Integer id;
+
+	public Employee() {
+
+	}
+
+	/**
+	 * @param id
+	 */
+	public Employee(Integer id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the assets
+	 */
+	public List<Asset> getAssets() {
+		return assets;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Employee2.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/Employee2.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+@Entity
+public class Employee2 {
+	/** */
+	@OneToMany(cascade = CascadeType.ALL, mappedBy = "employee", orphanRemoval = true)
+	@OrderBy
+	private final List<Asset2> assets = new ArrayList<Asset2>();
+	/** */
+	@Id
+	@Column(name = "id")
+	private Integer id;
+
+	public Employee2() {
+
+	}
+
+	/**
+	 * @param id
+	 */
+	public Employee2(Integer id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the assets
+	 */
+	public List<Asset2> getAssets() {
+		return assets;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OrderByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OrderByTest.java
@@ -410,13 +410,79 @@ public class OrderByTest extends BaseCoreFunctionalTestCase {
 		assertEquals( "john", forum.getUsers().get( 0 ).getName() );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-7630")
+	public void testOrderByOnJoinedClassIdentifier() {
+
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		Employee employee = new Employee(1);
+
+		Computer computer = new Computer(1);
+		computer.setComputerName("Bob's computer");
+		computer.setEmployee(employee);
+
+		Computer computer2 = new Computer(2);
+		computer2.setComputerName("Alice's computer");
+		computer2.setEmployee(employee);
+
+		s.save(employee);
+		s.save(computer2);
+		s.save(computer);
+
+		s.flush();
+		s.clear();
+		sessionFactory().getCache().evictEntityRegions();
+
+		employee = (Employee) s.get(Employee.class, employee.getId());
+
+		assertEquals(2, employee.getAssets().size());
+		assertEquals(1, employee.getAssets().get(0).getIdAsset().intValue());
+		assertEquals(2, employee.getAssets().get(1).getIdAsset().intValue());
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-7888")
+	public void testOrderByOnJoinedClassEmpty() {
+
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		Employee2 employee = new Employee2(1);
+
+		Computer2 computer = new Computer2(1);
+		computer.setComputerName("Bob's computer");
+		computer.setEmployee(employee);
+
+		Computer2 computer2 = new Computer2(2);
+		computer2.setComputerName("Alice's computer");
+		computer2.setEmployee(employee);
+
+		s.save(employee);
+		s.save(computer2);
+		s.save(computer);
+
+		s.flush();
+		s.clear();
+		sessionFactory().getCache().evictEntityRegions();
+
+		employee = (Employee2) s.get(Employee2.class, employee.getId());
+
+		assertEquals(2, employee.getAssets().size());
+		assertEquals(1, employee.getAssets().get(0).getIdAsset().intValue());
+		assertEquals(2, employee.getAssets().get(1).getIdAsset().intValue());
+	}
+
 	@Override
 	protected Class[] getAnnotatedClasses() {
 		return new Class[] {
 				Order.class, OrderItem.class, Zoo.class, Tiger.class,
 				Monkey.class, Visitor.class, Box.class, Item.class,
 				BankAccount.class, Transaction.class,
-				Comment.class, Forum.class, Post.class, User.class
+				Comment.class, Forum.class, Post.class, User.class,
+				Asset.class, Computer.class, Employee.class,
+				Asset2.class, Computer2.class, Employee2.class,
 		};
 	}
 }


### PR DESCRIPTION
I tried to solve the long standing issue of not being able to @OrderBy primary key of supperclass (regression since 4.1.5; change in JoinedSubclassEntityPersister.java). Besides I have found, that using @OrderBy without attribute name do nothing (maybe JIRA HHH-7888 ?). It can be solved by removing one check  (CollectionBinder.java; All tests still pass).

I added for both cases unit tests where I used Composite Primary key to better test the functionality.
