### PR TITLE
HHH-9106 : Merging multiple representations of the same entity (enabled ...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
@@ -163,7 +163,7 @@ public class EntityCopyAllowedLoggedObserver extends EntityCopyAllowedObserver {
 										session.getIdentifier( managedEntity )
 								)
 						)
-						.append( " being merged: " );
+						.append( "; " );
 				boolean first = true;
 				for ( Object mergeEntity : mergeEntities ) {
 					if ( first ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsLoggedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsLoggedTest.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.ops;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.StaleObjectStateException;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests merging multiple detached representations of the same entity
+ * using {@link org.hibernate.event.internal.EntityCopyAllowedLoggedObserver}.
+ *
+ * @author Gail Badner
+ */
+public class MergeMultipleEntityRepresentationsLoggedTest extends MergeMultipleEntityRepresentationsTest {
+
+	@Override
+	public void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyAllowedLoggedObserver"
+		);
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsNotAllowedExplicitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsNotAllowedExplicitTest.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.ops;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.testing.TestForIssue;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests merging multiple detached representations of the same entity
+ * using {@link org.hibernate.event.internal.EntityCopyNotAllowedObserver}.
+ *
+ * @author Gail Badner
+ */
+@TestForIssue( jiraKey = "HHH-9106")
+public class MergeMultipleEntityRepresentationsNotAllowedExplicitTest
+		extends MergeMultipleEntityRepresentationsNotAllowedTest{
+
+	@Override
+	public void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyNotAllowedObserver"
+		);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsNotAllowedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsNotAllowedTest.java
@@ -29,9 +29,6 @@ import org.junit.Test;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.event.internal.EntityCopyAllowedMergeEventListener;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
@@ -40,8 +37,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests merging multiple detached representations of the same entity using
- * a the default MergeEventListener (that does not allow this).
+ * Tests merging multiple detached representations of the same entity
+ * using the default {@link org.hibernate.event.internal.EntityCopyObserver},
+ * which does not allow merging entity copies..
  *
  * @author Gail Badner
  */

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsOrphanDeleteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsOrphanDeleteTest.java
@@ -30,22 +30,20 @@ import org.junit.Test;
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.event.internal.EntityCopyAllowedMergeEventListener;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.EventType;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.FailureExpected;
-import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Tests merging multiple detached representations of the same entity
  * where some associations include cascade="delete-orphan"
+ * using {@link org.hibernate.event.internal.EntityCopyAllowedObserver},
+
  *
  * @author Gail Badner
  */
@@ -57,9 +55,13 @@ public class MergeMultipleEntityRepresentationsOrphanDeleteTest extends BaseCore
 		};
 	}
 
-	protected void afterSessionFactoryBuilt() {
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry().getService( EventListenerRegistry.class );
-		registry.setListeners( EventType.MERGE, new EntityCopyAllowedMergeEventListener() );
+	@Override
+	public void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyAllowedObserver"
+		);
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeMultipleEntityRepresentationsTest.java
@@ -31,9 +31,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.Transaction;
-import org.hibernate.event.internal.EntityCopyAllowedMergeEventListener;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.EventType;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
@@ -45,7 +43,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests merging multiple detached representations of the same entity.
+ * Tests merging multiple detached representations of the same entity
+ * using {@link org.hibernate.event.internal.EntityCopyAllowedObserver}.
  *
  * @author Gail Badner
  */
@@ -57,9 +56,13 @@ public class MergeMultipleEntityRepresentationsTest extends BaseCoreFunctionalTe
 		};
 	}
 
-	protected void afterSessionFactoryBuilt() {
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry().getService( EventListenerRegistry.class );
-		registry.setListeners( EventType.MERGE, new EntityCopyAllowedMergeEventListener() );
+	@Override
+	public void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyAllowedObserver"
+		);
 	}
 
 	@Test

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsAllowedLoggedTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsAllowedLoggedTest.java
@@ -21,21 +21,36 @@
  * 51 Franklin Street, Fifth Floor
  * Boston, MA  02110-1301  USA
  */
+package org.hibernate.ejb.test.emops;
 
-package org.hibernate.event.internal;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+
+import org.hibernate.ejb.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
- * A {@link org.hibernate.event.spi.MergeEventListener} that allows merging
- * multiple representations of the same persistent entity.
+ * Tests merging multiple detached representations of the same entity using
+ * {@link org.hibernate.event.internal.EntityCopyAllowedLoggedObserver}
+ * with logging (if enabled).
  *
  * @author Gail Badner
  */
