### PR TITLE
Fixed StatelessSession inserting exception and testcase added

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1684,7 +1684,7 @@ public final class SessionFactoryImpl
 
 		@Override
 		public StatelessSession openStatelessSession() {
-			return new StatelessSessionImpl( connection, tenantIdentifier, sessionFactory );
+			return new StatelessSessionImpl( connection, tenantIdentifier, sessionFactory, sessionFactory.settings.getRegionFactory().nextTimestamp() );
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -84,10 +84,12 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 
 	private TransactionCoordinator transactionCoordinator;
 	private PersistenceContext temporaryPersistenceContext = new StatefulPersistenceContext( this );
+	private long timestamp;
 
-	StatelessSessionImpl(Connection connection, String tenantIdentifier, SessionFactoryImpl factory) {
+	StatelessSessionImpl(Connection connection, String tenantIdentifier, SessionFactoryImpl factory, long timestamp) {
 		super( factory, tenantIdentifier );
 		this.transactionCoordinator = new TransactionCoordinatorImpl( connection, this );
+		this.timestamp = timestamp;
 	}
 
 	// TransactionContext ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -532,7 +534,7 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 
 	@Override
 	public long getTimestamp() {
-		throw new UnsupportedOperationException();
+		return timestamp;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/Mappings.hbm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (c) 2009, Red Hat Middleware LLC or third-party contributors as
+  ~ indicated by the @author tags or express copyright attribution
+  ~ statements applied by the authors.  All third-party contributions are
+  ~ distributed under license by Red Hat Middleware LLC.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use, modify,
+  ~ copy, or redistribute it subject to the terms and conditions of the GNU
+  ~ Lesser General Public License, as published by the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+  ~ for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this distribution; if not, write to:
+  ~ Free Software Foundation, Inc.
+  ~ 51 Franklin Street, Fifth Floor
+  ~ Boston, MA  02110-1301  USA
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.test.stateless.insert">
+
+    <class name="Message">
+        <cache usage="read-write"/>
+        <id name="id">
+            <generator class="assigned"/>
+        </id>
+        <property name="subject"/>
+        <property name="content"/>
+    </class>
+
+    <class name="MessageRecipient">
+        <cache usage="read-write"/>
+        <id name="id">
+            <generator class="assigned"/>
+        </id>
+        <property name="email"/>
+        <many-to-one name="message" foreign-key="fk_message_recipient"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/Message.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/Message.java
@@ -1,0 +1,35 @@
+package org.hibernate.test.stateless.insert;
+
+/**
+ * @author mukhanov@gmail.com
+ */
+public class Message {
+
+    private String id;
+    private String subject;
+    private String content;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/MessageRecipient.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/MessageRecipient.java
@@ -1,0 +1,35 @@
+package org.hibernate.test.stateless.insert;
+
+/**
+ * @author mukhanov@gmail.com
+ */
+public class MessageRecipient {
+
+    private String id;
+    private String email;
+    private Message message;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/StatelessSessionInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/stateless/insert/StatelessSessionInsertTest.java
@@ -1,0 +1,81 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2009-2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.stateless.insert;
+
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.Transaction;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.jboss.logging.Logger;
+import org.junit.Test;
+
+/**
+ * @author mukhanov@gmail.com
+ */
+public class StatelessSessionInsertTest extends BaseCoreFunctionalTestCase {
+    private static final Logger log = Logger.getLogger(StatelessSessionInsertTest.class);
+
+    @Override
+    public String[] getMappings() {
+        return new String[]{"stateless/insert/Mappings.hbm.xml"};
+    }
+
+    @Test
+    public void testInsertWithForeignKey() {
+        Session session = sessionFactory().openSession();
+        Transaction tx = session.beginTransaction();
+
+        Message msg = new Message();
+        final String messageId = "message_id";
+        msg.setId(messageId);
+        msg.setContent("message_content");
+        msg.setSubject("message_subject");
+        session.save(msg);
+
+        tx.commit();
+        session.close();
+
+        StatelessSession statelessSession = sessionFactory().openStatelessSession();
+        tx = statelessSession.beginTransaction();
+
+        MessageRecipient signature = new MessageRecipient();
+        signature.setId("recipient");
+        signature.setEmail("recipient@hibernate.org");
+        signature.setMessage(msg);
+        statelessSession.insert(signature);
+
+        tx.commit();
+
+        cleanup();
+    }
+
+    private void cleanup() {
+        Session s = openSession();
+        s.beginTransaction();
+        s.createQuery("delete MessageRecipient").executeUpdate();
+        s.createQuery("delete Message").executeUpdate();
+        s.getTransaction().commit();
+        s.close();
+    }
+}


### PR DESCRIPTION
Reproducing conditions:
- 'assigned' generator strategy for master entity
- using cache for master entity.

Hibernate had tried to check if identity is transient using cache and fall down due to method getTimestamp() was not implemented for StatelessSession.
