### PR TITLE
HHH-9727: Delegating base class for session factory builders, allowing to pass integrator-specific options through SessionFactoryOptionsImpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bin
 # Miscellaneous
 *.log
 .clover
+.DS_Store
 
 # JBoss Transactions
 ObjectStore

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -149,7 +149,7 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 
 	@Override
 	public SessionFactoryBuilder getSessionFactoryBuilder() {
-		final SessionFactoryBuilder defaultBuilder = new SessionFactoryBuilderImpl( this );
+		final SessionFactoryBuilderImpl defaultBuilder = new SessionFactoryBuilderImpl( this );
 
 		final ClassLoaderService cls = metadataBuildingOptions.getServiceRegistry().getService( ClassLoaderService.class );
 		final java.util.Collection<SessionFactoryBuilderFactory> discoveredBuilderFactories = cls.loadJavaServices( SessionFactoryBuilderFactory.class );

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -46,7 +46,9 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryBuilderIntegrator;
 import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.boot.spi.SessionFactoryOptionsIntegrator;
 import org.hibernate.cache.internal.StandardQueryCacheFactory;
 import org.hibernate.cache.spi.QueryCacheFactory;
 import org.hibernate.cache.spi.RegionFactory;
@@ -69,7 +71,6 @@ import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
-
 import org.jboss.logging.Logger;
 
 import static org.hibernate.cfg.AvailableSettings.AUTO_CLOSE_SESSION;
@@ -118,7 +119,7 @@ import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
  * @author Gail Badner
  * @author Steve Ebersole
  */
-public class SessionFactoryBuilderImpl implements SessionFactoryBuilder {
+public class SessionFactoryBuilderImpl implements SessionFactoryBuilder, SessionFactoryBuilderIntegrator {
 	private static final Logger log = Logger.getLogger( SessionFactoryBuilderImpl.class );
 
 	private final MetadataImplementor metadata;
@@ -432,6 +433,12 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilder {
 	}
 
 	@Override
+	public SessionFactoryBuilderIntegrator applyIntegratorOptions(Object integratorOptions) {
+		this.options.integratorOptions = integratorOptions;
+		return this;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public <T extends SessionFactoryBuilder> T unwrap(Class<T> type) {
 		return (T) this;
@@ -443,7 +450,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilder {
 		return new SessionFactoryImpl( metadata, options );
 	}
 
-	public static class SessionFactoryOptionsImpl implements SessionFactoryOptions {
+	public static class SessionFactoryOptionsImpl implements SessionFactoryOptions, SessionFactoryOptionsIntegrator {
 		private final StandardServiceRegistry serviceRegistry;
 
 		// integration
@@ -520,6 +527,8 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilder {
 
 		private Map<String, SQLFunction> sqlFunctions;
 
+		// SessionFactoryOptionsIntegrator
+		private Object integratorOptions;
 
 		public SessionFactoryOptionsImpl(StandardServiceRegistry serviceRegistry) {
 			this.serviceRegistry = serviceRegistry;
@@ -936,6 +945,10 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilder {
 		public void setCheckNullability(boolean enabled) {
 			this.checkNullability = enabled;
 		}
-	}
 
+		@Override
+		public Object getIntegratorOptions() {
+			return integratorOptions;
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/ForwardingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/ForwardingSessionFactoryBuilder.java
@@ -1,0 +1,367 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2015, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.boot.spi;
+
+import java.util.Map;
+
+import org.hibernate.ConnectionReleaseMode;
+import org.hibernate.CustomEntityDirtinessStrategy;
+import org.hibernate.EntityMode;
+import org.hibernate.EntityNameResolver;
+import org.hibernate.Interceptor;
+import org.hibernate.MultiTenancyStrategy;
+import org.hibernate.NullPrecedence;
+import org.hibernate.SessionFactory;
+import org.hibernate.SessionFactoryObserver;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.cache.spi.QueryCacheFactory;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.hql.spi.MultiTableBulkIdStrategy;
+import org.hibernate.loader.BatchFetchStyle;
+import org.hibernate.proxy.EntityNotFoundDelegate;
+import org.hibernate.tuple.entity.EntityTuplizer;
+import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+/**
+ * Base class for {@link SessionFactoryBuilder} implementations that wish to implement only parts of that contract
+ * themselves while forwarding other method invocations to a delegate instance.
+ *
+ * @author Gunnar Morling
+ * @param <T> The type of a specific sub-class; Allows sub-classes to narrow down the return-type of the contract methods
+ * to a specialization of {@link SessionFactoryBuilder}
+ */
+public abstract class ForwardingSessionFactoryBuilder <T extends ForwardingSessionFactoryBuilder<T>> implements SessionFactoryBuilder {
+
+	private final SessionFactoryBuilder delegate;
+
+	public ForwardingSessionFactoryBuilder(SessionFactoryBuilder delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Returns a specific implementation. See the <a
+	 * href="http://www.angelikalanger.com/GenericsFAQ/FAQSections/ProgrammingIdioms.html#FAQ206">What is the
+	 * "getThis trick?"</a>.
+	 */
+	protected abstract T getThis();
+
+	@Override
+	public T applyValidatorFactory(Object validatorFactory) {
+		delegate.applyValidatorFactory( validatorFactory );
+		return getThis();
+	}
+
+	@Override
+	public T applyBeanManager(Object beanManager) {
+		delegate.applyBeanManager( beanManager );
+		return getThis();
+	}
+
+	@Override
+	public T applyName(String sessionFactoryName) {
+		delegate.applyName( sessionFactoryName );
+		return getThis();
+	}
+
+	@Override
+	public T applyNameAsJndiName(boolean isJndiName) {
+		delegate.applyNameAsJndiName( isJndiName );
+		return getThis();
+	}
+
+	@Override
+	public T applyAutoClosing(boolean enabled) {
+		delegate.applyAutoClosing( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyAutoFlushing(boolean enabled) {
+		delegate.applyAutoFlushing( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyStatisticsSupport(boolean enabled) {
+		delegate.applyStatisticsSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyInterceptor(Interceptor interceptor) {
+		delegate.applyInterceptor( interceptor );
+		return getThis();
+	}
+
+	@Override
+	public T addSessionFactoryObservers(SessionFactoryObserver... observers) {
+		delegate.addSessionFactoryObservers( observers );
+		return getThis();
+	}
+
+	@Override
+	public T applyCustomEntityDirtinessStrategy(CustomEntityDirtinessStrategy strategy) {
+		delegate.applyCustomEntityDirtinessStrategy( strategy );
+		return getThis();
+	}
+
+	@Override
+	public T addEntityNameResolver(EntityNameResolver... entityNameResolvers) {
+		delegate.addEntityNameResolver( entityNameResolvers );
+		return getThis();
+	}
+
+	@Override
+	public T applyEntityNotFoundDelegate(EntityNotFoundDelegate entityNotFoundDelegate) {
+		delegate.applyEntityNotFoundDelegate( entityNotFoundDelegate );
+		return getThis();
+	}
+
+	@Override
+	public T applyIdentifierRollbackSupport(boolean enabled) {
+		delegate.applyIdentifierRollbackSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyDefaultEntityMode(EntityMode entityMode) {
+		delegate.applyDefaultEntityMode( entityMode );
+		return getThis();
+	}
+
+	@Override
+	public T applyNullabilityChecking(boolean enabled) {
+		delegate.applyNullabilityChecking( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyLazyInitializationOutsideTransaction(boolean enabled) {
+		delegate.applyLazyInitializationOutsideTransaction( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyEntityTuplizerFactory(EntityTuplizerFactory entityTuplizerFactory) {
+		delegate.applyEntityTuplizerFactory( entityTuplizerFactory );
+		return getThis();
+	}
+
+	@Override
+	public T applyEntityTuplizer(EntityMode entityMode, Class<? extends EntityTuplizer> tuplizerClass) {
+		delegate.applyEntityTuplizer( entityMode, tuplizerClass );
+		return getThis();
+	}
+
+	@Override
+	public T applyMultiTableBulkIdStrategy(MultiTableBulkIdStrategy strategy) {
+		delegate.applyMultiTableBulkIdStrategy( strategy );
+		return getThis();
+	}
+
+	@Override
+	public T applyBatchFetchStyle(BatchFetchStyle style) {
+		delegate.applyBatchFetchStyle( style );
+		return getThis();
+	}
+
+	@Override
+	public T applyDefaultBatchFetchSize(int size) {
+		delegate.applyDefaultBatchFetchSize( size );
+		return getThis();
+	}
+
+	@Override
+	public T applyMaximumFetchDepth(int depth) {
+		delegate.applyMaximumFetchDepth( depth );
+		return getThis();
+	}
+
+	@Override
+	public T applyDefaultNullPrecedence(NullPrecedence nullPrecedence) {
+		delegate.applyDefaultNullPrecedence( nullPrecedence );
+		return getThis();
+	}
+
+	@Override
+	public T applyOrderingOfInserts(boolean enabled) {
+		delegate.applyOrderingOfInserts( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyOrderingOfUpdates(boolean enabled) {
+		delegate.applyOrderingOfUpdates( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyMultiTenancyStrategy(MultiTenancyStrategy strategy) {
+		delegate.applyMultiTenancyStrategy( strategy );
+		return getThis();
+	}
+
+	@Override
+	public T applyCurrentTenantIdentifierResolver(CurrentTenantIdentifierResolver resolver) {
+		delegate.applyCurrentTenantIdentifierResolver( resolver );
+		return getThis();
+	}
+
+	@Override
+	public T applyJtaTrackingByThread(boolean enabled) {
+		delegate.applyJtaTrackingByThread( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyQuerySubstitutions(Map substitutions) {
+		delegate.applyQuerySubstitutions( substitutions );
+		return getThis();
+	}
+
+	@Override
+	public T applyStrictJpaQueryLanguageCompliance(boolean enabled) {
+		delegate.applyStrictJpaQueryLanguageCompliance( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyNamedQueryCheckingOnStartup(boolean enabled) {
+		delegate.applyNamedQueryCheckingOnStartup( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applySecondLevelCacheSupport(boolean enabled) {
+		delegate.applySecondLevelCacheSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyQueryCacheSupport(boolean enabled) {
+		delegate.applyQueryCacheSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyQueryCacheFactory(QueryCacheFactory factory) {
+		delegate.applyQueryCacheFactory( factory );
+		return getThis();
+	}
+
+	@Override
+	public T applyCacheRegionPrefix(String prefix) {
+		delegate.applyCacheRegionPrefix( prefix );
+		return getThis();
+	}
+
+	@Override
+	public T applyMinimalPutsForCaching(boolean enabled) {
+		delegate.applyMinimalPutsForCaching( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyStructuredCacheEntries(boolean enabled) {
+		delegate.applyStructuredCacheEntries( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyDirectReferenceCaching(boolean enabled) {
+		delegate.applyDirectReferenceCaching( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyAutomaticEvictionOfCollectionCaches(boolean enabled) {
+		delegate.applyAutomaticEvictionOfCollectionCaches( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyJdbcBatchSize(int size) {
+		delegate.applyJdbcBatchSize( size );
+		return getThis();
+	}
+
+	@Override
+	public T applyJdbcBatchingForVersionedEntities(boolean enabled) {
+		delegate.applyJdbcBatchingForVersionedEntities( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyScrollableResultsSupport(boolean enabled) {
+		delegate.applyScrollableResultsSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyResultSetsWrapping(boolean enabled) {
+		delegate.applyResultSetsWrapping( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyGetGeneratedKeysSupport(boolean enabled) {
+		delegate.applyGetGeneratedKeysSupport( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applyJdbcFetchSize(int size) {
+		delegate.applyJdbcFetchSize( size );
+		return getThis();
+	}
+
+	@Override
+	public T applyConnectionReleaseMode(ConnectionReleaseMode connectionReleaseMode) {
+		delegate.applyConnectionReleaseMode( connectionReleaseMode );
+		return getThis();
+	}
+
+	@Override
+	public T applySqlComments(boolean enabled) {
+		delegate.applySqlComments( enabled );
+		return getThis();
+	}
+
+	@Override
+	public T applySqlFunction(String registrationName, SQLFunction sqlFunction) {
+		delegate.applySqlFunction( registrationName, sqlFunction );
+		return getThis();
+	}
+
+	@Override
+	public <S extends SessionFactoryBuilder> S unwrap(Class<S> type) {
+		return delegate.unwrap( type );
+	}
+
+	@Override
+	public SessionFactory build() {
+		return delegate.build();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderIntegrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryBuilderIntegrator.java
@@ -26,22 +26,14 @@ package org.hibernate.boot.spi;
 import org.hibernate.boot.SessionFactoryBuilder;
 
 /**
- * An extension point for integrators that wish to hook into the process of how a SessionFactory
- * is built.  Intended as a "discoverable service" ({@link java.util.ServiceLoader}).  There can
- * be at most one implementation discovered that returns a non-null SessionFactoryBuilder.
+ * A {@link SessionFactoryBuilder} extension geared towards integrators of Hibernate ORM.
  *
- * @author Steve Ebersole
+ * @author Gunnar Morling
  */
-public interface SessionFactoryBuilderFactory {
+public interface SessionFactoryBuilderIntegrator extends SessionFactoryBuilder {
+
 	/**
-	 * The contract method.  Return the SessionFactoryBuilder.  May return {@code null}
-	 *
-	 * @param metadata The metadata from which we will be building a SessionFactory.
-	 * @param defaultBuilder The default SessionFactoryBuilder instance.  If the SessionFactoryBuilder being built
-	 * here needs to use this passed SessionFactoryBuilder instance it is the responsibility of the built
-	 * SessionFactoryBuilder impl to delegate configuration calls to the passed default impl.
-	 *
-	 * @return The SessionFactoryBuilder, or {@code null}
+	 * Applies the given integrator-specific options.
 	 */
-	public SessionFactoryBuilder getSessionFactoryBuilder(MetadataImplementor metadata, SessionFactoryBuilderIntegrator defaultBuilder);
+	SessionFactoryBuilderIntegrator applyIntegratorOptions(Object integratorOptions);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptionsIntegrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptionsIntegrator.java
@@ -23,25 +23,17 @@
  */
 package org.hibernate.boot.spi;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
 /**
- * An extension point for integrators that wish to hook into the process of how a SessionFactory
- * is built.  Intended as a "discoverable service" ({@link java.util.ServiceLoader}).  There can
- * be at most one implementation discovered that returns a non-null SessionFactoryBuilder.
+ * {@link SessionFactoryOptions} extension geared towards integrators of Hibernate ORM.
  *
- * @author Steve Ebersole
+ * @author Gunnar Morling
  */
-public interface SessionFactoryBuilderFactory {
+public interface SessionFactoryOptionsIntegrator extends SessionFactoryOptions {
+
 	/**
-	 * The contract method.  Return the SessionFactoryBuilder.  May return {@code null}
+	 * Returns an integrator-specific options container if present.
 	 *
-	 * @param metadata The metadata from which we will be building a SessionFactory.
-	 * @param defaultBuilder The default SessionFactoryBuilder instance.  If the SessionFactoryBuilder being built
-	 * here needs to use this passed SessionFactoryBuilder instance it is the responsibility of the built
-	 * SessionFactoryBuilder impl to delegate configuration calls to the passed default impl.
-	 *
-	 * @return The SessionFactoryBuilder, or {@code null}
+	 * @return An integrator-specific options container or {@code null}.
 	 */
-	public SessionFactoryBuilder getSessionFactoryBuilder(MetadataImplementor metadata, SessionFactoryBuilderIntegrator defaultBuilder);
+	Object getIntegratorOptions();
 }


### PR DESCRIPTION
Hey @sebersole, this provides two things:

* `ForwardingSessionFactoryBuilder` as base class for builders delegating most work to the default one
* New contracts `SessionFactoryBuilderIntegrator` and `SessionFactoryOptionsIntegrator` (which extend `SessionFactoryBuilder` and `SessionFactoryOptions`, respectively).

The motivation for the latter is that I needed a way to pass options configured through `OgmSessionFactoryBuilder` to the `SessionFactoryServiceInitiator` consuming that option. These new SPIs just accept/expose a generic `Object` which fulfills that need through casting on the consuming end. This functionality is not exposed on the public `SessionFactoryBuilder`.