### PR TITLE
HHH-10375 - adding an entity at index to list with @OrderColumn in detached Entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentList.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentList.java
@@ -314,18 +314,8 @@ public class PersistentList extends AbstractPersistentCollection implements List
 		if ( index < 0 ) {
 			throw new ArrayIndexOutOfBoundsException( "negative index" );
 		}
-		if ( !isInitialized() || isConnectedToSession() ) {
-			// NOTE : we don't care about the inverse part here because
-			// even if the collection is inverse, this side is driving the
-			// writing of the indexes.  And because this is a positioned-add
-			// we need to load the underlying elements to know how that
-			// affects overall re-ordering
-			write();
-			list.add( index, value );
-		}
-		else {
-			queueOperation( new Add( index, value ) );
-		}
+		write();
+		list.add( index, value );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/delayedOperation/ListAddTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/delayedOperation/ListAddTest.java
@@ -23,13 +23,16 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.collection.spi.PersistentCollection;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -153,6 +156,24 @@ public class ListAddTest extends BaseNonConfigCoreFunctionalTestCase {
 
 		transaction.commit();
 		session.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-10375")
+	public void testAddQuestionAfterSessionIsClosed(){
+		Session session = openSession();
+		Transaction transaction = session.beginTransaction();
+
+		Quizz quizz = session.get( Quizz.class, 1 );
+		assertThat(  "expected 4 questions", quizz.getQuestions().size(), is(3) );
+		transaction.commit();
+		session.close();
+
+		quizz.addQuestion(  new Question( 4, "question 4" ) );
+		assertThat(  "expected 4 questions", quizz.getQuestions().size(), is(4) );
+
+		quizz.addQuestion(  1, new Question( 5, "question 5" ) );
+		assertThat(  "expected 5 questions", quizz.getQuestions().size(), is(5) );
 	}
 
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10375

the only solution I have found to solve this issue avoiding also that objects added using and index are added at the end of the list is not to queue the operation in the 
`PersistenList#add(int index, Object value)
` method, this because 
`OneToManyPersister#doProcessQueuedOps()
`calls
`writeIndex( collection, collection.queuedAdditionIterator(), id, false, session );
`
where the information related to the index is lost causing all objects to be added at the end of the list.