-public class EntityCopyAllowedMergeEventListener extends DefaultMergeEventListener {
+@TestForIssue( jiraKey = "HHH-9106")
+public class MergeMultipleEntityRepresentationsAllowedLoggedTest extends MergeMultipleEntityRepresentationsAllowedTest {
 
-	@Override
-	protected EntityCopyObserver createEntityCopyObserver() {
-		return EntityCopyAllowedLoggedObserver.isDebugLoggingEnabled() ?
-				new EntityCopyAllowedLoggedObserver() :
-				new EntityCopyAllowedObserver();
+	protected void addConfigOptions(Map options) {
+		options.put(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyAllowedLoggedObserver"
+		);
 	}
 }

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsAllowedTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsAllowedTest.java
@@ -24,17 +24,12 @@
 package org.hibernate.ejb.test.emops;
 
 import java.util.List;
+import java.util.Map;
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.ejb.HibernateEntityManagerFactory;
-import org.hibernate.ejb.event.EJB3EntityCopyAllowedMergeEventListener;
 import org.hibernate.ejb.test.BaseEntityManagerFunctionalTestCase;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.testing.TestForIssue;
 
 import static org.junit.Assert.assertFalse;
@@ -44,20 +39,18 @@ import static org.junit.Assert.assertSame;
 
 /**
  * Tests merging multiple detached representations of the same entity using
- * {@link org.hibernate.ejb.event.EJB3EntityCopyAllowedMergeEventListener}.
+ * {@link org.hibernate.event.internal.EntityCopyAllowedObserver}.
  *
  * @author Gail Badner
  */
 @TestForIssue( jiraKey = "HHH-9106")
 public class MergeMultipleEntityRepresentationsAllowedTest extends BaseEntityManagerFunctionalTestCase {
 
-	@Override
-	protected void afterEntityManagerFactoryBuilt() {
-		super.afterEntityManagerFactoryBuilt();
-		SessionFactory sf = ( (HibernateEntityManagerFactory) entityManagerFactory() ).getSessionFactory();
-		EventListenerRegistry registry =
-				( (SessionFactoryImplementor) sf ).getServiceRegistry().getService( EventListenerRegistry.class );
-		registry.setListeners( EventType.MERGE, new EJB3EntityCopyAllowedMergeEventListener() );
+	protected void addConfigOptions(Map options) {
+		options.put(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyAllowedObserver"
+		);
 	}
 
 	@Test

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsNotAllowedExplicitTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsNotAllowedExplicitTest.java
@@ -21,25 +21,27 @@
  * 51 Franklin Street, Fifth Floor
  * Boston, MA  02110-1301  USA
  */
-package org.hibernate.ejb.event;
+package org.hibernate.ejb.test.emops;
 
-import org.hibernate.event.internal.EntityCopyAllowedLoggedObserver;
-import org.hibernate.event.internal.EntityCopyAllowedObserver;
-import org.hibernate.event.internal.EntityCopyObserver;
+import java.util.Map;
+
+import org.hibernate.testing.TestForIssue;
 
 /**
- * Overrides {@link EJB3MergeEventListener} that allows merging multiple representations
- * of the same persistent entity.
+ * Tests merging multiple detached representations of the same entity
+ * using {@link org.hibernate.event.internal.EntityCopyNotAllowedObserver},
+ * which does not allow merging entity copies.
  *
  * @author Gail Badner
  */
-public class EJB3EntityCopyAllowedMergeEventListener extends EJB3MergeEventListener {
+@TestForIssue( jiraKey = "HHH-9106")
+public class MergeMultipleEntityRepresentationsNotAllowedExplicitTest
+		extends MergeMultipleEntityRepresentationsNotAllowedTest {
 
-	@Override
-	protected EntityCopyObserver createEntityCopyObserver() {
-		return EntityCopyAllowedLoggedObserver.isDebugLoggingEnabled() ?
-				new EntityCopyAllowedLoggedObserver() :
-				new EntityCopyAllowedObserver();
+	protected void addConfigOptions(Map options) {
+		options.put(
+				"hibernate.event.merge.entity_copy_observer",
+				"org.hibernate.event.internal.EntityCopyNotAllowedObserver"
+		);
 	}
-
 }

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsNotAllowedTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/emops/MergeMultipleEntityRepresentationsNotAllowedTest.java
@@ -37,8 +37,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests merging multiple detached representations of the same entity using
- * a the default MergeEventListener (that does not allow this).
+ * Tests merging multiple detached representations of the same entity
+ * using the default {@link org.hibernate.event.internal.EntityCopyObserver},
+ * which does not allow merging entity copies..
  *
  * @author Gail Badner
  */


### PR DESCRIPTION
...by property)

This is a pull request that creates the EntityCopyObserver implementation specified by  hibernate.event.merge.entity_copy_observer.

I don't think that the 3 implementations for EntityCopyObserver are sufficient. I think that if entity copies are going to be enabled, users will want to provide their own implementations in some cases (e.g., to allow (or disallow) entity copies for some entity classes).

For this reason, the value for hibernate.event.merge.entity_copy_observer should be a class name. I envision users wanting to start with EntityCopyAllowedLoggedObserver to see which entity classes are affected, and then ultimately extending EntityCopyAllowedObserver to suit their needs.
