### PR TITLE
HHH-10215 Upgrade to Infinispan 8.0

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/ClusteredTimestampsRegionImpl.java
@@ -16,7 +16,9 @@ import org.hibernate.cache.spi.RegionFactory;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.infinispan.AdvancedCache;
+import org.infinispan.CacheSet;
 import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.notifications.Listener;
@@ -109,14 +111,14 @@ public class ClusteredTimestampsRegionImpl extends TimestampsRegionImpl {
 	 * Brings all data from the distributed cache into our local cache.
 	 */
 	private void populateLocalCache() {
-		CloseableIterable<Object> iterable = Caches.keys(cache);
+		CloseableIterator iterator = cache.keySet().iterator();
 		try {
-			for (Object key : iterable) {
-				get(null, key);
+			while (iterator.hasNext()) {
+				get(null, iterator.next());
 			}
 		}
 		finally {
-			iterable.close();
+			iterator.close();
 		}
 	}
 

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/BeginInvalidationCommand.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/BeginInvalidationCommand.java
@@ -7,6 +7,7 @@
 package org.hibernate.cache.infinispan.util;
 
 import org.hibernate.internal.util.compare.EqualsHelper;
+import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.context.Flag;
@@ -14,7 +15,6 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.remoting.transport.Address;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
@@ -23,56 +23,14 @@ import java.util.Set;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class BeginInvalidationCommand extends InvalidateCommand {
-	// this is a hack to keep compatibility with both Infinispan 7 and 8
-	// TODO: remove this when rebasing on Infinispan 8
-	private static final Field commandInvocationIdField;
-	private static final Method generateIdMethod;
-
-	static {
-		Field commandInvocationId = null;
-		Method generateId = null;
-		try {
-			commandInvocationId = AbstractDataWriteCommand.class.getDeclaredField("commandInvocationId");
-			commandInvocationId.setAccessible(true);
-			Class commandInvocationIdClass = Class.forName("org.infinispan.commands.CommandInvocationId");
-			generateId = commandInvocationIdClass.getMethod("generateId", Address.class);
-		}
-		catch (NoSuchFieldException e) {
-		}
-		catch (ClassNotFoundException e) {
-			// already found field and not the class?
-			throw new IllegalStateException(e);
-		}
-		catch (NoSuchMethodException e) {
-			// already found field and not the method?
-			throw new IllegalStateException(e);
-		}
-		commandInvocationIdField = commandInvocationId;
-		generateIdMethod = generateId;
-	}
-
 	private Object sessionTransactionId;
 
 	public BeginInvalidationCommand() {
 	}
 
-	public BeginInvalidationCommand(CacheNotifier notifier, Set<Flag> flags, Object[] keys, Address address, Object sessionTransactionId) {
-		super();
-		this.notifier = notifier;
-		this.flags = flags;
-		this.keys = keys;
+	public BeginInvalidationCommand(CacheNotifier notifier, Set<Flag> flags, CommandInvocationId commandInvocationId, Object[] keys, Object sessionTransactionId) {
+		super(notifier, flags, commandInvocationId, keys);
 		this.sessionTransactionId = sessionTransactionId;
-		if (commandInvocationIdField != null) {
-			try {
-				commandInvocationIdField.set(this, generateIdMethod.invoke(null, address));
-			}
-			catch (IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			}
-			catch (InvocationTargetException e) {
-				throw new IllegalStateException(e);
-			}
-		}
 	}
 
 	public Object getSessionTransactionId() {
@@ -81,15 +39,6 @@ public class BeginInvalidationCommand extends InvalidateCommand {
 
 	@Override
 	public Object[] getParameters() {
-		Object commandInvocationId = null;
-		if (commandInvocationIdField != null) {
-			try {
-				commandInvocationId = commandInvocationIdField.get(this);
-			}
-			catch (IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			}
-		}
 		if (keys == null || keys.length == 0) {
 			return new Object[]{flags, sessionTransactionId, commandInvocationId, 0};
 		}
@@ -112,15 +61,7 @@ public class BeginInvalidationCommand extends InvalidateCommand {
 		}
 		flags = (Set<Flag>) args[0];
 		sessionTransactionId = args[1];
-		Object commandInvocationId = args[2];
-		if (commandInvocationIdField != null) {
-			try {
-				commandInvocationIdField.set(this, commandInvocationId);
-			}
-			catch (IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			}
-		}
+		commandInvocationId = (CommandInvocationId) args[2];
 		int size = (Integer) args[3];
 		keys = new Object[size];
 		if (size == 1) {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheCommandInitializer.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheCommandInitializer.java
@@ -7,6 +7,7 @@
 package org.hibernate.cache.infinispan.util;
 
 import org.hibernate.cache.infinispan.access.PutFromLoadValidator;
+import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.configuration.cache.Configuration;
@@ -66,7 +67,7 @@ public class CacheCommandInitializer implements ModuleCommandInitializer {
 	}
 
 	public BeginInvalidationCommand buildBeginInvalidationCommand(Set<Flag> flags, Object[] keys, Object sessionTransactionId) {
-		return new BeginInvalidationCommand(notifier, flags, keys, clusteringDependentLogic.getAddress(), sessionTransactionId);
+		return new BeginInvalidationCommand(notifier, flags, CommandInvocationId.generateId(clusteringDependentLogic.getAddress()), keys, sessionTransactionId);
 	}
 
 	public EndInvalidationCommand buildEndInvalidationCommand(String cacheName, Object[] keys, Object sessionTransactionId) {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
@@ -278,7 +278,7 @@ public class Caches {
 
 
 	public static void removeAll(AdvancedCache cache) {
-		CloseableIterator it = keys(cache).iterator();
+		CloseableIterator it = cache.keySet().iterator();
 		try {
 			while (it.hasNext()) {
 				// Cannot use it.next(); it.remove() due to ISPN-5653
@@ -301,24 +301,12 @@ public class Caches {
 		Map<K, V> toMap();
 	}
 
-	public static <K, V> CollectableCloseableIterable<K> keys(AdvancedCache<K, V> cache) {
-		return keys(cache, (KeyValueFilter<K, V>) AcceptAllKeyValueFilter.getInstance());
-	}
-
 	public static <K, V> CollectableCloseableIterable<K> keys(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use keySet()
 		final CloseableIterable<CacheEntry<K, Void>> entryIterable = cache
 				.filterEntries( filter )
 				.converter( NullValueConverter.getInstance() );
 		return new CollectableCloseableIterableImpl<K, Void, K>(entryIterable, Selector.KEY);
-	}
-
-	public static <K, V> CollectableCloseableIterable<V> values(AdvancedCache<K, V> cache) {
-		return values(cache, (KeyValueFilter<K, V>) AcceptAllKeyValueFilter.getInstance());
 	}
 
 	public static <K, V> CollectableCloseableIterable<V> values(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
@@ -340,7 +328,6 @@ public class Caches {
 		final CloseableIterable<CacheEntry<K, T>> entryIterable = cache.filterEntries(filter).converter(converter);
 		return new CollectableCloseableIterableImpl<K, T, T>(entryIterable, Selector.VALUE);
 	}
-
 
 	public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache) {
 		return entrySet(cache, (KeyValueFilter<K, V>) AcceptAllKeyValueFilter.getInstance());

--- a/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
+++ b/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
@@ -6,8 +6,8 @@
   ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
 <infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="urn:infinispan:config:7.2"
-            xsi:schemaLocation="urn:infinispan:config:7.2 http://www.infinispan.org/schemas/infinispan-config-7.2.xsd">
+            xmlns="urn:infinispan:config:8.0"
+            xsi:schemaLocation="urn:infinispan:config:8.0 http://www.infinispan.org/schemas/infinispan-config-8.0.xsd">
 
    <jgroups>
       <stack-file name="hibernate-jgroups" path="${hibernate.cache.infinispan.jgroups_cfg:default-configs/default-jgroups-tcp.xml}"/>
@@ -16,51 +16,51 @@
    <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache" shutdown-hook="DEFAULT">
       <transport stack="hibernate-jgroups" cluster="infinispan-hibernate-cluster"/>
 
-      <local-cache name="the-default-cache" statistics="false" />
+      <local-cache-configuration name="the-default-cache" statistics="false" />
 
       <!-- Default configuration is appropriate for entity/collection caching. -->
-      <invalidation-cache name="entity" mode="SYNC" remote-timeout="20000">
+      <invalidation-cache-configuration name="entity" mode="SYNC" remote-timeout="20000">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
          <transaction mode="NONE" />
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
-      </invalidation-cache>
+      </invalidation-cache-configuration>
 
       <!-- Default configuration for immutable entities -->
-      <invalidation-cache name="immutable-entity" mode="SYNC" remote-timeout="20000">
+      <invalidation-cache-configuration name="immutable-entity" mode="SYNC" remote-timeout="20000">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
          <transaction mode="NONE"/>
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
-      </invalidation-cache>
+      </invalidation-cache-configuration>
 
       <!-- A config appropriate for query caching. Does not replicate queries. -->
-      <local-cache name="local-query">
+      <local-cache-configuration name="local-query">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
          <transaction mode="NONE" />
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
-      </local-cache>
+      </local-cache-configuration>
 
       <!-- A query cache that replicates queries. Replication is asynchronous. -->
-      <replicated-cache name="replicated-query" mode="ASYNC">
+      <replicated-cache-configuration name="replicated-query" mode="ASYNC">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
          <transaction mode="NONE" />
          <eviction max-entries="10000" strategy="LRU"/>
          <expiration max-idle="100000" interval="5000"/>
-      </replicated-cache>
+      </replicated-cache-configuration>
 
       <!-- Optimized for timestamp caching. A clustered timestamp cache
            is required if query caching is used, even if the query cache
            itself is configured with CacheMode=LOCAL. -->
-      <replicated-cache name="timestamps" mode="ASYNC">
+      <replicated-cache-configuration name="timestamps" mode="ASYNC">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
          <!-- Explicitly non transactional -->
          <transaction mode="NONE"/>
          <!--  Don't ever evict modification timestamps -->
          <eviction strategy="NONE"/>
          <expiration interval="0"/>
-      </replicated-cache>
+      </replicated-cache-configuration>
    </cache-container>
 
 </infinispan>

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractGeneralDataRegionTest.java
@@ -170,10 +170,10 @@ public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTe
 			SessionImplementor remoteSession = (SessionImplementor) sessionFactories.get(1).openSession();
 
 			try {
-				Set localKeys = Caches.keys(localCache).toSet();
+				Set localKeys = localCache.keySet();
 				assertEquals( "No valid children in " + localKeys, 0, localKeys.size() );
 
-				Set remoteKeys = Caches.keys(remoteCache).toSet();
+				Set remoteKeys = remoteCache.keySet();
 				assertEquals( "No valid children in " + remoteKeys, 0, remoteKeys.size() );
 
 				assertNull( "local is clean", localRegion.get(null, KEY ) );
@@ -197,14 +197,14 @@ public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTe
 				sleep( 250 );
 				// This should re-establish the region root node in the optimistic case
 				assertNull( localRegion.get(null, KEY ) );
-				localKeys = Caches.keys(localCache).toSet();
+				localKeys = localCache.keySet();
 				assertEquals( "No valid children in " + localKeys, 0, localKeys.size() );
 
 				// Re-establishing the region root on the local node doesn't
 				// propagate it to other nodes. Do a get on the remote node to re-establish
 				// This only adds a node in the case of optimistic locking
 				assertEquals( null, remoteRegion.get(null, KEY ) );
-				remoteKeys = Caches.keys(remoteCache).toSet();
+				remoteKeys = remoteCache.keySet();
 				assertEquals( "No valid children in " + remoteKeys, 0, remoteKeys.size() );
 
 				assertEquals( "local is clean", null, localRegion.get(null, KEY ) );

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/AbstractNonInvalidationTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/AbstractNonInvalidationTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
       Item item = new Item("my item", "Original item");
       withTxSession(s -> s.persist(item));
       entityCache.clear();
-      assertEquals("Cache is not empty", Collections.EMPTY_SET, Caches.keys(entityCache).toSet());
+      assertEquals("Cache is not empty", Collections.EMPTY_SET, entityCache.keySet());
       itemId = item.getId();
       log.info("Insert and clear finished");
    }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/MultiTenancyTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/MultiTenancyTest.java
@@ -13,6 +13,7 @@ import org.hibernate.test.cache.infinispan.tm.XaConnectionProvider;
 import org.hibernate.testing.env.ConnectionProviderBuilder;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.context.Flag;
 import org.junit.Test;
 
@@ -101,8 +102,9 @@ public class MultiTenancyTest extends SingleNodeTest {
 //        }
 		  EntityRegionImpl region = (EntityRegionImpl) sessionFactory().getSecondLevelCacheRegion(Item.class.getName());
 		  AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
-		  CloseableIterable keys = Caches.keys(localCache);
 		  assertEquals(1, localCache.size());
-		  assertEquals("OldCacheKeyImplementation", keys.iterator().next().getClass().getSimpleName());
+		  try (CloseableIterator iterator = localCache.keySet().iterator()) {
+			  assertEquals("OldCacheKeyImplementation", iterator.next().getClass().getSimpleName());
+		  }
 	 }
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/NoTenancyTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/NoTenancyTest.java
@@ -5,6 +5,7 @@ import org.hibernate.cache.infinispan.util.Caches;
 import org.hibernate.test.cache.infinispan.functional.entities.Item;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.context.Flag;
 import org.junit.Test;
 
@@ -38,8 +39,9 @@ public class NoTenancyTest extends SingleNodeTest {
 		  }
 		  EntityRegionImpl region = (EntityRegionImpl) sessionFactory().getSecondLevelCacheRegion(Item.class.getName());
 		  AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
-		  CloseableIterable keys = Caches.keys(localCache);
 		  assertEquals(1, localCache.size());
-		  assertEquals(sessionFactory().getClassMetadata(Item.class).getIdentifierType().getReturnedClass(), keys.iterator().next().getClass());
+		  try (CloseableIterator iterator = localCache.keySet().iterator()) {
+			  assertEquals(sessionFactory().getClassMetadata(Item.class).getIdentifierType().getReturnedClass(), iterator.next().getClass());
+		  }
 	 }
 }

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/cluster/NaturalIdInvalidationTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/cluster/NaturalIdInvalidationTest.java
@@ -122,7 +122,7 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
 			deleteCitizenWithCriteria(remoteFactory);
 			sleep(250);
 
-			Set localKeys = Caches.keys(localNaturalIdCache.getAdvancedCache()).toSet();
+			Set localKeys = localNaturalIdCache.keySet();
 			assertEquals(1, localKeys.size());
 			// Only key left is the one for the citizen *not* in France
 			localKeys.toString().contains("000");

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/timestamp/TimestampsRegionImplTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/timestamp/TimestampsRegionImplTest.java
@@ -30,7 +30,6 @@ import org.infinispan.context.Flag;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryInvalidated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
@@ -132,7 +131,6 @@ public class TimestampsRegionImplTest extends AbstractGeneralDataRegionTest {
 
 			@CacheEntryActivated
 			@CacheEntryCreated
-			@CacheEntryEvicted
 			@CacheEntryInvalidated
 			@CacheEntryLoaded
 			@CacheEntryModified

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/ClassLoaderAwareCache.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/util/ClassLoaderAwareCache.java
@@ -26,7 +26,6 @@ import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryInvalidated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
@@ -95,7 +94,6 @@ public class ClassLoaderAwareCache<K, V> extends AbstractDelegatingAdvancedCache
    static {
       events.put(CacheEntryActivated.class, Event.Type.CACHE_ENTRY_ACTIVATED);
       events.put(CacheEntryCreated.class, Event.Type.CACHE_ENTRY_CREATED);
-      events.put(CacheEntryEvicted.class, Event.Type.CACHE_ENTRY_EVICTED);
       events.put(CacheEntryInvalidated.class, Event.Type.CACHE_ENTRY_INVALIDATED);
       events.put(CacheEntryLoaded.class, Event.Type.CACHE_ENTRY_LOADED);
       events.put(CacheEntryModified.class, Event.Type.CACHE_ENTRY_MODIFIED);
@@ -130,7 +128,6 @@ public class ClassLoaderAwareCache<K, V> extends AbstractDelegatingAdvancedCache
 
       @CacheEntryActivated
       @CacheEntryCreated
-      @CacheEntryEvicted
       @CacheEntryInvalidated
       @CacheEntryLoaded
       @CacheEntryModified

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
 //    h2Version = '1.2.145'
     h2Version = '1.3.176'
     bytemanVersion = '2.1.2'
-    infinispanVersion = '7.2.1.Final'
+    infinispanVersion = '8.0.1.Final'
     jnpVersion = '5.0.6.CR1'
     elVersion = '2.2.4'
 


### PR DESCRIPTION
This mostly involved removal of hacks required for 7.2.x - 8.0.1 compatibility. I have used configuration templates to stress the fact that we use these as templates rather than create the caches described in the config. I plan to add more changes in another PR to streamline the configuration a bit more and reduce the possibility of misconfiguration (e.g. when using old configuration).