### PR TITLE
HHH-6670: H2Dialect should use "if exists" when dropping sequences

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -253,7 +253,7 @@ public class H2Dialect extends Dialect {
 	}
 
 	public String getDropSequenceString(String sequenceName) {
-		return "drop sequence " + sequenceName;
+		return "drop sequence if exists " + sequenceName;
 	}
 
 	public String getSelectSequenceNextValString(String sequenceName) {


### PR DESCRIPTION
Fix for 4.2 branch