### PR TITLE
Memory usage improvements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
@@ -214,7 +214,7 @@ public class HQLQueryPlan implements Serializable {
 		final int guessedResultSize = guessResultSize( rowSelection );
 		final List combinedResults = new ArrayList( guessedResultSize );
 		final IdentitySet distinction;
-		if (needsLimit) {
+		if ( needsLimit ) {
 			distinction = new IdentitySet(guessedResultSize);
 		} else {
 			distinction = null;

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
@@ -213,7 +213,12 @@ public class HQLQueryPlan implements Serializable {
 
 		final int guessedResultSize = guessResultSize( rowSelection );
 		final List combinedResults = new ArrayList( guessedResultSize );
-		final IdentitySet distinction = new IdentitySet( guessedResultSize );
+		final IdentitySet distinction;
+		if (needsLimit) {
+			distinction = new IdentitySet(guessedResultSize);
+		} else {
+			distinction = null;
+		}
 		int includedCount = -1;
 		translator_loop:
 		for ( QueryTranslator translator : translators ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -137,7 +137,7 @@ public class ActionQueue {
 				l.clear();
 			}
 		}
-		if(unresolvedInsertions != null) {
+		if( unresolvedInsertions != null ) {
 			unresolvedInsertions.clear();
 		}
 	}
@@ -169,7 +169,7 @@ public class ActionQueue {
 				LOG.tracev( "Adding insert with non-nullable, transient entities; insert=[{0}], dependencies=[{1}]", insert,
 							nonNullableTransientDependencies.toLoggableString( insert.getSession() ) );
 			}
-			if(unresolvedInsertions == null) {
+			if( unresolvedInsertions == null ) {
 				unresolvedInsertions = new UnresolvedEntityInsertActions();
 			}
 			unresolvedInsertions.addUnresolvedEntityInsertAction( insert, nonNullableTransientDependencies );
@@ -185,13 +185,13 @@ public class ActionQueue {
 		}
 		else {
 			LOG.trace( "Adding resolved non-early insert action." );
-			if(insertions == null) {
+			if( insertions == null ) {
 				insertions = new ExecutableList<AbstractEntityInsertAction>( new InsertActionSorter() );
 			}
 			insertions.add(insert);
 		}
 		insert.makeEntityManaged();
-		if(unresolvedInsertions != null) {
+		if( unresolvedInsertions != null ) {
 			for (AbstractEntityInsertAction resolvedAction : unresolvedInsertions.resolveDependentActions(insert.getInstance(), session)) {
 				addResolvedEntityInsertAction(resolvedAction);
 			}
@@ -214,7 +214,7 @@ public class ActionQueue {
 	 * @param action The action representing the entity deletion
 	 */
 	public void addAction(EntityDeleteAction action) {
-		if(deletions == null) {
+		if( deletions == null ) {
 			deletions = new ExecutableList<EntityDeleteAction>();
 		}
 		deletions.add( action );
@@ -238,7 +238,7 @@ public class ActionQueue {
 	 * @param action The action representing the entity update
 	 */
 	public void addAction(EntityUpdateAction action) {
-		if(updates == null) {
+		if( updates == null ) {
 			updates = new ExecutableList<EntityUpdateAction>();
 		}
 		updates.add( action );
@@ -262,7 +262,7 @@ public class ActionQueue {
 	 * @param action The action representing the removal of a collection
 	 */
 	public void addAction(CollectionRemoveAction action) {
-		if(collectionRemovals == null) {
+		if( collectionRemovals == null ) {
 			collectionRemovals = new ExecutableList<CollectionRemoveAction>();
 		}
 		collectionRemovals.add( action );
@@ -441,7 +441,7 @@ public class ActionQueue {
 	 * @return {@code true} if insertions or deletions are currently queued; {@code false} otherwise.
 	 */
 	public boolean areInsertionsOrDeletionsQueued() {
-		return (insertions != null && !insertions.isEmpty()) || hasUnresolvedEntityInsertActions() || (deletions != null && !deletions.isEmpty()) || (orphanRemovals != null && !orphanRemovals.isEmpty());
+		return ( insertions != null && !insertions.isEmpty() ) || hasUnresolvedEntityInsertActions() || (deletions != null && !deletions.isEmpty()) || (orphanRemovals != null && !orphanRemovals.isEmpty());
 	}
 
 	/**
@@ -457,7 +457,7 @@ public class ActionQueue {
 		}
 		for ( int i = 0; i < EXECUTABLE_LISTS.length; ++i ) {
 			ExecutableList<?> l = EXECUTABLE_LISTS[i].get(this);
-			if (areTablesToBeUpdated(l, tables)) {
+			if ( areTablesToBeUpdated(l, tables) ) {
 				return true;
 			}
 		}
@@ -595,21 +595,21 @@ public class ActionQueue {
 	}
 
 	public int numberOfCollectionRemovals() {
-		if(collectionRemovals == null) {
+		if( collectionRemovals == null ) {
 			return 0;
 		}
 		return collectionRemovals.size();
 	}
 
 	public int numberOfCollectionUpdates() {
-		if(collectionUpdates == null) {
+		if( collectionUpdates == null ) {
 			return 0;
 		}
 		return collectionUpdates.size();
 	}
 
 	public int numberOfCollectionCreations() {
-		if(collectionCreations == null) {
+		if( collectionCreations == null ) {
 			return 0;
 		}
 		return collectionCreations.size();
@@ -622,14 +622,14 @@ public class ActionQueue {
 	}
 
 	public int numberOfUpdates() {
-		if(updates == null) {
+		if( updates == null ) {
 			return 0;
 		}
 		return updates.size();
 	}
 
 	public int numberOfInsertions() {
-		if(insertions == null) {
+		if( insertions == null ) {
 			return 0;
 		}
 		return insertions.size();
@@ -682,7 +682,7 @@ public class ActionQueue {
 			// sort the updates by pk
 			updates.sort();
 		}
-		if ( session.getFactory().getSessionFactoryOptions().isOrderInsertsEnabled() && insertions != null) {
+		if ( session.getFactory().getSessionFactoryOptions().isOrderInsertsEnabled() && insertions != null ) {
 			insertions.sort();
 		}
 	}
@@ -718,10 +718,10 @@ public class ActionQueue {
 	}
 
 	public boolean hasAnyQueuedActions() {
-		return (updates != null && !updates.isEmpty()) || (insertions != null && !insertions.isEmpty()) || hasUnresolvedEntityInsertActions()
-				|| (deletions != null && !deletions.isEmpty()) || (collectionUpdates != null && !collectionUpdates.isEmpty())
-				|| (collectionQueuedOps != null && !collectionQueuedOps.isEmpty()) || (collectionRemovals != null && !collectionRemovals.isEmpty())
-				|| (collectionCreations != null && !collectionCreations.isEmpty());
+		return ( updates != null && !updates.isEmpty() ) || ( insertions != null && !insertions.isEmpty() ) || hasUnresolvedEntityInsertActions()
+				|| ( deletions != null && !deletions.isEmpty()) || ( collectionUpdates != null && !collectionUpdates.isEmpty() )
+				|| ( collectionQueuedOps != null && !collectionQueuedOps.isEmpty() ) || ( collectionRemovals != null && !collectionRemovals.isEmpty() )
+				|| ( collectionCreations != null && !collectionCreations.isEmpty() );
 	}
 
 	public void unScheduleDeletion(EntityEntry entry, Object rescuedEntity) {
@@ -731,8 +731,8 @@ public class ActionQueue {
 				rescuedEntity = initializer.getImplementation( session );
 			}
 		}
-		if(deletions != null) {
-			for (int i = 0; i < deletions.size(); i++) {
+		if( deletions != null ) {
+			for ( int i = 0; i < deletions.size(); i++ ) {
 				EntityDeleteAction action = deletions.get(i);
 				if (action.getInstance() == rescuedEntity) {
 					deletions.remove(i);
@@ -740,8 +740,8 @@ public class ActionQueue {
 				}
 			}
 		}
-		if(orphanRemovals != null) {
-			for (int i = 0; i < orphanRemovals.size(); i++) {
+		if( orphanRemovals != null ) {
+			for ( int i = 0; i < orphanRemovals.size(); i++ ) {
 				EntityDeleteAction action = orphanRemovals.get(i);
 				if (action.getInstance() == rescuedEntity) {
 					orphanRemovals.remove(i);
@@ -760,14 +760,14 @@ public class ActionQueue {
 	 */
 	public void serialize(ObjectOutputStream oos) throws IOException {
 		LOG.trace( "Serializing action-queue" );
-		if(unresolvedInsertions == null) {
+		if( unresolvedInsertions == null ) {
 			unresolvedInsertions = new UnresolvedEntityInsertActions();
 		}
 		unresolvedInsertions.serialize( oos );
 
 		for ( ListProvider p : EXECUTABLE_LISTS ) {
 			ExecutableList<?> l = p.get(this);
-			if(l == null) {
+			if( l == null ) {
 				oos.writeBoolean(false);
 			} else {
 				oos.writeBoolean(true);

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
@@ -111,14 +111,14 @@ public class ExecutableList<E extends Executable & Comparable & Serializable> im
 		if ( querySpaces == null ) {
 			for ( E e : executables ) {
 				Serializable[] propertySpaces = e.getPropertySpaces();
-				if (propertySpaces != null && propertySpaces.length > 0) {
-					if(querySpaces == null) {
+				if ( propertySpaces != null && propertySpaces.length > 0 ) {
+					if( querySpaces == null ) {
 						querySpaces = new HashSet<Serializable>();
 					}
 					Collections.addAll( querySpaces, propertySpaces );
 				}
 			}
-			if(querySpaces == null) {
+			if( querySpaces == null ) {
 				return Collections.emptySet();
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
@@ -333,4 +333,8 @@ public class ExecutableList<E extends Executable & Comparable & Serializable> im
 		}
 	}
 
+	public String toString() {
+		return "ExecutableList{size=" + executables.size() + "}";
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
@@ -98,7 +98,7 @@ public class ExecutableList<E extends Executable & Comparable & Serializable> im
 	public ExecutableList(int initialCapacity, ExecutableList.Sorter<E> sorter) {
 		this.sorter = sorter;
 		this.executables = new ArrayList<E>( initialCapacity );
-		this.querySpaces = new HashSet<Serializable>();
+		this.querySpaces = null;
 		this.sorted = true;
 	}
 
@@ -109,12 +109,17 @@ public class ExecutableList<E extends Executable & Comparable & Serializable> im
 	 */
 	public Set<Serializable> getQuerySpaces() {
 		if ( querySpaces == null ) {
-			querySpaces = new HashSet<Serializable>();
 			for ( E e : executables ) {
 				Serializable[] propertySpaces = e.getPropertySpaces();
-				if ( querySpaces != null && propertySpaces != null ) {
+				if (propertySpaces != null && propertySpaces.length > 0) {
+					if(querySpaces == null) {
+						querySpaces = new HashSet<Serializable>();
+					}
 					Collections.addAll( querySpaces, propertySpaces );
 				}
+			}
+			if(querySpaces == null) {
+				return Collections.emptySet();
 			}
 		}
 		return querySpaces;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -434,7 +434,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 			return entity;
 		}
 
-		entity = loadFromSecondLevelCache( event, persister, options );
+		entity = loadFromSecondLevelCache( event, persister, options, keyToLoad );
 		if ( entity != null ) {
 			if ( traceEnabled ) {
 				LOG.tracev(
@@ -561,7 +561,8 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 	protected Object loadFromSecondLevelCache(
 			final LoadEvent event,
 			final EntityPersister persister,
-			final LoadEventListener.LoadType options) {
+			final LoadEventListener.LoadType options,
+			EntityKey entityKey) {
 
 		final SessionImplementor source = event.getSession();
 		final boolean useCache = persister.hasCache()
@@ -602,7 +603,7 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 		}
 
 		CacheEntry entry = (CacheEntry) persister.getCacheEntryStructure().destructure( ce, factory );
-		Object entity = convertCacheEntryToEntity( entry, event.getEntityId(), persister, event );
+		Object entity = convertCacheEntryToEntity( entry, event.getEntityId(), persister, event, entityKey );
 		
 		if ( !persister.isInstance( entity ) ) {
 			throw new WrongClassException(
@@ -619,7 +620,8 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 			CacheEntry entry,
 			Serializable entityId,
 			EntityPersister persister,
-			LoadEvent event) {
+			LoadEvent event,
+			EntityKey entityKey) {
 
 		final EventSource session = event.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
@@ -668,7 +670,6 @@ public class DefaultLoadEventListener extends AbstractLockUpgradeEventListener i
 		}
 
 		// make it circular-reference safe
-		final EntityKey entityKey = session.generateEntityKey( entityId, subclassPersister );
 		TwoPhaseLoad.addUninitializedCachedEntity(
 				entityKey,
 				entity,

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
@@ -138,7 +138,7 @@ public abstract class AbstractSessionImpl
 				this,
 				getHQLQueryPlan( queryString, false ).getParameterMetadata()
 		);
-		query.setComment( "named HQL query " + namedQueryDefinition.getName() );
+		query.setComment(namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName());
 		if ( namedQueryDefinition.getLockOptions() != null ) {
 			query.setLockOptions( namedQueryDefinition.getLockOptions() );
 		}
@@ -156,7 +156,7 @@ public abstract class AbstractSessionImpl
 				this,
 				parameterMetadata
 		);
-		query.setComment( "named native SQL query " + namedQueryDefinition.getName() );
+		query.setComment(namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName());
 		return query;
 	}
 
@@ -193,7 +193,7 @@ public abstract class AbstractSessionImpl
 				this,
 				factory.getQueryPlanCache().getSQLParameterMetadata( nsqlqd.getQueryString() )
 		);
-		query.setComment( "named native SQL query " + queryName );
+		query.setComment(nsqlqd.getComment() != null ? nsqlqd.getComment() : nsqlqd.getName());
 		initQuery( query, nsqlqd );
 		return query;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSessionImpl.java
@@ -138,7 +138,7 @@ public abstract class AbstractSessionImpl
 				this,
 				getHQLQueryPlan( queryString, false ).getParameterMetadata()
 		);
-		query.setComment(namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName());
+		query.setComment( namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName() );
 		if ( namedQueryDefinition.getLockOptions() != null ) {
 			query.setLockOptions( namedQueryDefinition.getLockOptions() );
 		}
@@ -156,7 +156,7 @@ public abstract class AbstractSessionImpl
 				this,
 				parameterMetadata
 		);
-		query.setComment(namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName());
+		query.setComment( namedQueryDefinition.getComment() != null ? namedQueryDefinition.getComment() : namedQueryDefinition.getName() );
 		return query;
 	}
 
@@ -193,7 +193,7 @@ public abstract class AbstractSessionImpl
 				this,
 				factory.getQueryPlanCache().getSQLParameterMetadata( nsqlqd.getQueryString() )
 		);
-		query.setComment(nsqlqd.getComment() != null ? nsqlqd.getComment() : nsqlqd.getName());
+		query.setComment( nsqlqd.getComment() != null ? nsqlqd.getComment() : nsqlqd.getName() );
 		initQuery( query, nsqlqd );
 		return query;
 	}


### PR DESCRIPTION
This PR improves memory usage by lazily allocating many of the lists in the ActionQueue, and removes the executableLists allocation altogether. 

Also note that this changes the serialized representation of ActionQueue, if this is a problem I can change this to eagerly allocate all the lists before serializations/deserialization.