### PR TITLE
Hhh 7572 2

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -7,9 +7,10 @@
 package org.hibernate;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
- * Loads an entity by its primary identifier.
+ * Loads an entity (or multiple) by its primary identifier.
  * 
  * @author Eric Dalquist
  * @author Steve Ebersole
@@ -22,7 +23,16 @@ public interface IdentifierLoadAccess<T> {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	public IdentifierLoadAccess<T> with(LockOptions lockOptions);
+	IdentifierLoadAccess<T> with(LockOptions lockOptions);
+
+	/**
+	 * Specify the {@link CacheMode} to use when retrieving the entity.
+	 *
+	 * @param cacheMode The CacheMode to use.
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	IdentifierLoadAccess<T> with(CacheMode cacheMode);
 
 	/**
 	 * Return the persistent instance with the given identifier, assuming that the instance exists. This method
@@ -36,7 +46,7 @@ public interface IdentifierLoadAccess<T> {
 	 *
 	 * @return the persistent instance or proxy
 	 */
-	public T getReference(Serializable id);
+	T getReference(Serializable id);
 
 	/**
 	 * Return the persistent instance with the given identifier, or null if there is no such persistent instance.
@@ -47,5 +57,25 @@ public interface IdentifierLoadAccess<T> {
 	 *
 	 * @return The persistent instance or {@code null}
 	 */
-	public T load(Serializable id);
+	T load(Serializable id);
+
+	/**
+	 * Perform a load of multiple entities by identifiers
+	 *
+	 * @param ids The ids to load
+	 * @param <K> The identifier type
+	 *
+	 * @return The persistent entities.
+	 */
+	<K extends Serializable> List<T> multiLoad(K... ids);
+
+	/**
+	 * Perform a load of multiple entities by identifiers
+	 *
+	 * @param ids The ids to load
+	 * @param <K> The identifier type
+	 *
+	 * @return The persistent entities.
+	 */
+	<K extends Serializable> List<T> multiLoad(List<K> ids);
 }

--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -7,10 +7,9 @@
 package org.hibernate;
 
 import java.io.Serializable;
-import java.util.List;
 
 /**
- * Loads an entity (or multiple) by its primary identifier.
+ * Loads an entity by its primary identifier.
  * 
  * @author Eric Dalquist
  * @author Steve Ebersole
@@ -58,24 +57,4 @@ public interface IdentifierLoadAccess<T> {
 	 * @return The persistent instance or {@code null}
 	 */
 	T load(Serializable id);
-
-	/**
-	 * Perform a load of multiple entities by identifiers
-	 *
-	 * @param ids The ids to load
-	 * @param <K> The identifier type
-	 *
-	 * @return The persistent entities.
-	 */
-	<K extends Serializable> List<T> multiLoad(K... ids);
-
-	/**
-	 * Perform a load of multiple entities by identifiers
-	 *
-	 * @param ids The ids to load
-	 * @param <K> The identifier type
-	 *
-	 * @return The persistent entities.
-	 */
-	<K extends Serializable> List<T> multiLoad(List<K> ids);
 }

