### PR TITLE
Updated ColumnValues.java: fixed incorrect variable assignment

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/source/annotations/attribute/ColumnValues.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/source/annotations/attribute/ColumnValues.java
@@ -70,7 +70,7 @@ public class ColumnValues {
 
 		AnnotationValue uniqueValue = columnAnnotation.value( "unique" );
 		if ( uniqueValue != null ) {
-			this.unique = nameValue.asBoolean();
+			this.unique = uniqueValue.asBoolean();
 		}
 
 		AnnotationValue nullableValue = columnAnnotation.value( "nullable" );


### PR DESCRIPTION
(Updated since creating pull request) first of all apologies, I may have jumped the gun with this pull request, I read the contributing.md page after doing this, and haven't signed the CLA, or ran any tests. This is the first time I've working on OSS and I signed up to GitHub just to make this edit. It's a very simple fix and don't know how this hasn't been picked up yet. I haven't created a JIRA ticket, I need to familiarise myself with the process. I will try to do things "proper" if I make any more contributions :)

this.unique = nameValue.asBoolean() was throwing Exception with message "not a Boolean". This is a typo, and should be this.unique = uniqueValue.asBoolean()
