### PR TITLE
HHH-9840 Allow custom key implementations for 2nd level cache regions and define a typesafe contract for keys

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -12,7 +12,8 @@ import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.action.spi.Executable;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -76,12 +77,14 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		// bidirectional association and it is one of the earlier entity actions which actually updates
 		// the database (this action is responsible for second-level cache invalidation only)
 		if ( persister.hasCache() ) {
-			final CacheKey ck = session.generateCacheKey(
+			final CollectionRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final CollectionCacheKey ck = cache.generateCacheKey(
 					key,
-					persister.getKeyType(),
-					persister.getRole()
+					persister,
+					session.getFactory(),
+					session.getTenantIdentifier()
 			);
-			final SoftLock lock = persister.getCacheAccessStrategy().lockItem( ck, null );
+			final SoftLock lock = cache.lockItem( ck, null );
 			// the old behavior used key as opposed to getKey()
 			afterTransactionProcess = new CacheCleanupProcess( key, persister, lock );
 		}
@@ -127,12 +130,14 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 
 	protected final void evict() throws CacheException {
 		if ( persister.hasCache() ) {
-			final CacheKey ck = session.generateCacheKey(
+			final CollectionRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final CollectionCacheKey ck = cache.generateCacheKey(
 					key, 
-					persister.getKeyType(), 
-					persister.getRole()
+					persister,
+					session.getFactory(),
+					session.getTenantIdentifier()
 			);
-			persister.getCacheAccessStrategy().remove( ck );
+			cache.remove( ck );
 		}
 	}
 
@@ -169,12 +174,14 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 
 		@Override
 		public void doAfterTransactionCompletion(boolean success, SessionImplementor session) {
-			final CacheKey ck = session.generateCacheKey(
+			final CollectionRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final CollectionCacheKey ck = cache.generateCacheKey(
 					key,
-					persister.getKeyType(),
-					persister.getRole()
+					persister,
+					session.getFactory(),
+					session.getTenantIdentifier()
 			);
-			persister.getCacheAccessStrategy().unlockItem( ck, lock );
+			cache.unlockItem( ck, lock );
 		}
 	}
 
@@ -190,9 +197,4 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		return (EventSource) getSession();
 	}
 }
-
-
-
-
-
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -84,10 +85,11 @@ public class EntityDeleteAction extends EntityAction {
 			version = persister.getVersion( instance );
 		}
 
