### PR TITLE
HHH-10308 : Don't make deep copy of property with AttributeConverter …

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterTypeAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterTypeAdapter.java
@@ -9,6 +9,7 @@ package org.hibernate.type.descriptor.converter;
 import javax.persistence.AttributeConverter;
 
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
@@ -32,8 +33,9 @@ public class AttributeConverterTypeAdapter<T> extends AbstractSingleColumnStanda
 	private final Class jdbcType;
 	private final AttributeConverter<? extends T,?> attributeConverter;
 
-	private final AttributeConverterMutabilityPlanImpl<T> mutabilityPlan;
+	private final MutabilityPlan<T> mutabilityPlan;
 
+	@SuppressWarnings("unchecked")
 	public AttributeConverterTypeAdapter(
 			String name,
 			String description,
@@ -49,7 +51,10 @@ public class AttributeConverterTypeAdapter<T> extends AbstractSingleColumnStanda
 		this.jdbcType = jdbcType;
 		this.attributeConverter = attributeConverter;
 
-		this.mutabilityPlan = new AttributeConverterMutabilityPlanImpl<T>( attributeConverter );
+		this.mutabilityPlan =
+				entityAttributeJavaTypeDescriptor.getMutabilityPlan().isMutable() ?
+						new AttributeConverterMutabilityPlanImpl<T>( attributeConverter ) :
+						ImmutableMutabilityPlan.INSTANCE;
 
 		log.debug( "Created AttributeConverterTypeAdapter -> " + name );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptorRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptorRegistry.java
@@ -122,9 +122,19 @@ public class JavaTypeDescriptorRegistry {
 
 	public static class FallbackJavaTypeDescriptor<T> extends AbstractTypeDescriptor<T> {
 		@SuppressWarnings("unchecked")
-		protected FallbackJavaTypeDescriptor(Class<T> type) {
-			// MutableMutabilityPlan would be the "safest" option, but we do not necessarily know how to deepCopy etc...
-			super( type, ImmutableMutabilityPlan.INSTANCE );
+		protected FallbackJavaTypeDescriptor(final Class<T> type) {
+			// MutableMutabilityPlan is the "safest" option, but we do not necessarily know how to deepCopy etc...
+			super(
+					type,
+					new MutableMutabilityPlan<T>() {
+						@Override
+						protected T deepCopyNotNull(T value) {
+							throw new HibernateException(
+									"Not known how to deep copy value of type: [" + type.getName() + "]"
+							);
+						}
+					}
+			);
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/DirtyCheckingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/DirtyCheckingTest.java
@@ -14,10 +14,13 @@ import javax.persistence.Id;
 
 import org.hibernate.Session;
 
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -107,6 +110,13 @@ public class DirtyCheckingTest extends BaseNonConfigCoreFunctionalTestCase {
 		session.delete( loaded );
 		session.getTransaction().commit();
 		session.close();
+	}
+
+	@Test
+	public void checkConverterMutabilityPlans() {
+		final EntityPersister persister = sessionFactory().getEntityPersister( SomeEntity.class.getName() );
+		assertFalse( persister.getPropertyType( "number" ).isMutable() );
+		assertTrue( persister.getPropertyType( "name" ).isMutable() );
 	}
 
 	@Override


### PR DESCRIPTION
…if Java type is known to be immutable.

Pull request changes FallbackJavaTypeDescriptor to use a MutableMutabilityPlan that throws an exception if #deepCopyNotNull is called. 

AttributeConverterTypeAdapter decides if the MutibilityPlan should be immutable based on the attribute's JavaTypeDescriptor mutability plan. 