### PR TITLE
HHH-10649 - When 2LC enabled, flush session and then refresh entity cause dirty read in another session / transaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -13,18 +13,22 @@ import java.util.Map;
 import org.hibernate.HibernateException;
 import org.hibernate.PersistentObjectException;
 import org.hibernate.UnresolvableObjectException;
+import org.hibernate.action.spi.AfterTransactionCompletionProcess;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
+import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.RefreshEvent;
 import org.hibernate.event.spi.RefreshEventListener;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.type.CollectionType;
@@ -136,17 +140,31 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		}
 
 		if ( persister.hasCache() ) {
+			Object previousVersion = null;
+			if ( persister.isVersionPropertyGenerated() ) {
+				// we need to grab the version value from the entity, otherwise
+				// we have issues with generated-version entities that may have
+				// multiple actions queued during the same flush
+				previousVersion = persister.getVersion( object );
+			}
 			final EntityRegionAccessStrategy cache = persister.getCacheAccessStrategy();
-			Object ck = cache.generateCacheKey(
+			final Object ck = cache.generateCacheKey(
 					id,
 					persister,
 					source.getFactory(),
 					source.getTenantIdentifier()
 			);
-			cache.evict( ck );
+			final SoftLock lock = cache.lockItem( source, ck, previousVersion );
+			source.getActionQueue().registerProcess( new AfterTransactionCompletionProcess() {
+				@Override
+				public void doAfterTransactionCompletion(boolean success, SessionImplementor session) {
+					cache.unlockItem( session, ck, lock );
+				}
+			} );
+			cache.remove( source, ck );
 		}
 
-		evictCachedCollections( persister, id, source.getFactory() );
+		evictCachedCollections( persister, id, source );
 
 		String previousFetchProfile = source.getLoadQueryInfluencers().getInternalFetchProfile();
 		source.getLoadQueryInfluencers().setInternalFetchProfile( "refresh" );
@@ -168,19 +186,37 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 
 	}
 
-	private void evictCachedCollections(EntityPersister persister, Serializable id, SessionFactoryImplementor factory) {
-		evictCachedCollections( persister.getPropertyTypes(), id, factory );
+	private void evictCachedCollections(EntityPersister persister, Serializable id, EventSource source) {
+		evictCachedCollections( persister.getPropertyTypes(), id, source );
 	}
 
-	private void evictCachedCollections(Type[] types, Serializable id, SessionFactoryImplementor factory)
+	private void evictCachedCollections(Type[] types, Serializable id, EventSource source)
 			throws HibernateException {
 		for ( Type type : types ) {
 			if ( type.isCollectionType() ) {
-				factory.getCache().evictCollection( ( (CollectionType) type ).getRole(), id );
+				CollectionPersister collectionPersister = source.getFactory().getCollectionPersister( ( (CollectionType) type ).getRole() );
+				if ( collectionPersister.hasCache() ) {
+					final CollectionRegionAccessStrategy cache = collectionPersister.getCacheAccessStrategy();
+					final Object ck = cache.generateCacheKey(
+						id,
+						collectionPersister,
+						source.getFactory(),
+						source.getTenantIdentifier()
+					);
+					// FIXME: need version?
+					final SoftLock lock = cache.lockItem( source, ck, null );
+					source.getActionQueue().registerProcess( new AfterTransactionCompletionProcess() {
+						@Override
+						public void doAfterTransactionCompletion(boolean success, SessionImplementor session) {
+							cache.unlockItem( session, ck, lock );
+						}
+					} );
+					cache.remove( source, ck );
+				}
 			}
 			else if ( type.isComponentType() ) {
 				CompositeType actype = (CompositeType) type;
-				evictCachedCollections( actype.getSubtypes(), id, factory );
+				evictCachedCollections( actype.getSubtypes(), id, source );
 			}
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/InsertedDataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/InsertedDataTest.java
@@ -164,7 +164,7 @@ public class InsertedDataTest extends BaseCoreFunctionalTestCase {
 		s.close();
 
 		Map cacheMap = sessionFactory().getStatistics().getSecondLevelCacheStatistics( "item" ).getEntries();
-		assertEquals( 0, cacheMap.size() );
+		assertEquals( 1, cacheMap.size() );
 
 		s = openSession();
 		s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/RefreshUpdatedDataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/RefreshUpdatedDataTest.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cache;
+
+import org.hibernate.PessimisticLockException;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * @author Zhenlei Huang
+ */
+@TestForIssue(jiraKey = "HHH-10649")
+public class RefreshUpdatedDataTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { CacheableItem.class };
+	}
+
+	@Override
+	protected void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty( Environment.CACHE_REGION_PREFIX, "" );
+		cfg.setProperty( Environment.GENERATE_STATISTICS, "true" );
+		cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "true" );
+		cfg.setProperty( Environment.CACHE_PROVIDER_CONFIG, "true" );
+	}
+
+	@Test
+	public void testUpdateAndFlushThenRefresh() {
+		// prepare data
+		Session s = openSession();
+		s.beginTransaction();
+		CacheableItem item = new CacheableItem( "data" );
+		s.save( item );
+		s.getTransaction().commit();
+		s.close();
+
+		Session s1 = openSession();
+		s1.beginTransaction();
+
+		CacheableItem item1 = s1.get( CacheableItem.class, item.getId() ); // into persistent context
+		item1.setName( "some name" );
+
+		s1.flush();
+		s1.refresh( item1 );
+
+		item1 = s1.get( CacheableItem.class, item.getId() );
+		assertEquals( "some name", item1.getName() );
+
+		// open another session
+		Session s2 = sessionFactory().openSession();
+		try {
+			s2.beginTransaction();
+			CacheableItem item2 = s2.get( CacheableItem.class, item.getId() );
+
+			assertEquals( "data", item2.getName() );
+
+			s2.getTransaction().commit();
+		} catch (PessimisticLockException expected) {
+			// expected if mvcc is not used
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			if ( s2.getTransaction().getStatus().canRollback() ) {
+				s2.getTransaction().rollback();
+			}
+			s2.close();
+		}
+
+		s1.getTransaction().rollback();
+		s1.close();
+
+		s = openSession();
+		s.beginTransaction();
+		s.createQuery( "delete CacheableItem" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+}


### PR DESCRIPTION
[https://hibernate.atlassian.net/browse/HHH-10649](https://hibernate.atlassian.net/browse/HHH-10649)