### PR TITLE
HHH-9500: H2Dialect shoud not drop constraints

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -427,4 +427,11 @@ public class H2Dialect extends Dialect {
 	public boolean supportsTuplesInSubqueries() {
 		return false;
 	}
+	
+	@Override
+	public boolean dropConstraints() {
+		// We don't need to drop constraints before dropping tables, that just leads to error
+		// messages about missing tables when we don't have a schema in the database
+		return false;
+	}	
 }


### PR DESCRIPTION
The constraints are automatically dropped when the table is also dropped.
Trying to drop a constraint on a table that doesn't exist present unnecessary error messages.
