### PR TITLE
HHH-5654 PostgreSQL81Dialect will now correctly apply "for update of" for...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -256,6 +256,14 @@ public class PostgreSQL81Dialect extends Dialect {
 	public String getForUpdateString(String aliases) {
 		return getForUpdateString() + " of " + aliases;
 	}
+	
+	@Override
+	public String getForUpdateString(String aliases, LockOptions lockOptions) {
+		/*
+		 * Parent's implementation for (aliases, lockOptions) ignores aliases.
+		 */
+		return getForUpdateString(aliases);
+	}
 
 	@Override
 	public String getIdentitySelectString(String table, String column, int type) {


### PR DESCRIPTION
... any necessary table aliases. Added test.  PostgreSQL 8.1+ does support SELECT ... FOR UPDATE OF x,y,z
http://www.postgresql.org/docs/8.1/static/sql-select.html

Fix for this old issue can very likely be cherry-picked and applied to older release branches as well.

Signed-off-by: Bradley Plies <pliesb@yahoo.com>