### PR TITLE
HHH-10674 SessionFactoryObserver could use a sessionFactoryAboutToClose method

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
@@ -22,6 +22,14 @@ public interface SessionFactoryObserver extends Serializable {
 	public void sessionFactoryCreated(SessionFactory factory);
 
 	/**
+	 * Callback to indicate that the given factory is about to be closed. This factory is open
+	 * when this method is called.
+	 *
+	 * @param factory The factory closed.
+	 */
+	public void sessionFactoryAboutToClose(SessionFactory factory);
+
+	/**
 	 * Callback to indicate that the given factory has been closed.  Care should be taken
 	 * in how (if at all) the passed factory reference is used since it is closed.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
@@ -27,7 +27,7 @@ public interface SessionFactoryObserver extends Serializable {
 	 *
 	 * @param factory The factory closed.
 	 */
-	public void sessionFactoryAboutToClose(SessionFactory factory);
+	public void sessionFactoryBeforeClose(SessionFactory factory);
 
 	/**
 	 * Callback to indicate that the given factory has been closed.  Care should be taken

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -263,7 +263,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			}
 
 			@Override
-			public void sessionFactoryAboutToClose(SessionFactory factory) {
+			public void sessionFactoryBeforeClose(SessionFactory factory) {
 			}
 
 			@Override
@@ -1048,7 +1048,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			return;
 		}
 
-		observer.sessionFactoryAboutToClose( this );
+		observer.sessionFactoryBeforeClose( this );
 
 		LOG.closing();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -263,6 +263,10 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			}
 
 			@Override
+			public void sessionFactoryAboutToClose(SessionFactory factory) {
+			}
+
+			@Override
 			public void sessionFactoryClosed(SessionFactory factory) {
 				for ( Integrator integrator : integrators ) {
 					integrator.disintegrate( SessionFactoryImpl.this, SessionFactoryImpl.this.serviceRegistry );
@@ -1043,6 +1047,8 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			LOG.trace( "Already closed" );
 			return;
 		}
+
+		observer.sessionFactoryAboutToClose( this );
 
 		LOG.closing();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryObserverChain.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryObserverChain.java
@@ -37,13 +37,13 @@ public class SessionFactoryObserverChain implements SessionFactoryObserver {
 	}
 
 	@Override
-	public void sessionFactoryAboutToClose(SessionFactory factory) {
+	public void sessionFactoryBeforeClose(SessionFactory factory) {
 		if ( observers == null ) {
 			return;
 		}
 
 		for ( SessionFactoryObserver observer : observers ) {
-			observer.sessionFactoryAboutToClose( factory );
+			observer.sessionFactoryBeforeClose( factory );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryObserverChain.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryObserverChain.java
@@ -37,6 +37,17 @@ public class SessionFactoryObserverChain implements SessionFactoryObserver {
 	}
 
 	@Override
+	public void sessionFactoryAboutToClose(SessionFactory factory) {
+		if ( observers == null ) {
+			return;
+		}
+
+		for ( SessionFactoryObserver observer : observers ) {
+			observer.sessionFactoryAboutToClose( factory );
+		}
+	}
+
+	@Override
 	public void sessionFactoryClosed(SessionFactory factory) {
 		if ( observers == null ) {
 			return;

--- a/hibernate-core/src/test/java/org/hibernate/test/events/CallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/events/CallbackTest.java
@@ -84,16 +84,22 @@ public class CallbackTest extends BaseCoreFunctionalTestCase {
 
 		sessionFactory().close();
 
+		assertEquals( "observer not notified of aboutToClose", 1, observer.aboutToCloseCount );
 		assertEquals( "observer not notified of close", 1, observer.closedCount );
 		assertEquals( "listener not notified of close", 1, listener.destoryCount );
 	}
 
 	private static class TestingObserver implements SessionFactoryObserver {
 		private int creationCount = 0;
+		private int aboutToCloseCount = 0;
 		private int closedCount = 0;
 
 		public void sessionFactoryCreated(SessionFactory factory) {
 			creationCount++;
+		}
+
+		public void sessionFactoryAboutToClose(SessionFactory factory) {
+			aboutToCloseCount++;
 		}
 
 		public void sessionFactoryClosed(SessionFactory factory) {

--- a/hibernate-core/src/test/java/org/hibernate/test/events/CallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/events/CallbackTest.java
@@ -84,22 +84,22 @@ public class CallbackTest extends BaseCoreFunctionalTestCase {
 
 		sessionFactory().close();
 
-		assertEquals( "observer not notified of aboutToClose", 1, observer.aboutToCloseCount );
+		assertEquals( "observer not notified of before close", 1, observer.beforeCloseCount );
 		assertEquals( "observer not notified of close", 1, observer.closedCount );
 		assertEquals( "listener not notified of close", 1, listener.destoryCount );
 	}
 
 	private static class TestingObserver implements SessionFactoryObserver {
 		private int creationCount = 0;
-		private int aboutToCloseCount = 0;
+		private int beforeCloseCount = 0;
 		private int closedCount = 0;
 
 		public void sessionFactoryCreated(SessionFactory factory) {
 			creationCount++;
 		}
 
-		public void sessionFactoryAboutToClose(SessionFactory factory) {
-			aboutToCloseCount++;
+		public void sessionFactoryBeforeClose(SessionFactory factory) {
+			beforeCloseCount++;
 		}
 
 		public void sessionFactoryClosed(SessionFactory factory) {

--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -937,7 +937,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 		}
 
 		@Override
-		public void sessionFactoryAboutToClose(SessionFactory factory) {
+		public void sessionFactoryBeforeClose(SessionFactory factory) {
 			// nothing to do
 		}
 

--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -937,6 +937,11 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 		}
 
 		@Override
+		public void sessionFactoryAboutToClose(SessionFactory factory) {
+			// nothing to do
+		}
+
+		@Override
 		public void sessionFactoryClosed(SessionFactory sessionFactory) {
 			SessionFactoryImplementor sfi = ( (SessionFactoryImplementor) sessionFactory );
 			sfi.getServiceRegistry().destroy();

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/ejb3configuration/SessionFactoryObserverTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/ejb3configuration/SessionFactoryObserverTest.java
@@ -48,6 +48,8 @@ public class SessionFactoryObserverTest {
 	public static class GoofySessionFactoryObserver implements SessionFactoryObserver {
 		public void sessionFactoryCreated(SessionFactory factory) {
 		}
+		public void sessionFactoryAboutToClose(SessionFactory factory) {
+		}
 
 		public void sessionFactoryClosed(SessionFactory factory) {
 			throw new GoofyException();

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/ejb3configuration/SessionFactoryObserverTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/ejb3configuration/SessionFactoryObserverTest.java
@@ -48,7 +48,7 @@ public class SessionFactoryObserverTest {
 	public static class GoofySessionFactoryObserver implements SessionFactoryObserver {
 		public void sessionFactoryCreated(SessionFactory factory) {
 		}
-		public void sessionFactoryAboutToClose(SessionFactory factory) {
+		public void sessionFactoryBeforeClose(SessionFactory factory) {
 		}
 
 		public void sessionFactoryClosed(SessionFactory factory) {


### PR DESCRIPTION
I haven't followed the dicussion about Java 8 completely on the mailing list, but if Java 8 were to become standard before this PR is to be applied the aboutToBeClosed method could also have a default implementation so this change doesn't break any existing code.