### PR TITLE
HHH-10087 allow locks to be prepended to SQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java
@@ -184,7 +184,7 @@ public class SelectStatementBuilder {
 	 * @return the SQL <tt>SELECT</tt> statement.
 	 */
 	public String toStatementString() {
-		final StringBuilder buf = new StringBuilder( guesstimatedBufferSize );
+		StringBuilder buf = new StringBuilder( guesstimatedBufferSize );
 
 		if ( StringHelper.isNotEmpty( comment ) ) {
 			buf.append( "/* " ).append( comment ).append( " */ " );
@@ -219,7 +219,7 @@ public class SelectStatementBuilder {
 		}
 
 		if ( lockOptions.getLockMode() != LockMode.NONE ) {
-			buf.append( dialect.getForUpdateString( lockOptions ) );
+			buf = new StringBuilder(dialect.applyLocksToSql( buf.toString(), lockOptions, null ) );
 		}
 
 		return dialect.transformSelectString( buf.toString() );

--- a/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
@@ -179,7 +179,7 @@ public class SimpleSelect {
 		}
 
 		if ( lockOptions != null ) {
-			buf.append( dialect.getForUpdateString( lockOptions ) );
+			buf = new StringBuilder(dialect.applyLocksToSql( buf.toString(), lockOptions, null ) );
 		}
 
 		return dialect.transformSelectString( buf.toString() );


### PR DESCRIPTION
This allows locking code to work for the Teradata database

This fix uses the existing applyLocksToSql() method. An alternate solution would be to add a new method to Dialect to determine whether lock precede or follow sql and then use either buf.append() or buf.insert() as needed.