### PR TITLE
HHH-9985 - bytecode enhancer - fix merge use case

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/DirtyTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/DirtyTracker.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.enhance.internal.tracker;
+
+/**
+ * Interface to be implemented by dirty trackers, a simplified Set of String.
+ *
+ * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public interface DirtyTracker {
+
+	void add(String name);
+
+	boolean contains(String name);
+
+	void clear();
+
+	boolean isEmpty();
+
+	String[] get();
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
@@ -16,14 +16,15 @@ import java.util.Arrays;
  *
  * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
  */
-public final class SimpleDirtyTracker {
+public final class SimpleFieldTracker implements DirtyTracker {
 
 	private String[] names;
 
-	public SimpleDirtyTracker() {
+	public SimpleFieldTracker() {
 		names = new String[0];
 	}
 
+	@Override
 	public void add(String name) {
 		if ( !contains( name ) ) {
 			names = Arrays.copyOf( names, names.length + 1 );
@@ -31,6 +32,7 @@ public final class SimpleDirtyTracker {
 		}
 	}
 
+	@Override
 	public boolean contains(String name) {
 		for ( String existing : names ) {
 			if ( existing.equals( name ) ) {
@@ -40,14 +42,17 @@ public final class SimpleDirtyTracker {
 		return false;
 	}
 
+	@Override
 	public void clear() {
 		names = new String[0];
 	}
 
+	@Override
 	public boolean isEmpty() {
 		return names.length == 0;
 	}
 
+	@Override
 	public String[] get() {
 		return names;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
@@ -13,14 +13,15 @@ package org.hibernate.bytecode.enhance.internal.tracker;
  *
  * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
  */
-public final class SortedDirtyTracker {
+public final class SortedFieldTracker implements DirtyTracker {
 
 	private String[] names;
 
-	public SortedDirtyTracker() {
+	public SortedFieldTracker() {
 		names = new String[0];
 	}
 
+	@Override
 	public void add(String name) {
 		// we do a binary search: even if we don't find the name at least we get the position to insert into the array
 		int insert = 0;
@@ -41,12 +42,13 @@ public final class SortedDirtyTracker {
 			}
 		}
 		final String[] newNames = new String[names.length + 1];
-		System.arraycopy( names, 0, newNames, 0, insert);
-		System.arraycopy( names, insert, newNames, insert + 1, names.length - insert);
+		System.arraycopy( names, 0, newNames, 0, insert );
+		System.arraycopy( names, insert, newNames, insert + 1, names.length - insert );
 		newNames[insert] = name;
 		names = newNames;
 	}
 
+	@Override
 	public boolean contains(String name) {
 		for ( int low = 0, high = names.length - 1; low <= high; ) {
 			final int middle = low + ( ( high - low ) / 2 );
@@ -66,14 +68,17 @@ public final class SortedDirtyTracker {
 		return false;
 	}
 
+	@Override
 	public void clear() {
 		names = new String[0];
 	}
 
+	@Override
 	public boolean isEmpty() {
 		return names.length == 0;
 	}
 
+	@Override
 	public String[] get() {
 		return names;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
@@ -11,7 +11,8 @@ package org.hibernate.bytecode.enhance.spi;
  *
  * @author Steve Ebersole
  */
-public class EnhancerConstants {
+public final class EnhancerConstants {
+
 	/**
 	 * Prefix for persistent-field reader methods.
 	 */
@@ -141,22 +142,34 @@ public class EnhancerConstants {
 	 */
 	public static final String TRACKER_COLLECTION_CHANGED_NAME = "$$_hibernate_areCollectionFieldsDirty";
 
+	/**
+	 * Name of the field that holds the collection tracker
+	 */
 	public static final String TRACKER_COLLECTION_NAME = "$$_hibernate_collectionTracker";
+
 	/**
 	 * Name of method to get dirty collection field names
 	 */
 	public static final String TRACKER_COLLECTION_CHANGED_FIELD_NAME = "$$_hibernate_getCollectionFieldDirtyNames";
 
+	/**
+	 * Name of method to clear dirty attribute on collection fields
+	 */
 	public static final String TRACKER_COLLECTION_CLEAR_NAME = "$$_hibernate_clearDirtyCollectionNames";
 
-	public static final String TRACKER_COMPOSITE_DIRTY_CHECK = "$$_hibernate_areCompositeFieldsDirty";
-
-	public static final String TRACKER_COMPOSITE_DIRTY_FIELDS_GETTER = "$$_hibernate_getCompositeDirtyFields";
-
+	/**
+	 * Field to hold the track the owner of the embeddable entity
+	 */
 	public static final String TRACKER_COMPOSITE_FIELD_NAME = "$$_hibernate_compositeOwners";
 
+	/**
+	 * Method to set the owner of the embedded entity
+	 */
 	public static final String TRACKER_COMPOSITE_SET_OWNER = "$$_hibernate_setOwner";
 
+	/**
+	 * Method to clear the owner of the embedded entity
+	 */
 	public static final String TRACKER_COMPOSITE_CLEAR_OWNER = "$$_hibernate_clearOwner";
 
 	private EnhancerConstants() {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoader.java
@@ -10,7 +10,7 @@ package org.hibernate.bytecode.enhance.spi.interceptor;
 import java.util.Set;
 
 import org.hibernate.LazyInitializationException;
-import org.hibernate.bytecode.enhance.internal.tracker.SimpleDirtyTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -26,7 +26,7 @@ public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 	private final Set<String> lazyFields;
 	private final String entityName;
 
-	private final SimpleDirtyTracker initializedFields = new SimpleDirtyTracker();
+	private final SimpleFieldTracker initializedFields = new SimpleFieldTracker();
 
 	public LazyAttributeLoader(SessionImplementor session, Set<String> lazyFields, String entityName) {
 		this.session = session;
@@ -56,6 +56,14 @@ public class LazyAttributeLoader implements PersistentAttributeInterceptor {
 		else {
 			return value;
 		}
+	}
+
+	public void setLoaded(String attributeName) {
+		initializedFields.add( attributeName );
+	}
+
+	public String[] getiInitializedFields() {
+		return initializedFields.get();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -287,7 +287,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 		}
 
 		if( entity instanceof SelfDirtinessTracker ) {
-			((SelfDirtinessTracker) entity).$$_hibernate_clearDirtyAttributes();
+			( (SelfDirtinessTracker) entity ).$$_hibernate_clearDirtyAttributes();
 		}
 
 		persistenceContext.getSession()
@@ -342,7 +342,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 	private boolean isUnequivocallyNonDirty(Object entity) {
 
 		if(entity instanceof SelfDirtinessTracker) {
-			return ((SelfDirtinessTracker) entity).$$_hibernate_hasDirtyAttributes();
+			return ! ( (SelfDirtinessTracker) entity ).$$_hibernate_hasDirtyAttributes();
 		}
 
 		final CustomEntityDirtinessStrategy customEntityDirtinessStrategy =

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SelfDirtinessTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SelfDirtinessTracker.java
@@ -33,6 +33,11 @@ public interface SelfDirtinessTracker {
 	String[] $$_hibernate_getDirtyAttributes();
 
 	/**
+	 * Adds persistent attribute to the set of values that have changed
+	 */
+	void $$_hibernate_trackChange(String attributes);
+
+	/**
 	 * Clear the stored dirty attributes
 	 */
 	void $$_hibernate_clearDirtyAttributes();

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -415,6 +415,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 		final Object[] copiedValues = TypeHelper.replace(
 				persister.getPropertyValues( entity ),
 				persister.getPropertyValues( target ),
+				persister.getPropertyNames(),
 				persister.getPropertyTypes(),
 				source,
 				target,
@@ -452,6 +453,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			copiedValues = TypeHelper.replace(
 					persister.getPropertyValues( entity ),
 					persister.getPropertyValues( target ),
+					persister.getPropertyNames(),
 					persister.getPropertyTypes(),
 					source,
 					target,

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -524,9 +524,10 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		Object[] values = TypeHelper.replace(
 				getPropertyValues( original, entityMode ),
 				getPropertyValues( result, entityMode ),
+				propertyNames,
 				propertyTypes,
 				session,
-				owner,
+				result,
 				copyCache
 		);
 
@@ -556,9 +557,10 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		Object[] values = TypeHelper.replace(
 				getPropertyValues( original, entityMode ),
 				getPropertyValues( result, entityMode ),
+				propertyNames,
 				propertyTypes,
 				session,
-				owner,
+				result,
 				copyCache,
 				foreignKeyDirection
 		);

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
+import org.hibernate.engine.spi.CompositeOwner;
+import org.hibernate.engine.spi.CompositeTracker;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.tuple.NonIdentifierAttribute;
@@ -147,6 +149,7 @@ public class TypeHelper {
 	public static Object[] replace(
 			final Object[] original,
 			final Object[] target,
+			final String[] names,
 			final Type[] types,
 			final SessionImplementor session,
 			final Object owner,
@@ -176,6 +179,11 @@ public class TypeHelper {
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache );
 			}
+
+			// for bytecode enhanced entities, set the composite tracking structure
+			if ( copied[i] instanceof CompositeTracker && owner instanceof CompositeOwner ) {
+				( (CompositeTracker) copied[i] ).$$_hibernate_setOwner( names[i], (CompositeOwner) owner );
+			}
 		}
 		return copied;
 	}
@@ -196,6 +204,7 @@ public class TypeHelper {
 	public static Object[] replace(
 			final Object[] original,
 			final Object[] target,
+			final String[] names,
 			final Type[] types,
 			final SessionImplementor session,
 			final Object owner,
@@ -204,11 +213,16 @@ public class TypeHelper {
 		Object[] copied = new Object[original.length];
 		for ( int i = 0; i < types.length; i++ ) {
 			if ( original[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
-				|| original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
+					|| original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				copied[i] = target[i];
 			}
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache, foreignKeyDirection );
+			}
+
+			// for bytecode enhanced entities, set the composite tracking structure
+			if ( copied[i] instanceof CompositeTracker && owner instanceof CompositeOwner ) {
+				( (CompositeTracker) copied[i] ).$$_hibernate_setOwner( names[i], (CompositeOwner) owner );
 			}
 		}
 		return copied;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/DecompileUtils.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/DecompileUtils.java
@@ -98,6 +98,7 @@ public abstract class DecompileUtils {
 					}
 					if ( interfaceNames.contains( SelfDirtinessTracker.class.getName() ) ) {
 						assertTrue( fieldNames.contains( EnhancerConstants.TRACKER_FIELD_NAME ) );
+						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_CHANGER_NAME ) );
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_GET_NAME ) );
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_CLEAR_NAME ) );
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_HAS_CHANGED_NAME ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/tracker/DirtyTrackerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/tracker/DirtyTrackerTest.java
@@ -6,8 +6,9 @@
  */
 package org.hibernate.test.bytecode.enhancement.tracker;
 
-import org.hibernate.bytecode.enhance.internal.tracker.SimpleDirtyTracker;
-import org.hibernate.bytecode.enhance.internal.tracker.SortedDirtyTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.DirtyTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.SortedFieldTracker;
 
 import org.junit.Test;
 
@@ -22,7 +23,7 @@ public class DirtyTrackerTest {
 
     @Test
     public void testSimpleTracker() {
-        SimpleDirtyTracker tracker = new SimpleDirtyTracker();
+        DirtyTracker tracker = new SimpleFieldTracker();
         assertTrue(tracker.isEmpty());
         assertTrue(tracker.get().length == 0);
 
@@ -46,7 +47,7 @@ public class DirtyTrackerTest {
 
     @Test
     public void testSortedTracker() {
-        SortedDirtyTracker tracker = new SortedDirtyTracker();
+        DirtyTracker tracker = new SortedFieldTracker();
         assertTrue(tracker.isEmpty());
         assertTrue(tracker.get().length == 0);
 


### PR DESCRIPTION
 I see 3 possible ways of dealing with the copy: 

1. don't do reflection and use the enhanced setters 
2. copy dirty tracking and interceptors as well (using reflection) 
3. expose methods on dirty tracking and interceptor to deal with it

This fix is according to strategy 3. main changes are:

* `SelfDirtinessTracker` interface exposes an additional method to mark a field dirty
* `LazyAttributeLoader` exposes additional methods to get the set of initialized fields and add a field to that same set.

Those changes allow `DefaultMergeEventListener` to copy the state of the dirty tracker and interceptor

