### PR TITLE
HHH 9432 Remove where clause from middle entity

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
@@ -398,8 +398,7 @@ public final class CollectionMetadataGenerator {
 
 			middleEntityXml = createMiddleEntityXml(
 					auditMiddleTableName,
-					auditMiddleEntityName,
-					pluralAttributeBinding.getWhere()
+					auditMiddleEntityName
 			);
 		}
 		else {
@@ -850,7 +849,7 @@ public final class CollectionMetadataGenerator {
 		}
 	}
 
-	private Element createMiddleEntityXml(String auditMiddleTableName, String auditMiddleEntityName, String where) {
+	private Element createMiddleEntityXml(String auditMiddleTableName, String auditMiddleEntityName) {
 		final String schema = mainGenerator.getSchema(
 				propertyAuditingData.getJoinTable().schema(),
 				pluralAttributeBinding.getPluralAttributeKeyBinding().getCollectionTable()
@@ -865,11 +864,6 @@ public final class CollectionMetadataGenerator {
 				new AuditTableData( auditMiddleEntityName, auditMiddleTableName, schema, catalog ), null, null
 		);
 		final Element middleEntityXmlId = middleEntityXml.addElement( "composite-id" );
-
-		// If there is a where clause on the relation, adding it to the middle entity.
-		if ( where != null ) {
-			middleEntityXml.addAttribute( "where", where );
-		}
 
 		middleEntityXmlId.addAttribute( "name", context.getAuditEntitiesConfiguration().getOriginalIdPropName() );
 


### PR DESCRIPTION
As the middle entity contains only the id columns, any where-clause refering to a column of one of the associated tables leads to an sql-error, as the sql refers to an unknown column.
The lines I removed came in with commit ed2d72e492f0fb88f0dbf86440ec098dd675a1d3 to fix [HHH-4633]. But the test described there executes successfully with and without my change.
