### PR TITLE
HHH-9406 Add method for get avg execution time for offen but really fast queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/stat/QueryStatistics.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/QueryStatistics.java
@@ -31,4 +31,8 @@ public interface QueryStatistics extends Serializable {
 	long getExecutionMaxTime();
 
 	long getExecutionMinTime();
+
+	long getExecutionTotalTime();
+
+	double getExecutionAvgTimeDouble();
 }

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentQueryStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentQueryStatisticsImpl.java
@@ -99,6 +99,25 @@ public class ConcurrentQueryStatisticsImpl extends CategorizedStatistics impleme
 	}
 
 	/**
+	 * average time in ms taken by the excution of this query onto the DB
+	 */
+	public double getExecutionAvgTimeDouble() {
+		// We write lock here to be sure that we always calculate the average time
+		// with all updates from the executed applied: executionCount and totalExecutionTime
+		// both used in the calculation
+		writeLock.lock();
+		try {
+			double avgExecutionTime = 0;
+			if (executionCount.get() > 0) {
+				avgExecutionTime = totalExecutionTime.get() / (double) executionCount.get();
+			}
+			return avgExecutionTime;
+		} finally {
+			writeLock.unlock();
+		}
+	}
+
+	/**
 	 * max time in ms taken by the excution of this query onto the DB
 	 */
 	public long getExecutionMaxTime() {
@@ -110,6 +129,13 @@ public class ConcurrentQueryStatisticsImpl extends CategorizedStatistics impleme
 	 */
 	public long getExecutionMinTime() {
 		return executionMinTime.get();
+	}
+
+	/**
+	 * total time in ms taken by the excution of this query onto the DB
+	 */
+	public long getExecutionTotalTime() {
+		return totalExecutionTime.get();
 	}
 
 	/**


### PR DESCRIPTION
For really fast queres getExecutionAvgTime() can be zero.
And you can't get a total execution time by current API.