### PR TITLE
[HHH-10587] skip NationalizedIgnoreCaseTest on db2 and postgresql(plu…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/criterion/NationalizedIgnoreCaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/criterion/NationalizedIgnoreCaseTest.java
@@ -17,18 +17,25 @@ import org.hibernate.Transaction;
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.criterion.Restrictions;
 
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.SkipForDialects;
 import org.junit.Test;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Chris Cranford (aka Naros)
  */
 @TestForIssue( jiraKey = "HHH-8657" )
+@SkipForDialects({
+		@SkipForDialect(value = DB2Dialect.class, comment = "DB2 jdbc driver doesn't support setNString"),
+		@SkipForDialect(value = PostgreSQL81Dialect.class, comment = "PostgreSQL jdbc driver doesn't support setNString"),
+})
 public class NationalizedIgnoreCaseTest extends BaseCoreFunctionalTestCase {
 	
 	@Override


### PR DESCRIPTION
…s) as they don't support nString

https://hibernate.atlassian.net/browse/HHH-10587