### PR TITLE
change default cache region name

### DIFF
--- a/documentation/src/main/docbook/devguide/en-US/appendix-Configuration_Properties.xml
+++ b/documentation/src/main/docbook/devguide/en-US/appendix-Configuration_Properties.xml
@@ -258,6 +258,16 @@
             <entry>A prefix for second-level cache region names.</entry>
           </row>
           <row>
+            <entry>hibernate.cache.region.updatetimestamps</entry>
+            <entry>A string</entry>
+            <entry>A cache region name for UpdateTimestampsCache. Default: "org.hibernate.cache.spi.UpdateTimestampsCache"</entry>
+          </row>
+          <row>
+            <entry>hibernate.cache.region.standardquery</entry>
+            <entry>A string</entry>
+            <entry>A cache region name for StandardQueryCache. Default: "org.hibernate.cache.internal.StandardQueryCache"</entry>
+          </row>
+          <row>
             <entry>hibernate.cache.use_structured_entries</entry>
             <entry><para><literal>true</literal> or <literal>false</literal></para></entry>
             <entry>Forces Hibernate to store data in the second-level cache in a more human-readable format.</entry>

--- a/etc/hibernate.properties
+++ b/etc/hibernate.properties
@@ -474,6 +474,13 @@ hibernate.jdbc.use_streams_for_binary true
 
 hibernate.cache.region_prefix hibernate.test
 
+## set cache region name for UpdateTimestampsCache
+
+#hibernate.cache.region.updatetimestamps org.hibernate.cache.spi.UpdateTimestampsCache
+
+## set cache region name for StandardQueryCache
+
+#hibernate.cache.region.standardquery org.hibernate.cache.internal.StandardQueryCache
 
 ## disable the second-level cache
 

--- a/etc/hibernate.properties.template
+++ b/etc/hibernate.properties.template
@@ -433,6 +433,13 @@ hibernate.jdbc.use_streams_for_binary true
 
 hibernate.cache.region_prefix hibernate.test
 
