### PR TITLE
Hhh 10181: CacheableFileXmlSource.doBind uses obsolete .bin file.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1747,4 +1747,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	@Message(value = "Hikari properties were encountered, but the Hikari ConnectionProvider was not found on the classpath; these properties are going to be ignored.",
 			id = 472)
 	void hikariProviderClassNotFound();
+
+	@LogMessage(level = INFO)
+	@Message(value = "Omitting cached file [%s] as the mapping file is newer", id = 473)
+	void cachedFileObsolete(File cachedFile);
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/CacheableFileTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/CacheableFileTest.java
@@ -59,5 +59,12 @@ public class CacheableFileTest extends BaseUnitTestCase {
 		assertTrue( mappingBinFile.exists() );
 
 		new Configuration().addCacheableFileStrictly( mappingFile );
+
+		// make mappingBinFile obsolete by declaring it a minute older than mappingFile
+		mappingBinFile.setLastModified( mappingFile.lastModified() - 60000L );
+
+		new Configuration().addCacheableFile( mappingFile );
+		assertTrue( mappingBinFile.exists() );
+		assertTrue( "mappingFile should have been recreated.", mappingBinFile.lastModified() >= mappingFile.lastModified());
 	}
 }


### PR DESCRIPTION
Test and fix for Hibernate ORM HHH-10181: CacheableFileXmlSource.doBind uses obsolete .bin file.

CachableFileXmlSource now behaves as documented at JavaDoc
org.hibernate.boot.MetadataSources.addCacheableFile(File file):

"If a cached  {xmlFile}.bin} exists and is newer than  {xmlFile}}, the  {xmlFile}.bin} file will be read directly. Otherwise  {xmlFile}} is read and then serialized to  {xmlFile}.bin} for use the next time."