### PR TITLE
HHH-9411 : Fix downcast of treat statement in criteria.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -620,6 +620,21 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			if ( !queryable.isAbstract() ) {
 				values.add( queryable.getDiscriminatorSQLValue() );
 			}
+			else if ( queryable.hasSubclasses() ) {
+				// if the treat is an abstract class, add the concrete implementations to values if any
+				Set<String> actualSubClasses = queryable.getEntityMetamodel().getSubclassEntityNames();
+
+				for ( String actualSubClass : actualSubClasses ) {
+					if ( actualSubClass.equals( subclass ) ) {
+						continue;
+					}
+
+					Queryable actualQueryable = (Queryable) getFactory().getEntityPersister( actualSubClass );
+					if ( !actualQueryable.hasSubclasses() ) {
+						values.add( actualQueryable.getDiscriminatorSQLValue() );
+					}
+				}
+			}
 		}
 		return values.toArray( new String[values.size()] );
 	}


### PR DESCRIPTION
Hello,

This PR is not terminated yet but I need help to finish it (for the unit test part). Indeed, I do not find how can I use Criteria API in a unit test in hibernate-core. It seems that we can use the API in the hibernate-entitymanager project but not in the hibernate-core. Yet the bug seems to be in the hibernate-core... Do I have to switch to HQL ?

To talk about the bug, the 1=2 in the where statement seen by Matt Todd comes to the fact that Hibernate uses the Dog class instead of its subclasses. The result is that there is no value in the treat underlying condition (so Hibernate put a 1=2). I'm not sure about how I implemented it but it fixes the bug.

Any advice will be appreciated.