### PR TITLE
Fix NPE on merge of entity with transient component (HHH-3868)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -680,6 +680,9 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public Object proxyFor(Object impl) throws HibernateException {
 		final EntityEntry e = getEntry( impl );
+		if (e == null) {
+			return impl;
+		}
 		return proxyFor( e.getPersister(), e.getEntityKey(), impl );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/embedded/EmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/embedded/EmbeddedTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -515,6 +516,21 @@ public class EmbeddedTest extends BaseCoreFunctionalTestCase {
 			"http://www.hibernate.org/".equals( favs[3].getUrl() ));
 		tx.commit();
 		s.close();
+	}
+
+	/*
+	 * support for merging a Book with a transient component (Summary)
+	 * See HHH-3868
+	 */
+	@Test
+	public void testTransientMergeComponentParent() {
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		Book b = new Book();
+		b.setIsbn(UUID.randomUUID().toString());
+		b.setSummary(new Summary());
+		b = (Book) session.merge(b);
+		tx.commit();
 	}
 
 	@Override


### PR DESCRIPTION
A NullPointerException was thrown in StatefulPersistenceContext.proxyFor
when the EntityEntry returned by getEntry was null. The proxyFor method
which takes an EntityPersister simply returns the impl if hasProxy is
false, so this strategy has been copied.

Affected versions:
- 3.5.6
- 4.2.0.Final
- 4.3.6.Final
