### PR TITLE
HHH-9365 Upgrade to JBoss Logging 3.1.4.GA

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -58,7 +58,7 @@ ext {
             jacc:           'org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.4_spec:1.0.2.Final',
 
             // logging
-            logging:        'org.jboss.logging:jboss-logging:3.1.3.GA',
+            logging:        'org.jboss.logging:jboss-logging:3.1.4.GA',
             logging_annotations: 'org.jboss.logging:jboss-logging-annotations:1.2.0.Beta1',
             logging_processor:  'org.jboss.logging:jboss-logging-processor:1.2.0.Beta1',
 


### PR DESCRIPTION
JBoss Logging 3.1.4.GA supports Log4J 2.0 (https://issues.jboss.org/browse/JBLOGGING-94)
