### PR TITLE
DDL typo fix: Add only one space before unique keyword

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
@@ -71,7 +71,7 @@ public class DefaultUniqueDelegate implements UniqueDelegate {
 
 	protected String uniqueConstraintSql( org.hibernate.mapping.UniqueKey uniqueKey ) {
 		final StringBuilder sb = new StringBuilder();
-		sb.append( " unique (" );
+		sb.append( "unique (" );
 		final Iterator<org.hibernate.mapping.Column> columnIterator = uniqueKey.columnIterator();
 		while ( columnIterator.hasNext() ) {
 			final org.hibernate.mapping.Column column = columnIterator.next();


### PR DESCRIPTION
Not so usefull, but allows a clean DDL