### PR TITLE
[4.3] HHH-9337 Region.destroy() attempts to remove a cache listener, but regio...

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
@@ -145,12 +145,7 @@ public abstract class BaseRegion implements Region {
 
 	@Override
 	public void destroy() throws CacheException {
-		try {
-			cache.stop();
-		}
-		finally {
-			cache.removeListener( this );
-		}
+		cache.stop();
 	}
 
 	@Override


### PR DESCRIPTION
...n class is not annotated with @Listener

https://hibernate.atlassian.net/browse/HHH-9337