### PR TITLE
Use an explicit empty object array to prevent the varargs method allocating one

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterMethodImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterMethodImpl.java
@@ -26,6 +26,9 @@ import static org.hibernate.internal.CoreLogging.messageLogger;
  * @author Steve Ebersole
  */
 public class EnhancedGetterMethodImpl implements Getter {
+
+	private static final Object[] EMPTY = new Object[0];
+
 	private static final CoreMessageLogger LOG = messageLogger( EnhancedGetterMethodImpl.class );
 
 	private final Class containerClass;
@@ -54,7 +57,7 @@ public class EnhancedGetterMethodImpl implements Getter {
 
 			// We don't want to trigger lazy loading of byte code enhanced attributes
 			if ( isAttributeLoaded( owner ) ) {
-				return getterMethod.invoke( owner );
+				return getterMethod.invoke( owner, EMPTY );
 			}
 			return null;
 


### PR DESCRIPTION
In some of the profiles we are seeing a lot of Object[] allocations from this method. I think the varargs method is allocating a new empty Object[] array for every call. 

In master this has been changed to use Field rather than Method so this PR is not applicable.