### PR TITLE
HHH-9781 : Add test configuration for Infinispan 7.2; update tests to…

### DIFF
--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
@@ -110,6 +110,7 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 		assertNull( "remote is clean", remoteRegion.get( KEY ) );
 
       regionPut(localRegion);
+		sleep( 1000 );
       assertEquals( VALUE1, localRegion.get( KEY ) );
 
 		// allow async propagation

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/InfinispanRegionFactoryTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/InfinispanRegionFactoryTestCase.java
@@ -24,11 +24,14 @@ package org.hibernate.test.cache.infinispan;
 import java.util.Properties;
 import javax.transaction.TransactionManager;
 
+import org.hibernate.cfg.Environment;
 import org.hibernate.test.cache.infinispan.functional.SingleNodeTestCase;
+
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -65,7 +68,7 @@ public class InfinispanRegionFactoryTestCase  {
    public void testConfigurationProcessing() {
       final String person = "com.acme.Person";
       final String addresses = "com.acme.Person.addresses";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.eviction.strategy", "LRU");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.eviction.wake_up_interval", "2000");
@@ -114,7 +117,7 @@ public class InfinispanRegionFactoryTestCase  {
       final String car = "com.acme.Car";
       final String addresses = "com.acme.Person.addresses";
       final String parts = "com.acme.Car.parts";
-      Properties p = new Properties();
+      Properties p = createProperties();
       // First option, cache defined for entity and overrides for generic entity data type and entity itself.
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.eviction.strategy", "LRU");
@@ -225,7 +228,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildEntityCollectionRegionOverridesOnly() {
       AdvancedCache cache;
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.entity.eviction.strategy", "LIRS");
       p.setProperty("hibernate.cache.infinispan.entity.eviction.wake_up_interval", "3000");
       p.setProperty("hibernate.cache.infinispan.entity.eviction.max_entries", "30000");
@@ -261,7 +264,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildEntityRegionPersonPlusEntityOverridesWithoutCfg() {
       final String person = "com.acme.Person";
-      Properties p = new Properties();
+      Properties p = createProperties();
       // Third option, no cache defined for entity and overrides for generic entity data type and entity itself.
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.eviction.strategy", "LRU");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
@@ -292,8 +295,8 @@ public class InfinispanRegionFactoryTestCase  {
 
    @Test
    public void testTimestampValidation() {
-      Properties p = new Properties();
-      final DefaultCacheManager manager = new DefaultCacheManager();
+      Properties p = createProperties();
+      final DefaultCacheManager manager = new DefaultCacheManager( GlobalConfigurationBuilder.defaultClusteredBuilder().build());
       InfinispanRegionFactory factory = createRegionFactory(manager, p);
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.clustering().cacheMode(CacheMode.INVALIDATION_SYNC);
@@ -308,7 +311,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildDefaultTimestampsRegion() {
       final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       InfinispanRegionFactory factory = createRegionFactory(p);
       try {
          assertTrue(factory.getDefinedConfigurations().contains("timestamps"));
@@ -329,7 +332,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildDiffCacheNameTimestampsRegion() {
       final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.timestamps.cfg", "unrecommended-timestamps");
       InfinispanRegionFactory factory = createRegionFactory(p);
       try {
@@ -356,7 +359,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildTimestamRegionWithCacheNameOverride() {
       final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.timestamps.cfg", "mytimestamps-cache");
       InfinispanRegionFactory factory = createRegionFactory(p);
       try {
@@ -370,7 +373,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildTimestamRegionWithFifoEvictionOverride() {
       final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.timestamps.cfg", "mytimestamps-cache");
       p.setProperty("hibernate.cache.infinispan.timestamps.eviction.strategy", "FIFO");
       p.setProperty("hibernate.cache.infinispan.timestamps.eviction.wake_up_interval", "3000");
@@ -390,7 +393,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildTimestamRegionWithNoneEvictionOverride() {
       final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.timestamps.cfg", "timestamps-none-eviction");
       p.setProperty("hibernate.cache.infinispan.timestamps.eviction.strategy", "NONE");
       p.setProperty("hibernate.cache.infinispan.timestamps.eviction.wake_up_interval", "3000");
@@ -407,7 +410,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildQueryRegion() {
       final String query = "org.hibernate.cache.internal.StandardQueryCache";
-      Properties p = new Properties();
+      Properties p = createProperties();
       InfinispanRegionFactory factory = createRegionFactory(p);
       try {
          assertTrue(factory.getDefinedConfigurations().contains("local-query"));
@@ -424,7 +427,7 @@ public class InfinispanRegionFactoryTestCase  {
    @Test
    public void testBuildQueryRegionWithCustomRegionName() {
       final String queryRegionName = "myquery";
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.myquery.cfg", "timestamps-none-eviction");
       p.setProperty("hibernate.cache.infinispan.myquery.eviction.strategy", "LIRS");
       p.setProperty("hibernate.cache.infinispan.myquery.eviction.wake_up_interval", "2222");
@@ -446,7 +449,7 @@ public class InfinispanRegionFactoryTestCase  {
    }
    @Test
    public void testEnableStatistics() {
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.statistics", "true");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
@@ -497,7 +500,7 @@ public class InfinispanRegionFactoryTestCase  {
 
    @Test
    public void testDisableStatistics() {
-      Properties p = new Properties();
+      Properties p = createProperties();
       p.setProperty("hibernate.cache.infinispan.statistics", "false");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
       p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
@@ -576,4 +579,14 @@ public class InfinispanRegionFactoryTestCase  {
       return factory;
    }
 
+   private static Properties createProperties() {
+      final Properties properties = new Properties();
+      // If configured in the environment, add configuration file name to properties.
+      final String cfgFileName =
+              (String) Environment.getProperties().get( InfinispanRegionFactory.INFINISPAN_CONFIG_RESOURCE_PROP );
+      if ( cfgFileName != null ) {
+         properties.put( InfinispanRegionFactory.INFINISPAN_CONFIG_RESOURCE_PROP, cfgFileName );
+      }
+      return properties;
+   }
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/JndiRegionFactoryTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/JndiRegionFactoryTestCase.java
@@ -98,7 +98,13 @@ public class JndiRegionFactoryTestCase extends SingleNodeTestCase {
 				props.put( "java.naming.factory.initial", "org.jnp.interfaces.NamingContextFactory" );
 				props.put( "java.naming.factory.url.pkgs", "org.jboss.naming:org.jnp.interfaces" );
 
-				manager = new DefaultCacheManager( InfinispanRegionFactory.DEF_INFINISPAN_CONFIG_RESOURCE, false );
+				final String cfgFileName = (String) mappings.getConfigurationProperties().get(
+						InfinispanRegionFactory.INFINISPAN_CONFIG_RESOURCE_PROP
+				);
+				manager = new DefaultCacheManager(
+						cfgFileName == null ? InfinispanRegionFactory.DEF_INFINISPAN_CONFIG_RESOURCE : cfgFileName,
+						false
+				);
 				Context ctx = new InitialContext( props );
 				bind( JNDI_NAME, manager, EmbeddedCacheManager.class, ctx );
 			}

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/tm/XaTransactionImpl.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/tm/XaTransactionImpl.java
@@ -82,9 +82,11 @@ public class XaTransactionImpl implements Transaction {
       } else {
          status = Status.STATUS_PREPARING;
 
-         for (int i = 0; i < synchronizations.size(); i++) {
-            Synchronization s = (Synchronization) synchronizations.get(i);
-            s.beforeCompletion();
+         if ( synchronizations != null ) {
+            for ( int i = 0; i < synchronizations.size(); i++ ) {
+               Synchronization s = (Synchronization) synchronizations.get( i );
+               s.beforeCompletion();
+            }
          }
          
          if (!runXaResourcePrepare()) {
@@ -109,9 +111,11 @@ public class XaTransactionImpl implements Transaction {
 
          status = Status.STATUS_COMMITTED;
 
-         for (int i = 0; i < synchronizations.size(); i++) {
-            Synchronization s = (Synchronization) synchronizations.get(i);
-            s.afterCompletion(status);
+         if ( synchronizations != null ) {
+            for ( int i = 0; i < synchronizations.size(); i++ ) {
+               Synchronization s = (Synchronization) synchronizations.get( i );
+               s.afterCompletion( status );
+            }
          }
 
          // status = Status.STATUS_NO_TRANSACTION;

--- a/hibernate-infinispan/src/test/resources/infinispan-7-configs.xml
+++ b/hibernate-infinispan/src/test/resources/infinispan-7-configs.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="urn:infinispan:config:7.2"
+            xsi:schemaLocation="urn:infinispan:config:7.2 http://www.infinispan.org/schemas/infinispan-config-7.2.xsd">
+
+   <jgroups>
+      <stack-file name="hibernate-jgroups" path="${hibernate.cache.infinispan.jgroups_cfg:default-configs/default-jgroups-tcp.xml}"/>
+   </jgroups>
+
+   <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache" shutdown-hook="DEFAULT">
+      <transport stack="hibernate-jgroups" cluster="infinispan-hibernate-cluster"/>
+
+      <local-cache name="the-default-cache" statistics="false" />
+
+      <!-- Default configuration is appropriate for entity/collection caching. -->
+      <invalidation-cache name="entity" mode="SYNC" remote-timeout="20000">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </invalidation-cache>
+
+      <!-- Default configuration is appropriate for entity/collection caching. -->
+      <invalidation-cache name="entity-repeatable" mode="SYNC" remote-timeout="20000">
+         <locking isolation="REPEATABLE_READ" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </invalidation-cache>
+
+      <!-- An alternative configuration for entity/collection caching that uses replication instead of invalidation -->
+      <replicated-cache name="replicated-entity" mode="SYNC" remote-timeout="20000">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+         <state-transfer enabled="false"/>
+      </replicated-cache>
+
+      <!-- A config appropriate for query caching. Does not replicate queries. -->
+      <local-cache name="local-query">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+      </local-cache>
+
+      <!-- A query cache that replicates queries. Replication is asynchronous. -->
+      <replicated-cache name="replicated-query" mode="ASYNC">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <eviction max-entries="10000" strategy="LRU"/>
+         <expiration max-idle="100000" interval="5000"/>
+         <persistence passivation="false">
+            <!-- State transfer forces all replication calls to be synchronous,
+                 so for calls to remain async, use a cluster cache loader instead -->
+            <cluster-loader remote-timeout="20000"/>
+         </persistence>
+      </replicated-cache>
+
+      <!-- Optimized for timestamp caching. A clustered timestamp cache
+           is required if query caching is used, even if the query cache
+           itself is configured with CacheMode=LOCAL. -->
+      <replicated-cache name="timestamps" mode="ASYNC">
+         <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
+         <!-- Explicitly non transactional -->
+         <transaction mode="NONE"/>
+         <!--  Don't ever evict modification timestamps -->
+         <eviction strategy="NONE"/>
+         <expiration interval="0"/>
+         <persistence passivation="false">
+            <!-- State transfer forces all replication calls to be synchronous,
+                 so for calls to remain async, use a cluster cache loader instead -->
+            <cluster-loader remote-timeout="20000"/>
+         </persistence>
+         <state-transfer enabled="false"/>
+      </replicated-cache>
+   </cache-container>
+
+</infinispan>


### PR DESCRIPTION
… use configuration specifed by hibernate.cache.infinispan.cfg

This pull request:
- adds the new Infinispan 7.2 configuration as a test resource;
- fixes test cases to use hibernate.cache.infinispan.cfg to determine the Infinispan configuration to use;
- incorporates some test fixes from https://github.com/galderz/hibernate-orm/commit/b825be25d1b7dce1e47f09a16111ae7ab12214aa;
- corrects org.hibernate.test.cache.infinispan.tm.XaTransactionImpl.commit() to check for synchonizations == null to avoid NullPointerException.

It is currently a manual process to run hibernate-infinispan unit tests with Infinispan 7.2:
- In libraries.gradle change infinispan version from 6.0.0.Final to 7.2.1.Final;
- cd hibernate-infinispan
- ../gradlew clean test -Dhibernate.cache.infinispan.cfg=src/test/resources/infinispan-7-configs.xml