### PR TITLE
HHH-10329 ClassCastException on runtime with Infinispan 8.0.1.Final

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/TypeEquivalance.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/TypeEquivalance.java
@@ -21,12 +21,23 @@ public class TypeEquivalance implements Equivalence<Object> {
 
 	@Override
 	public int hashCode(Object o) {
-		return type.getHashCode(o);
+		if (type.getReturnedClass().isInstance(o)) {
+			return type.getHashCode(o);
+		}
+		else {
+			return o != null ? o.hashCode() : 0;
+		}
 	}
 
 	@Override
 	public boolean equals(Object x, Object y) {
-		return type.isEqual(x, y);
+		Class<?> typeClass = type.getReturnedClass();
+		if (typeClass.isInstance(x) && typeClass.isInstance(y)) {
+			return type.isEqual(x, y);
+		}
+		else {
+			return (x == y) || (x != null && x.equals(y));
+		}
 	}
 
 	@Override
@@ -41,6 +52,12 @@ public class TypeEquivalance implements Equivalence<Object> {
 
 	@Override
 	public int compare(Object x, Object y) {
-		return type.compare(x, y);
+		Class<?> typeClass = type.getReturnedClass();
+		if (typeClass.isInstance(x) && typeClass.isInstance(y)) {
+			return type.compare(x, y);
+		}
+		else {
+			return 0;
+		}
 	}
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/Caches.java
@@ -306,10 +306,6 @@ public class Caches {
 	}
 
 	public static <K, V> CollectableCloseableIterable<K> keys(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use keySet()
 		final CloseableIterable<CacheEntry<K, Void>> entryIterable = cache
 				.filterEntries( filter )
@@ -322,20 +318,12 @@ public class Caches {
 	}
 
 	public static <K, V> CollectableCloseableIterable<V> values(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use values()
 		final CloseableIterable<CacheEntry<K, V>> entryIterable = cache.filterEntries(filter);
 		return new CollectableCloseableIterableImpl<K, V, V>(entryIterable, Selector.VALUE);
 	}
 
 	public static <K, V, T> CollectableCloseableIterable<T> values(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter, Converter<K, V, T> converter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use values()
 		final CloseableIterable<CacheEntry<K, T>> entryIterable = cache.filterEntries(filter).converter(converter);
 		return new CollectableCloseableIterableImpl<K, T, T>(entryIterable, Selector.VALUE);
@@ -347,20 +335,12 @@ public class Caches {
 	}
 
 	public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use values()
 		final CloseableIterable<CacheEntry<K, V>> entryIterable = cache.filterEntries(filter);
 		return new MapCollectableCloseableIterableImpl<K, V>(entryIterable);
 	}
 
 	public static <K, V, T> MapCollectableCloseableIterable<K, T> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter, Converter<K, V, T> converter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
 		// HHH-10023: we can't use values()
 		final CloseableIterable<CacheEntry<K, T>> entryIterable = cache.filterEntries(filter).converter(converter);
 		return new MapCollectableCloseableIterableImpl<K, T>(entryIterable);

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/EqualityTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/EqualityTest.java
@@ -3,6 +3,7 @@ package org.hibernate.test.cache.infinispan.functional;
 import org.hibernate.stat.Statistics;
 import org.hibernate.test.cache.infinispan.functional.entities.Name;
 import org.hibernate.test.cache.infinispan.functional.entities.Person;
+import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
 import java.util.List;
@@ -63,4 +64,13 @@ public class EqualityTest extends SingleNodeTest {
 		  assertEquals(expected.getName().getLastName(), person.getName().getLastName());
 		  assertEquals(expected.getAge(), person.getAge());
 	 }
+
+
+	@TestForIssue(jiraKey = "HHH-10329")
+	@Test
+	public void testInvalidationWithEmbeddedId() throws Exception {
+		Person person = new Person("John", "Brown", 33);
+		withTxSession(s -> s.persist(person));
+		withTx(() -> { cleanupCache(); return 0; });
+	}
 }

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -13,7 +13,7 @@ ext {
 //    h2Version = '1.2.145'
     h2Version = '1.3.176'
     bytemanVersion = '2.1.2'
-    infinispanVersion = '7.2.1.Final'
+    infinispanVersion = '7.2.5.Final'
     jnpVersion = '5.0.6.CR1'
     elVersion = '2.2.4'
 


### PR DESCRIPTION
* upgraded Infinispan version to 7.2.5.Final (contains fix for ISPN-5676)
* removed workaround introduced in HHH-10023
* made TypeEquivalence more robust when dealing with objects that do not belong to the type