### PR TITLE
HHH-9876 Extract interface from Database and Schema classes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -44,6 +44,7 @@ import org.hibernate.boot.model.naming.ImplicitIndexNameSource;
 import org.hibernate.boot.model.naming.ImplicitUniqueKeyNameSource;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.DatabaseImpl;
 import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.boot.model.relational.Schema;
 import org.hibernate.boot.model.source.internal.ConstraintSecondPass;
@@ -206,7 +207,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 	public Database getDatabase() {
 		// important to delay this instantiation until as late as possible.
 		if ( database == null ) {
-			this.database = new Database( options );
+			this.database = new DatabaseImpl( options );
 		}
 		return database;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/Database.java
@@ -1,92 +1,24 @@
-/*
- * Hibernate, Relational Persistence for Idiomatic Java
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.hibernate.boot.model.relational;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 
-/**
- * @author Steve Ebersole
- */
-public class Database {
-	private final Dialect dialect;
-	private final MetadataBuildingOptions buildingOptions;
-	private final JdbcEnvironment jdbcEnvironment;
+public interface Database {
 
-	private Schema implicitSchema;
+	MetadataBuildingOptions getBuildingOptions();
 
-	private final Map<Schema.Name,Schema> schemaMap = new TreeMap<Schema.Name, Schema>();
+	Dialect getDialect();
 
-	private List<AuxiliaryDatabaseObject> auxiliaryDatabaseObjects;
-	private List<InitCommand> initCommands;
-
-	public Database(MetadataBuildingOptions buildingOptions) {
-		this( buildingOptions, buildingOptions.getServiceRegistry().getService( JdbcEnvironment.class ) );
-	}
-
-	public Database(MetadataBuildingOptions buildingOptions, JdbcEnvironment jdbcEnvironment) {
-		this.buildingOptions = buildingOptions;
-
-		this.jdbcEnvironment = jdbcEnvironment;
-
-		this.dialect = determineDialect( buildingOptions );
-
-		this.implicitSchema = makeSchema(
-				new Schema.Name(
-						toIdentifier( buildingOptions.getMappingDefaults().getImplicitCatalogName() ),
-						toIdentifier( buildingOptions.getMappingDefaults().getImplicitSchemaName() )
-				)
-		);
-	}
-
-	private static Dialect determineDialect(MetadataBuildingOptions buildingOptions) {
-		final Dialect dialect = buildingOptions.getServiceRegistry().getService( JdbcServices.class ).getDialect();
-		if ( dialect != null ) {
-			return dialect;
-		}
-
-		// Use H2 dialect as default
-		return new H2Dialect();
-	}
-
-	private Schema makeSchema(Schema.Name name) {
-		Schema schema;
-		schema = new Schema( this, name );
-		schemaMap.put( name, schema );
-		return schema;
-	}
-
-	public MetadataBuildingOptions getBuildingOptions() {
-		return buildingOptions;
-	}
-
-	public Dialect getDialect() {
-		return dialect;
-	}
-
-	public JdbcEnvironment getJdbcEnvironment() {
-		return jdbcEnvironment;
-	}
+	JdbcEnvironment getJdbcEnvironment();
 
 	/**
-	 * Wrap the raw name of a database object in it's Identifier form accounting for quoting from
-	 * any of:<ul>
+	 * Wrap the raw name of a database object in its Identifier form accounting for quoting from any of:
+	 * <ul>
 	 *     <li>explicit quoting in the name itself</li>
 	 *     <li>global request to quote all identifiers</li>
 	 * </ul>
@@ -97,78 +29,26 @@ public class Database {
 	 *
 	 * @return The wrapped Identifier form
 	 */
-	public Identifier toIdentifier(String text) {
-		return text == null
-				? null
-				: jdbcEnvironment.getIdentifierHelper().toIdentifier( text );
-	}
+	Identifier toIdentifier(String text);
 
-	public PhysicalNamingStrategy getPhysicalNamingStrategy() {
-		return getBuildingOptions().getPhysicalNamingStrategy();
-	}
+	PhysicalNamingStrategy getPhysicalNamingStrategy();
 
-	public Iterable<Schema> getSchemas() {
-		return schemaMap.values();
-	}
+	Iterable<Schema> getSchemas();
 
-	public Schema getDefaultSchema() {
-		return implicitSchema;
-	}
+	Schema getDefaultSchema();
 
-	public Schema locateSchema(Identifier catalogName, Identifier schemaName) {
-		if ( catalogName == null && schemaName == null ) {
-			return getDefaultSchema();
-		}
+	Schema locateSchema(Identifier catalogName, Identifier schemaName);
 
-		final Schema.Name name = new Schema.Name( catalogName, schemaName );
-		Schema schema = schemaMap.get( name );
-		if ( schema == null ) {
-			schema = makeSchema( name );
-		}
-		return schema;
-	}
+	Schema adjustDefaultSchema(Identifier catalogName, Identifier schemaName);
 
-	public Schema adjustDefaultSchema(Identifier catalogName, Identifier schemaName) {
-		final Schema.Name name = new Schema.Name( catalogName, schemaName );
-		if ( implicitSchema.getName().equals( name ) ) {
-			return implicitSchema;
-		}
+	Schema adjustDefaultSchema(String implicitCatalogName, String implicitSchemaName);
 
-		Schema schema = schemaMap.get( name );
-		if ( schema == null ) {
-			schema = makeSchema( name );
-		}
-		implicitSchema = schema;
-		return implicitSchema;
-	}
+	void addAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject);
 
-	public Schema adjustDefaultSchema(String implicitCatalogName, String implicitSchemaName) {
-		return adjustDefaultSchema( toIdentifier( implicitCatalogName ), toIdentifier( implicitSchemaName ) );
-	}
+	Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects();
 
-	public void addAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject) {
-		if ( auxiliaryDatabaseObjects == null ) {
-			auxiliaryDatabaseObjects = new ArrayList<AuxiliaryDatabaseObject>();
-		}
-		auxiliaryDatabaseObjects.add( auxiliaryDatabaseObject );
-	}
+	Collection<InitCommand> getInitCommands();
 
-	public Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects() {
-		return auxiliaryDatabaseObjects == null
-				? Collections.<AuxiliaryDatabaseObject>emptyList()
-				: auxiliaryDatabaseObjects;
-	}
+	void addInitCommand(InitCommand initCommand);
 
-	public Collection<InitCommand> getInitCommands() {
-		return initCommands == null
-				? Collections.<InitCommand>emptyList()
-				: initCommands;
-	}
-
-	public void addInitCommand(InitCommand initCommand) {
-		if ( initCommands == null ) {
-			initCommands = new ArrayList<InitCommand>();
-		}
-		initCommands.add( initCommand );
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/DatabaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/DatabaseImpl.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.boot.model.relational;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+
+/**
+ * @author Steve Ebersole
+ */
+public class DatabaseImpl implements Database {
+	private final Dialect dialect;
+	private final MetadataBuildingOptions buildingOptions;
+	private final JdbcEnvironment jdbcEnvironment;
+
+	private Schema implicitSchema;
+
+	private final Map<SchemaImpl.Name,Schema> schemaMap = new TreeMap<SchemaImpl.Name, Schema>();
+
+	private List<AuxiliaryDatabaseObject> auxiliaryDatabaseObjects;
+	private List<InitCommand> initCommands;
+
+	public DatabaseImpl(MetadataBuildingOptions buildingOptions) {
+		this( buildingOptions, buildingOptions.getServiceRegistry().getService( JdbcEnvironment.class ) );
+	}
+
+	public DatabaseImpl(MetadataBuildingOptions buildingOptions, JdbcEnvironment jdbcEnvironment) {
+		this.buildingOptions = buildingOptions;
+
+		this.jdbcEnvironment = jdbcEnvironment;
+
+		this.dialect = determineDialect( buildingOptions );
+
+		this.implicitSchema = makeSchema(
+				new SchemaImpl.Name(
+						toIdentifier( buildingOptions.getMappingDefaults().getImplicitCatalogName() ),
+						toIdentifier( buildingOptions.getMappingDefaults().getImplicitSchemaName() )
+				)
+		);
+	}
+
+	private static Dialect determineDialect(MetadataBuildingOptions buildingOptions) {
+		final Dialect dialect = buildingOptions.getServiceRegistry().getService( JdbcServices.class ).getDialect();
+		if ( dialect != null ) {
+			return dialect;
+		}
+
+		// Use H2 dialect as default
+		return new H2Dialect();
+	}
+
+	private Schema makeSchema(SchemaImpl.Name name) {
+		SchemaImpl schema;
+		schema = new SchemaImpl( this, name );
+		schemaMap.put( name, schema );
+		return schema;
+	}
+
+	@Override
+	public MetadataBuildingOptions getBuildingOptions() {
+		return buildingOptions;
+	}
+
+	@Override
+	public Dialect getDialect() {
+		return dialect;
+	}
+
+	@Override
+	public JdbcEnvironment getJdbcEnvironment() {
+		return jdbcEnvironment;
+	}
+
+	/**
+	 * Wrap the raw name of a database object in it's Identifier form accounting for quoting from
+	 * any of:<ul>
+	 *     <li>explicit quoting in the name itself</li>
+	 *     <li>global request to quote all identifiers</li>
+	 * </ul>
+	 * <p/>
+	 * NOTE : quoting from database keywords happens only when building physical identifiers
+	 *
+	 * @param text The raw object name
+	 *
+	 * @return The wrapped Identifier form
+	 */
+	@Override
+	public Identifier toIdentifier(String text) {
+		return text == null
+				? null
+				: jdbcEnvironment.getIdentifierHelper().toIdentifier( text );
+	}
+
+	@Override
+	public PhysicalNamingStrategy getPhysicalNamingStrategy() {
+		return getBuildingOptions().getPhysicalNamingStrategy();
+	}
+
+	@Override
+	public Iterable<Schema> getSchemas() {
+		return schemaMap.values();
+	}
+
+	@Override
+	public Schema getDefaultSchema() {
+		return implicitSchema;
+	}
+
+	@Override
+	public Schema locateSchema(Identifier catalogName, Identifier schemaName) {
+		if ( catalogName == null && schemaName == null ) {
+			return getDefaultSchema();
+		}
+
+		final SchemaImpl.Name name = new SchemaImpl.Name( catalogName, schemaName );
+		Schema schema = schemaMap.get( name );
+		if ( schema == null ) {
+			schema = makeSchema( name );
+		}
+		return schema;
+	}
+
+	@Override
+	public Schema adjustDefaultSchema(Identifier catalogName, Identifier schemaName) {
+		final SchemaImpl.Name name = new SchemaImpl.Name( catalogName, schemaName );
+		if ( implicitSchema.getName().equals( name ) ) {
+			return implicitSchema;
+		}
+
+		Schema schema = schemaMap.get( name );
+		if ( schema == null ) {
+			schema = makeSchema( name );
+		}
+		implicitSchema = schema;
+		return implicitSchema;
+	}
+
+	@Override
+	public Schema adjustDefaultSchema(String implicitCatalogName, String implicitSchemaName) {
+		return adjustDefaultSchema( toIdentifier( implicitCatalogName ), toIdentifier( implicitSchemaName ) );
+	}
+
+	@Override
+	public void addAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject) {
+		if ( auxiliaryDatabaseObjects == null ) {
+			auxiliaryDatabaseObjects = new ArrayList<AuxiliaryDatabaseObject>();
+		}
+		auxiliaryDatabaseObjects.add( auxiliaryDatabaseObject );
+	}
+
+	@Override
+	public Collection<AuxiliaryDatabaseObject> getAuxiliaryDatabaseObjects() {
+		return auxiliaryDatabaseObjects == null
+				? Collections.<AuxiliaryDatabaseObject>emptyList()
+				: auxiliaryDatabaseObjects;
+	}
+
+	@Override
+	public Collection<InitCommand> getInitCommands() {
+		return initCommands == null
+				? Collections.<InitCommand>emptyList()
+				: initCommands;
+	}
+
+	@Override
+	public void addInitCommand(InitCommand initCommand) {
+		if ( initCommands == null ) {
+			initCommands = new ArrayList<InitCommand>();
+		}
+		initCommands.add( initCommand );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SchemaImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SchemaImpl.java
@@ -1,0 +1,161 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.boot.model.relational;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hibernate.HibernateException;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.compare.EqualsHelper;
+import org.hibernate.mapping.DenormalizedTable;
+import org.hibernate.mapping.Table;
+import org.hibernate.mapping.Table;
+
+/**
+ * @author Steve Ebersole
+ */
+public class SchemaImpl implements Schema {
+	private static final CoreMessageLogger log = CoreLogging.messageLogger( SchemaImpl.class );
+
+	private final Database database;
+	private final Name name;
+
+	private final Name physicalName;
+
+	private Map<Identifier, Table> tables = new TreeMap<Identifier, Table>();
+	private Map<Identifier, Sequence> sequences = new TreeMap<Identifier, Sequence>();
+
+	public SchemaImpl(Database database, Name name) {
+		this.database = database;
+		this.name = name;
+
+		final Identifier physicalCatalogIdentifier = database.getPhysicalNamingStrategy()
+				.toPhysicalCatalogName( name.getCatalog(), database.getJdbcEnvironment() );
+		final Identifier physicalSchemaIdentifier = database.getPhysicalNamingStrategy()
+				.toPhysicalCatalogName( name.getSchema(), database.getJdbcEnvironment() );
+		this.physicalName = new Name( physicalCatalogIdentifier, physicalSchemaIdentifier );
+	}
+
+	@Override
+	public Name getName() {
+		return name;
+	}
+
+	@Override
+	public Name getPhysicalName() {
+		return physicalName;
+	}
+
+	@Override
+	public Collection<Table> getTables() {
+		return tables.values();
+	}
+
+	/**
+	 * Returns the table with the specified logical table name.
+	 *
+	 * @param logicalTableName - the logical name of the table
+	 *
+	 * @return the table with the specified table name,
+	 *         or null if there is no table with the specified
+	 *         table name.
+	 */
+	@Override
+	public Table locateTable(Identifier logicalTableName) {
+		return tables.get( logicalTableName );
+	}
+
+	/**
+	 * Creates a mapping Table instance.
+	 *
+	 * @param logicalTableName The logical table name
+	 *
+	 * @return the created table.
+	 */
+	@Override
+	public Table createTable(Identifier logicalTableName, boolean isAbstract) {
+		final Table existing = tables.get( logicalTableName );
+		if ( existing != null ) {
+			return existing;
+		}
+
+		final Identifier physicalTableName = database.getPhysicalNamingStrategy().toPhysicalTableName( logicalTableName, database.getJdbcEnvironment() );
+		Table table = new Table( this, physicalTableName, isAbstract );
+		tables.put( logicalTableName, table );
+		return table;
+	}
+
+	@Override
+	public DenormalizedTable createDenormalizedTable(Identifier logicalTableName, boolean isAbstract, Table includedTable) {
+		final Table existing = tables.get( logicalTableName );
+		if ( existing != null ) {
+			// for now assume it is
+			return (DenormalizedTable) existing;
+		}
+
+		final Identifier physicalTableName = database.getPhysicalNamingStrategy().toPhysicalTableName( logicalTableName, database.getJdbcEnvironment() );
+		DenormalizedTable table = new DenormalizedTable( this, physicalTableName, isAbstract, includedTable );
+		tables.put( logicalTableName, table );
+		return table;
+	}
+
+	@Override
+	public Sequence locateSequence(Identifier name) {
+		return sequences.get( name );
+	}
+
+	@Override
+	public Sequence createSequence(Identifier logicalName, int initialValue, int increment) {
+		if ( sequences.containsKey( logicalName ) ) {
+			throw new HibernateException( "Sequence was already registered with that name [" + logicalName.toString() + "]" );
+		}
+
+		final Identifier physicalName = database.getPhysicalNamingStrategy().toPhysicalSequenceName( logicalName, database.getJdbcEnvironment() );
+
+		Sequence sequence = new Sequence(
+				this.physicalName.getCatalog(),
+				this.physicalName.getSchema(),
+				physicalName,
+				initialValue,
+				increment
+		);
+		sequences.put( logicalName, sequence );
+		return sequence;
+	}
+
+	@Override
+	public String toString() {
+		return "Schema" + "{name=" + name + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+
+		final SchemaImpl that = (SchemaImpl) o;
+		return EqualsHelper.equals( this.name, that.name );
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public Iterable<Sequence> getSequences() {
+		return sequences.values();
+	}
+}


### PR DESCRIPTION
This allows for the creation of wrapper classes.

For example, in my case I need to be able to filter the tables that are used for schema operations: I only want to run create and drop operations for tables that start with a specific prefix. I implemented this by creating a FilteredMetadata, FilteredDatabase and FilteredSchema that delegate all calls to the regular implementation, except that Schema.getTables() only returns the tables that satisfy the filter.

See https://hibernate.atlassian.net/browse/HHH-9876