### PR TITLE
Fix HHH-8930 - rebuildSessionFactory leaking resources

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -155,6 +155,10 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		}
 		try {
 			sessionFactory.close();
+			sessionFactory = null;
+			configuration = null;
+			serviceRegistry.destroy();
+			serviceRegistry = null;
 		}
 		catch (Exception ignore) {
 		}


### PR DESCRIPTION
Make the rebuildSessionFactory() method be more aggressive about closing
everything. Particularly calling serviceRegistry.destroy(), which
releases all of the pool connections upon failure. Otherwise they're
left hanging around to cause problems on the server.