-		final CacheKey ck;
+		final EntityCacheKey ck;
 		if ( persister.hasCache() ) {
-			ck = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
-			lock = persister.getCacheAccessStrategy().lockItem( ck, version );
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			ck = cache.generateCacheKey( id, persister, session.getFactory(), session.getTenantIdentifier() );
+			lock = cache.lockItem( ck, version );
 		}
 		else {
 			ck = null;
@@ -184,13 +186,16 @@ public class EntityDeleteAction extends EntityAction {
 
 	@Override
 	public void doAfterTransactionCompletion(boolean success, SessionImplementor session) throws HibernateException {
-		if ( getPersister().hasCache() ) {
-			final CacheKey ck = getSession().generateCacheKey(
+		EntityPersister entityPersister = getPersister();
+		if ( entityPersister.hasCache() ) {
+			EntityRegionAccessStrategy cache = entityPersister.getCacheAccessStrategy();
+			final EntityCacheKey ck = cache.generateCacheKey(
 					getId(),
-					getPersister().getIdentifierType(),
-					getPersister().getRootEntityName()
+					entityPersister,
+					session.getFactory(),
+					session.getTenantIdentifier()
 			);
-			getPersister().getCacheAccessStrategy().unlockItem( ck, lock );
+			cache.unlockItem( ck, lock );
 		}
 		postCommitDelete( success );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -10,11 +10,14 @@ import java.io.Serializable;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CacheEntry;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.service.spi.EventListenerGroup;
@@ -85,8 +88,8 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		if ( !veto ) {
 			
 			persister.insert( id, getState(), instance, session );
-
-			final EntityEntry entry = session.getPersistenceContext().getEntry( instance );
+			PersistenceContext persistenceContext = session.getPersistenceContext();
+			final EntityEntry entry = persistenceContext.getEntry( instance );
 			if ( entry == null ) {
 				throw new AssertionFailure( "possible non-threadsafe access to session" );
 			}
@@ -101,10 +104,10 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 				entry.postUpdate( instance, getState(), version );
 			}
 
-			getSession().getPersistenceContext().registerInsertedKey( getPersister(), getId() );
+			persistenceContext.registerInsertedKey( persister, getId() );
 		}
 
-		final SessionFactoryImplementor factory = getSession().getFactory();
+		final SessionFactoryImplementor factory = session.getFactory();
 
 		if ( isCachePutEnabled( persister, session ) ) {
 			final CacheEntry ce = persister.buildCacheEntry(
@@ -114,12 +117,13 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 					session
 			);
 			cacheEntry = persister.getCacheEntryStructure().structure( ce );
-			final CacheKey ck = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final EntityCacheKey ck = cache.generateCacheKey( id, persister, factory, session.getTenantIdentifier() );
 
 			final boolean put = cacheInsert( persister, ck );
 
 			if ( put && factory.getStatistics().isStatisticsEnabled() ) {
-				factory.getStatisticsImplementor().secondLevelCachePut( getPersister().getCacheAccessStrategy().getRegion().getName() );
+				factory.getStatisticsImplementor().secondLevelCachePut( cache.getRegion().getName() );
 			}
 		}
 
@@ -134,7 +138,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		markExecuted();
 	}
 
-	private boolean cacheInsert(EntityPersister persister, CacheKey ck) {
+	private boolean cacheInsert(EntityPersister persister, EntityCacheKey ck) {
 		try {
 			getSession().getEventListenerManager().cachePutStart();
 			return persister.getCacheAccessStrategy().insert( ck, cacheEntry, version );
@@ -207,24 +211,27 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 	public void doAfterTransactionCompletion(boolean success, SessionImplementor session) throws HibernateException {
 		final EntityPersister persister = getPersister();
 		if ( success && isCachePutEnabled( persister, getSession() ) ) {
-			final CacheKey ck = getSession().generateCacheKey( getId(), persister.getIdentifierType(), persister.getRootEntityName() );
-			final boolean put = cacheAfterInsert( persister, ck );
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			SessionFactoryImplementor sessionFactoryImplementor = session.getFactory();
+			final EntityCacheKey ck = cache.generateCacheKey( getId(), persister, sessionFactoryImplementor, session.getTenantIdentifier() );
+			final boolean put = cacheAfterInsert( cache, ck );
 
-			if ( put && getSession().getFactory().getStatistics().isStatisticsEnabled() ) {
-				getSession().getFactory().getStatisticsImplementor()
-						.secondLevelCachePut( getPersister().getCacheAccessStrategy().getRegion().getName() );
+			if ( put && sessionFactoryImplementor.getStatistics().isStatisticsEnabled() ) {
+				sessionFactoryImplementor.getStatisticsImplementor()
+						.secondLevelCachePut( cache.getRegion().getName() );
 			}
 		}
 		postCommitInsert( success );
 	}
 
-	private boolean cacheAfterInsert(EntityPersister persister, CacheKey ck) {
+	private boolean cacheAfterInsert(EntityRegionAccessStrategy cache, EntityCacheKey ck) {
+		final SessionEventListenerManager eventListenerManager = getSession().getEventListenerManager();
 		try {
-			getSession().getEventListenerManager().cachePutStart();
-			return persister.getCacheAccessStrategy().afterInsert( ck, cacheEntry, version );
+			eventListenerManager.cachePutStart();
+			return cache.afterInsert( ck, cacheEntry, version );
 		}
 		finally {
-			getSession().getEventListenerManager().cachePutEnd();
+			eventListenerManager.cachePutEnd();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -11,12 +11,14 @@ import java.io.Serializable;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.entry.CacheEntry;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.CachedNaturalIdValueSource;
 import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.Status;
@@ -116,7 +118,7 @@ public final class EntityUpdateAction extends EntityAction {
 
 		final boolean veto = preUpdate();
 
-		final SessionFactoryImplementor factory = getSession().getFactory();
+		final SessionFactoryImplementor factory = session.getFactory();
 		Object previousVersion = this.previousVersion;
 		if ( persister.isVersionPropertyGenerated() ) {
 			// we need to grab the version value from the entity, otherwise
@@ -125,14 +127,16 @@ public final class EntityUpdateAction extends EntityAction {
 			previousVersion = persister.getVersion( instance );
 		}
 		
-		final CacheKey ck;
+		final EntityCacheKey ck;
 		if ( persister.hasCache() ) {
-			ck = session.generateCacheKey(
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			ck = cache.generateCacheKey(
 					id, 
-					persister.getIdentifierType(), 
-					persister.getRootEntityName()
+					persister,
+					factory,
+					session.getTenantIdentifier()
 			);
-			lock = persister.getCacheAccessStrategy().lockItem( ck, previousVersion );
+			lock = cache.lockItem( ck, previousVersion );
 		}
 		else {
 			ck = null;
@@ -152,7 +156,7 @@ public final class EntityUpdateAction extends EntityAction {
 			);
 		}
 
-		final EntityEntry entry = getSession().getPersistenceContext().getEntry( instance );
+		final EntityEntry entry = session.getPersistenceContext().getEntry( instance );
 		if ( entry == null ) {
 			throw new AssertionFailure( "possible nonthreadsafe access to session" );
 		}
@@ -212,7 +216,7 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private boolean cacheUpdate(EntityPersister persister, Object previousVersion, CacheKey ck) {
+	private boolean cacheUpdate(EntityPersister persister, Object previousVersion, EntityCacheKey ck) {
 		try {
 			getSession().getEventListenerManager().cachePutStart();
 			return persister.getCacheAccessStrategy().update( ck, cacheEntry, nextVersion, previousVersion );
@@ -307,34 +311,37 @@ public final class EntityUpdateAction extends EntityAction {
 	public void doAfterTransactionCompletion(boolean success, SessionImplementor session) throws CacheException {
 		final EntityPersister persister = getPersister();
 		if ( persister.hasCache() ) {
-			
-			final CacheKey ck = getSession().generateCacheKey(
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final EntityCacheKey ck = cache.generateCacheKey(
 					getId(),
-					persister.getIdentifierType(), 
-					persister.getRootEntityName()
+					persister,
+					session.getFactory(),
+					session.getTenantIdentifier()
+					
 			);
-			
+
 			if ( success && cacheEntry!=null /*!persister.isCacheInvalidationRequired()*/ ) {
-				final boolean put = cacheAfterUpdate( persister, ck );
+				final boolean put = cacheAfterUpdate( cache, ck );
 
 				if ( put && getSession().getFactory().getStatistics().isStatisticsEnabled() ) {
-					getSession().getFactory().getStatisticsImplementor().secondLevelCachePut( getPersister().getCacheAccessStrategy().getRegion().getName() );
+					getSession().getFactory().getStatisticsImplementor().secondLevelCachePut( cache.getRegion().getName() );
 				}
 			}
 			else {
-				persister.getCacheAccessStrategy().unlockItem( ck, lock );
+				cache.unlockItem( ck, lock );
 			}
 		}
 		postCommitUpdate( success );
 	}
 
-	private boolean cacheAfterUpdate(EntityPersister persister, CacheKey ck) {
+	private boolean cacheAfterUpdate(EntityRegionAccessStrategy cache, EntityCacheKey ck) {
+		SessionEventListenerManager eventListenerManager = getSession().getEventListenerManager();
 		try {
-			getSession().getEventListenerManager().cachePutStart();
-			return persister.getCacheAccessStrategy().afterUpdate( ck, cacheEntry, nextVersion, previousVersion, lock );
+			eventListenerManager.cachePutStart();
+			return cache.afterUpdate( ck, cacheEntry, nextVersion, previousVersion, lock );
 		}
 		finally {
-			getSession().getEventListenerManager().cachePutEnd();
+			eventListenerManager.cachePutEnd();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
 import java.util.Set;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventSource;
@@ -136,8 +137,16 @@ public class CollectionCacheInvalidator
 	}
 
 	private void evict(Serializable id, CollectionPersister collectionPersister, EventSource session) {
-		LOG.debug( "Evict CollectionRegion " + collectionPersister.getRole() + " for id " + id );
-		CacheKey key = session.generateCacheKey( id, collectionPersister.getKeyType(), collectionPersister.getRole() );
-		collectionPersister.getCacheAccessStrategy().evict( key );
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debug( "Evict CollectionRegion " + collectionPersister.getRole() + " for id " + id );
+		}
+		CollectionRegionAccessStrategy cache = collectionPersister.getCacheAccessStrategy();
+		CollectionCacheKey key = cache.generateCacheKey(
+				id,
+				collectionPersister,
+				session.getFactory(),
+				session.getTenantIdentifier()
+		);
+		cache.evict( key );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.internal;
+
+import java.io.Serializable;
+
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * Second level cache providers now have the option to use custom key implementations.
+ * This was done as the default key implementation is very generic and is quite
+ * a large object to allocate in large quantities at runtime.
+ * In some extreme cases, for example when the hit ratio is very low, this was making the efficiency
+ * penalty vs its benefits tradeoff questionable.
+ * <p/>
+ * Depending on configuration settings there might be opportunities to
+ * use simpler key implementations, for example when multi-tenancy is not being used to
+ * avoid the tenant identifier, or when a cache instance is entirely dedicated to a single type
+ * to use the primary id only, skipping the role or entity name.
+ * <p/>
+ * Even with multiple types sharing the same cache, their identifiers could be of the same
+ * {@link org.hibernate.type.Type}; in this case the cache container could
+ * use a single type reference to implement a custom equality function without having
+ * to look it up on each equality check: that's a small optimisation but the
+ * equality function is often invoked extremely frequently.
+ * <p/>
+ * Another reason is to make it more convenient to implement custom serialization protocols when the
+ * implementation supports clustering.
+ *
+ * @see org.hibernate.type.Type#getHashCode(Object, SessionFactoryImplementor)
+ * @see org.hibernate.type.Type#isEqual(Object, Object)
+ * @author Sanne Grinovero
+ * @since 5.0
+ */
+public class DefaultCacheKeysFactory {
+
+	public static CollectionCacheKey createCollectionKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return new OldCacheKeyImplementation( id, persister.getKeyType(), persister.getRole(), tenantIdentifier, factory );
+	}
+
+	public static EntityCacheKey createEntityKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return new OldCacheKeyImplementation( id, persister.getIdentifierType(), persister.getRootEntityName(), tenantIdentifier, factory );
+	}
+
+	public static NaturalIdCacheKey createNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return new OldNaturalIdCacheKey( naturalIdValues, persister, session );
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/OldCacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/OldCacheKeyImplementation.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.internal;
+
+import java.io.Serializable;
+
+import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.compare.EqualsHelper;
+import org.hibernate.type.Type;
+
+/**
+ * Allows multiple entity classes / collection roles to be stored in the same cache region. Also allows for composite
+ * keys which do not properly implement equals()/hashCode().
+ *
+ * This was named org.hibernate.cache.spi.CacheKey in Hibernate until version 5.
+ * Temporarily maintained as a reference while all components catch up with the refactoring to interface.
+ *
+ * @author Gavin King
+ * @author Steve Ebersole
+ */
+@Deprecated
+public class OldCacheKeyImplementation implements CacheKey, Serializable {
+	private final Serializable key;
+	private final Type type;
+	private final String entityOrRoleName;
+	private final String tenantId;
+	private final int hashCode;
+
+	/**
+	 * Construct a new key for a collection or entity instance.
+	 * Note that an entity name should always be the root entity
+	 * name, not a subclass entity name.
+	 *
+	 * @param id The identifier associated with the cached data
+	 * @param type The Hibernate type mapping
+	 * @param entityOrRoleName The entity or collection-role name.
+	 * @param tenantId The tenant identifier associated this data.
+	 * @param factory The session factory for which we are caching
+	 */
+	public OldCacheKeyImplementation(
+			final Serializable id,
+			final Type type,
+			final String entityOrRoleName,
+			final String tenantId,
+			final SessionFactoryImplementor factory) {
+		this.key = id;
+		this.type = type;
+		this.entityOrRoleName = entityOrRoleName;
+		this.tenantId = tenantId;
+		this.hashCode = calculateHashCode( type, factory );
+	}
+
+	private int calculateHashCode(Type type, SessionFactoryImplementor factory) {
+		int result = type.getHashCode( key, factory );
+		result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+		return result;
+	}
+
+	public Serializable getKey() {
+		return key;
+	}
+
+	public String getEntityOrRoleName() {
+		return entityOrRoleName;
+	}
+
+	public String getTenantId() {
+		return tenantId;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if ( other == null ) {
+			return false;
+		}
+		if ( this == other ) {
+			return true;
+		}
+		if ( hashCode != other.hashCode() || !( other instanceof OldCacheKeyImplementation ) ) {
+			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
+			return false;
+		}
+		final OldCacheKeyImplementation that = (OldCacheKeyImplementation) other;
+		return EqualsHelper.equals( entityOrRoleName, that.entityOrRoleName )
+				&& type.isEqual( key, that.key )
+				&& EqualsHelper.equals( tenantId, that.tenantId );
+	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
+	@Override
+	public String toString() {
+		// Used to be required for OSCache
+		return entityOrRoleName + '#' + key.toString();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/OldCacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/OldCacheKeyImplementation.java
@@ -8,7 +8,8 @@ package org.hibernate.cache.internal;
 
 import java.io.Serializable;
 
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.compare.EqualsHelper;
 import org.hibernate.type.Type;
@@ -18,13 +19,13 @@ import org.hibernate.type.Type;
  * keys which do not properly implement equals()/hashCode().
  *
  * This was named org.hibernate.cache.spi.CacheKey in Hibernate until version 5.
- * Temporarily maintained as a reference while all components catch up with the refactoring to interface.
+ * Temporarily maintained as a reference while all components catch up with the refactoring to the caching interfaces.
  *
  * @author Gavin King
  * @author Steve Ebersole
  */
 @Deprecated
-public class OldCacheKeyImplementation implements CacheKey, Serializable {
+final class OldCacheKeyImplementation implements EntityCacheKey, CollectionCacheKey, Serializable {
 	private final Serializable key;
 	private final Type type;
 	private final String entityOrRoleName;
@@ -42,7 +43,7 @@ public class OldCacheKeyImplementation implements CacheKey, Serializable {
 	 * @param tenantId The tenant identifier associated this data.
 	 * @param factory The session factory for which we are caching
 	 */
-	public OldCacheKeyImplementation(
+	OldCacheKeyImplementation(
 			final Serializable id,
 			final Type type,
 			final String entityOrRoleName,
@@ -61,14 +62,24 @@ public class OldCacheKeyImplementation implements CacheKey, Serializable {
 		return result;
 	}
 
+	@Override
 	public Serializable getKey() {
 		return key;
 	}
 
-	public String getEntityOrRoleName() {
+	@Override
+	public String getEntityName() {
+		//defined exclusively on EntityCacheKey
 		return entityOrRoleName;
 	}
 
+	@Override
+	public String getCollectionRole() {
+		//defined exclusively on CollectionCacheKey
+		return entityOrRoleName;
+	}
+
+	@Override
 	public String getTenantId() {
 		return tenantId;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/OldNaturalIdCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/OldNaturalIdCacheKey.java
@@ -1,0 +1,160 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.internal;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+
+import org.hibernate.cache.spi.NaturalIdCacheKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.util.ValueHolder;
+import org.hibernate.internal.util.compare.EqualsHelper;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.EntityType;
+import org.hibernate.type.Type;
+
+/**
+ * Defines a key for caching natural identifier resolutions into the second level cache.
+ *
+ * This was named org.hibernate.cache.spi.NaturalIdCacheKey in Hibernate until version 5.
+ * Temporarily maintained as a reference while all components catch up with the refactoring to the caching interfaces.
+ *
+ * @author Eric Dalquist
+ * @author Steve Ebersole
+ */
+@Deprecated
+public class OldNaturalIdCacheKey implements NaturalIdCacheKey, Serializable {
+	private final Serializable[] naturalIdValues;
+	private final String entityName;
+	private final String tenantId;
+	private final int hashCode;
+	// "transient" is important here -- NaturalIdCacheKey needs to be Serializable
+	private transient ValueHolder<String> toString;
+
+	/**
+	 * Construct a new key for a caching natural identifier resolutions into the second level cache.
+	 *
+	 * @param naturalIdValues The naturalIdValues associated with the cached data
+	 * @param persister The persister for the entity
+	 * @param session The originating session
+	 */
+	public OldNaturalIdCacheKey(
+			final Object[] naturalIdValues,
+			final EntityPersister persister,
+			final SessionImplementor session) {
+
+		this.entityName = persister.getRootEntityName();
+		this.tenantId = session.getTenantIdentifier();
+
+		this.naturalIdValues = new Serializable[naturalIdValues.length];
+
+		final SessionFactoryImplementor factory = session.getFactory();
+		final int[] naturalIdPropertyIndexes = persister.getNaturalIdentifierProperties();
+		final Type[] propertyTypes = persister.getPropertyTypes();
+
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( this.entityName == null ) ? 0 : this.entityName.hashCode() );
+		result = prime * result + ( ( this.tenantId == null ) ? 0 : this.tenantId.hashCode() );
+		for ( int i = 0; i < naturalIdValues.length; i++ ) {
+			final int naturalIdPropertyIndex = naturalIdPropertyIndexes[i];
+			final Type type = propertyTypes[naturalIdPropertyIndex];
+			final Object value = naturalIdValues[i];
+
+			result = prime * result + (value != null ? type.getHashCode( value, factory ) : 0);
+
+			// The natural id may not be fully resolved in some situations.  See HHH-7513 for one of them
+			// (re-attaching a mutable natural id uses a database snapshot and hydration does not resolve associations).
+			// TODO: The snapshot should probably be revisited at some point.  Consider semi-resolving, hydrating, etc.
+			if (type instanceof EntityType && type.getSemiResolvedType( factory ).getReturnedClass().isInstance( value )) {
+				this.naturalIdValues[i] = (Serializable) value;
+			}
+			else {
+				this.naturalIdValues[i] = type.disassemble( value, session, null );
+			}
+		}
+
+		this.hashCode = result;
+		initTransients();
+	}
+
+	private void initTransients() {
+		this.toString = new ValueHolder<String>(
+				new ValueHolder.DeferredInitializer<String>() {
+					@Override
+					public String initialize() {
+						//Complex toString is needed as naturalIds for entities are not simply based on a single value like primary keys
+						//the only same way to differentiate the keys is to included the disassembled values in the string.
+						final StringBuilder toStringBuilder = new StringBuilder( entityName ).append( "##NaturalId[" );
+						for ( int i = 0; i < naturalIdValues.length; i++ ) {
+							toStringBuilder.append( naturalIdValues[i] );
+							if ( i + 1 < naturalIdValues.length ) {
+								toStringBuilder.append( ", " );
+							}
+						}
+						toStringBuilder.append( "]" );
+
+						return toStringBuilder.toString();
+					}
+				}
+		);
+	}
+
+	@SuppressWarnings( {"UnusedDeclaration"})
+	public String getEntityName() {
+		return entityName;
+	}
+
+	@SuppressWarnings( {"UnusedDeclaration"})
+	public String getTenantId() {
+		return tenantId;
+	}
+
+	@SuppressWarnings( {"UnusedDeclaration"})
+	public Serializable[] getNaturalIdValues() {
+		return naturalIdValues;
+	}
+
+	@Override
+	public String toString() {
+		return toString.getValue();
+	}
+
+	@Override
+	public int hashCode() {
+		return this.hashCode;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( o == null ) {
+			return false;
+		}
+		if ( this == o ) {
+			return true;
+		}
+
+		if ( hashCode != o.hashCode() || !( o instanceof OldNaturalIdCacheKey ) ) {
+			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
+			return false;
+		}
+
+		final OldNaturalIdCacheKey other = (OldNaturalIdCacheKey) o;
+		return EqualsHelper.equals( entityName, other.entityName )
+				&& EqualsHelper.equals( tenantId, other.tenantId )
+				&& Arrays.deepEquals( this.naturalIdValues, other.naturalIdValues );
+	}
+
+	private void readObject(ObjectInputStream ois)
+			throws ClassNotFoundException, IOException {
+		ois.defaultReadObject();
+		initTransients();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheKey.java
@@ -8,10 +8,6 @@ package org.hibernate.cache.spi;
 
 import java.io.Serializable;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.util.compare.EqualsHelper;
-import org.hibernate.type.Type;
-
 /**
  * Allows multiple entity classes / collection roles to be stored in the same cache region. Also allows for composite
  * keys which do not properly implement equals()/hashCode().
@@ -19,81 +15,12 @@ import org.hibernate.type.Type;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public class CacheKey implements Serializable {
-	private final Serializable key;
-	private final Type type;
-	private final String entityOrRoleName;
-	private final String tenantId;
-	private final int hashCode;
+public interface CacheKey {
+	
+	public Serializable getKey();
 
-	/**
-	 * Construct a new key for a collection or entity instance.
-	 * Note that an entity name should always be the root entity
-	 * name, not a subclass entity name.
-	 *
-	 * @param id The identifier associated with the cached data
-	 * @param type The Hibernate type mapping
-	 * @param entityOrRoleName The entity or collection-role name.
-	 * @param tenantId The tenant identifier associated this data.
-	 * @param factory The session factory for which we are caching
-	 */
-	public CacheKey(
-			final Serializable id,
-			final Type type,
-			final String entityOrRoleName,
-			final String tenantId,
-			final SessionFactoryImplementor factory) {
-		this.key = id;
-		this.type = type;
-		this.entityOrRoleName = entityOrRoleName;
-		this.tenantId = tenantId;
-		this.hashCode = calculateHashCode( type, factory );
-	}
+	public String getEntityOrRoleName();
 
-	private int calculateHashCode(Type type, SessionFactoryImplementor factory) {
-		int result = type.getHashCode( key, factory );
-		result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
-		return result;
-	}
+	public String getTenantId();
 
-	public Serializable getKey() {
-		return key;
-	}
-
-	public String getEntityOrRoleName() {
-		return entityOrRoleName;
-	}
-
-	public String getTenantId() {
-		return tenantId;
-	}
-
-	@Override
-	public boolean equals(Object other) {
-		if ( other == null ) {
-			return false;
-		}
-		if ( this == other ) {
-			return true;
-		}
-		if ( hashCode != other.hashCode() || !( other instanceof CacheKey ) ) {
-			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
-			return false;
-		}
-		final CacheKey that = (CacheKey) other;
-		return EqualsHelper.equals( entityOrRoleName, that.entityOrRoleName )
-				&& type.isEqual( key, that.key )
-				&& EqualsHelper.equals( tenantId, that.tenantId );
-	}
-
-	@Override
-	public int hashCode() {
-		return hashCode;
-	}
-
-	@Override
-	public String toString() {
-		// Used to be required for OSCache
-		return entityOrRoleName + '#' + key.toString();
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CollectionCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CollectionCacheKey.java
@@ -6,13 +6,21 @@
  */
 package org.hibernate.cache.spi;
 
+import java.io.Serializable;
+
 /**
- * Allows multiple entity roles to be stored in the same cache region. Also allows for composite
+ * Allows multiple collection roles to be stored in the same cache region. Also allows for composite
  * keys which do not properly implement equals()/hashCode().
  *
- * @author Gavin King
- * @author Steve Ebersole
+ * @author Sanne Grinovero
+ * @since 5.0
  */
-public interface CacheKey {
+public interface CollectionCacheKey extends CacheKey {
+
+	public Serializable getKey();
+
+	public String getCollectionRole();
+
+	public String getTenantId();
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/EntityCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/EntityCacheKey.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.cache.spi;
 
+import java.io.Serializable;
+
 /**
  * Allows multiple entity roles to be stored in the same cache region. Also allows for composite
  * keys which do not properly implement equals()/hashCode().
@@ -13,6 +15,12 @@ package org.hibernate.cache.spi;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface CacheKey {
+public interface EntityCacheKey extends CacheKey {
+
+	public Serializable getKey();
+
+	public String getEntityName();
+
+	public String getTenantId();
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/NaturalIdCacheKey.java
@@ -6,151 +6,18 @@
  */
 package org.hibernate.cache.spi;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.Serializable;
-import java.util.Arrays;
-
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.internal.util.ValueHolder;
-import org.hibernate.internal.util.compare.EqualsHelper;
-import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.type.EntityType;
-import org.hibernate.type.Type;
-
 /**
  * Defines a key for caching natural identifier resolutions into the second level cache.
  *
- * @author Eric Dalquist
- * @author Steve Ebersole
+ * @author Sanne Grinovero
+ * @since 5.0
  */
-public class NaturalIdCacheKey implements Serializable {
-	private final Serializable[] naturalIdValues;
-	private final String entityName;
-	private final String tenantId;
-	private final int hashCode;
-	// "transient" is important here -- NaturalIdCacheKey needs to be Serializable
-	private transient ValueHolder<String> toString;
+public interface NaturalIdCacheKey extends CacheKey {
 
-	/**
-	 * Construct a new key for a caching natural identifier resolutions into the second level cache.
-	 * Note that an entity name should always be the root entity name, not a subclass entity name.
-	 *
-	 * @param naturalIdValues The naturalIdValues associated with the cached data
-	 * @param persister The persister for the entity
-	 * @param session The originating session
-	 */
-	public NaturalIdCacheKey(
-			final Object[] naturalIdValues,
-			final EntityPersister persister,
-			final SessionImplementor session) {
+	String getEntityName();
 
-		this.entityName = persister.getRootEntityName();
-		this.tenantId = session.getTenantIdentifier();
+	Object[] getNaturalIdValues();
 
-		this.naturalIdValues = new Serializable[naturalIdValues.length];
+	String getTenantId();
 
-		final SessionFactoryImplementor factory = session.getFactory();
-		final int[] naturalIdPropertyIndexes = persister.getNaturalIdentifierProperties();
-		final Type[] propertyTypes = persister.getPropertyTypes();
-
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ( ( this.entityName == null ) ? 0 : this.entityName.hashCode() );
-		result = prime * result + ( ( this.tenantId == null ) ? 0 : this.tenantId.hashCode() );
-		for ( int i = 0; i < naturalIdValues.length; i++ ) {
-			final int naturalIdPropertyIndex = naturalIdPropertyIndexes[i];
-			final Type type = propertyTypes[naturalIdPropertyIndex];
-			final Object value = naturalIdValues[i];
-
-			result = prime * result + (value != null ? type.getHashCode( value, factory ) : 0);
-
-			// The natural id may not be fully resolved in some situations.  See HHH-7513 for one of them
-			// (re-attaching a mutable natural id uses a database snapshot and hydration does not resolve associations).
-			// TODO: The snapshot should probably be revisited at some point.  Consider semi-resolving, hydrating, etc.
-			if (type instanceof EntityType && type.getSemiResolvedType( factory ).getReturnedClass().isInstance( value )) {
-				this.naturalIdValues[i] = (Serializable) value;
-			}
-			else {
-				this.naturalIdValues[i] = type.disassemble( value, session, null );
-			}
-		}
-
-		this.hashCode = result;
-		initTransients();
-	}
-
-	private void initTransients() {
-		this.toString = new ValueHolder<String>(
-				new ValueHolder.DeferredInitializer<String>() {
-					@Override
-					public String initialize() {
-						//Complex toString is needed as naturalIds for entities are not simply based on a single value like primary keys
-						//the only same way to differentiate the keys is to included the disassembled values in the string.
-						final StringBuilder toStringBuilder = new StringBuilder( entityName ).append( "##NaturalId[" );
-						for ( int i = 0; i < naturalIdValues.length; i++ ) {
-							toStringBuilder.append( naturalIdValues[i] );
-							if ( i + 1 < naturalIdValues.length ) {
-								toStringBuilder.append( ", " );
-							}
-						}
-						toStringBuilder.append( "]" );
-
-						return toStringBuilder.toString();
-					}
-				}
-		);
-	}
-
-	@SuppressWarnings( {"UnusedDeclaration"})
-	public String getEntityName() {
-		return entityName;
-	}
-
-	@SuppressWarnings( {"UnusedDeclaration"})
-	public String getTenantId() {
-		return tenantId;
-	}
-
-	@SuppressWarnings( {"UnusedDeclaration"})
-	public Serializable[] getNaturalIdValues() {
-		return naturalIdValues;
-	}
-
-	@Override
-	public String toString() {
-		return toString.getValue();
-	}
-
-	@Override
-	public int hashCode() {
-		return this.hashCode;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if ( o == null ) {
-			return false;
-		}
-		if ( this == o ) {
-			return true;
-		}
-
-		if ( hashCode != o.hashCode() || !( o instanceof NaturalIdCacheKey ) ) {
-			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
-			return false;
-		}
-
-		final NaturalIdCacheKey other = (NaturalIdCacheKey) o;
-		return EqualsHelper.equals( entityName, other.entityName )
-				&& EqualsHelper.equals( tenantId, other.tenantId )
-				&& Arrays.deepEquals( this.naturalIdValues, other.naturalIdValues );
-	}
-
-	private void readObject(ObjectInputStream ois)
-			throws ClassNotFoundException, IOException {
-		ois.defaultReadObject();
-		initTransients();
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CollectionRegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CollectionRegionAccessStrategy.java
@@ -6,7 +6,12 @@
  */
 package org.hibernate.cache.spi.access;
 
+import java.io.Serializable;
+
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * Contract for managing transactional and concurrent access to cached collection
@@ -21,7 +26,18 @@ import org.hibernate.cache.spi.CollectionRegion;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface CollectionRegionAccessStrategy extends RegionAccessStrategy {
+public interface CollectionRegionAccessStrategy extends RegionAccessStrategy<CollectionCacheKey> {
+
+	/**
+	 * To create instances of CollectionCacheKey for this region, Hibernate will invoke this method
+	 * exclusively so that generated implementations can generate optimised keys.
+	 * @param id the primary identifier of the Collection
+	 * @param persister the persister for the type for which a key is being generated
+	 * @param factory a reference to the current SessionFactory
+	 * @param tenantIdentifier the tenant id, or null if multi-tenancy is not being used.
+	 * @return a key which can be used to identify this collection on this same region
+	 */
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier);
 
 	/**
 	 * Get the wrapped collection cache region

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityRegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityRegionAccessStrategy.java
@@ -6,8 +6,13 @@
  */
 package org.hibernate.cache.spi.access;
 
+import java.io.Serializable;
+
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Contract for managing transactional and concurrent access to cached entity
@@ -25,7 +30,18 @@ import org.hibernate.cache.spi.EntityRegion;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface EntityRegionAccessStrategy extends RegionAccessStrategy{
+public interface EntityRegionAccessStrategy extends RegionAccessStrategy<EntityCacheKey> {
+
+	/**
+	 * To create instances of EntityCacheKey for this region, Hibernate will invoke this method
+	 * exclusively so that generated implementations can generate optimised keys.
+	 * @param id the primary identifier of the entity
+	 * @param persister the persister for the type for which a key is being generated
+	 * @param factory a reference to the current SessionFactory
+	 * @param tenantIdentifier the tenant id, or null if multi-tenancy is not being used.
+	 * @return a key which can be used to identify this entity on this same region
+	 */
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier);
 
 	/**
 	 * Get the wrapped entity cache region
@@ -43,9 +59,9 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy{
 	 * @param value The item
 	 * @param version The item's version value
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean insert(Object key, Object value, Object version) throws CacheException;
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException;
 
 	/**
 	 * Called after an item has been inserted (after the transaction completes),
@@ -56,9 +72,9 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy{
 	 * @param value The item
 	 * @param version The item's version value
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException;
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (before the transaction completes),
@@ -70,9 +86,9 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy{
 	 * @param currentVersion The item's current version value
 	 * @param previousVersion The item's previous version value
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException;
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (after the transaction completes),
@@ -85,7 +101,7 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy{
 	 * @param previousVersion The item's previous version value
 	 * @param lock The lock previously obtained from {@link #lockItem}
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) throws CacheException;
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) throws CacheException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdRegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdRegionAccessStrategy.java
@@ -7,7 +7,10 @@
 package org.hibernate.cache.spi.access;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Contract for managing transactional and concurrent access to cached naturalId
@@ -34,7 +37,17 @@ import org.hibernate.cache.spi.NaturalIdRegion;
  * @author Steve Ebersole
  * @author Eric Dalquist
  */
-public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
+public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy<NaturalIdCacheKey> {
+
+	/**
+	 * To create instances of NaturalIdCacheKey for this region, Hibernate will invoke this method
+	 * exclusively so that generated implementations can generate optimised keys.
+	 * @param naturalIdValues the sequence of values which unequivocally identifies a cached element on this region
+	 * @param persister the persister of the element being cached
+	 * @param session
+	 * @return a key which can be used to identify this an element unequivocally on this same region
+	 */
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session);
 
 	/**
 	 * Get the wrapped naturalId cache region
@@ -51,9 +64,9 @@ public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean insert(Object key, Object value) throws CacheException;
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been inserted (after the transaction completes),
@@ -63,9 +76,9 @@ public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterInsert(Object key, Object value) throws CacheException;
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (before the transaction completes),
@@ -75,9 +88,9 @@ public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
+	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean update(Object key, Object value) throws CacheException;
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (after the transaction completes),
@@ -90,5 +103,5 @@ public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException;
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/RegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/RegionAccessStrategy.java
@@ -6,14 +6,17 @@
  */
 package org.hibernate.cache.spi.access;
 
+
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheKey;
 
 /**
  * Base access strategy for all regions.
  *
  * @author Gail Badner
  */
-public interface RegionAccessStrategy {
+public interface RegionAccessStrategy<T extends CacheKey> {
+
 	/**
 	 * Attempt to retrieve an object from the cache. Mainly used in attempting
 	 * to resolve entities/collections from the second level cache.
@@ -23,7 +26,7 @@ public interface RegionAccessStrategy {
 	 * @return the cached object or <tt>null</tt>
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	Object get(Object key, long txTimestamp) throws CacheException;
+	Object get(T key, long txTimestamp) throws CacheException;
 
 	/**
 	 * Attempt to cache an object, after loading from the database.
@@ -36,7 +39,7 @@ public interface RegionAccessStrategy {
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
 	boolean putFromLoad(
-			Object key,
+			T key,
 			Object value,
 			long txTimestamp,
 			Object version) throws CacheException;
@@ -54,7 +57,7 @@ public interface RegionAccessStrategy {
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
 	boolean putFromLoad(
-			Object key,
+			T key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -73,7 +76,7 @@ public interface RegionAccessStrategy {
 	 * @return A representation of our lock on the item; or null.
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	SoftLock lockItem(Object key, Object version) throws CacheException;
+	SoftLock lockItem(T key, Object version) throws CacheException;
 
 	/**
 	 * Lock the entire region
@@ -92,7 +95,7 @@ public interface RegionAccessStrategy {
 	 * @param lock The lock previously obtained from {@link #lockItem}
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void unlockItem(Object key, SoftLock lock) throws CacheException;
+	void unlockItem(T key, SoftLock lock) throws CacheException;
 
 	/**
 	 * Called after we have finished the attempted invalidation of the entire
@@ -110,7 +113,7 @@ public interface RegionAccessStrategy {
 	 * @param key The key of the item to remove
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void remove(Object key) throws CacheException;
+	void remove(T key) throws CacheException;
 
 	/**
 	 * Called to evict data from the entire region
@@ -126,7 +129,7 @@ public interface RegionAccessStrategy {
 	 * @param key The key of the item to remove
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void evict(Object key) throws CacheException;
+	void evict(T key) throws CacheException;
 
 	/**
 	 * Forcibly evict all items from the cache immediately without regard for transaction

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/CacheHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/CacheHelper.java
@@ -9,44 +9,33 @@ package org.hibernate.engine.internal;
 import java.io.Serializable;
 
 import org.hibernate.cache.spi.CacheKey;
-import org.hibernate.cache.spi.NaturalIdCacheKey;
-import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.RegionAccessStrategy;
+import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Steve Ebersole
+ * @author Sanne Grinovero
  */
 public final class CacheHelper {
+
 	private CacheHelper() {
 	}
 
-	public static Serializable fromSharedCache(
+	public static <T extends CacheKey> Serializable fromSharedCache(
 			SessionImplementor session,
-			NaturalIdCacheKey cacheKey,
-			NaturalIdRegionAccessStrategy cacheAccessStrategy) {
-		return fromSharedCache( session, (Object) cacheKey, cacheAccessStrategy );
-	}
-
-	private static Serializable fromSharedCache(
-			SessionImplementor session,
-			Object cacheKey,
-			RegionAccessStrategy cacheAccessStrategy) {
+			T cacheKey,
+			RegionAccessStrategy<T> cacheAccessStrategy) {
+		final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 		Serializable cachedValue = null;
+		eventListenerManager.cacheGetStart();
 		try {
-			session.getEventListenerManager().cacheGetStart();
 			cachedValue = (Serializable) cacheAccessStrategy.get( cacheKey, session.getTimestamp() );
 		}
 		finally {
-			session.getEventListenerManager().cacheGetEnd( cachedValue != null );
+			eventListenerManager.cacheGetEnd( cachedValue != null );
 		}
 		return cachedValue;
 	}
 
-	public static Serializable fromSharedCache(
-			SessionImplementor session,
-			CacheKey cacheKey,
-			RegionAccessStrategy cacheAccessStrategy) {
-		return fromSharedCache( session, (Object) cacheKey, cacheAccessStrategy );
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
@@ -110,12 +110,12 @@ public class NaturalIdXrefDelegate {
 		if ( persister.hasNaturalIdCache() ) {
 			final NaturalIdRegionAccessStrategy naturalIdCacheAccessStrategy = persister
 					.getNaturalIdCacheAccessStrategy();
-			final NaturalIdCacheKey naturalIdCacheKey = new NaturalIdCacheKey( naturalIdValues, persister, session() );
+			final NaturalIdCacheKey naturalIdCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( naturalIdValues, persister, session() );
 			naturalIdCacheAccessStrategy.evict( naturalIdCacheKey );
 
 			if ( sessionCachedNaturalIdValues != null
 					&& !Arrays.equals( sessionCachedNaturalIdValues, naturalIdValues ) ) {
-				final NaturalIdCacheKey sessionNaturalIdCacheKey = new NaturalIdCacheKey( sessionCachedNaturalIdValues, persister, session() );
+				final NaturalIdCacheKey sessionNaturalIdCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( sessionCachedNaturalIdValues, persister, session() );
 				naturalIdCacheAccessStrategy.evict( sessionNaturalIdCacheKey );
 			}
 		}
@@ -239,9 +239,9 @@ public class NaturalIdXrefDelegate {
 		}
 
 		// Try resolution from second-level cache
-		final NaturalIdCacheKey naturalIdCacheKey = new NaturalIdCacheKey( naturalIdValues, persister, session() );
-
 		final NaturalIdRegionAccessStrategy naturalIdCacheAccessStrategy = persister.getNaturalIdCacheAccessStrategy();
+		final NaturalIdCacheKey naturalIdCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( naturalIdValues, persister, session() );
+
 		pk = CacheHelper.fromSharedCache( session(), naturalIdCacheKey, naturalIdCacheAccessStrategy );
 
 		// Found in second-level cache, store in session cache

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1738,7 +1738,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 				Object[] previousNaturalIdValues,
 				CachedNaturalIdValueSource source) {
 			final NaturalIdRegionAccessStrategy naturalIdCacheAccessStrategy = persister.getNaturalIdCacheAccessStrategy();
-			final NaturalIdCacheKey naturalIdCacheKey = new NaturalIdCacheKey( naturalIdValues, persister, session );
+			final NaturalIdCacheKey naturalIdCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( naturalIdValues, persister, session );
 
 			final SessionFactoryImplementor factory = session.getFactory();
 
@@ -1793,7 +1793,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 					break;
 				}
 				case UPDATE: {
-					final NaturalIdCacheKey previousCacheKey = new NaturalIdCacheKey( previousNaturalIdValues, persister, session );
+					final NaturalIdCacheKey previousCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( previousNaturalIdValues, persister, session );
 					if ( naturalIdCacheKey.equals( previousCacheKey ) ) {
 						// prevent identical re-caching, solves HHH-7309
 						return;
@@ -1877,7 +1877,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 			persister = locateProperPersister( persister );
 			final NaturalIdRegionAccessStrategy naturalIdCacheAccessStrategy = persister.getNaturalIdCacheAccessStrategy();
-			final NaturalIdCacheKey naturalIdCacheKey = new NaturalIdCacheKey( naturalIdValues, persister, session );
+			final NaturalIdCacheKey naturalIdCacheKey = naturalIdCacheAccessStrategy.generateCacheKey( naturalIdValues, persister, session );
 			naturalIdCacheAccessStrategy.evict( naturalIdCacheKey );
 
 //			if ( sessionCachedNaturalIdValues != null

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -13,11 +13,13 @@ import org.hibernate.CacheMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CacheEntry;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.Status;
@@ -182,7 +184,8 @@ public final class TwoPhaseLoad {
 
 			final Object version = Versioning.getVersion( hydratedState, persister );
 			final CacheEntry entry = persister.buildCacheEntry( entity, hydratedState, version, session );
-			final CacheKey cacheKey = session.generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final EntityCacheKey cacheKey = cache.generateCacheKey( id, persister, factory, session.getTenantIdentifier() );
 
 			// explicit handling of caching for rows just inserted and then somehow forced to be read
 			// from the database *within the same transaction*.  usually this is done by
@@ -191,7 +194,7 @@ public final class TwoPhaseLoad {
 			//
 			// we need to be careful not to clobber the lock here in the cache so that it can be rolled back if need be
 			if ( session.getPersistenceContext().wasInsertedDuringTransaction( persister, id ) ) {
-				persister.getCacheAccessStrategy().update(
+				cache.update(
 						cacheKey,
 						persister.getCacheEntryStructure().structure( entry ),
 						version,
@@ -199,9 +202,10 @@ public final class TwoPhaseLoad {
 				);
 			}
 			else {
+				final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 				try {
-					session.getEventListenerManager().cachePutStart();
-					final boolean put = persister.getCacheAccessStrategy().putFromLoad(
+					eventListenerManager.cachePutStart();
+					final boolean put = cache.putFromLoad(
 							cacheKey,
 							persister.getCacheEntryStructure().structure( entry ),
 							session.getTimestamp(),
@@ -210,11 +214,11 @@ public final class TwoPhaseLoad {
 					);
 
 					if ( put && factory.getStatistics().isStatisticsEnabled() ) {
-						factory.getStatisticsImplementor().secondLevelCachePut( persister.getCacheAccessStrategy().getRegion().getName() );
+						factory.getStatisticsImplementor().secondLevelCachePut( cache.getRegion().getName() );
 					}
 				}
 				finally {
-					session.getEventListenerManager().cachePutEnd();
+					eventListenerManager.cachePutEnd();
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -35,7 +35,6 @@ import org.hibernate.SimpleNaturalIdLoadAccess;
 import org.hibernate.Transaction;
 import org.hibernate.TypeHelper;
 import org.hibernate.UnknownProfileException;
-import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
@@ -47,7 +46,6 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.resource.transaction.TransactionCoordinator;
 import org.hibernate.stat.SessionStatistics;
-import org.hibernate.type.Type;
 
 /**
  * This class is meant to be extended.
@@ -95,11 +93,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor, Session {
 	@Override
 	public EntityKey generateEntityKey(Serializable id, EntityPersister persister) {
 		return sessionImplementor.generateEntityKey( id, persister );
-	}
-
-	@Override
-	public CacheKey generateCacheKey(Serializable id, Type type, String entityOrRoleName) {
-		return sessionImplementor.generateCacheKey( id, type, entityOrRoleName );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -20,7 +20,6 @@ import org.hibernate.Query;
 import org.hibernate.SQLQuery;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
-import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -63,17 +62,6 @@ public interface SessionImplementor extends Serializable, LobCreationContext {
 	 * @return The entity key
 	 */
 	EntityKey generateEntityKey(Serializable id, EntityPersister persister);
-
-	/**
-	 * Hide the changing requirements of cache key creation.
-	 *
-	 * @param id The entity identifier or collection key.
-	 * @param type The type
-	 * @param entityOrRoleName The entity name or collection role.
-	 *
-	 * @return The cache key
-	 */
-	CacheKey generateCacheKey(Serializable id, final Type type, final String entityOrRoleName);
 
 	/**
 	 * Retrieves the interceptor currently in use by this event source.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
@@ -9,7 +9,8 @@ package org.hibernate.event.internal;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ObjectDeletedException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.Status;
@@ -17,7 +18,6 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -62,18 +62,16 @@ public abstract class AbstractLockUpgradeEventListener extends AbstractReassocia
 				);
 			}
 
-			final SoftLock lock;
-			final CacheKey ck;
-			if ( persister.hasCache() ) {
-				ck = source.generateCacheKey( entry.getId(), persister.getIdentifierType(), persister.getRootEntityName() );
-				lock = persister.getCacheAccessStrategy().lockItem( ck, entry.getVersion() );
-			}
-			else {
-				ck = null;
-				lock = null;
-			}
-
+			final boolean cachingEnabled = persister.hasCache();
+			SoftLock lock = null;
+			EntityCacheKey ck = null;
 			try {
+				if ( cachingEnabled ) {
+					EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+					ck = cache.generateCacheKey( entry.getId(), persister, source.getFactory(), source.getTenantIdentifier() );
+					lock = cache.lockItem( ck, entry.getVersion() );
+				}
+
 				if ( persister.isVersioned() && requestedLockMode == LockMode.FORCE  ) {
 					// todo : should we check the current isolation mode explicitly?
 					Object nextVersion = persister.forceVersionIncrement(
@@ -89,7 +87,7 @@ public abstract class AbstractLockUpgradeEventListener extends AbstractReassocia
 			finally {
 				// the database now holds a lock + the object is flushed from the cache,
 				// so release the soft lock
-				if ( persister.hasCache() ) {
+				if ( cachingEnabled ) {
 					persister.getCacheAccessStrategy().unlockItem( ck, lock );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -9,7 +9,8 @@ package org.hibernate.event.internal;
 import java.io.Serializable;
 
 import org.hibernate.HibernateException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CollectionCacheEntry;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.CacheHelper;
@@ -116,17 +117,18 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 		}
 
 		final SessionFactoryImplementor factory = source.getFactory();
-		final CacheKey ck = source.generateCacheKey( id, persister.getKeyType(), persister.getRole() );
+		final CollectionRegionAccessStrategy cacheAccessStrategy = persister.getCacheAccessStrategy();
+		final CollectionCacheKey ck = cacheAccessStrategy.generateCacheKey( id, persister, factory, source.getTenantIdentifier() );
 		final Object ce = CacheHelper.fromSharedCache( source, ck, persister.getCacheAccessStrategy() );
 
 		if ( factory.getStatistics().isStatisticsEnabled() ) {
 			if ( ce == null ) {
 				factory.getStatisticsImplementor()
-						.secondLevelCacheMiss( persister.getCacheAccessStrategy().getRegion().getName() );
+						.secondLevelCacheMiss( cacheAccessStrategy.getRegion().getName() );
 			}
 			else {
 				factory.getStatisticsImplementor()
-						.secondLevelCacheHit( persister.getCacheAccessStrategy().getRegion().getName() );
+						.secondLevelCacheHit( cacheAccessStrategy.getRegion().getName() );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -13,7 +13,8 @@ import java.util.Map;
 import org.hibernate.HibernateException;
 import org.hibernate.PersistentObjectException;
 import org.hibernate.UnresolvableObjectException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingActions;
@@ -136,12 +137,14 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		}
 
 		if ( persister.hasCache() ) {
-			final CacheKey ck = source.generateCacheKey(
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			EntityCacheKey ck = cache.generateCacheKey(
 					id,
-					persister.getIdentifierType(),
-					persister.getRootEntityName()
+					persister,
+					source.getFactory(),
+					source.getTenantIdentifier()
 			);
-			persister.getCacheAccessStrategy().evict( ck );
+			cache.evict( ck );
 		}
 
 		evictCachedCollections( persister, id, source.getFactory() );

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
@@ -26,6 +26,7 @@ import org.hibernate.SessionException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
 import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.internal.OldCacheKeyImplementation;
 import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
@@ -338,7 +339,7 @@ public abstract class AbstractSessionImpl
 
 	@Override
 	public CacheKey generateCacheKey(Serializable id, Type type, String entityOrRoleName) {
-		return new CacheKey( id, type, entityOrRoleName, getTenantIdentifier(), getFactory() );
+		return new OldCacheKeyImplementation( id, type, entityOrRoleName, getTenantIdentifier(), getFactory() );
 	}
 
 	private transient JdbcConnectionAccess jdbcConnectionAccess;

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
@@ -26,8 +26,6 @@ import org.hibernate.SessionException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
 import org.hibernate.boot.spi.SessionFactoryOptions;
-import org.hibernate.cache.internal.OldCacheKeyImplementation;
-import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -59,7 +57,6 @@ import org.hibernate.resource.transaction.TransactionCoordinatorBuilder;
 import org.hibernate.resource.transaction.TransactionCoordinatorBuilder.TransactionCoordinatorOptions;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.type.Type;
 
 /**
  * Functionality common to stateless and stateful sessions
@@ -335,11 +332,6 @@ public abstract class AbstractSessionImpl
 	@Override
 	public EntityKey generateEntityKey(Serializable id, EntityPersister persister) {
 		return new EntityKey( id, persister );
-	}
-
-	@Override
-	public CacheKey generateCacheKey(Serializable id, Type type, String entityOrRoleName) {
-		return new OldCacheKeyImplementation( id, type, entityOrRoleName, getTenantIdentifier(), getFactory() );
 	}
 
 	private transient JdbcConnectionAccess jdbcConnectionAccess;

--- a/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.internal.OldCacheKeyImplementation;
 import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.QueryCache;
 import org.hibernate.cache.spi.Region;
@@ -97,7 +98,7 @@ public class CacheImpl implements CacheImplementor {
 	}
 
 	private CacheKey buildCacheKey(Serializable identifier, EntityPersister p) {
-		return new CacheKey(
+		return new OldCacheKeyImplementation(
 				identifier,
 				p.getIdentifierType(),
 				p.getRootEntityName(),
@@ -175,7 +176,7 @@ public class CacheImpl implements CacheImplementor {
 	}
 
 	private CacheKey buildCacheKey(Serializable ownerIdentifier, CollectionPersister p) {
-		return new CacheKey(
+		return new OldCacheKeyImplementation(
 				ownerIdentifier,
 				p.getKeyType(),
 				p.getRole(),

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -28,7 +28,8 @@ import org.hibernate.SessionException;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.UnresolvableObjectException;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.SessionEventListenerManagerImpl;
 import org.hibernate.engine.internal.StatefulPersistenceContext;
@@ -270,8 +271,9 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 //		}
 
 		if ( persister.hasCache() ) {
-			final CacheKey ck = generateCacheKey( id, persister.getIdentifierType(), persister.getRootEntityName() );
-			persister.getCacheAccessStrategy().evict( ck );
+			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+			final EntityCacheKey ck = cache.generateCacheKey( id, persister, getFactory(), getTenantIdentifier() );
+			cache.evict( ck );
 		}
 		String previousFetchProfile = this.getLoadQueryInfluencers().getInternalFetchProfile();
 		Object result = null;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -36,7 +36,7 @@ import org.hibernate.StaleStateException;
 import org.hibernate.bytecode.instrumentation.spi.FieldInterceptor;
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
 import org.hibernate.bytecode.spi.EntityInstrumentationMetadata;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -906,8 +906,9 @@ public abstract class AbstractEntityPersister
 		}
 
 		if ( session.getCacheMode().isGetEnabled() && hasCache() ) {
-			final CacheKey cacheKey = session.generateCacheKey( id, getIdentifierType(), getRootEntityName() );
-			final Object ce = CacheHelper.fromSharedCache( session, cacheKey, getCacheAccessStrategy() );
+			final EntityRegionAccessStrategy cache = getCacheAccessStrategy();
+			final EntityCacheKey cacheKey = cache.generateCacheKey(id, this, session.getFactory(), session.getTenantIdentifier() );
+			final Object ce = CacheHelper.fromSharedCache( session, cacheKey, cache );
 			if ( ce != null ) {
 				final CacheEntry cacheEntry = (CacheEntry) getCacheEntryStructure().destructure( ce, factory );
 				if ( !cacheEntry.areLazyPropertiesUnfetched() ) {
@@ -4269,7 +4270,8 @@ public abstract class AbstractEntityPersister
 
 		// check to see if it is in the second-level cache
 		if ( session.getCacheMode().isGetEnabled() && hasCache() ) {
-			final CacheKey ck = session.generateCacheKey( id, getIdentifierType(), getRootEntityName() );
+			final EntityRegionAccessStrategy cache = getCacheAccessStrategy();
+			final EntityCacheKey ck = cache.generateCacheKey( id, this, session.getFactory(), session.getTenantIdentifier() );
 			final Object ce = CacheHelper.fromSharedCache( session, ck, getCacheAccessStrategy() );
 			if ( ce != null ) {
 				return Boolean.FALSE;

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentSecondLevelCacheStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/ConcurrentSecondLevelCacheStatisticsImpl.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 
@@ -60,7 +60,7 @@ public class ConcurrentSecondLevelCacheStatisticsImpl extends CategorizedStatist
 		Iterator iter = region.toMap().entrySet().iterator();
 		while (iter.hasNext()) {
 			Map.Entry me = (Map.Entry) iter.next();
-			map.put(((CacheKey) me.getKey()).getKey(), me.getValue());
+			map.put(((EntityCacheKey) me.getKey()).getKey(), me.getValue());
 		}
 		return map;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
@@ -58,8 +59,8 @@ public class NaturalIdCacheKeyTest {
                 return invocation.getArguments()[0];
             }
         });
-        
-        final NaturalIdCacheKey key = new NaturalIdCacheKey(new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor);
+
+        final NaturalIdCacheKey key = DefaultCacheKeysFactory.createNaturalIdKey( new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor );
         
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(baos);

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
@@ -20,7 +20,8 @@ import org.hibernate.FetchMode;
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.entry.CollectionCacheEntry;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.criterion.DetachedCriteria;
@@ -100,12 +101,14 @@ public class DynamicFilterTest extends BaseNonConfigCoreFunctionalTestCase {
 		Hibernate.initialize( sp.getOrders() );
 		CollectionPersister persister = sessionFactory().getCollectionPersister( Salesperson.class.getName() + ".orders" );
 		assertTrue( "No cache for collection", persister.hasCache() );
-		CacheKey cacheKey = ( (SessionImplementor) session ).generateCacheKey(
+		CollectionRegionAccessStrategy cache = persister.getCacheAccessStrategy();
+		CollectionCacheKey cacheKey = cache.generateCacheKey(
 				testData.steveId,
-				persister.getKeyType(),
-				persister.getRole()
+				persister,
+				sessionFactory(),
+				session.getTenantIdentifier()
 		);
-		CollectionCacheEntry cachedData = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( cacheKey, ts );
+		CollectionCacheEntry cachedData = ( CollectionCacheEntry ) cache.get( cacheKey, ts );
 		assertNotNull( "collection was not in cache", cachedData );
 
 		session.close();
@@ -114,14 +117,15 @@ public class DynamicFilterTest extends BaseNonConfigCoreFunctionalTestCase {
 		ts = ( ( SessionImplementor ) session ).getTimestamp();
 		session.enableFilter( "fulfilledOrders" ).setParameter( "asOfDate", testData.lastMonth.getTime() );
 		sp = ( Salesperson ) session.createQuery( "from Salesperson as s where s.id = :id" )
-		        .setLong( "id", testData.steveId )
-		        .uniqueResult();
+				.setLong( "id", testData.steveId )
+				.uniqueResult();
 		assertEquals( "Filtered-collection not bypassing 2L-cache", 1, sp.getOrders().size() );
 
-		CacheKey cacheKey2 = ( (SessionImplementor) session ).generateCacheKey(
+		CollectionCacheKey cacheKey2 = cache.generateCacheKey(
 				testData.steveId,
-				persister.getKeyType(),
-				persister.getRole()
+				persister,
+				sessionFactory(),
+				session.getTenantIdentifier()
 		);
 		CollectionCacheEntry cachedData2 = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( cacheKey2, ts );
 		assertNotNull( "collection no longer in cache!", cachedData2 );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
@@ -6,12 +6,18 @@
  */
 package org.hibernate.cache.ehcache.internal.nonstop;
 
+import java.io.Serializable;
+
 import net.sf.ehcache.constructs.nonstop.NonStopCacheException;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * Implementation of {@link CollectionRegionAccessStrategy} that handles {@link NonStopCacheException} using
@@ -43,7 +49,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public void evict(Object key) throws CacheException {
+	public void evict(CollectionCacheKey key) throws CacheException {
 		try {
 			actualStrategy.evict( key );
 		}
@@ -63,7 +69,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(CollectionCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			return actualStrategy.get( key, txTimestamp );
 		}
@@ -74,7 +80,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(CollectionCacheKey key, Object version) throws CacheException {
 		try {
 			return actualStrategy.lockItem( key, version );
 		}
@@ -96,7 +102,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
@@ -108,7 +114,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
 		}
@@ -119,7 +125,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		try {
 			actualStrategy.remove( key );
 		}
@@ -139,7 +145,7 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 		try {
 			actualStrategy.unlockItem( key, lock );
 		}
@@ -156,6 +162,11 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
 		}
+	}
+
+	@Override
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
@@ -6,12 +6,18 @@
  */
 package org.hibernate.cache.ehcache.internal.nonstop;
 
+import java.io.Serializable;
+
 import net.sf.ehcache.constructs.nonstop.NonStopCacheException;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Implementation of {@link EntityRegionAccessStrategy} that handles {@link net.sf.ehcache.constructs.nonstop.NonStopCacheException} using
@@ -43,7 +49,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		try {
 			return actualStrategy.afterInsert( key, value, version );
 		}
@@ -54,7 +60,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		try {
 			return actualStrategy.afterUpdate( key, value, currentVersion, previousVersion, lock );
@@ -66,7 +72,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public void evict(Object key) throws CacheException {
+	public void evict(EntityCacheKey key) throws CacheException {
 		try {
 			actualStrategy.evict( key );
 		}
@@ -86,7 +92,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(EntityCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			return actualStrategy.get( key, txTimestamp );
 		}
@@ -97,7 +103,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		try {
 			return actualStrategy.insert( key, value, version );
 		}
@@ -108,7 +114,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(EntityCacheKey key, Object version) throws CacheException {
 		try {
 			return actualStrategy.lockItem( key, version );
 		}
@@ -130,7 +136,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(EntityCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
@@ -142,7 +148,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(EntityCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
 		}
@@ -153,7 +159,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(EntityCacheKey key) throws CacheException {
 		try {
 			actualStrategy.remove( key );
 		}
@@ -173,7 +179,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 		try {
 			actualStrategy.unlockItem( key, lock );
 		}
@@ -193,7 +199,7 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		try {
 			return actualStrategy.update( key, value, currentVersion, previousVersion );
@@ -202,5 +208,10 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
 			return false;
 		}
+	}
+
+	@Override
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
@@ -9,9 +9,13 @@ package org.hibernate.cache.ehcache.internal.nonstop;
 import net.sf.ehcache.constructs.nonstop.NonStopCacheException;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Implementation of {@link NaturalIdRegionAccessStrategy} that handles {@link NonStopCacheException} using
@@ -38,7 +42,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		try {
 			return actualStrategy.insert( key, value );
 		}
@@ -49,7 +53,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		try {
 			return actualStrategy.afterInsert( key, value );
 		}
@@ -60,7 +64,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		try {
 			return actualStrategy.update( key, value );
 		}
@@ -71,7 +75,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		try {
 			return actualStrategy.afterUpdate( key, value, lock );
 		}
@@ -87,7 +91,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public void evict(Object key) throws CacheException {
+	public void evict(NaturalIdCacheKey key) throws CacheException {
 		try {
 			actualStrategy.evict( key );
 		}
@@ -107,7 +111,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(NaturalIdCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			return actualStrategy.get( key, txTimestamp );
 		}
@@ -118,7 +122,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(NaturalIdCacheKey key, Object version) throws CacheException {
 		try {
 			return actualStrategy.lockItem( key, version );
 		}
@@ -140,7 +144,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
@@ -152,7 +156,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
 			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
 		}
@@ -163,7 +167,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		try {
 			actualStrategy.remove( key );
 		}
@@ -183,7 +187,7 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		try {
 			actualStrategy.unlockItem( key, lock );
 		}
@@ -200,6 +204,11 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
 		}
+	}
+
+	@Override
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
 	}
 
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractEhcacheAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractEhcacheAccessStrategy.java
@@ -6,10 +6,21 @@
  */
 package org.hibernate.cache.ehcache.internal.strategy;
 
+import java.io.Serializable;
+
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheTransactionalDataRegion;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Ultimate superclass for all Ehcache specific Hibernate AccessStrategy implementations.
@@ -19,7 +30,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Chris Dennis
  * @author Alex Snaps
  */
-abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataRegion> {
+abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataRegion, K extends CacheKey> {
 	private final T region;
 	private final SessionFactoryOptions settings;
 
@@ -55,7 +66,7 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object)
 	 */
-	public final boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public final boolean putFromLoad(K key, Object value, long txTimestamp, Object version) throws CacheException {
 		return putFromLoad( key, value, txTimestamp, version, settings.isMinimalPutsEnabled() );
 	}
 
@@ -66,7 +77,7 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
 	 */
-	public abstract boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public abstract boolean putFromLoad(K key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException;
 
 	/**
@@ -99,7 +110,7 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#remove(java.lang.Object)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#remove(java.lang.Object)
 	 */
-	public void remove(Object key) throws CacheException {
+	public void remove(K key) throws CacheException {
 	}
 
 	/**
@@ -120,7 +131,7 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#evict(java.lang.Object)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#evict(java.lang.Object)
 	 */
-	public final void evict(Object key) throws CacheException {
+	public final void evict(K key) throws CacheException {
 		region.remove( key );
 	}
 
@@ -133,5 +144,17 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	@SuppressWarnings("UnusedDeclaration")
 	public final void evictAll() throws CacheException {
 		region.clear();
+	}
+
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+	}
+
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+	}
+
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractReadWriteEhcacheAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractReadWriteEhcacheAccessStrategy.java
@@ -15,8 +15,8 @@ import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.EhCacheMessageLogger;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheTransactionalDataRegion;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -27,9 +27,8 @@ import org.jboss.logging.Logger;
  * @author Chris Dennis
  * @author Alex Snaps
  */
-abstract class AbstractReadWriteEhcacheAccessStrategy<T
-		extends EhcacheTransactionalDataRegion>
-		extends AbstractEhcacheAccessStrategy<T> {
+abstract class AbstractReadWriteEhcacheAccessStrategy<T extends EhcacheTransactionalDataRegion, K extends CacheKey>
+		extends AbstractEhcacheAccessStrategy<T, K> {
 
 	private static final EhCacheMessageLogger LOG = Logger.getMessageLogger(
 			EhCacheMessageLogger.class,
@@ -56,7 +55,7 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#get(java.lang.Object, long)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#get(java.lang.Object, long)
 	 */
-	public final Object get(Object key, long txTimestamp) throws CacheException {
+	public final Object get(K key, long txTimestamp) throws CacheException {
 		readLockIfNeeded( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -83,7 +82,7 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T
 	 */
 	@Override
 	public final boolean putFromLoad(
-			Object key,
+			K key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -112,7 +111,7 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#lockItem(java.lang.Object, java.lang.Object)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#lockItem(java.lang.Object, java.lang.Object)
 	 */
-	public final SoftLock lockItem(Object key, Object version) throws CacheException {
+	public final SoftLock lockItem(K key, Object version) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -136,7 +135,7 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T
 	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#unlockItem(java.lang.Object, org.hibernate.cache.spi.access.SoftLock)
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#unlockItem(java.lang.Object, org.hibernate.cache.spi.access.SoftLock)
 	 */
-	public final void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public final void unlockItem(K key, SoftLock lock) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheCollectionRegion;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -20,7 +21,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion,CollectionCacheKey>
 		implements CollectionRegionAccessStrategy {
 
 	/**
@@ -39,12 +40,12 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(CollectionCacheKey key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -61,7 +62,7 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(CollectionCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -71,12 +72,12 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		region().remove( key );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -9,9 +9,12 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheNaturalIdRegion;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Ehcache specific non-strict read/write NaturalId region access strategy
@@ -20,7 +23,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion,NaturalIdCacheKey>
 		implements NaturalIdRegionAccessStrategy {
 
 	/**
@@ -39,12 +42,12 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(NaturalIdCacheKey key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -61,7 +64,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(NaturalIdCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -71,7 +74,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
@@ -81,7 +84,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Returns <code>false</code> since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -91,7 +94,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Returns <code>false</code> since this is a non-strict read/write cache access strategy
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -101,19 +104,20 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Removes the entry since this is a non-strict read/write cache strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		remove( key );
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		unlockItem( key, lock );
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		region().remove( key );
 	}
+
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheCollectionRegion;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -20,7 +21,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class ReadOnlyEhcacheCollectionRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion,CollectionCacheKey>
 		implements CollectionRegionAccessStrategy {
 
 	/**
@@ -39,12 +40,12 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(CollectionCacheKey key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -56,7 +57,7 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(CollectionCacheKey key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -66,6 +67,6 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheEntityRegion;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -19,7 +20,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Chris Dennis
  * @author Alex Snaps
  */
-public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAccessStrategy<EhcacheEntityRegion>
+public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAccessStrategy<EhcacheEntityRegion,EntityCacheKey>
 		implements EntityRegionAccessStrategy {
 
 	/**
@@ -38,12 +39,12 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(EntityCacheKey key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(EntityCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -55,7 +56,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(EntityCacheKey key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -65,7 +66,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -75,12 +76,12 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		region().put( key, value );
 		return true;
 	}
@@ -93,7 +94,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
@@ -106,7 +107,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheNaturalIdRegion;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -20,7 +21,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion,NaturalIdCacheKey>
 		implements NaturalIdRegionAccessStrategy {
 
 	/**
@@ -39,12 +40,12 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(NaturalIdCacheKey key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -56,7 +57,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(NaturalIdCacheKey key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -66,7 +67,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
@@ -76,12 +77,12 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		region().put( key, value );
 		return true;
 	}
@@ -94,7 +95,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws UnsupportedOperationException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
 
@@ -106,7 +107,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws UnsupportedOperationException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheCollectionRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheCollectionRegion;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 
@@ -18,7 +19,7 @@ import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
  * @author Alex Snaps
  */
 public class ReadWriteEhcacheCollectionRegionAccessStrategy
-		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheCollectionRegion>
+		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheCollectionRegion,CollectionCacheKey>
 		implements CollectionRegionAccessStrategy {
 
 	/**

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheEntityRegion;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -20,7 +21,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class ReadWriteEhcacheEntityRegionAccessStrategy
-		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheEntityRegion>
+		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheEntityRegion,EntityCacheKey>
 		implements EntityRegionAccessStrategy {
 
 	/**
@@ -44,7 +45,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -54,7 +55,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * Inserts will only succeed if there is no existing value mapped to this key.
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -77,7 +78,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
@@ -90,7 +91,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * the course of this transaction.
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		//what should we do with previousVersion here?
 		region().writeLock( key );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheNaturalIdRegion;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -20,7 +21,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
-		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheNaturalIdRegion>
+		extends AbstractReadWriteEhcacheAccessStrategy<EhcacheNaturalIdRegion,NaturalIdCacheKey>
 		implements NaturalIdRegionAccessStrategy {
 
 	/**
@@ -44,7 +45,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -54,7 +55,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Inserts will only succeed if there is no existing value mapped to this key.
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -77,7 +78,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -89,7 +90,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * the course of this transaction.
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		//what should we do with previousVersion here?
 		region().writeLock( key );
 		try {

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
@@ -6,15 +6,20 @@
  */
 package org.hibernate.cache.ehcache.internal.strategy;
 
+import java.io.Serializable;
+
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheCollectionRegion;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * JTA CollectionRegionAccessStrategy.
@@ -24,7 +29,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class TransactionalEhcacheCollectionRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheCollectionRegion,CollectionCacheKey>
 		implements CollectionRegionAccessStrategy {
 
 	private final Ehcache ehcache;
@@ -45,7 +50,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(CollectionCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -61,13 +66,13 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(CollectionCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
-			Object key,
+			CollectionCacheKey key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -86,7 +91,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -96,7 +101,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
@@ -12,6 +12,7 @@ import net.sf.ehcache.Element;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheEntityRegion;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -23,7 +24,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Ludovic Orban
  * @author Alex Snaps
  */
-public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAccessStrategy<EhcacheEntityRegion>
+public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAccessStrategy<EhcacheEntityRegion,EntityCacheKey>
 		implements EntityRegionAccessStrategy {
 
 	private final Ehcache ehcache;
@@ -44,17 +45,17 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(EntityCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -70,7 +71,7 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version)
+	public boolean insert(EntityCacheKey key, Object value, Object version)
 			throws CacheException {
 		//OptimisticCache? versioning?
 		try {
@@ -83,13 +84,13 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(EntityCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
-			Object key,
+			EntityCacheKey key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -108,7 +109,7 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(EntityCacheKey key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -118,13 +119,13 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 
 	@Override
 	public boolean update(
-			Object key,
+			EntityCacheKey key,
 			Object value,
 			Object currentVersion,
 			Object previousVersion) throws CacheException {

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
@@ -12,6 +12,7 @@ import net.sf.ehcache.Element;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheNaturalIdRegion;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -24,7 +25,7 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Alex Snaps
  */
 public class TransactionalEhcacheNaturalIdRegionAccessStrategy
-		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion>
+		extends AbstractEhcacheAccessStrategy<EhcacheNaturalIdRegion,NaturalIdCacheKey>
 		implements NaturalIdRegionAccessStrategy {
 
 	private final Ehcache ehcache;
@@ -45,17 +46,17 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(NaturalIdCacheKey key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -71,7 +72,7 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		//OptimisticCache? versioning?
 		try {
 			ehcache.put( new Element( key, value ) );
@@ -83,13 +84,13 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(NaturalIdCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
-			Object key,
+			NaturalIdCacheKey key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -108,7 +109,7 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -118,12 +119,12 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		try {
 			ehcache.put( new Element( key, value ) );
 			return true;

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/collection/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/collection/TransactionalAccess.java
@@ -6,11 +6,17 @@
  */
 package org.hibernate.cache.infinispan.collection;
 
+import java.io.Serializable;
+
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.access.TransactionalAccessDelegate;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * Transactional collection region access for Infinispan.
@@ -30,7 +36,7 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		this.delegate = new TransactionalAccessDelegate( region, region.getPutFromLoadValidator() );
 	}
 
-	public void evict(Object key) throws CacheException {
+	public void evict(CollectionCacheKey key) throws CacheException {
 		delegate.evict( key );
 	}
 
@@ -38,20 +44,20 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(CollectionCacheKey key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(CollectionCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -63,7 +69,7 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		return region;
 	}
 
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(CollectionCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -71,10 +77,15 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 	}
 
 	public void unlockRegion(SoftLock lock) throws CacheException {
+	}
+
+	@Override
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/ReadOnlyAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/ReadOnlyAccess.java
@@ -7,6 +7,7 @@
 package org.hibernate.cache.infinispan.entity;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -25,14 +26,14 @@ class ReadOnlyAccess extends TransactionalAccess {
 
 	@Override
 	public boolean update(
-			Object key, Object value, Object currentVersion,
+			EntityCacheKey key, Object value, Object currentVersion,
 			Object previousVersion) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
 	@Override
 	public boolean afterUpdate(
-			Object key, Object value, Object currentVersion,
+			EntityCacheKey key, Object value, Object currentVersion,
 			Object previousVersion, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/TransactionalAccess.java
@@ -6,11 +6,17 @@
  */
 package org.hibernate.cache.infinispan.entity;
 
+import java.io.Serializable;
+
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.access.TransactionalAccessDelegate;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * Transactional entity region access for Infinispan.
@@ -30,7 +36,7 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		this.delegate = new TransactionalAccessDelegate( region, region.getPutFromLoadValidator() );
 	}
 
-	public void evict(Object key) throws CacheException {
+	public void evict(EntityCacheKey key) throws CacheException {
 		delegate.evict( key );
 	}
 
@@ -38,7 +44,7 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(EntityCacheKey key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
@@ -46,20 +52,20 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		return this.region;
 	}
 
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return delegate.insert( key, value, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(EntityCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(EntityCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(Object key) throws CacheException {
+	public void remove(EntityCacheKey key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -67,12 +73,12 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		delegate.removeAll();
 	}
 
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return delegate.update( key, value, currentVersion, previousVersion );
 	}
 
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(EntityCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -80,18 +86,24 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 	}
 
 	public void unlockRegion(SoftLock lock) throws CacheException {
 	}
 
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		return false;
 	}
+
+	@Override
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+	}
+
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/ReadOnlyAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/ReadOnlyAccess.java
@@ -7,6 +7,7 @@
 package org.hibernate.cache.infinispan.naturalid;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -18,14 +19,14 @@ class ReadOnlyAccess extends TransactionalAccess {
 		super( naturalIdRegion );
 	}
 
-
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
+
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/TransactionalAccess.java
@@ -8,9 +8,13 @@ package org.hibernate.cache.infinispan.naturalid;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.access.TransactionalAccessDelegate;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -25,12 +29,12 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return delegate.insert( key, value, null );
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		return delegate.update( key, value, null, null );
 	}
 
@@ -40,7 +44,7 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public void evict(Object key) throws CacheException {
+	public void evict(NaturalIdCacheKey key) throws CacheException {
 		delegate.evict( key );
 	}
 
@@ -50,23 +54,23 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(NaturalIdCacheKey key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(NaturalIdCacheKey key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -76,7 +80,7 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(NaturalIdCacheKey key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -86,7 +90,7 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 	}
 
 	@Override
@@ -94,13 +98,18 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		return false;
+	}
+
+	@Override
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
 	}
 
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractEntityCollectionRegionTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractEntityCollectionRegionTestCase.java
@@ -12,10 +12,10 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.TransactionalDataRegion;
 import org.hibernate.cache.spi.access.AccessType;
-
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
  * @author Galder Zamarreño
  * @since 3.5
  */
-public abstract class AbstractEntityCollectionRegionTestCase extends AbstractRegionImplTestCase {
+public abstract class AbstractEntityCollectionRegionTestCase<T extends CacheKey> extends AbstractRegionImplTestCase<T> {
 	@Test
 	public void testSupportedAccessTypes() throws Exception {
 		supportedAccessTypeTest();

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
@@ -12,17 +12,15 @@ import java.util.Set;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.GeneralDataRegion;
 import org.hibernate.cache.spi.QueryResultsRegion;
 import org.hibernate.cache.spi.Region;
-
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.infinispan.AdvancedCache;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
-
 import org.jboss.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +32,7 @@ import static org.junit.Assert.assertNull;
  * @author Galder Zamarreño
  * @since 3.5
  */
-public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionImplTestCase {
+public abstract class AbstractGeneralDataRegionTestCase<T extends CacheKey> extends AbstractRegionImplTestCase<T> {
 	private static final Logger log = Logger.getLogger( AbstractGeneralDataRegionTestCase.class );
 
 	protected static final String KEY = "Key";
@@ -52,12 +50,12 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 	}
 
 	@Override
-	protected void putInRegion(Region region, Object key, Object value) {
+	protected void putInRegion(Region region, T key, Object value) {
 		((GeneralDataRegion) region).put( key, value );
 	}
 
 	@Override
-	protected void removeFromRegion(Region region, Object key) {
+	protected void removeFromRegion(Region region, T key) {
 		((GeneralDataRegion) region).evict( key );
 	}
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractRegionImplTestCase.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.infinispan.AdvancedCache;
@@ -21,15 +22,15 @@ import org.infinispan.AdvancedCache;
  * @author Galder Zamarreño
  * @since 3.5
  */
-public abstract class AbstractRegionImplTestCase extends AbstractNonFunctionalTestCase {
+public abstract class AbstractRegionImplTestCase<T extends CacheKey> extends AbstractNonFunctionalTestCase {
 
    protected abstract AdvancedCache getInfinispanCache(InfinispanRegionFactory regionFactory);
 
    protected abstract Region createRegion(InfinispanRegionFactory regionFactory, String regionName, Properties properties, CacheDataDescription cdd);
 
-   protected abstract void putInRegion(Region region, Object key, Object value);
+   protected abstract void putInRegion(Region region, T key, Object value);
 
-   protected abstract void removeFromRegion(Region region, Object key);
+   protected abstract void removeFromRegion(Region region, T key);
 
    protected CacheDataDescription getCacheDataDescription() {
       return new CacheDataDescriptionImpl(true, true, ComparableComparator.INSTANCE);

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/AbstractCollectionRegionAccessStrategyTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/AbstractCollectionRegionAccessStrategyTestCase.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import javax.transaction.TransactionManager;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -22,22 +23,23 @@ import org.hibernate.cache.infinispan.collection.CollectionRegionImpl;
 import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.internal.util.compare.ComparableComparator;
-
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import junit.framework.AssertionFailedError;
 
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
-
 import org.jboss.logging.Logger;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
@@ -230,7 +232,7 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 	private void putFromLoadTest(final boolean useMinimalAPI) throws Exception {
 
-		final String KEY = KEY_BASE + testCount++;
+		final CollectionCacheKey KEY = TestingKeyFactory.generateCollectionCacheKey( KEY_BASE + testCount++ );
 
 		final CountDownLatch writeLatch1 = new CountDownLatch( 1 );
 		final CountDownLatch writeLatch2 = new CountDownLatch( 1 );
@@ -382,7 +384,7 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 	private void evictOrRemoveTest(final boolean evict) throws Exception {
 
-		final String KEY = KEY_BASE + testCount++;
+		final CollectionCacheKey KEY = TestingKeyFactory.generateCollectionCacheKey( KEY_BASE + testCount++ );
 
 		assertNull( "local is clean", localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
 		assertNull( "remote is clean", remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
@@ -413,7 +415,7 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 	private void evictOrRemoveAllTest(final boolean evict) throws Exception {
 
-		final String KEY = KEY_BASE + testCount++;
+		final CollectionCacheKey KEY = TestingKeyFactory.generateCollectionCacheKey( KEY_BASE + testCount++ );
 
 		assertEquals( 0, getValidKeyCount( localCollectionRegion.getCache().keySet() ) );
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/CollectionRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/CollectionRegionImplTestCase.java
@@ -10,6 +10,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.cache.spi.RegionFactory;
@@ -28,7 +29,8 @@ import static org.junit.Assert.fail;
  * 
  * @author Galder Zamarreño
  */
-public class CollectionRegionImplTestCase extends AbstractEntityCollectionRegionTestCase {
+public class CollectionRegionImplTestCase extends AbstractEntityCollectionRegionTestCase<CollectionCacheKey> {
+
    private static CacheDataDescription MUTABLE_NON_VERSIONED = new CacheDataDescriptionImpl(true, false, null);
 
    @Override
@@ -60,13 +62,13 @@ public class CollectionRegionImplTestCase extends AbstractEntityCollectionRegion
    }
 
    @Override
-   protected void putInRegion(Region region, Object key, Object value) {
+   protected void putInRegion(Region region, CollectionCacheKey key, Object value) {
       CollectionRegionAccessStrategy strategy = ((CollectionRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL);
       strategy.putFromLoad(key, value, System.currentTimeMillis(), new Integer(1));
    }
 
    @Override
-   protected void removeFromRegion(Region region, Object key) {
+   protected void removeFromRegion(Region region, CollectionCacheKey key) {
       ((CollectionRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(key);
    }
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
@@ -8,13 +8,14 @@ package org.hibernate.test.cache.infinispan.collection;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,7 +31,7 @@ import static org.junit.Assert.assertNull;
 public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase {
 
 	public static final String REGION_NAME = "test/com.foo.test";
-	public static final String KEY = "KEY";
+	public static final CollectionCacheKey KEY = TestingKeyFactory.generateCollectionCacheKey( "KEY" );
 	public static final String VALUE1 = "VALUE1";
 	public static final String VALUE2 = "VALUE2";
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractEntityRegionAccessStrategyTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractEntityRegionAccessStrategyTestCase.java
@@ -17,22 +17,23 @@ import org.hibernate.cache.infinispan.entity.EntityRegionImpl;
 import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.internal.util.compare.ComparableComparator;
-
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import junit.framework.AssertionFailedError;
 
 import org.infinispan.Cache;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
-
 import org.jboss.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -193,7 +194,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
     */
    private void putFromLoadTest(final boolean useMinimalAPI) throws Exception {
 
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
       final CountDownLatch writeLatch1 = new CountDownLatch(1);
       final CountDownLatch writeLatch2 = new CountDownLatch(1);
@@ -297,7 +298,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
    @Test
    public void testInsert() throws Exception {
 
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
       final CountDownLatch readLatch = new CountDownLatch(1);
       final CountDownLatch commitLatch = new CountDownLatch(1);
@@ -386,7 +387,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
    @Test
    public void testUpdate() throws Exception {
 
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
       // Set up initial state
       localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
@@ -502,7 +503,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
    }
 
    private void evictOrRemoveTest(final boolean evict) throws Exception {
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
 
@@ -531,7 +532,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
    }
 
    private void evictOrRemoveAllTest(final boolean evict) throws Exception {
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
       assertNull("local is clean", localAccessStrategy.get(KEY, System.currentTimeMillis()));

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractReadOnlyAccessTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractReadOnlyAccessTestCase.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.test.cache.infinispan.entity;
 
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
-
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 import org.junit.Test;
-
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
 
 import static org.junit.Assert.assertEquals;
@@ -42,7 +42,7 @@ public abstract class AbstractReadOnlyAccessTestCase extends AbstractEntityRegio
 
    private void putFromLoadTest(boolean minimal) throws Exception {
 
-      final String KEY = KEY_BASE + testCount++;
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
       long txTimestamp = System.currentTimeMillis();
       BatchModeTransactionManager.getInstance().begin();
@@ -64,8 +64,8 @@ public abstract class AbstractReadOnlyAccessTestCase extends AbstractEntityRegio
    @Test(expected = UnsupportedOperationException.class)
    @Override
    public void testUpdate() throws Exception {
-      localAccessStrategy.update(KEY_BASE + testCount++,
-            VALUE2, 2, 1);
+      final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
+      localAccessStrategy.update( KEY, VALUE2, 2, 1);
    }
 
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractTransactionalAccessTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractTransactionalAccessTestCase.java
@@ -10,10 +10,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import junit.framework.AssertionFailedError;
+
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
 import org.jboss.logging.Logger;
-
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +36,7 @@ public abstract class AbstractTransactionalAccessTestCase extends AbstractEntity
 
     public void testContestedPutFromLoad() throws Exception {
 
-        final String KEY = KEY_BASE + testCount++;
+        final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
         localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/EntityRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/EntityRegionImplTestCase.java
@@ -10,6 +10,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.Region;
 import org.hibernate.cache.spi.RegionFactory;
@@ -28,7 +29,8 @@ import static org.junit.Assert.fail;
  * @author Galder Zamarreño
  * @since 3.5
  */
-public class EntityRegionImplTestCase extends AbstractEntityCollectionRegionTestCase {
+public class EntityRegionImplTestCase extends AbstractEntityCollectionRegionTestCase<EntityCacheKey> {
+
    private static CacheDataDescription MUTABLE_NON_VERSIONED = new CacheDataDescriptionImpl(true, false, null);
 
    @Override
@@ -50,12 +52,12 @@ public class EntityRegionImplTestCase extends AbstractEntityCollectionRegionTest
    }
 
    @Override
-   protected void putInRegion(Region region, Object key, Object value) {
+   protected void putInRegion(Region region, EntityCacheKey key, Object value) {
       ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).insert(key, value, 1);
    }
 
    @Override
-   protected void removeFromRegion(Region region, Object key) {
+   protected void removeFromRegion(Region region, EntityCacheKey key) {
       ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(key);
    }
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
@@ -9,13 +9,14 @@ package org.hibernate.test.cache.infinispan.entity;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.infinispan.InfinispanRegionFactory;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
 import org.hibernate.test.cache.infinispan.util.CacheTestUtil;
+import org.hibernate.test.cache.infinispan.util.TestingKeyFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertNull;
  */
 public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase {
 	public static final String REGION_NAME = "test/com.foo.test";
-	public static final String KEY = "KEY";
+	public static final EntityCacheKey KEY = TestingKeyFactory.generateEntityCacheKey( "KEY" );
 	public static final String VALUE1 = "VALUE1";
 	public static final String VALUE2 = "VALUE2";
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/cluster/EntityCollectionInvalidationTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/cluster/EntityCollectionInvalidationTestCase.java
@@ -9,6 +9,7 @@ package org.hibernate.test.cache.infinispan.functional.cluster;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+
 import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
@@ -20,10 +21,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.jboss.util.collection.ConcurrentSet;
 import org.junit.Test;
-
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.cache.spi.CacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.test.cache.infinispan.functional.Contact;
 import org.hibernate.test.cache.infinispan.functional.Customer;
 
@@ -345,9 +345,9 @@ public class EntityCollectionInvalidationTestCase extends DualNodeTestCase {
 		public void nodeVisited(CacheEntryVisitedEvent event) {
 			log.debug( event.toString() );
 			if ( !event.isPre() ) {
-				CacheKey cacheKey = (CacheKey) event.getKey();
+				EntityCacheKey cacheKey = (EntityCacheKey) event.getKey();
 				Integer primKey = (Integer) cacheKey.getKey();
-				String key = cacheKey.getEntityOrRoleName() + '#' + primKey;
+				String key = cacheKey.getEntityName() + '#' + primKey;
 				log.debug( "MyListener[" + name + "] - Visiting key " + key );
 				// String name = fqn.toString();
 				String token = ".functional.";

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/TestingKeyFactory.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/TestingKeyFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cache.infinispan.util;
+
+import java.io.Serializable;
+
+import org.hibernate.cache.spi.CollectionCacheKey;
+import org.hibernate.cache.spi.EntityCacheKey;
+
+public class TestingKeyFactory {
+
+	private TestingKeyFactory() {
+		//Not to be constructed
+	}
+
+	public static EntityCacheKey generateEntityCacheKey(String id) {
+		return new TestingEntityCacheKey( id );
+	}
+
+	public static CollectionCacheKey generateCollectionCacheKey(String id) {
+		return new TestingEntityCacheKey( id );
+	}
+
+	//For convenience implement both interfaces.
+	private static class TestingEntityCacheKey implements EntityCacheKey, CollectionCacheKey, Serializable {
+
+		private final String id;
+
+		public TestingEntityCacheKey(String id) {
+			this.id = id;
+		}
+
+		@Override
+		public Serializable getKey() {
+			return null;
+		}
+
+		@Override
+		public String getEntityName() {
+			return null;
+		}
+
+		@Override
+		public String getCollectionRole() {
+			return null;
+		}
+
+		@Override
+		public String getTenantId() {
+			return null;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((id == null) ? 0 : id.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			TestingEntityCacheKey other = (TestingEntityCacheKey) obj;
+			if (id == null) {
+				if (other.id != null)
+					return false;
+			} else if (!id.equals(other.id))
+				return false;
+			return true;
+		}
+
+	}
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/AbstractReadWriteAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/AbstractReadWriteAccessStrategy.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 import org.jboss.logging.Logger;
@@ -20,7 +21,7 @@ import org.jboss.logging.Logger;
 /**
  * @author Strong Liu
  */
-abstract class AbstractReadWriteAccessStrategy extends BaseRegionAccessStrategy {
+abstract class AbstractReadWriteAccessStrategy<T extends CacheKey> extends BaseRegionAccessStrategy<T> {
 	private static final Logger LOG = Logger.getLogger( AbstractReadWriteAccessStrategy.class.getName() );
 
 	private final UUID uuid = UUID.randomUUID();
@@ -34,7 +35,7 @@ abstract class AbstractReadWriteAccessStrategy extends BaseRegionAccessStrategy 
 	 * after the start of this transaction.
 	 */
 	@Override
-	public final Object get(Object key, long txTimestamp) throws CacheException {
+	public final Object get(T key, long txTimestamp) throws CacheException {
 		LOG.debugf( "getting key[%s] from region[%s]", key, getInternalRegion().getName() );
 		try {
 			readLock.lock();
@@ -68,7 +69,7 @@ abstract class AbstractReadWriteAccessStrategy extends BaseRegionAccessStrategy 
 	 */
 	@Override
 	public final boolean putFromLoad(
-			Object key,
+			T key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -108,7 +109,7 @@ abstract class AbstractReadWriteAccessStrategy extends BaseRegionAccessStrategy 
 	 * Soft-lock a cache item.
 	 */
 	@Override
-	public final SoftLock lockItem(Object key, Object version) throws CacheException {
+	public final SoftLock lockItem(T key, Object version) throws CacheException {
 
 		try {
 			LOG.debugf( "locking key[%s] in region[%s]", key, getInternalRegion().getName() );
@@ -132,7 +133,7 @@ abstract class AbstractReadWriteAccessStrategy extends BaseRegionAccessStrategy 
 	 * Soft-unlock a cache item.
 	 */
 	@Override
-	public final void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public final void unlockItem(T key, SoftLock lock) throws CacheException {
 
 		try {
 			LOG.debugf( "unlocking key[%s] in region[%s]", key, getInternalRegion().getName() );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseCollectionRegionAccessStrategy.java
@@ -6,13 +6,20 @@
  */
 package org.hibernate.testing.cache;
 
+import java.io.Serializable;
+
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * @author Strong Liu
  */
-class BaseCollectionRegionAccessStrategy extends BaseRegionAccessStrategy implements CollectionRegionAccessStrategy {
+class BaseCollectionRegionAccessStrategy extends BaseRegionAccessStrategy<CollectionCacheKey> implements CollectionRegionAccessStrategy {
+
 	private final CollectionRegionImpl region;
 
 	BaseCollectionRegionAccessStrategy(CollectionRegionImpl region) {
@@ -33,4 +40,10 @@ class BaseCollectionRegionAccessStrategy extends BaseRegionAccessStrategy implem
 	public CollectionRegion getRegion() {
 		return region;
 	}
+
+	@Override
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+	}
+
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseEntityRegionAccessStrategy.java
@@ -6,21 +6,27 @@
  */
 package org.hibernate.testing.cache;
 
+import java.io.Serializable;
+
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * @author Strong Liu
  */
-class BaseEntityRegionAccessStrategy extends BaseRegionAccessStrategy implements EntityRegionAccessStrategy {
+class BaseEntityRegionAccessStrategy extends BaseRegionAccessStrategy<EntityCacheKey> implements EntityRegionAccessStrategy {
+
 	private final EntityRegionImpl region;
 
 	BaseEntityRegionAccessStrategy(EntityRegionImpl region) {
 		this.region = region;
 	}
-
 
 	@Override
 	public EntityRegion getRegion() {
@@ -28,23 +34,23 @@ class BaseEntityRegionAccessStrategy extends BaseRegionAccessStrategy implements
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return putFromLoad( key, value, 0, version );
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return true;
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		return false;
 	}
@@ -58,4 +64,10 @@ class BaseEntityRegionAccessStrategy extends BaseRegionAccessStrategy implements
 	protected boolean isDefaultMinimalPutOverride() {
 		return region.getSettings().isMinimalPutsEnabled();
 	}
+
+	@Override
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+	}
+
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseNaturalIdRegionAccessStrategy.java
@@ -6,15 +6,23 @@
  */
 package org.hibernate.testing.cache;
 
+import java.io.Serializable;
+
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.Type;
 
 /**
  * @author Eric Dalquist
  */
-class BaseNaturalIdRegionAccessStrategy extends BaseRegionAccessStrategy implements NaturalIdRegionAccessStrategy {
+class BaseNaturalIdRegionAccessStrategy extends BaseRegionAccessStrategy<NaturalIdCacheKey> implements NaturalIdRegionAccessStrategy {
 	private final NaturalIdRegionImpl region;
 
 	@Override
@@ -33,26 +41,31 @@ class BaseNaturalIdRegionAccessStrategy extends BaseRegionAccessStrategy impleme
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return putFromLoad( key, value, 0, null );
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		return putFromLoad( key, value, 0, null );
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		return false;
 	}
 
 	BaseNaturalIdRegionAccessStrategy(NaturalIdRegionImpl region) {
 		this.region = region;
+	}
+
+	@Override
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseRegionAccessStrategy.java
@@ -7,34 +7,34 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
-
 import org.jboss.logging.Logger;
 
 /**
  * @author Strong Liu
  */
-abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
-	private static final Logger LOG = Logger.getLogger( BaseRegionAccessStrategy.class );
+abstract class BaseRegionAccessStrategy<T extends CacheKey> implements RegionAccessStrategy<T> {
 
+	private static final Logger LOG = Logger.getLogger( BaseRegionAccessStrategy.class );
 
 	protected abstract BaseGeneralDataRegion getInternalRegion();
 
 	protected abstract boolean isDefaultMinimalPutOverride();
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(T key, long txTimestamp) throws CacheException {
 		return getInternalRegion().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(T key, Object value, long txTimestamp, Object version) throws CacheException {
 		return putFromLoad( key, value, txTimestamp, version, isDefaultMinimalPutOverride() );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(T key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 
 		if ( key == null || value == null ) {
@@ -75,12 +75,12 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(T key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(T key, SoftLock lock) throws CacheException {
 	}
 
 
@@ -91,7 +91,7 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#remove(java.lang.Object)
 	 */
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(T key) throws CacheException {
 	}
 
 	/**
@@ -107,7 +107,7 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 	}
 
 	@Override
-	public void evict(Object key) throws CacheException {
+	public void evict(T key) throws CacheException {
 		getInternalRegion().evict( key );
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteCollectionRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -18,12 +19,12 @@ class NonstrictReadWriteCollectionRegionAccessStrategy extends BaseCollectionReg
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(CollectionCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteEntityRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -21,7 +22,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -29,7 +30,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Returns <code>false</code> since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -37,7 +38,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Returns <code>false</code> since this is a non-strict read/write cache access strategy
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -45,21 +46,21 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Removes the entry since this is a non-strict read/write cache strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		evict( key );
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		unlockItem( key, lock );
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(EntityCacheKey key) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteNaturalIdRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -18,27 +19,27 @@ class NonstrictReadWriteNaturalIdRegionAccessStrategy extends BaseNaturalIdRegio
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		remove( key );
 		return false;
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyEntityRegionAccessStrategy.java
@@ -7,8 +7,8 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -26,18 +26,18 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false; //wait until tx complete, see afterInsert().
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		getInternalRegion().put( key, value ); //save into cache since the tx is completed
 		return true;
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(EntityCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -47,7 +47,7 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		LOG.info( "Illegal attempt to update item cached as read-only : " + key );
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
@@ -59,7 +59,7 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		LOG.info( "Illegal attempt to update item cached as read-only : " + key );
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyNaturalIdRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -18,7 +19,7 @@ class ReadOnlyNaturalIdRegionAccessStrategy extends BaseNaturalIdRegionAccessStr
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(NaturalIdCacheKey key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteCollectionRegionAccessStrategy.java
@@ -6,15 +6,20 @@
  */
 package org.hibernate.testing.cache;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CollectionCacheKey;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
 
 /**
  * @author Strong Liu
  */
-class ReadWriteCollectionRegionAccessStrategy extends AbstractReadWriteAccessStrategy
+class ReadWriteCollectionRegionAccessStrategy extends AbstractReadWriteAccessStrategy<CollectionCacheKey>
 		implements CollectionRegionAccessStrategy {
 
 	private final CollectionRegionImpl region;
@@ -42,4 +47,10 @@ class ReadWriteCollectionRegionAccessStrategy extends AbstractReadWriteAccessStr
 	public CollectionRegion getRegion() {
 		return region;
 	}
+
+	@Override
+	public CollectionCacheKey generateCacheKey(Serializable id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+	}
+
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteEntityRegionAccessStrategy.java
@@ -6,17 +6,22 @@
  */
 package org.hibernate.testing.cache;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * @author Strong Liu
  */
-class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrategy
+class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrategy<EntityCacheKey>
 		implements EntityRegionAccessStrategy {
 	private final EntityRegionImpl region;
 
@@ -25,18 +30,18 @@ class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrateg
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(EntityCacheKey key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) throws CacheException {
 
 		try {
 			writeLock.lock();
@@ -56,7 +61,7 @@ class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrateg
 
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		try {
 			writeLock.lock();
@@ -103,4 +108,10 @@ class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrateg
 	public EntityRegion getRegion() {
 		return region;
 	}
+
+	@Override
+	public EntityCacheKey generateCacheKey(Serializable id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+	}
+
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteNaturalIdRegionAccessStrategy.java
@@ -9,14 +9,18 @@ package org.hibernate.testing.cache;
 import java.util.Comparator;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * @author Eric Dalquist
  */
-class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStrategy
+class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStrategy<NaturalIdCacheKey>
 		implements NaturalIdRegionAccessStrategy {
 
 	private final NaturalIdRegionImpl region;
@@ -26,17 +30,17 @@ class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStra
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(NaturalIdCacheKey key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(NaturalIdCacheKey key, Object value) throws CacheException {
 
 		try {
 			writeLock.lock();
@@ -56,7 +60,7 @@ class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStra
 
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(NaturalIdCacheKey key, Object value, SoftLock lock) throws CacheException {
 		try {
 			writeLock.lock();
 			Lockable item = (Lockable) region.get( key );
@@ -100,5 +104,10 @@ class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStra
 	@Override
 	public NaturalIdRegion getRegion() {
 		return region;
+	}
+
+	@Override
+	public NaturalIdCacheKey generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SessionImplementor session) {
+		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalCollectionRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CollectionCacheKey;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -17,7 +18,7 @@ class TransactionalCollectionRegionAccessStrategy extends BaseCollectionRegionAc
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(CollectionCacheKey key) throws CacheException {
 		evict( key );
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalEntityRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.EntityCacheKey;
 import org.hibernate.cache.spi.access.SoftLock;
 
 /**
@@ -18,23 +19,23 @@ class TransactionalEntityRegionAccessStrategy extends BaseEntityRegionAccessStra
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) {
+	public boolean afterInsert(EntityCacheKey key, Object value, Object version) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(EntityCacheKey key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(EntityCacheKey key) throws CacheException {
 		evict( key );
 	}
 
 	@Override
 	public boolean update(
-			Object key, Object value, Object currentVersion,
+			EntityCacheKey key, Object value, Object currentVersion,
 			Object previousVersion) throws CacheException {
 		return insert( key, value, currentVersion );
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalNaturalIdRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.NaturalIdCacheKey;
 
 /**
  * @author Eric Dalquist
@@ -17,7 +18,7 @@ class TransactionalNaturalIdRegionAccessStrategy extends BaseNaturalIdRegionAcce
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(NaturalIdCacheKey key) throws CacheException {
 		evict( key );
 	}
 


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HHH-9840

From JIRA:

I would like to allow second level cache providers the option to use custom key implementations.
The current default key implementation is very generic and is quite a large object to allocate in large quantities at runtime.

In some extreme cases, for example when the hit ratio is very low, this was making the efficiency penalty vs its benefits tradeoff questionable.

Depending on configuration settings there might be opportunities to use simpler key implementations, for example when multi-tenancy is not being used to avoid the tenant identifier, or when a cache instance is entirely dedicated to a single type to use the primary id only, skipping the role or entity name.

Even with multiple types sharing the same cache, their identifiers could be of the same org.hibernate.type.Type; in this case the cache container could use a single Type reference to implement a custom equality function without having to look up the Type on each equality check: that's a small optimisation but the equality function is invoked extremely frequently in many practical configurations.

Another reason is to make it more convenient to implement custom serialization protocols when the implementation supports clustering.

It might open the doors to more complex improvements, like HHH-9780.
