### PR TITLE
HHH-8990 Improve backwards compatibility of 4.2 branch by reintroducing ...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/NonFlushedChanges.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/NonFlushedChanges.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2009-2011, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.engine.spi;
+
+import java.io.Serializable;
+
+/**
+ * This interface is going to be removed: only exists to improve backwards compatibility
+ * for other frameworks like Hibernate Search which still import it.
+ */
+@Deprecated
+public interface NonFlushedChanges extends Serializable {
+	/**
+	 * Remove the non-flushed changes from this NonFlushedChanges object.
+	 */
+	void clear();
+}


### PR DESCRIPTION
...the deleted NonFlushedChanges interface

https://hibernate.atlassian.net/browse/HHH-8990

@brmeyer turns out this is all I really need to get Hibernate Search to work on the full 4.2 range: we can ignore some of those methods as they are just compile-time dependencies, so the only remaining problem is that to compile with the older version it would import this interface.

@sebersole a good compromise?
