### PR TITLE
HHH-10017 - bytecode enhancement - consistent handling of persistent attributes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/FieldWriter.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/FieldWriter.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.bytecode.enhance.internal;
 
+import javax.persistence.Transient;
+
 import javassist.CannotCompileException;
 import javassist.CtClass;
 import javassist.CtField;
@@ -13,11 +15,10 @@ import javassist.Modifier;
 import javassist.bytecode.AnnotationsAttribute;
 import javassist.bytecode.FieldInfo;
 import javassist.bytecode.annotation.Annotation;
+
 import org.hibernate.bytecode.enhance.spi.EnhancementException;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-
-import javax.persistence.Transient;
 
 /**
  * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
@@ -50,7 +51,7 @@ public class FieldWriter {
 
 	private static void addPrivateTransient(CtClass target, CtClass type, String name) {
 		addWithModifiers( target, type, name, Modifier.PRIVATE | Modifier.TRANSIENT, Transient.class );
-		log.debugf( "Wrote field into [%s]: @Transient private transient %s %s;%n", target.getName(), type.getName(), name );
+		log.debugf( "Wrote field into [%s]: @Transient private transient %s %s;", target.getName(), type.getName(), name );
 	}
 
 	private static void addWithModifiers(CtClass target, CtClass type, String  name, int modifiers, Class<?> ... annotations ) {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/MethodWriter.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/MethodWriter.java
@@ -37,7 +37,7 @@ public class MethodWriter {
 	public static CtMethod write(CtClass target, String format, Object ... args) throws CannotCompileException {
 		final String body = String.format( format, args );
 		// System.out.printf( "writing method into [%s]:%n%s%n", target.getName(), body );
-		log.debugf( "writing method into [%s]:%n%s%n", target.getName(), body );
+		log.debugf( "writing method into [%s]:%n%s", target.getName(), body );
 		final CtMethod method = CtNewMethod.make( body, target );
 		target.addMethod( method );
 		return method;
@@ -47,7 +47,7 @@ public class MethodWriter {
 
 	public static CtMethod addGetter(CtClass target, String field, String name) {
 		try {
-			log.debugf( "Writing getter method [%s] into [%s] for field [%s]%n", name, target.getName(), field );
+			log.debugf( "Writing getter method [%s] into [%s] for field [%s]", name, target.getName(), field );
 			final CtMethod method = CtNewMethod.getter( name, target.getField( field ) );
 			target.addMethod( method );
 			return method;
@@ -64,7 +64,7 @@ public class MethodWriter {
 
 	public static CtMethod addSetter(CtClass target, String field, String name) {
 		try {
-			log.debugf( "Writing setter method [%s] into [%s] for field [%s]%n", name, target.getName(), field );
+			log.debugf( "Writing setter method [%s] into [%s] for field [%s]", name, target.getName(), field );
 			final CtMethod method = CtNewMethod.setter( name, target.getField( field ) );
 			target.addMethod( method );
 			return method;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/PersistentAttributesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/PersistentAttributesHelper.java
@@ -1,0 +1,384 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.enhance.internal;
+
+import java.beans.Introspector;
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Map;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMember;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import javassist.bytecode.BadBytecode;
+import javassist.bytecode.SignatureAttribute;
+
+import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+
+/**
+ * util methods to fetch attribute metadata. consistent for both field and property access types.
+ *
+ * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
+ * @see org.hibernate.internal.util.ReflectHelper
+ */
+public class PersistentAttributesHelper {
+
+	private PersistentAttributesHelper() {
+	}
+
+	private static final CoreMessageLogger log = CoreLogging.messageLogger( PersistentAttributesHelper.class );
+
+	public static boolean hasAnnotation(CtField attribute, Class<? extends Annotation> annotation) {
+		return getAnnotation( attribute, annotation ) != null;
+	}
+
+	public static boolean hasAnnotation(CtClass ctClass, String attributeName, Class<? extends Annotation> annotation) {
+		return getAnnotation( ctClass, attributeName, annotation ) != null;
+	}
+
+	public static <T extends Annotation> T getAnnotation(CtField attribute, Class<T> annotation) {
+		return getAnnotation( attribute.getDeclaringClass(), attribute.getName(), annotation );
+	}
+
+	public static <T extends Annotation> T getAnnotation(CtClass ctClass, String attributeName, Class<T> annotation) {
+		AccessType classAccessType = getAccessTypeOrNull( ctClass );
+		CtField field = findFieldOrNull( ctClass, attributeName );
+		CtMethod getter = findGetterOrNull( ctClass, attributeName );
+
+		if ( classAccessType == AccessType.FIELD || ( field != null && getAccessTypeOrNull( field ) == AccessType.FIELD ) ) {
+			return field == null ? null : getAnnotationOrNull( field, annotation );
+		}
+		if ( classAccessType == AccessType.PROPERTY || ( getter != null && getAccessTypeOrNull( getter ) == AccessType.PROPERTY ) ) {
+			return getter == null ? null : getAnnotationOrNull( getter, annotation );
+		}
+
+		T found = ( getter == null ? null : getAnnotationOrNull( getter, annotation ) );
+		if ( found == null && field != null ) {
+			return getAnnotationOrNull( field, annotation );
+		}
+		return found;
+	}
+
+	private static <T extends Annotation> T getAnnotationOrNull(CtMember ctMember, Class<T> annotation) {
+		try {
+			if ( ctMember.hasAnnotation( annotation ) ) {
+				return annotation.cast( ctMember.getAnnotation( annotation ) );
+			}
+		}
+		catch (ClassNotFoundException cnfe) {
+			// should never happen
+		}
+		return null;
+	}
+
+	private static AccessType getAccessTypeOrNull(CtMember ctMember) {
+		Access access = getAnnotationOrNull( ctMember, Access.class );
+		return access == null ? null : access.value();
+	}
+
+	private static AccessType getAccessTypeOrNull(CtClass ctClass) {
+		try {
+			if ( ctClass.hasAnnotation( Access.class ) ) {
+				return ( (Access) ctClass.getAnnotation( Access.class ) ).value();
+			}
+			else {
+				CtClass extendsClass = ctClass.getSuperclass();
+				return extendsClass == null ? null : getAccessTypeOrNull( extendsClass );
+			}
+		}
+		catch (ClassNotFoundException e) {
+			return null;
+		}
+		catch (NotFoundException e) {
+			return null;
+		}
+	}
+
+	//
+
+	/**
+	 * duplicated here to take CtClass instead of Class
+	 * @see org.hibernate.internal.util.ReflectHelper#locateField
+	 */
+	private static CtField findFieldOrNull(CtClass ctClass, String propertyName) {
+		if ( ctClass == null ) {
+			return null;
+		}
+		try {
+			return ctClass.getField( propertyName );
+		}
+		catch ( NotFoundException nsfe ) {
+			try {
+				return findFieldOrNull( ctClass.getSuperclass(), propertyName );
+			}
+			catch (NotFoundException e) {
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * duplicated here to take CtClass instead of Class
+	 * @see org.hibernate.internal.util.ReflectHelper#findGetterMethod
+	 */
+	private static CtMethod findGetterOrNull(CtClass ctClass, String propertyName) {
+		if ( ctClass == null ) {
+			return null;
+		}
+		CtMethod method = getterOrNull( ctClass, propertyName );
+		if ( method != null ) {
+			return method;
+		}
+		try {
+			// check if extends
+			method = findGetterOrNull( ctClass.getSuperclass(), propertyName );
+			if ( method != null ) {
+				return method;
+			}
+			// check if implements
+			for ( CtClass interfaceCtClass : ctClass.getInterfaces() ) {
+				method = getterOrNull( interfaceCtClass, propertyName );
+				if ( method != null ) {
+					return method;
+				}
+			}
+		}
+		catch (NotFoundException nfe) {
+			// give up
+		}
+		return null;
+	}
+
+	private static CtMethod getterOrNull(CtClass containerClass, String propertyName) {
+		for ( CtMethod method : containerClass.getDeclaredMethods() ) {
+			try {
+				// if the method has parameters, skip it
+				if ( method.isEmpty() || method.getParameterTypes().length != 0 ) {
+					continue;
+				}
+			}
+			catch (NotFoundException e) {
+				continue;
+			}
+
+			final String methodName = method.getName();
+
+			// try "get"
+			if ( methodName.startsWith( "get" ) ) {
+				String testStdMethod = Introspector.decapitalize( methodName.substring( 3 ) );
+				String testOldMethod = methodName.substring( 3 );
+				if ( testStdMethod.equals( propertyName ) || testOldMethod.equals( propertyName ) ) {
+					return method;
+				}
+			}
+
+			// if not "get", then try "is"
+			if ( methodName.startsWith( "is" ) ) {
+				String testStdMethod = Introspector.decapitalize( methodName.substring( 2 ) );
+				String testOldMethod = methodName.substring( 2 );
+				if ( testStdMethod.equals( propertyName ) || testOldMethod.equals( propertyName ) ) {
+					return method;
+				}
+			}
+		}
+		return null;
+	}
+
+	//
+
+	public static boolean isPossibleBiDirectionalAssociation(CtField persistentField) {
+		return PersistentAttributesHelper.hasAnnotation( persistentField, OneToOne.class ) ||
+				PersistentAttributesHelper.hasAnnotation( persistentField, OneToMany.class ) ||
+				PersistentAttributesHelper.hasAnnotation( persistentField, ManyToOne.class ) ||
+				PersistentAttributesHelper.hasAnnotation( persistentField, ManyToMany.class );
+	}
+
+	public static String getMappedBy(CtField persistentField, CtClass targetEntity, EnhancementContext context) {
+		final String local = getMappedByFromAnnotation( persistentField );
+		return local.isEmpty() ? getMappedByFromTargetEntity( persistentField, targetEntity, context ) : local;
+	}
+
+	private static String getMappedByFromAnnotation(CtField persistentField) {
+
+		OneToOne oto = PersistentAttributesHelper.getAnnotation( persistentField, OneToOne.class );
+		if ( oto != null ) {
+			return oto.mappedBy();
+		}
+
+		OneToMany otm = PersistentAttributesHelper.getAnnotation( persistentField, OneToMany.class );
+		if ( otm != null ) {
+			return otm.mappedBy();
+		}
+
+		// For @ManyToOne associations, mappedBy must come from the @OneToMany side of the association
+
+		ManyToMany mtm = PersistentAttributesHelper.getAnnotation( persistentField, ManyToMany.class );
+		return mtm == null ? "" : mtm.mappedBy();
+	}
+
+	private static String getMappedByFromTargetEntity(
+			CtField persistentField,
+			CtClass targetEntity,
+			EnhancementContext context) {
+		// get mappedBy value by searching in the fields of the target entity class
+		for ( CtField f : targetEntity.getDeclaredFields() ) {
+			if ( context.isPersistentField( f ) && getMappedByFromAnnotation( f ).equals( persistentField.getName() ) ) {
+				log.debugf(
+						"mappedBy association for field [%s#%s] is [%s#%s]",
+						persistentField.getDeclaringClass().getName(),
+						persistentField.getName(),
+						targetEntity.getName(),
+						f.getName()
+				);
+				return f.getName();
+			}
+		}
+		return "";
+	}
+
+	public static CtClass getTargetEntityClass(CtClass managedCtClass, CtField persistentField) throws NotFoundException {
+		// get targetEntity defined in the annotation
+		try {
+			OneToOne oto = PersistentAttributesHelper.getAnnotation( persistentField, OneToOne.class );
+			OneToMany otm = PersistentAttributesHelper.getAnnotation( persistentField, OneToMany.class );
+			ManyToOne mto = PersistentAttributesHelper.getAnnotation( persistentField, ManyToOne.class );
+			ManyToMany mtm = PersistentAttributesHelper.getAnnotation( persistentField, ManyToMany.class );
+
+			Class<?> targetClass = null;
+			if ( oto != null ) {
+				targetClass = oto.targetEntity();
+			}
+			if ( otm != null ) {
+				targetClass = otm.targetEntity();
+			}
+			if ( mto != null ) {
+				targetClass = mto.targetEntity();
+			}
+			if ( mtm != null ) {
+				targetClass = mtm.targetEntity();
+			}
+
+			if ( targetClass != null && targetClass != void.class ) {
+				return managedCtClass.getClassPool().get( targetClass.getName() );
+			}
+		}
+		catch (NotFoundException ignore) {
+		}
+
+		// infer targetEntity from generic type signature
+		String inferredTypeName = inferTypeName( managedCtClass, persistentField.getName() );
+		return inferredTypeName == null ? null : managedCtClass.getClassPool().get( inferredTypeName );
+	}
+
+	/**
+	 * Consistent with hasAnnotation()
+	 */
+	private static String inferTypeName(CtClass ctClass, String attributeName ) {
+		AccessType classAccessType = getAccessTypeOrNull( ctClass );
+		CtField field = findFieldOrNull( ctClass, attributeName );
+		CtMethod getter = findGetterOrNull( ctClass, attributeName );
+
+		if ( classAccessType == AccessType.FIELD || ( field != null && getAccessTypeOrNull( field ) == AccessType.FIELD ) ) {
+			return field == null ? null : inferFieldTypeName( field );
+		}
+		if ( classAccessType == AccessType.PROPERTY || ( getter != null && getAccessTypeOrNull( getter ) == AccessType.PROPERTY ) ) {
+			return getter == null ? null : inferMethodTypeName( getter );
+		}
+
+		String found = ( getter == null ? null : inferMethodTypeName( getter ) );
+		if ( found == null && field != null ) {
+			return inferFieldTypeName( field );
+		}
+		return found;
+	}
+
+	private static String inferFieldTypeName(CtField field) {
+		try {
+			if ( field.getFieldInfo().getAttribute( SignatureAttribute.tag ) == null ){
+				return field.getType().getName();
+			}
+			return inferGenericTypeName(
+					field.getType(),
+					SignatureAttribute.toTypeSignature( field.getGenericSignature() )
+			);
+		}
+		catch (BadBytecode ignore) {
+			return null;
+		}
+		catch (NotFoundException e) {
+			return null;
+		}
+	}
+
+	private static String inferMethodTypeName(CtMethod method) {
+		try {
+			if ( method.getMethodInfo().getAttribute( SignatureAttribute.tag ) == null ){
+				return method.getReturnType().getName();
+			}
+			return inferGenericTypeName(
+					method.getReturnType(),
+					SignatureAttribute.toMethodSignature( method.getGenericSignature() ).getReturnType()
+			);
+		}
+		catch (BadBytecode ignore) {
+			return null;
+		}
+		catch (NotFoundException e) {
+			return null;
+		}
+	}
+
+	private static String inferGenericTypeName(CtClass ctClass, SignatureAttribute.Type genericSignature) {
+		// infer targetEntity from generic type signature
+		if ( isAssignable( ctClass, Collection.class.getName() ) ) {
+			return ( (SignatureAttribute.ClassType) genericSignature ).getTypeArguments()[0].toString();
+		}
+		if ( isAssignable( ctClass, Map.class.getName() ) ) {
+			return ( (SignatureAttribute.ClassType) genericSignature ).getTypeArguments()[1].toString();
+		}
+		return ctClass.getName();
+	}
+
+	//
+
+	public static boolean isAssignable(CtClass thisCtClass, String targetClassName) {
+		if ( thisCtClass == null ) {
+			return false;
+		}
+		if ( thisCtClass.getName().equals( targetClassName ) ) {
+			return true;
+		}
+
+		try {
+			// check if extends
+			if ( isAssignable( thisCtClass.getSuperclass(), targetClassName ) ) {
+				return true;
+			}
+			// check if implements
+			for ( CtClass interfaceCtClass : thisCtClass.getInterfaces() ) {
+				if ( isAssignable( interfaceCtClass, targetClassName ) ) {
+					return true;
+				}
+			}
+		}
+		catch (NotFoundException e) {
+			// keep going
+		}
+		return false;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleCollectionTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleCollectionTracker.java
@@ -8,21 +8,24 @@ package org.hibernate.bytecode.enhance.internal.tracker;
 
 import java.util.Arrays;
 
+import org.hibernate.bytecode.enhance.spi.CollectionTracker;
+
 /**
  * small low memory class to keep track of the number of elements in a collection
  *
  * @author <a href="mailto:stale.pedersen@jboss.org">Ståle W. Pedersen</a>
  */
-public final class CollectionTracker {
+public final class SimpleCollectionTracker implements CollectionTracker {
 
 	private String[] names;
 	private int[] sizes;
 
-	public CollectionTracker() {
+	public SimpleCollectionTracker() {
 		names = new String[0];
 		sizes = new int[0];
 	}
 
+	@Override
 	public void add(String name, int size) {
 		for ( int i = 0; i < names.length; i++ ) {
 			if ( names[i].equals( name ) ) {
@@ -36,6 +39,7 @@ public final class CollectionTracker {
 		sizes[sizes.length - 1] = size;
 	}
 
+	@Override
 	public int getSize(String name) {
 		for ( int i = 0; i < names.length; i++ ) {
 			if ( name.equals( names[i] ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 public final class SimpleFieldTracker implements DirtyTracker {
 
 	private String[] names;
+	private boolean suspended;
 
 	public SimpleFieldTracker() {
 		names = new String[0];
@@ -26,6 +27,9 @@ public final class SimpleFieldTracker implements DirtyTracker {
 
 	@Override
 	public void add(String name) {
+		if ( suspended ) {
+			return;
+		}
 		if ( !contains( name ) ) {
 			names = Arrays.copyOf( names, names.length + 1 );
 			names[names.length - 1] = name;
@@ -44,7 +48,9 @@ public final class SimpleFieldTracker implements DirtyTracker {
 
 	@Override
 	public void clear() {
-		names = new String[0];
+		if ( !isEmpty() ) {
+			names = new String[0];
+		}
 	}
 
 	@Override
@@ -55,6 +61,11 @@ public final class SimpleFieldTracker implements DirtyTracker {
 	@Override
 	public String[] get() {
 		return names;
+	}
+
+	@Override
+	public void suspend(boolean suspend) {
+		this.suspended = suspend;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
@@ -16,6 +16,7 @@ package org.hibernate.bytecode.enhance.internal.tracker;
 public final class SortedFieldTracker implements DirtyTracker {
 
 	private String[] names;
+	private boolean suspended;
 
 	public SortedFieldTracker() {
 		names = new String[0];
@@ -23,6 +24,9 @@ public final class SortedFieldTracker implements DirtyTracker {
 
 	@Override
 	public void add(String name) {
+		if ( suspended ) {
+			return;
+		}
 		// we do a binary search: even if we don't find the name at least we get the position to insert into the array
 		int insert = 0;
 		for ( int low = 0, high = names.length - 1; low <= high; ) {
@@ -70,7 +74,9 @@ public final class SortedFieldTracker implements DirtyTracker {
 
 	@Override
 	public void clear() {
-		names = new String[0];
+		if ( !isEmpty() ) {
+			names = new String[0];
+		}
 	}
 
 	@Override
@@ -81,6 +87,11 @@ public final class SortedFieldTracker implements DirtyTracker {
 	@Override
 	public String[] get() {
 		return names;
+	}
+
+	@Override
+	public void suspend(boolean suspend) {
+		this.suspended = suspend;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/CollectionTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/CollectionTracker.java
@@ -4,24 +4,16 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.bytecode.enhance.internal.tracker;
+package org.hibernate.bytecode.enhance.spi;
 
 /**
- * Interface to be implemented by dirty trackers, a simplified Set of String.
+ * Interface to be implemented by collection trackers that hold the expected size od collections, a simplified Map<String, int>.
  *
  * @author <a href="mailto:lbarreiro@redhat.com">Luis Barreiro</a>
  */
-public interface DirtyTracker {
+public interface CollectionTracker {
 
-	void add(String name);
+	void add(String name, int size);
 
-	boolean contains(String name);
-
-	void clear();
-
-	boolean isEmpty();
-
-	String[] get();
-
-	void suspend(boolean suspend);
+	int getSize(String name);
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
@@ -138,6 +138,16 @@ public final class EnhancerConstants {
 	public static final String TRACKER_CLEAR_NAME = "$$_hibernate_clearDirtyAttributes";
 
 	/**
+	 * Name of method to suspend dirty tracking
+	 */
+	public static final String TRACKER_SUSPEND_NAME = "$$_hibernate_suspendDirtyTracking";
+
+	/**
+	 * Name of method to check if collection fields are dirty
+	 */
+	public static final String TRACKER_COLLECTION_GET_NAME = "$$_hibernate_getCollectionTracker";
+
+	/**
 	 * Name of method to check if collection fields are dirty
 	 */
 	public static final String TRACKER_COLLECTION_CHANGED_NAME = "$$_hibernate_areCollectionFieldsDirty";

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SelfDirtinessTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SelfDirtinessTracker.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.engine.spi;
 
+import org.hibernate.bytecode.enhance.spi.CollectionTracker;
+
 /**
  * Contract for an entity to report that it tracks the dirtiness of its own state,
  * as opposed to needing Hibernate to perform state-diff dirty calculations.
@@ -41,4 +43,14 @@ public interface SelfDirtinessTracker {
 	 * Clear the stored dirty attributes
 	 */
 	void $$_hibernate_clearDirtyAttributes();
+
+	/**
+	 * Temporarily enable / disable dirty tracking
+	 */
+	void $$_hibernate_suspendDirtyTracking(boolean suspend);
+
+	/**
+	 * Get access to the CollectionTracker
+	 */
+	CollectionTracker $$_hibernate_getCollectionTracker();
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -15,7 +15,6 @@ import org.hibernate.ObjectDeletedException;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.WrongClassException;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
-import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoader;
 import org.hibernate.bytecode.instrumentation.spi.FieldInterceptor;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.internal.Cascade;
@@ -24,8 +23,6 @@ import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
-import org.hibernate.engine.spi.PersistentAttributeInterceptable;
-import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -346,24 +343,13 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			}
 		}
 
-		// for enhanced entities, copy over the dirty attributes and the lazy/loaded fields in the interceptor
+		// for enhanced entities, copy over the dirty attributes
 		if ( entity instanceof SelfDirtinessTracker && target instanceof SelfDirtinessTracker ) {
+			// clear, because setting the embedded attributes dirties them
+			( (SelfDirtinessTracker) target ).$$_hibernate_clearDirtyAttributes();
+
 			for ( String fieldName : ( (SelfDirtinessTracker) entity ).$$_hibernate_getDirtyAttributes() ) {
 				( (SelfDirtinessTracker) target ).$$_hibernate_trackChange( fieldName );
-			}
-		}
-		if ( entity instanceof PersistentAttributeInterceptable
-				&& target instanceof PersistentAttributeInterceptable
-				&& ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor() != null
-				&& ( (PersistentAttributeInterceptable) target ).$$_hibernate_getInterceptor() != null ) {
-
-			PersistentAttributeInterceptor entityInterceptor = ( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
-			PersistentAttributeInterceptor targetInterceptor = ( (PersistentAttributeInterceptable) target ).$$_hibernate_getInterceptor();
-
-			if ( entityInterceptor instanceof LazyAttributeLoader && targetInterceptor instanceof LazyAttributeLoader ) {
-				for ( String fieldName : ( (LazyAttributeLoader) entityInterceptor ).getiInitializedFields() ) {
-					( (LazyAttributeLoader) targetInterceptor ).setLoaded( fieldName );
-				}
 			}
 		}
 	}
@@ -415,7 +401,6 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 		final Object[] copiedValues = TypeHelper.replace(
 				persister.getPropertyValues( entity ),
 				persister.getPropertyValues( target ),
-				persister.getPropertyNames(),
 				persister.getPropertyTypes(),
 				source,
 				target,
@@ -453,7 +438,6 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			copiedValues = TypeHelper.replace(
 					persister.getPropertyValues( entity ),
 					persister.getPropertyValues( target ),
-					persister.getPropertyNames(),
 					persister.getPropertyTypes(),
 					source,
 					target,

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -330,6 +330,7 @@ public class Property implements Serializable, MetaAttributable {
 				: EntityMode.POJO;
 
 		return resolveServiceRegistry().getService( PropertyAccessStrategyResolver.class ).resolvePropertyAccessStrategy(
+				clazz,
 				accessName,
 				entityMode
 		);

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
@@ -1,0 +1,152 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.hibernate.PropertyNotFoundException;
+import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
+import org.hibernate.internal.util.ReflectHelper;
+import org.hibernate.property.access.spi.EnhancedGetterMethodImpl;
+import org.hibernate.property.access.spi.EnhancedSetterMethodImpl;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.property.access.spi.GetterFieldImpl;
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.property.access.spi.PropertyAccessBuildingException;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
+import org.hibernate.property.access.spi.Setter;
+import org.hibernate.property.access.spi.SetterFieldImpl;
+
+/**
+ * A PropertyAccess for byte code enhanced entities. Enhanced getter / setter methods ( if available ) are used for
+ * field access. Regular getter / setter methods are used for property access. In both cases, delegates calls to
+ * EnhancedMethodGetterImpl / EnhancedMethodGetterImpl. Based upon PropertyAccessMixedImpl.
+ *
+ * @author Steve Ebersole
+ * @author Luis Barreiro
+ */
+public class PropertyAccessEnhancedImpl implements PropertyAccess {
+	private final PropertyAccessStrategyEnhancedImpl strategy;
+
+	private final Getter getter;
+	private final Setter setter;
+
+	public PropertyAccessEnhancedImpl(
+			PropertyAccessStrategyEnhancedImpl strategy,
+			Class containerJavaType,
+			String propertyName) {
+		this.strategy = strategy;
+
+		final Field field = fieldOrNull( containerJavaType, propertyName );
+		final Method getterMethod = getterMethodOrNull( containerJavaType, propertyName );
+
+		final Class propertyJavaType;
+
+		// need one of field or getterMethod to be non-null
+		if ( field == null && getterMethod == null ) {
+			String msg = String.format( "Could not locate field nor getter method for property named [%s#%s]",
+										containerJavaType.getName(),
+										propertyName );
+			throw new PropertyAccessBuildingException( msg );
+		}
+		else if ( field != null ) {
+			propertyJavaType = field.getType();
+			this.getter = resolveGetterForField( containerJavaType, propertyName, field );
+		}
+		else {
+			propertyJavaType = getterMethod.getReturnType();
+			this.getter = new EnhancedGetterMethodImpl( containerJavaType, propertyName, getterMethod );
+		}
+
+		final Method setterMethod = setterMethodOrNull( containerJavaType, propertyName, propertyJavaType );
+
+		// need one of field or setterMethod to be non-null
+		if ( field == null && setterMethod == null ) {
+			String msg = String.format( "Could not locate field nor getter method for property named [%s#%s]",
+										containerJavaType.getName(),
+										propertyName );
+			throw new PropertyAccessBuildingException( msg );
+		}
+		else if ( field != null ) {
+			this.setter = resolveSetterForField( containerJavaType, propertyName, field );
+		}
+		else {
+			this.setter = new EnhancedSetterMethodImpl( containerJavaType, propertyName, setterMethod );
+		}
+	}
+
+	private static Field fieldOrNull(Class containerJavaType, String propertyName) {
+		try {
+			return ReflectHelper.findField( containerJavaType, propertyName );
+		}
+		catch (PropertyNotFoundException e) {
+			return null;
+		}
+	}
+
+	private static Method getterMethodOrNull(Class containerJavaType, String propertyName) {
+		try {
+			return ReflectHelper.findGetterMethod( containerJavaType, propertyName );
+		}
+		catch (PropertyNotFoundException e) {
+			return null;
+		}
+	}
+
+	private static Method setterMethodOrNull(Class containerJavaType, String propertyName, Class propertyJavaType) {
+		try {
+			return ReflectHelper.findSetterMethod( containerJavaType, propertyName, propertyJavaType );
+		}
+		catch (PropertyNotFoundException e) {
+			return null;
+		}
+	}
+
+	//
+
+	private static Getter resolveGetterForField(Class<?> containerClass, String propertyName, Field field) {
+		try {
+			String enhancedGetterName = EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + propertyName;
+			Method enhancedGetter = containerClass.getDeclaredMethod( enhancedGetterName );
+			enhancedGetter.setAccessible( true );
+			return new EnhancedGetterMethodImpl( containerClass, propertyName, enhancedGetter );
+		}
+		catch (NoSuchMethodException e) {
+			// enhancedGetter = null --- field not enhanced: fallback to reflection using the field
+			return new GetterFieldImpl( containerClass, propertyName, field );
+		}
+	}
+
+	private static Setter resolveSetterForField(Class<?> containerClass, String propertyName, Field field) {
+		try {
+			String enhancedSetterName = EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX + propertyName;
+			Method enhancedSetter = containerClass.getDeclaredMethod( enhancedSetterName, field.getType() );
+			enhancedSetter.setAccessible( true );
+			return new EnhancedSetterMethodImpl( containerClass, propertyName, enhancedSetter );
+		}
+		catch (NoSuchMethodException e) {
+			// enhancedSetter = null --- field not enhanced: fallback to reflection using the field
+			return new SetterFieldImpl( containerClass, propertyName, field );
+		}
+	}
+
+	@Override
+	public PropertyAccessStrategy getPropertyAccessStrategy() {
+		return strategy;
+	}
+
+	@Override
+	public Getter getGetter() {
+		return getter;
+	}
+
+	@Override
+	public Setter getSetter() {
+		return setter;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessFieldImpl.java
@@ -22,8 +22,8 @@ import org.hibernate.property.access.spi.SetterFieldImpl;
  */
 public class PropertyAccessFieldImpl implements PropertyAccess {
 	private final PropertyAccessStrategyFieldImpl strategy;
-	private final GetterFieldImpl getter;
-	private final SetterFieldImpl setter;
+	private final Getter getter;
+	private final Setter setter;
 
 	public PropertyAccessFieldImpl(
 			PropertyAccessStrategyFieldImpl strategy,
@@ -50,4 +50,5 @@ public class PropertyAccessFieldImpl implements PropertyAccess {
 	public Setter getSetter() {
 		return setter;
 	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.internal;
+
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
+
+/**
+ * Defines a strategy for accessing property values via a get/set pair, which may be nonpublic.  This
+ * is the default (and recommended) strategy.
+ *
+ * @author Steve Ebersole
+ * @author Gavin King
+ */
+public class PropertyAccessStrategyEnhancedImpl implements PropertyAccessStrategy {
+	/**
+	 * Singleton access
+	 */
+	public static final PropertyAccessStrategyEnhancedImpl INSTANCE = new PropertyAccessStrategyEnhancedImpl();
+
+	@Override
+	public PropertyAccess buildPropertyAccess(Class containerJavaType, final String propertyName) {
+		return new PropertyAccessEnhancedImpl( this, containerJavaType, propertyName );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterMethodImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterMethodImpl.java
@@ -1,0 +1,152 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.spi;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.hibernate.PropertyAccessException;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoader;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.CoreMessageLogger;
+
+import static org.hibernate.internal.CoreLogging.messageLogger;
+
+/**
+ * @author Steve Ebersole
+ */
+public class EnhancedGetterMethodImpl implements Getter {
+	private static final CoreMessageLogger LOG = messageLogger( EnhancedGetterMethodImpl.class );
+
+	private final Class containerClass;
+	private final String propertyName;
+	private final Method getterMethod;
+
+	public EnhancedGetterMethodImpl(Class containerClass, String propertyName, Method getterMethod) {
+		this.containerClass = containerClass;
+		this.propertyName = propertyName;
+		this.getterMethod = getterMethod;
+	}
+
+	private boolean isAttributeLoaded(Object owner) {
+		if ( owner instanceof PersistentAttributeInterceptable ) {
+			PersistentAttributeInterceptor interceptor = ( (PersistentAttributeInterceptable) owner ).$$_hibernate_getInterceptor();
+			if ( interceptor != null && interceptor instanceof LazyAttributeLoader ) {
+				return ( (LazyAttributeLoader) interceptor ).isAttributeLoaded( propertyName );
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public Object get(Object owner) {
+		try {
+
+			// We don't want to trigger lazy loading of byte code enhanced attributes
+			if ( isAttributeLoaded( owner ) ) {
+				return getterMethod.invoke( owner );
+			}
+			return null;
+
+		}
+		catch (InvocationTargetException ite) {
+			throw new PropertyAccessException(
+					ite,
+					"Exception occurred inside",
+					false,
+					containerClass,
+					propertyName
+			);
+		}
+		catch (IllegalAccessException iae) {
+			throw new PropertyAccessException(
+					iae,
+					"IllegalAccessException occurred while calling",
+					false,
+					containerClass,
+					propertyName
+			);
+			//cannot occur
+		}
+		catch (IllegalArgumentException iae) {
+			LOG.illegalPropertyGetterArgument( containerClass.getName(), propertyName );
+			throw new PropertyAccessException(
+					iae,
+					"IllegalArgumentException occurred calling",
+					false,
+					containerClass,
+					propertyName
+			);
+		}
+	}
+
+	@Override
+	public Object getForInsert(Object owner, Map mergeMap, SessionImplementor session) {
+		return get( owner );
+	}
+
+	@Override
+	public Class getReturnType() {
+		return getterMethod.getReturnType();
+	}
+
+	@Override
+	public Member getMember() {
+		return getterMethod;
+	}
+
+	@Override
+	public String getMethodName() {
+		return getterMethod.getName();
+	}
+
+	@Override
+	public Method getMethod() {
+		return getterMethod;
+	}
+
+	private Object writeReplace() throws ObjectStreamException {
+		return new SerialForm( containerClass, propertyName, getterMethod );
+	}
+
+	private static class SerialForm implements Serializable {
+		private final Class containerClass;
+		private final String propertyName;
+
+		private final Class declaringClass;
+		private final String methodName;
+
+		private SerialForm(Class containerClass, String propertyName, Method method) {
+			this.containerClass = containerClass;
+			this.propertyName = propertyName;
+			this.declaringClass = method.getDeclaringClass();
+			this.methodName = method.getName();
+		}
+
+		private Object readResolve() {
+			return new EnhancedGetterMethodImpl( containerClass, propertyName, resolveMethod() );
+		}
+
+		@SuppressWarnings("unchecked")
+		private Method resolveMethod() {
+			try {
+				return declaringClass.getDeclaredMethod( methodName );
+			}
+			catch (NoSuchMethodException e) {
+				throw new PropertyAccessSerializationException(
+						"Unable to resolve getter method on deserialization : " + declaringClass.getName() + "#" + methodName
+				);
+			}
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedSetterMethodImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedSetterMethodImpl.java
@@ -1,0 +1,168 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.spi;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.hibernate.PropertyAccessException;
+import org.hibernate.PropertySetterAccessException;
+import org.hibernate.engine.spi.SelfDirtinessTracker;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.CoreMessageLogger;
+
+import static org.hibernate.internal.CoreLogging.messageLogger;
+
+/**
+ * @author Steve Ebersole
+ */
+public class EnhancedSetterMethodImpl implements Setter {
+	private static final CoreMessageLogger LOG = messageLogger( EnhancedSetterMethodImpl.class );
+
+	private final Class containerClass;
+	private final String propertyName;
+	private final Method setterMethod;
+
+	private final boolean isPrimitive;
+
+	public EnhancedSetterMethodImpl(Class containerClass, String propertyName, Method setterMethod) {
+		this.containerClass = containerClass;
+		this.propertyName = propertyName;
+		this.setterMethod = setterMethod;
+		this.isPrimitive = setterMethod.getParameterTypes()[0].isPrimitive();
+	}
+
+	@Override
+	public void set(Object target, Object value, SessionFactoryImplementor factory) {
+		try {
+
+			// for enhanced attribute, don't flag as dirty
+			if ( target instanceof SelfDirtinessTracker ) {
+				( (SelfDirtinessTracker) target ).$$_hibernate_suspendDirtyTracking( true );
+				setterMethod.invoke( target, value );
+				( (SelfDirtinessTracker) target ).$$_hibernate_suspendDirtyTracking( false );
+			}
+			else {
+				setterMethod.invoke( target, value );
+			}
+
+		}
+		catch (NullPointerException npe) {
+			if ( value == null && isPrimitive ) {
+				throw new PropertyAccessException(
+						npe,
+						"Null value was assigned to a property of primitive type",
+						true,
+						containerClass,
+						propertyName
+				);
+			}
+			else {
+				throw new PropertyAccessException(
+						npe,
+						"NullPointerException occurred while calling",
+						true,
+						containerClass,
+						propertyName
+				);
+			}
+		}
+		catch (InvocationTargetException ite) {
+			throw new PropertyAccessException(
+					ite,
+					"Exception occurred inside",
+					true,
+					containerClass,
+					propertyName
+			);
+		}
+		catch (IllegalAccessException iae) {
+			throw new PropertyAccessException(
+					iae,
+					"IllegalAccessException occurred while calling",
+					true,
+					containerClass,
+					propertyName
+			);
+			//cannot occur
+		}
+		catch (IllegalArgumentException iae) {
+			if ( value == null && isPrimitive ) {
+				throw new PropertyAccessException(
+						iae,
+						"Null value was assigned to a property of primitive type",
+						true,
+						containerClass,
+						propertyName
+				);
+			}
+			else {
+				final Class expectedType = setterMethod.getParameterTypes()[0];
+				LOG.illegalPropertySetterArgument( containerClass.getName(), propertyName );
+				LOG.expectedType( expectedType.getName(), value == null ? null : value.getClass().getName() );
+				throw new PropertySetterAccessException(
+						iae,
+						containerClass,
+						propertyName,
+						expectedType,
+						target,
+						value
+				);
+			}
+		}
+	}
+
+	@Override
+	public String getMethodName() {
+		return setterMethod.getName();
+	}
+
+	@Override
+	public Method getMethod() {
+		return setterMethod;
+	}
+
+	private Object writeReplace() throws ObjectStreamException {
+		return new SerialForm( containerClass, propertyName, setterMethod );
+	}
+
+	private static class SerialForm implements Serializable {
+		private final Class containerClass;
+		private final String propertyName;
+
+		private final Class declaringClass;
+		private final String methodName;
+		private final Class argumentType;
+
+		private SerialForm(Class containerClass, String propertyName, Method method) {
+			this.containerClass = containerClass;
+			this.propertyName = propertyName;
+			this.declaringClass = method.getDeclaringClass();
+			this.methodName = method.getName();
+			this.argumentType = method.getParameterTypes()[0];
+		}
+
+		private Object readResolve() {
+			return new EnhancedSetterMethodImpl( containerClass, propertyName, resolveMethod() );
+		}
+
+		@SuppressWarnings("unchecked")
+		private Method resolveMethod() {
+			try {
+				return declaringClass.getDeclaredMethod( methodName, argumentType );
+			}
+			catch (NoSuchMethodException e) {
+				throw new PropertyAccessSerializationException(
+						"Unable to resolve setter method on deserialization : " + declaringClass.getName() + "#"
+								+ methodName + "(" + argumentType.getName() + ")"
+				);
+			}
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/PropertyAccessStrategyResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/PropertyAccessStrategyResolver.java
@@ -20,10 +20,14 @@ public interface PropertyAccessStrategyResolver extends Service {
 	/**
 	 * Resolve the PropertyAccessStrategy to use
 	 *
+	 * @param containerClass The java class of the entity
 	 * @param explicitAccessStrategyName The access strategy name explicitly specified, if any.
 	 * @param entityMode The entity mode in effect for the property, used to interpret different default strategies.
 	 *
 	 * @return The resolved PropertyAccessStrategy
 	 */
-	PropertyAccessStrategy resolvePropertyAccessStrategy(String explicitAccessStrategyName, EntityMode entityMode);
+	PropertyAccessStrategy resolvePropertyAccessStrategy(
+			Class containerClass,
+			String explicitAccessStrategyName,
+			EntityMode entityMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/PropertyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/PropertyFactory.java
@@ -315,6 +315,7 @@ public final class PropertyFactory {
 				mappingProperty.getPersistentClass().getServiceRegistry().getService( PropertyAccessStrategyResolver.class );
 
 		final PropertyAccessStrategy propertyAccessStrategy = propertyAccessStrategyResolver.resolvePropertyAccessStrategy(
+				mappingProperty.getClass(),
 				mappingProperty.getPropertyAccessorName(),
 				EntityMode.POJO
 		);

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -524,10 +524,9 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		Object[] values = TypeHelper.replace(
 				getPropertyValues( original, entityMode ),
 				getPropertyValues( result, entityMode ),
-				propertyNames,
 				propertyTypes,
 				session,
-				result,
+				owner,
 				copyCache
 		);
 
@@ -557,10 +556,9 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		Object[] values = TypeHelper.replace(
 				getPropertyValues( original, entityMode ),
 				getPropertyValues( result, entityMode ),
-				propertyNames,
 				propertyTypes,
 				session,
-				result,
+				owner,
 				copyCache,
 				foreignKeyDirection
 		);

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -10,8 +10,6 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.hibernate.bytecode.instrumentation.spi.LazyPropertyInitializer;
-import org.hibernate.engine.spi.CompositeOwner;
-import org.hibernate.engine.spi.CompositeTracker;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.tuple.NonIdentifierAttribute;
@@ -149,7 +147,6 @@ public class TypeHelper {
 	public static Object[] replace(
 			final Object[] original,
 			final Object[] target,
-			final String[] names,
 			final Type[] types,
 			final SessionImplementor session,
 			final Object owner,
@@ -179,11 +176,6 @@ public class TypeHelper {
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache );
 			}
-
-			// for bytecode enhanced entities, set the composite tracking structure
-			if ( copied[i] instanceof CompositeTracker && owner instanceof CompositeOwner ) {
-				( (CompositeTracker) copied[i] ).$$_hibernate_setOwner( names[i], (CompositeOwner) owner );
-			}
 		}
 		return copied;
 	}
@@ -204,7 +196,6 @@ public class TypeHelper {
 	public static Object[] replace(
 			final Object[] original,
 			final Object[] target,
-			final String[] names,
 			final Type[] types,
 			final SessionImplementor session,
 			final Object owner,
@@ -218,11 +209,6 @@ public class TypeHelper {
 			}
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache, foreignKeyDirection );
-			}
-
-			// for bytecode enhanced entities, set the composite tracking structure
-			if ( copied[i] instanceof CompositeTracker && owner instanceof CompositeOwner ) {
-				( (CompositeTracker) copied[i] ).$$_hibernate_setOwner( names[i], (CompositeOwner) owner );
 			}
 		}
 		return copied;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/DecompileUtils.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/DecompileUtils.java
@@ -102,6 +102,8 @@ public abstract class DecompileUtils {
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_GET_NAME ) );
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_CLEAR_NAME ) );
 						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_HAS_CHANGED_NAME ) );
+						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_SUSPEND_NAME ) );
+						assertTrue( methodNames.contains( EnhancerConstants.TRACKER_COLLECTION_GET_NAME ) );
 					}
 					if ( interfaceNames.contains( CompositeTracker.class.getName() ) ) {
 						assertTrue( fieldNames.contains( EnhancerConstants.TRACKER_COMPOSITE_FIELD_NAME ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -23,6 +23,9 @@ import org.hibernate.test.bytecode.enhancement.join.HHH3949TestTask4;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingIntegrationTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingTestTask;
+import org.hibernate.test.bytecode.enhancement.lazy.basic.LazyBasicFieldAccessTestTask;
+import org.hibernate.test.bytecode.enhancement.lazy.basic.LazyBasicPropertyAccessTestTask;
+import org.hibernate.test.bytecode.enhancement.merge.CompositeMergeTestTask;
 import org.junit.Test;
 
 /**
@@ -51,7 +54,16 @@ public class EnhancerTest extends BaseUnitTestCase {
 	public void testLazy() {
 		EnhancerTestUtils.runEnhancerTestTask( LazyLoadingTestTask.class );
 		EnhancerTestUtils.runEnhancerTestTask( LazyLoadingIntegrationTestTask.class );
+
+		EnhancerTestUtils.runEnhancerTestTask( LazyBasicPropertyAccessTestTask.class );
+		EnhancerTestUtils.runEnhancerTestTask( LazyBasicFieldAccessTestTask.class );
 	}
+
+	@Test
+	public void testMerge() {
+		EnhancerTestUtils.runEnhancerTestTask( CompositeMergeTestTask.class );
+	}
+
 
 	@Test
 	public void testFieldAccess() {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTestUtils.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTestUtils.java
@@ -9,13 +9,10 @@ package org.hibernate.test.bytecode.enhancement;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 
 import javassist.ClassPool;
@@ -150,9 +147,12 @@ public abstract class EnhancerTestUtils extends BaseUnitTestCase {
 
 					final byte[] enhanced = new Enhancer( enhancementContext ).enhance( name, original );
 
-					Path debugOutput = Paths.get( workingDir + File.separator +  name.replace( '.', '/' ) + ".class" );
-					Files.createDirectories( debugOutput.getParent() );
-					Files.write( debugOutput, enhanced, StandardOpenOption.CREATE );
+					File f = new File( workingDir + File.separator + name.replace( ".", File.separator ) + ".class" );
+					f.getParentFile().mkdirs();
+					f.createNewFile();
+					FileOutputStream out = new FileOutputStream( f );
+					out.write( enhanced );
+					out.close();
 
 					return defineClass( name, enhanced, 0, enhanced.length );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/dirty/DirtyTrackingTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/dirty/DirtyTrackingTestTask.java
@@ -30,19 +30,19 @@ public class DirtyTrackingTestTask extends AbstractEnhancerTestTask {
 		SimpleEntity entity = new SimpleEntity();
 
 		// Basic single field
-		entity.getId();
+		entity.getSomeNumber();
 		EnhancerTestUtils.checkDirtyTracking( entity );
-		entity.setId( 1l );
-		EnhancerTestUtils.checkDirtyTracking( entity, "id" );
+		entity.setSomeNumber( 1l );
+		EnhancerTestUtils.checkDirtyTracking( entity, "someNumber" );
 		EnhancerTestUtils.clearDirtyTracking( entity );
-		entity.setId( entity.getId() );
+		entity.setSomeNumber( entity.getSomeNumber() );
 		EnhancerTestUtils.checkDirtyTracking( entity );
 
-		// Basic multi-field
+		// Basic multi-field (Id properties are not flagged as dirty)
 		entity.setId( 2l );
 		entity.setActive( !entity.isActive() );
 		entity.setSomeNumber( 193L );
-		EnhancerTestUtils.checkDirtyTracking( entity, "id", "active", "someNumber" );
+		EnhancerTestUtils.checkDirtyTracking( entity, "active", "someNumber" );
 		EnhancerTestUtils.clearDirtyTracking( entity );
 
 		// Setting the same value should not make it dirty
@@ -70,7 +70,7 @@ public class DirtyTrackingTestTask extends AbstractEnhancerTestTask {
 		Address address = new Address();
 		entity.setAddress( address );
 		address.setCity( "Arendal" );
-		EnhancerTestUtils.checkDirtyTracking( entity, "address", "address.city" );
+		EnhancerTestUtils.checkDirtyTracking( entity, "address" );
 		EnhancerTestUtils.clearDirtyTracking( entity );
 
 		// make sure that new composite instances are cleared
@@ -82,7 +82,7 @@ public class DirtyTrackingTestTask extends AbstractEnhancerTestTask {
 		Country country = new Country();
 		address2.setCountry( country );
 		country.setName( "Norway" );
-		EnhancerTestUtils.checkDirtyTracking( entity, "address", "address.country", "address.country.name" );
+		EnhancerTestUtils.checkDirtyTracking( entity, "address", "address.country" );
 
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyLoadingIntegrationTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyLoadingIntegrationTestTask.java
@@ -75,7 +75,7 @@ public class LazyLoadingIntegrationTestTask extends AbstractEnhancerTestTask {
 		loadedChildren.remove( loadedChild );
 		loadedParent.setChildren( loadedChildren );
 
-		EnhancerTestUtils.checkDirtyTracking( loadedParent );
+		EnhancerTestUtils.checkDirtyTracking( loadedParent, "children" );
 		Assert.assertNull( loadedChild.parent );
 
 		s.getTransaction().commit();

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/Parent.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/Parent.java
@@ -22,13 +22,12 @@ import javax.persistence.OneToMany;
 @Entity
 public class Parent {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
 	Long id;
 
-	@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	List<Child> children;
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
 	public Long getId() {
 		return id;
 	}
@@ -37,6 +36,7 @@ public class Parent {
 		this.id = id;
 	}
 
+	@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	public List<Child> getChildren() {
 		return children;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/basic/LazyBasicFieldAccessTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/basic/LazyBasicFieldAccessTestTask.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.basic;
+
+
+import javax.persistence.Basic;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.hibernate.test.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Assert;
+
+/**
+ * @author Gail Badner
+ */
+public class LazyBasicFieldAccessTestTask extends AbstractEnhancerTestTask {
+
+	private Long entityId;
+
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {Entity.class};
+	}
+
+	public void prepare() {
+		Configuration cfg = new Configuration();
+		cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+		cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+		super.prepare( cfg );
+
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+
+		Entity entity = new Entity();
+		entity.setDescription( "desc" );
+		s.persist( entity );
+		entityId = entity.getId();
+
+		s.getTransaction().commit();
+		s.clear();
+		s.close();
+	}
+
+	public void execute() {
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+
+		Entity entity = s.get( Entity.class, entityId );
+
+		Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity );
+
+		Assert.assertEquals( "desc", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity.setDescription( "desc1" );
+		s.update( entity );
+
+		//Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity, "description" );
+
+		Assert.assertEquals( "desc1", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity = s.get( Entity.class, entityId );
+		Assert.assertEquals( "desc1", entity.getDescription() );
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity.setDescription( "desc2" );
+		entity = (Entity) s.merge( entity );
+
+		//Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity, "description" );
+
+		Assert.assertEquals( "desc2", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity = s.get( Entity.class, entityId );
+		Assert.assertEquals( "desc2", entity.getDescription() );
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	protected void cleanup() {
+	}
+
+	@javax.persistence.Entity
+	public static class Entity {
+		private Long id;
+
+		private String description;
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@Basic(fetch = FetchType.LAZY)
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/basic/LazyBasicPropertyAccessTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/basic/LazyBasicPropertyAccessTestTask.java
@@ -1,0 +1,145 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.basic;
+
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Basic;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.hibernate.test.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Assert;
+
+/**
+ * @author Gail Badner
+ */
+public class LazyBasicPropertyAccessTestTask extends AbstractEnhancerTestTask {
+
+	private Long entityId;
+
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {Entity.class};
+	}
+
+	public void prepare() {
+		Configuration cfg = new Configuration();
+		cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+		cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+		super.prepare( cfg );
+
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+
+		Entity entity = new Entity();
+		entity.setDescription( "desc" );
+		s.persist( entity );
+		entityId = entity.getId();
+
+		s.getTransaction().commit();
+		s.clear();
+		s.close();
+	}
+
+	public void execute() {
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+
+		Entity entity = s.get( Entity.class, entityId );
+
+		Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity );
+
+		Assert.assertEquals( "desc", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity.setDescription( "desc1" );
+		s.update( entity );
+
+		// Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity, "description" );
+
+		Assert.assertEquals( "desc1", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity = s.get( Entity.class, entityId );
+		Assert.assertEquals( "desc1", entity.getDescription() );
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity.setDescription( "desc2" );
+		entity = (Entity) s.merge( entity );
+
+		//Assert.assertFalse( Hibernate.isPropertyInitialized( entity, "description" ) );
+		EnhancerTestUtils.checkDirtyTracking( entity, "description" );
+
+		Assert.assertEquals( "desc2", entity.getDescription() );
+		Assert.assertTrue( Hibernate.isPropertyInitialized( entity, "description" ) );
+
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		entity = s.get( Entity.class, entityId );
+		Assert.assertEquals( "desc2", entity.getDescription() );
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	protected void cleanup() {
+	}
+
+	@javax.persistence.Entity
+	@Access(AccessType.FIELD )
+	public static class Entity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Basic(fetch = FetchType.LAZY)
+		private String description;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/CompositeMergeTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/CompositeMergeTestTask.java
@@ -1,0 +1,149 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.merge;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.Basic;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.hibernate.test.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Assert;
+
+/**
+ * @author Luis Barreiro
+ */
+public class CompositeMergeTestTask extends AbstractEnhancerTestTask {
+
+	private long entityId;
+
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {	ParentEntity.class, Address.class, Country.class };
+	}
+
+	public void prepare() {
+		Configuration cfg = new Configuration();
+		cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+		cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+		super.prepare( cfg );
+
+		ParentEntity parent = new ParentEntity();
+		parent.description = "desc";
+		parent.address = new Address();
+		parent.address.street = "Sesame street";
+		parent.address.country = new Country();
+		parent.address.country.name = "Suriname";
+		parent.address.country.languages = Arrays.asList( "english", "spanish" );
+
+		parent.lazyField = new byte[100];
+
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+		s.persist( parent );
+		s.getTransaction().commit();
+		s.close();
+
+		EnhancerTestUtils.checkDirtyTracking( parent );
+		entityId = parent.id;
+	}
+
+	public void execute() {
+		Session s = getFactory().openSession();
+		s.beginTransaction();
+		ParentEntity parent = s.get( ParentEntity.class, entityId );
+		s.getTransaction().commit();
+		s.close();
+
+		EnhancerTestUtils.checkDirtyTracking( parent );
+
+		parent.address.country.name = "Paraguai";
+
+		EnhancerTestUtils.checkDirtyTracking( parent, "address.country" );
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		ParentEntity mergedParent = (ParentEntity) s.merge( parent );
+		EnhancerTestUtils.checkDirtyTracking( parent, "address.country" );
+		EnhancerTestUtils.checkDirtyTracking( mergedParent, "address.country" );
+		s.getTransaction().commit();
+		s.close();
+
+		EnhancerTestUtils.checkDirtyTracking( parent, "address.country" );
+		EnhancerTestUtils.checkDirtyTracking( mergedParent );
+
+		mergedParent.address.country.name = "Honduras";
+
+		EnhancerTestUtils.checkDirtyTracking( mergedParent, "address.country" );
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		s.saveOrUpdate( mergedParent );
+		EnhancerTestUtils.checkDirtyTracking( mergedParent, "address.country" );
+		s.getTransaction().commit();
+		s.close();
+
+		s = getFactory().openSession();
+		s.beginTransaction();
+		parent = s.get( ParentEntity.class, entityId );
+		s.getTransaction().commit();
+		s.close();
+
+		Assert.assertEquals( "Honduras", parent.address.country.name );
+	}
+
+	protected void cleanup() {
+	}
+
+	@Entity
+	private static class ParentEntity {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String description;
+
+		@Embedded
+		private Address address;
+
+		@Basic(fetch = FetchType.LAZY)
+		private byte[] lazyField;
+
+	}
+
+	@Embeddable
+	private static class Address {
+
+		private String street;
+
+		@Embedded
+		private Country country;
+
+	}
+
+	@Embeddable
+	private static class Country {
+
+		private String name;
+
+		@ElementCollection
+		List<String> languages;
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/tracker/DirtyTrackerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/tracker/DirtyTrackerTest.java
@@ -43,6 +43,9 @@ public class DirtyTrackerTest {
         tracker.add("another.bar");
         assertTrue(tracker.get().length == 4);
 
+        tracker.suspend(true);
+        tracker.add("one more");
+        assertTrue(tracker.get().length == 4);
     }
 
     @Test
@@ -69,6 +72,10 @@ public class DirtyTrackerTest {
 
         // we the algorithm for this implementation relies on the fact that the array is kept sorted, so let's check it really is
         assertTrue(isSorted(tracker.get()));
+
+        tracker.suspend(true);
+        tracker.add("one more");
+        assertTrue(tracker.get().length == 4);
     }
 
     private boolean isSorted(String[] arr) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
@@ -37,9 +37,9 @@ public abstract class ReflectionTools {
 					ConcurrentReferenceHashMap.ReferenceType.SOFT
 	);
 
-	private static PropertyAccessStrategy getAccessStrategy(ServiceRegistry serviceRegistry, String accessorType) {
+	private static PropertyAccessStrategy getAccessStrategy(Class<?> cls, ServiceRegistry serviceRegistry, String accessorType) {
 		return serviceRegistry.getService( PropertyAccessStrategyResolver.class )
-				.resolvePropertyAccessStrategy( accessorType, null );
+				.resolvePropertyAccessStrategy( cls, accessorType, null );
 	}
 
 	public static Getter getGetter(Class cls, PropertyData propertyData, ServiceRegistry serviceRegistry) {
@@ -50,7 +50,7 @@ public abstract class ReflectionTools {
 		final Pair<Class, String> key = Pair.make( cls, propertyName );
 		Getter value = GETTER_CACHE.get( key );
 		if ( value == null ) {
-			value = getAccessStrategy( serviceRegistry, accessorType ).buildPropertyAccess( cls, propertyName ).getGetter();
+			value = getAccessStrategy( cls, serviceRegistry, accessorType ).buildPropertyAccess( cls, propertyName ).getGetter();
 			// It's ok if two getters are generated concurrently
 			GETTER_CACHE.put( key, value );
 		}
@@ -66,7 +66,7 @@ public abstract class ReflectionTools {
 		final Pair<Class, String> key = Pair.make( cls, propertyName );
 		Setter value = SETTER_CACHE.get( key );
 		if ( value == null ) {
-			value = getAccessStrategy( serviceRegistry, accessorType ).buildPropertyAccess( cls, propertyName ).getSetter();
+			value = getAccessStrategy( cls, serviceRegistry, accessorType ).buildPropertyAccess( cls, propertyName ).getSetter();
 			// It's ok if two setters are generated concurrently
 			SETTER_CACHE.put( key, value );
 		}


### PR DESCRIPTION
Several improvements in bytecode enhancement. Besides better handling of the attribute definitions, better isolation of enhancement features (lazy loading is not triggered from enhanced code) and exposes more functionality (it's now possible to suspend dirty tracking).

Also reverts #1029. After some thought and discussion, went for solution `1`. Replace the field setter / getter using reflection for calls to the enhanced method, if available. Calls to the getter do not trigger lazy loading and calls to the setter do not set the attribute as dirty .