### PR TITLE
Fixing a bug for query parsing in StringHelper

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -171,8 +171,10 @@ public final class StringHelper {
 		boolean encloseInParens =
 				actuallyReplace &&
 				encloseInParensIfNecessary &&
-				! ( getLastNonWhitespaceCharacter( beforePlaceholder ) == '(' ) &&
-				! ( getFirstNonWhitespaceCharacter( afterPlaceholder ) == ')' );		
+				! (
+					( getLastNonWhitespaceCharacter( beforePlaceholder ) == '(' ) &&
+					( getFirstNonWhitespaceCharacter( afterPlaceholder ) == ')' )
+				);		
 		StringBuilder buf = new StringBuilder( beforePlaceholder );
 		if ( encloseInParens ) {
 			buf.append( '(' );


### PR DESCRIPTION
enclosing parens checker was broken and evaluates that it doesn't need to enclose in parens if a query like "description in : descriptions ))"
