### PR TITLE
HHH 9937 - bytecode enhancer - add support in Hibernate#isPropertyInitialized()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoader.java
@@ -22,7 +22,7 @@ import org.hibernate.engine.spi.SessionImplementor;
  */
 public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 
-	private final transient SessionImplementor session;
+	private transient SessionImplementor session;
 	private final Set<String> lazyFields;
 	private final String entityName;
 
@@ -35,7 +35,7 @@ public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 	}
 
 	protected final Object intercept(Object target, String fieldName, Object value) {
-		if ( lazyFields != null && lazyFields.contains( fieldName ) && !initializedFields.contains( fieldName ) ) {
+		if ( !isAttributeLoaded( fieldName ) ) {
 			if ( session == null ) {
 				throw new LazyInitializationException( "entity with lazy properties is not associated with a session" );
 			}
@@ -43,12 +43,8 @@ public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 				throw new LazyInitializationException( "session is not connected" );
 			}
 
-			Object loadedValue = ( (LazyPropertyInitializer) session.getFactory()
-					.getEntityPersister( entityName ) ).initializeLazyProperty(
-					fieldName,
-					target,
-					session
-			);
+			Object loadedValue = ( (LazyPropertyInitializer) session.getFactory().getEntityPersister( entityName ) )
+					.initializeLazyProperty( fieldName, target, session	);
 
 			initializedFields.add( fieldName );
 			return loadedValue;
@@ -56,6 +52,25 @@ public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 		else {
 			return value;
 		}
+	}
+
+	public final void setSession(SessionImplementor session) {
+		this.session = session;
+	}
+
+	public boolean isAttributeLoaded(String fieldName) {
+		return lazyFields == null || !lazyFields.contains( fieldName ) || initializedFields.contains( fieldName );
+	}
+
+	public boolean isUninitialized() {
+		if ( lazyFields != null ) {
+			for ( String fieldName : lazyFields ) {
+				if ( !initializedFields.contains( fieldName ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -33,6 +33,7 @@ import org.hibernate.QueryException;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.StaleStateException;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoader;
 import org.hibernate.bytecode.instrumentation.spi.FieldInterceptor;
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
 import org.hibernate.bytecode.spi.EntityInstrumentationMetadata;
@@ -62,6 +63,8 @@ import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.PersistenceContext.NaturalIdHelper;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.ValueInclusion;
@@ -4193,6 +4196,13 @@ public abstract class AbstractEntityPersister
 						session
 				);
 				fieldInterceptor.dirty();
+			}
+		}
+
+		if ( entity instanceof PersistentAttributeInterceptable ) {
+			PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
+			if ( interceptor != null && interceptor instanceof LazyAttributeLoader ) {
+				( (LazyAttributeLoader) interceptor ).setSession( session );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -309,6 +309,12 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 	@Override
 	public boolean hasUninitializedLazyProperties(Object entity) {
 		if ( getEntityMetamodel().hasLazyProperties() ) {
+			if ( entity instanceof PersistentAttributeInterceptable ) {
+				PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
+				if ( interceptor != null && interceptor instanceof LazyAttributeLoader ) {
+					return ( (LazyAttributeLoader) interceptor ).isUninitialized();
+				}
+			}
 			FieldInterceptor callback = FieldInterceptionHelper.extractFieldInterceptor( entity );
 			return callback != null && !callback.isInitialized();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.test.bytecode.enhancement;
 
-import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -19,6 +18,7 @@ import org.hibernate.test.bytecode.enhancement.join.HHH3949TestTask1;
 import org.hibernate.test.bytecode.enhancement.join.HHH3949TestTask2;
 import org.hibernate.test.bytecode.enhancement.join.HHH3949TestTask3;
 import org.hibernate.test.bytecode.enhancement.join.HHH3949TestTask4;
+import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingIntegrationTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingTestTask;
 import org.junit.Test;
@@ -75,7 +75,6 @@ public class EnhancerTest extends BaseUnitTestCase {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-9937")
-	@FailureExpected( jiraKey = "HHH-9937")
 	public void testLazyBasicFieldNotInitialized() {
 		EnhancerTestUtils.runEnhancerTestTask( LazyBasicFieldNotInitializedTestTask.class );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.bytecode.enhancement;
 
+import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -72,4 +73,10 @@ public class EnhancerTest extends BaseUnitTestCase {
 		EnhancerTestUtils.runEnhancerTestTask( HHH3949TestTask4.class );
 	}
 
+	@Test
+	@TestForIssue( jiraKey = "HHH-9937")
+	@FailureExpected( jiraKey = "HHH-9937")
+	public void testLazyBasicFieldNotInitialized() {
+		EnhancerTestUtils.runEnhancerTestTask( LazyBasicFieldNotInitializedTestTask.class );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyBasicFieldNotInitializedTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyBasicFieldNotInitializedTestTask.java
@@ -1,0 +1,93 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+
+import javax.persistence.Basic;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.hibernate.test.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Assert;
+
+/**
+ * @author Gail Badner
+ */
+public class LazyBasicFieldNotInitializedTestTask extends AbstractEnhancerTestTask {
+
+	private Long entityId;
+
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {Entity.class};
+	}
+
+	public void prepare() {
+		Configuration cfg = new Configuration();
+		cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+		cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+		super.prepare( cfg );
+
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+
+		Entity entity = new Entity();
+		entity.setDescription( "desc" );
+		s.persist( entity );
+		entityId = entity.getId();
+
+		s.getTransaction().commit();
+		s.clear();
+		s.close();
+	}
+
+	public void execute() {
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+		Entity entity = s.get( Entity.class, entityId );
+		Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	protected void cleanup() {
+	}
+
+	@javax.persistence.Entity
+	public static class Entity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Basic(fetch = FetchType.LAZY)
+		private String description;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+	}
+
+
+}


### PR DESCRIPTION
`Hibernate#isPropertyInitialized()` only supports the old instrumentation. For the new enhancement it always returns `true`

Thanks @gbadner for the test case!