### PR TITLE
test case for [HHH-9568] EntityManager.flush() does not behave properly ...

### DIFF
--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/A.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/A.java
@@ -1,0 +1,51 @@
+//$Id$
+package org.hibernate.jpa.test.cascade;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import java.io.Serializable;
+
+/**
+ * @author Martin Simka
+ */
+@Entity
+public class A implements Serializable {
+	private Integer id;
+	private B b;
+
+	@Id
+	@GeneratedValue
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	@OneToOne(targetEntity=B.class, mappedBy="a", orphanRemoval = true)
+	public B getB() {
+		return b;
+	}
+
+	public void setB(B b) {
+		this.b = b;
+	}
+
+	public boolean equals(Object o) {
+		if ( this == o ) return true;
+		if ( !( o instanceof A) ) return false;
+
+		final A a = (A) o;
+
+		if ( !id.equals( a.id ) ) return false;
+
+		return true;
+	}
+
+	public int hashCode() {
+		return id.hashCode();
+	}
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/B.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/B.java
@@ -1,0 +1,56 @@
+//$Id$
+package org.hibernate.jpa.test.cascade;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import java.io.Serializable;
+
+/**
+ * @author Martin Simka
+ */
+@Entity
+public class B implements Serializable {
+	private Integer id;
+	private A a;
+
+	@Id
+	@GeneratedValue
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	@OneToOne(targetEntity=A.class, cascade=CascadeType.ALL,optional = true, orphanRemoval = true)
+	@JoinColumn(name="FK_FOR_B")
+	public A getA() {
+		return a;
+	}
+
+	public void setA(A a) {
+		this.a = a;
+	}
+
+	public boolean equals(Object o) {
+		if ( this == o ) return true;
+		if ( !( o instanceof B) ) return false;
+
+		final B b = (B) o;
+
+		if ( !id.equals( b.id ) ) return false;
+
+		return true;
+	}
+
+	public int hashCode() {
+		return id.hashCode();
+	}
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/CascadeTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/cascade/CascadeTest.java
@@ -26,9 +26,14 @@ package org.hibernate.jpa.test.cascade;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Max Rydahl Andersen
@@ -99,13 +104,37 @@ public class CascadeTest extends BaseEntityManagerFunctionalTestCase {
 		em.close();
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-9568")
+	@FailureExpected(jiraKey = "HHH-9568")
+	public void testFlushTransientOneToOne() throws Exception {
+			EntityManager em = getOrCreateEntityManager();
+			em.getTransaction().begin();
+
+			B b = new B();
+		    A a = new A();
+
+		    a.setB(b);
+		try {
+			em.persist(a);
+			em.flush();
+			em.getTransaction().commit();
+			fail("should have raised an IllegalStateException");
+		} catch (IllegalStateException ex) {
+			// IllegalStateException caught as expected
+		}
+		em.close();
+	}
+
 	@Override
 	public Class[] getAnnotatedClasses() {
 		return new Class[]{
 				Teacher.class,
 				Student.class,
 				Song.class,
-				Author.class
+				Author.class,
+				A.class,
+				B.class
 		};
 	}
 


### PR DESCRIPTION
...with transient one-to-one association and no cascade

added test CascadeTest.testFlushTransientOneToOne, marked as FailureExpected

test for https://hibernate.atlassian.net/browse/HHH-9568