### PR TITLE
HHH-10059 Make EntityManagerFactoryBuilderImpl.populate(SessionFactor…

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -816,7 +816,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 		);
 	}
 
-	private void populate(SessionFactoryBuilder sfBuilder, StandardServiceRegistry ssr) {
+	protected void populate(SessionFactoryBuilder sfBuilder, StandardServiceRegistry ssr) {
 		final StrategySelector strategySelector = ssr.getService( StrategySelector.class );
 
 		// Locate and apply the requested SessionFactory-level interceptor (if one)


### PR DESCRIPTION
…yBuilder sfBuilder, StandardServiceRegistry ssr) protected

To be able to inject Spring managed interceptors into Hibernate, we need the
EntityManagerFactoryBuilderImpl.populate(SessionFactoryBuilder sfBuilder, StandardServiceRegistry ssr)
method to be protected.

This is a follow up of this discussion: http://markmail.org/thread/jslaxcep2j3v4cru .