### PR TITLE
HHH-9634: Correctly search for sequences (by removing any backticks or quotes from...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/DatabaseMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/DatabaseMetadata.java
@@ -196,7 +196,10 @@ public class DatabaseMetadata {
 	public boolean isSequence(Object key) {
 		if (key instanceof String){
 			String[] strings = StringHelper.split(".", (String) key);
-			return sequences.contains( StringHelper.toLowerCase(strings[strings.length-1]));
+			String sequenceName = StringHelper.toLowerCase(strings[strings.length-1]);
+			String unquotedSequenceName = sequenceName.replaceAll("`","");
+			unquotedSequenceName = unquotedSequenceName.replaceAll("\"","");
+			return sequences.contains(unquotedSequenceName);
 		}
 		return false;
 	}


### PR DESCRIPTION
... the sequence name) when used in conjunction with hibernate.globally_quoted_identifiers.

I ran across this using postgres 9.4 and trunk hibernate (and recent releases), in conjunction with Spring Data and JPA. When hibernate.globally_quoted_identifiers=true, the string passed in to DatabaseMetadata.isSequence() has backticks around it. The sequences Set in the class is initialised directly from the database, and does not take in to account the quoted identifiers setting.

This patch seemed like the smallest thing that would work (it fixes the immediate issue I was having). Line 201 may be unnecessary - I only saw backpacks being passed in - but added it 'just in case'.

Feel free to use/reject as you like.

Cheers,
Andrew
