### PR TITLE
Fixed a typo in the docs.

### DIFF
--- a/documentation/src/main/docbook/manual/de-DE/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/de-DE/content/basic_mapping.po
@@ -1,4 +1,4 @@
-# translation of Collection_Mapping.po to 
+# translation of Collection_Mapping.po to
 # translation of Collection_Mapping.po to
 # translation of Collection_Mapping.po to
 # translation of Collection_Mapping.po to
@@ -641,7 +641,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 

--- a/documentation/src/main/docbook/manual/es-ES/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/es-ES/content/basic_mapping.po
@@ -315,7 +315,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 

--- a/documentation/src/main/docbook/manual/fr-FR/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/fr-FR/content/basic_mapping.po
@@ -307,7 +307,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 

--- a/documentation/src/main/docbook/manual/ja-JP/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/ja-JP/content/basic_mapping.po
@@ -368,7 +368,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 

--- a/documentation/src/main/docbook/manual/pot/content/basic_mapping.pot
+++ b/documentation/src/main/docbook/manual/pot/content/basic_mapping.pot
@@ -262,7 +262,8 @@ msgstr ""
 #. Tag: para
 #: basic_mapping.xml:104
 #, no-c-format
-msgid "That's pretty much it, the rest is optional. There are however any options to tweak your entity mapping, let's explore them."
+msgid "That's pretty much it, the rest is optional. There are however many options to tweak your
+entity mapping, let's explore them."
 msgstr ""
 
 #. Tag: para

--- a/documentation/src/main/docbook/manual/pt-BR/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/pt-BR/content/basic_mapping.po
@@ -409,7 +409,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 

--- a/documentation/src/main/docbook/manual/zh-CN/content/basic_mapping.po
+++ b/documentation/src/main/docbook/manual/zh-CN/content/basic_mapping.po
@@ -365,7 +365,7 @@ msgstr ""
 #: basic_mapping.xml:104
 #, no-c-format
 msgid ""
-"That's pretty much it, the rest is optional. There are however any options "
+"That's pretty much it, the rest is optional. There are however many options "
 "to tweak your entity mapping, let's explore them."
 msgstr ""
 


### PR DESCRIPTION
In the basic mapping doc, in the @Entity subsection, right after the first code sample: “there are any options…” – it should be " “there are many options…”.