### PR TITLE
HHH-9708: Removing wrong error reports by the AnimalSniffer plug-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,6 @@ subprojects { subProject ->
 			all*.exclude group: 'xml-apis', module: 'xml-apis'
 		}
 		animalSnifferSignature
-		javaApiSignature
 	}
 
 	// appropriately inject the common dependencies into each sub-project
@@ -175,8 +174,8 @@ subprojects { subProject ->
 		jaxb( libraries.jaxb2_jaxb )
 		jaxb( libraries.jaxb2_jaxb_xjc )
 
+		// Referenced by AS Groovy plug-in
 		animalSnifferSignature( libraries.java16_signature )
-		javaApiSignature ( libraries.java16_signature )
 	}
 
 	// mac-specific stuff ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -341,7 +340,7 @@ subprojects { subProject ->
 		apply plugin: org.hibernate.build.animalsniffer.AnimalSnifferPlugin
 
 		animalSniffer {
-			skip = true;
+			skip = false;
 		}
 	}
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,11 +2,15 @@ repositories {
 	mavenCentral()
 }
 
+apply from: "../libraries.gradle"
 apply plugin: "groovy"
 
 dependencies {
 	compile gradleApi()
 	compile localGroovy()
 
-	compile "org.codehaus.mojo:animal-sniffer:1.14"
+	compile libraries.animal_sniffer
+
+	// TODO: This can be removed once using AS > 1.14
+	compile libraries.as_asm
 }

--- a/buildSrc/src/main/groovy/org/hibernate/build/animalsniffer/AnimalSnifferPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/hibernate/build/animalsniffer/AnimalSnifferPlugin.groovy
@@ -46,7 +46,7 @@ class AnimalSnifferPlugin implements Plugin<Project> {
 		project.configurations.maybeCreate( "animalSnifferSignature" )
 		final AnimalSnifferExtension extension = project.extensions.create( "animalSniffer", AnimalSnifferExtension )
 
-		project.tasks.findByName( JavaPlugin.CLASSES_TASK_NAME ).doLast(
+		project.tasks.findByName( JavaPlugin.COMPILE_JAVA_TASK_NAME ).doLast(
 				new Action<Task>() {
 					@Override
 					void execute(Task task) {

--- a/buildSrc/src/main/groovy/org/hibernate/build/animalsniffer/AnimalSnifferPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/hibernate/build/animalsniffer/AnimalSnifferPlugin.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.plugins.JavaPlugin
 
 import groovy.transform.Canonical
@@ -97,6 +98,12 @@ class AnimalSnifferPlugin implements Plugin<Project> {
 		// TODO: This could be made configurable via includes/excludes as done for the Maven plug-in
 		def dependencies = project.configurations.compile.resolvedConfiguration.resolvedArtifacts*.file +
 			project.configurations.provided.resolvedConfiguration.resolvedArtifacts*.file
+
+		// Add files from self-resolving dependencies ( gradleApi(), localGroovy() ) if present; These don't show up in
+		// the list of resolved artifacts created before
+		project.configurations.compile.dependencies.withType( SelfResolvingDependency.class ).each {
+			dependencies.addAll( it.resolve() )
+		}
 
 		dependencies.each {
 			clb.process( it )

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 
@@ -150,7 +152,6 @@ import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.type.AssociationType;
 import org.hibernate.type.Type;
 import org.hibernate.type.TypeResolver;
-
 import org.jboss.logging.Logger;
 
 
@@ -205,7 +206,7 @@ public final class SessionFactoryImpl
 	private final transient CurrentSessionContext currentSessionContext;
 	private final transient SQLFunctionRegistry sqlFunctionRegistry;
 	private final transient SessionFactoryObserverChain observer = new SessionFactoryObserverChain();
-	private final transient ConcurrentHashMap<EntityNameResolver,Object> entityNameResolvers = new ConcurrentHashMap<EntityNameResolver, Object>();
+	private final transient ConcurrentMap<EntityNameResolver,Object> entityNameResolvers = new ConcurrentHashMap<EntityNameResolver, Object>();
 	private final transient QueryPlanCache queryPlanCache;
 	private final transient CacheImplementor cacheAccess;
 	private transient boolean isClosed;

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -75,9 +75,10 @@ ext {
 			jaxb2_jaxb:     'org.jvnet.jaxb2_commons:jaxb2-basics-jaxb:2.2.4-1',
 			jaxb2_jaxb_xjc: 'org.jvnet.jaxb2_commons:jaxb2-basics-jaxb-xjc:2.2.4-1',
 
-            // Animal Sniffer Ant Task and Java 1.6 API signature file
-            // not using 1.9 for the time being due to MANIMALSNIFFER-34
-            animal_sniffer:     'org.codehaus.mojo:animal-sniffer-ant-tasks:1.13',
+            // Animal Sniffer and Java 1.6 API signature file; Intentionally not using AS 1.14 for the time being due
+            // to MANIMALSNIFFER-62; ASM 5 is enforced to make AS work with Java 8 class files; This will not be
+            // required anymore once AS > 1.14 is used
+            animal_sniffer:     'org.codehaus.mojo:animal-sniffer:1.13',
             as_asm:             'org.ow2.asm:asm-all:5.0.3',
             java16_signature:   'org.codehaus.mojo.signature:java16:1.0@signature',
 


### PR DESCRIPTION
@sebersole: This removes wrong error reports by the AnimalSniffer plug-in and also the reference to Java 8's `KeySetView` type.