### PR TITLE
fix for HHH-9119

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
@@ -126,7 +126,7 @@ public class CollectionCacheInvalidator implements Integrator, PostInsertEventLi
 				}
 				// this is the property this OneToMany relation is mapped by
 				String mappedBy = collectionPersister.getMappedByProperty();
-				if ( mappedBy != null ) {
+				if ( mappedBy != null && !"".equals(mappedBy)) {
 					int i = persister.getEntityMetamodel().getPropertyIndex( mappedBy );
 					Serializable oldId = null;
 					if ( oldState != null ) {


### PR DESCRIPTION
The CollectionCacheInvalidator looks for a mappedBy property on an entity's @ManyToMany or @ManyToOne or other hibernate managed annotations. If one is using the JPA2 standard @JoinColumn annotations, the mappedBy may not be defined or needed.
