### PR TITLE
HHH-8644 Perform build-time instrumentation via maven.

### DIFF
--- a/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -8,6 +8,7 @@ repositories {
 dependencies {
     compile( libraries.maven_plugin )
     compile( libraries.maven_plugin_tools )
+    compile( libraries.plexus_utils )
     compile( project(':hibernate-core') )
     compile( libraries.jpa )
     compile( libraries.javassist )

--- a/hibernate-maven-plugin/src/main/java/org/hibernate/bytecode/instrument/plugins/InstrumentMojo.java
+++ b/hibernate-maven-plugin/src/main/java/org/hibernate/bytecode/instrument/plugins/InstrumentMojo.java
@@ -1,0 +1,70 @@
+package org.hibernate.bytecode.instrument.plugin;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.hibernate.bytecode.buildtime.internal.JavassistInstrumenter;
+import org.hibernate.bytecode.buildtime.spi.Instrumenter.Options;
+
+/**
+ * Instruments class files to enable compile-time Hibernate field-interceptors.
+ */
+@Mojo(name = "instrument", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
+public final class InstrumentMojo extends AbstractMojo {
+	/**
+	 * The build directory, to perform instrumentation on. Defaults to ${project.build.directory}.
+	 */
+	@Parameter(property = "project.build.directory", readonly = true, required = true)
+	private File buildDirectory = new File("");
+	/**
+	 * A list of file patterns to exclude from instrumentation. Defaults to nothing.
+	 */
+	@Parameter
+	private String[] excludes = new String[] {};
+	/**
+	 * Whether or not extended instrumentation should be performed on class files. Defaults to false.
+	 */
+	@Parameter
+	private boolean extendedInstrumentation = false;
+	/**
+	 * A list of file patterns to include in instrumentation. Defaults to all class files in the build directory.
+	 */
+	@Parameter
+	private String[] includes = new String[] {"**/*.class"};
+	
+	@Component
+	private Logger logger;
+	
+	/* (non-Javadoc)
+	 * @see org.apache.maven.plugin.Mojo#execute()
+	 */
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		JavassistInstrumenter task = new JavassistInstrumenter(new LoggerBridge(logger), new Options() {
+			@Override
+			public boolean performExtendedInstrumentation() {
+				return extendedInstrumentation;
+			}});
+		DirectoryScanner scanner = new DirectoryScanner();
+		scanner.setBasedir(buildDirectory);
+		scanner.setCaseSensitive(true);
+		scanner.setIncludes(includes);
+		scanner.setExcludes(excludes);
+		scanner.scan();
+		Set<File> files = new HashSet<File>();
+		for (String file : scanner.getIncludedFiles()) {
+			files.add(new File(buildDirectory, file));
+		}
+		task.execute(files);
+	}
+}

--- a/hibernate-maven-plugin/src/main/java/org/hibernate/bytecode/instrument/plugins/LoggerBridge.java
+++ b/hibernate-maven-plugin/src/main/java/org/hibernate/bytecode/instrument/plugins/LoggerBridge.java
@@ -1,0 +1,57 @@
+package com.awesomeware.hibernate.plugin;
+
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * A bridge to allow Maven's plexus logging to be used in Hibernate's buildtime tasks.
+ */
+public final class LoggerBridge implements org.hibernate.bytecode.buildtime.spi.Logger {
+	private final Logger mavenLogger;
+	
+	/**
+	 * Constructs a bridge, using a provided Maven plexus logger to direct logger output to.
+	 * 
+	 * @param mavenLogger The Maven plexus logger to direct logger output to.
+	 */
+	public LoggerBridge(final Logger mavenLogger) {
+		this.mavenLogger = mavenLogger;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.hibernate.bytecode.buildtime.spi.Logger#trace()
+	 */
+	@Override
+	public void trace(String message) {}
+
+	/* (non-Javadoc)
+	 * @see org.hibernate.bytecode.buildtime.spi.Logger#debug()
+	 */
+	@Override
+	public void debug(String message) {
+		mavenLogger.debug(message);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.hibernate.bytecode.buildtime.spi.Logger#info()
+	 */
+	@Override
+	public void info(String message) {
+		mavenLogger.info(message);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.hibernate.bytecode.buildtime.spi.Logger#warn()
+	 */
+	@Override
+	public void warn(String message) {
+		mavenLogger.warn(message);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.hibernate.bytecode.buildtime.spi.Logger#error()
+	 */
+	@Override
+	public void error(String message) {
+		mavenLogger.error(message);
+	}
+}

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -75,6 +75,7 @@ ext {
             //Maven plugin framework
             maven_plugin: 'org.apache.maven:maven-plugin-api:3.0.5',
             maven_plugin_tools: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.2',
+            plexus_utils: 'org.codehaus.plexus:plexus-utils:3.0.15',
 
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~ testing
 


### PR DESCRIPTION
Provides a maven mojo, that performs the same kind of function as the existing ant InstrumentTask. This mojo will allow users to perform build-time instrumentation of field-accessors as part of the maven life-cycle.
