### PR TITLE
HHH-8435 @Lob/@Nationalized results in NCLOB in MSSQL2005 rather than…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2005Dialect.java
@@ -50,7 +50,9 @@ public class SQLServer2005Dialect extends SQLServerDialect {
 
 		registerColumnType( Types.BIGINT, "bigint" );
 		registerColumnType( Types.BIT, "bit" );
-
+		
+		// HHH-8435 fix
+		registerColumnType( Types.NCLOB, "nvarchar(MAX)" );
 
 		registerFunction( "row_number", new NoArgSQLFunction( "row_number", StandardBasicTypes.INTEGER, true ) );
 	}


### PR DESCRIPTION
… NVARCHAR(MAX)

HHH-8435 @Lob/@Nationalized results in NCLOB in MSSQL2005 rather than
NVARCHAR(MAX)