### PR TITLE
HHH-3813 Automatic flush to the join table before a criteria query (4.3)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
@@ -54,6 +54,7 @@ import org.hibernate.hql.internal.ast.util.SessionFactoryHelper;
 import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.Loadable;
 import org.hibernate.persister.entity.PropertyMapping;
 import org.hibernate.persister.entity.Queryable;
@@ -143,6 +144,19 @@ public class CriteriaQueryTranslator implements CriteriaQuery {
 		Set<Serializable> result = new HashSet<Serializable>();
 		for ( CriteriaInfoProvider info : criteriaInfoMap.values() ) {
 			result.addAll( Arrays.asList( info.getSpaces() ) );
+		}
+		for ( final Map.Entry<String, Criteria> entry : associationPathCriteriaMap.entrySet() ) {
+			String path = entry.getKey();
+			CriteriaImpl.Subcriteria crit = (CriteriaImpl.Subcriteria) entry.getValue();
+			int index = path.lastIndexOf( '.' );
+			if ( index > 0 ) {
+				path = path.substring( index + 1, path.length() );
+			}
+			CriteriaInfoProvider info = (CriteriaInfoProvider) criteriaInfoMap.get( crit.getParent() );
+			CollectionPersister persister = (CollectionPersister) getFactory().getAllCollectionMetadata().get( info.getName() + "." + path );
+			if ( persister != null ) {
+				result.addAll( Arrays.asList( persister.getCollectionSpaces() ) );
+			}
 		}
 		return result;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/NativeCriteriaSyncTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/NativeCriteriaSyncTest.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.test.flush;
+
+import static org.junit.Assert.*;
+
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.test.hql.SimpleEntityWithAssociation;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * @author Etienne Miret
+ */
+public class NativeCriteriaSyncTest extends BaseCoreFunctionalTestCase {
+
+	private Session session;
+
+	@Before
+	public void setUp() throws Exception {
+		session = openSession();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		session.close();
+	}
+
+	/**
+	 * Tests that the join table of a many-to-many relationship is properly flushed before making a related Criteria
+	 * query.
+	 */
+	@Test
+	@TestForIssue( jiraKey = "HHH-3813" )
+	public void test() {
+		final Transaction txn = session.beginTransaction();
+
+		final SimpleEntityWithAssociation e1 = new SimpleEntityWithAssociation( "e1" );
+		final SimpleEntityWithAssociation e2 = new SimpleEntityWithAssociation( "e2" );
+		e1.getManyToManyAssociatedEntities().add( e2 );
+		session.save( e1 );
+
+		final Criteria criteria = session.createCriteria( SimpleEntityWithAssociation.class );
+		criteria.createCriteria( "manyToManyAssociatedEntities" ).add( Restrictions.eq( "name", "e2" ) );
+		assertEquals( 1, criteria.list().size() );
+
+		txn.commit();
+	}
+
+	@Override
+	protected String[] getMappings() {
+		return new String[] { "hql/SimpleEntityWithAssociation.hbm.xml" };
+	}
+
+}


### PR DESCRIPTION
Same PR as #885 but on 4.3 branch. Fixes [HHH-3813](https://hibernate.atlassian.net/browse/HHH-3813).
