### PR TITLE
HHH-9570: Auto-detect SQL Server 2014

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolver.java
@@ -156,6 +156,7 @@ public class StandardDialectResolver implements DialectResolver {
 				case 10:
 					return new SQLServer2008Dialect();
 				case 11:
+				case 12:
 					return new SQLServer2012Dialect();
 				default:
 					LOG.unknownSqlServerVersion( majorVersion );

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
@@ -9,7 +9,6 @@ package org.hibernate.engine.jdbc.dialect.internal;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.hibernate.dialect.Dialect;
@@ -18,8 +17,8 @@ import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 import org.hibernate.dialect.SQLServer2008Dialect;
+import org.hibernate.dialect.SQLServer2012Dialect;
 import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.resolver.DialectResolverTest;
 import org.hibernate.dialect.resolver.TestingDialectResolutionInfo;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -54,6 +53,12 @@ public class StandardDialectResolverTest extends BaseUnitTestCase {
 	public void testResolveDialectInternalForSQLServer2012() 
 			throws SQLException {
 		runSQLServerDialectTest( 11, SQLServer2008Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForSQLServer2014()
+			throws SQLException {
+		runSQLServerDialectTest( 12, SQLServer2012Dialect.class );
 	}
 
 	@Test


### PR DESCRIPTION
Copying a previous workaround for the same issue: https://github.com/hibernate/hibernate-orm/pull/395

- Previously, SQL Server version 12 (SQL Server 2014) was an unknown version, resulting in the SQLServerDialect
- Added version 12 to the switch statement so that SQLServer2012Dialect  is now returned by default, as SQL Server 2014 is much more similar to SQL Server 2012 than SQL Server 2000
- Added test case