### PR TITLE
HHH-9204 and HHH-9205

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -1708,8 +1708,25 @@ public abstract class AbstractCollectionPersister
 		}
 	}
 
-	protected abstract void doProcessQueuedOps(PersistentCollection collection, Serializable key,
+	/**
+	 * Process queued operations within the PersistentCollection.
+	 *
+	 * @param collection The collection
+	 * @param key The collection key
+	 * @param nextIndex The next index to write
+	 * @param session The session
+	 * @throws HibernateException
+	 *
+	 * @deprecated Use {@link #doProcessQueuedOps(org.hibernate.collection.spi.PersistentCollection, java.io.Serializable, org.hibernate.engine.spi.SessionImplementor)}
+	 */
+	@Deprecated
+	protected void doProcessQueuedOps(PersistentCollection collection, Serializable key,
 			int nextIndex, SessionImplementor session)
+			throws HibernateException {
+		doProcessQueuedOps( collection, key, session );
+	}
+
+	protected abstract void doProcessQueuedOps(PersistentCollection collection, Serializable key, SessionImplementor session)
 			throws HibernateException;
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -155,8 +155,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	}
 	
 	@Override
-	protected void doProcessQueuedOps(PersistentCollection collection, Serializable id,
-			int nextIndex, SessionImplementor session)
+	protected void doProcessQueuedOps(PersistentCollection collection, Serializable id, SessionImplementor session)
 			throws HibernateException {
 		// nothing to do
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
@@ -193,9 +193,9 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	}
 	
 	@Override
-	protected void doProcessQueuedOps(PersistentCollection collection, Serializable id,
-			int nextIndex, SessionImplementor session) throws HibernateException {
-		writeIndex( collection, collection.queuedAdditionIterator(), id, nextIndex, session );
+	protected void doProcessQueuedOps(PersistentCollection collection, Serializable id, SessionImplementor session)
+			throws HibernateException {
+		writeIndex( collection, collection.queuedAdditionIterator(), id, getSize( id, session ), session );
 	}
 	
 	private void writeIndex(PersistentCollection collection, Iterator entries, Serializable id,


### PR DESCRIPTION
Restores in AbstractCollectionPersister:

void doProcessQueuedOps(PersistentCollection, Serializable, SessionImplementor)

Deprecates in AbstractCollectionPersister:

void doProcessQueuedOps(PersistentCollection, Serializable, int, SessionImplementor)
