### PR TITLE
HH-8900 : Test fails because it's looking for "nextval".

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OneToOneTest.java
@@ -412,60 +412,60 @@ public class OneToOneTest extends BaseCoreFunctionalTestCase {
 	protected String[] getXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/onetoone/orm.xml" };
 	}
-}
 
+	/**
+	 * Verifies that generated 'select' statement has desired number of joins 
+	 * @author Sharath Reddy
+	 *
+	 */
+	class JoinCounter extends EmptyInterceptor {
+	     
+	    private static final long serialVersionUID = -3689681272273261051L;
+	    
+	    private int expectedNumberOfJoins = 0;
+	    private String nextValString;
+	            
+	    public JoinCounter(int val) {
+	        super();
+	        this.expectedNumberOfJoins = val;
+	        try {
+	            nextValString = getDialect().getSequenceNextValString("");
+	        } catch (MappingException ex) {
+	            nextValString = "nextval";
+	        }
+	    }
 
-/**
- * Verifies that generated 'select' statement has desired number of joins 
- * @author Sharath Reddy
- *
- */
-class JoinCounter extends EmptyInterceptor {
-	 
-	private static final long serialVersionUID = -3689681272273261051L;
-	
-	private int expectedNumberOfJoins = 0;
-	private String nextValString;
-			
-	public JoinCounter(int val) {
-		super();
-		this.expectedNumberOfJoins = val;
-		try {
-		    nextValString = Dialect.getDialect().getSequenceNextValString("");
-		} catch (MappingException ex) {
-		    nextValString = "nextval";
-		}
-	}
-
-	public String onPrepareStatement(String sql) {
-		int numberOfJoins = 0;
-		if (sql.startsWith("select") & !sql.contains(nextValString)) {
-			 numberOfJoins = count(sql, "join");
-			 assertEquals( sql,  expectedNumberOfJoins, numberOfJoins );
-		}
-						
-		return sql;
-	 }
-	
-	 /**
-	   * Count the number of instances of substring within a string.
-	   *
-	   * @param string     String to look for substring in.
-	   * @param substring  Sub-string to look for.
-	   * @return           Count of substrings in string.
-	   */
-	  private int count(final String string, final String substring)
-	  {
-	     int count = 0;
-	     int idx = 0;
-
-	     while ((idx = string.indexOf(substring, idx)) != -1)
-	     {
-	        idx++;
-	        count++;
+	    public String onPrepareStatement(String sql) {
+	        int numberOfJoins = 0;
+	        if (sql.startsWith("select") & !sql.contains(nextValString)) {
+	             numberOfJoins = count(sql, "join");
+	             assertEquals( sql,  expectedNumberOfJoins, numberOfJoins );
+	        }
+	                        
+	        return sql;
 	     }
+	    
+	     /**
+	       * Count the number of instances of substring within a string.
+	       *
+	       * @param string     String to look for substring in.
+	       * @param substring  Sub-string to look for.
+	       * @return           Count of substrings in string.
+	       */
+	      private int count(final String string, final String substring)
+	      {
+	         int count = 0;
+	         int idx = 0;
 
-	     return count;
-	  }
-	
+	         while ((idx = string.indexOf(substring, idx)) != -1)
+	         {
+	            idx++;
+	            count++;
+	         }
+
+	         return count;
+	      }
+	}
 }
+
+


### PR DESCRIPTION
The test assumes "nextval" as the sequence generator statment , but FDB doesn't (like a number of other dialects) use "nextval". Update the test to skip based upon the Dialect sequence generator string.
