### PR TITLE
HHH-4161 - persistence.xml <jar-file> not following JSR220 spec

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/StandardArchiveDescriptorFactory.java
@@ -101,7 +101,7 @@ public class StandardArchiveDescriptorFactory implements ArchiveDescriptorFactor
 		}
 
 		final String filePart = extractLocalFilePath( url );
-		if ( filePart.startsWith( "/" ) ) {
+		if ( filePart.startsWith( "/" ) || new File(url.getFile()).isAbsolute() ) {
 			// the URL is already an absolute form
 			return url;
 		}


### PR DESCRIPTION
Switch to an OS-independent  way of checking absolute paths