### PR TITLE
HHH-10333: Use null instead of an empty string for schemaFilter and c…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -282,7 +282,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl implements Information
 
 		if ( extractionContext.getJdbcEnvironment().getNameQualifierSupport().supportsCatalogs() ) {
 			if ( catalog == null ) {
-				catalogFilter = "";
+				catalogFilter = null;
 			}
 			else {
 				catalogToUse = catalog;
@@ -295,7 +295,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl implements Information
 
 		if ( extractionContext.getJdbcEnvironment().getNameQualifierSupport().supportsSchemas() ) {
 			if ( schema == null ) {
-				schemaFilter = "";
+				schemaFilter = null;
 			}
 			else {
 				schemaToUse = schema;


### PR DESCRIPTION
Assigned null instead of an empty string to schemaFilter and catalogFilter when corresponding value is null since null and the empty string do not represent the same thing when filtering result set (see java.sql.DatabaseMetaData.getTables())
