### PR TITLE
HHH-10439 Log a message while executing the import script(s)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1729,4 +1729,9 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = INFO)
 	@Message(value = "Cannot locate column information using identifier [%s]; ignoring index [%s]", id = 475 )
 	void logCannotLocateIndexColumnInformation(String columnIdentifierText, String indexIdentifierText);
+	
+	@LogMessage(level = INFO)
+	@Message(value = "Executing import script %s", id = 476 )
+	void executingImportScript(String scriptName);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
@@ -433,6 +433,7 @@ public class SchemaExport {
 				perform( createSQL, exporters );
 				if ( !importFileReaders.isEmpty() ) {
 					for ( NamedReader namedReader : importFileReaders ) {
+						LOG.executingImportScript(namedReader.getName());
 						importScript( namedReader, exporters );
 					}
 				}


### PR DESCRIPTION
The commit here adds a log message to print out the name of the import file being executed by the SchemaExporter. This helps in easily knowing whether or not an import script was picked up and executed during deployment.

More context for this change can be found in the forum discussion here https://developer.jboss.org/thread/241596