### PR TITLE
HHH-10429 - Change SimpleValue isIdentityColumn method to return true…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -298,8 +298,7 @@ public class SimpleValue implements KeyValue {
 	
 	public boolean isIdentityColumn(IdentifierGeneratorFactory identifierGeneratorFactory, Dialect dialect) {
 		identifierGeneratorFactory.setDialect( dialect );
-		return identifierGeneratorFactory.getIdentifierGeneratorClass( identifierGeneratorStrategy )
-				.equals( IdentityGenerator.class );
+		return IdentityGenerator.class.isAssignableFrom(identifierGeneratorFactory.getIdentifierGeneratorClass( identifierGeneratorStrategy ));
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/test/cid/PurchaseRecordIdGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cid/PurchaseRecordIdGenerator.java
@@ -8,14 +8,15 @@ package org.hibernate.test.cid;
 import java.io.Serializable;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.IdentityGenerator;
 
 /**
- * Simple {@link IdentityGenerator} implementation for testing composite-id.
+ * Simple {@link IdentifierGenerator} implementation for testing composite-id.
  * 
  * @author Jacob Robertson
  */
-public class PurchaseRecordIdGenerator extends IdentityGenerator {
+public class PurchaseRecordIdGenerator implements IdentifierGenerator {
 
 	private static int nextPurchaseNumber = 2;
 	private static int nextPurchaseSequence = 3;

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/CustomIdentityGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/CustomIdentityGenerator.java
@@ -1,0 +1,9 @@
+package org.hibernate.test.idgen.identity.hhh10429;
+
+import org.hibernate.id.IdentityGenerator;
+
+/**
+ * Created by yinzara on 1/14/16.
+ */
+public class CustomIdentityGenerator extends IdentityGenerator {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/IdentityGeneratorExtendsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/IdentityGeneratorExtendsTest.java
@@ -1,0 +1,80 @@
+package org.hibernate.test.idgen.identity.hhh10429;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.id.factory.IdentifierGeneratorFactory;
+import org.hibernate.mapping.KeyValue;
+import org.hibernate.test.annotations.id.entities.Bunny;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by yinzara on 1/14/16.
+ */
+@TestForIssue(jiraKey = "HHH-10429")
+@RequiresDialectFeature( DialectChecks.SupportsIdentityColumns.class )
+public class IdentityGeneratorExtendsTest extends BaseCoreFunctionalTestCase {
+
+    @Entity
+    @Table
+    public static class EntityBean {
+
+        @Id
+        @Column
+        @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "customGenerator")
+        @GenericGenerator(name = "customGenerator", strategy = "org.hibernate.test.idgen.identity.hhh10429.CustomIdentityGenerator")
+        private int entityId;
+
+        public int getEntityId() {
+            return entityId;
+        }
+
+        public void setEntityId(int entityId) {
+            this.entityId = entityId;
+        }
+    }
+
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class[] { EntityBean.class };
+    }
+
+    @Test
+    public void testIdentifierGeneratorExtendsIdentityGenerator() {
+        final MetadataSources sources  = new MetadataSources(serviceRegistry());
+        sources.addAnnotatedClass(EntityBean.class);
+
+        final MetadataBuilder builder = sources.getMetadataBuilder();
+        final Metadata metadata = builder.build();
+
+        for (final Namespace ns : metadata.getDatabase().getNamespaces()) {
+            for (final org.hibernate.mapping.Table table : ns.getTables()) {
+                final KeyValue value = table.getIdentifierValue();
+                assertNotNull("IdentifierValue was null", value);
+                assertTrue(value.isIdentityColumn(metadata.getIdentifierGeneratorFactory(), getDialect()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
… if the generator class used extends from IdentityGenerator instead of simply being equal to IdentityGenerator

Added test case to verify new functionality.
Discovered defect in PurchaseRecordIdGenerator used in CompositeIdWithGeneratorTest as it should implement IdentifierGenerator not extend IdentityGenerator (as it is not an Identity column).
This caused the CompositeIdWithGeneratorTest to fail with the change to SimpleValue