### PR TITLE
HHH-9639 - HikariCP can unwrap to DataSource

### DIFF
--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
@@ -35,6 +35,8 @@ import org.jboss.logging.Logger;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import javax.sql.DataSource;
+
 /**
  * HikariCP Connection provider for Hibernate.
  * 
@@ -112,12 +114,16 @@ public class HikariCPConnectionProvider implements ConnectionProvider, Configura
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T unwrap(Class<T> unwrapType) {
-		if ( isUnwrappableAs( unwrapType ) ) {
-			return (T) this;
-		}
-		else {
-			throw new UnknownUnwrapTypeException( unwrapType );
-		}
+        if ( ConnectionProvider.class.equals( unwrapType ) ||
+                HikariCPConnectionProvider.class.isAssignableFrom( unwrapType ) ) {
+            return (T) this;
+        }
+        else if ( DataSource.class.isAssignableFrom( unwrapType ) ) {
+            return (T) hds;
+        }
+        else {
+            throw new UnknownUnwrapTypeException( unwrapType );
+        }
 	}
 
 	// *************************************************************************

--- a/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariCPConnectionProviderTest.java
+++ b/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariCPConnectionProviderTest.java
@@ -23,11 +23,6 @@
  */
 package org.hibernate.test.hikaricp;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -38,6 +33,10 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.hikaricp.internal.HikariCPConnectionProvider;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
+
+import javax.sql.DataSource;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Brett Meyer
@@ -87,4 +86,12 @@ public class HikariCPConnectionProviderTest extends BaseCoreFunctionalTestCase {
 			assertTrue( e.getMessage().contains( "shutdown" ) );
 		}
 	}
+
+    @Test
+    public void testUnwrapAsDataSource() {
+        JdbcServices jdbcServices = serviceRegistry().getService( JdbcServices.class );
+        ConnectionProvider provider = jdbcServices.getConnectionProvider();
+
+        assertNotNull(provider.unwrap(DataSource.class));
+    }
 }


### PR DESCRIPTION
Unwrapping to DataSource so that Spring's SessionFactoryUtils can call cp.unwrap(DataSource.class);