### PR TITLE
HHH-9356 Fix "between" operator with literal values when there is a converter.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/BetweenOperatorNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/BetweenOperatorNode.java
@@ -51,9 +51,26 @@ public class BetweenOperatorNode extends SqlNode implements OperatorNode {
 			throw new SemanticException( "high operand of a between operator was null" );
 		}
 
-		check( fixture, low, high );
-		check( low, high, fixture );
-		check( high, fixture, low );
+		Type expectedType = null;
+		if ( fixture instanceof SqlNode ) {
+			expectedType = ( (SqlNode) fixture ).getDataType();
+		}
+		if ( expectedType == null && low instanceof SqlNode ) {
+			expectedType = ( (SqlNode) low ).getDataType();
+		}
+		if ( expectedType == null && high instanceof SqlNode ) {
+			expectedType = ( (SqlNode) high ).getDataType();
+		}
+
+		if ( fixture instanceof ExpectedTypeAwareNode ) {
+			( (ExpectedTypeAwareNode) fixture ).setExpectedType( expectedType );
+		}
+		if ( low instanceof ExpectedTypeAwareNode ) {
+			( (ExpectedTypeAwareNode) low ).setExpectedType( expectedType );
+		}
+		if ( high instanceof ExpectedTypeAwareNode ) {
+			( (ExpectedTypeAwareNode) high ).setExpectedType( expectedType );
+		}
 	}
 
 	@Override
@@ -74,16 +91,4 @@ public class BetweenOperatorNode extends SqlNode implements OperatorNode {
 		return (Node) getFirstChild().getNextSibling().getNextSibling();
 	}
 
-	private void check(Node check, Node first, Node second) {
-		if ( ExpectedTypeAwareNode.class.isAssignableFrom( check.getClass() ) ) {
-			Type expectedType = null;
-			if ( SqlNode.class.isAssignableFrom( first.getClass() ) ) {
-				expectedType = ( (SqlNode) first ).getDataType();
-			}
-			if ( expectedType == null && SqlNode.class.isAssignableFrom( second.getClass() ) ) {
-				expectedType = ( (SqlNode) second ).getDataType();
-			}
-			( (ExpectedTypeAwareNode) check ).setExpectedType( expectedType );
-		}
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/AddTenConverter.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/AddTenConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.jpa.convert;
+
+import javax.persistence.AttributeConverter;
+
+/**
+ * This converter adds 10 to each integer stored in the database, and remove
+ * 10 from integer retrieved from the database. It is mainly intended to test
+ * that converters are always applied when they should.
+ *
+ * @author Etienne Miret
+ */
+public class AddTenConverter implements AttributeConverter<Integer, Integer> {
+
+	@Override
+	public Integer convertToDatabaseColumn(final Integer attribute) {
+		if ( attribute == null ) {
+			return null;
+		}
+		else {
+			return new Integer( attribute.intValue() + 10 );
+		}
+	}
+
+	@Override
+	public Integer convertToEntityAttribute(final Integer dbData) {
+		if ( dbData == null ) {
+			return null;
+		}
+		else {
+			return new Integer( dbData.intValue() - 10 );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/BigDecimalToStringConverter.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/BigDecimalToStringConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.jpa.convert;
+
+import java.math.BigDecimal;
+
+import javax.persistence.AttributeConverter;
+
+/**
+ * @author Etienne Miret
+ */
+public class BigDecimalToStringConverter implements AttributeConverter<BigDecimal, String> {
+
+	@Override
+	public String convertToDatabaseColumn(BigDecimal attribute) {
+		if ( attribute == null ) {
+			return null;
+		}
+		else {
+			return attribute.toString();
+		}
+	}
+
+	@Override
+	public BigDecimal convertToEntityAttribute(String dbData) {
+		if ( dbData == null ) {
+			return null;
+		}
+		else {
+			return new BigDecimal( dbData );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/ConvertBetweenTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/ConvertBetweenTest.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.jpa.convert;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.test.jpa.AbstractJPATest;
+import org.hibernate.testing.TestForIssue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests using converters with the between construction.
+ *
+ * @author Etienne Miret
+ */
+public class ConvertBetweenTest extends AbstractJPATest {
+
+	@Override
+	public String[] getMappings() {
+		return new String[0];
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Item.class };
+	}
+
+	@Before
+	public void fillData() {
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		final Item i0 = new Item();
+		i0.setPrice( new BigDecimal( "12.05" ) );
+		i0.setQuantity( 10 );
+		s.persist( i0 );
+
+		final Item i1 = new Item();
+		i1.setPrice( new BigDecimal( "5.35" ) );
+		i1.setQuantity( 5 );
+		s.persist( i1 );
+
+		final Item i2 = new Item();
+		i2.setPrice( new BigDecimal( "99.99" ) );
+		i2.setQuantity( 15 );
+		s.persist( i2 );
+
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@After
+	public void cleanUpData() {
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		s.createQuery( "delete from Item" ).executeUpdate();
+
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-9356" )
+	public void testBetweenLiteral() {
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		@SuppressWarnings("unchecked")
+		final List<Item> result = s.createQuery( "from Item where quantity between 9 and 11" ).list();
+		assertEquals( 1, result.size() );
+		assertEquals( 10, result.get( 0 ).getQuantity().intValue() );
+
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Test
+	public void testBetweenParameters() {
+		final Session s = openSession();
+		s.getTransaction().begin();
+
+		final Query query = s.createQuery( "from Item where quantity between :low and :high" );
+		query.setParameter( "low", new Integer( 9 ) );
+		query.setParameter( "high", new Integer( 11 ) );
+		@SuppressWarnings("unchecked")
+		final List<Item> result = query.list();
+		assertEquals( 1, result.size() );
+		assertEquals( 10, result.get( 0 ).getQuantity().intValue() );
+
+		s.getTransaction().commit();
+		s.close();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/Item.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/Item.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.jpa.convert;
+
+import java.math.BigDecimal;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author Etienne Miret
+ */
+@Entity
+public class Item {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Convert( converter = BigDecimalToStringConverter.class )
+	private BigDecimal price;
+
+	private String description;
+
+	@Convert( converter = AddTenConverter.class )
+	private Integer quantity;
+
+	public Long getId() {
+		return id;
+	}
+
+	public BigDecimal getPrice() {
+		return price;
+	}
+
+	public void setPrice(final BigDecimal price) {
+		this.price = price;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(final String description) {
+		this.description = description;
+	}
+
+	public Integer getQuantity() {
+		return quantity;
+	}
+
+	public void setQuantity(final Integer quantity) {
+		this.quantity = quantity;
+	}
+
+	/*
+	 * For those who hate auto (un)boxing.
+	 */
+	public void setQuantity(final int quantity) {
+		this.quantity = Integer.valueOf( quantity );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/convert/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+/**
+ * Package for testing JPA converters and the {@link javax.persistence.Convert @Convert} annotation. 
+ */
+package org.hibernate.test.jpa.convert;


### PR DESCRIPTION
When a type converter is configured and both high end and low end of a between construct are literals, the previous behavior was to convert only the high end operand.

This fix ensures that all operands will be given the same type, hence all are converted if applicable.
