### PR TITLE
HHH-6541 ColumnValues.applyColumnValues tests presence of uniqueValue but reads nameValue

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/source/annotations/attribute/ColumnValues.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/source/annotations/attribute/ColumnValues.java
@@ -70,7 +70,7 @@ public class ColumnValues {
 
 		AnnotationValue uniqueValue = columnAnnotation.value( "unique" );
 		if ( uniqueValue != null ) {
-			this.unique = nameValue.asBoolean();
+			this.unique = uniqueValue.asBoolean();
 		}
 
 		AnnotationValue nullableValue = columnAnnotation.value( "nullable" );


### PR DESCRIPTION
See: https://hibernate.atlassian.net/browse/HHH-6541.

Not sure how to add this to 4.3.  Whether it should be a hotfix or rolled into 4.3.11.Final with some other issues/fixes.
