### PR TITLE
HHH-7898 Regression on org.hibernate.cache.infinispan.query.QueryResu…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -83,7 +83,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			final SoftLock lock = cache.lockItem( ck, null );
+			final SoftLock lock = cache.lockItem( session, ck, null );
 			// the old behavior used key as opposed to getKey()
 			afterTransactionProcess = new CacheCleanupProcess( key, persister, lock );
 		}
@@ -136,7 +136,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.remove( ck );
+			cache.remove( session, ck);
 		}
 	}
 
@@ -180,7 +180,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.unlockItem( ck, lock );
+			cache.unlockItem( session, ck, lock );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -88,7 +88,7 @@ public class EntityDeleteAction extends EntityAction {
 		if ( persister.hasCache() ) {
 			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
 			ck = cache.generateCacheKey( id, persister, session.getFactory(), session.getTenantIdentifier() );
-			lock = cache.lockItem( ck, version );
+			lock = cache.lockItem( session, ck, version );
 		}
 		else {
 			ck = null;
@@ -113,7 +113,7 @@ public class EntityDeleteAction extends EntityAction {
 		persistenceContext.removeProxy( entry.getEntityKey() );
 		
 		if ( persister.hasCache() ) {
-			persister.getCacheAccessStrategy().remove( ck );
+			persister.getCacheAccessStrategy().remove( session, ck);
 		}
 
 		persistenceContext.getNaturalIdHelper().removeSharedNaturalIdCrossReference( persister, id, naturalIdValues );
@@ -194,7 +194,7 @@ public class EntityDeleteAction extends EntityAction {
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.unlockItem( ck, lock );
+			cache.unlockItem( session, ck, lock );
 		}
 		postCommitDelete( success );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -138,12 +138,13 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 	}
 
 	private boolean cacheInsert(EntityPersister persister, Object ck) {
+		SessionImplementor session = getSession();
 		try {
-			getSession().getEventListenerManager().cachePutStart();
-			return persister.getCacheAccessStrategy().insert( ck, cacheEntry, version );
+			session.getEventListenerManager().cachePutStart();
+			return persister.getCacheAccessStrategy().insert( session, ck, cacheEntry, version);
 		}
 		finally {
-			getSession().getEventListenerManager().cachePutEnd();
+			session.getEventListenerManager().cachePutEnd();
 		}
 	}
 
@@ -224,10 +225,11 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 	}
 
 	private boolean cacheAfterInsert(EntityRegionAccessStrategy cache, Object ck) {
-		final SessionEventListenerManager eventListenerManager = getSession().getEventListenerManager();
+		SessionImplementor session = getSession();
+		final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 		try {
 			eventListenerManager.cachePutStart();
-			return cache.afterInsert( ck, cacheEntry, version );
+			return cache.afterInsert( session, ck, cacheEntry, version );
 		}
 		finally {
 			eventListenerManager.cachePutEnd();

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
@@ -132,7 +132,7 @@ public class StandardQueryCache implements QueryCache {
 
 		try {
 			session.getEventListenerManager().cachePutStart();
-			cacheRegion.put( key, cacheable );
+			cacheRegion.put( session, key, cacheable );
 		}
 		finally {
 			session.getEventListenerManager().cachePutEnd();
@@ -221,7 +221,7 @@ public class StandardQueryCache implements QueryCache {
 		List cacheable = null;
 		try {
 			session.getEventListenerManager().cacheGetStart();
-			cacheable = (List) cacheRegion.get( key );
+			cacheable = (List) cacheRegion.get( session, key );
 		}
 		finally {
 			session.getEventListenerManager().cacheGetEnd( cacheable != null );

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/GeneralDataRegion.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/GeneralDataRegion.java
@@ -7,6 +7,7 @@
 package org.hibernate.cache.spi;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Contract for general-purpose cache regions.
@@ -18,20 +19,24 @@ public interface GeneralDataRegion extends Region {
 	/**
 	 * Get an item from the cache.
 	 *
+	 *
+	 * @param session
 	 * @param key The key of the item to be retrieved.
 	 * @return the cached object or <tt>null</tt>
 	 * @throws org.hibernate.cache.CacheException Indicates a problem accessing the item or region.
 	 */
-	public Object get(Object key) throws CacheException;
+	public Object get(SessionImplementor session, Object key) throws CacheException;
 
 	/**
 	 * Put an item into the cache.
 	 *
+	 *
+	 * @param session
 	 * @param key The key under which to cache the item.
 	 * @param value The item to cache.
 	 * @throws CacheException Indicates a problem accessing the region.
 	 */
-	public void put(Object key, Object value) throws CacheException;
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException;
 
 	/**
 	 * Evict an item from the cache immediately (without regard for transaction

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
@@ -92,7 +92,7 @@ public class UpdateTimestampsCache {
 
 				//put() has nowait semantics, is this really appropriate?
 				//note that it needs to be async replication, never local or sync
-				region.put( space, ts );
+				region.put( session, space, ts );
 			}
 			finally {
 				session.getEventListenerManager().cachePutEnd();
@@ -128,7 +128,7 @@ public class UpdateTimestampsCache {
 
 				//put() has nowait semantics, is this really appropriate?
 				//note that it needs to be async replication, never local or sync
-				region.put( space, ts );
+				region.put( session, space, ts );
 			}
 			finally {
 				session.getEventListenerManager().cachePutEnd();
@@ -189,7 +189,7 @@ public class UpdateTimestampsCache {
 		Long ts = null;
 		try {
 			session.getEventListenerManager().cacheGetStart();
-			ts = (Long) region.get( space );
+			ts = (Long) region.get( session, space );
 		}
 		finally {
 			session.getEventListenerManager().cacheGetEnd( ts != null );

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityRegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.cache.spi.access;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -60,32 +61,36 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy {
 	 * instead of calling evict().
 	 * This method is used by "synchronous" concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @param version The item's version value
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean insert(Object key, Object value, Object version) throws CacheException;
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException;
 
 	/**
 	 * Called after an item has been inserted (after the transaction completes),
 	 * instead of calling release().
 	 * This method is used by "asynchronous" concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @param version The item's version value
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException;
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (before the transaction completes),
 	 * instead of calling evict(). This method is used by "synchronous" concurrency
 	 * strategies.
 	 *
+	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @param currentVersion The item's current version value
@@ -93,13 +98,14 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException;
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (after the transaction completes),
 	 * instead of calling release().  This method is used by "asynchronous"
 	 * concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @param currentVersion The item's current version value
@@ -108,5 +114,5 @@ public interface EntityRegionAccessStrategy extends RegionAccessStrategy {
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) throws CacheException;
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) throws CacheException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdRegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdRegionAccessStrategy.java
@@ -27,9 +27,9 @@ import org.hibernate.persister.entity.EntityPersister;
  * {@link #lockRegion} -> {@link #removeAll} -> {@link #unlockRegion}
  * <p/>
  * IMPORTANT : NaturalIds are not versioned so {@code null} will always be passed to the version parameter to:<ul>
- *     <li>{@link #putFromLoad(Object, Object, long, Object)}</li>
- *     <li>{@link #putFromLoad(Object, Object, long, Object, boolean)}</li>
- *     <li>{@link #lockItem(Object, Object)}</li>
+ *     <li>{@link RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object)}</li>
+ *     <li>{@link RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object, boolean)}</li>
+ *     <li>{@link RegionAccessStrategy#lockItem(SessionImplementor, Object, Object)}</li>
  * </ul>
  *
  * @author Gavin King
@@ -68,47 +68,51 @@ public interface NaturalIdRegionAccessStrategy extends RegionAccessStrategy {
 	 * instead of calling evict().
 	 * This method is used by "synchronous" concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean insert(Object key, Object value) throws CacheException;
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been inserted (after the transaction completes),
 	 * instead of calling release().
 	 * This method is used by "asynchronous" concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterInsert(Object key, Object value) throws CacheException;
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (before the transaction completes),
 	 * instead of calling evict(). This method is used by "synchronous" concurrency
 	 * strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean update(Object key, Object value) throws CacheException;
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException;
 
 	/**
 	 * Called after an item has been updated (after the transaction completes),
 	 * instead of calling release().  This method is used by "asynchronous"
 	 * concurrency strategies.
 	 *
+	 * @param session Current session
 	 * @param key The item key
 	 * @param value The item
 	 * @param lock The lock previously obtained from {@link #lockItem}
 	 * @return Were the contents of the cache actual changed by this operation?
 	 * @throws CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException;
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/RegionAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/RegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.cache.spi.access;
 
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Base access strategy for all regions.
@@ -20,16 +21,18 @@ public interface RegionAccessStrategy {
 	 * Attempt to retrieve an object from the cache. Mainly used in attempting
 	 * to resolve entities/collections from the second level cache.
 	 *
+	 * @param session Current session.
 	 * @param key The key of the item to be retrieved.
 	 * @param txTimestamp a timestamp prior to the transaction start time
 	 * @return the cached object or <tt>null</tt>
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	Object get(Object key, long txTimestamp) throws CacheException;
+	Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException;
 
 	/**
 	 * Attempt to cache an object, after loading from the database.
 	 *
+	 * @param session Current session.
 	 * @param key The item key
 	 * @param value The item
 	 * @param txTimestamp a timestamp prior to the transaction start time
@@ -38,6 +41,7 @@ public interface RegionAccessStrategy {
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
 	boolean putFromLoad(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			long txTimestamp,
@@ -47,6 +51,7 @@ public interface RegionAccessStrategy {
 	 * Attempt to cache an object, after loading from the database, explicitly
 	 * specifying the minimalPut behavior.
 	 *
+	 * @param session Current session.
 	 * @param key The item key
 	 * @param value The item
 	 * @param txTimestamp a timestamp prior to the transaction start time
@@ -56,6 +61,7 @@ public interface RegionAccessStrategy {
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
 	boolean putFromLoad(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			long txTimestamp,
@@ -70,12 +76,13 @@ public interface RegionAccessStrategy {
 	 * lock. Concurrency strategies which do not support client-visible
 	 * locks may silently return null.
 	 *
+	 * @param session Current session.
 	 * @param key The key of the item to lock
 	 * @param version The item's current version value
 	 * @return A representation of our lock on the item; or null.
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	SoftLock lockItem(Object key, Object version) throws CacheException;
+	SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException;
 
 	/**
 	 * Lock the entire region
@@ -90,11 +97,12 @@ public interface RegionAccessStrategy {
 	 * may not have been successful), after transaction completion.  This method
 	 * is used by "asynchronous" concurrency strategies.
 	 *
+	 * @param session Current session.
 	 * @param key The item key
 	 * @param lock The lock previously obtained from {@link #lockItem}
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void unlockItem(Object key, SoftLock lock) throws CacheException;
+	void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException;
 
 	/**
 	 * Called after we have finished the attempted invalidation of the entire
@@ -109,10 +117,11 @@ public interface RegionAccessStrategy {
 	 * Called after an item has become stale (before the transaction completes).
 	 * This method is used by "synchronous" concurrency strategies.
 	 *
+	 * @param session
 	 * @param key The key of the item to remove
 	 * @throws org.hibernate.cache.CacheException Propogated from underlying {@link org.hibernate.cache.spi.Region}
 	 */
-	void remove(Object key) throws CacheException;
+	void remove(SessionImplementor session, Object key) throws CacheException;
 
 	/**
 	 * Called to evict data from the entire region

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/CacheHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/CacheHelper.java
@@ -29,7 +29,7 @@ public final class CacheHelper {
 		Serializable cachedValue = null;
 		eventListenerManager.cacheGetStart();
 		try {
-			cachedValue = (Serializable) cacheAccessStrategy.get( cacheKey, session.getTimestamp() );
+			cachedValue = (Serializable) cacheAccessStrategy.get( session, cacheKey, session.getTimestamp() );
 		}
 		finally {
 			eventListenerManager.cacheGetEnd( cachedValue != null );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -194,6 +194,7 @@ public final class TwoPhaseLoad {
 			// we need to be careful not to clobber the lock here in the cache so that it can be rolled back if need be
 			if ( session.getPersistenceContext().wasInsertedDuringTransaction( persister, id ) ) {
 				cache.update(
+						session,
 						cacheKey,
 						persister.getCacheEntryStructure().structure( entry ),
 						version,
@@ -205,6 +206,7 @@ public final class TwoPhaseLoad {
 				try {
 					eventListenerManager.cachePutStart();
 					final boolean put = cache.putFromLoad(
+							session,
 							cacheKey,
 							persister.getCacheEntryStructure().structure( entry ),
 							session.getTimestamp(),

--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -354,6 +354,7 @@ public class CollectionLoadContext {
 			try {
 				session.getEventListenerManager().cachePutStart();
 				final boolean put = cache.putFromLoad(
+						session,
 						cacheKey,
 						persister.getCacheEntryStructure().structure( entry ),
 						session.getTimestamp(),

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
@@ -68,7 +68,7 @@ public abstract class AbstractLockUpgradeEventListener extends AbstractReassocia
 				if ( cachingEnabled ) {
 					EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
 					ck = cache.generateCacheKey( entry.getId(), persister, source.getFactory(), source.getTenantIdentifier() );
-					lock = cache.lockItem( ck, entry.getVersion() );
+					lock = cache.lockItem( source, ck, entry.getVersion() );
 				}
 
 				if ( persister.isVersioned() && requestedLockMode == LockMode.FORCE  ) {
@@ -87,7 +87,7 @@ public abstract class AbstractLockUpgradeEventListener extends AbstractReassocia
 				// the database now holds a lock + the object is flushed from the cache,
 				// so release the soft lock
 				if ( cachingEnabled ) {
-					persister.getCacheAccessStrategy().unlockItem( ck, lock );
+					persister.getCacheAccessStrategy().unlockItem( source, ck, lock );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -366,7 +366,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 					source.getFactory(),
 					source.getTenantIdentifier()
 			);
-			lock = persister.getCacheAccessStrategy().lockItem( ck, null );
+			lock = persister.getCacheAccessStrategy().lockItem( source, ck, null );
 		}
 		else {
 			ck = null;
@@ -378,7 +378,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 		}
 		finally {
 			if ( persister.hasCache() ) {
-				cache.unlockItem( ck, lock );
+				cache.unlockItem( source, ck, lock );
 			}
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/DynamicFilterTest.java
@@ -107,7 +107,7 @@ public class DynamicFilterTest extends BaseNonConfigCoreFunctionalTestCase {
 				sessionFactory(),
 				session.getTenantIdentifier()
 		);
-		CollectionCacheEntry cachedData = ( CollectionCacheEntry ) cache.get( cacheKey, ts );
+		CollectionCacheEntry cachedData = ( CollectionCacheEntry ) cache.get( ( SessionImplementor ) session, cacheKey, ts );
 		assertNotNull( "collection was not in cache", cachedData );
 
 		session.close();
@@ -126,7 +126,7 @@ public class DynamicFilterTest extends BaseNonConfigCoreFunctionalTestCase {
 				sessionFactory(),
 				session.getTenantIdentifier()
 		);
-		CollectionCacheEntry cachedData2 = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( cacheKey2, ts );
+		CollectionCacheEntry cachedData2 = ( CollectionCacheEntry ) persister.getCacheAccessStrategy().get( ( SessionImplementor ) session, cacheKey2, ts );
 		assertNotNull( "collection no longer in cache!", cachedData2 );
 		assertSame( "Different cache values!", cachedData, cachedData2 );
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
@@ -13,6 +13,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -65,9 +66,9 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
-			return actualStrategy.get( key, txTimestamp );
+			return actualStrategy.get( session, key, txTimestamp );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -76,9 +77,9 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		try {
-			return actualStrategy.lockItem( key, version );
+			return actualStrategy.lockItem( session, key, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -98,10 +99,10 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -110,9 +111,9 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -121,9 +122,9 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
-			actualStrategy.remove( key );
+			actualStrategy.remove( session, key);
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -141,9 +142,9 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		try {
-			actualStrategy.unlockItem( key, lock );
+			actualStrategy.unlockItem( session, key, lock );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
@@ -13,6 +13,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -45,9 +46,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		try {
-			return actualStrategy.afterInsert( key, value, version );
+			return actualStrategy.afterInsert( session, key, value, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -56,10 +57,10 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		try {
-			return actualStrategy.afterUpdate( key, value, currentVersion, previousVersion, lock );
+			return actualStrategy.afterUpdate( session, key, value, currentVersion, previousVersion, lock );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -88,9 +89,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
-			return actualStrategy.get( key, txTimestamp );
+			return actualStrategy.get( session, key, txTimestamp );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -99,9 +100,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		try {
-			return actualStrategy.insert( key, value, version );
+			return actualStrategy.insert( session, key, value, version);
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -110,9 +111,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		try {
-			return actualStrategy.lockItem( key, version );
+			return actualStrategy.lockItem( session, key, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -132,10 +133,10 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -144,9 +145,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -155,9 +156,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
-			actualStrategy.remove( key );
+			actualStrategy.remove( session, key);
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -175,9 +176,9 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		try {
-			actualStrategy.unlockItem( key, lock );
+			actualStrategy.unlockItem( session, key, lock );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -195,10 +196,10 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		try {
-			return actualStrategy.update( key, value, currentVersion, previousVersion );
+			return actualStrategy.update( session, key, value, currentVersion, previousVersion );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
@@ -40,9 +40,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		try {
-			return actualStrategy.insert( key, value );
+			return actualStrategy.insert( session, key, value );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -51,9 +51,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		try {
-			return actualStrategy.afterInsert( key, value );
+			return actualStrategy.afterInsert( session, key, value );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -62,9 +62,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		try {
-			return actualStrategy.update( key, value );
+			return actualStrategy.update( session, key, value );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -73,9 +73,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		try {
-			return actualStrategy.afterUpdate( key, value, lock );
+			return actualStrategy.afterUpdate( session, key, value, lock);
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -109,9 +109,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
-			return actualStrategy.get( key, txTimestamp );
+			return actualStrategy.get( session, key, txTimestamp );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -120,9 +120,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		try {
-			return actualStrategy.lockItem( key, version );
+			return actualStrategy.lockItem( session, key, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -142,10 +142,10 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version, minimalPutOverride );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -154,9 +154,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		try {
-			return actualStrategy.putFromLoad( key, value, txTimestamp, version );
+			return actualStrategy.putFromLoad( session, key, value, txTimestamp, version );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -165,9 +165,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
-			actualStrategy.remove( key );
+			actualStrategy.remove( session, key );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );
@@ -185,9 +185,9 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		try {
-			actualStrategy.unlockItem( key, lock );
+			actualStrategy.unlockItem( session, key, lock );
 		}
 		catch (NonStopCacheException nonStopCacheException) {
 			hibernateNonstopExceptionHandler.handleNonstopCacheException( nonStopCacheException );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/regions/EhcacheGeneralDataRegion.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/regions/EhcacheGeneralDataRegion.java
@@ -18,6 +18,7 @@ import org.hibernate.cache.ehcache.internal.nonstop.HibernateNonstopCacheExcepti
 import org.hibernate.cache.ehcache.internal.strategy.EhcacheAccessStrategyFactory;
 import org.hibernate.cache.spi.GeneralDataRegion;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.jboss.logging.Logger;
 
 /**
@@ -52,7 +53,7 @@ abstract class EhcacheGeneralDataRegion extends EhcacheDataRegion implements Gen
 	}
 
 	@Override
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		try {
 			LOG.debugf( "key: %s", key );
 			if ( key == null ) {
@@ -82,7 +83,7 @@ abstract class EhcacheGeneralDataRegion extends EhcacheDataRegion implements Gen
 	}
 
 	@Override
-	public void put(Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		LOG.debugf( "key: %s value: %s", key, value );
 		try {
 			final Element element = new Element( key, value );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractEhcacheAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractEhcacheAccessStrategy.java
@@ -9,7 +9,9 @@ package org.hibernate.cache.ehcache.internal.strategy;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheTransactionalDataRegion;
+import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * Ultimate superclass for all Ehcache specific Hibernate AccessStrategy implementations.
@@ -52,21 +54,21 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	 * This method is a placeholder for method signatures supplied by interfaces pulled in further down the class
 	 * hierarchy.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object)
 	 */
-	public final boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
-		return putFromLoad( key, value, txTimestamp, version, settings.isMinimalPutsEnabled() );
+	public final boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
+		return putFromLoad( session, key, value, txTimestamp, version, settings.isMinimalPutsEnabled() );
 	}
 
 	/**
 	 * This method is a placeholder for method signatures supplied by interfaces pulled in further down the class
 	 * hierarchy.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object, boolean)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object, boolean)
 	 */
-	public abstract boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public abstract boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException;
 
 	/**
@@ -96,10 +98,10 @@ abstract class AbstractEhcacheAccessStrategy<T extends EhcacheTransactionalDataR
 	/**
 	 * A no-op since this is an asynchronous cache access strategy.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#remove(java.lang.Object)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#remove(java.lang.Object)
+	 * @see RegionAccessStrategy#remove(SessionImplementor, Object)
+	 * @see RegionAccessStrategy#remove(SessionImplementor, Object)
 	 */
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 	}
 
 	/**

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractReadWriteEhcacheAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/AbstractReadWriteEhcacheAccessStrategy.java
@@ -15,7 +15,9 @@ import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.ehcache.EhCacheMessageLogger;
 import org.hibernate.cache.ehcache.internal.regions.EhcacheTransactionalDataRegion;
+import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.jboss.logging.Logger;
 
 /**
@@ -51,10 +53,10 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T extends EhcacheTransacti
 	 * Returns <code>null</code> if the item is not readable.  Locked items are not readable, nor are items created
 	 * after the start of this transaction.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#get(java.lang.Object, long)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#get(java.lang.Object, long)
+	 * @see RegionAccessStrategy#get(SessionImplementor, Object, long)
+	 * @see RegionAccessStrategy#get(SessionImplementor, Object, long)
 	 */
-	public final Object get(Object key, long txTimestamp) throws CacheException {
+	public final Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		readLockIfNeeded( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -76,11 +78,12 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T extends EhcacheTransacti
 	 * Returns <code>false</code> and fails to put the value if there is an existing un-writeable item mapped to this
 	 * key.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#putFromLoad(java.lang.Object, java.lang.Object, long, java.lang.Object, boolean)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object, boolean)
+	 * @see RegionAccessStrategy#putFromLoad(SessionImplementor, Object, Object, long, Object, boolean)
 	 */
 	@Override
 	public final boolean putFromLoad(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			long txTimestamp,
@@ -107,10 +110,10 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T extends EhcacheTransacti
 	/**
 	 * Soft-lock a cache item.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#lockItem(java.lang.Object, java.lang.Object)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#lockItem(java.lang.Object, java.lang.Object)
+	 * @see RegionAccessStrategy#lockItem(SessionImplementor, Object, Object)
+	 * @see RegionAccessStrategy#lockItem(SessionImplementor, Object, Object)
 	 */
-	public final SoftLock lockItem(Object key, Object version) throws CacheException {
+	public final SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -131,10 +134,10 @@ abstract class AbstractReadWriteEhcacheAccessStrategy<T extends EhcacheTransacti
 	/**
 	 * Soft-unlock a cache item.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#unlockItem(java.lang.Object, org.hibernate.cache.spi.access.SoftLock)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#unlockItem(java.lang.Object, org.hibernate.cache.spi.access.SoftLock)
+	 * @see RegionAccessStrategy#unlockItem(SessionImplementor, Object, SoftLock)
+	 * @see RegionAccessStrategy#unlockItem(SessionImplementor, Object, SoftLock)
 	 */
-	public final void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public final void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -42,12 +43,12 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -64,7 +65,7 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -74,12 +75,12 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		region().remove( key );
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheEntityRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -42,12 +43,12 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -64,7 +65,7 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -74,7 +75,7 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
@@ -84,7 +85,7 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	 * Returns <code>false</code> since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -94,7 +95,7 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	 * Returns <code>false</code> since this is a non-strict read/write cache access strategy
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -104,21 +105,21 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 	 * Removes the entry since this is a non-strict read/write cache strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
-		remove( key );
+		remove( session, key );
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
-		unlockItem( key, lock );
+		unlockItem( session, key, lock );
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		region().remove( key );
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -42,12 +42,12 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -64,7 +64,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -74,7 +74,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
@@ -84,7 +84,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Returns <code>false</code> since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -94,7 +94,7 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Returns <code>false</code> since this is a non-strict read/write cache access strategy
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -104,19 +104,19 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Removes the entry since this is a non-strict read/write cache strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
-		remove( key );
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
+		remove( session, key );
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
-		unlockItem( key, lock );
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
+		unlockItem( session, key, lock );
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		region().remove( key );
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -42,12 +43,12 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -59,7 +60,7 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -69,7 +70,7 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 	}
 
 	@Override

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -41,12 +42,12 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -58,7 +59,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -68,7 +69,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -78,12 +79,12 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		region().put( key, value );
 		return true;
 	}
@@ -96,7 +97,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
@@ -109,7 +110,7 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
@@ -42,12 +42,12 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return region().get( key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		if ( minimalPutOverride && region().contains( key ) ) {
 			return false;
@@ -59,7 +59,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws UnsupportedOperationException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws UnsupportedOperationException {
 		return null;
 	}
 
@@ -69,7 +69,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this cache is read-only
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		region().remove( key );
 	}
 
@@ -79,12 +79,12 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		region().put( key, value );
 		return true;
 	}
@@ -97,7 +97,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws UnsupportedOperationException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
 
@@ -109,7 +109,7 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws UnsupportedOperationException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -47,7 +48,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -57,7 +58,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * Inserts will only succeed if there is no existing value mapped to this key.
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -80,7 +81,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
@@ -93,7 +94,7 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 	 * the course of this transaction.
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		//what should we do with previousVersion here?
 		region().writeLock( key );

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -47,7 +47,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -57,7 +57,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * Inserts will only succeed if there is no existing value mapped to this key.
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		region().writeLock( key );
 		try {
 			final Lockable item = (Lockable) region().get( key );
@@ -80,7 +80,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * A no-op since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
@@ -92,7 +92,7 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 	 * the course of this transaction.
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		//what should we do with previousVersion here?
 		region().writeLock( key );
 		try {

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
@@ -16,6 +16,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -47,7 +48,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -63,12 +64,13 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			long txTimestamp,
@@ -88,7 +90,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -98,7 +100,7 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
@@ -16,6 +16,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -46,17 +47,17 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -72,7 +73,7 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version)
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version)
 			throws CacheException {
 		//OptimisticCache? versioning?
 		try {
@@ -85,12 +86,13 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			long txTimestamp,
@@ -110,7 +112,7 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -120,12 +122,13 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 
 	@Override
 	public boolean update(
+			SessionImplementor session,
 			Object key,
 			Object value,
 			Object currentVersion,

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
@@ -47,17 +47,17 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		try {
 			final Element element = ehcache.get( key );
 			return element == null ? null : element.getObjectValue();
@@ -73,7 +73,7 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		//OptimisticCache? versioning?
 		try {
 			ehcache.put( new Element( key, value ) );
@@ -85,13 +85,13 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
 	public boolean putFromLoad(
-			Object key,
+			SessionImplementor session, Object key,
 			Object value,
 			long txTimestamp,
 			Object version,
@@ -110,7 +110,7 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		try {
 			ehcache.remove( key );
 		}
@@ -120,12 +120,12 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		// no-op
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		try {
 			ehcache.put( new Element( key, value ) );
 			return true;

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/collection/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/collection/TransactionalAccess.java
@@ -12,6 +12,7 @@ import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -40,20 +41,20 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -65,7 +66,7 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		return region;
 	}
 
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -73,7 +74,7 @@ class TransactionalAccess implements CollectionRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 	}
 
 	public void unlockRegion(SoftLock lock) throws CacheException {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/ReadOnlyAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/ReadOnlyAccess.java
@@ -8,6 +8,7 @@ package org.hibernate.cache.infinispan.entity;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * A specialization of {@link TransactionalAccess} that ensures we never update data. Infinispan
@@ -25,14 +26,14 @@ class ReadOnlyAccess extends TransactionalAccess {
 
 	@Override
 	public boolean update(
-			Object key, Object value, Object currentVersion,
+			SessionImplementor session, Object key, Object value, Object currentVersion,
 			Object previousVersion) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
 	@Override
 	public boolean afterUpdate(
-			Object key, Object value, Object currentVersion,
+			SessionImplementor session, Object key, Object value, Object currentVersion,
 			Object previousVersion, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/entity/TransactionalAccess.java
@@ -12,6 +12,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -40,7 +41,7 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		delegate.evictAll();
 	}
 
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
@@ -48,20 +49,20 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		return this.region;
 	}
 
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return delegate.insert( key, value, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -69,12 +70,12 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		delegate.removeAll();
 	}
 
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return delegate.update( key, value, currentVersion, previousVersion );
 	}
 
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -82,17 +83,17 @@ class TransactionalAccess implements EntityRegionAccessStrategy {
 		return null;
 	}
 
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 	}
 
 	public void unlockRegion(SoftLock lock) throws CacheException {
 	}
 
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		return false;
 	}

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseGeneralDataRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseGeneralDataRegion.java
@@ -11,6 +11,7 @@ import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.spi.GeneralDataRegion;
 import org.hibernate.cache.spi.RegionFactory;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.infinispan.AdvancedCache;
 
 /**
@@ -49,13 +50,13 @@ public abstract class BaseGeneralDataRegion extends BaseRegion implements Genera
 	}
 
 	@Override
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		return cache.get( key );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		putCache.put( key, value );
 	}
 

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/ReadOnlyAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/ReadOnlyAccess.java
@@ -8,6 +8,7 @@ package org.hibernate.cache.infinispan.naturalid;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -19,12 +20,12 @@ class ReadOnlyAccess extends TransactionalAccess {
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		throw new UnsupportedOperationException( "Illegal attempt to edit read only item" );
 	}
 

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/TransactionalAccess.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/naturalid/TransactionalAccess.java
@@ -27,12 +27,12 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return delegate.insert( key, value, null );
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		return delegate.update( key, value, null, null );
 	}
 
@@ -52,23 +52,23 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
 		return delegate.get( key, txTimestamp );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 		return delegate.putFromLoad( key, value, txTimestamp, version, minimalPutOverride );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		delegate.remove( key );
 	}
 
@@ -78,7 +78,7 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
@@ -88,7 +88,7 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 	}
 
 	@Override
@@ -96,12 +96,12 @@ class TransactionalAccess implements NaturalIdRegionAccessStrategy {
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		return false;
 	}
 

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.cache.infinispan.impl.BaseTransactionalDataRegion;
 import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.spi.QueryResultsRegion;
 import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.infinispan.AdvancedCache;
 import org.infinispan.context.Flag;
 
@@ -70,7 +71,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 	}
 
 	@Override
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		// If the region is not valid, skip cache store to avoid going remote to retrieve the query.
 		// The aim of this is to maintain same logic/semantics as when state transfer was configured.
 		// TODO: Once https://issues.jboss.org/browse/ISPN-835 has been resolved, revert to state transfer and remove workaround
@@ -98,7 +99,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		if ( checkValid() ) {
 			// Here we don't want to suspend the tx. If we do:
 			// 1) We might be caching query results that reflect uncommitted

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.spi.RegionFactory;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.infinispan.AdvancedCache;
 import org.infinispan.context.Flag;
 import org.infinispan.notifications.Listener;
@@ -62,7 +63,7 @@ public class ClusteredTimestampsRegionImpl extends TimestampsRegionImpl {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		Object value = localCache.get( key );
 
 		// If the region is not valid, skip cache store to avoid going remote to retrieve the query.
@@ -122,7 +123,7 @@ public class ClusteredTimestampsRegionImpl extends TimestampsRegionImpl {
 	private void populateLocalCache() {
 		final Set children = cache.keySet();
 		for ( Object key : children ) {
-			get( key );
+			get( null, key );
 		}
 	}
 

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampsRegionImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.TimestampsRegion;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.infinispan.AdvancedCache;
 import org.infinispan.context.Flag;
 
@@ -80,7 +81,7 @@ public class TimestampsRegionImpl extends BaseGeneralDataRegion implements Times
 
 
 	@Override
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		if ( checkValid() ) {
 			return cache.get( key );
 		}
@@ -90,7 +91,7 @@ public class TimestampsRegionImpl extends BaseGeneralDataRegion implements Times
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void put(final Object key, final Object value) throws CacheException {
+	public void put(SessionImplementor session, final Object key, final Object value) throws CacheException {
 		try {
 			// We ensure ASYNC semantics (JBCACHE-1175) and make sure previous
 			// value is not loaded from cache store cos it's not needed.

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
@@ -87,6 +87,16 @@ public class Caches {
 		}
 	}
 
+	public static void withinTx(TransactionManager tm, final Runnable runnable) throws Exception {
+		withinTx(tm, new Callable<Void>() {
+			@Override
+			public Void call() throws Exception {
+				runnable.run();
+				return null;
+			}
+		});
+	}
+
    /**
     * Transform a given cache into a local cache
     *

--- a/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
+++ b/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
@@ -54,7 +54,7 @@
       <!-- A config appropriate for query caching. Does not replicate queries. -->
       <local-cache name="local-query">
          <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
-         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <transaction mode="NONE" />
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
       </local-cache>
@@ -62,7 +62,7 @@
       <!-- A query cache that replicates queries. Replication is asynchronous. -->
       <replicated-cache name="replicated-query" mode="ASYNC">
          <locking isolation="READ_COMMITTED" concurrency-level="1000" acquire-timeout="15000" striping="false"/>
-         <transaction mode="NON_XA" locking="OPTIMISTIC" auto-commit="false"/>
+         <transaction mode="NONE" />
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
       </replicated-cache>

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTestCase.java
@@ -52,7 +52,7 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 
 	@Override
 	protected void putInRegion(Region region, Object key, Object value) {
-		((GeneralDataRegion) region).put( key, value );
+		((GeneralDataRegion) region).put(null, key, value );
 	}
 
 	@Override
@@ -100,21 +100,21 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 					properties,
 					null
 			);
-			assertNull( "local is clean", localRegion.get( KEY ) );
-			assertNull( "remote is clean", remoteRegion.get( KEY ) );
+			assertNull( "local is clean", localRegion.get(null, KEY ) );
+			assertNull( "remote is clean", remoteRegion.get(null, KEY ) );
 
 			regionPut( localRegion );
 
 			Callable<Object> getFromLocalRegion = new Callable<Object>() {
 				@Override
 				public Object call() throws Exception {
-					return localRegion.get(KEY);
+					return localRegion.get(null, KEY);
 				}
 			};
 			Callable<Object> getFromRemoteRegion = new Callable<Object>() {
 				@Override
 				public Object call() throws Exception {
-					return remoteRegion.get(KEY);
+					return remoteRegion.get(null, KEY);
 				}
 			};
 
@@ -137,7 +137,7 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
    }
 
    protected void regionPut(GeneralDataRegion region) throws Exception {
-	  region.put(KEY, VALUE1);
+	  region.put(null, KEY, VALUE1);
    }
 
    protected abstract String getStandardRegionName(String regionPrefix);
@@ -198,17 +198,17 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 			keys = remoteCache.keySet();
 			assertEquals( "No valid children in " + keys, 0, getValidKeyCount( keys ) );
 
-			assertNull( "local is clean", localRegion.get( KEY ) );
-			assertNull( "remote is clean", remoteRegion.get( KEY ) );
+			assertNull( "local is clean", localRegion.get(null, KEY ) );
+			assertNull( "remote is clean", remoteRegion.get(null, KEY ) );
 
 			regionPut(localRegion);
-			assertEquals( VALUE1, localRegion.get( KEY ) );
+			assertEquals( VALUE1, localRegion.get(null, KEY ) );
 
 			// Allow async propagation
 			sleep( 250 );
 
 			regionPut(remoteRegion);
-			assertEquals( VALUE1, remoteRegion.get( KEY ) );
+			assertEquals( VALUE1, remoteRegion.get(null, KEY ) );
 
 			// Allow async propagation
 			sleep( 250 );
@@ -218,17 +218,17 @@ public abstract class AbstractGeneralDataRegionTestCase extends AbstractRegionIm
 			// allow async propagation
 			sleep( 250 );
 			// This should re-establish the region root node in the optimistic case
-			assertNull( localRegion.get( KEY ) );
+			assertNull( localRegion.get(null, KEY ) );
 			assertEquals( "No valid children in " + keys, 0, getValidKeyCount( localCache.keySet() ) );
 
 			// Re-establishing the region root on the local node doesn't
 			// propagate it to other nodes. Do a get on the remote node to re-establish
 			// This only adds a node in the case of optimistic locking
-			assertEquals( null, remoteRegion.get( KEY ) );
+			assertEquals( null, remoteRegion.get(null, KEY ) );
 			assertEquals( "No valid children in " + keys, 0, getValidKeyCount( remoteCache.keySet() ) );
 
-			assertEquals( "local is clean", null, localRegion.get( KEY ) );
-			assertEquals( "remote is clean", null, remoteRegion.get( KEY ) );
+			assertEquals( "local is clean", null, localRegion.get(null, KEY ) );
+			assertEquals( "remote is clean", null, remoteRegion.get(null, KEY ) );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( registry1 );

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/AbstractCollectionRegionAccessStrategyTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/AbstractCollectionRegionAccessStrategyTestCase.java
@@ -241,15 +241,15 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 					long txTimestamp = System.currentTimeMillis();
 					BatchModeTransactionManager.getInstance().begin();
 
-					assertEquals( "node1 starts clean", null, localAccessStrategy.get( KEY, txTimestamp ) );
+					assertEquals( "node1 starts clean", null, localAccessStrategy.get(null, KEY, txTimestamp ) );
 
 					writeLatch1.await();
 
 					if ( useMinimalAPI ) {
-						localAccessStrategy.putFromLoad( KEY, VALUE2, txTimestamp, new Integer( 2 ), true );
+						localAccessStrategy.putFromLoad(null, KEY, VALUE2, txTimestamp, new Integer( 2 ), true );
 					}
 					else {
-						localAccessStrategy.putFromLoad( KEY, VALUE2, txTimestamp, new Integer( 2 ) );
+						localAccessStrategy.putFromLoad(null, KEY, VALUE2, txTimestamp, new Integer( 2 ) );
 					}
 
 					BatchModeTransactionManager.getInstance().commit();
@@ -279,7 +279,7 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 					long txTimestamp = System.currentTimeMillis();
 					BatchModeTransactionManager.getInstance().begin();
 
-					assertNull( "node2 starts clean", remoteAccessStrategy.get( KEY, txTimestamp ) );
+					assertNull( "node2 starts clean", remoteAccessStrategy.get(null, KEY, txTimestamp ) );
 
 					// Let node1 write
 					writeLatch1.countDown();
@@ -290,10 +290,10 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 					sleep( 200 );
 
 					if ( useMinimalAPI ) {
-						remoteAccessStrategy.putFromLoad( KEY, VALUE1, txTimestamp, new Integer( 1 ), true );
+						remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer( 1 ), true );
 					}
 					else {
-						remoteAccessStrategy.putFromLoad( KEY, VALUE1, txTimestamp, new Integer( 1 ) );
+						remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer( 1 ) );
 					}
 
 					BatchModeTransactionManager.getInstance().commit();
@@ -353,8 +353,8 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 			expected2 = VALUE2;
 		}
 
-		assertEquals( msg1, expected1, localAccessStrategy.get( KEY, txTimestamp ) );
-		assertEquals( msg2, expected2, remoteAccessStrategy.get( KEY, txTimestamp ) );
+		assertEquals( msg1, expected1, localAccessStrategy.get(null, KEY, txTimestamp ) );
+		assertEquals( msg2, expected2, remoteAccessStrategy.get(null, KEY, txTimestamp ) );
 	}
 
 	@Test
@@ -381,13 +381,13 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 		final Object KEY = TestingKeyFactory.generateCollectionCacheKey( KEY_BASE + testCount++ );
 
-		assertNull( "local is clean", localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
-		assertNull( "remote is clean", remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertNull( "local is clean", localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
+		assertNull( "remote is clean", remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
-		localAccessStrategy.putFromLoad( KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
-		assertEquals( VALUE1, localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
-		remoteAccessStrategy.putFromLoad( KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
-		assertEquals( VALUE1, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
+		assertEquals( VALUE1, localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
+		remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
+		assertEquals( VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
 		// Wait for async propagation
 		sleep( 250 );
@@ -398,14 +398,14 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
             if (evict)
                localAccessStrategy.evict(KEY);
             else
-               localAccessStrategy.remove(KEY);
+               localAccessStrategy.remove(null, KEY);
             return null;
          }
       });
 
-		assertEquals( null, localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertEquals( null, localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
-		assertEquals( null, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertEquals( null, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 	}
 
 	private void evictOrRemoveAllTest(final boolean evict) throws Exception {
@@ -416,13 +416,13 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 		assertEquals( 0, getValidKeyCount( remoteCollectionRegion.getCache().keySet() ) );
 
-		assertNull( "local is clean", localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
-		assertNull( "remote is clean", remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertNull( "local is clean", localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
+		assertNull( "remote is clean", remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
-		localAccessStrategy.putFromLoad( KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
-		assertEquals( VALUE1, localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
-		remoteAccessStrategy.putFromLoad( KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
-		assertEquals( VALUE1, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
+		assertEquals( VALUE1, localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
+		remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
+		assertEquals( VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
 		// Wait for async propagation
 		sleep( 250 );
@@ -439,19 +439,19 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
       });
 
 		// This should re-establish the region root node
-		assertNull( localAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertNull( localAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
 		assertEquals( 0, getValidKeyCount( localCollectionRegion.getCache().keySet() ) );
 
 		// Re-establishing the region root on the local node doesn't
 		// propagate it to other nodes. Do a get on the remote node to re-establish
-		assertEquals( null, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertEquals( null, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
 		assertEquals( 0, getValidKeyCount( remoteCollectionRegion.getCache().keySet() ) );
 
 		// Test whether the get above messes up the optimistic version
-		remoteAccessStrategy.putFromLoad( KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
-		assertEquals( VALUE1, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer( 1 ) );
+		assertEquals( VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 
 		assertEquals( 1, getValidKeyCount( remoteCollectionRegion.getCache().keySet() ) );
 
@@ -460,11 +460,11 @@ public abstract class AbstractCollectionRegionAccessStrategyTestCase extends Abs
 
 		assertEquals(
 				"local is correct", (isUsingInvalidation() ? null : VALUE1), localAccessStrategy.get(
-				KEY, System
+						null, KEY, System
 				.currentTimeMillis()
 		)
 		);
-		assertEquals( "remote is correct", VALUE1, remoteAccessStrategy.get( KEY, System.currentTimeMillis() ) );
+		assertEquals( "remote is correct", VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis() ) );
 	}
 
 	private void rollback() {

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/CollectionRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/CollectionRegionImplTestCase.java
@@ -59,12 +59,12 @@ public class CollectionRegionImplTestCase extends AbstractEntityCollectionRegion
    @Override
    protected void putInRegion(Region region, Object key, Object value) {
       CollectionRegionAccessStrategy strategy = ((CollectionRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL);
-      strategy.putFromLoad(key, value, System.currentTimeMillis(), new Integer(1));
+      strategy.putFromLoad(null, key, value, System.currentTimeMillis(), new Integer(1));
    }
 
    @Override
    protected void removeFromRegion(Region region, Object key) {
-      ((CollectionRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(key);
+      ((CollectionRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(null, key);
    }
 
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
@@ -80,7 +80,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testLockItem() {
-		assertNull( getCollectionAccessStrategy().lockItem( KEY, new Integer( 1 ) ) );
+		assertNull( getCollectionAccessStrategy().lockItem(null, KEY, new Integer( 1 ) ) );
 	}
 
 	@Test
@@ -90,12 +90,12 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testUnlockItem() {
-		getCollectionAccessStrategy().unlockItem( KEY, new MockSoftLock() );
+		getCollectionAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
 	}
 
 	@Test
 	public void testUnlockRegion() {
-		getCollectionAccessStrategy().unlockItem( KEY, new MockSoftLock() );
+		getCollectionAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
 	}
 
 	public static class MockSoftLock implements SoftLock {

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractEntityRegionAccessStrategyTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractEntityRegionAccessStrategyTestCase.java
@@ -206,17 +206,17 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
                long txTimestamp = System.currentTimeMillis();
                BatchModeTransactionManager.getInstance().begin();
 
-               assertNull("node1 starts clean", localAccessStrategy.get(KEY, txTimestamp));
+               assertNull("node1 starts clean", localAccessStrategy.get(null, KEY, txTimestamp));
 
                writeLatch1.await();
 
                if (useMinimalAPI) {
-                  localAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, new Integer(1), true);
+                  localAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer(1), true);
                } else {
-                  localAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, new Integer(1));
+                  localAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer(1));
                }
 
-               localAccessStrategy.update(KEY, VALUE2, new Integer(2), new Integer(1));
+               localAccessStrategy.update(null, KEY, VALUE2, new Integer(2), new Integer(1));
 
                BatchModeTransactionManager.getInstance().commit();
             } catch (Exception e) {
@@ -243,7 +243,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
                long txTimestamp = System.currentTimeMillis();
                BatchModeTransactionManager.getInstance().begin();
 
-               assertNull("node1 starts clean", remoteAccessStrategy.get(KEY, txTimestamp));
+               assertNull("node1 starts clean", remoteAccessStrategy.get(null, KEY, txTimestamp));
 
                // Let node1 write
                writeLatch1.countDown();
@@ -251,9 +251,9 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
                writeLatch2.await();
 
                if (useMinimalAPI) {
-                  remoteAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, new Integer(1), true);
+                  remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer(1), true);
                } else {
-                  remoteAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, new Integer(1));
+                  remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer(1));
                }
 
                BatchModeTransactionManager.getInstance().commit();
@@ -281,14 +281,14 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       assertThreadsRanCleanly();
 
       long txTimestamp = System.currentTimeMillis();
-      assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(KEY, txTimestamp));
+      assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(null, KEY, txTimestamp));
 
       if (isUsingInvalidation()) {
          // no data version to prevent the PFER; we count on db locks preventing this
-         assertEquals("Expected node2 value", VALUE1, remoteAccessStrategy.get(KEY, txTimestamp));
+         assertEquals("Expected node2 value", VALUE1, remoteAccessStrategy.get(null, KEY, txTimestamp));
       } else {
          // The node1 update is replicated, preventing the node2 PFER
-         assertEquals("Correct node2 value", VALUE2, remoteAccessStrategy.get(KEY, txTimestamp));
+         assertEquals("Correct node2 value", VALUE2, remoteAccessStrategy.get(null, KEY, txTimestamp));
       }
    }
 
@@ -310,9 +310,9 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
                long txTimestamp = System.currentTimeMillis();
                BatchModeTransactionManager.getInstance().begin();
 
-               assertNull("Correct initial value", localAccessStrategy.get(KEY, txTimestamp));
+               assertNull("Correct initial value", localAccessStrategy.get(null, KEY, txTimestamp));
 
-               localAccessStrategy.insert(KEY, VALUE1, new Integer(1));
+               localAccessStrategy.insert(null, KEY, VALUE1, new Integer(1));
 
                readLatch.countDown();
                commitLatch.await();
@@ -346,7 +346,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
 
                assertEquals(
                      "Correct initial value", expected, localAccessStrategy.get(
-                     KEY,
+                           null, KEY,
                      txTimestamp
                )
                );
@@ -376,9 +376,9 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       assertThreadsRanCleanly();
 
       long txTimestamp = System.currentTimeMillis();
-      assertEquals("Correct node1 value", VALUE1, localAccessStrategy.get(KEY, txTimestamp));
+      assertEquals("Correct node1 value", VALUE1, localAccessStrategy.get(null, KEY, txTimestamp));
       Object expected = isUsingInvalidation() ? null : VALUE1;
-      assertEquals("Correct node2 value", expected, remoteAccessStrategy.get(KEY, txTimestamp));
+      assertEquals("Correct node2 value", expected, remoteAccessStrategy.get(null, KEY, txTimestamp));
    }
 
    @Test
@@ -387,8 +387,8 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
       // Set up initial state
-      localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      remoteAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
 
       // Let the async put propagate
       sleep(250);
@@ -406,9 +406,9 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
                long txTimestamp = System.currentTimeMillis();
                BatchModeTransactionManager.getInstance().begin();
                log.debug("Transaction began, get initial value");
-               assertEquals("Correct initial value", VALUE1, localAccessStrategy.get(KEY, txTimestamp));
+               assertEquals("Correct initial value", VALUE1, localAccessStrategy.get(null, KEY, txTimestamp));
                log.debug("Now update value");
-               localAccessStrategy.update(KEY, VALUE2, new Integer(2), new Integer(1));
+               localAccessStrategy.update(null, KEY, VALUE2, new Integer(2), new Integer(1));
                log.debug("Notify the read latch");
                readLatch.countDown();
                readerUnlocked = true;
@@ -445,7 +445,7 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
 
                // This won't block w/ mvc and will read the old value
                Object expected = VALUE1;
-               assertEquals("Correct value", expected, localAccessStrategy.get(KEY, txTimestamp));
+               assertEquals("Correct value", expected, localAccessStrategy.get(null, KEY, txTimestamp));
 
                BatchModeTransactionManager.getInstance().commit();
             } catch (Exception e) {
@@ -474,9 +474,9 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       assertThreadsRanCleanly();
 
       long txTimestamp = System.currentTimeMillis();
-      assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(KEY, txTimestamp));
+      assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(null, KEY, txTimestamp));
       Object expected = isUsingInvalidation() ? null : VALUE2;
-      assertEquals("Correct node2 value", expected, remoteAccessStrategy.get(KEY, txTimestamp));
+      assertEquals("Correct node2 value", expected, remoteAccessStrategy.get(null, KEY, txTimestamp));
    }
 
    @Test
@@ -504,13 +504,13 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
 
-      assertNull("local is clean", localAccessStrategy.get(KEY, System.currentTimeMillis()));
-      assertNull("remote is clean", remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertNull("local is clean", localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
+      assertNull("remote is clean", remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
-      localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      assertEquals(VALUE1, localAccessStrategy.get(KEY, System.currentTimeMillis()));
-      remoteAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      assertEquals(VALUE1, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      assertEquals(VALUE1, localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
+      remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      assertEquals(VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
       Caches.withinTx(localEntityRegion.getTransactionManager(), new Callable<Void>() {
          @Override
@@ -518,13 +518,13 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
             if (evict)
                localAccessStrategy.evict(KEY);
             else
-               localAccessStrategy.remove(KEY);
+               localAccessStrategy.remove(null, KEY);
             return null;
          }
       });
-      assertEquals(null, localAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertEquals(null, localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
-      assertEquals(null, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertEquals(null, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
    }
 
@@ -532,17 +532,17 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
-      assertNull("local is clean", localAccessStrategy.get(KEY, System.currentTimeMillis()));
-      assertNull("remote is clean", remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertNull("local is clean", localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
+      assertNull("remote is clean", remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
-      localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      assertEquals(VALUE1, localAccessStrategy.get(KEY, System.currentTimeMillis()));
+      localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      assertEquals(VALUE1, localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
       // Wait for async propagation
       sleep(250);
 
-      remoteAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      assertEquals(VALUE1, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      assertEquals(VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
       // Wait for async propagation
       sleep(250);
@@ -561,17 +561,17 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
       });
 
       // This should re-establish the region root node in the optimistic case
-      assertNull(localAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertNull(localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       assertEquals(0, getValidKeyCount(localEntityRegion.getCache().keySet()));
 
       // Re-establishing the region root on the local node doesn't
       // propagate it to other nodes. Do a get on the remote node to re-establish
-      assertEquals(null, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertEquals(null, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       assertEquals(0, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
 
       // Test whether the get above messes up the optimistic version
-      remoteAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
-      assertEquals(VALUE1, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      remoteAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+      assertEquals(VALUE1, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       assertEquals(1, getValidKeyCount(remoteEntityRegion.getCache().keySet()));
 
       // Wait for async propagation
@@ -579,11 +579,11 @@ public abstract class AbstractEntityRegionAccessStrategyTestCase extends Abstrac
 
       assertEquals(
             "local is correct", (isUsingInvalidation() ? null : VALUE1), localAccessStrategy
-            .get(KEY, System.currentTimeMillis())
+            .get(null, KEY, System.currentTimeMillis())
       );
       assertEquals(
             "remote is correct", VALUE1, remoteAccessStrategy.get(
-            KEY, System
+                  null, KEY, System
             .currentTimeMillis()
       )
       );

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractReadOnlyAccessTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractReadOnlyAccessTestCase.java
@@ -45,26 +45,26 @@ public abstract class AbstractReadOnlyAccessTestCase extends AbstractEntityRegio
 
       long txTimestamp = System.currentTimeMillis();
       BatchModeTransactionManager.getInstance().begin();
-      assertNull(localAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertNull(localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
       if (minimal)
-         localAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, 1, true);
+         localAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, 1, true);
       else
-         localAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, 1);
+         localAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, 1);
 
       sleep(250);
       Object expected = isUsingInvalidation() ? null : VALUE1;
-      assertEquals(expected, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertEquals(expected, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
 
       BatchModeTransactionManager.getInstance().commit();
-      assertEquals(VALUE1, localAccessStrategy.get(KEY, System.currentTimeMillis()));
-      assertEquals(expected, remoteAccessStrategy.get(KEY, System.currentTimeMillis()));
+      assertEquals(VALUE1, localAccessStrategy.get(null, KEY, System.currentTimeMillis()));
+      assertEquals(expected, remoteAccessStrategy.get(null, KEY, System.currentTimeMillis()));
    }
 
    @Test(expected = UnsupportedOperationException.class)
    @Override
    public void testUpdate() throws Exception {
       final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
-      localAccessStrategy.update( KEY, VALUE2, 2, 1);
+      localAccessStrategy.update(null, KEY, VALUE2, 2, 1);
    }
 
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractTransactionalAccessTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/AbstractTransactionalAccessTestCase.java
@@ -36,7 +36,7 @@ public abstract class AbstractTransactionalAccessTestCase extends AbstractEntity
 
         final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
 
-        localAccessStrategy.putFromLoad(KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
+        localAccessStrategy.putFromLoad(null, KEY, VALUE1, System.currentTimeMillis(), new Integer(1));
 
         final CountDownLatch pferLatch = new CountDownLatch(1);
         final CountDownLatch pferCompletionLatch = new CountDownLatch(1);
@@ -52,9 +52,9 @@ public abstract class AbstractTransactionalAccessTestCase extends AbstractEntity
                     long txTimestamp = System.currentTimeMillis();
                     BatchModeTransactionManager.getInstance().begin();
 
-                    assertEquals("Correct initial value", VALUE1, localAccessStrategy.get(KEY, txTimestamp));
+                    assertEquals("Correct initial value", VALUE1, localAccessStrategy.get(null, KEY, txTimestamp));
 
-                    localAccessStrategy.update(KEY, VALUE2, new Integer(2), new Integer(1));
+                    localAccessStrategy.update(null, KEY, VALUE2, new Integer(2), new Integer(1));
 
                     pferLatch.countDown();
                     commitLatch.await();
@@ -82,7 +82,7 @@ public abstract class AbstractTransactionalAccessTestCase extends AbstractEntity
                     long txTimestamp = System.currentTimeMillis();
                     BatchModeTransactionManager.getInstance().begin();
 
-                    localAccessStrategy.putFromLoad(KEY, VALUE1, txTimestamp, new Integer(1));
+                    localAccessStrategy.putFromLoad(null, KEY, VALUE1, txTimestamp, new Integer(1));
 
                     BatchModeTransactionManager.getInstance().commit();
                 } catch (Exception e) {
@@ -110,7 +110,7 @@ public abstract class AbstractTransactionalAccessTestCase extends AbstractEntity
         assertThreadsRanCleanly();
 
         long txTimestamp = System.currentTimeMillis();
-        assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(KEY, txTimestamp));
+        assertEquals("Correct node1 value", VALUE2, localAccessStrategy.get(null, KEY, txTimestamp));
     }
 
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/EntityRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/EntityRegionImplTestCase.java
@@ -49,12 +49,12 @@ public class EntityRegionImplTestCase extends AbstractEntityCollectionRegionTest
 
    @Override
    protected void putInRegion(Region region, Object key, Object value) {
-      ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).insert(key, value, 1);
+      ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).insert(null, key, value, 1);
    }
 
    @Override
    protected void removeFromRegion(Region region, Object key) {
-      ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(key);
+      ((EntityRegion) region).buildAccessStrategy(AccessType.TRANSACTIONAL).remove(null, key);
    }
 
    @Override

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/ReadOnlyExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/ReadOnlyExtraAPITestCase.java
@@ -28,6 +28,6 @@ public class ReadOnlyExtraAPITestCase extends TransactionalExtraAPITestCase {
 	@Test(expected = UnsupportedOperationException.class)
 	@Override
 	public void testAfterUpdate() {
-		getEntityAccessStrategy().afterUpdate(KEY, VALUE2, 1, 2, new MockSoftLock());
+		getEntityAccessStrategy().afterUpdate(null, KEY, VALUE2, 1, 2, new MockSoftLock());
 	}
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
@@ -89,7 +89,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	@Test
 	@SuppressWarnings( {"UnnecessaryBoxing"})
 	public void testLockItem() {
-		assertNull( getEntityAccessStrategy().lockItem( KEY, Integer.valueOf( 1 ) ) );
+		assertNull( getEntityAccessStrategy().lockItem(null, KEY, Integer.valueOf( 1 ) ) );
 	}
 
 	@Test
@@ -99,12 +99,12 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testUnlockItem() {
-		getEntityAccessStrategy().unlockItem( KEY, new MockSoftLock() );
+		getEntityAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
 	}
 
 	@Test
 	public void testUnlockRegion() {
-		getEntityAccessStrategy().unlockItem( KEY, new MockSoftLock() );
+		getEntityAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public void testAfterInsert() {
 		assertFalse(
 				"afterInsert always returns false",
-				getEntityAccessStrategy().afterInsert(
+				getEntityAccessStrategy().afterInsert(null,
 						KEY,
 						VALUE1,
 						Integer.valueOf( 1 )
@@ -125,7 +125,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public void testAfterUpdate() {
 		assertFalse(
 				"afterInsert always returns false",
-				getEntityAccessStrategy().afterUpdate(
+				getEntityAccessStrategy().afterUpdate(null,
 						KEY,
 						VALUE2,
 						Integer.valueOf( 1 ),

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/query/QueryRegionImplTestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/query/QueryRegionImplTestCase.java
@@ -66,7 +66,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
       Caches.withinTx(BatchModeTransactionManager.getInstance(), new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-            region.put(KEY, VALUE1);
+            region.put(null, KEY, VALUE1);
             return null;
          }
       });
@@ -112,8 +112,8 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 					properties
 			);
 
-			region.put( KEY, VALUE1 );
-			assertEquals( VALUE1, region.get( KEY ) );
+			region.put(null, KEY, VALUE1 );
+			assertEquals( VALUE1, region.get(null, KEY ) );
 
 			final CountDownLatch readerLatch = new CountDownLatch( 1 );
 			final CountDownLatch writerLatch = new CountDownLatch( 1 );
@@ -126,7 +126,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 					try {
 						BatchModeTransactionManager.getInstance().begin();
 						log.debug( "Transaction began, get value for key" );
-						assertTrue( VALUE2.equals( region.get( KEY ) ) == false );
+						assertTrue( VALUE2.equals( region.get(null, KEY ) ) == false );
 						BatchModeTransactionManager.getInstance().commit();
 					}
 					catch (AssertionFailedError e) {
@@ -149,7 +149,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 					try {
 						BatchModeTransactionManager.getInstance().begin();
 						log.debug( "Put value2" );
-						region.put( KEY, VALUE2 );
+						region.put(null, KEY, VALUE2 );
 						log.debug( "Put finished for value2, await writer latch" );
 						writerLatch.await();
 						log.debug( "Writer latch finished" );
@@ -179,7 +179,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 			writerLatch.countDown();
 			assertTrue( "Reader finished promptly", completionLatch.await( 100, TimeUnit.MILLISECONDS ) );
 
-			assertEquals( VALUE2, region.get( KEY ) );
+			assertEquals( VALUE2, region.get(null, KEY ) );
 
 			if ( holder.a1 != null ) {
 				throw holder.a1;
@@ -218,8 +218,8 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 					properties
 			);
 
-			region.put( KEY, VALUE1 );
-			assertEquals( VALUE1, region.get( KEY ) );
+			region.put(null, KEY, VALUE1 );
+			assertEquals( VALUE1, region.get(null, KEY ) );
 
 			// final Fqn rootFqn = getRegionFqn(getStandardRegionName(REGION_PREFIX), REGION_PREFIX);
 			final AdvancedCache jbc = getInfinispanCache(regionFactory);
@@ -239,7 +239,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 						jbc.addListener( blocker );
 
 						BatchModeTransactionManager.getInstance().begin();
-						region.get( KEY );
+						region.get(null, KEY );
 						BatchModeTransactionManager.getInstance().commit();
 					}
 					catch (Exception e) {
@@ -260,7 +260,7 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 						writerLatch.await();
 
 						BatchModeTransactionManager.getInstance().begin();
-						region.put( KEY, VALUE2 );
+						region.put(null, KEY, VALUE2 );
 						BatchModeTransactionManager.getInstance().commit();
 					}
 					catch (Exception e) {
@@ -290,10 +290,10 @@ public class QueryRegionImplTestCase extends AbstractGeneralDataRegionTestCase {
 				unblocked = true;
 
 				if ( IsolationLevel.REPEATABLE_READ.equals( jbc.getCacheConfiguration().locking().isolationLevel() ) ) {
-					assertEquals( VALUE1, region.get( KEY ) );
+					assertEquals( VALUE1, region.get(null, KEY ) );
 				}
 				else {
-					assertEquals( VALUE2, region.get( KEY ) );
+					assertEquals( VALUE2, region.get(null, KEY ) );
 				}
 
 				if ( holder.a1 != null ) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseEntityRegionAccessStrategy.java
@@ -12,6 +12,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -31,23 +32,23 @@ class BaseEntityRegionAccessStrategy extends BaseRegionAccessStrategy implements
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
-		return putFromLoad( key, value, 0, version );
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
+		return putFromLoad( session, key, value, 0, version );
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return true;
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		return false;
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseGeneralDataRegion.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseGeneralDataRegion.java
@@ -9,6 +9,7 @@ package org.hibernate.testing.cache;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.GeneralDataRegion;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.jboss.logging.Logger;
 
 /**
@@ -22,7 +23,7 @@ class BaseGeneralDataRegion extends BaseRegion implements GeneralDataRegion {
 	}
 
 	@Override
-	public Object get(Object key) throws CacheException {
+	public Object get(SessionImplementor session, Object key) throws CacheException {
 		LOG.debugf( "Cache[%s] lookup : key[%s]", getName(), key );
 		if ( key == null ) {
 			return null;
@@ -35,7 +36,7 @@ class BaseGeneralDataRegion extends BaseRegion implements GeneralDataRegion {
 	}
 
 	@Override
-	public void put(Object key, Object value) throws CacheException {
+	public void put(SessionImplementor session, Object key, Object value) throws CacheException {
 		LOG.debugf( "Caching[%s] : [%s] -> [%s]", getName(), key, value );
 		if ( key == null || value == null ) {
 			LOG.debug( "Key or Value is null" );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseNaturalIdRegionAccessStrategy.java
@@ -36,22 +36,22 @@ class BaseNaturalIdRegionAccessStrategy extends BaseRegionAccessStrategy impleme
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
-		return putFromLoad( key, value, 0, null );
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
+		return putFromLoad( session, key, value, 0, null );
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
-		return putFromLoad( key, value, 0, null );
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
+		return putFromLoad( session, key, value, 0, null );
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		return false;
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/BaseRegionAccessStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.testing.cache;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.RegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.jboss.logging.Logger;
 
 /**
@@ -23,17 +24,17 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 	protected abstract boolean isDefaultMinimalPutOverride();
 
 	@Override
-	public Object get(Object key, long txTimestamp) throws CacheException {
-		return getInternalRegion().get( key );
+	public Object get(SessionImplementor session, Object key, long txTimestamp) throws CacheException {
+		return getInternalRegion().get( session, key );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version) throws CacheException {
-		return putFromLoad( key, value, txTimestamp, version, isDefaultMinimalPutOverride() );
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version) throws CacheException {
+		return putFromLoad(session, key, value, txTimestamp, version, isDefaultMinimalPutOverride() );
 	}
 
 	@Override
-	public boolean putFromLoad(Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+	public boolean putFromLoad(SessionImplementor session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
 			throws CacheException {
 
 		if ( key == null || value == null ) {
@@ -44,7 +45,7 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 			return false;
 		}
 		LOG.debugf( "Caching: %s", key );
-		getInternalRegion().put( key, value );
+		getInternalRegion().put( session, key, value );
 		return true;
 
 	}
@@ -74,23 +75,23 @@ abstract class BaseRegionAccessStrategy implements RegionAccessStrategy {
 	}
 
 	@Override
-	public SoftLock lockItem(Object key, Object version) throws CacheException {
+	public SoftLock lockItem(SessionImplementor session, Object key, Object version) throws CacheException {
 		return null;
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 	}
 
 
 	/**
 	 * A no-op since this is an asynchronous cache access strategy.
 	 *
-	 * @see org.hibernate.cache.spi.access.EntityRegionAccessStrategy#remove(java.lang.Object)
-	 * @see org.hibernate.cache.spi.access.CollectionRegionAccessStrategy#remove(java.lang.Object)
+	 * @see RegionAccessStrategy#remove(SessionImplementor, Object)
+	 * @see RegionAccessStrategy#remove(SessionImplementor, Object)
 	 */
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 	}
 
 	/**

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteCollectionRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu
@@ -18,12 +19,12 @@ class NonstrictReadWriteCollectionRegionAccessStrategy extends BaseCollectionReg
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteEntityRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu
@@ -21,7 +22,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Since this is a non-strict read/write strategy item locking is not used.
 	 */
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -29,7 +30,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Returns <code>false</code> since this is an asynchronous cache access strategy.
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -37,7 +38,7 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Returns <code>false</code> since this is a non-strict read/write cache access strategy
 	 */
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
@@ -45,21 +46,21 @@ class NonstrictReadWriteEntityRegionAccessStrategy extends BaseEntityRegionAcces
 	 * Removes the entry since this is a non-strict read/write cache strategy.
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		evict( key );
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
-		unlockItem( key, lock );
+		unlockItem( session, key, lock );
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/NonstrictReadWriteNaturalIdRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Eric Dalquist
@@ -18,28 +19,28 @@ class NonstrictReadWriteNaturalIdRegionAccessStrategy extends BaseNaturalIdRegio
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
-		remove( key );
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
+		remove( session, key );
 		return false;
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyEntityRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.jboss.logging.Logger;
 
 /**
@@ -25,18 +26,18 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * This cache is asynchronous hence a no-op
 	 */
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false; //wait until tx complete, see afterInsert().
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
-		getInternalRegion().put( key, value ); //save into cache since the tx is completed
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
+		getInternalRegion().put( session, key, value ); //save into cache since the tx is completed
 		return true;
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 
@@ -46,7 +47,7 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		LOG.info( "Illegal attempt to update item cached as read-only : " + key );
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );
@@ -58,7 +59,7 @@ class ReadOnlyEntityRegionAccessStrategy extends BaseEntityRegionAccessStrategy 
 	 * @throws UnsupportedOperationException always
 	 */
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		LOG.info( "Illegal attempt to update item cached as read-only : " + key );
 		throw new UnsupportedOperationException( "Can't write to a readonly object" );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadOnlyNaturalIdRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Eric Dalquist
@@ -18,7 +19,7 @@ class ReadOnlyNaturalIdRegionAccessStrategy extends BaseNaturalIdRegionAccessStr
 	}
 
 	@Override
-	public void unlockItem(Object key, SoftLock lock) throws CacheException {
+	public void unlockItem(SessionImplementor session, Object key, SoftLock lock) throws CacheException {
 		evict( key );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteEntityRegionAccessStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -28,24 +29,24 @@ class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrateg
 	}
 
 	@Override
-	public boolean insert(Object key, Object value, Object version) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value, Object currentVersion, Object previousVersion)
+	public boolean update(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion)
 			throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) throws CacheException {
 
 		try {
 			writeLock.lock();
-			Lockable item = (Lockable) region.get( key );
+			Lockable item = (Lockable) region.get( session, key );
 			if ( item == null ) {
-				region.put( key, new Item( value, version, region.nextTimestamp() ) );
+				region.put( session, key, new Item( value, version, region.nextTimestamp() ) );
 				return true;
 			}
 			else {
@@ -59,25 +60,25 @@ class ReadWriteEntityRegionAccessStrategy extends AbstractReadWriteAccessStrateg
 
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock)
 			throws CacheException {
 		try {
 			writeLock.lock();
-			Lockable item = (Lockable) region.get( key );
+			Lockable item = (Lockable) region.get( session, key );
 
 			if ( item != null && item.isUnlockable( lock ) ) {
 				Lock lockItem = (Lock) item;
 				if ( lockItem.wasLockedConcurrently() ) {
-					decrementLock( key, lockItem );
+					decrementLock(session, key, lockItem );
 					return false;
 				}
 				else {
-					region.put( key, new Item( value, currentVersion, region.nextTimestamp() ) );
+					region.put( session, key, new Item( value, currentVersion, region.nextTimestamp() ) );
 					return true;
 				}
 			}
 			else {
-				handleLockExpiry( key, item );
+				handleLockExpiry(session, key, item );
 				return false;
 			}
 		}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/ReadWriteNaturalIdRegionAccessStrategy.java
@@ -29,23 +29,23 @@ class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStra
 	}
 
 	@Override
-	public boolean insert(Object key, Object value) throws CacheException {
+	public boolean insert(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean update(Object key, Object value) throws CacheException {
+	public boolean update(SessionImplementor session, Object key, Object value) throws CacheException {
 		return false;
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value) throws CacheException {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value) throws CacheException {
 
 		try {
 			writeLock.lock();
-			Lockable item = (Lockable) region.get( key );
+			Lockable item = (Lockable) region.get( session, key );
 			if ( item == null ) {
-				region.put( key, new Item( value, null, region.nextTimestamp() ) );
+				region.put( session, key, new Item( value, null, region.nextTimestamp() ) );
 				return true;
 			}
 			else {
@@ -59,24 +59,24 @@ class ReadWriteNaturalIdRegionAccessStrategy extends AbstractReadWriteAccessStra
 
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, SoftLock lock) throws CacheException {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, SoftLock lock) throws CacheException {
 		try {
 			writeLock.lock();
-			Lockable item = (Lockable) region.get( key );
+			Lockable item = (Lockable) region.get( session, key );
 
 			if ( item != null && item.isUnlockable( lock ) ) {
 				Lock lockItem = (Lock) item;
 				if ( lockItem.wasLockedConcurrently() ) {
-					decrementLock( key, lockItem );
+					decrementLock( session, key, lockItem );
 					return false;
 				}
 				else {
-					region.put( key, new Item( value, null, region.nextTimestamp() ) );
+					region.put( session, key, new Item( value, null, region.nextTimestamp() ) );
 					return true;
 				}
 			}
 			else {
-				handleLockExpiry( key, item );
+				handleLockExpiry( session, key, item );
 				return false;
 			}
 		}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalCollectionRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalCollectionRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -17,7 +18,7 @@ class TransactionalCollectionRegionAccessStrategy extends BaseCollectionRegionAc
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalEntityRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalEntityRegionAccessStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Strong Liu <stliu@hibernate.org>
@@ -18,24 +19,24 @@ class TransactionalEntityRegionAccessStrategy extends BaseEntityRegionAccessStra
 	}
 
 	@Override
-	public boolean afterInsert(Object key, Object value, Object version) {
+	public boolean afterInsert(SessionImplementor session, Object key, Object value, Object version) {
 		return false;
 	}
 
 	@Override
-	public boolean afterUpdate(Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+	public boolean afterUpdate(SessionImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
 		return false;
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 
 	@Override
 	public boolean update(
-			Object key, Object value, Object currentVersion,
+			SessionImplementor session, Object key, Object value, Object currentVersion,
 			Object previousVersion) throws CacheException {
-		return insert( key, value, currentVersion );
+		return insert(session, key, value, currentVersion);
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalNaturalIdRegionAccessStrategy.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/TransactionalNaturalIdRegionAccessStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.cache;
 
 import org.hibernate.cache.CacheException;
+import org.hibernate.engine.spi.SessionImplementor;
 
 /**
  * @author Eric Dalquist
@@ -17,7 +18,7 @@ class TransactionalNaturalIdRegionAccessStrategy extends BaseNaturalIdRegionAcce
 	}
 
 	@Override
-	public void remove(Object key) throws CacheException {
+	public void remove(SessionImplementor session, Object key) throws CacheException {
 		evict( key );
 	}
 


### PR DESCRIPTION
…ltsRegionImpl.put(Object, Object)

* Moved query cache update to second phase of transaction commit
* Query caches are now recommended to be non-transactional (transactional ones will be slower)

JIRA: https://hibernate.atlassian.net/browse/HHH-7898