### PR TITLE
HHH-8961 Reduce allocation cost of org.hibernate.cache.spi.CacheKey inst...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -95,8 +95,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		if ( persister.hasCache() ) {
 			final CacheKey ck = session.generateCacheKey(
 					key,
-					persister.getKeyType(),
-					persister.getRole()
+					persister
 			);
 			final SoftLock lock = persister.getCacheAccessStrategy().lockItem( ck, null );
 			// the old behavior used key as opposed to getKey()
@@ -146,8 +145,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		if ( persister.hasCache() ) {
 			final CacheKey ck = session.generateCacheKey(
 					key, 
-					persister.getKeyType(), 
-					persister.getRole()
+					persister
 			);
 			persister.getCacheAccessStrategy().remove( ck );
 		}
@@ -188,8 +186,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		public void doAfterTransactionCompletion(boolean success, SessionImplementor session) {
 			final CacheKey ck = session.generateCacheKey(
 					key,
-					persister.getKeyType(),
-					persister.getRole()
+					persister
 			);
 			persister.getCacheAccessStrategy().unlockItem( ck, lock );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -102,7 +102,7 @@ public class EntityDeleteAction extends EntityAction {
 
 		final CacheKey ck;
 		if ( persister.hasCache() ) {
-			ck = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
+			ck = session.generateCacheKey( id, persister );
 			lock = persister.getCacheAccessStrategy().lockItem( ck, version );
 		}
 		else {
@@ -192,8 +192,7 @@ public class EntityDeleteAction extends EntityAction {
 		if ( getPersister().hasCache() ) {
 			final CacheKey ck = getSession().generateCacheKey(
 					getId(),
-					getPersister().getIdentifierType(),
-					getPersister().getRootEntityName()
+					getPersister()
 			);
 			getPersister().getCacheAccessStrategy().unlockItem( ck, lock );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -130,7 +130,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 					session
 			);
 			cacheEntry = persister.getCacheEntryStructure().structure( ce );
-			final CacheKey ck = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
+			final CacheKey ck = session.generateCacheKey( id, persister );
 
 			final boolean put = cacheInsert( persister, ck );
 
@@ -212,7 +212,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 	public void doAfterTransactionCompletion(boolean success, SessionImplementor session) throws HibernateException {
 		final EntityPersister persister = getPersister();
 		if ( success && isCachePutEnabled( persister, getSession() ) ) {
-			final CacheKey ck = getSession().generateCacheKey( getId(), persister.getIdentifierType(), persister.getRootEntityName() );
+			final CacheKey ck = getSession().generateCacheKey( getId(), persister );
 			final boolean put = cacheAfterInsert( persister, ck );
 
 			if ( put && getSession().getFactory().getStatistics().isStatisticsEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -145,8 +145,7 @@ public final class EntityUpdateAction extends EntityAction {
 		if ( persister.hasCache() ) {
 			ck = session.generateCacheKey(
 					id, 
-					persister.getIdentifierType(), 
-					persister.getRootEntityName()
+					persister
 			);
 			lock = persister.getCacheAccessStrategy().lockItem( ck, previousVersion );
 		}
@@ -315,8 +314,7 @@ public final class EntityUpdateAction extends EntityAction {
 			
 			final CacheKey ck = getSession().generateCacheKey(
 					getId(),
-					persister.getIdentifierType(), 
-					persister.getRootEntityName()
+					persister
 			);
 			
 			if ( success && cacheEntry!=null /*!persister.isCacheInvalidationRequired()*/ ) {

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
@@ -161,7 +161,7 @@ public class CollectionCacheInvalidator implements Integrator, PostInsertEventLi
 
 	private void evict(Serializable id, CollectionPersister collectionPersister, EventSource session) {
 		LOG.debug( "Evict CollectionRegion " + collectionPersister.getRole() + " for id " + id );
-		CacheKey key = session.generateCacheKey( id, collectionPersister.getKeyType(), collectionPersister.getRole() );
+		CacheKey key = session.generateCacheKey( id, collectionPersister );
 		collectionPersister.getCacheAccessStrategy().evict( key );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/SurrogatePersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/SurrogatePersister.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Middleware LLC or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Middleware LLC.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ *
+ */
+package org.hibernate.cache.internal;
+
+import org.hibernate.persister.Persister;
+import org.hibernate.type.Type;
+
+
+/**
+ * SurrogatePersister. This class was created as Deprecated already:
+ * the intention is to use it temporarily only to avoid breaking some APIs
+ * while improving the implementation of org.hibernate.cache.spi.CacheKey.
+ * 
+ * @deprecated
+ * @author Sanne Grinovero
+ * @since 4.3
+ */
+@Deprecated
+public final class SurrogatePersister implements Persister {
+
+	private final Type identifierType;
+	private final String role;
+
+	/**
+	 * Create a new SurrogatePersister.
+	 * 
+	 * @param identifierType
+	 * @param role
+	 */
+	public SurrogatePersister(Type identifierType, String role) {
+		this.identifierType = identifierType;
+		this.role = role;
+	}
+
+	@Override
+	public Type getIdentifierType() {
+		return identifierType;
+	}
+
+	@Override
+	public String getRole() {
+		return role;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/TenantAwareCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/TenantAwareCacheKey.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.cache.internal;
+
+import java.io.Serializable;
+
+import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.Persister;
+
+/**
+ * Variation of CacheKey to be used when multi-tenancy is applied.
+ * The tenantId field was not simply added to the superclass because of performance considerations:
+ * CacheKey instances are have a very high allocation frequency and this field would enlarge the
+ * size by 50%.
+ *
+ * @author Sanne Grinovero
+ */
+public final class TenantAwareCacheKey extends CacheKey {
+
+	private final String tenantId;
+
+	/**
+	 * Create a new TenantAwareCacheKey.
+	 *
+	 * @param id
+	 * @param typePersister
+	 * @param factory
+	 * @param tenantIdentifier
+	 */
+	public TenantAwareCacheKey(Serializable id, Persister typePersister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		super( id, typePersister, factory );
+		this.tenantId = tenantIdentifier;
+	}
+
+	@Override
+	public String getTenantId() {
+		return tenantId;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -199,7 +199,7 @@ public final class TwoPhaseLoad {
 
 			final Object version = Versioning.getVersion( hydratedState, persister );
 			final CacheEntry entry = persister.buildCacheEntry( entity, hydratedState, version, session );
-			final CacheKey cacheKey = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
+			final CacheKey cacheKey = session.generateCacheKey( id, persister );
 
 			// explicit handling of caching for rows just inserted and then somehow forced to be read
 			// from the database *within the same transaction*.  usually this is done by

--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -347,7 +347,7 @@ public class CollectionLoadContext {
 		}
 
 		final CollectionCacheEntry entry = new CollectionCacheEntry( lce.getCollection(), persister );
-		final CacheKey cacheKey = session.generateCacheKey( lce.getKey(), persister.getKeyType(), persister.getRole() );
+		final CacheKey cacheKey = session.generateCacheKey( lce.getKey(), persister );
 
 		try {
 			session.getEventListenerManager().cachePutStart();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -221,8 +221,7 @@ public class BatchFetchQueue {
 		if ( persister.hasCache() ) {
 			final CacheKey key = context.getSession().generateCacheKey(
 					entityKey.getIdentifier(),
-					persister.getIdentifierType(),
-					entityKey.getEntityName()
+					persister
 			);
 			return CacheHelper.fromSharedCache( context.getSession(), key, persister.getCacheAccessStrategy() ) != null;
 		}
@@ -334,8 +333,7 @@ public class BatchFetchQueue {
 		if ( persister.hasCache() ) {
 			CacheKey cacheKey = context.getSession().generateCacheKey(
 					collectionKey,
-					persister.getKeyType(),
-					persister.getRole()
+					persister
 			);
 			return CacheHelper.fromSharedCache( context.getSession(), cacheKey, persister.getCacheAccessStrategy() ) != null;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -61,6 +61,7 @@ import org.hibernate.engine.transaction.spi.TransactionCoordinator;
 import org.hibernate.jdbc.ReturningWork;
 import org.hibernate.jdbc.Work;
 import org.hibernate.loader.custom.CustomQuery;
+import org.hibernate.persister.Persister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.stat.SessionStatistics;
@@ -114,9 +115,14 @@ public class SessionDelegatorBaseImpl implements SessionImplementor, Session {
 		return sessionImplementor.generateEntityKey( id, persister );
 	}
 
-	@Override
+	@Override @Deprecated
 	public CacheKey generateCacheKey(Serializable id, Type type, String entityOrRoleName) {
 		return sessionImplementor.generateCacheKey( id, type, entityOrRoleName );
+	}
+
+	@Override
+	public CacheKey generateCacheKey(Serializable id, Persister persister) {
+		return sessionImplementor.generateCacheKey( id, persister );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -45,6 +45,7 @@ import org.hibernate.engine.jdbc.spi.JdbcConnectionAccess;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
 import org.hibernate.engine.transaction.spi.TransactionCoordinator;
 import org.hibernate.loader.custom.CustomQuery;
+import org.hibernate.persister.Persister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.Type;
 
@@ -89,8 +90,20 @@ public interface SessionImplementor extends Serializable, LobCreationContext {
 	 * @param entityOrRoleName The entity name or collection role.
 	 *
 	 * @return The cache key
+	 * @deprecated use {@link #generateCacheKey(Serializable, Persister)}
 	 */
+	@Deprecated
 	public CacheKey generateCacheKey(Serializable id, final Type type, final String entityOrRoleName);
+
+	/**
+	 * Hide the changing requirements of cache key creation.
+	 *
+	 * @param id The entity identifier or collection key.
+	 * @param typePersister The type of the entity or collection
+	 *
+	 * @return The cache key
+	 */
+	public CacheKey generateCacheKey(Serializable id, Persister typePersister);
 
 	/**
 	 * Retrieves the interceptor currently in use by this event source.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
@@ -82,7 +82,7 @@ public abstract class AbstractLockUpgradeEventListener extends AbstractReassocia
 			final SoftLock lock;
 			final CacheKey ck;
 			if ( persister.hasCache() ) {
-				ck = source.generateCacheKey( entry.getId(), persister.getIdentifierType(), persister.getRootEntityName() );
+				ck = source.generateCacheKey( entry.getId(), persister );
 				lock = persister.getCacheAccessStrategy().lockItem( ck, entry.getVersion() );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -133,7 +133,7 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 		}
 
 		final SessionFactoryImplementor factory = source.getFactory();
-		final CacheKey ck = source.generateCacheKey( id, persister.getKeyType(), persister.getRole() );
+		final CacheKey ck = source.generateCacheKey( id, persister );
 		final Object ce = CacheHelper.fromSharedCache( source, ck, persister.getCacheAccessStrategy() );
 
 		if ( factory.getStatistics().isStatisticsEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -377,8 +377,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 		if ( persister.hasCache() ) {
 			ck = source.generateCacheKey(
 					event.getEntityId(),
-					persister.getIdentifierType(),
-					persister.getRootEntityName()
+					persister
 			);
 			lock = persister.getCacheAccessStrategy().lockItem( ck, null );
 		}
@@ -590,8 +589,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 		final SessionFactoryImplementor factory = source.getFactory();
 		final CacheKey ck = source.generateCacheKey(
 				event.getEntityId(),
-				persister.getIdentifierType(),
-				persister.getRootEntityName()
+				persister
 		);
 
 		final Object ce = CacheHelper.fromSharedCache( source, ck, persister.getCacheAccessStrategy() );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -152,8 +152,7 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		if ( persister.hasCache() ) {
 			final CacheKey ck = source.generateCacheKey(
 					id,
-					persister.getIdentifierType(),
-					persister.getRootEntityName()
+					persister
 			);
 			persister.getCacheAccessStrategy().evict( ck );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
@@ -119,11 +119,10 @@ public class CacheImpl implements CacheImplementor {
 	}
 
 	private CacheKey buildCacheKey(Serializable identifier, EntityPersister p) {
+		// have to assume non tenancy
 		return new CacheKey(
 				identifier,
-				p.getIdentifierType(),
-				p.getRootEntityName(),
-				null,                         // have to assume non tenancy
+				p,
 				sessionFactory
 		);
 	}
@@ -197,11 +196,10 @@ public class CacheImpl implements CacheImplementor {
 	}
 
 	private CacheKey buildCacheKey(Serializable ownerIdentifier, CollectionPersister p) {
+		// have to assume non tenancy
 		return new CacheKey(
 				ownerIdentifier,
-				p.getKeyType(),
-				p.getRole(),
-				null,                        // have to assume non tenancy
+				p,
 				sessionFactory
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1597,8 +1597,7 @@ public abstract class Loader {
 					session,
 					session.generateCacheKey(
 							key.getIdentifier(),
-							persister.getEntityMetamodel().getEntityType(),
-							key.getEntityName()
+							persister
 					),
 					persister.getCacheAccessStrategy()
 			);

--- a/hibernate-core/src/main/java/org/hibernate/persister/Persister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/Persister.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Middleware LLC or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Middleware LLC.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ *
+ */
+package org.hibernate.persister;
+
+import org.hibernate.type.Type;
+
+
+/**
+ * Unifying interface to entity persisters and collection persisters.
+ * 
+ * @author Sanne Grinovero
+ * @since 4.3
+ */
+public interface Persister {
+
+	/**
+	 * Get the "key" type (the type of the foreign key for collections or entity primary key).
+	 * Also used to be known as getKeyType
+	 */
+	public Type getIdentifierType();
+
+	/**
+	 * Get the name of this collection role (the fully qualified class name,
+	 * extended by a "property path") or entity name.
+	 * Also known as getEntityName()
+	 */
+	public String getRole();
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -815,6 +815,7 @@ public abstract class AbstractCollectionPersister
 		return sqlDeleteRowString;
 	}
 
+	@Deprecated//use getIdentifierType
 	@Override
 	public Type getKeyType() {
 		return keyType;

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -37,6 +37,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.metadata.CollectionMetadata;
+import org.hibernate.persister.Persister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.walking.spi.CollectionDefinition;
 import org.hibernate.type.CollectionType;
@@ -61,7 +62,7 @@ import org.hibernate.type.Type;
  * @see org.hibernate.collection.spi.PersistentCollection
  * @author Gavin King
  */
-public interface CollectionPersister extends CollectionDefinition {
+public interface CollectionPersister extends CollectionDefinition, Persister {
 	/**
 	 * Initialize the given collection with the given key
 	 */
@@ -85,7 +86,9 @@ public interface CollectionPersister extends CollectionDefinition {
 	public CollectionType getCollectionType();
 	/**
 	 * Get the "key" type (the type of the foreign key)
+	 * Use getIdentifierType()
 	 */
+	@Deprecated
 	public Type getKeyType();
 	/**
 	 * Get the "index" type for a list or map (optional operation)
@@ -209,11 +212,6 @@ public interface CollectionPersister extends CollectionDefinition {
 			SessionImplementor session)
 			throws HibernateException;
 	
-	/**
-	 * Get the name of this collection role (the fully qualified class name,
-	 * extended by a "property path")
-	 */
-	public String getRole();
 	/**
 	 * Get the persister of the entity that "owns" this collection
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -112,6 +112,7 @@ import org.hibernate.metamodel.binding.SimpleValueBinding;
 import org.hibernate.metamodel.binding.SingularAttributeBinding;
 import org.hibernate.metamodel.relational.DerivedValue;
 import org.hibernate.metamodel.relational.Value;
+import org.hibernate.persister.Persister;
 import org.hibernate.persister.walking.internal.EntityIdentifierDefinitionHelper;
 import org.hibernate.persister.walking.spi.AttributeDefinition;
 import org.hibernate.persister.walking.spi.EntityIdentifierDefinition;
@@ -151,7 +152,7 @@ import org.jboss.logging.Logger;
  */
 public abstract class AbstractEntityPersister
 		implements OuterJoinLoadable, Queryable, ClassMetadata, UniqueKeyLoadable,
-		SQLLoadable, LazyPropertyInitializer, PostInsertIdentityPersister, Lockable {
+		SQLLoadable, LazyPropertyInitializer, PostInsertIdentityPersister, Lockable, Persister {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, AbstractEntityPersister.class.getName() );
 
@@ -1235,7 +1236,7 @@ public abstract class AbstractEntityPersister
 		}
 
 		if ( hasCache() ) {
-			final CacheKey cacheKey = session.generateCacheKey( id, getIdentifierType(), getEntityName() );
+			final CacheKey cacheKey = session.generateCacheKey( id, this );
 			final Object ce = CacheHelper.fromSharedCache( session, cacheKey, getCacheAccessStrategy() );
 			if ( ce != null ) {
 				final CacheEntry cacheEntry = (CacheEntry) getCacheEntryStructure().destructure(ce, factory);
@@ -4348,6 +4349,11 @@ public abstract class AbstractEntityPersister
 		return entityMetamodel.getName();
 	}
 
+	@Override
+	public final String getRole() {
+		return getEntityName();
+	}
+
 	public EntityType getEntityType() {
 		return entityMetamodel.getEntityType();
 	}
@@ -4494,7 +4500,7 @@ public abstract class AbstractEntityPersister
 
 		// check to see if it is in the second-level cache
 		if ( hasCache() ) {
-			final CacheKey ck = session.generateCacheKey( id, getIdentifierType(), getRootEntityName() );
+			final CacheKey ck = session.generateCacheKey( id, this );
 			final Object ce = CacheHelper.fromSharedCache( session, ck, getCacheAccessStrategy() );
 			if ( ce != null ) {
 				return Boolean.FALSE;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -45,6 +45,7 @@ import org.hibernate.engine.spi.ValueInclusion;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.persister.Persister;
 import org.hibernate.persister.walking.spi.EntityDefinition;
 import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.tuple.entity.EntityTuplizer;
@@ -63,7 +64,7 @@ import org.hibernate.type.VersionType;
  * @see org.hibernate.persister.spi.PersisterFactory
  * @see org.hibernate.persister.spi.PersisterClassResolver
  */
-public interface EntityPersister extends OptimisticCacheSource, EntityDefinition {
+public interface EntityPersister extends OptimisticCacheSource, EntityDefinition, Persister {
 
 	/**
 	 * The property name of the "special" identifier property in HQL

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -614,6 +614,11 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		public boolean canUseReferenceCacheEntries() {
 			return false;
 		}
+
+		@Override
+		public String getRole() {
+			return null;
+		}
 	}
 
 	public static class NoopCollectionPersister implements CollectionPersister {

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
@@ -118,8 +118,7 @@ public class DynamicFilterTest extends BaseCoreFunctionalTestCase {
 		assertTrue( "No cache for collection", persister.hasCache() );
 		CacheKey cacheKey = ( (SessionImplementor) session ).generateCacheKey(
 				testData.steveId,
-				persister.getKeyType(),
-				persister.getRole()
+				persister
 		);
 		CollectionCacheEntry cachedData = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( cacheKey, ts );
 		assertNotNull( "collection was not in cache", cachedData );
@@ -136,8 +135,7 @@ public class DynamicFilterTest extends BaseCoreFunctionalTestCase {
 
 		CacheKey cacheKey2 = ( (SessionImplementor) session ).generateCacheKey(
 				testData.steveId,
-				persister.getKeyType(),
-				persister.getRole()
+				persister
 		);
 		CollectionCacheEntry cachedData2 = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( cacheKey2, ts );
 		assertNotNull( "collection no longer in cache!", cachedData2 );

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
@@ -136,6 +136,11 @@ public class CustomPersister implements EntityPersister {
 	}
 
 	@Override
+	public String getRole() {
+		return getEntityName();
+	}
+
+	@Override
 	public boolean implementsLifecycle() {
 		return false;
 	}


### PR DESCRIPTION
...ances

Remove tenantId field from CacheKey: use a different type when tenants are needed.
Also remove the Type as we should be able to rely on the entityOrRoleName String.

https://hibernate.atlassian.net/browse/HHH-8961
