### PR TITLE
HHH-9962 Second level query cache returns stale data

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/StandardQueryCache.java
@@ -111,15 +111,13 @@ public class StandardQueryCache implements QueryCache {
 		if ( isNaturalKeyLookup && result.isEmpty() ) {
 			return false;
 		}
-		final long ts = cacheRegion.nextTimestamp();
-
 		if ( DEBUGGING ) {
-			LOG.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), ts );
+			LOG.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getTimestamp() );
 		}
 
 		final List cacheable = new ArrayList( result.size() + 1 );
 		logCachedResultDetails( key, null, returnTypes, cacheable );
-		cacheable.add( ts );
+		cacheable.add( session.getTimestamp() );
 
 		final boolean isSingleResult = returnTypes.length == 1;
 		for ( Object aResult : result ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1436,6 +1436,10 @@ public final class SessionImpl extends AbstractSessionImpl implements EventSourc
 	public Transaction beginTransaction() throws HibernateException {
 		errorIfClosed();
 		Transaction result = getTransaction();
+		// begin on already started transaction is noop, therefore, don't update the timestamp
+		if (result.getStatus() != TransactionStatus.ACTIVE) {
+			timestamp = factory.getSettings().getRegionFactory().nextTimestamp();
+		}
 		result.begin();
 		return result;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -528,6 +528,10 @@ public class StatelessSessionImpl extends AbstractSessionImpl implements Statele
 	public Transaction beginTransaction() throws HibernateException {
 		errorIfClosed();
 		Transaction result = getTransaction();
+		// begin on already started transaction is noop, therefore, don't update the timestamp
+		if (result.getStatus() != TransactionStatus.ACTIVE) {
+			timestamp = factory.getSettings().getRegionFactory().nextTimestamp();
+		}
 		result.begin();
 		return result;
 	}


### PR DESCRIPTION
Test in courtesy of Giambattista Bloisi
Includes HHH-10008 fix as well because without that one the testHitCacheInSameSession would fail.
https://hibernate.atlassian.net/browse/HHH-9962
https://hibernate.atlassian.net/browse/HHH-10008