### PR TITLE
HHH-9993 IsolationDelegate: add method to execute code without obtain…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/IsolationDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/IsolationDelegate.java
@@ -9,6 +9,8 @@ package org.hibernate.engine.transaction.spi;
 import org.hibernate.HibernateException;
 import org.hibernate.jdbc.WorkExecutorVisitable;
 
+import java.util.concurrent.Callable;
+
 /**
  * Contract for performing work in a manner that isolates it from any current transaction.
  *
@@ -26,4 +28,16 @@ public interface IsolationDelegate {
 	 * @throws HibernateException Indicates a problem performing the work.
 	 */
 	public <T> T delegateWork(WorkExecutorVisitable<T> work, boolean transacted) throws HibernateException;
+
+	/**
+	 * Invoke the given callable in isolation from current transaction.
+	 *
+	 * @param callable The callable to be invoked.
+	 * @param transacted Should the work itself be done in a (isolated) transaction?
+	 *
+	 * @return The work result
+	 *
+	 * @throws HibernateException Indicates a problem performing the work.
+	 */
+	public <T> T delegateCallable(Callable<T> callable, boolean transacted) throws HibernateException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcIsolationDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcIsolationDelegate.java
@@ -8,6 +8,7 @@ package org.hibernate.resource.transaction.backend.jdbc.internal;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.Callable;
 
 import org.hibernate.HibernateException;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -100,6 +101,20 @@ public class JdbcIsolationDelegate implements IsolationDelegate {
 		}
 		catch (SQLException sqle) {
 			throw sqlExceptionHelper().convert( sqle, "unable to obtain isolated JDBC connection" );
+		}
+	}
+
+	@Override
+	public <T> T delegateCallable(Callable<T> callable, boolean transacted) throws HibernateException {
+		// No connection, nothing to be suspended
+		try {
+			return callable.call();
+		}
+		catch (HibernateException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw new HibernateException(e);
 		}
 	}
 }


### PR DESCRIPTION
…ing a connection

https://hibernate.atlassian.net/browse/HHH-9993

In `JtaIsolationDelegate` I took the same approach as with the connection-including version, so basically the callable is executed as it is. However, that does not feel really transactionally; e.g. even in the previous code the code cannot grab the new transaction and hook some synchronizations on that.