### PR TITLE
HHH-10222 - AttributeConverter not applied to @ElementCollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
@@ -323,12 +323,12 @@ public class SimpleValueBinder {
 			return;
 		}
 
-		if ( property.isAnnotationPresent( Temporal.class ) ) {
+		if ( !key && property.isAnnotationPresent( Temporal.class ) ) {
 			LOG.debugf( "Skipping AttributeConverter checks for Temporal attribute [%s]", property.getName() );
 			return;
 		}
 
-		if ( property.isAnnotationPresent( Enumerated.class ) ) {
+		if ( !key && property.isAnnotationPresent( Enumerated.class ) ) {
 			LOG.debugf( "Skipping AttributeConverter checks for Enumerated attribute [%s]", property.getName() );
 			return;
 		}


### PR DESCRIPTION
Check `CollectionElementConversionTest` first, please. Without my fix, converter would be ignored and there would be attempt to store map's keys in binary form (failing as `Color` is not `Serializable`). With fix, keys are correctly stored as text (converter is used).

Only two conditions were changed in `SimpleValueBinder`.
