### PR TITLE
Add pagination support to the SQLServer2012Dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
@@ -65,4 +65,16 @@ public class SQLServer2012Dialect extends SQLServer2008Dialect {
 	public String getQuerySequencesString() {
 		return "select name from sys.sequences";
 	}
+
+	@Override
+	public String getLimitString(String sql, boolean hasOffset) {
+		return new StringBuffer( sql.length()+20 )
+				.append( sql )
+				.append( hasOffset ? " offset ? rows fetch next ? rows only" : " offset 0 rows fetch next ? rows only" )
+				.toString();
+	}
+
+	public boolean bindLimitParametersInReverseOrder() {
+		return false ;
+	}
 }


### PR DESCRIPTION
Override the getLimitString and bindLimitParametersReverseOrder methods to support SQL Server 2012's pagination syntax:

SELECT \* FROM TableName ORDER BY id OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY;
