### PR TITLE
Lazy initialization of static fields should be synchronized

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/AttributeConverterDescriptorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/AttributeConverterDescriptorImpl.java
@@ -150,7 +150,7 @@ public class AttributeConverterDescriptorImpl implements AttributeConverterDescr
 
 	private static Method memberMethod;
 
-	private static Member toMember(XProperty xProperty) {
+	private static synchronized Member toMember(XProperty xProperty) {
 		if ( memberMethod == null ) {
 			Class<JavaXMember> javaXMemberClass = JavaXMember.class;
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1139,7 +1139,7 @@ public final class AnnotationBinder {
 
 	private static CacheConcurrencyStrategy DEFAULT_CACHE_CONCURRENCY_STRATEGY;
 
-	private static CacheConcurrencyStrategy determineCacheConcurrencyStrategy(MetadataBuildingContext context) {
+	private static synchronized CacheConcurrencyStrategy determineCacheConcurrencyStrategy(MetadataBuildingContext context) {
 		if ( DEFAULT_CACHE_CONCURRENCY_STRATEGY == null ) {
 			DEFAULT_CACHE_CONCURRENCY_STRATEGY = CacheConcurrencyStrategy.fromAccessType(
 					context.getBuildingOptions().getImplicitCacheAccessType()

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/HCANNHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/HCANNHelper.java
@@ -55,7 +55,7 @@ public class HCANNHelper {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static void resolveGetMemberMethod() {
+	private static synchronized void resolveGetMemberMethod() {
 		try {
 			getMemberMethod = javaXMemberClass.getDeclaredMethod( "getMember" );
 			getMemberMethod.setAccessible( true );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupport.java
@@ -175,7 +175,7 @@ public class StandardRefCursorSupport implements RefCursorSupport {
 
 	private static Integer refCursorTypeCode;
 
-	private int refCursorTypeCode() {
+	private synchronized int refCursorTypeCode() {
 		if ( refCursorTypeCode == null ) {
 			try {
 				refCursorTypeCode = (Integer) Types.class.getField( "REF_CURSOR" ).get( null );
@@ -193,7 +193,7 @@ public class StandardRefCursorSupport implements RefCursorSupport {
 
 	private static Method getResultSetByPositionMethod;
 
-	private Method getResultSetByPositionMethod() {
+	private synchronized Method getResultSetByPositionMethod() {
 		if ( getResultSetByPositionMethod == null ) {
 			try {
 				getResultSetByPositionMethod = CallableStatement.class.getMethod( "getObject", int.class, Class.class );
@@ -211,7 +211,7 @@ public class StandardRefCursorSupport implements RefCursorSupport {
 
 	private static Method getResultSetByNameMethod;
 
-	private Method getResultSetByNameMethod() {
+	private synchronized Method getResultSetByNameMethod() {
 		if ( getResultSetByNameMethod == null ) {
 			try {
 				getResultSetByNameMethod = CallableStatement.class.getMethod( "getObject", String.class, Class.class );

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/jts/EnvelopeAdapter.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/jts/EnvelopeAdapter.java
@@ -44,7 +44,7 @@ public class EnvelopeAdapter {
 		return pg;
 	}
 
-	public static void setGeometryFactory(GeometryFactory gf) {
+	public static synchronized void setGeometryFactory(GeometryFactory gf) {
 		geomFactory = gf;
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of static fields should be synchronized
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444
Please let me know if you have any questions.
Kirill Vlasov
