### PR TITLE
HHH9968 -fix identifier is too long on Oracle DB - irrelevantInstantE…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/type/AttributeConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AttributeConverterTest.java
@@ -471,6 +471,7 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 	}
 
 	@Entity
+	@Table(name = "irrelevantInstantEntity")
 	@SuppressWarnings("UnusedDeclaration")
 	public static class IrrelevantInstantEntity {
 		@Id


### PR DESCRIPTION
Oracle DB has max size of table name 30 chars
https://hibernate.atlassian.net/browse/HHH-9968