### PR TITLE
Bug-Fix when super-class is Audited-Entity

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/ToOneIdMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/ToOneIdMapper.java
@@ -107,7 +107,7 @@ public class ToOneIdMapper extends AbstractToOneMapper {
 				boolean ignoreNotFound = false;
 				if ( !referencedEntity.isAudited() ) {
 					final String referencingEntityName = verCfg.getEntCfg().getEntityNameForVersionsEntityName( (String) data.get( "$type$" ) );
-					ignoreNotFound = verCfg.getEntCfg().get( referencingEntityName ).getRelationDescription( getPropertyData().getName() ).isIgnoreNotFound();
+					ignoreNotFound = verCfg.getEntCfg().getRelationDescription(referencingEntityName, getPropertyData().getName()).isIgnoreNotFound();
 				}
 				if ( ignoreNotFound ) {
 					// Eagerly loading referenced entity to silence potential (in case of proxy)


### PR DESCRIPTION
The prior-code did not support a scenario involving an audited-property in a super-class referencing a non-audited entity; it presumed the property was defined/audited in the entity been retrieved. Prior-code was only checking for relationdescription in the entity-configuration of the retrieved entity instead of recursively checking as done in other parts of the code.
java.lang.NullPointerException
    at org.hibernate.envers.internal.entities.mapper.relation.ToOneIdMapper.nullSafeMapToEntityFromMap(ToOneIdMapper.java:110)
    at org.hibernate.envers.internal.entities.mapper.relation.AbstractToOneMapper.mapToEntityFromMap(AbstractToOneMapper.java:67)
    at org.hibernate.envers.internal.entities.mapper.MultiPropertyMapper.mapToEntityFromMap(MultiPropertyMapper.java:172)
    at org.hibernate.envers.internal.entities.mapper.SubclassPropertyMapper.mapToEntityFromMap(SubclassPropertyMapper.java:102)
    at org.hibernate.envers.internal.entities.mapper.SubclassPropertyMapper.mapToEntityFromMap(SubclassPropertyMapper.java:102)
    at org.hibernate.envers.internal.entities.EntityInstantiator.createInstanceFromVersionsEntity(EntityInstantiator.java:113)
    at org.hibernate.envers.internal.entities.EntityInstantiator.addInstancesFromVersionsEntities(EntityInstantiator.java:174)
    at org.hibernate.envers.query.internal.impl.EntitiesAtRevisionQuery.list(EntitiesAtRevisionQuery.java:136)
    at org.hibernate.envers.query.internal.impl.AbstractAuditQuery.getSingleResult(AbstractAuditQuery.java:113)
    at org.hibernate.envers.internal.reader.AuditReaderImpl.find(AuditReaderImpl.java:138)
    at org.hibernate.envers.internal.reader.AuditReaderImpl.find(AuditReaderImpl.java:108)
    at org.hibernate.envers.internal.reader.AuditReaderImpl.find(AuditReaderImpl.java:102)
