### PR TITLE
HHH-9781 Allow 2LC to parse Infinispan 6 and 7 configurations

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
@@ -174,13 +174,18 @@ public abstract class BaseRegion implements Region {
 							log.tracef("Transaction, clearing one element at the time");
 							Caches.removeAll(localAndSkipLoadCache);
 						} else {
-							Caches.withinTx( cache, new Callable<Void>() {
-								@Override
-								public Void call() throws Exception {
-									localAndSkipLoadCache.clear();
-									return null;
-								}
-							} );
+							try {
+								Caches.withinTx( cache, new Callable<Void>() {
+									@Override
+									public Void call() throws Exception {
+										localAndSkipLoadCache.clear();
+										return null;
+									}
+								} );
+							} catch (Exception e) {
+								// If get any exceptions, try clearing directly
+								localAndSkipLoadCache.clear();
+							}
 						}
 
 						log.tracef("Transition state from CLEARING to VALID");

--- a/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-7-configs.xml
+++ b/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-7-configs.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="urn:infinispan:config:7.2"
+            xsi:schemaLocation="urn:infinispan:config:7.2 http://www.infinispan.org/schemas/infinispan-config-7.2.xsd">
+
+   <jgroups>
+      <stack-file name="hibernate-jgroups" path="${hibernate.cache.infinispan.jgroups_cfg:default-configs/default-jgroups-tcp.xml}"/>
+   </jgroups>
+
+   <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache" shutdown-hook="DEFAULT">
+      <transport stack="hibernate-jgroups" cluster="infinispan-hibernate-cluster"/>
+
+      <local-cache name="the-default-cache" statistics="false" />
+
+      <!-- Default configuration is appropriate for entity/collection caching. -->
+      <invalidation-cache name="entity" mode="SYNC" remote-timeout="20000">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </invalidation-cache>
+
+      <!-- Default configuration is appropriate for entity/collection caching. -->
+      <invalidation-cache name="entity-repeatable" mode="SYNC" remote-timeout="20000">
+         <locking isolation="REPEATABLE_READ" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </invalidation-cache>
+
+      <!-- An alternative configuration for entity/collection caching that uses replication instead of invalidation -->
+      <replicated-cache name="replicated-entity" mode="SYNC" remote-timeout="20000">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+         <state-transfer enabled="false"/>
+      </replicated-cache>
+
+      <!-- A config appropriate for query caching. Does not replicate queries. -->
+      <local-cache name="local-query">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </local-cache>
+
+      <!-- A query cache that replicates queries. Replication is asynchronous. -->
+      <replicated-cache name="replicated-query" mode="ASYNC">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+         <persistence passivation="false">
+            <!-- State transfer forces all replication calls to be synchronous,
+                 so for calls to remain async, use a cluster cache loader instead -->
+            <cluster-loader remote-timeout="20000"/>
+         </persistence>
+      </replicated-cache>
+
+      <!-- Optimized for timestamp caching. A clustered timestamp cache
+           is required if query caching is used, even if the query cache
+           itself is configured with CacheMode=LOCAL. -->
+      <replicated-cache name="timestamps" mode="ASYNC">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <!-- Explicitly non transactional -->
+         <transaction mode="NONE"/>
+         <!--  Don't ever evict modification timestamps -->
+         <eviction strategy="NONE"/>
+         <expiration interval="0"/>
+         <persistence passivation="false">
+            <!-- State transfer forces all replication calls to be synchronous,
+                 so for calls to remain async, use a cluster cache loader instead -->
+            <cluster-loader remote-timeout="20000"/>
+         </persistence>
+         <state-transfer enabled="false"/>
+      </replicated-cache>
+   </cache-container>
+
+</infinispan>

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
@@ -110,6 +110,7 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 		assertNull( "remote is clean", remoteRegion.get( KEY ) );
 
       regionPut(localRegion);
+		sleep( 1000 );
       assertEquals( VALUE1, localRegion.get( KEY ) );
 
 		// allow async propagation

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/InfinispanRegionFactoryTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/InfinispanRegionFactoryTestCase.java
@@ -29,6 +29,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -293,7 +294,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testTimestampValidation() {
       Properties p = new Properties();
-      final DefaultCacheManager manager = new DefaultCacheManager();
+      final DefaultCacheManager manager = new DefaultCacheManager(GlobalConfigurationBuilder.defaultClusteredBuilder().build());
       InfinispanRegionFactory factory = createRegionFactory(manager, p);
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().cacheMode(CacheMode.INVALIDATION_SYNC);

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/JndiRegionFactoryTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/JndiRegionFactoryTestCase.java
@@ -23,6 +23,7 @@
  */
 package org.hibernate.test.cache.infinispan.functional;
 
+import java.io.IOException;
 import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -32,6 +33,7 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -98,7 +100,11 @@ public class JndiRegionFactoryTestCase extends SingleNodeTestCase {
 				props.put( "java.naming.factory.initial", "org.jnp.interfaces.NamingContextFactory" );
 				props.put( "java.naming.factory.url.pkgs", "org.jboss.naming:org.jnp.interfaces" );
 
-				manager = new DefaultCacheManager( InfinispanRegionFactory.DEF_INFINISPAN_CONFIG_RESOURCE, false );
+				try {
+					manager = new DefaultCacheManager( InfinispanRegionFactory.DEF_INFINISPAN_CONFIG_RESOURCE, false );
+				} catch (CacheConfigurationException e) {
+					manager = new DefaultCacheManager( "org/hibernate/cache/infinispan/builder/infinispan-7-configs.xml", false );
+				}
 				Context ctx = new InitialContext( props );
 				bind( JNDI_NAME, manager, EmbeddedCacheManager.class, ctx );
 			}


### PR DESCRIPTION
* By doing so, Hibernate 4.3 can read standalone XML configurations for both Infinispan 6.x and 7.x versions.
* In Infinispan 7, clear is not transactional and hence does not need a new transaction around it, so protect against that in region invalidation code.
* Other minor testsuite adjustments that also present in master.