### PR TITLE
HHH-10313 Make SessionImplementor extend WrapperOptions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -37,6 +37,7 @@ import org.hibernate.Transaction;
 import org.hibernate.TypeHelper;
 import org.hibernate.UnknownProfileException;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
@@ -47,6 +48,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.resource.transaction.TransactionCoordinator;
 import org.hibernate.stat.SessionStatistics;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
 /**
  * This class is meant to be extended.
@@ -776,5 +778,20 @@ public class SessionDelegatorBaseImpl implements SessionImplementor, Session {
 	@Override
 	public void addEventListeners(SessionEventListener... listeners) {
 		session.addEventListeners( listeners );
+	}
+
+	@Override
+	public boolean useStreamForLobBinding() {
+		return sessionImplementor.useStreamForLobBinding();
+	}
+
+	@Override
+	public LobCreator getLobCreator() {
+		return sessionImplementor.getLobCreator();
+	}
+
+	@Override
+	public SqlTypeDescriptor remapSqlTypeDescriptor(SqlTypeDescriptor sqlTypeDescriptor) {
+		return sessionImplementor.remapSqlTypeDescriptor( sqlTypeDescriptor );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -29,6 +29,7 @@ import org.hibernate.loader.custom.CustomQuery;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.resource.transaction.TransactionCoordinator;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * Defines the internal contract between {@link org.hibernate.Session} / {@link org.hibernate.StatelessSession} and
@@ -38,7 +39,7 @@ import org.hibernate.type.Type;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface SessionImplementor extends Serializable, LobCreationContext {
+public interface SessionImplementor extends Serializable, LobCreationContext, WrapperOptions {
 	/**
 	 * Match te method on {@link org.hibernate.Session} and {@link org.hibernate.StatelessSession}
 	 *


### PR DESCRIPTION
As per the TODO in AbstractStandardBasicType. This removes the need to allocate a new WrapperOptions for every call and saves a lot of allocations.