### PR TITLE
HHH-9802 : Allow running hibernate-infispan unit tests using Infinisp…

### DIFF
--- a/hibernate-infinispan/hibernate-infinispan.gradle
+++ b/hibernate-infinispan/hibernate-infinispan.gradle
@@ -15,7 +15,7 @@ if ( useInfinispan7ForTesting() ) {
 private boolean useInfinispan7ForTesting() {
     if ( project.hasProperty( 'useInfinispan7ForTesting' ) ) {
         println 'useInfinispan7ForTesting = ' + useInfinispan7ForTesting
-	return useInfinispan7ForTesting.equals( 'true' );
+        return useInfinispan7ForTesting.equals( 'true' );
     }
     else {
         return false;
@@ -57,6 +57,10 @@ test {
    // Use Infinispan's test JGroups stack that uses TEST_PING
    systemProperties['hibernate.cache.infinispan.jgroups_cfg'] = '2lc-test-tcp.xml'
    // systemProperties['log4j.configuration'] = 'file:/log4j/log4j-infinispan.xml'
+   if ( useInfinispan7ForTesting() ) {
+      systemProperties['hibernate.cache.infinispan.cfg'] = 'src/test/resources/infinispan-7-configs.xml';
+   }
+
    enabled = true
 }
 

--- a/hibernate-infinispan/hibernate-infinispan.gradle
+++ b/hibernate-infinispan/hibernate-infinispan.gradle
@@ -2,6 +2,26 @@ configurations {
     all*.exclude group: 'org.jboss.logging', module: 'jboss-logging-spi'
 }
 
+if ( useInfinispan7ForTesting() ) {
+    configurations {
+        testRuntime {
+            resolutionStrategy {
+                force 'org.infinispan:infinispan-core:7.2.1.Final'
+            }
+        }
+    }
+}
+
+private boolean useInfinispan7ForTesting() {
+    if ( project.hasProperty( 'useInfinispan7ForTesting' ) ) {
+        println 'useInfinispan7ForTesting = ' + useInfinispan7ForTesting
+	return useInfinispan7ForTesting.equals( 'true' );
+    }
+    else {
+        return false;
+    } 
+}
+
 dependencies {
     compile project( ':hibernate-core' )
     compile( libraries.infinispan )


### PR DESCRIPTION
…an 7.2.1.Final as a run-time dependency

To run unit tests with Infinispan 7.2.1Final as run-time dependency with a 7.2 configuration:

cd hibernate-infinispan
../gradlew -PuseInfinispan7ForTesting=true -Dhibernate.cache.infinispan.cfg=src/test/resources/infinispan-7-configs.xml cleanTest test

Note that this currently causes several failure in InfinispanRegionFactoryTestCase due to NoSuchMethodError.