### PR TITLE
added many-to-one on-delete="cascade" xml mapping

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/SingularAttributeSourceManyToOneImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/SingularAttributeSourceManyToOneImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.boot.model.source.internal.hbm;
 import java.util.List;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmManyToOneType;
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmOnDeleteEnum;
 import org.hibernate.boot.model.JavaTypeDescriptor;
 import org.hibernate.boot.model.source.spi.AttributePath;
 import org.hibernate.boot.model.source.spi.AttributeRole;
@@ -191,7 +192,7 @@ class SingularAttributeSourceManyToOneImpl
 
 	@Override
 	public boolean isCascadeDeleteEnabled() {
-		return false;
+		return manyToOneElement.getOnDelete().equals(JaxbHbmOnDeleteEnum.CASCADE);
 	}
 
 	@Override

--- a/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd
@@ -1014,6 +1014,7 @@
                 <xs:attribute name="node" type="xs:string"/>
                 <xs:attribute name="not-found" default="exception" type="NotFoundEnum"/>
                 <xs:attribute name="not-null" type="xs:boolean"/>
+                <xs:attribute name="on-delete" default="noaction" type="OnDeleteEnum"/>
                 <xs:attribute name="optimistic-lock" default="true" type="xs:boolean"/>
                 <!-- only supported for properties of a class (not component) -->
                 <xs:attribute name="outer-join" type="OuterJoinEnum"/>


### PR DESCRIPTION
I don't know if there was a reason this already wasn't in the XML mapping DTD/XSD.  but i added it because I needed it.  I cannot use annotations in my project, we are using generated sources.  