### PR TITLE
HHH-8228 - enable foreign keys in HANA dialects by defaulting to 'ON UPD...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
@@ -31,7 +31,7 @@ package org.hibernate.dialect;
  * @author Andrew Clemons <andrew.clemons@sap.com>
  */
 public class HANARowStoreDialect extends AbstractHANADialect {
-	
+
 	// Even though it's currently pointless, provide this structure in case HANA row store merits additional
 	// differences in the future.
 


### PR DESCRIPTION
As discussed. The HANA dialects pass the matrix test suite with foreign keys enabled if the default behaviour on update is cascade.
