### PR TITLE
HHH-9519: Fix envers NonUniqueObjectException

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversEventListener.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversEventListener.java
@@ -112,10 +112,10 @@ public abstract class BaseEnversEventListener implements EnversListener {
 
 		if ( value instanceof HibernateProxy ) {
 			final HibernateProxy hibernateProxy = (HibernateProxy) value;
-			toEntityName = session.bestGuessEntityName( value );
-			id = hibernateProxy.getHibernateLazyInitializer().getIdentifier();
 			// We've got to initialize the object from the proxy to later read its state.
 			value = EntityTools.getTargetFromProxy( session.getFactory(), hibernateProxy );
+			toEntityName = session.bestGuessEntityName( value );
+			id = hibernateProxy.getHibernateLazyInitializer().getIdentifier();
 		}
 		else {
 			toEntityName = session.guessEntityName( value );


### PR DESCRIPTION
We ran into the same issue documented in HHH-9519 "NonUniqueObjectException on bidirectional lazy loaded collection update with inheritance".

This is the fix we applied locally to resolve.
