### PR TITLE
HHH-10045 Added ability to force Primary Key columns to be non-null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2803,4 +2803,13 @@ public abstract class Dialect implements ConversionContext {
 	public NameQualifierSupport getNameQualifierSupport() {
 		return null;
 	}
+
+	/**
+	 * Does this dialect require that primary key columns be non nullable?
+	 *
+	 * @return boolean
+	 */
+	public boolean forcePrimaryKeyColumnsNonNullable() {
+			return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Teradata14Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Teradata14Dialect.java
@@ -200,5 +200,10 @@ public class Teradata14Dialect extends TeradataDialect {
 	public boolean supportsLockTimeouts() {
 		return false;
 	}
+
+	@Override
+	public boolean forcePrimaryKeyColumnsNonNullable() {
+		return true;
+	}
 }
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -18,6 +18,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
+import org.hibernate.mapping.PrimaryKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.schema.spi.Exporter;
@@ -100,6 +101,16 @@ public class StandardTableExporter implements Exporter<Table> {
 
 				if ( col.isNullable() ) {
 					buf.append( dialect.getNullColumnString() );
+					if (dialect.forcePrimaryKeyColumnsNonNullable()) {
+						PrimaryKey pk = table.getPrimaryKey();
+						if (pk != null && pk.containsColumn(col)) {
+							buf.append( " not null" );
+							col.setNullable(false);
+						}
+					}
+					else {
+						buf.append( dialect.getNullColumnString() );
+					}
 				}
 				else {
 					buf.append( " not null" );


### PR DESCRIPTION
Added the method forcePrimaryKeyColumnsNonNullable() to Dialect. Many tests in the hibernate test harness were failing as a result of null primary keys when run against the Teradata database. 