### PR TITLE
HHH-5255 Fix merging of lazy basic properties (4.2)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -173,6 +173,10 @@ public class TypeHelper {
 				|| original[i] == BackrefPropertyAccessor.UNKNOWN ) {
 				copied[i] = target[i];
 			}
+			else if (target[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
+					|| target[i] == BackrefPropertyAccessor.UNKNOWN) {
+				copied[i] = original[i];
+			}
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/test/instrument/buildtime/InstrumentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/instrument/buildtime/InstrumentTest.java
@@ -24,7 +24,6 @@
 package org.hibernate.test.instrument.buildtime;
 
 import org.junit.Test;
-
 import org.hibernate.bytecode.instrumentation.internal.FieldInterceptionHelper;
 import org.hibernate.test.instrument.cases.Executable;
 import org.hibernate.test.instrument.cases.TestCustomColumnReadAndWrite;
@@ -32,6 +31,7 @@ import org.hibernate.test.instrument.cases.TestDirtyCheckExecutable;
 import org.hibernate.test.instrument.cases.TestFetchAllExecutable;
 import org.hibernate.test.instrument.cases.TestInjectFieldInterceptorExecutable;
 import org.hibernate.test.instrument.cases.TestIsPropertyInitializedExecutable;
+import org.hibernate.test.instrument.cases.TestLazyBasicPropertyUpdateExecutable;
 import org.hibernate.test.instrument.cases.TestLazyExecutable;
 import org.hibernate.test.instrument.cases.TestLazyManyToOneExecutable;
 import org.hibernate.test.instrument.cases.TestLazyPropertyCustomTypeExecutable;
@@ -87,6 +87,11 @@ public class InstrumentTest extends BaseUnitTestCase {
 	@Test
 	public void testLazyPropertyCustomTypeExecutable() throws Exception {
 		execute( new TestLazyPropertyCustomTypeExecutable() );
+	}
+
+	@Test
+	public void testLazyBasicPropertyUpdate() throws Exception {
+		execute( new TestLazyBasicPropertyUpdateExecutable() );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/instrument/cases/TestLazyBasicPropertyUpdateExecutable.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/instrument/cases/TestLazyBasicPropertyUpdateExecutable.java
@@ -1,0 +1,41 @@
+package org.hibernate.test.instrument.cases;
+import org.junit.Assert;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.test.instrument.domain.Document;
+import org.hibernate.test.instrument.domain.Folder;
+import org.hibernate.test.instrument.domain.Owner;
+
+/**
+ * @author Andrei Ivanov
+ */
+public class TestLazyBasicPropertyUpdateExecutable extends AbstractExecutable {
+	public void execute() {
+		Session s = getFactory().openSession();
+		Transaction t = s.beginTransaction();
+		Owner o = new Owner();
+		Document doc = new Document();
+		Folder fol = new Folder();
+		o.setName("gavin");
+		doc.setName("Hibernate in Action");
+		doc.setSummary("blah");
+		doc.updateText("blah blah");
+		fol.setName("books");
+		doc.setOwner(o);
+		doc.setFolder(fol);
+		fol.getDocuments().add(doc);
+		Assert.assertTrue( Hibernate.isPropertyInitialized( doc, "summary" ) );
+		s.persist(o);
+		s.persist(fol);
+		t.commit();
+
+		s.evict(doc);
+
+		doc.setSummary("u");
+		s.merge(doc);
+		
+		s.close();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/instrument/runtime/AbstractTransformingClassLoaderInstrumentTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/instrument/runtime/AbstractTransformingClassLoaderInstrumentTestCase.java
@@ -124,6 +124,11 @@ public abstract class AbstractTransformingClassLoaderInstrumentTestCase extends 
 	}
 
 	@Test
+	public void testLazyBasicPropertyUpdate() {
+		executeExecutable( "org.hibernate.test.instrument.cases.TestLazyBasicPropertyUpdateExecutable" );
+	}
+
+	@Test
 	public void testSharedPKOneToOne() {
 		executeExecutable( "org.hibernate.test.instrument.cases.TestSharedPKOneToOneExecutable" );
 	}


### PR DESCRIPTION
This PR fix the test introduced in #881 by @andrei-ivanov. While [HHH-5255](https://hibernate.atlassian.net/browse/HHH-5255) mentions only ``byte[]`` properties, Andrei’s test is actually on a ``java.util.Date`` lazy property and I think all basic lazy properties are concerned.