### PR TITLE
HHH-9166 - Enhance constraint extractor to be able to examine nested exceptions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -382,23 +382,41 @@ public class PostgreSQL81Dialect extends Dialect {
 	private static final ViolatedConstraintNameExtracter EXTRACTER = new TemplatedViolatedConstraintNameExtracter() {
 		public String extractConstraintName(SQLException sqle) {
 			try {
-				final int sqlState = Integer.valueOf( JdbcExceptionHelper.extractSqlState( sqle ) );
-				switch (sqlState) {
-					// CHECK VIOLATION
-					case 23514: return extractUsingTemplate( "violates check constraint \"","\"", sqle.getMessage() );
-					// UNIQUE VIOLATION
-					case 23505: return extractUsingTemplate( "violates unique constraint \"","\"", sqle.getMessage() );
-					// FOREIGN KEY VIOLATION
-					case 23503: return extractUsingTemplate( "violates foreign key constraint \"","\"", sqle.getMessage() );
-					// NOT NULL VIOLATION
-					case 23502: return extractUsingTemplate( "null value in column \"","\" violates not-null constraint", sqle.getMessage() );
-					// TODO: RESTRICT VIOLATION
-					case 23001: return null;
-					// ALL OTHER
-					default: return null;
-				}
-			}
-			catch (NumberFormatException nfe) {
+				final int sqlState = Integer.valueOf(JdbcExceptionHelper.extractSqlState(sqle));
+				String constraintName = null;
+				do {
+					switch (sqlState) {
+						// CHECK VIOLATION
+						case 23514:
+							constraintName = extractUsingTemplate("violates check constraint \"", "\"", sqle.getMessage());
+							break;
+						// UNIQUE VIOLATION
+						case 23505:
+							constraintName = extractUsingTemplate("violates unique constraint \"", "\"", sqle.getMessage());
+							break;
+						// FOREIGN KEY VIOLATION
+						case 23503:
+							constraintName = extractUsingTemplate("violates foreign key constraint \"", "\"", sqle.getMessage());
+							break;
+						// NOT NULL VIOLATION
+						case 23502:
+							constraintName = extractUsingTemplate("null value in column \"", "\" violates not-null constraint", sqle.getMessage());
+							break;
+						// TODO: RESTRICT VIOLATION
+						case 23001:
+							constraintName = null;
+							break;
+						// ALL OTHER
+						default:
+							constraintName = null;
+							break;
+					}
+					if (sqle.getNextException() == sqle) break;
+					if (sqle.getNextException() == null) break;
+					sqle = sqle.getNextException();
+				} while (constraintName == null);
+				return constraintName;
+			} catch (NumberFormatException nfe) {
 				return null;
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/dialect/PostgreSQL81DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/PostgreSQL81DialectTestCase.java
@@ -25,6 +25,7 @@ package org.hibernate.dialect;
 
 import org.junit.Test;
 
+import java.sql.BatchUpdateException;
 import java.sql.SQLException;
 import org.hibernate.JDBCException;
 import org.hibernate.PessimisticLockException;
@@ -34,6 +35,8 @@ import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
@@ -43,10 +46,11 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author Bryan Varner
  */
-@TestForIssue( jiraKey = "HHH-7251" )
+
 public class PostgreSQL81DialectTestCase extends BaseUnitTestCase {
 	
 	@Test
+    @TestForIssue( jiraKey = "HHH-7251" )
 	public void testDeadlockException() {
 		PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
 		SQLExceptionConversionDelegate delegate = dialect.buildSQLExceptionConversionDelegate();
@@ -57,6 +61,7 @@ public class PostgreSQL81DialectTestCase extends BaseUnitTestCase {
 	}
 	
 	@Test
+    @TestForIssue( jiraKey = "HHH-7251" )
 	public void testTimeoutException() {
 		PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
 		SQLExceptionConversionDelegate delegate = dialect.buildSQLExceptionConversionDelegate();
@@ -65,4 +70,17 @@ public class PostgreSQL81DialectTestCase extends BaseUnitTestCase {
 		JDBCException exception = delegate.convert(new SQLException("Lock Not Available", "55P03"), "", "");
 		assertTrue(exception instanceof PessimisticLockException);
 	}
+
+    @Test
+    public void testExtractConstraintName() {
+        PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
+
+
+        SQLException psqlException = new java.sql.SQLException("ERROR: duplicate key value violates unique constraint \"uk_4bm1x2ultdmq63y3h5r3eg0ej\"  Detail: Key (username, server_config)=(user, 1) already exists.", "23505");
+        BatchUpdateException batchUpdateException = new BatchUpdateException("Concurrent Error", "23505", null);
+        batchUpdateException.setNextException(psqlException);
+
+        String constraintName = dialect.getViolatedConstraintNameExtracter().extractConstraintName(batchUpdateException);
+        assertThat(constraintName, is("uk_4bm1x2ultdmq63y3h5r3eg0ej"));
+    }
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/PostgreSQL81DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/PostgreSQL81DialectTestCase.java
@@ -23,22 +23,19 @@
  */
 package org.hibernate.dialect;
 
-import org.junit.Test;
-
-import java.sql.BatchUpdateException;
-import java.sql.SQLException;
 import org.hibernate.JDBCException;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import java.sql.BatchUpdateException;
+import java.sql.SQLException;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 
 /**
@@ -48,39 +45,39 @@ import static org.junit.Assert.assertNotNull;
  */
 
 public class PostgreSQL81DialectTestCase extends BaseUnitTestCase {
-	
+
 	@Test
-    @TestForIssue( jiraKey = "HHH-7251" )
+	@TestForIssue(jiraKey = "HHH-7251")
 	public void testDeadlockException() {
 		PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
 		SQLExceptionConversionDelegate delegate = dialect.buildSQLExceptionConversionDelegate();
 		assertNotNull(delegate);
-		
+
 		JDBCException exception = delegate.convert(new SQLException("Deadlock Detected", "40P01"), "", "");
 		assertTrue(exception instanceof LockAcquisitionException);
 	}
-	
+
 	@Test
-    @TestForIssue( jiraKey = "HHH-7251" )
+	@TestForIssue(jiraKey = "HHH-7251")
 	public void testTimeoutException() {
 		PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
 		SQLExceptionConversionDelegate delegate = dialect.buildSQLExceptionConversionDelegate();
 		assertNotNull(delegate);
-		
+
 		JDBCException exception = delegate.convert(new SQLException("Lock Not Available", "55P03"), "", "");
 		assertTrue(exception instanceof PessimisticLockException);
 	}
 
-    @Test
-    public void testExtractConstraintName() {
-        PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
+	@Test
+	public void testExtractConstraintName() {
+		PostgreSQL81Dialect dialect = new PostgreSQL81Dialect();
 
 
-        SQLException psqlException = new java.sql.SQLException("ERROR: duplicate key value violates unique constraint \"uk_4bm1x2ultdmq63y3h5r3eg0ej\"  Detail: Key (username, server_config)=(user, 1) already exists.", "23505");
-        BatchUpdateException batchUpdateException = new BatchUpdateException("Concurrent Error", "23505", null);
-        batchUpdateException.setNextException(psqlException);
+		SQLException psqlException = new java.sql.SQLException("ERROR: duplicate key value violates unique constraint \"uk_4bm1x2ultdmq63y3h5r3eg0ej\"  Detail: Key (username, server_config)=(user, 1) already exists.", "23505");
+		BatchUpdateException batchUpdateException = new BatchUpdateException("Concurrent Error", "23505", null);
+		batchUpdateException.setNextException(psqlException);
 
-        String constraintName = dialect.getViolatedConstraintNameExtracter().extractConstraintName(batchUpdateException);
-        assertThat(constraintName, is("uk_4bm1x2ultdmq63y3h5r3eg0ej"));
-    }
+		String constraintName = dialect.getViolatedConstraintNameExtracter().extractConstraintName(batchUpdateException);
+		assertThat(constraintName, is("uk_4bm1x2ultdmq63y3h5r3eg0ej"));
+	}
 }


### PR DESCRIPTION
This fix will allow the PostgreSQL dialect to parse out constraint name if it needs to descend into a nested exception.