### PR TITLE
Update configuration.xml

### DIFF
--- a/documentation/src/main/docbook/manual/en-US/content/configuration.xml
+++ b/documentation/src/main/docbook/manual/en-US/content/configuration.xml
@@ -197,7 +197,8 @@
     Hibernate in the <filename>lib</filename> directory. Hibernate will use
     its <classname>org.hibernate.connection.C3P0ConnectionProvider</classname>
     for connection pooling if you set <property>hibernate.c3p0.*</property>
-    properties. If you would like to use Proxool, refer to the packaged
+    properties and add the appropriate hibernate-c3p0 dependency or JAR file
+    to your project. If you would like to use Proxool, refer to the packaged
     <filename>hibernate.properties</filename> and the Hibernate web site for
     more information.</para>
 


### PR DESCRIPTION
Specified that you have to add the hibernate.c3p0 dependency to your project because this is required and adding c3p0 alone (not the hibernate-wrapped distribution) didn't work for me.  Having this spelled out would have saved me an embarrassing amount of time.  I am happy to create a JIRA issue, but I don't have an account and didn't know if it was necessary to change one sentence of the documentation.