### PR TITLE
can you please add gitignore for the output files of ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,5 @@ ObjectStore
 *.jps
 *.hprof
 /.nb-gradle/
-
 # ctags output for hibernate-core
-./hibernate-core/src/main/java/tags
+hibernate-core/src/main/java/tags

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ ObjectStore
 *.jps
 *.hprof
 /.nb-gradle/
+
+# ctags output for hibernate-core
+./hibernate-core/src/main/java/tags


### PR DESCRIPTION
because many of us us vim + catgs to read the src files ,so we need to add different tags for each jar files,so can you add the this config info into .gitignore 