### PR TITLE
Removing validation that breaks

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
@@ -61,7 +61,6 @@ public abstract class AbstractScannerImpl implements Scanner {
 			);
 		}
 		else {
-			validateReuse( descriptorInfo, isRootUrl );
 			descriptor = descriptorInfo.archiveDescriptor;
 		}
 		return descriptor;
@@ -78,14 +77,6 @@ public abstract class AbstractScannerImpl implements Scanner {
 			this.isRoot = isRoot;
 		}
 	}
-
-	@SuppressWarnings("UnusedParameters")
-	protected void validateReuse(ArchiveDescriptorInfo descriptor, boolean root) {
-		// is it really reasonable that a single url be processed multiple times?
-		// for now, throw an exception, mainly because I am interested in situations where this might happen
-		throw new IllegalStateException( "ArchiveDescriptor reused; can URLs be processed multiple times?" );
-	}
-
 
 	public static class ArchiveContextImpl implements ArchiveContext {
 		private final boolean isRootUrl;


### PR DESCRIPTION
In some circumstances this validation seems to break the code.
By the comments I read in the code, it is regarded as unecessary anyways.
Is it ok to remove? Or could we get more insight on how can we fix our code to fix the "error"?
