### PR TITLE
Fixes for HHH-10742

### DIFF
--- a/hibernate-osgi/src/test/java/org/hibernate/osgi/test/OsgiIntegrationTest.java
+++ b/hibernate-osgi/src/test/java/org/hibernate/osgi/test/OsgiIntegrationTest.java
@@ -24,6 +24,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.osgi.test.client.DataPoint;
+import org.hibernate.osgi.test.client.OsgiTestActivator;
 import org.hibernate.osgi.test.client.SomeService;
 import org.hibernate.osgi.test.client.TestIntegrator;
 import org.hibernate.osgi.test.client.TestStrategyRegistrationProvider;
@@ -140,32 +141,43 @@ public class OsgiIntegrationTest {
 	public TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
 		System.out.println( "Configuring probe..." );
 
-		// Note : I found locally that this part is not needed.  But I am leaving this here as I might
-		// 		someday have a need for tweaking the probe and I want to remember how it is done...
+		// PAX-Exam has a default DynamicImport-Package: * for the probe, which hides
+		// ClassLoader problems by allowing the client to see everything. We override
+		// this to get better testing, however the imports are still wider than they
+		// should be. In an ideal world the JPA tests would packaged in a separate
+		// bundle and have no imports other than javax.persistence...
+		
+		// For now we make sure that javassist and hibernate proxy are not needed.
 
-//		// attempt to override PaxExam's default of dynamically importing everything
-//		probe.setHeader( Constants.DYNAMICIMPORT_PACKAGE, "" );
-//		// and use defined imports instead
-//		probe.setHeader(
-//				Constants.IMPORT_PACKAGE,
-//				"javassist.util.proxy"
-//						+ ",javax.persistence"
-//						+ ",javax.persistence.spi"
-//						+ ",org.h2"
-//						+ ",org.osgi.framework"
-//						+ ",org.hibernate"
-////						+ ",org.hibernate.boot.model"
-////						+ ",org.hibernate.boot.registry.selector"
-////						+ ",org.hibernate.boot.registry.selector.spi"
-////						+ ",org.hibernate.cfg"
-////						+ ",org.hibernate.engine.spi"
-////						+ ",org.hibernate.integrator.spi"
-////						+ ",org.hibernate.proxy"
-////						+ ",org.hibernate.service"
-////						+ ",org.hibernate.service.spi"
-////						+ ",org.ops4j.pax.exam.options"
-////						+ ",org.ops4j.pax.exam"
-//		);
+		// Remove DynamicImport-Package: *
+		probe.setHeader( Constants.DYNAMICIMPORT_PACKAGE, "" );
+		
+		// Use defined imports instead
+		// This is to avoid PAX EXAM "helping" and shadowing class loading issues elsewhere
+		// This test bundle needs the OSGi API, JPA API, JUnit API and core Hibernate API.
+		// The karaf API and Hibernate service integration APIs are needed for specific tests
+		probe.setHeader(
+				Constants.IMPORT_PACKAGE,
+						"javax.inject"
+						+ ",javax.persistence"
+						+ ",javax.persistence.spi"
+						+ ",org.h2"
+						+ ",org.junit"
+						+ ",org.osgi.framework"
+						+ ",org.apache.karaf.features"
+						+ ",org.hibernate"
+						+ ",org.hibernate.annotations"
+						+ ",org.hibernate.boot.model"
+						+ ",org.hibernate.boot.registry.selector"
+						+ ",org.hibernate.engine.spi"
+						+ ",org.hibernate.integrator.spi"
+						+ ",org.hibernate.service"
+						+ ",org.hibernate.service.spi"
+						+ ",org.hibernate.usertype"
+						+ ",org.ops4j.pax.exam.options"
+						+ ",org.ops4j.pax.exam"
+		);
+		
 		probe.setHeader( Constants.BUNDLE_ACTIVATOR, "org.hibernate.osgi.test.client.OsgiTestActivator" );
 		return probe;
 	}

--- a/hibernate-osgi/src/test/java/org/hibernate/osgi/test/client/OsgiTestActivator.java
+++ b/hibernate-osgi/src/test/java/org/hibernate/osgi/test/client/OsgiTestActivator.java
@@ -25,10 +25,17 @@ public class OsgiTestActivator implements BundleActivator {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		// register example extension point services
-		context.registerService( Integrator.class, new TestIntegrator(), new Hashtable() );
-		context.registerService( StrategyRegistrationProvider.class, new TestStrategyRegistrationProvider(), new Hashtable() );
-		context.registerService( TypeContributor.class, new TestTypeContributor(), new Hashtable() );
-		context.registerService( ServiceContributor.class, new SomeServiceContributor(), new Hashtable() );
+		System.out.println("Registering test integration services");
+		try {
+			context.registerService( Integrator.class, new TestIntegrator(), new Hashtable() );
+			context.registerService( StrategyRegistrationProvider.class, new TestStrategyRegistrationProvider(), new Hashtable() );
+			context.registerService( TypeContributor.class, new TestTypeContributor(), new Hashtable() );
+			context.registerService( ServiceContributor.class, new SomeServiceContributor(), new Hashtable() );
+		} catch (Exception e) {
+			System.out.println("test integration service registration failed");
+			e.printStackTrace();
+			throw e;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This PR forms the basis of some suggested fixes for [HHH-10742](https://hibernate.atlassian.net/browse/HHH-10742)

So far I have disabled `DynamicImport-Package: *` in the OSGi tests, and fixed the basic JPA/Hibernate tests by fixing the Proxy factory class loader.

If anyone can work out what's going wrong with the other tests that would be great - they start working again with DynamicImport-Package: *, so there's clearly a class loader issue somewhere. I just can't see a stack trace!