### PR TITLE
HHH-10023 Make hibernate-infinispan compiled with Infinispan 7.x but …

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
@@ -122,10 +122,10 @@ public class ClusteredTimestampsRegionImpl extends TimestampsRegionImpl {
 	 * Brings all data from the distributed cache into our local cache.
 	 */
 	private void populateLocalCache() {
-		CloseableIterable<CacheEntry<Object, Void>> iterable = Caches.keys(cache);
+		CloseableIterable<Object> iterable = Caches.keys(cache);
 		try {
-			for (CacheEntry<Object, Void> entry : iterable) {
-				get(null, entry.getKey());
+			for (Object key : iterable) {
+				get(null, key);
 			}
 		}
 		finally {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
@@ -291,6 +291,10 @@ public class Caches {
 	}
 
 	public static CollectableCloseableIterable keys(AdvancedCache cache) {
+		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
+			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
+			cache.containsKey(false);
+		}
 		// HHH-10023: we can't use keySet()
 		final CloseableIterable<CacheEntry<Object, Void>> entryIterable = cache
 				.filterEntries( AcceptAllKeyValueFilter.getInstance() )

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/collection/TransactionalExtraAPITestCase.java
@@ -13,6 +13,7 @@ import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
@@ -25,6 +26,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 /**
  * TransactionalExtraAPITestCase.
@@ -41,6 +43,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public static final Object KEY = TestingKeyFactory.generateCollectionCacheKey( "KEY" );
 	public static final CacheDataDescription CACHE_DATA_DESCRIPTION
 			= new CacheDataDescriptionImpl(false, false, ComparableComparator.INSTANCE, null);
+	private static final SessionImplementor SESSION = mock(SessionImplementor.class);
 
 	private NodeEnvironment environment;
 	private static CollectionRegionAccessStrategy accessStrategy;
@@ -85,7 +88,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testLockItem() {
-		assertNull( getCollectionAccessStrategy().lockItem(null, KEY, new Integer( 1 ) ) );
+		assertNull( getCollectionAccessStrategy().lockItem(SESSION, KEY, new Integer( 1 ) ) );
 	}
 
 	@Test
@@ -95,12 +98,12 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testUnlockItem() {
-		getCollectionAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
+		getCollectionAccessStrategy().unlockItem(SESSION, KEY, new MockSoftLock() );
 	}
 
 	@Test
 	public void testUnlockRegion() {
-		getCollectionAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
+		getCollectionAccessStrategy().unlockItem(SESSION, KEY, new MockSoftLock() );
 	}
 
 	public static class MockSoftLock implements SoftLock {

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/entity/TransactionalExtraAPITestCase.java
@@ -12,6 +12,7 @@ import org.hibernate.cache.internal.CacheDataDescriptionImpl;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.hibernate.test.cache.infinispan.AbstractNonFunctionalTestCase;
 import org.hibernate.test.cache.infinispan.NodeEnvironment;
@@ -25,6 +26,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the "extra API" in EntityRegionAccessStrategy;.
@@ -47,6 +49,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public static final String VALUE2 = "VALUE2";
 	protected static final CacheDataDescriptionImpl CACHE_DATA_DESCRIPTION
 			= new CacheDataDescriptionImpl(true, false, ComparableComparator.INSTANCE, null);
+	private static final SessionImplementor SESSION = mock(SessionImplementor.class);
 
 	private NodeEnvironment environment;
 	private EntityRegionAccessStrategy accessStrategy;
@@ -95,7 +98,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	@Test
 	@SuppressWarnings( {"UnnecessaryBoxing"})
 	public void testLockItem() {
-		assertNull( getEntityAccessStrategy().lockItem(null, KEY, Integer.valueOf( 1 ) ) );
+		assertNull( getEntityAccessStrategy().lockItem(SESSION, KEY, Integer.valueOf( 1 ) ) );
 	}
 
 	@Test
@@ -105,12 +108,12 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 
 	@Test
 	public void testUnlockItem() {
-		getEntityAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
+		getEntityAccessStrategy().unlockItem(SESSION, KEY, new MockSoftLock() );
 	}
 
 	@Test
 	public void testUnlockRegion() {
-		getEntityAccessStrategy().unlockItem(null, KEY, new MockSoftLock() );
+		getEntityAccessStrategy().unlockItem(SESSION, KEY, new MockSoftLock() );
 	}
 
 	@Test
@@ -118,7 +121,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public void testAfterInsert() {
 		assertFalse(
 				"afterInsert always returns false",
-				getEntityAccessStrategy().afterInsert(null,
+				getEntityAccessStrategy().afterInsert(SESSION,
 						KEY,
 						VALUE1,
 						Integer.valueOf( 1 )
@@ -131,7 +134,7 @@ public class TransactionalExtraAPITestCase extends AbstractNonFunctionalTestCase
 	public void testAfterUpdate() {
 		assertFalse(
 				"afterInsert always returns false",
-				getEntityAccessStrategy().afterUpdate(null,
+				getEntityAccessStrategy().afterUpdate(SESSION,
 						KEY,
 						VALUE2,
 						Integer.valueOf( 1 ),


### PR DESCRIPTION
…runnable with Infinispan 8.x

https://hibernate.atlassian.net/browse/HHH-10023

There are two tests failing yet because of https://issues.jboss.org/browse/ISPN-5605 - that should be fixed in Infinispan upstream.