### PR TITLE
HHH-10780 - Provide a PrimitiveByteArrayTypeDescriptor toString implementation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTypeDescriptor.java
@@ -79,7 +79,7 @@ public abstract class AbstractTypeDescriptor<T> implements JavaTypeDescriptor<T>
 
 	@Override
 	public String extractLoggableRepresentation(T value) {
-		return (value == null) ? "null" : value.toString();
+		return (value == null) ? "null" : (value instanceof byte[] ? new String(value) : value.toString());
 	}
 
 	protected HibernateException unknownUnwrap(Class conversionType) {


### PR DESCRIPTION
I tried to logging sql queries and its parameters. When the parameter type is VARBINARY then I got some line like these:

15:42:39.633 [http-bio-8080-exec-9] TRACE BasicExtractor - extracted value ([id1_13_0_] : [VARBINARY]) - [[B@28befe6e]
15:42:55.624 [http-bio-8080-exec-9] TRACE BasicExtractor - extracted value ([id1_18_1_] : [VARBINARY]) - [[B@2de05243]

In this case the parameter is not useable. The VARBINARY type is represented as byte array. This is the reason I added the condition.

As I see there is a ByteArrayTypeDescriptor class, as well. But why is its member not called when the T is byte array?
But its actual type is PrimitiveByteArrayTypeDescriptor. However not its toString() method is called in AbstractTypeDescriptor.extractLoggableRepresentation() method but the Object class' toString() method.