### PR TITLE
HHH-9784 Scroll method does not support provided HQLQueryPlan

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1321,7 +1321,12 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 	public ScrollableResults scroll(String query, QueryParameters queryParameters) throws HibernateException {
 		errorIfClosed();
 		checkTransactionSynchStatus();
-		HQLQueryPlan plan = getHQLQueryPlan( query, false );
+		
+		HQLQueryPlan plan = queryParameters.getQueryPlan();
+		if (plan == null) {
+			plan = getHQLQueryPlan( query, false );
+		}
+		
 		autoFlushIfRequired( plan.getQuerySpaces() );
 		dontFlushFromFind++;
 		try {


### PR DESCRIPTION
Replaces https://github.com/hibernate/hibernate-orm/pull/795

In our project, we need to be able to provide a HQLQueryPlan when scrolling in results the same way we do it with result listing.

We would be grateful if you merged those changes with branch 4.3 :)