### PR TITLE
Made this only remove "and " and " and"

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java
@@ -125,10 +125,10 @@ public class SelectStatementBuilder {
 
 	private String cleanRestrictions(String restrictions) {
 		restrictions = restrictions.trim();
-		if ( restrictions.startsWith( "and" ) ) {
+		if ( restrictions.startsWith( "and " ) ) {
 			restrictions = restrictions.substring( 4 );
 		}
-		if ( restrictions.endsWith( "and" ) ) {
+		if ( restrictions.endsWith( " and" ) ) {
 			restrictions = restrictions.substring( 0, restrictions.length()-4 );
 		}
 


### PR DESCRIPTION
Made this only remove "and " and " and" as otherwise tables named android end up being queried as "roid". That tends to be bad.
