### PR TITLE
HHH-0372 OffsetDateTime value changes after fetching the row from the database

### DIFF
--- a/hibernate-java8/src/main/java/org/hibernate/type/OffsetDateTimeType.java
+++ b/hibernate-java8/src/main/java/org/hibernate/type/OffsetDateTimeType.java
@@ -16,6 +16,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.hibernate.type.descriptor.java.OffsetDateTimeJavaDescriptor;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
+import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
 
 /**
  * @author Steve Ebersole
@@ -29,15 +30,13 @@ public class OffsetDateTimeType
 	 */
 	public static final OffsetDateTimeType INSTANCE = new OffsetDateTimeType();
 
-	public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss.S xxxxx", Locale.ENGLISH );
-
 	public OffsetDateTimeType() {
-		super( TimestampTypeDescriptor.INSTANCE, OffsetDateTimeJavaDescriptor.INSTANCE );
+		super( VarcharTypeDescriptor.INSTANCE, OffsetDateTimeJavaDescriptor.INSTANCE );
 	}
 
 	@Override
 	public String objectToSQLString(OffsetDateTime value, Dialect dialect) throws Exception {
-		return "{ts '" + FORMATTER.format( value ) + "'}";
+		return value.toString();
 	}
 
 	@Override

--- a/hibernate-java8/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
+++ b/hibernate-java8/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
@@ -35,12 +35,12 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 
 	@Override
 	public String toString(OffsetDateTime value) {
-		return OffsetDateTimeType.FORMATTER.format( value );
+		return value.toString();
 	}
 
 	@Override
 	public OffsetDateTime fromString(String string) {
-		return (OffsetDateTime) OffsetDateTimeType.FORMATTER.parse( string );
+		return OffsetDateTime.parse( string );
 	}
 
 	@Override
@@ -78,6 +78,10 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 			return (X) Long.valueOf( offsetDateTime.toInstant().toEpochMilli() );
 		}
 
+		if ( String.class.isAssignableFrom( type ) ) {
+			return (X) offsetDateTime.toString();
+		}
+
 		throw unknownUnwrap( type );
 	}
 
@@ -108,6 +112,10 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 		if ( Calendar.class.isInstance( value ) ) {
 			final Calendar calendar = (Calendar) value;
 			return OffsetDateTime.ofInstant( calendar.toInstant(), calendar.getTimeZone().toZoneId() );
+		}
+
+		if ( String.class.isInstance( value ) ) {
+			return OffsetDateTime.parse( (String) value );
 		}
 
 		throw unknownWrap( value.getClass() );

--- a/hibernate-java8/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
+++ b/hibernate-java8/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.hibernate.Session;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+import org.junit.Test;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public class OffsetDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {OffsetDateTimeEvent.class};
+	}
+
+	@Test
+	public void testOffsetDateTimeWithUTCZoneOffsetAndYearLessThan1848() {
+		final OffsetDateTime expectedStartDate = OffsetDateTime.of(
+				1847,
+				1,
+				1,
+				0,
+				0,
+				0,
+				0,
+				ZoneOffset.UTC
+		);
+
+		testOffsetDateTime( expectedStartDate );
+	}
+
+	@Test
+	public void testOffsetDateTimeWithHoursZoneOffset() {
+		final OffsetDateTime expectedStartDate = OffsetDateTime.of(
+				2015,
+				1,
+				1,
+				0,
+				0,
+				0,
+				0,
+				ZoneOffset.ofHours( 5 )
+		);
+
+		testOffsetDateTime( expectedStartDate );
+	}
+
+	@Test
+	public void testOffsetDateTimeWithUTCZoneOffset() {
+		final OffsetDateTime expectedStartDate = OffsetDateTime.of(
+				1848,
+				1,
+				1,
+				0,
+				0,
+				0,
+				0,
+				ZoneOffset.UTC
+		);
+
+		testOffsetDateTime( expectedStartDate );
+	}
+
+	private void testOffsetDateTime(OffsetDateTime expectedStartDate) {
+		final OffsetDateTimeEvent event = new OffsetDateTimeEvent();
+		event.id = 1L;
+		event.startDate = expectedStartDate;
+
+		Session s = openSession();
+		s.getTransaction().begin();
+		try {
+			s.save( event );
+			s.getTransaction().commit();
+		}
+		catch (Exception e) {
+			if ( s.getTransaction() != null && s.getTransaction().getStatus() == TransactionStatus.ACTIVE ) {
+				s.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			s.close();
+		}
+
+		s = openSession();
+		try {
+			final OffsetDateTimeEvent offsetDateEvent = s.get( OffsetDateTimeEvent.class, 1L );
+			assertThat( offsetDateEvent.startDate, is( expectedStartDate ) );
+		}
+		finally {
+			s.close();
+		}
+	}
+
+	@Entity(name = "OffsetDateTimeEvent")
+	@Table(name = "OFFSET_DATE_TIME_EVENT")
+	public static class OffsetDateTimeEvent {
+
+		@Id
+		private Long id;
+
+		@Column(name = "START_DATE")
+		private OffsetDateTime startDate;
+	}
+
+	@Override
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10372

I have found no other way than changing the OffsetDateTimeType from TimestampType to VarcharType. 

The problem is the lost of the ZoneOffset info during the 
```java
Timestamp ts = Timestamp.from( offsetDateTime.toInstant() );

OffsetDateTime offsetDateTimeAfterConversion = OffsetDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() );
```
conversion