### PR TITLE
Add matrix testing configuration for Oracle database

### DIFF
--- a/databases/oracle/matrix.gradle
+++ b/databases/oracle/matrix.gradle
@@ -1,0 +1,7 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+jdbcDependency 'com.oracle.ojdbc:ojdbc7:12.1.0.2.0'

--- a/databases/oracle/resources/hibernate.properties
+++ b/databases/oracle/resources/hibernate.properties
@@ -1,0 +1,25 @@
+#
+# Hibernate, Relational Persistence for Idiomatic Java
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+
+hibernate.dialect org.hibernate.dialect.Oracle12cDialect
+hibernate.connection.driver_class oracle.jdbc.driver.OracleDriver
+hibernate.connection.url jdbc:oracle:thin:@orm-testing.ccuzkqo3zqzq.us-east-1.rds.amazonaws.com:1521:ORCL
+hibernate.connection.username ormmasteruser
+hibernate.connection.password 6Ku65MTGNNnz
+
+hibernate.connection.pool_size 5
+
+hibernate.show_sql false
+hibernate.format_sql true
+
+hibernate.max_fetch_depth 5
+
+hibernate.cache.region_prefix hibernate.test
+hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
+
+hibernate.service.allow_crawling=false
+hibernate.session.events.log=true


### PR DESCRIPTION

Contains the configurations needed to run on Oracle database when running tests on ci.hibernate.org