### PR TITLE
ScrollableResult implementing AutoCloseable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/ScrollableResults.java
+++ b/hibernate-core/src/main/java/org/hibernate/ScrollableResults.java
@@ -46,7 +46,7 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  */
-public interface ScrollableResults {
+public interface ScrollableResults extends AutoCloseable {
 	/**
 	 * Advance to the next result.
 	 *


### PR DESCRIPTION
It is my opinion that ScrollableResults, having a close() method, should implement AutoCloseable to be supported in a try-with-resources block **and** rising a compiler warning in Eclipse when the resource is not closed.

Looking at AbstractScrollableResults, the close() method perform useful cleanup activity (as stated in the comment, that's not "absolutely necessary"). I would have commited the same modification to both Session and StatelessSession but Session's close() contract returns the connection, so it's not compatible with AutoCloseable.

Only doubt about this PR is backward-compatibility. I found no indication of compatibility requirements but this could potentially break compatibility with older-than-7 JREs. No test provided as the modification has no impact on existing code (the provided close() implementation narrows the throws clause)
