### PR TITLE
HHH-4161 (persistence.xml <jar-file> not following JSR220 spec)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.hibernate.boot.archive.spi.ArchiveException;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.boot.archive.spi.ArchiveDescriptor;
 import org.hibernate.boot.archive.spi.ArchiveDescriptorFactory;
@@ -70,7 +71,7 @@ public class StandardArchiveDescriptorFactory implements ArchiveDescriptorFactor
 				}
 
 				if ( ! file.exists() ) {
-					throw new IllegalArgumentException(
+					throw new ArchiveException(
 							String.format(
 									"File [%s] referenced by given URL [%s] does not exist",
 									filePart,
@@ -80,7 +81,7 @@ public class StandardArchiveDescriptorFactory implements ArchiveDescriptorFactor
 				}
 			}
 			catch (URISyntaxException e) {
-				throw new IllegalArgumentException(
+				throw new ArchiveException(
 						"Unable to visit JAR " + url + ". Cause: " + e.getMessage(), e
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
- * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
  * indicated by the @author tags or express copyright attribution
  * statements applied by the authors.  All third-party contributions are
  * distributed under license by Red Hat Inc.

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
- * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
  * indicated by the @author tags or express copyright attribution
  * statements applied by the authors.  All third-party contributions are
  * distributed under license by Red Hat Inc.

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
@@ -68,22 +68,24 @@ public abstract class AbstractScannerImpl implements Scanner {
 		return collector.toScanResult();
 	}
 
-    private ArchiveDescriptor getNonRootArchiveDescriptor(URL url, URL environmentRoot) {
-        try {
-            // Try finding the resource using JVM working directory (4.3.8-FINAL behavior)
-            return buildArchiveDescriptor( url, false );
-        } catch (ArchiveException ae) {
-            // Not there; try finding relative to root, as specified in JSR220 for <jar-file> (HHH-4161)
-            try {
-                URL rootRelativeURL = new URL(environmentRoot, url.getFile());
-                return buildArchiveDescriptor(rootRelativeURL, false);
-            } catch (MalformedURLException mue) {
-                throw new IllegalArgumentException(
-                        String.format("Could not create URL to find file [%s] from root URL [%s].",
-                                url.getFile(), environmentRoot), mue);
-            }
-        }
-    }
+	private ArchiveDescriptor getNonRootArchiveDescriptor(URL url, URL environmentRoot) {
+		try {
+			// Try finding the resource using JVM working directory (4.3.8-FINAL behavior)
+			return buildArchiveDescriptor( url, false );
+		}
+		catch (ArchiveException ae) {
+			// Not there; try finding relative to root, as specified in JSR220 for <jar-file> (HHH-4161)
+			try {
+				final URL rootRelativeURL = new URL(environmentRoot, url.getFile());
+				return buildArchiveDescriptor( rootRelativeURL, false);
+			}
+			catch (MalformedURLException mue) {
+				throw new IllegalArgumentException(
+						String.format( "Could not create URL to find file [%s] from root URL [%s].",
+								url.getFile(), environmentRoot), mue);
+			}
+		}
+	}
 
 	private ArchiveDescriptor buildArchiveDescriptor(URL url, boolean isRootUrl) {
 		final ArchiveDescriptor descriptor;

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/ArchiveDescriptorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/ArchiveDescriptorFactory.java
@@ -1,7 +1,7 @@
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
- * Copyright (c) 2013, Red Hat Inc. or third-party contributors as
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
  * indicated by the @author tags or express copyright attribution
  * statements applied by the authors.  All third-party contributions are
  * distributed under license by Red Hat Inc.

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/ArchiveDescriptorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/ArchiveDescriptorFactory.java
@@ -37,6 +37,7 @@ public interface ArchiveDescriptorFactory {
 	 * @param url The url to the archive
 	 *
 	 * @return The descriptor
+     * @throws ArchiveException if building the archive descriptor fails
 	 */
 	public ArchiveDescriptor buildArchiveDescriptor(URL url);
 
@@ -47,6 +48,7 @@ public interface ArchiveDescriptorFactory {
 	 * @param path The path within the given url that refers to the archive
 	 *
 	 * @return The descriptor
+     * @throws ArchiveException if building the archive descriptor fails
 	 */
 	public ArchiveDescriptor buildArchiveDescriptor(URL url, String path);
 

--- a/hibernate-core/src/test/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImplTest.java
@@ -1,0 +1,104 @@
+package org.hibernate.boot.archive.scan.spi;
+
+import org.hibernate.boot.archive.scan.internal.StandardScanOptions;
+import org.hibernate.boot.archive.spi.ArchiveContext;
+import org.hibernate.boot.archive.spi.ArchiveDescriptor;
+import org.hibernate.boot.archive.spi.ArchiveDescriptorFactory;
+import org.hibernate.boot.archive.spi.ArchiveException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.URL;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AbstractScannerImplTest {
+
+    private AbstractScannerImpl abstractScanner;
+    private URL jarFileTagContent;
+    private URL persistenceXMLRoot;
+
+    @Mock private ArchiveDescriptorFactory archiveDescriptorFactory;
+    @Mock private ArchiveDescriptor descriptor;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        abstractScanner = new AbstractScannerImpl(archiveDescriptorFactory) {};
+
+        // URLs (example persistence.xml location and a jar-file reference)
+        jarFileTagContent = new URL("file:earEntities.jar");
+        String earLibPUnitLocation = "file:/jboss-eap-4.3.0/jboss-as/server/default/tmp/deploy/" +
+                        "tmp8928495357123867261example-ear.ear-contents/lib/earLibPUnit.jar";
+        persistenceXMLRoot = new URL(earLibPUnitLocation).toURI().toURL();
+
+        // Return a mock by default; tests override this for more specific behavior
+        doReturn(mock(ArchiveDescriptor.class)).when(archiveDescriptorFactory)
+                .buildArchiveDescriptor(any(URL.class));
+    }
+
+    /**
+     * <p>
+     * When searching for otherModule.jar based on a <pre>{@code <jar-file>otherModule.jar</jar-file>}</pre>
+     * markup in persistence.xml, default behavior for Hibernate 4.3.8-FINAL
+     * was to look for otherModule.jar in the JVM working directory. This behavior
+     * should be preserved to avoid regressions in production systems.
+     * </p>
+     */
+    @Test
+    public void scanFindsNonRootUrlsFromJVMWorkingDirectory() throws Exception {
+        scanFindsNonRootUrlsFromDirectory(jarFileTagContent);
+    }
+
+    /**
+     * <p>
+     * When searching for otherModule.jar based on a <pre>{@code <jar-file>otherModule.jar</jar-file>}</pre>
+     * markup in persistence.xml, Hibernate should look for otherModule.jar relative
+     * to the root of the persistence unit (according to the JSR220 spec).
+     * </p>
+     *
+     * @see <a href="https://hibernate.atlassian.net/browse/HHH-4161">persistence.xml &lt;jar-file&gt; not following JSR220 spec</a>
+     */
+    @Test
+    public void scanFindsNonRootUrlsFromPersistenceXmlDirectory() throws Exception {
+        // Attempt to find the JAR in the JVM working directory fails
+        doThrow(new ArchiveException("File does not exist.")).when(archiveDescriptorFactory).buildArchiveDescriptor(jarFileTagContent);
+
+        // Should look relative to the persistence unit root next
+        URL rootRelativeJARUrl = new URL(persistenceXMLRoot, jarFileTagContent.getFile());
+        scanFindsNonRootUrlsFromDirectory(rootRelativeJARUrl);
+    }
+
+    /**
+     * Ensure the implementation builds a descriptor based on the given URL and then visits
+     * the descriptor.
+     *
+     * @param directoryAndFileName expected location to build the descriptor from
+     */
+    private void scanFindsNonRootUrlsFromDirectory(URL directoryAndFileName) throws Exception {
+        // Arrange
+        doReturn(descriptor).when(archiveDescriptorFactory).buildArchiveDescriptor(directoryAndFileName);
+        ScanEnvironment scanEnvironment = getEnvironment();
+
+        // Act
+        abstractScanner.scan(scanEnvironment, new StandardScanOptions(), mock(ScanParameters.class));
+
+        // Assert
+        verify(descriptor).visitArchive(any(ArchiveContext.class));
+    }
+
+    private ScanEnvironment getEnvironment() throws Exception {
+        ScanEnvironment jpaScanEnvironment = mock(ScanEnvironment.class);
+        doReturn(Arrays.asList(jarFileTagContent)).when(jpaScanEnvironment).getNonRootUrls();
+        doReturn(persistenceXMLRoot).when(jpaScanEnvironment).getRootUrl();
+
+        return jpaScanEnvironment;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImplTest.java
@@ -1,3 +1,26 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
 package org.hibernate.boot.archive.scan.spi;
 
 import org.hibernate.boot.archive.scan.internal.StandardScanOptions;


### PR DESCRIPTION
Fixes HHH-4161: Uses 4.3.8.Final behavior (relative to JVM working directory) as default; if jar is
not found, falls back to JSR220-compatible behavior.

There are at least three use cases to consider for JARs listed in jar-file of persistence.xml:

1. Absolute path is used in jar-file
2. Relative path is used in jar-file and JAR is placed relative to JVM working directory
3. Relative path is used in jar-file and JAR is placed according to JSR220 spec

4.3.8.Final works with 1 and 2, but not with 3. AFAIK, this patch supports all three cases. Further details at:

http://stackoverflow.com/questions/26628425/error-when-referencing-jar-files-in-jpa-persistence-xml-using-jar-file
http://stackoverflow.com/a/16503869/843984
https://hibernate.atlassian.net/browse/HHH-4161

_Note:_ I'm getting four test failures both with and without this patch when doing `./gradlew test`. I believe it to be a problem my environment (or in the tests), but have not had the chance to look further into it.

    :hibernate-core:test

    org.hibernate.test.fileimport.CommandExtractorServiceTest > testImportFile FAILED 
    org.junit.ComparisonFailure
    org.hibernate.test.fileimport.MultiLineImportFileTest > testImportFile FAILED 
    org.junit.ComparisonFailure at MultiLineImportFileTest.java:83
    org.hibernate.test.schematoolsnaming.StandaloneSchemaToolsNamingTest > testSchemaExportNamingAndNamingDelegatorSpecified FAILED 
    java.lang.AssertionError at StandaloneSchemaToolsNamingTest.java:108
    org.hibernate.test.schematoolsnaming.StandaloneSchemaToolsNamingTest > testSchemaUpdateNamingAndNamingDelegatorSpecified FAILED
    java.lang.AssertionError at StandaloneSchemaToolsNamingTest.java:124

    3930 tests completed, 4 failed, 126 skipped
    :hibernate-core:test FAILED
