### PR TITLE
HHH-10612 Check for support of RefCursor in Java 8

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupport.java
@@ -161,7 +161,7 @@ public class StandardRefCursorSupport implements RefCursorSupport {
 		// Standard JDBC REF_CURSOR support was not added until Java 8, so we need to use reflection to attempt to
 		// access these fields/methods...
 		try {
-			return (Boolean) meta.getClass().getMethod( "supportsRefCursors" ).invoke( null );
+			return (Boolean) meta.getClass().getMethod( "supportsRefCursors" ).invoke( meta );
 		}
 		catch (NoSuchMethodException e) {
 			log.trace( "JDBC DatabaseMetaData class does not define supportsRefCursors method..." );

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.engine.jdbc.cursor.internal;
 
+import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -15,6 +16,7 @@ import static org.junit.Assert.assertThat;
  *
  * @author Daniel Heinrich
  */
+@TestForIssue(jiraKey = "OGM-986")
 public class StandardRefCursorSupportTest {
 
     interface TestDatabaseMetaData extends DatabaseMetaData {

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
@@ -23,10 +23,8 @@ public class StandardRefCursorSupportTest {
 
     @Test
     public void testSupportsRefCursorsAboveJava8() throws Exception {
-        DatabaseMetaData metaMock = Mockito.mock(TestDatabaseMetaData.class);
-
-        Method refCursors = DatabaseMetaData.class.getMethod("supportsRefCursors");
-        Mockito.when(refCursors.invoke(metaMock)).thenReturn(true);
+        TestDatabaseMetaData metaMock = Mockito.mock(TestDatabaseMetaData.class);
+        Mockito.when(metaMock.supportsRefCursors()).thenReturn(true);
 
         boolean result = StandardRefCursorSupport.supportsRefCursors(metaMock);
         assertThat(result, is(true));

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/cursor/internal/StandardRefCursorSupportTest.java
@@ -1,0 +1,34 @@
+package org.hibernate.engine.jdbc.cursor.internal;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit test of the {@link StandardRefCursorSupport} class.
+ *
+ * @author Daniel Heinrich
+ */
+public class StandardRefCursorSupportTest {
+
+    interface TestDatabaseMetaData extends DatabaseMetaData {
+        boolean supportsRefCursors() throws SQLException;
+    }
+
+    @Test
+    public void testSupportsRefCursorsAboveJava8() throws Exception {
+        DatabaseMetaData metaMock = Mockito.mock(TestDatabaseMetaData.class);
+
+        Method refCursors = DatabaseMetaData.class.getMethod("supportsRefCursors");
+        Mockito.when(refCursors.invoke(metaMock)).thenReturn(true);
+
+        boolean result = StandardRefCursorSupport.supportsRefCursors(metaMock);
+        assertThat(result, is(true));
+    }
+}


### PR DESCRIPTION
The code always produced a NullpointerException with a Java8 DatabaseMetaData class, which was caught in the method. This has the effect, that the method always returns 'false' for the Java8 class  DatabaseMetaData.