### PR TITLE
HHH-10161 : Hibernate ignores return value from javax.persistence.Par…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractQueryImpl.java
@@ -463,7 +463,11 @@ public abstract class AbstractQueryImpl implements Query {
 
 	public Query setParameter(int position, Object val) throws HibernateException {
 		if ( val == null ) {
-			setParameter( position, val, StandardBasicTypes.SERIALIZABLE );
+			Type type = parameterMetadata.getOrdinalParameterDescriptor( position + 1 ).getExpectedType();
+			if ( type == null ) {
+				type = StandardBasicTypes.SERIALIZABLE;
+			}
+			setParameter( position, val, type );
 		}
 		else {
 			setParameter( position, val, determineType( position, val ) );
@@ -530,7 +534,7 @@ public abstract class AbstractQueryImpl implements Query {
 		return guessType( clazz );
 	}
 
-	private Type guessType(Class clazz) throws HibernateException {
+	public Type guessType(Class clazz) throws HibernateException {
 		String typename = clazz.getName();
 		Type type = session.getFactory().getTypeResolver().heuristicType( typename );
 		boolean serializable = type != null && type instanceof SerializableType;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
@@ -22,6 +22,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -29,10 +30,13 @@ import org.hibernate.stat.Statistics;
 
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.test.annotations.A320;
 import org.hibernate.test.annotations.A320b;
 import org.hibernate.test.annotations.Plane;
+import org.hibernate.type.StandardBasicTypes;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -89,6 +93,174 @@ public class QueryAndSQLTest extends BaseCoreFunctionalTestCase {
 		s.beginTransaction();
 		s.createSQLQuery( sql ).addEntity( "t", AllTables.class ).list();
 		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-10161")
+	@SkipForDialect(
+			value = Oracle8iDialect.class,
+			jiraKey = "HHH-10161",
+			comment = "Oracle cannot convert untyped null (assumed to be BINARY type) to NUMBER")
+	public void testQueryWithNullParameter(){
+		Chaos c0 = new Chaos();
+		c0.setId( 0L );
+		c0.setName( "c0" );
+		c0.setSize( 0L );
+		Chaos c1 = new Chaos();
+		c1.setId( 1L );
+		c1.setName( "c1" );
+		c1.setSize( 1L );
+		Chaos c2 = new Chaos();
+		c2.setId( 2L );
+		c2.setName( "c2" );
+		c2.setSize( null );
+
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( c0 );
+		s.persist( c1 );
+		s.persist( c2 );
+
+		s.flush();
+		s.clear();
+
+		List chaoses = s.createQuery( "from Chaos where chaos_size is null or chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null )
+				.list();
+		assertEquals( 1, chaoses.size() );
+
+		chaoses = s.createQuery( "from Chaos where chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null )
+				.list();
+		// should be no results because null != null
+		assertEquals( 0, chaoses.size() );
+
+		s.getTransaction().rollback();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-10161")
+	public void testQueryWithNullParameterTyped(){
+		Chaos c0 = new Chaos();
+		c0.setId( 0L );
+		c0.setName( "c0" );
+		c0.setSize( 0L );
+		Chaos c1 = new Chaos();
+		c1.setId( 1L );
+		c1.setName( "c1" );
+		c1.setSize( 1L );
+		Chaos c2 = new Chaos();
+		c2.setId( 2L );
+		c2.setName( "c2" );
+		c2.setSize( null );
+
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( c0 );
+		s.persist( c1 );
+		s.persist( c2 );
+
+		s.flush();
+		s.clear();
+
+		List chaoses = s.createQuery( "from Chaos where chaos_size is null or chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null, StandardBasicTypes.LONG )
+				.list();
+		assertEquals( 1, chaoses.size() );
+
+		chaoses = s.createQuery( "from Chaos where chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null, StandardBasicTypes.LONG )
+				.list();
+		// should be no results because null != null
+		assertEquals( 0, chaoses.size() );
+
+		s.getTransaction().rollback();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-10161")
+	@SkipForDialect(
+			value = Oracle8iDialect.class,
+			jiraKey = "HHH-10161",
+			comment = "Oracle cannot convert untyped null (assumed to be BINARY type) to NUMBER")
+	public void testNativeQueryWithNullParameter(){
+		Chaos c0 = new Chaos();
+		c0.setId( 0L );
+		c0.setName( "c0" );
+		c0.setSize( 0L );
+		Chaos c1 = new Chaos();
+		c1.setId( 1L );
+		c1.setName( "c1" );
+		c1.setSize( 1L );
+		Chaos c2 = new Chaos();
+		c2.setId( 2L );
+		c2.setName( "c2" );
+		c2.setSize( null );
+
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( c0 );
+		s.persist( c1 );
+		s.persist( c2 );
+
+		s.flush();
+		s.clear();
+
+		List chaoses = s.createSQLQuery( "select * from Chaos where chaos_size is null or chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null )
+				.list();
+		assertEquals( 1, chaoses.size() );
+
+		chaoses = s.createSQLQuery( "select * from Chaos where chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null )
+				.list();
+		// should be no results because null != null
+		assertEquals( 0, chaoses.size() );
+
+		s.getTransaction().rollback();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-10161")
+	public void testNativeQueryWithNullParameterTyped(){
+		Chaos c0 = new Chaos();
+		c0.setId( 0L );
+		c0.setName( "c0" );
+		c0.setSize( 0L );
+		Chaos c1 = new Chaos();
+		c1.setId( 1L );
+		c1.setName( "c1" );
+		c1.setSize( 1L );
+		Chaos c2 = new Chaos();
+		c2.setId( 2L );
+		c2.setName( "c2" );
+		c2.setSize( null );
+
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( c0 );
+		s.persist( c1 );
+		s.persist( c2 );
+
+		s.flush();
+		s.clear();
+
+		List chaoses = s.createSQLQuery( "select * from Chaos where chaos_size is null or chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null, StandardBasicTypes.LONG )
+				.list();
+		assertEquals( 1, chaoses.size() );
+
+		chaoses = s.createSQLQuery( "select * from Chaos where chaos_size = :chaos_size" )
+				.setParameter( "chaos_size", null, StandardBasicTypes.LONG )
+				.list();
+		// should be no results because null != null
+		assertEquals( 0, chaoses.size() );
+
+		s.getTransaction().rollback();
 		s.close();
 	}
 

--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/spi/NullTypeBindableParameterRegistration.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/spi/NullTypeBindableParameterRegistration.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.spi;
+
+/**
+ * A {@link ParameterRegistration} that allows providing Java type information when
+ * binding a null value for a parameter when there is no other available type information
+ * for that parameter.
+ *
+ * @author Gail Badner
+ */
+public interface NullTypeBindableParameterRegistration<T> extends ParameterRegistration<T> {
+
+	/**
+	 * If bindable, bind a null value using the provided parameter type.
+	 * This method is only valid if {@link #getParameterType} returns {@code null}.
+	 *
+	 * @param nullParameterType the Java type to be used for binding the null value;
+	 * must be non-null.
+	 *
+	 * @throws IllegalArgumentException {@code parameterType} is null or if
+	 * {@link #getParameterType} does not return null.
+	 */
+	public void bindNullValue(Class<?> nullParameterType);
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/Item.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/Item.java
@@ -69,6 +69,7 @@ public class Item implements Serializable {
 
 	private String name;
 	private String descr;
+	private Integer intVal;
 	private Set<Distributor> distributors = new HashSet<Distributor>();
 
 	public Item() {
@@ -96,6 +97,13 @@ public class Item implements Serializable {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public Integer getIntVal() {
+		return intVal;
+	}
+	public void setIntVal(Integer intVal) {
+		this.intVal = intVal;
 	}
 
 	@OneToMany

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.jpa.test.query;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -19,6 +18,7 @@ import org.junit.Test;
 
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.jpa.test.Distributor;
@@ -28,6 +28,7 @@ import org.hibernate.stat.Statistics;
 
 import junit.framework.Assert;
 
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 
 import static junit.framework.Assert.assertNull;
@@ -79,7 +80,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 		catch (IllegalArgumentException expected) {
 		}
 	}
-	
+
 	@Test
 	public void testPagedQuery() throws Exception {
 		EntityManager em = getOrCreateEntityManager();
@@ -96,6 +97,341 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 		q.setParameter( "itemName", "%" );
 		q.setFirstResult( 1 );
 		q.setMaxResults( 1 );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullPositionalParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=?" );
+		q.setParameter( 1, null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and ? is null" );
+		q.setParameter( 1, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = ?" );
+		q.setParameter( 1, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullPositionalParameterParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=?" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return null;
+			}
+			@Override
+			public Integer getPosition() {
+				return 1;
+			}
+			@Override
+			public Class getParameterType() {
+				return Integer.class;
+			}
+		};
+		q.setParameter( p, null );
+		Parameter pGotten = q.getParameter( p.getPosition() );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and ? is null" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = ?" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullPositionalParameterParameterIncompatible() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=?" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return null;
+			}
+			@Override
+			public Integer getPosition() {
+				return 1;
+			}
+			@Override
+			public Class getParameterType() {
+				return Long.class;
+			}
+		};
+		q.setParameter( p, null );
+		Parameter pGotten = q.getParameter( p.getPosition() );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and ? is null" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = ?" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullNamedParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=:iVal" );
+		q.setParameter( "iVal", null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and :iVal is null" );
+		q.setParameter( "iVal", null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = :iVal" );
+		q.setParameter( "iVal", null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullNamedParameterParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=:iVal" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return "iVal";
+			}
+			@Override
+			public Integer getPosition() {
+				return null;
+			}
+			@Override
+			public Class getParameterType() {
+				return Integer.class;
+			}
+		};
+		q.setParameter( p, null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and :iVal is null" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = :iVal" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	public void testNullNamedParameterParameterIncompatible() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		Query q = em.createQuery( "from Item i where i.intVal=:iVal" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return "iVal";
+			}
+			@Override
+			public Integer getPosition() {
+				return null;
+			}
+			@Override
+			public Class getParameterType() {
+				return Long.class;
+			}
+		};
+		q.setParameter( p, null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null and :iVal is null" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createQuery( "from Item i where i.intVal is null or i.intVal = :iVal" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	@SkipForDialect(
+			value = Oracle8iDialect.class,
+			jiraKey = "HHH-10161",
+			comment = "Oracle cannot convert untyped null (assumed to be BINARY type) to NUMBER")
+	public void testNativeQueryNullPositionalParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		// native queries don't seem to flush by default ?!?
+		em.flush();
+		Query q = em.createNativeQuery( "select * from Item i where i.intVal=?" );
+		q.setParameter( 1, null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null and ? is null" );
+		q.setParameter( 1, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = ?" );
+		q.setParameter( 1, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10161"  )
+	public void testNativeQueryNullPositionalParameterParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		// native queries don't seem to flush by default ?!?
+		em.flush();
+		Query q = em.createNativeQuery( "select * from Item i where i.intVal=?" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return null;
+			}
+			@Override
+			public Integer getPosition() {
+				return 1;
+			}
+			@Override
+			public Class getParameterType() {
+				return Integer.class;
+			}
+		};
+		q.setParameter( p, null );
+		Parameter pGotten = q.getParameter( p.getPosition() );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null and ? is null" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = ?" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	@SkipForDialect(
+			value = Oracle8iDialect.class,
+			jiraKey = "HHH-10161",
+			comment = "Oracle cannot convert untyped null (assumed to be BINARY type) to NUMBER")
+	public void testNativeQueryNullNamedParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		// native queries don't seem to flush by default ?!?
+		em.flush();
+		Query q = em.createNativeQuery( "select * from Item i where i.intVal=:iVal" );
+		q.setParameter( "iVal", null );
+		List results = q.getResultList();
+		// null != null
+		assertEquals( 0, results.size() );
+		q = em.createNativeQuery( "select * from Item i where (i.intVal is null) and (:iVal is null)" );
+		q.setParameter( "iVal", null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = :iVal" );
+		q.setParameter( "iVal", null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		em.getTransaction().rollback();
+		em.close();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10161"  )
+	public void testNativeQueryNullNamedParameterParameter() throws Exception {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Item item = new Item( "Mouse", "Micro$oft mouse" );
+		em.persist( item );
+		// native queries don't seem to flush by default ?!?
+		em.flush();
+		Query q = em.createNativeQuery( "select * from Item i where i.intVal=:iVal" );
+		Parameter p = new Parameter() {
+			@Override
+			public String getName() {
+				return "iVal";
+			}
+			@Override
+			public Integer getPosition() {
+				return null;
+			}
+			@Override
+			public Class getParameterType() {
+				return Integer.class;
+			}
+		};
+		q.setParameter( p, null );
+		Parameter pGotten = q.getParameter( p.getName() );
+		List results = q.getResultList();
+		assertEquals( 0, results.size() );
+		q = em.createNativeQuery( "select * from Item i where (i.intVal is null) and (:iVal is null)" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
+		q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = :iVal" );
+		q.setParameter( p, null );
+		results = q.getResultList();
+		assertEquals( 1, results.size() );
 		em.getTransaction().rollback();
 		em.close();
 	}


### PR DESCRIPTION
…ameter#getParameterType()

If Hibernate has no information available about the parameter type when binding a null value, the pull request allows using the return value from javax.persistence.Parameter#getParameterType() when provided by javax.persistence.Query#setParameter(Parameter<T> param, T value),

According to Javadoc for javax.persistenceParameter#getParameterType:

"Applications that use this method for Java Persistence query language queries and native queries will not be portable."

Although not portable, it is helpful in this case when Hibernate has no information about the property type to use when binding a null value This is especially helpful when using Oracle, because Oracle throws an exception when a null is bound as BINARY (the default) that cannot be converted to the type for an intended column (e.g., a NUMBER column).