--- a/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Loads multiple entities at once by identifiers
+ *
+ * @author Steve Ebersole
+ */
+public interface MultiIdentifierLoadAccess<T> {
+	/**
+	 * Specify the {@link LockOptions} to use when retrieving the entity.
+	 *
+	 * @param lockOptions The lock options to use.
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> with(LockOptions lockOptions);
+
+	/**
+	 * Specify the {@link CacheMode} to use when retrieving the entity.
+	 *
+	 * @param cacheMode The CacheMode to use.
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> with(CacheMode cacheMode);
+
+	/**
+	 * Specify a batch size for loading the entities (how many at a time).  The default is
+	 * to use a batch sizing strategy defined by the Dialect in use.  Any greater-than-one
+	 * value here will override that default behavior.  If giving an explicit value here,
+	 * care should be taken to not exceed the capabilities of of the underlying database.
+	 *
+	 * @param batchSize The batch size
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> withBatchSize(int batchSize);
+
+	/**
+	 * Should we check the Session to see whether it already contains any of the
+	 * entities to be loaded in a managed state?
+	 *
+	 * @param enabled {@code true} enables this checking; {@code false} disables it.
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> enableSessionCheck(boolean enabled);
+
+	/**
+	 * Perform a load of multiple entities by identifiers
+	 *
+	 * @param ids The ids to load
+	 * @param <K> The identifier type
+	 *
+	 * @return The persistent entities.
+	 */
+	<K extends Serializable> List<T> multiLoad(K... ids);
+
+	/**
+	 * Perform a load of multiple entities by identifiers
+	 *
+	 * @param ids The ids to load
+	 * @param <K> The identifier type
+	 *
+	 * @return The persistent entities.
+	 */
+	<K extends Serializable> List<T> multiLoad(List<K> ids);
+}

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -783,6 +783,30 @@ public interface Session extends SharedSessionContract, java.io.Closeable {
 	IdentifierLoadAccess byId(String entityName);
 
 	/**
+	 * Create a {@link MultiIdentifierLoadAccess} instance to retrieve multiple entities at once
+	 * as specified by primary key values.
+	 *
+	 * @param entityClass The entity type to be retrieved
+	 *
+	 * @return load delegate for loading the specified entity type by primary key values
+	 *
+	 * @throws HibernateException If the specified Class cannot be resolved as a mapped entity
+	 */
+	<T> MultiIdentifierLoadAccess<T> byMultipleIds(Class<T> entityClass);
+
+	/**
+	 * Create a {@link MultiIdentifierLoadAccess} instance to retrieve multiple entities at once
+	 * as specified by primary key values.
+	 *
+	 * @param entityName The entity name of the entity type to be retrieved
+	 *
+	 * @return load delegate for loading the specified entity type by primary key values
+	 *
+	 * @throws HibernateException If the specified entity name cannot be resolved as an entity name
+	 */
+	MultiIdentifierLoadAccess byMultipleIds(String entityName);
+
+	/**
 	 * Create an {@link IdentifierLoadAccess} instance to retrieve the specified entity by
 	 * primary key.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -77,6 +77,7 @@ import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.io.StreamCopier;
+import org.hibernate.loader.BatchLoadSizingStrategy;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.ForeignKey;
@@ -2812,5 +2813,16 @@ public abstract class Dialect implements ConversionContext {
 	 */
 	public NameQualifierSupport getNameQualifierSupport() {
 		return null;
+	}
+
+	protected final BatchLoadSizingStrategy STANDARD_DEFAULT_BATCH_LOAD_SIZING_STRATEGY = new BatchLoadSizingStrategy() {
+		@Override
+		public int determineOptimalBatchLoadSize(int numberOfKeyColumns, int numberOfKeys) {
+			return 50;
+		}
+	};
+
+	public BatchLoadSizingStrategy getDefaultBatchLoadSizingStrategy() {
+		return STANDARD_DEFAULT_BATCH_LOAD_SIZING_STRATEGY;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.Interceptor;
 import org.hibernate.LobHelper;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.NaturalIdLoadAccess;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
@@ -660,6 +661,16 @@ public class SessionDelegatorBaseImpl implements SessionImplementor, Session {
 	@Override
 	public IdentifierLoadAccess byId(String entityName) {
 		return session.byId( entityName );
+	}
+
+	@Override
+	public <T> MultiIdentifierLoadAccess<T> byMultipleIds(Class<T> entityClass) {
+		return session.byMultipleIds( entityClass );
+	}
+
+	@Override
+	public MultiIdentifierLoadAccess byMultipleIds(String entityName) {
+		return session.byMultipleIds( entityName );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/BatchLoadSizingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/BatchLoadSizingStrategy.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.loader;
+
+/**
+ * Strategy (pluggable) for determining an optimal size for batch loads.
+ *
+ * @author Steve Ebersole
+ */
+public interface BatchLoadSizingStrategy {
+	int determineOptimalBatchLoadSize(int numberOfKeyColumns, int numberOfKeys);
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/multiLoad/MultiLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/multiLoad/MultiLoadTest.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.ops.multiLoad;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Steve Ebersole
+ */
+public class MultiLoadTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { SimpleEntity.class };
+	}
+
+	@Before
+	public void before() {
+		Session session = sessionFactory().openSession();
+		session.getTransaction().begin();
+		for ( int i = 0; i < 60; i++ ) {
+			session.save( new SimpleEntity( i, "Entity #" + i ) );
+		}
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@After
+	public void after() {
+		Session session = sessionFactory().openSession();
+		session.getTransaction().begin();
+		session.createQuery( "delete SimpleEntity" ).executeUpdate();
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@Test
+	public void testBasicMultiLoad() {
+		Session session = openSession();
+		session.getTransaction().begin();
+		List<SimpleEntity> list = session.byId( SimpleEntity.class ).multiLoad( ids(56) );
+		assertEquals( 56, list.size() );
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	private Integer[] ids(int count) {
+		Integer[] ids = new Integer[count];
+		for ( int i = 0; i < count; i++ ) {
+			ids[i] = i;
+		}
+		return ids;
+	}
+
+	@Entity( name = "SimpleEntity" )
+	@Table( name = "SimpleEntity" )
+	public static class SimpleEntity {
+		Integer id;
+		String text;
+
+		public SimpleEntity() {
+		}
+
+		public SimpleEntity(Integer id, String text) {
+			this.id = id;
+			this.text = text;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+}


### PR DESCRIPTION
Second version using a dedicated MultiIdentifierLoadAccess exposing the ability to specify:

* LockOptions
* CacheMode
* whether to check Session for ids matching already managed entities and exclude those from the SQL
* an explicit batch size

In regards to the batch size this initial work takes the tact that if the user specifies an explicit batch size we use it, without any kind of validation whether that is a valid batch size for the underlying database.  That is something we might want to add.

Also, I based this work on the previous PR to make it easier to see the changes from those we already discussed..