### PR TITLE
HHH-10416 Drop superfluous immutable-entity cache configuration.

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
@@ -191,11 +191,6 @@ public class InfinispanRegionFactory implements RegionFactory {
 	public static final String DEF_ENTITY_RESOURCE = "entity";
 
 	/**
-	 * Default value for {@link #IMMUTABLE_ENTITY_CACHE_RESOURCE_PROP}.
-	 */
-	public static final String DEF_IMMUTABLE_ENTITY_RESOURCE = "immutable-entity";
-
-	/**
 	 * Default value for {@link #TIMESTAMPS_CACHE_RESOURCE_PROP}.
 	 */
 	public static final String DEF_TIMESTAMPS_RESOURCE = "timestamps";
@@ -522,7 +517,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 		entityOverrides.setCacheName( DEF_ENTITY_RESOURCE );
 		typeOverrides.put( ENTITY_KEY, entityOverrides );
 		final TypeOverrides immutableEntityOverrides = new TypeOverrides();
-		immutableEntityOverrides.setCacheName( DEF_IMMUTABLE_ENTITY_RESOURCE );
+		immutableEntityOverrides.setCacheName( DEF_ENTITY_RESOURCE );
 		typeOverrides.put( IMMUTABLE_ENTITY_KEY, immutableEntityOverrides );
 		final TypeOverrides collectionOverrides = new TypeOverrides();
 		collectionOverrides.setCacheName( DEF_ENTITY_RESOURCE );

--- a/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
+++ b/hibernate-infinispan/src/main/resources/org/hibernate/cache/infinispan/builder/infinispan-configs.xml
@@ -26,14 +26,6 @@
          <expiration max-idle="100000" interval="5000"/>
       </invalidation-cache-configuration>
 
-      <!-- Default configuration for immutable entities -->
-      <invalidation-cache-configuration name="immutable-entity" mode="SYNC" remote-timeout="20000">
-         <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE"/>
-         <eviction max-entries="10000" strategy="LRU"/>
-         <expiration max-idle="100000" interval="5000"/>
-      </invalidation-cache-configuration>
-
       <!-- A config appropriate for query caching. Does not replicate queries. -->
       <local-cache-configuration name="local-query">
          <locking concurrency-level="1000" acquire-timeout="15000"/>


### PR DESCRIPTION
Default to entity cache configuration if undefined.

https://hibernate.atlassian.net/browse/HHH-10416