### PR TITLE
HHH-5932 Test and fix on 4.2

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
@@ -52,6 +52,11 @@ import org.hibernate.type.Type;
 public final class QueryParameters {
     private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, QueryParameters.class.getName());
 
+	/**
+	 * Symbols used to split SQL string into tokens in {@link #processFilters(String, Map, SessionFactoryImplementor)}.
+	 */
+    private static final String SYMBOLS = ParserHelper.HQL_SEPARATORS.replace( "'", "" );
+
 	private Type[] positionalParameterTypes;
 	private Object[] positionalParameterValues;
 	private Map<String,TypedValue> namedParameters;
@@ -471,12 +476,7 @@ public final class QueryParameters {
 			processedSQL = sql;
 		}
 		else {
-			final Dialect dialect = factory.getDialect();
-			String symbols = new StringBuilder().append( ParserHelper.HQL_SEPARATORS )
-					.append( dialect.openQuote() )
-					.append( dialect.closeQuote() )
-					.toString();
-			StringTokenizer tokens = new StringTokenizer( sql, symbols, true );
+			StringTokenizer tokens = new StringTokenizer( sql, SYMBOLS, true );
 			StringBuilder result = new StringBuilder();
 
 			List parameters = new ArrayList();

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
@@ -474,7 +474,6 @@ public class DynamicFilterTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5932" )
-	@FailureExpected( jiraKey = "HHH-5932" )
 	public void testHqlQueryWithColons() {
 		final Session session = openSession();
 		session.enableFilter( "region" ).setParameter( "region", "PACA" );

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
@@ -33,7 +33,6 @@ import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.junit.Test;
-
 import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.Hibernate;
@@ -51,7 +50,9 @@ import org.hibernate.dialect.IngresDialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.transform.DistinctRootEntityResultTransformer;
 
@@ -469,6 +470,16 @@ public class DynamicFilterTest extends BaseCoreFunctionalTestCase {
 
 		session.close();
 		testData.release();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-5932" )
+	@FailureExpected( jiraKey = "HHH-5932" )
+	public void testHqlQueryWithColons() {
+		final Session session = openSession();
+		session.enableFilter( "region" ).setParameter( "region", "PACA" );
+		session.createQuery( "from Salesperson p where p.name = ':hibernate'" ).list();
+		session.close();
 	}
 
 	@Test


### PR DESCRIPTION
See [HHH-5932](https://hibernate.atlassian.net/browse/HHH-5932). Fix an issue when enabling a filter on an HQL query that contains a literal string starting with a colon.

The fix is to remove strings open and close quote from the symbols used to split the SQL string into tokens. This doesn’t break any existing test, but worries me in that the open and close quote were clearly voluntarily added.