### PR TITLE
add geo_BOS to dballocator arguments

### DIFF
--- a/buildSrc/src/main/groovy/org/hibernate/build/qalab/EnabledDatabaseAllocation.groovy
+++ b/buildSrc/src/main/groovy/org/hibernate/build/qalab/EnabledDatabaseAllocation.groovy
@@ -88,7 +88,7 @@ class EnabledDatabaseAllocation implements DatabaseAllocation {
                 Thread.sleep( 60000 );
             }
             def allocatorUrl = DB_ALLOCATOR_URL +
-                    "?operation=alloc&label=${databaseProfile.name}&requestee=${requester}&expiry=${EXPIRY}"
+		     "?operation=allocate&expression=${databaseProfile.name}%26%26geo_BOS&requestee=${requester}&expiry=${EXPIRY}"
             ant.get(
                     src: allocatorUrl,
                     dest: allocatorOutputFile.absolutePath,


### PR DESCRIPTION
DBAllocator now supports different geographical locations of our database servers. Additonal parameter is required to ensure that we get database from BOS lab.
