### PR TITLE
HHH-9584: MavenEnhancePlugin should optionally fail on error.

### DIFF
--- a/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml.original
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml.original
@@ -37,9 +37,17 @@
           <editable>true</editable>
           <description></description>
         </parameter>
+        <parameter>
+          <name>failOnError</name>
+          <type>boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Whether the build should fail if an error occurs.</description>
+        </parameter>
       </parameters>
       <configuration>
         <dir implementation="java.lang.String" default-value="${project.build.outputDirectory}">${dir}</dir>
+        <failOnError implementation="boolean" default-value="false">${failOnError}</failOnError>
       </configuration>
     </mojo>
   </mojos>


### PR DESCRIPTION
Added a new plugin configuration parameter "failOnError" (boolean) that
allows the user to request the build to fail if an error occurs. 
The default value is "false", for backwards compatibility. 
If failOnError is "true", the plugin throws a MojoExecutionException
instead of logging an ERROR.