### PR TITLE
JUnit demonstrating issue https://hibernate.atlassian.net/browse/HHH-5757 with hibernate 5

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
@@ -6,18 +6,18 @@
  */
 package org.hibernate.test.annotations.onetoone;
 
-import org.junit.Test;
-
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.exception.GenericJDBCException;
 import org.hibernate.id.IdentifierGenerationException;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import org.junit.Test;
 
 /**
  * @author Emmanuel Bernard
@@ -102,6 +102,69 @@ public class OptionalOneToOneMappedByTest extends BaseCoreFunctionalTestCase {
 		personAddress = ( PersonAddress ) s.get( PersonAddress.class, personAddress.getId() );
 		assertNull( personAddress.getPerson() );
 
+		s.delete( personAddress );
+		tx.commit();
+		s.close();
+	}
+        
+        /**
+         * <p>
+         * Test case for HHH-5757
+         * </p>
+         * <p>
+         * The SQL query :
+         * <pre>
+         * select this_.id as id1_4_1_, personaddr2_.id as id1_5_0_ from Person this_ left outer join PersonAddress personaddr2_ on this_.id=personaddr2_.id where personaddr2_.id=?
+         * </pre>
+         * is reduced by :
+         * <pre>
+         * select this_.id as id1_4_1_, personaddr2_.id as id1_5_0_ from Person this_ left outer join PersonAddress personaddr2_ on this_.id=personaddr2_.id where this_.id=?
+         * </pre>
+         * due to the OneToOne annotation.
+         * </p>
+         * <p>
+         * It is not triggered by the optional specificity of the relation, but the fact person is optional should enforce the fact that the query
+         * should not be reduced.
+         * </p>
+         * 
+         * @throws Exception 
+         */
+        @Test(expected = GenericJDBCException.class)
+        @TestForIssue(jiraKey = "HHH-5757")
+	public void testBidirQueryEntityProperty() throws Exception {
+		Session s = openSession();
+		s.getTransaction().begin();
+		PersonAddress personAddress = new PersonAddress();
+                Person person = new Person();
+		personAddress.setPerson( person);
+                person.setPersonAddress(personAddress);
+
+                s.persist(person);
+		s.persist( personAddress );
+		s.getTransaction().commit();
+
+		s.clear();
+
+		Transaction tx = s.beginTransaction();
+
+		personAddress = ( PersonAddress ) s.createCriteria(PersonAddress.class)
+				.add( Restrictions.idEq( personAddress.getId() ) )
+				.uniqueResult();
+		assertNotNull( personAddress );
+		assertNotNull( personAddress.getPerson() );
+
+		s.clear();
+                
+                // this call throws GenericJDBCException
+                personAddress = ( PersonAddress ) s.createCriteria(PersonAddress.class)
+                                .add(Restrictions.eq("person", person))
+                                .uniqueResult();
+                
+                // the other way should also work
+                person = ( Person ) s.createCriteria(Person.class)
+                                .add(Restrictions.eq("personAddress", person))
+                                .uniqueResult();
+                
 		s.delete( personAddress );
 		tx.commit();
 		s.close();


### PR DESCRIPTION
I commented the issue as well. The code demonstrates that querying a oneToOne association with an entity throws an exception because of a parameter not set.
The problem is deeper than that, actually a oneToOne relationship query :

select this_.id as id1_4_1_, personaddr2_.id as id1_5_0_ from Person this_ left outer join PersonAddress personaddr2_ on this_.id=personaddr2_.id where personaddr2_.id=?

is reduced to :

select this_.id as id1_4_1_, personaddr2_.id as id1_5_0_ from Person this_ left outer join PersonAddress personaddr2_ on this_.id=personaddr2_.id where this_.id=?

I understand that in case of a shared primary key not optional relationship, that makes sense (but complex to develop and bugged here). But the reduction is done systematically (even with a foreign key I am afraid) and it should not be done when optional.
