### PR TITLE
Update ImprovedNamingStrategy.java

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/ImprovedNamingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ImprovedNamingStrategy.java
@@ -57,15 +57,17 @@ public class ImprovedNamingStrategy implements NamingStrategy, Serializable {
 	}
 	/**
 	 * Convert mixed case to underscores
+	 * This Method called if you specify name in @Table
 	 */
 	public String tableName(String tableName) {
-		return addUnderscores(tableName);
+		return tableName;
 	}
 	/**
 	 * Convert mixed case to underscores
+	 * This Method called if you specify name in @Column
 	 */
 	public String columnName(String columnName) {
-		return addUnderscores(columnName);
+		return columnName;
 	}
 
 	protected static String addUnderscores(String name) {


### PR DESCRIPTION
columnName and tableName methods called when name specified in Column and Table annotations so it should not be changed, and the user "developer" specify the name and want to use it as is, otherwise making sql error.