+## set cache region name for UpdateTimestampsCache
+
+#hibernate.cache.region.updatetimestamps org.hibernate.cache.spi.UpdateTimestampsCache
+
+## set cache region name for StandardQueryCache
+
+#hibernate.cache.region.standardquery org.hibernate.cache.internal.StandardQueryCache
 
 ## disable the second-level cache
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
@@ -81,6 +81,9 @@ public class StandardQueryCache implements QueryCache {
 			final String regionName) {
 		String regionNameToUse = regionName;
 		if ( regionNameToUse == null ) {
+			regionNameToUse = settings.getStandardQueryCacheRegionName();
+		}
+		if ( regionNameToUse == null ) {
 			regionNameToUse = StandardQueryCache.class.getName();
 		}
 		final String prefix = settings.getCacheRegionPrefix();

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
@@ -66,8 +66,17 @@ public class UpdateTimestampsCache {
 	 */
 	public UpdateTimestampsCache(Settings settings, Properties props, final SessionFactoryImplementor factory) {
 		this.factory = factory;
+		String regionName;
+		if ( settings.getUpdateTimestampsCacheRegionName() != null ) {
+			regionName = settings.getUpdateTimestampsCacheRegionName();
+		} else {
+			regionName = REGION_NAME;
+		}
+
 		final String prefix = settings.getCacheRegionPrefix();
-		final String regionName = prefix == null ? REGION_NAME : prefix + '.' + REGION_NAME;
+		if ( prefix != null ) {
+			regionName = prefix + "." + regionName;
+		}
 
 		LOG.startingUpdateTimestampsCache( regionName );
 		this.region = settings.getRegionFactory().buildTimestampsRegion( regionName, props );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -322,6 +322,14 @@ public interface AvailableSettings {
 	 */
 	String CACHE_REGION_PREFIX = "hibernate.cache.region_prefix";
 	/**
+	 * Cache region name for <tt>UpdateTimestampsCache</tt>. Fallback to "org.hibernate.cache.spi.UpdateTimestampsCache" if none specified
+	 */
+	String UPDATE_TIMESTAMPS_CACHE_REGION_NAME = "hibernate.cache.region.updatetimestamps";
+	/**
+	 * Cache region name for <tt>StandardQueryCache</tt>. Fallback to "org.hibernate.cache.internal.StandardQueryCache" if none specified 
+	 */
+	String STANDARD_QUERY_CACHE_REGION_NAME = "hibernate.cache.region.standardquery";
+	/**
 	 * Enable use of structured second-level cache entries
 	 */
 	String USE_STRUCTURED_CACHE = "hibernate.cache.use_structured_entries";

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
@@ -64,6 +64,8 @@ public final class Settings {
 	private boolean secondLevelCacheEnabled;
 	private boolean autoEvictCollectionCache;
 	private String cacheRegionPrefix;
+	private String updateTimestampsCacheRegionName;
+	private String standardQueryCacheRegionName;
 	private boolean minimalPutsEnabled;
 	private boolean commentsEnabled;
 	private boolean statisticsEnabled;
@@ -109,7 +111,14 @@ public final class Settings {
 	}
 
 	// public getters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+	public String getStandardQueryCacheRegionName() {
+		return standardQueryCacheRegionName;
+	}
+	
+	public String getUpdateTimestampsCacheRegionName() {
+		return updateTimestampsCacheRegionName;
+	}
+	
 	public String getImportFiles() {
 		return importFiles;
 	}
@@ -287,6 +296,13 @@ public final class Settings {
 	}
 
 	// package protected setters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	void setStandardQueryCacheRegionName(String standardQueryCacheRegionName) {
+		this.standardQueryCacheRegionName = standardQueryCacheRegionName;
+	}
+	
+	void setUpdateTimestampsCacheRegionName(String updateTimestampsCacheRegionName) {
+		this.updateTimestampsCacheRegionName = updateTimestampsCacheRegionName;
+	}
 
 	void setDefaultSchemaName(String string) {
 		defaultSchemaName = string;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SettingsFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SettingsFactory.java
@@ -310,6 +310,24 @@ public class SettingsFactory implements Serializable {
 			LOG.debugf( "Cache region prefix: %s", prefix );
 		}
 		settings.setCacheRegionPrefix( prefix );
+		
+		String updateTimestampsCacheRegionName = properties.getProperty(AvailableSettings.UPDATE_TIMESTAMPS_CACHE_REGION_NAME);
+		if ( StringHelper.isEmpty(updateTimestampsCacheRegionName) ) {
+			updateTimestampsCacheRegionName = null;
+		}
+		if ( updateTimestampsCacheRegionName != null && debugEnabled ) {
+			LOG.debugf( "UpdateTimestampsCache region prefix: %s", updateTimestampsCacheRegionName );
+		}
+		settings.setUpdateTimestampsCacheRegionName(updateTimestampsCacheRegionName);
+		
+		String standardQueryCacheRegionName = properties.getProperty(AvailableSettings.STANDARD_QUERY_CACHE_REGION_NAME);
+		if ( StringHelper.isEmpty(standardQueryCacheRegionName) ) {
+			standardQueryCacheRegionName = null;
+		}
+		if ( standardQueryCacheRegionName != null && debugEnabled ) {
+			LOG.debugf( "StandardQueryCache region prefix: %s", standardQueryCacheRegionName );
+		}
+		settings.setStandardQueryCacheRegionName(standardQueryCacheRegionName);
 
 		boolean useStructuredCacheEntries = ConfigurationHelper.getBoolean( AvailableSettings.USE_STRUCTURED_CACHE, properties, false );
 		if ( debugEnabled ) {


### PR DESCRIPTION
Background:
* we monitor our caches using collected:
** we expose ehcache via jmx
** iterate over mbeans
** create standard collectd message from mbean attributes and send to deamon

Collectd limits metric identifiers to 64 symbols. We configured shortened region names for our entities, however it is not possible to define sortened name for UpdateTimestampsCache and StandardQueryCache.

Currently, by default they use "org.hibernate.cache.spi.UpdateTimestampsCache" and "org.hibernate.cache.internal.StandardQueryCache".
