### PR TITLE
HHH-9244 Using collection owner name in exception message

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.CollectionTable;
@@ -97,7 +98,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
-
 import org.jboss.logging.Logger;
 
 import static org.hibernate.cfg.BinderHelper.toAliasEntityMap;
@@ -156,7 +156,7 @@ public abstract class CollectionBinder {
 	private SortComparator comparatorSort;
 
 	private String explicitType;
-	private Properties explicitTypeParameters = new Properties();
+	private final Properties explicitTypeParameters = new Properties();
 
 	protected MetadataBuildingContext getBuildingContext() {
 		return buildingContext;
@@ -912,8 +912,8 @@ public abstract class CollectionBinder {
 		FilterJoinTable simpleFilterJoinTable = property.getAnnotation( FilterJoinTable.class );
 		if ( simpleFilterJoinTable != null ) {
 			if ( hasAssociationTable ) {
-				collection.addFilter(simpleFilterJoinTable.name(), simpleFilterJoinTable.condition(), 
-						simpleFilterJoinTable.deduceAliasInjectionPoints(), 
+				collection.addFilter(simpleFilterJoinTable.name(), simpleFilterJoinTable.condition(),
+						simpleFilterJoinTable.deduceAliasInjectionPoints(),
 						toAliasTableMap(simpleFilterJoinTable.aliases()), toAliasEntityMap(simpleFilterJoinTable.aliases()));
 					}
 			else {
@@ -927,8 +927,8 @@ public abstract class CollectionBinder {
 		if ( filterJoinTables != null ) {
 			for (FilterJoinTable filter : filterJoinTables.value()) {
 				if ( hasAssociationTable ) {
-					collection.addFilter(filter.name(), filter.condition(), 
-							filter.deduceAliasInjectionPoints(), 
+					collection.addFilter(filter.name(), filter.condition(),
+							filter.deduceAliasInjectionPoints(),
 							toAliasTableMap(filter.aliases()), toAliasEntityMap(filter.aliases()));
 				}
 				else {
@@ -974,14 +974,14 @@ public abstract class CollectionBinder {
 //				);
 //		}
 	}
-	
+
 	private String getCondition(FilterJoinTable filter) {
 		//set filtering
 		String name = filter.name();
 		String cond = filter.condition();
 		return getCondition( cond, name );
 	}
-	
+
 	private String getCondition(Filter filter) {
 		//set filtering
 		String name = filter.name();
@@ -1520,7 +1520,7 @@ public abstract class CollectionBinder {
 			);
 		}
 		catch (AnnotationException ex) {
-			throw new AnnotationException( "Unable to map collection " + collectionEntity.getClassName() + "." + property.getName(), ex );
+			throw new AnnotationException( "Unable to map collection " + collValue.getOwner().getClassName() + "." + property.getName(), ex );
 		}
 		SimpleValue key = buildCollectionKey( collValue, joinColumns, cascadeDeleteEnabled, property, buildingContext );
 		if ( property.isAnnotationPresent( ElementCollection.class ) && joinColumns.length > 0 ) {


### PR DESCRIPTION
@sebersole, @dreab8: Also came across this NPE reported in [HHH-9244](https://hibernate.atlassian.net/browse/HHH-9244) in the course of updating OGM to the latest ORM CR. I believe the owner entity type should be used in that exception, which fixes the NPE.

I am not sure though why null is passed for `collectionEntity` in the one-to-many case and whether that's actually correct. Maybe it should be `associatedClass` instead of null?