### PR TITLE
HHH-10182 Backport HHH-7898 for JTA environment only

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
@@ -94,7 +94,9 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
    public void evict(Object key) throws CacheException {
       for (Map<Object, PostTransactionQueryUpdate> map : transactionContext.values()) {
          PostTransactionQueryUpdate update = map.remove(key);
-         update.setValue(null);
+         if (update != null) {
+            update.setValue(null);
+         }
       }
       evictCache.remove( key );
    }


### PR DESCRIPTION
* this fix works only for JTA transactions! (JDBC transactions behavior was not altered)
* removed cluster loader from default configuration since this can insert already evicted entries to the cache, and with current version of Infinispan its use is not justified (configuration was outdated)