### PR TITLE
HHH-9419: Remove after get with optimistic lock fails

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityVerifyVersionProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityVerifyVersionProcess.java
@@ -55,6 +55,11 @@ public class EntityVerifyVersionProcess implements BeforeTransactionCompletionPr
 	public void doBeforeTransactionCompletion(SessionImplementor session) {
 		final EntityPersister persister = entry.getPersister();
 
+		if ( !entry.isExistsInDatabase() ) {
+			// HHH-9419: We cannot check for a version of an entry we ourselves deleted
+			return;
+		}
+
 		final Object latestVersion = persister.getCurrentVersion( entry.getId(), session );
 		if ( !entry.getVersion().equals( latestVersion ) ) {
 			throw new OptimisticLockException(

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -294,6 +294,31 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-9419")
+	public void testNoVersionCheckAfterRemove() {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Lockable lock = new Lockable( "name" );
+		em.persist( lock );
+		em.getTransaction().commit();
+		em.close();
+		Integer initial = lock.getVersion();
+		assertNotNull( initial );
+
+		em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Lockable reread = em.createQuery( "from Lockable", Lockable.class )
+				.setLockMode( LockModeType.OPTIMISTIC )
+				.getSingleResult();
+		assertEquals( initial, reread.getVersion() );
+		assertTrue( em.unwrap( SessionImpl.class ).getActionQueue().hasBeforeTransactionActions() );
+		em.remove( reread );
+		em.getTransaction().commit();
+		em.close();
+		assertEquals( initial, reread.getVersion() );
+	}
+
+	@Test
 	public void testOptimisticSpecific() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();


### PR DESCRIPTION
Do not perform a version check on a non-existing entry when entry was removed in the same session after being optimistically locked

Unit test provided