### PR TITLE
HHH-9563 fix for l2 caching with lazy property fetching enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5245,7 +5245,7 @@ public abstract class AbstractEntityPersister
 			return new StandardCacheEntryImpl(
 					state,
 					persister,
-					persister.hasUninitializedLazyProperties( entity ),
+					session.getPersistenceContext().getEntry( entity ).isLoadedWithLazyPropertiesUnfetched(),
 					version,
 					session,
 					entity
@@ -5290,7 +5290,7 @@ public abstract class AbstractEntityPersister
 			return new StandardCacheEntryImpl(
 					state,
 					persister,
-					persister.hasUninitializedLazyProperties( entity ),
+					session.getPersistenceContext().getEntry( entity ).isLoadedWithLazyPropertiesUnfetched(),
 					version,
 					session,
 					entity

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyDateEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyDateEntity.java
@@ -1,0 +1,56 @@
+package org.hibernate.test.lazyload;
+
+import java.util.Date;
+
+import javax.persistence.*;
+import javax.persistence.Entity;
+
+import org.hibernate.annotations.*;
+import org.hibernate.bytecode.instrumentation.spi.AbstractFieldInterceptor;
+import org.hibernate.bytecode.internal.javassist.FieldHandler;
+
+@Entity
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+public class LazyDateEntity implements org.hibernate.bytecode.internal.javassist.FieldHandled {
+    private Long id;
+    private Date date;
+    private AbstractFieldInterceptor interceptor;
+
+    @Override
+    public void setFieldHandler(final FieldHandler handler) {
+        this.interceptor = (AbstractFieldInterceptor) handler;
+    }
+
+    @Override
+    public FieldHandler getFieldHandler() {
+        return (FieldHandler) interceptor;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    @Basic(fetch = FetchType.LAZY)
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getDate() {
+        if (interceptor != null && !interceptor.isInitialized("date")) {
+            return (Date) getFieldHandler().readObject(this, "date", date);
+        } else {
+            return date;
+        }
+    }
+
+    public void setDate(final Date date) {
+        if (interceptor == null || interceptor.isInitializing()) {
+            this.date = date;
+        } else {
+            this.date = (Date) getFieldHandler().writeObject(this, "date", this.date, date);
+        }
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyDateTest.java
@@ -1,0 +1,65 @@
+package org.hibernate.test.lazyload;
+
+import java.util.Date;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+@TestForIssue(jiraKey = "HHH-9563")
+public class LazyDateTest extends BaseCoreFunctionalTestCase {
+
+    private final LazyDateEntity persistedEntity = new LazyDateEntity();
+
+    @Override
+    protected void configure(Configuration cfg) {
+        super.configure(cfg);
+        cfg.setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true");
+    }
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { LazyDateEntity.class };
+    }
+
+    @Test
+    public void testLazyDate() throws Exception {
+        persistEntity();
+        putEntityIntoL2Cache();
+        loadEntityFromL2Cache();
+    }
+
+    private void persistEntity() {
+        Session s = openSession();
+        s.beginTransaction();
+        persistedEntity.setDate(new Date());
+        s.persist(persistedEntity);
+        s.getTransaction().commit();
+        s.close();
+    }
+
+    private void putEntityIntoL2Cache() {
+        Session s = openSession();
+        //clear cache to get rid of entry created by persist
+        s.getSessionFactory().getCache().evictAllRegions();
+        s.beginTransaction();
+        LazyDateEntity proxy = (LazyDateEntity) s.load(LazyDateEntity.class, persistedEntity.getId());
+        assertNotNull("getDate() returned null (but shouldn't have)", proxy.getDate());
+        s.getTransaction().commit();
+        s.close();
+    }
+
+    private void loadEntityFromL2Cache() {
+        Session s = openSession();
+        s.beginTransaction();
+        LazyDateEntity proxy = (LazyDateEntity) s.load(LazyDateEntity.class, persistedEntity.getId());
+        assertNotNull("getDate() returned null (but shouldn't have)", proxy.getDate());
+        s.getTransaction().commit();
+        s.close();
+    }
+}


### PR DESCRIPTION
A possible fix for https://hibernate.atlassian.net/browse/HHH-9563. This fixes the test and AFAICS doesn't break any other tests in obvious ways, but I'm not sure that it's ok for other code paths, e.g. when called from  `org.hibernate.action.internal.EntityInsertAction#execute` or `org.hibernate.action.internal.EntityUpdateAction#execute`. The most defensive (but also most expensive) way would possibly be to search the state array for lazy markers.