### PR TITLE
HHH-10429 - Change SimpleValue isIdentityColumn method to return true…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -313,8 +313,7 @@ public class SimpleValue implements KeyValue {
 	
 	public boolean isIdentityColumn(IdentifierGeneratorFactory identifierGeneratorFactory, Dialect dialect) {
 		identifierGeneratorFactory.setDialect( dialect );
-		return identifierGeneratorFactory.getIdentifierGeneratorClass( identifierGeneratorStrategy )
-				.equals( IdentityGenerator.class );
+		return IdentityGenerator.class.isAssignableFrom(identifierGeneratorFactory.getIdentifierGeneratorClass( identifierGeneratorStrategy ));
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/test/cid/PurchaseRecordIdGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cid/PurchaseRecordIdGenerator.java
@@ -8,14 +8,15 @@ package org.hibernate.test.cid;
 import java.io.Serializable;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.IdentityGenerator;
 
 /**
- * Simple {@link IdentityGenerator} implementation for testing composite-id.
+ * Simple {@link IdentifierGenerator} implementation for testing composite-id.
  * 
  * @author Jacob Robertson
  */
-public class PurchaseRecordIdGenerator extends IdentityGenerator {
+public class PurchaseRecordIdGenerator implements IdentifierGenerator {
 
 	private static int nextPurchaseNumber = 2;
 	private static int nextPurchaseSequence = 3;

--- a/hibernate-core/src/test/java/org/hibernate/test/generated/DefaultGeneratedValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/generated/DefaultGeneratedValueTest.java
@@ -24,10 +24,10 @@ import org.hibernate.annotations.GeneratorType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.testing.SkipForDialects;
 import org.hibernate.tuple.ValueGenerator;
 
 import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.SkipForDialects;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -120,7 +120,10 @@ public class DefaultGeneratedValueTest extends BaseCoreFunctionalTestCase {
 
 		theEntity = (TheEntity) s.get( TheEntity.class, 1 );
 		theEntity.lastName = "Smith";
-
+		try {
+			Thread.sleep( 1 );
+		}
+		catch (InterruptedException ignore) {}
 		s.getTransaction().commit();
 		s.close();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/CustomIdentityGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/CustomIdentityGenerator.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.identity.hhh10429;
+
+import org.hibernate.id.IdentityGenerator;
+
+/**
+ * @author Matthew Morrissette
+ */
+public class CustomIdentityGenerator extends IdentityGenerator {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/IdentityGeneratorExtendsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/hhh10429/IdentityGeneratorExtendsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.identity.hhh10429;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.Session;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.mapping.KeyValue;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Matthew Morrissette
+ */
+@TestForIssue(jiraKey = "HHH-10429")
+@RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
+public class IdentityGeneratorExtendsTest extends BaseCoreFunctionalTestCase {
+
+	@Entity(name = "EntityBean")
+	@Table
+	public static class EntityBean {
+
+		@Id
+		@Column
+		@GeneratedValue(strategy = GenerationType.IDENTITY, generator = "customGenerator")
+		@GenericGenerator(name = "customGenerator", strategy = "org.hibernate.test.idgen.identity.hhh10429.CustomIdentityGenerator")
+		private int entityId;
+
+		public int getEntityId() {
+			return entityId;
+		}
+
+		public void setEntityId(int entityId) {
+			this.entityId = entityId;
+		}
+	}
+
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {EntityBean.class};
+	}
+
+	@Test
+	public void testIdentifierGeneratorExtendsIdentityGenerator() {
+		final MetadataSources sources = new MetadataSources( serviceRegistry() );
+		sources.addAnnotatedClass( EntityBean.class );
+
+		final MetadataBuilder builder = sources.getMetadataBuilder();
+		final Metadata metadata = builder.build();
+
+
+		for ( final Namespace ns : metadata.getDatabase().getNamespaces() ) {
+			for ( final org.hibernate.mapping.Table table : ns.getTables() ) {
+				final KeyValue value = table.getIdentifierValue();
+				assertNotNull( "IdentifierValue was null", value );
+				assertTrue( value.isIdentityColumn( metadata.getIdentifierGeneratorFactory(), getDialect() ) );
+			}
+		}
+		
+		Session s = openSession();
+		s.beginTransaction();
+		s.save( new EntityBean() );
+		s.getTransaction().commit();
+		s.close();
+	}
+}


### PR DESCRIPTION
Replacement for this [PR](https://github.com/hibernate/hibernate-orm/pull/1248)

- it contains the License headers
- it's formatted using the Hibernate code styling
- I removed the `PurchaseRecordIdGenerator ` changes which were unrelated to the issue because the `CompositeIdwithGeneratorTest` didn't fail on H2, HSQLDB, or MySQL.