### PR TITLE
Avoid useless creation of an array in #getColumnSpan(Mapping).

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -151,7 +151,7 @@ public abstract class AbstractStandardBasicType<T>
 	}
 
 	public final int getColumnSpan(Mapping mapping) throws MappingException {
-		return sqlTypes( mapping ).length;
+		return 1;
 	}
 
 	public final int[] sqlTypes(Mapping mapping) throws MappingException {


### PR DESCRIPTION
The method AbstractStandardBasicType#getColumnSpan(Mapping) returns always the length of the array returned by the method AbstractStandardBasicType#sqlTypes(Mapping). But the size of the returned array is a constant value. The method #sqlTypes(Mapping) is final and returns always an array of the size 1. Changing the #getColumnSpan(Mapping)-method to return the constant value of 1 should avoid useless creation of an array and therefore reduce the garbage produced by Hibernate.
