### PR TITLE
Patch for HHH-1237

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
@@ -102,7 +102,11 @@ public class ParameterParser {
 				recognizer.other( sqlString.charAt( ++indx ) );
 			}
 			else {
-				if ( c == ':' ) {
+				if ( c == ':' && indx < stringLength - 1 && sqlString.charAt( indx + 1 ) == ':') {
+					// colon character has been escaped
+					recognizer.other( c );
+					indx++;
+				} else if ( c == ':' ) {
 					// named parameter
 					final int right = StringHelper.firstIndexOfChar( sqlString, ParserHelper.HQL_SEPARATORS_BITSET, indx + 1 );
 					final int chopLocation = right < 0 ? sqlString.length() : right;

--- a/hibernate-core/src/test/java/org/hibernate/engine/query/ParameterParserTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/query/ParameterParserTest.java
@@ -6,24 +6,20 @@
  */
 package org.hibernate.engine.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.junit.Test;
 
 import org.hibernate.engine.query.spi.ParameterParser;
-import org.hibernate.engine.query.spi.ParameterParser.Recognizer;
-import org.junit.Test;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests of the ParameterParser class
  *
  * @author Steve Ebersole
  */
-public class ParameterParserTest {
+public class ParameterParserTest extends BaseUnitTestCase {
 	@Test
 	public void testEscapeCallRecognition() {
 		assertTrue( ParameterParser.startsWithEscapeCallTemplate( "{ ? = call abc(?) }" ) );
@@ -31,66 +27,4 @@ public class ParameterParserTest {
 				"from User u where u.userName = ? and u.userType = 'call'"
 		) );
 	}
-	
-	@Test
-	public void testParseColonCharacterEscaped() {
-	    final StringBuilder captured = new StringBuilder();
-	    Recognizer recognizer = new Recognizer() {
-            @Override
-            public void outParameter(int position) {
-                fail();
-            }
-            @Override
-            public void ordinalParameter(int position) {
-                fail();
-            }
-            @Override
-            public void namedParameter(String name, int position) {
-                fail();
-            }
-            @Override
-            public void jpaPositionalParameter(String name, int position) {
-                fail();
-            }
-            @Override
-            public void other(char character) {
-                captured.append(character);
-            }
-	    };
-	    ParameterParser.parse("SELECT @a,(@a::=20) FROM tbl_name", recognizer);
-	    assertEquals("SELECT @a,(@a:=20) FROM tbl_name", captured.toString());
-	}
-	
-    @Test
-    public void testParseNamedParameter() {
-        final StringBuilder other = new StringBuilder();
-        final List<String> params = new ArrayList<String>();
-        Recognizer recognizer = new Recognizer() {
-            @Override
-            public void outParameter(int position) {
-                fail();
-            }
-            @Override
-            public void ordinalParameter(int position) {
-                fail();
-            }
-            @Override
-            public void namedParameter(String name, int position) {
-                params.add(name);
-            }
-            @Override
-            public void jpaPositionalParameter(String name, int position) {
-                fail();
-            }
-            @Override
-            public void other(char character) {
-                other.append(character);
-            }
-        };
-        ParameterParser.parse("from Stock s where s.stockCode = :stockCode and s.xyz = :pxyz", recognizer);
-        assertEquals("from Stock s where s.stockCode =  and s.xyz = ", other.toString());
-        assertEquals("stockCode", params.get(0));
-        assertEquals("pxyz", params.get(1));
-    }
-    
 }

--- a/hibernate-core/src/test/java/org/hibernate/engine/query/ParameterParserTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/query/ParameterParserTest.java
@@ -6,20 +6,24 @@
  */
 package org.hibernate.engine.query;
 
-import org.junit.Test;
-
-import org.hibernate.engine.query.spi.ParameterParser;
-import org.hibernate.testing.junit4.BaseUnitTestCase;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.engine.query.spi.ParameterParser;
+import org.hibernate.engine.query.spi.ParameterParser.Recognizer;
+import org.junit.Test;
 
 /**
  * Unit tests of the ParameterParser class
  *
  * @author Steve Ebersole
  */
-public class ParameterParserTest extends BaseUnitTestCase {
+public class ParameterParserTest {
 	@Test
 	public void testEscapeCallRecognition() {
 		assertTrue( ParameterParser.startsWithEscapeCallTemplate( "{ ? = call abc(?) }" ) );
@@ -27,4 +31,66 @@ public class ParameterParserTest extends BaseUnitTestCase {
 				"from User u where u.userName = ? and u.userType = 'call'"
 		) );
 	}
+	
+	@Test
+	public void testParseColonCharacterEscaped() {
+	    final StringBuilder captured = new StringBuilder();
+	    Recognizer recognizer = new Recognizer() {
+            @Override
+            public void outParameter(int position) {
+                fail();
+            }
+            @Override
+            public void ordinalParameter(int position) {
+                fail();
+            }
+            @Override
+            public void namedParameter(String name, int position) {
+                fail();
+            }
+            @Override
+            public void jpaPositionalParameter(String name, int position) {
+                fail();
+            }
+            @Override
+            public void other(char character) {
+                captured.append(character);
+            }
+	    };
+	    ParameterParser.parse("SELECT @a,(@a::=20) FROM tbl_name", recognizer);
+	    assertEquals("SELECT @a,(@a:=20) FROM tbl_name", captured.toString());
+	}
+	
+    @Test
+    public void testParseNamedParameter() {
+        final StringBuilder other = new StringBuilder();
+        final List<String> params = new ArrayList<String>();
+        Recognizer recognizer = new Recognizer() {
+            @Override
+            public void outParameter(int position) {
+                fail();
+            }
+            @Override
+            public void ordinalParameter(int position) {
+                fail();
+            }
+            @Override
+            public void namedParameter(String name, int position) {
+                params.add(name);
+            }
+            @Override
+            public void jpaPositionalParameter(String name, int position) {
+                fail();
+            }
+            @Override
+            public void other(char character) {
+                other.append(character);
+            }
+        };
+        ParameterParser.parse("from Stock s where s.stockCode = :stockCode and s.xyz = :pxyz", recognizer);
+        assertEquals("from Stock s where s.stockCode =  and s.xyz = ", other.toString());
+        assertEquals("stockCode", params.get(0));
+        assertEquals("pxyz", params.get(1));
+    }
+    
 }


### PR DESCRIPTION
A patch for bug "Escaping : with :: in queries" (HHH-1237) was provided four years ago, but never applied to the code: https://hibernate.atlassian.net/browse/HHH-1237

I canceled my old pull request from 11 May 2014 (https://github.com/hibernate/hibernate-orm/pull/738/) and created this new one. Hopefully it gets into the branch this time.
