### PR TITLE
Fix HSQLDB dialect for non-existing constraints.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -292,8 +292,16 @@ public class HSQLDialect extends Dialect {
 		return hsqldbVersion < 20;
 	}
 
+	// Note : HSQLDB actually supports [IF EXISTS] before AND after the <tablename>
+	// But as CASCADE has to be AFTER IF EXISTS in case it's after the tablename, 
+	// We put the IF EXISTS before the tablename to be able to add CASCADE after.
 	@Override
 	public boolean supportsIfExistsAfterTableName() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsIfExistsBeforeTableName() {
 		return true;
 	}
 
@@ -643,5 +651,16 @@ public class HSQLDialect extends Dialect {
 	@Override
 	public boolean supportsTupleDistinctCounts() {
 		return false;
+	}
+
+	// Do not drop constraints explicitly, just do this by cascading instead.
+	@Override
+	public boolean dropConstraints() {
+		return false;
+	}
+
+	@Override
+	public String getCascadeConstraintsString() {
+		return " CASCADE ";
 	}
 }


### PR DESCRIPTION
This commits relates to https://hibernate.atlassian.net/browse/HHH-7002.
It basically removes the explicit constraints dropping, and uses
cascading instead.

As HSQLDB requires to put CASCADE last, but fortunately accepts IF
EXISTS also before tablename, we just put the IF EXISTS _before_ the
tablename, and CASCADE after it. And there you go.
