### PR TITLE
HHH-9342 HQL "x member of treat(y as Type).collection" fails to parse

### DIFF
--- a/hibernate-core/src/main/antlr/hql.g
+++ b/hibernate-core/src/main/antlr/hql.g
@@ -598,7 +598,7 @@ relationalExpression
 					#l.setText( (n == null) ? "like" : "not like");
 				}
 				concatenation likeEscape)
-			| (MEMBER! (OF!)? p:path! {
+			| (MEMBER! (OF!)? p:treatAsPath! {
 				processMemberOf(n,#p,currentAST);
 			  } ) )
 		)
@@ -844,6 +844,13 @@ constant
 
 path
 	: identifier ( DOT^ { weakKeywords(); } identifier )*
+	;
+
+treatAsPath
+	: path
+	| i:IDENT! OPEN! p:treatAsPath AS! a:path! CLOSE! ( DOT^ path )? {i.getText().equalsIgnoreCase("treat") }? {
+        registerTreat( #p, #a );
+    }
 	;
 
 // Wraps the IDENT token from the lexer, in order to provide

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/TreatTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/TreatTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.hql;
+
+import org.hibernate.Session;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * Tests the "treat" keyword in HQL.
+ *
+ * @author Etienne Miret
+ */
+public class TreatTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	public String[] getMappings() {
+		return new String[] { "hql/Animal.hbm.xml" };
+	}
+
+	@Test
+	public void memberOfTreatTest() {
+		final Session s = openSession();
+
+		s.createQuery( "select pet"
+				+ " from Animal pet, Animal owner"
+				+ " where pet member of treat (owner as Human).pets"
+		);
+
+		s.close();
+	}
+
+}


### PR DESCRIPTION
See [HHH-9342](https://hibernate.atlassian.net/browse/HHH-9342).

I added a new construction "treatAsPath" in the grammar and used it in the "member of" rule. This solves the specific bug I found. However I’m pretty sure this new construction should be used at other places too.