### PR TITLE
[HHH-9647] Update jboss logging to 3.2.1.Final

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -58,7 +58,7 @@ ext {
             jacc:           'org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.4_spec:1.0.2.Final',
 
             // logging
-            logging:        'org.jboss.logging:jboss-logging:3.1.3.GA',
+            logging:        'org.jboss.logging:jboss-logging:3.2.1.Final',
             logging_annotations: 'org.jboss.logging:jboss-logging-annotations:1.2.0.Beta1',
             logging_processor:  'org.jboss.logging:jboss-logging-processor:1.2.0.Beta1',
 


### PR DESCRIPTION
When using Hibernate 4 with Log4J2, all messages are printed on CONSOLE instead of using Log4J2.
Upgrading the `pom.xml` with:

```xml
<dependency>
    <groupId>org.jboss.logging</groupId>
    <artifactId>jboss-logging</artifactId>
    <version>3.2.1.Final</version>
</dependency>
```

Fixes the issue. See [JBLOGGING-107](https://issues.jboss.org/browse/JBLOGGING-107). It worths upgrading Hibernate to depend on 3.2.0 (minimum) or 3.2.1 (latest).

See https://hibernate.atlassian.net/browse/HHH-9647