### PR TITLE
HHH 8854

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AttributeConverterDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AttributeConverterDefinition.java
@@ -26,12 +26,15 @@ package org.hibernate.cfg;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -126,6 +129,12 @@ public class AttributeConverterDefinition {
 
 		final Class attributeConverterClass = attributeConverter.getClass();
 		final ParameterizedType attributeConverterSignature = extractAttributeConverterParameterizedType( attributeConverterClass );
+		if ( attributeConverterSignature == null ) {
+			throw new AssertionFailure(
+					"Could not extract ParameterizedType representation of AttributeConverter definition " +
+							"from AttributeConverter implementation class [" + attributeConverterClass.getName() + "]"
+			);
+		}
 
 		if ( attributeConverterSignature.getActualTypeArguments().length < 2 ) {
 			throw new AnnotationException(
@@ -157,20 +166,26 @@ public class AttributeConverterDefinition {
 		}
 	}
 
-	private ParameterizedType extractAttributeConverterParameterizedType(Class attributeConverterClass) {
-		for ( Type type : attributeConverterClass.getGenericInterfaces() ) {
-			if ( ParameterizedType.class.isInstance( type ) ) {
-				final ParameterizedType parameterizedType = (ParameterizedType) type;
-				if ( AttributeConverter.class.equals( parameterizedType.getRawType() ) ) {
+	private ParameterizedType extractAttributeConverterParameterizedType(Type base) {
+		if ( base != null ) {
+			Class clazz = extractClass( base );
+			List<Type> types = new ArrayList<Type>();
+			types.add( clazz.getGenericSuperclass() );
+			types.addAll( Arrays.asList( clazz.getGenericInterfaces() ) );
+			for ( Type type : types ) {
+				if ( ParameterizedType.class.isInstance( type ) ) {
+					final ParameterizedType parameterizedType = (ParameterizedType) type;
+					if ( AttributeConverter.class.equals( parameterizedType.getRawType() ) ) {
+						return parameterizedType;
+					}
+				}
+				ParameterizedType parameterizedType = extractAttributeConverterParameterizedType( type );
+				if ( parameterizedType != null ) {
 					return parameterizedType;
 				}
 			}
 		}
-
-		throw new AssertionFailure(
-				"Could not extract ParameterizedType representation of AttributeConverter definition " +
-						"from AttributeConverter implementation class [" + attributeConverterClass.getName() + "]"
-		);
+		return null;
 	}
 
 	public AttributeConverter getAttributeConverter() {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AttributeConverterDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AttributeConverterDefinition.java
@@ -173,6 +173,7 @@ public class AttributeConverterDefinition {
 			types.add( clazz.getGenericSuperclass() );
 			types.addAll( Arrays.asList( clazz.getGenericInterfaces() ) );
 			for ( Type type : types ) {
+				type = resolveType( type, base );
 				if ( ParameterizedType.class.isInstance( type ) ) {
 					final ParameterizedType parameterizedType = (ParameterizedType) type;
 					if ( AttributeConverter.class.equals( parameterizedType.getRawType() ) ) {
@@ -186,6 +187,54 @@ public class AttributeConverterDefinition {
 			}
 		}
 		return null;
+	}
+
+	private static Type resolveType(Type target, Type context) {
+		if ( target instanceof ParameterizedType ) {
+			return resolveParameterizedType( (ParameterizedType) target, context );
+		}
+		else if ( target instanceof TypeVariable ) {
+			return resolveTypeVariable( (TypeVariable) target, (ParameterizedType) context );
+		}
+		return target;
+	}
+
+	private static ParameterizedType resolveParameterizedType(final ParameterizedType parameterizedType, Type context) {
+		Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+
+		final Type[] resolvedTypeArguments = new Type[actualTypeArguments.length];
+		for ( int idx = 0; idx < actualTypeArguments.length; idx++ ) {
+			resolvedTypeArguments[idx] = resolveType( actualTypeArguments[idx], context );
+		}
+		return new ParameterizedType() {
+
+			@Override
+			public Type[] getActualTypeArguments() {
+				return resolvedTypeArguments;
+			}
+
+			@Override
+			public Type getRawType() {
+				return parameterizedType.getRawType();
+			}
+
+			@Override
+			public Type getOwnerType() {
+				return parameterizedType.getOwnerType();
+			}
+
+		};
+	}
+
+	private static Type resolveTypeVariable(TypeVariable typeVariable, ParameterizedType context) {
+		Class clazz = extractClass( context.getRawType() );
+		TypeVariable[] typeParameters = clazz.getTypeParameters();
+		for ( int idx = 0; idx < typeParameters.length; idx++ ) {
+			if ( typeVariable.getName().equals( typeParameters[idx].getName() ) ) {
+				return resolveType( context.getActualTypeArguments()[idx], context );
+			}
+		}
+		return typeVariable;
 	}
 
 	public AttributeConverter getAttributeConverter() {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/AttributeConverterOnSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AttributeConverterOnSuperclassTest.java
@@ -1,0 +1,65 @@
+package org.hibernate.test.type;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.persistence.AttributeConverter;
+
+import org.hibernate.cfg.AttributeConverterDefinition;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+/**
+ * Test the ability to interpret and understand AttributeConverter impls when the base class does not
+ * explicitly implement AttributeConverter but implements it via an interface or superclass.
+ * 
+ * @author Svein Baardsen
+ */
+@TestForIssue(jiraKey = "HHH-8854")
+public class AttributeConverterOnSuperclassTest extends BaseUnitTestCase {
+
+	public static class StringIntegerAttributeConverter implements AttributeConverter<String, Integer> {
+
+		@Override
+		public Integer convertToDatabaseColumn(String attribute) {
+			return Integer.valueOf( attribute );
+		}
+
+		@Override
+		public String convertToEntityAttribute(Integer dbData) {
+			return String.valueOf( dbData );
+		}
+	}
+
+	public static class StringIntegerConverterSubclass extends StringIntegerAttributeConverter {
+	}
+
+	@Test
+	public void testAttributeConverterOnSuperclass() {
+		AttributeConverterDefinition def = AttributeConverterDefinition.from( StringIntegerConverterSubclass.class );
+		assertEquals( String.class, def.getEntityAttributeType() );
+	}
+
+	public interface StringLongAttributeConverter extends AttributeConverter<String, Long> {
+	}
+
+	public static class StringLongAttributeConverterImpl implements StringLongAttributeConverter {
+
+		@Override
+		public Long convertToDatabaseColumn(String attribute) {
+			return Long.valueOf( attribute );
+		}
+
+		@Override
+		public String convertToEntityAttribute(Long dbData) {
+			return String.valueOf( dbData );
+		}
+	}
+
+	@Test
+	public void testAttributeConverterOnInterface() {
+		AttributeConverterDefinition def = AttributeConverterDefinition.from( StringLongAttributeConverterImpl.class );
+		assertEquals( String.class, def.getEntityAttributeType() );
+	}
+
+}


### PR DESCRIPTION
It is no longer necessary to explicitly implement AttributeConverter if it is already implemented on a superclass or interface. Fixes [HHH-8854](https://hibernate.atlassian.net/browse/HHH-8854).