### PR TITLE
LoadQueryJoinAndFetchProcessor - wrong alias for OrderBy https://hibernate.atlassian.net/browse/HHH-9002

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/LoadQueryJoinAndFetchProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/LoadQueryJoinAndFetchProcessor.java
@@ -571,12 +571,12 @@ public class LoadQueryJoinAndFetchProcessor {
 			);
 
 			// add SQL ORDER-BY fragments
-			final String manyToManyOrdering = queryableCollection.getManyToManyOrderByString( collectionTableAlias );
+			final String manyToManyOrdering = queryableCollection.getManyToManyOrderByString( elementTableAlias );
 			if ( StringHelper.isNotEmpty( manyToManyOrdering ) ) {
 				selectStatementBuilder.appendOrderByFragment( manyToManyOrdering );
 			}
 
-			final String ordering = queryableCollection.getSQLOrderByString( collectionTableAlias );
+			final String ordering = queryableCollection.getSQLOrderByString( elementTableAlias );
 			if ( StringHelper.isNotEmpty( ordering ) ) {
 				selectStatementBuilder.appendOrderByFragment( ordering );
 			}


### PR DESCRIPTION
elementTableAlias used instead of collectionTableAlias for collection fetch order by statement,
