### PR TITLE
HHH-9915 - test fail on Oracle (long identifier name)

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/indexcoll/ExchangeOffice.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/indexcoll/ExchangeOffice.java
@@ -10,6 +10,7 @@ package org.hibernate.test.annotations.indexcoll;
 import java.math.BigDecimal;
 import java.util.Map;
 
+import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -46,6 +47,7 @@ public class ExchangeOffice {
 	}
 
 	@ElementCollection
+	@CollectionTable(name = "ExchangeO_exchangeRateFees")
 	private Map<ExchangeRateKey, BigDecimal> exchangeRateFees = new java.util.HashMap<ExchangeRateKey, BigDecimal>();
 
 	public Map<ExchangeRateKey,BigDecimal> getExchangeRateFees() {


### PR DESCRIPTION
Oracle DB has max size of table name 30 chars
https://hibernate.atlassian.net/browse/HHH-9915