### PR TITLE
Ensure that CacheKey is serializable across JVMs for entities with a composite primary key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -58,7 +58,7 @@ import org.dom4j.Node;
  */
 public class ComponentType extends AbstractType implements CompositeType, ProcedureParameterExtractionAware {
 
-	private final TypeFactory.TypeScope typeScope;
+	private transient final TypeFactory.TypeScope typeScope;
 	private final String[] propertyNames;
 	private final Type[] propertyTypes;
 	private final boolean[] propertyNullability;

--- a/hibernate-core/src/test/java/org/hibernate/test/type/EmbeddedComponentTypeSerializableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/EmbeddedComponentTypeSerializableTest.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.type;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.tuple.component.ComponentMetamodel;
+import org.hibernate.type.EmbeddedComponentType;
+import org.junit.Test;
+
+public class EmbeddedComponentTypeSerializableTest {
+    @Test
+    public void testEmbeddedComponentTypeSerializable() throws Exception {
+        final Configuration cfg = new Configuration().addAnnotatedClass( EntityWithCompositeKey.class );
+        cfg.buildMappings();
+        final PersistentClass classMetadata = cfg.getClassMapping( EntityWithCompositeKey.class.getName() );
+        final Property idProperty = classMetadata.getProperty( "id" );
+        final Component idComponent = (Component)idProperty.getValue();
+        assertEquals( 2, idComponent.getColumnSpan() );
+
+        final EmbeddedComponentType type =
+            new EmbeddedComponentType(
+                new NonSerializableTypeScope(), new ComponentMetamodel( idComponent ) );
+        final ObjectOutputStream out = new ObjectOutputStream( new ByteArrayOutputStream() );
+        out.writeObject( type );
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/EntityWithCompositeKey.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/EntityWithCompositeKey.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.type;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+public class EntityWithCompositeKey
+{
+    @EmbeddedId private final EntityWithCompositeKeyId id = new EntityWithCompositeKeyId();
+
+    private String otherField;
+
+    public String getOtherField() {
+        return otherField;
+    }
+
+    public void setOtherField( final String otherField ) {
+        this.otherField = otherField;
+    }
+
+    public EntityWithCompositeKeyId getId() {
+        return id;
+    }
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/EntityWithCompositeKeyId.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/EntityWithCompositeKeyId.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.type;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class EntityWithCompositeKeyId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long tableOneId;
+    private Long tableTwoId;
+
+    public Long getTableOneId() {
+        return tableOneId;
+    }
+
+    public void setTableOneId( final Long tableOneId ) {
+        this.tableOneId = tableOneId;
+    }
+
+    public Long getTableTwoId() {
+        return tableTwoId;
+    }
+
+    public void setTableTwoId( final Long tableTwoId ) {
+        this.tableTwoId = tableTwoId;
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/NonSerializableTypeScope.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/NonSerializableTypeScope.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.type;
+
+import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.type.EmbeddedComponentType;
+import org.hibernate.type.TypeFactory;
+import org.hibernate.type.TypeFactory.TypeScope;
+
+/**
+ * This class mocks the behaviour of {@link TypeFactory.TypeScopeImpl} which holds a reference
+ * to {@link SessionFactoryImpl}.  While SessionFactoryImpl is serializable within a JVM, it
+ * is not serializable across JVM instances.  This causes a problem when serializing a
+ * {@link CacheKey} instance for a composite key that is sent to other nodes in a distributed
+ * cluster.  The instance of CacheKey will have a type field set to
+ * {@link EmbeddedComponentType} which in turn references the not-quite-serializable
+ * TypeScopeImpl.
+ */
+public class NonSerializableTypeScope implements TypeScope
+{
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("unused")
+    private final Object notSerializable = new Object();
+
+    @Override
+    public SessionFactoryImplementor resolveFactory()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
The Infinispan L2 cache serializes the `CacheKey` instance and sends that to other nodes in the cluster to invalidate cache entries.  The `CacheKey` implements `Serializable`, but it is not always actually serializable.  When the `CacheKey` represents a composite primary key, the `type` variable is set to an instance of `EmbeddedComponentType`, which indirectly references `SessionFactoryImpl`.  While `SessionFactoryImpl` is serializable within a JVM, it is not serializable across JVMs.

See HHH-9424
