### PR TITLE
HHH-9158 Apply cascade-persist in orm.xml to annotated relationships

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1767,6 +1767,7 @@ public final class AnnotationBinder {
 		else {
 			final boolean forcePersist = property.isAnnotationPresent( MapsId.class )
 					|| property.isAnnotationPresent( Id.class );
+			final String defaultCascade = mappings.getDefaultCascade();
 			if ( property.isAnnotationPresent( ManyToOne.class ) ) {
 				ManyToOne ann = property.getAnnotation( ManyToOne.class );
 
@@ -1793,7 +1794,7 @@ public final class AnnotationBinder {
 				}
 				final boolean mandatory = !ann.optional() || forcePersist;
 				bindManyToOne(
-						getCascadeStrategy( ann.cascade(), hibernateCascade, false, forcePersist ),
+						getCascadeStrategy( ann.cascade(), hibernateCascade, false, forcePersist, defaultCascade ),
 						joinColumns,
 						!mandatory,
 						ignoreNotFound, onDeleteCascade,
@@ -1834,7 +1835,7 @@ public final class AnnotationBinder {
 				//@OneToOne with @PKJC can still be optional
 				final boolean mandatory = !ann.optional() || forcePersist;
 				bindOneToOne(
-						getCascadeStrategy( ann.cascade(), hibernateCascade, ann.orphanRemoval(), forcePersist ),
+						getCascadeStrategy( ann.cascade(), hibernateCascade, ann.orphanRemoval(), forcePersist, defaultCascade ),
 						joinColumns,
 						!mandatory,
 						getFetchMode( ann.fetch() ),
@@ -1872,7 +1873,7 @@ public final class AnnotationBinder {
 					}
 				}
 				bindAny(
-						getCascadeStrategy( null, hibernateCascade, false, forcePersist ),
+						getCascadeStrategy( null, hibernateCascade, false, forcePersist, defaultCascade ),
 						//@Any has not cascade attribute
 						joinColumns,
 						onDeleteCascade,
@@ -2092,7 +2093,7 @@ public final class AnnotationBinder {
 					);
 					collectionBinder.setCascadeStrategy(
 							getCascadeStrategy(
-									oneToManyAnn.cascade(), hibernateCascade, oneToManyAnn.orphanRemoval(), false
+									oneToManyAnn.cascade(), hibernateCascade, oneToManyAnn.orphanRemoval(), forcePersist, defaultCascade
 							)
 					);
 					collectionBinder.setOneToMany( true );
@@ -2119,7 +2120,7 @@ public final class AnnotationBinder {
 					);
 					collectionBinder.setCascadeStrategy(
 							getCascadeStrategy(
-									manyToManyAnn.cascade(), hibernateCascade, false, false
+									manyToManyAnn.cascade(), hibernateCascade, false, false, defaultCascade
 							)
 					);
 					collectionBinder.setOneToMany( false );
@@ -2129,7 +2130,7 @@ public final class AnnotationBinder {
 					collectionBinder.setTargetEntity(
 							mappings.getReflectionManager().toXClass( void.class )
 					);
-					collectionBinder.setCascadeStrategy( getCascadeStrategy( null, hibernateCascade, false, false ) );
+					collectionBinder.setCascadeStrategy( getCascadeStrategy( null, hibernateCascade, false, false, defaultCascade ) );
 					collectionBinder.setOneToMany( false );
 				}
 				collectionBinder.setMappedBy( mappedBy );
@@ -3149,11 +3150,36 @@ public final class AnnotationBinder {
 		return hibernateCascadeSet;
 	}
 
+	private static EnumSet<CascadeType> convertToHibernateCascadeType(String defaultCascade) {
+		EnumSet<CascadeType> hibernateCascadeSet = EnumSet.noneOf( CascadeType.class );
+		if( defaultCascade != null && !defaultCascade.isEmpty() ) {
+			for( String cascade : defaultCascade.split("\\s+") ) {
+				cascade = cascade.toUpperCase();
+				if( "ALL".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.ALL );
+				} else if( "PERSIST".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.PERSIST );
+				} else if( "MERGE".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.MERGE );
+				} else if( "REMOVE".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.REMOVE );
+				} else if( "REFRESH".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.REFRESH );
+				} else if( "DETACH".equals(cascade) ) {
+					hibernateCascadeSet.add( CascadeType.DETACH );
+				}
+			}
+		}
+
+		return hibernateCascadeSet;
+	}
+
 	private static String getCascadeStrategy(
 			javax.persistence.CascadeType[] ejbCascades,
 			Cascade hibernateCascadeAnnotation,
 			boolean orphanRemoval,
-			boolean forcePersist) {
+			boolean forcePersist,
+			String defaultCascade ) {
 		EnumSet<CascadeType> hibernateCascadeSet = convertToHibernateCascadeType( ejbCascades );
 		CascadeType[] hibernateCascades = hibernateCascadeAnnotation == null ?
 				null :
@@ -3170,6 +3196,8 @@ public final class AnnotationBinder {
 		if ( forcePersist ) {
 			hibernateCascadeSet.add( CascadeType.PERSIST );
 		}
+
+		hibernateCascadeSet.addAll(convertToHibernateCascadeType(defaultCascade));
 
 		StringBuilder cascade = new StringBuilder();
 		for ( CascadeType aHibernateCascadeSet : hibernateCascadeSet ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -145,6 +145,11 @@ public interface AvailableSettings {
 	String DEFAULT_CATALOG = "hibernate.default_catalog";
 
 	/**
+	 * Enable transitive persistence by default
+	 */
+	String CASCADE_PERSIST = "hibernate.cascade_persist";
+
+	/**
 	 * Enable logging of generated SQL to the console
 	 */
 	String SHOW_SQL ="hibernate.show_sql";

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -1398,6 +1398,11 @@ public class Configuration implements Serializable {
 				if ( StringHelper.isNotEmpty( catalog ) ) {
 					getProperties().put( Environment.DEFAULT_CATALOG, catalog );
 				}
+				// Set cascade-persist if orm.xml declares it.
+				final Object cascadePersist = defaults.get( "cascade-persist" );
+				if ( cascadePersist != null && cascadePersist == Boolean.TRUE ) {
+					getProperties().put( Environment.CASCADE_PERSIST, "true" );
+				}
 
 				AnnotationBinder.bindDefaults( createMappings() );
 				isDefaultProcessed = true;
@@ -3779,6 +3784,9 @@ public class Configuration implements Serializable {
 			//bind classes in the correct order calculating some inheritance state
 			List<XClass> orderedClasses = orderAndFillHierarchy( annotatedClasses );
 			Mappings mappings = createMappings();
+			if("true".equals(getProperty(AvailableSettings.CASCADE_PERSIST))) {
+				mappings.setDefaultCascade("persist");
+			}
 			Map<XClass, InheritanceState> inheritanceStatePerClass = AnnotationBinder.buildInheritanceStates(
 					orderedClasses, mappings
 			);

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
@@ -88,6 +88,7 @@ public class JPAMetadataProvider implements MetadataProvider, Serializable {
 			defaults.put( "schema", xmlDefaults.getSchema() );
 			defaults.put( "catalog", xmlDefaults.getCatalog() );
 			defaults.put( "delimited-identifier", xmlDefaults.getDelimitedIdentifier() );
+			defaults.put( "cascade-persist", xmlDefaults.getCascadePersist() );
 			List<Class> entityListeners = new ArrayList<Class>();
 			for ( String className : xmlContext.getDefaultEntityListeners() ) {
 				try {


### PR DESCRIPTION
In hibernate-core 4.3.5, the value of "cascade-persist" is not respected for relationships specified by annotations; for these annotations, the default cascade is an empty array even if "cascade-persist" is set in orm.xml.  This is not what is expected based on the JPA 2.1 spec.

I'm submitting this pull request, though I feel that stashing the "persist" cascade value in the defaultCascade of the Mappings is not the appropriate place to put it.  I would like some guidance on what a better route of plumbing it through would be.  I have verified the fix locally.
