### PR TITLE
HHH-9869 - fix the order in which SizeExpression.toString() emits size and property so that the toString of a SizeExpression is logically correct

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/SizeExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/SizeExpression.java
@@ -59,7 +59,7 @@ public class SizeExpression implements Criterion {
 
 	@Override
 	public String toString() {
-		return propertyName + ".size" + op + size;
+		return Integer.toString(size) + op + propertyName + ".size";
 	}
 
 }


### PR DESCRIPTION
This fixes https://hibernate.atlassian.net/browse/HHH-9869 by correcting the output of toString for SizeExpression