### PR TITLE
HHH-9849 Duplicate column name for mixed case column name on schema update 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -426,9 +426,8 @@ public class Table implements RelationalModel, Serializable, Exportable {
 		
 		while ( iter.hasNext() ) {
 			final Column column = (Column) iter.next();
-			final ColumnInformation columnInfo = tableInfo.getColumn( Identifier.toIdentifier( column.getName(), column.isQuoted() ) );
 
-			if ( columnInfo == null ) {
+			if ( !existsColumn( tableInfo, column ) ) {
 				// the column doesnt exist at all.
 				StringBuilder alter = new StringBuilder( root.toString() )
 						.append( ' ' )
@@ -479,6 +478,20 @@ public class Table implements RelationalModel, Serializable, Exportable {
 		}
 
 		return results.iterator();
+	}
+
+	private boolean existsColumn(TableInformation tableInfo, Column column) {
+		final Iterator<ColumnInformation> iterator = tableInfo.getColumns().iterator();
+		boolean columnExists = false;
+		while ( iterator.hasNext() ) {
+			if ( iterator.next().getColumnIdentifier().getText().toLowerCase().equals(
+					column.getName()
+							.toLowerCase()
+			) ) {
+				columnExists = true;
+			}
+		}
+		return columnExists;
 	}
 
 	public boolean hasPrimaryKey() {

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/MixedFieldPropertyAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/MixedFieldPropertyAnnotationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) {DATE}, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.schemaupdate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.CustomRunner;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-9849")
+@RunWith(CustomRunner.class)
+@RequiresDialect(MySQLDialect.class)
+public class MixedFieldPropertyAnnotationTest {
+	protected ServiceRegistry serviceRegistry;
+	protected MetadataImplementor metadata;
+
+	@Test
+	public void testUpdateSchema() throws Exception {
+
+
+		new SchemaUpdate(
+				metadata
+		).execute( true, true );
+	}
+
+	@Entity
+	@Table(name = "MyEntity")
+	class MyEntity {
+
+		@Id
+		public int getId() {
+			return 0;
+		}
+
+		@Column(name = "Ul")
+		public int getValue() {
+			return 0;
+		}
+
+		public void setId(final int _id) {
+		}
+
+		public void setValue(int value) {
+		}
+	}
+
+	@Before
+	public void setUp() {
+		serviceRegistry = new StandardServiceRegistryBuilder().applySetting(
+				Environment.GLOBALLY_QUOTED_IDENTIFIERS,
+				"false"
+		).build();
+		metadata = (MetadataImplementor) new MetadataSources( serviceRegistry )
+				.addAnnotatedClass( MyEntity.class )
+				.buildMetadata();
+
+		System.out.println( "********* Starting SchemaExport for START-UP *************************" );
+		SchemaExport schemaExport = new SchemaExport( serviceRegistry, metadata );
+		schemaExport.create( true, true );
+		System.out.println( "********* Completed SchemaExport for START-UP *************************" );
+	}
+
+	@After
+	public void tearDown() {
+		System.out.println( "********* Starting SchemaExport (drop) for TEAR-DOWN *************************" );
+		SchemaExport schemaExport = new SchemaExport( serviceRegistry, metadata );
+		schemaExport.drop( true, true );
+		System.out.println( "********* Completed SchemaExport (drop) for TEAR-DOWN *************************" );
+
+		StandardServiceRegistryBuilder.destroy( serviceRegistry );
+		serviceRegistry = null;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-9849

for mysql db and  mixed case column names
`final ColumnInformation columnInfo = tableInfo.getColumn( Identifier.toIdentifier( column.getName(), column.isQuoted() ) );`
was null because  the Identifier for the db column schema obtained through `NormalizingIdentifierHelperImpl#toIdentifierFromMetaData `
is considered quoted , while the one from the entity is not quoted. so 			
`final ColumnInformation columnInfo = tableInfo.getColumn( Identifier.toIdentifier( column.getName(), column.isQuoted() ) );`
returns null and the alter sql for the colum is generated causing the exception.

