### PR TITLE
HHH-10181: Little facelift for my previous PR

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/CacheableFileXmlSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/CacheableFileXmlSource.java
@@ -32,7 +32,6 @@ public class CacheableFileXmlSource extends XmlSource {
 	private final File xmlFile;
 	private final File serFile;
 	private final boolean strict;
-	private final boolean serFileObsolete;
 
 	public CacheableFileXmlSource(Origin origin, File xmlFile, boolean strict) {
 		super( origin );
@@ -41,8 +40,6 @@ public class CacheableFileXmlSource extends XmlSource {
 
 		this.serFile = determineCachedFile( xmlFile );
 
-		this.serFileObsolete = xmlFile.exists() && serFile.exists() && xmlFile.lastModified() > serFile.lastModified();
-
 		if ( strict ) {
 			if ( !serFile.exists() ) {
 				throw new MappingException(
@@ -50,7 +47,7 @@ public class CacheableFileXmlSource extends XmlSource {
 						origin
 				);
 			}
-			if ( serFileObsolete ) {
+			if ( isSerfileObsolete() ) {
 				throw new MappingException(
 						String.format( "Cached file [%s] could not be used as the mapping file is newer", origin.getName() ),
 						origin
@@ -86,7 +83,7 @@ public class CacheableFileXmlSource extends XmlSource {
 			}
 		}
 		else {
-			if ( !serFileObsolete ) {
+			if ( !isSerfileObsolete() ) {
 				try {
 					return readSerFile();
 				}
@@ -140,6 +137,10 @@ public class CacheableFileXmlSource extends XmlSource {
 				xmlFile,
 				determineCachedFile( xmlFile )
 		);
+	}
+	
+	private boolean isSerfileObsolete() {
+		return xmlFile.exists() && serFile.exists() && xmlFile.lastModified() > serFile.lastModified();
 	}
 
 }


### PR DESCRIPTION
Check for obsolete cache file during runtime of doBind(..) instead of
CacheableFileXmlSource instantiation only. Subsequent calls of doBind on
a given CacheableFileXmlSource instance should detect that cache file is
fresh and make use of it.

But due to the fact that doBind is actually called only once per instance in current Hibernate implementation, this PR won't have any effect other than a code cleanup.