### PR TITLE
(HHH-10466) fix AliasTest and MappingReorderedAliasTest failing on DB2

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/mapping/UserConfEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/mapping/UserConfEntity.java
@@ -25,8 +25,8 @@ public class UserConfEntity implements Serializable{
 	@Id
 	@ManyToOne
 	@JoinColumns({
-			@JoinColumn(name="cnf_key", referencedColumnName="confKey"),
-			@JoinColumn(name="cnf_value", referencedColumnName="confValue")})
+			@JoinColumn(name="cnf_key", referencedColumnName="confKey", nullable = false),
+			@JoinColumn(name="cnf_value", referencedColumnName="confValue", nullable = false)})
 	private ConfEntity conf;
 
 	public ConfEntity getConf() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10466
not required for Hibernate 5.x because https://hibernate.atlassian.net/browse/HHH-10045 is applied there