### PR TITLE
HHH-7412 AFTER_TRANSACTION instead of ON_CLOSE for JDBC

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorBuilderImpl.java
@@ -45,7 +45,7 @@ public class JdbcResourceLocalTransactionCoordinatorBuilderImpl implements Trans
 
 	@Override
 	public ConnectionReleaseMode getDefaultConnectionReleaseMode() {
-		return ConnectionReleaseMode.ON_CLOSE;
+		return ConnectionReleaseMode.AFTER_TRANSACTION;
 	}
 
 	@Override


### PR DESCRIPTION
Either this pull request should be merged or the documentation needs to be updated.
See http://docs.jboss.org/hibernate/orm/5.0/manual/en-US/html_single/#transactions-connection-release:

> The configuration parameter hibernate.connection.release_mode is used to specify which release mode to use. The possible values are as follows:

> auto (the default): this choice delegates to the release mode returned by the org.hibernate.transaction.TransactionFactory.getDefaultReleaseMode() method. For JTATransactionFactory, this returns ConnectionReleaseMode.AFTER_STATEMENT; **for JDBCTransactionFactory, this returns ConnectionReleaseMode.AFTER_TRANSACTION**. Do not change this default behavior as failures due to the value of this setting tend to indicate bugs and/or invalid assumptions in user code.