### PR TITLE
HHH-9247 Named entity graph can now be configured in orm.xml.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -1949,7 +1949,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		List<NamedAttributeNode> annNamedAttributeNodes = new ArrayList<NamedAttributeNode>(  );
 		for(Element namedAttributeNode : namedAttributeNodes){
 			AnnotationDescriptor annNamedAttributeNode = new AnnotationDescriptor( NamedAttributeNode.class );
-			copyStringAttribute( annNamedAttributeNode, namedAttributeNode, "value", true );
+			copyStringAttribute( annNamedAttributeNode, namedAttributeNode, "value", "name", true );
 			copyStringAttribute( annNamedAttributeNode, namedAttributeNode, "subgraph", false );
 			copyStringAttribute( annNamedAttributeNode, namedAttributeNode, "key-subgraph", false );
 			annNamedAttributeNodes.add( (NamedAttributeNode) AnnotationFactory.create( annNamedAttributeNode ) );
@@ -2903,12 +2903,34 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		return pkJoinColumns;
 	}
 
-	private static void copyStringAttribute(
-			AnnotationDescriptor annotation, Element element, String attributeName, boolean mandatory
-	) {
+	/**
+	 * Copy a string attribute from an XML element to an annotation descriptor. The name of the annotation attribute is
+	 * computed from the name of the XML attribute by {@link #getJavaAttributeNameFromXMLOne(String)}.
+	 *
+	 * @param annotation annotation descriptor where to copy to the attribute.
+	 * @param element XML element from where to copy the attribute.
+	 * @param attributeName name of the XML attribute to copy.
+	 * @param mandatory whether the attribute is mandatory.
+	 */
+	private static void copyStringAttribute( final AnnotationDescriptor annotation, final Element element,
+			final String attributeName, final boolean mandatory ) {
+		copyStringAttribute( annotation, element, getJavaAttributeNameFromXMLOne( attributeName ), attributeName, mandatory );
+	}
+
+	/**
+	 * Copy a string attribute from an XML element to an annotation descriptor. The name of the annotation attribute is
+	 * explicitely given.
+	 *
+	 * @param annotation annotation where to copy to the attribute.
+	 * @param element XML element from where to copy the attribute.
+	 * @param annotationAttributeName name of the annotation attribute where to copy.
+	 * @param attributeName name of the XML attribute to copy.
+	 * @param mandatory whether the attribute is mandatory.
+	 */
+	private static void copyStringAttribute( final AnnotationDescriptor annotation, final Element element,
+			final String annotationAttributeName, final String attributeName, boolean mandatory	) {
 		String attribute = element.attributeValue( attributeName );
 		if ( attribute != null ) {
-			String annotationAttributeName = getJavaAttributeNameFromXMLOne( attributeName );
 			annotation.setValue( annotationAttributeName, attribute );
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/Author.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/Author.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.test.annotations.entityGraph;
+
+import java.util.Date;
+import java.util.Set;
+
+
+/**
+ * @author Etienne Miret
+ */
+public class Author {
+
+	private Long id;
+
+	private String name;
+
+	private Date birth;
+
+	private Set<Book> books;
+
+	public Author() {
+		super();
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Date getBirth() {
+		return birth;
+	}
+
+	public void setBirth(Date birth) {
+		this.birth = birth;
+	}
+
+	public Set<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(Set<Book> books) {
+		this.books = books;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/Book.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.test.annotations.entityGraph;
+
+import java.util.Set;
+
+
+/**
+ * @author Etienne Miret
+ */
+public class Book {
+
+	private Long id;
+
+	private String isbn;
+
+	private String title;
+
+	private Set<Author> authors;
+
+	public Book() {
+		super();
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getIsbn() {
+		return isbn;
+	}
+
+	public void setIsbn(String isbn) {
+		this.isbn = isbn;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Set<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(Set<Author> authors) {
+		this.authors = authors;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/OrmXmlParseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/OrmXmlParseTest.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.test.annotations.entityGraph;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.internal.util.ConfigHelper;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+
+/**
+ * @author Etienne Miret
+ */
+public class OrmXmlParseTest {
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-9247" )
+	public void parseNamedAttributeNode() {
+		final Configuration cfg = new Configuration();
+		cfg.addURL( ConfigHelper.findAsResource( "org/hibernate/test/annotations/entityGraph/orm.xml" ) );
+		cfg.buildMappings();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/entityGraph/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+/**
+ * This package groups tests about the JPA 2.1 Entity Graph feature.
+ * See section 3.7 from the JPA 2.1 specification.
+ */
+package org.hibernate.test.annotations.entityGraph;

--- a/hibernate-core/src/test/resources/org/hibernate/test/annotations/entityGraph/orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/annotations/entityGraph/orm.xml
@@ -1,0 +1,43 @@
+<entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+    version="2.1">
+  <package>org.hibernate.test.annotations.entityGraph</package>
+  <access>FIELD</access>
+
+  <entity class="Book">
+    <named-entity-graph name="basic">
+      <named-attribute-node name="id"/>
+      <named-attribute-node name="isbn"/>
+      <named-attribute-node name="title"/>
+    </named-entity-graph>
+    <named-entity-graph name="full">
+      <named-attribute-node name="id"/>
+      <named-attribute-node name="isbn"/>
+      <named-attribute-node name="title"/>
+      <named-attribute-node name="authors" subgraph="authors"/>
+      <subgraph name="authors" class="Author">
+        <named-attribute-node name="id"/>
+        <named-attribute-node name="name"/>
+        <named-attribute-node name="birth"/>
+      </subgraph>
+    </named-entity-graph>
+    <attributes>
+      <id name="id"/>
+      <basic name="isbn"/>
+      <basic name="title"/>
+      <many-to-many name="authors">
+      	<join-table name="book_author"/>
+      </many-to-many>
+    </attributes>
+  </entity>
+
+  <entity class="Author">
+    <attributes>
+      <id name="id"/>
+      <basic name="name"/>
+      <basic name="birth"/>
+      <many-to-many name="books" mapped-by="authors"/>
+    </attributes>
+  </entity>
+
+</entity-mappings>


### PR DESCRIPTION
This PR fixes [HHH-9247](https://hibernate.atlassian.net/browse/HHH-9247).

The issue was that the "name" attribute of the "named-attribute-node" XML element maps to the "value" attribute of the corresponding annotation and the code assumed that XML elements attributes names always matched attribute names of the corresponding annotations (subject to camel-case translation).
