### PR TITLE
HHH-10471: Added java.util.stream.Stream conversion in ScrollableResults

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/ScrollableResults.java
+++ b/hibernate-core/src/main/java/org/hibernate/ScrollableResults.java
@@ -13,7 +13,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
+import org.hibernate.internal.ScrollableResultsStreamSupport;
 import org.hibernate.type.Type;
 
 /**
@@ -355,4 +357,27 @@ public interface ScrollableResults extends java.io.Closeable {
 	 * @throws IndexOutOfBoundsException If col is an invalid index.
 	 */
 	public TimeZone getTimeZone(int col);
+
+	/**
+	 * @param type the class of the {@link Stream}'s elements
+	 *
+	 * @param <T> the type of the {@link Stream}'s elements
+	 *
+	 * @return a {@link Stream} with values from the {@link ScrollableResults}
+	 */
+	default <T> Stream<T> asStream(Class<T> type){
+		return ScrollableResultsStreamSupport.asStream( this, type );
+	}
+
+	/**
+	 * @param type the class of the {@link Stream}'s elements
+	 *
+	 * @param <T> the type of the {@link Stream}'s elements
+	 *
+	 * @return a parallel {@link Stream} with values from the {@link ScrollableResults}
+	 */
+	default <T> Stream<T> asParallelStream(Class<T> type){
+		return ScrollableResultsStreamSupport.asParallelStream( this, type );
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsStreamSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsStreamSupport.java
@@ -1,0 +1,95 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal;
+
+import org.hibernate.ScrollableResults;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * Utilities for obtaining {@link Stream} with an underlying {@link ScrollableResults}
+ *
+ * @author Christophe Taret
+ */
+public class ScrollableResultsStreamSupport {
+
+	/**
+	 * @see Spliterator for description
+	 */
+	private static final int DEFAULT_CHARACTERISTICS =
+			Spliterator.NONNULL |
+					Spliterator.IMMUTABLE;
+
+	private ScrollableResultsStreamSupport() {
+	}
+
+	/**
+	 * @param scrollableResults the {@link ScrollableResults}
+	 * @param type              the class of the {@link Stream}
+	 * @param <T>               the type of the {@link Stream}
+	 * @return a {@link Stream} with values from the {@link ScrollableResults}
+	 */
+	public static <T> Stream<T> asStream(ScrollableResults scrollableResults, Class<T> type) {
+		return asStream( scrollableResults, type, DEFAULT_CHARACTERISTICS, false );
+	}
+
+	/**
+	 * @param scrollableResults the {@link ScrollableResults}
+	 * @param type              the class of the {@link Stream}
+	 * @param <T>               the type of the {@link Stream}
+	 * @return a parallel {@link Stream} with values from the {@link ScrollableResults}
+	 */
+	public static <T> Stream<T> asParallelStream(ScrollableResults scrollableResults, Class<T> type) {
+		return asStream( scrollableResults, type, DEFAULT_CHARACTERISTICS, true );
+	}
+
+	private static <T> Stream<T> asStream(
+			ScrollableResults scrollableResults,
+			Class<T> type,
+			int characteristics,
+			boolean parallel) {
+		// build the stream whether parallel or not, with all required information
+		return stream(
+				spliteratorUnknownSize(
+						new ScrollableResultIterator<>(scrollableResults, type),
+						characteristics),
+				parallel);
+	}
+
+	/**
+	 * A {@link Iterator} implementation with an underlying {@link ScrollableResults}
+	 *
+	 * @param <T>
+	 */
+	private static class ScrollableResultIterator<T> implements Iterator<T> {
+		private final ScrollableResults sr;
+		private final Class<T> type;
+
+		ScrollableResultIterator(ScrollableResults sr, Class<T> type) {
+			this.sr = sr;
+			this.type = type;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return !sr.isLast();
+		}
+
+		@Override
+		public T next() {
+			if (sr.next()) {
+				return type.cast( sr.get()[0] );
+			}
+			return null;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/batch/ScrollableResultsStreamTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/batch/ScrollableResultsStreamTest.java
@@ -1,0 +1,205 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.batch;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.stream.LongStream.rangeClosed;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This test persist 10 {@link ParentEntity}s, each having a list of 10 {@link ChildEntity}s, each having a value
+ * between 1 and 100.
+ * When retrieving this entities, the aim of the test is, using {@link org.hibernate.ScrollableResults}'s stream
+ * feature, to compute the sum of the values and verify that it is equal to the expected sum, using the well known
+ * property for the sum S of the first n integers
+ * S = n*(n+1)/2
+ *
+ * @author Christophe Taret
+ */
+public class ScrollableResultsStreamTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private static final long EXPECTED_SUM = 100L * 101L / 2;
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ParentEntity.class, ChildEntity.class};
+	}
+
+	@Before
+	public void setup() {
+		executeInTransaction( session -> {
+			// we have ten parents
+			rangeClosed( 0, 9 ).forEach( parentIndex -> {
+				// each parent has ten SimpleEntities as child
+				List<ChildEntity> simpleEntities = rangeClosed( 1, 10 ).boxed()
+						// each ChildEntity has a value (from 1 to 100)
+						.map( childIndex ->
+								new ChildEntity( 10 * parentIndex + childIndex ) )
+						.collect( Collectors.toList() );
+				session.save( new ParentEntity( simpleEntities ) );
+			});
+		});
+	}
+
+	@After
+	public void teardown() throws Exception {
+		executeInTransaction( session -> {
+			session.createQuery( "delete from ChildEntity" ).executeUpdate();
+			session.createQuery( "delete from ParentEntity" ).executeUpdate();
+		});
+	}
+
+	@Test
+	public void testStandardStream() {
+		long sum = computeSum(
+				"from ChildEntity",
+				sr -> sr.asStream( ChildEntity.class ));
+
+		assertThat( sum, is( EXPECTED_SUM ) );
+	}
+
+	@Test
+	public void testParallelStream() {
+		long sum = computeSum(
+				"from ChildEntity",
+				sr -> sr.asParallelStream( ChildEntity.class ));
+
+		assertThat( sum, is( EXPECTED_SUM ) );
+	}
+
+	@Test
+	public void testFlatMap() {
+		long sum = computeSum(
+				"from ParentEntity l join fetch l.children",
+				sr -> sr.asStream( ParentEntity.class )
+						.flatMap( l -> l.getChildren().stream() ) );
+
+		assertThat( sum, is( EXPECTED_SUM ) );
+	}
+
+	@Test
+	public void testFlatMapParallelStream() {
+		long sum = computeSum(
+				"from ParentEntity l join fetch l.children",
+				sr -> sr.asParallelStream( ParentEntity.class )
+						.flatMap( l -> l.getChildren().stream() ) );
+
+		assertThat( sum, is( EXPECTED_SUM ) );
+	}
+
+	private void executeInTransaction(Consumer<Session> action) {
+		final Session s = openSession();
+		s.getTransaction().begin();
+		try {
+			action.accept( s );
+			s.getTransaction().commit();
+		}
+		catch (Exception e) {
+			if (s.getTransaction() != null && s.getTransaction().getStatus() == TransactionStatus.ACTIVE) {
+				s.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			s.close();
+		}
+	}
+
+	private long computeSum(String queryString, Function<ScrollableResults, Stream<ChildEntity>> asStreamFunction) {
+		long sum;
+		final Session s = openSession();
+		ScrollableResults scroll = null;
+		try {
+			scroll = s.createQuery( queryString ).setFetchSize( 5 ).scroll();
+			sum = asStreamFunction.apply( scroll )
+					.map( ChildEntity::getValue )
+					.reduce( 0L, (a, b) -> a + b );
+		}
+		finally {
+			if (scroll != null) {
+				scroll.close();
+			}
+			s.close();
+		}
+		return sum;
+	}
+
+
+	@Entity(name = "ParentEntity")
+	@Table(name = "LESS_SIMPLE_ENTITY")
+	public static class ParentEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		private Long id;
+
+		@OneToMany(mappedBy = "parent", cascade = {CascadeType.ALL})
+		private List<ChildEntity> children;
+
+		public ParentEntity(List<ChildEntity> children) {
+			assignChildren( children );
+		}
+
+		public ParentEntity() {
+		}
+
+		private void assignChildren(List<ChildEntity> children) {
+			this.children = children;
+			children.forEach( s -> s.parent = this );
+		}
+
+		public List<ChildEntity> getChildren() {
+			return children;
+		}
+	}
+
+	@Entity(name = "ChildEntity")
+	@Table(name = "SIMPLE_ENTITY")
+	public static class ChildEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		private Long id;
+		private Long value;
+		@ManyToOne(fetch = FetchType.LAZY)
+		private ParentEntity parent;
+
+		public ChildEntity() {
+		}
+
+		public ChildEntity(Long value) {
+			this.value = value;
+		}
+
+		public Long getValue() {
+			return value;
+		}
+	}
+
+}


### PR DESCRIPTION
Following advices given in [PR 1347](https://github.com/hibernate/hibernate-orm/pull/1347), here is a proposal for enhancement of ScrollableResults interface (targeting 5.2 release), with 2 default methods added:
- asStream: build a standard java.util.stream.Stream
- asParallelStream: build a parallel java.util.stream.Stream

The stream building stuff is delegated to org.hibernate.internal.ScrollableResultsStreamSupport.
