### PR TITLE
HHH-9290 : Do not truncate HT_ temporary table name prefix on Oracle

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -538,7 +538,7 @@ public class Oracle8iDialect extends Dialect {
 	@Override
 	public String generateTemporaryTableName(String baseTableName) {
 		final String name = super.generateTemporaryTableName( baseTableName );
-		return name.length() > 30 ? name.substring( 1, 30 ) : name;
+		return name.length() > 30 ? name.substring( 0, 30 ) : name;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/dialect/Oracle8iDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/Oracle8iDialectTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.dialect;
+
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+
+import static org.junit.Assert.assertEquals;
+
+public class Oracle8iDialectTestCase extends BaseUnitTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-9290")
+	public void testTemporaryTableNameTruncation() throws Exception {
+		String temporaryTableName = new Oracle8iDialect().generateTemporaryTableName(
+				"TABLE_NAME_THAT_EXCEEDS_30_CHARACTERS"
+		);
+
+		assertEquals(
+				"Temporary table names should be truncated to 30 characters",
+				30,
+				temporaryTableName.length()
+		);
+		assertEquals(
+				"Temporary table names should start with HT_",
+				"HT_TABLE_NAME_THAT_EXCEEDS_30_",
+				temporaryTableName
+		);
+	}
+}


### PR DESCRIPTION
`Oracle8iDialect.generateTemporaryTableName` usually prefixes all temporary table names with "HT_".  However, temporary table names for for table names longer than 27 characters just start with "T_".

This PR ensures that all temporary table names start with "HT_"

As a side-effect of this fix, temporary table name can be 30 characters long (instead of only 29).  I believe the previous 29 character limit was a mistake.

https://hibernate.atlassian.net/browse/HHH-9290
