### PR TITLE
HHH-10057 hibernate-infinispan incompatible with Infinispan 8.0.0.CR1

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/NonTxInvalidationInterceptor.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/NonTxInvalidationInterceptor.java
@@ -125,14 +125,14 @@ public class NonTxInvalidationInterceptor extends BaseRpcInterceptor implements 
 		// increment invalidations counter if statistics maintained
 		incrementInvalidations();
 		InvalidateCommand invalidateCommand;
-		Object lockOwner = putFromLoadValidator.registerRemoteInvalidations(keys);
+		Object sessionTransactionId = putFromLoadValidator.registerRemoteInvalidations(keys);
 		if (!isLocalModeForced(command)) {
-			if (lockOwner == null) {
+			if (sessionTransactionId == null) {
 				invalidateCommand = commandsFactory.buildInvalidateCommand(InfinispanCollections.<Flag>emptySet(), keys);
 			}
 			else {
 				invalidateCommand = commandInitializer.buildBeginInvalidationCommand(
-						InfinispanCollections.<Flag>emptySet(), keys, lockOwner);
+						InfinispanCollections.<Flag>emptySet(), keys, sessionTransactionId);
 			}
 			if (log.isDebugEnabled()) {
 				log.debug("Cache [" + rpcManager.getAddress() + "] replicating " + invalidateCommand);

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/NonTxPutFromLoadInterceptor.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/NonTxPutFromLoadInterceptor.java
@@ -45,16 +45,16 @@ public class NonTxPutFromLoadInterceptor extends BaseCustomInterceptor {
 	public Object visitInvalidateCommand(InvocationContext ctx, InvalidateCommand command) throws Throwable {
 		if (!ctx.isOriginLocal() && command instanceof BeginInvalidationCommand) {
 			for (Object key : command.getKeys()) {
-				putFromLoadValidator.beginInvalidatingKey(((BeginInvalidationCommand) command).getLockOwner(), key);
+				putFromLoadValidator.beginInvalidatingKey(((BeginInvalidationCommand) command).getSessionTransactionId(), key);
 			}
 		}
 		return invokeNextInterceptor(ctx, command);
 	}
 
-	public void broadcastEndInvalidationCommand(Object[] keys, Object lockOwner) {
-		assert lockOwner != null;
+	public void broadcastEndInvalidationCommand(Object[] keys, Object sessionTransactionId) {
+		assert sessionTransactionId != null;
 		EndInvalidationCommand endInvalidationCommand = commandInitializer.buildEndInvalidationCommand(
-				cacheName, keys, lockOwner);
+				cacheName, keys, sessionTransactionId);
 		rpcManager.invokeRemotely(null, endInvalidationCommand, rpcManager.getDefaultRpcOptions(false, DeliverOrder.NONE));
 	}
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/EndInvalidationCommand.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/EndInvalidationCommand.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
  */
 public class EndInvalidationCommand extends BaseRpcCommand {
 	private Object[] keys;
-	private Object lockOwner;
+	private Object sessionTransactionId;
 	private PutFromLoadValidator putFromLoadValidator;
 
 	public EndInvalidationCommand(String cacheName) {
@@ -30,16 +30,16 @@ public class EndInvalidationCommand extends BaseRpcCommand {
 	/**
 	 * @param cacheName name of the cache to evict
 	 */
-	public EndInvalidationCommand(String cacheName, Object[] keys, Object lockOwner) {
+	public EndInvalidationCommand(String cacheName, Object[] keys, Object sessionTransactionId) {
 		super(cacheName);
 		this.keys = keys;
-		this.lockOwner = lockOwner;
+		this.sessionTransactionId = sessionTransactionId;
 	}
 
 	@Override
 	public Object perform(InvocationContext ctx) throws Throwable {
 		for (Object key : keys) {
-			putFromLoadValidator.endInvalidatingKey(lockOwner, key);
+			putFromLoadValidator.endInvalidatingKey(sessionTransactionId, key);
 		}
 		return null;
 	}
@@ -51,13 +51,13 @@ public class EndInvalidationCommand extends BaseRpcCommand {
 
 	@Override
 	public Object[] getParameters() {
-		return new Object[] { keys, lockOwner };
+		return new Object[] { keys, sessionTransactionId};
 	}
 
 	@Override
 	public void setParameters(int commandId, Object[] parameters) {
 		keys = (Object[]) parameters[0];
-		lockOwner = parameters[1];
+		sessionTransactionId = parameters[1];
 	}
 
 	@Override
@@ -75,11 +75,40 @@ public class EndInvalidationCommand extends BaseRpcCommand {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof EndInvalidationCommand)) {
+			return false;
+		}
+
+		EndInvalidationCommand that = (EndInvalidationCommand) o;
+
+		if (cacheName == null ? cacheName != null : !cacheName.equals(that.cacheName)) {
+			return false;
+		}
+		if (!Arrays.equals(keys, that.keys)) {
+			return false;
+		}
+		return !(sessionTransactionId != null ? !sessionTransactionId.equals(that.sessionTransactionId) : that.sessionTransactionId != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = cacheName != null ? cacheName.hashCode() : 0;
+		result = 31 * result + (keys != null ? Arrays.hashCode(keys) : 0);
+		result = 31 * result + (sessionTransactionId != null ? sessionTransactionId.hashCode() : 0);
+		return result;
+	}
+
+	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder("EndInvalidationCommand{");
 		sb.append("cacheName=").append(cacheName);
 		sb.append(", keys=").append(Arrays.toString(keys));
-		sb.append(", lockOwner=").append(lockOwner);
+		sb.append(", sessionTransactionId=").append(sessionTransactionId);
 		sb.append('}');
 		return sb.toString();
 	}

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/CacheCommandsInitializerTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/CacheCommandsInitializerTest.java
@@ -1,0 +1,65 @@
+package org.hibernate.test.cache.infinispan.util;
+
+import org.hibernate.cache.infinispan.util.BeginInvalidationCommand;
+import org.hibernate.cache.infinispan.util.CacheCommandInitializer;
+import org.hibernate.cache.infinispan.util.EndInvalidationCommand;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.distribution.TestAddress;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class CacheCommandsInitializerTest {
+   private static CacheCommandInitializer initializer = new CacheCommandInitializer();
+
+   @BeforeClass
+   public static void setUp() {
+      ClusteringDependentLogic cdl = mock(ClusteringDependentLogic.class);
+      when(cdl.getAddress()).thenReturn(new TestAddress(0));
+      initializer.injectDependencies(null, null, cdl);
+   }
+
+   @Test
+   public void testBeginInvalidationCommand1() {
+      BeginInvalidationCommand command = initializer.buildBeginInvalidationCommand(Collections.EMPTY_SET, new Object[]{}, UUID.randomUUID());
+      checkParameters(command, () -> new BeginInvalidationCommand());
+   }
+
+   @Test
+   public void testBeginInvalidationCommand2() {
+      BeginInvalidationCommand command = initializer.buildBeginInvalidationCommand(Collections.EMPTY_SET, new Object[]{ 1 }, UUID.randomUUID());
+      checkParameters(command, () -> new BeginInvalidationCommand());
+   }
+
+   @Test
+   public void testBeginInvalidationCommand3() {
+      BeginInvalidationCommand command = initializer.buildBeginInvalidationCommand(Collections.EMPTY_SET, new Object[]{ 2, 3 }, UUID.randomUUID());
+      checkParameters(command, () -> new BeginInvalidationCommand());
+   }
+
+   @Test
+   public void testEndInvalidationCommmand() {
+      EndInvalidationCommand command = initializer.buildEndInvalidationCommand("foo", new Object[] { 2, 3 }, UUID.randomUUID());
+      checkParameters(command, () -> new EndInvalidationCommand("foo"));
+   }
+
+   protected <T extends ReplicableCommand> void checkParameters(T command, Supplier<T> commandSupplier) {
+      Object[] parameters = command.getParameters();
+      ReplicableCommand newCommand = commandSupplier.get();
+      newCommand.setParameters(command.getCommandId(), parameters);
+      assertEquals(command, newCommand);
+      assertArrayEquals(parameters, newCommand.getParameters());
+   }
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10057

* ISPN-5609 changed InvalidateCommand constructors: used reflection to work around that; now should work with 8.0.0.CR1
* renamed BeginInvalidationCommand.getLockOwner to getSessionTransactionId() to prevent further conflicts
* added commands tests