### PR TITLE
HHH-10643 - Add support for foreignKeyDefinition

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -2925,6 +2925,7 @@ public final class AnnotationBinder {
 			}
 			else if ( joinColumn != null ) {
 				value.setForeignKeyName( StringHelper.nullIfEmpty( joinColumn.foreignKey().name() ) );
+				value.setForeignKeyDefinition( StringHelper.nullIfEmpty( joinColumn.foreignKey().foreignKeyDefinition() ) );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -258,6 +258,7 @@ public class OneToOneSecondPass implements SecondPass {
 				}
 				else {
 					value.setForeignKeyName( StringHelper.nullIfEmpty( jpaFk.name() ) );
+					value.setForeignKeyDefinition( StringHelper.nullIfEmpty( jpaFk.foreignKeyDefinition() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -1132,17 +1132,20 @@ public abstract class CollectionBinder {
 					}
 					else {
 						key.setForeignKeyName( StringHelper.nullIfEmpty( collectionTableAnn.foreignKey().name() ) );
+						key.setForeignKeyDefinition( StringHelper.nullIfEmpty( collectionTableAnn.foreignKey().foreignKeyDefinition() ) );
 					}
 				}
 				else {
 					final JoinTable joinTableAnn = property.getAnnotation( JoinTable.class );
 					if ( joinTableAnn != null ) {
 						String foreignKeyName = joinTableAnn.foreignKey().name();
+						String foreignKeyDefinition = joinTableAnn.foreignKey().foreignKeyDefinition();
 						ConstraintMode foreignKeyValue = joinTableAnn.foreignKey().value();
 						if ( joinTableAnn.joinColumns().length != 0 ) {
 							final JoinColumn joinColumnAnn = joinTableAnn.joinColumns()[0];
 							if ( "".equals( foreignKeyName ) ) {
 								foreignKeyName = joinColumnAnn.foreignKey().name();
+								foreignKeyDefinition = joinColumnAnn.foreignKey().foreignKeyDefinition();
 							}
 							if ( foreignKeyValue != ConstraintMode.NO_CONSTRAINT ) {
 								foreignKeyValue = joinColumnAnn.foreignKey().value();
@@ -1153,6 +1156,7 @@ public abstract class CollectionBinder {
 						}
 						else {
 							key.setForeignKeyName( StringHelper.nullIfEmpty( foreignKeyName ) );
+							key.setForeignKeyDefinition( StringHelper.nullIfEmpty( foreignKeyDefinition ) );
 						}
 					}
 					else {
@@ -1163,6 +1167,7 @@ public abstract class CollectionBinder {
 							}
 							else {
 								key.setForeignKeyName( StringHelper.nullIfEmpty( joinColumnAnn.foreignKey().name() ) );
+								key.setForeignKeyDefinition( StringHelper.nullIfEmpty( joinColumnAnn.foreignKey().foreignKeyDefinition() ) );
 							}
 						}
 					}
@@ -1342,11 +1347,13 @@ public abstract class CollectionBinder {
 				final JoinTable joinTableAnn = property.getAnnotation( JoinTable.class );
 				if ( joinTableAnn != null ) {
 					String foreignKeyName = joinTableAnn.inverseForeignKey().name();
+					String foreignKeyDefinition = joinTableAnn.inverseForeignKey().foreignKeyDefinition();
 					ConstraintMode foreignKeyValue = joinTableAnn.foreignKey().value();
 					if ( joinTableAnn.inverseJoinColumns().length != 0 ) {
 						final JoinColumn joinColumnAnn = joinTableAnn.inverseJoinColumns()[0];
 						if ( "".equals( foreignKeyName ) ) {
 							foreignKeyName = joinColumnAnn.foreignKey().name();
+							foreignKeyDefinition = joinColumnAnn.foreignKey().foreignKeyDefinition();
 						}
 						if ( foreignKeyValue != ConstraintMode.NO_CONSTRAINT ) {
 							foreignKeyValue = joinColumnAnn.foreignKey().value();
@@ -1357,6 +1364,7 @@ public abstract class CollectionBinder {
 					}
 					else {
 						element.setForeignKeyName( StringHelper.nullIfEmpty( foreignKeyName ) );
+						element.setForeignKeyDefinition( StringHelper.nullIfEmpty( foreignKeyDefinition ) );
 					}
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -807,6 +807,7 @@ public class EntityBinder {
 				}
 				else {
 					( (SimpleValue) join.getKey() ).setForeignKeyName( StringHelper.nullIfEmpty( jpaSecondaryTable.foreignKey().name() ) );
+					( (SimpleValue) join.getKey() ).setForeignKeyDefinition( StringHelper.nullIfEmpty( jpaSecondaryTable.foreignKey().foreignKeyDefinition() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -724,9 +724,9 @@ public abstract class AbstractHANADialect extends Dialect {
 	 * to work around the issue.
 	 */
 	@Override
-	public String getAddForeignKeyConstraintString(final String constraintName, final String[] foreignKey,
+	public String getAddForeignKeyConstraintString(final String constraintName, String foreignKeyDefinition, final String[] foreignKey,
 			final String referencedTable, final String[] primaryKey, final boolean referencesPrimaryKey) {
-		return super.getAddForeignKeyConstraintString(constraintName, foreignKey, referencedTable, primaryKey, referencesPrimaryKey) + " on update cascade";
+		return super.getAddForeignKeyConstraintString(constraintName, foreignKeyDefinition, foreignKey, referencedTable, primaryKey, referencesPrimaryKey) + (foreignKeyDefinition == null ? " on update cascade" : "");
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -388,15 +388,22 @@ public class Cache71Dialect extends Dialect {
 	@SuppressWarnings("StringBufferReplaceableByString")
 	public String getAddForeignKeyConstraintString(
 			String constraintName,
+			String foreignKeyDefinition,
 			String[] foreignKey,
 			String referencedTable,
 			String[] primaryKey,
 			boolean referencesPrimaryKey) {
 		// The syntax used to add a foreign key constraint to a table.
-		return new StringBuilder( 300 )
+		StringBuilder result = new StringBuilder( 300 );
+		result
 				.append( " ADD CONSTRAINT " )
-				.append( constraintName )
-				.append( " FOREIGN KEY " )
+				.append( constraintName );
+
+		if( foreignKeyDefinition != null ) {
+				result.append( " " )
+				.append( foreignKeyDefinition );
+		} else {
+				result.append( " FOREIGN KEY " )
 				.append( constraintName )
 				.append( " (" )
 				.append( StringHelper.join( ", ", foreignKey ) )
@@ -404,8 +411,9 @@ public class Cache71Dialect extends Dialect {
 				.append( referencedTable )
 				.append( " (" )
 				.append( StringHelper.join( ", ", primaryKey ) )
-				.append( ") " )
-				.toString();
+				.append( ") " );
+		}
+		return result.toString();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2051,6 +2051,7 @@ public abstract class Dialect implements ConversionContext {
 	 */
 	public String getAddForeignKeyConstraintString(
 			String constraintName,
+			String foreignKeyDefinition,
 			String[] foreignKey,
 			String referencedTable,
 			String[] primaryKey,
@@ -2058,16 +2059,22 @@ public abstract class Dialect implements ConversionContext {
 		final StringBuilder res = new StringBuilder( 30 );
 
 		res.append( " add constraint " )
-				.append( quote( constraintName ) )
-				.append( " foreign key (" )
-				.append( StringHelper.join( ", ", foreignKey ) )
-				.append( ") references " )
-				.append( referencedTable );
-
-		if ( !referencesPrimaryKey ) {
-			res.append( " (" )
-					.append( StringHelper.join( ", ", primaryKey ) )
-					.append( ')' );
+				.append( quote( constraintName ) );
+		
+		if(foreignKeyDefinition != null) {
+			res.append(  " " );
+			res.append(  foreignKeyDefinition );
+		} else {
+			res.append( " foreign key (" )
+					.append( StringHelper.join( ", ", foreignKey ) )
+					.append( ") references " )
+					.append( referencedTable );
+	
+			if ( !referencesPrimaryKey ) {
+				res.append( " (" )
+						.append( StringHelper.join( ", ", primaryKey ) )
+						.append( ')' );
+			}
 		}
 
 		return res.toString();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -89,21 +89,27 @@ public class InformixDialect extends Dialect {
 	@Override
 	public String getAddForeignKeyConstraintString(
 			String constraintName,
+			String foreignKeyDefinition,
 			String[] foreignKey,
 			String referencedTable,
 			String[] primaryKey,
 			boolean referencesPrimaryKey) {
 		final StringBuilder result = new StringBuilder( 30 )
-				.append( " add constraint " )
-				.append( " foreign key (" )
+				.append( " add constraint " );
+
+		if( foreignKeyDefinition != null ) {
+				result.append( foreignKeyDefinition );
+		} else {
+				result.append( " foreign key (" )
 				.append( StringHelper.join( ", ", foreignKey ) )
 				.append( ") references " )
 				.append( referencedTable );
 
-		if ( !referencesPrimaryKey ) {
-			result.append( " (" )
-					.append( StringHelper.join( ", ", primaryKey ) )
-					.append( ')' );
+			if ( !referencesPrimaryKey ) {
+				result.append( " (" )
+						.append( StringHelper.join( ", ", primaryKey ) )
+						.append( ')' );
+			}
 		}
 
 		result.append( " constraint " ).append( constraintName );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -218,19 +218,29 @@ public class MySQLDialect extends Dialect {
 	@Override
 	public String getAddForeignKeyConstraintString(
 			String constraintName,
+			String foreignKeyDefinition,
 			String[] foreignKey,
 			String referencedTable,
 			String[] primaryKey,
 			boolean referencesPrimaryKey) {
-		final String cols = StringHelper.join( ", ", foreignKey );
-		final String referencedCols = StringHelper.join( ", ", primaryKey );
-		return String.format(
-				" add constraint %s foreign key (%s) references %s (%s)",
-				constraintName,
-				cols,
-				referencedTable,
-				referencedCols
-		);
+		StringBuilder result = new StringBuilder();
+		result.append(" add constraint ")
+			.append(constraintName);
+
+		if( foreignKeyDefinition != null ) {
+			result.append(" ");
+			result.append(foreignKeyDefinition);
+		} else {
+			final String cols = StringHelper.join( ", ", foreignKey );
+			final String referencedCols = StringHelper.join( ", ", primaryKey );
+			result.append(String.format(
+					" foreign key (%s) references %s (%s)",
+					cols,
+					referencedTable,
+					referencedCols
+			));
+		}
+		return result.toString();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
@@ -140,10 +140,14 @@ public class SAPDBDialect extends Dialect {
 	@Override
 	public String getAddForeignKeyConstraintString(
 			String constraintName,
+			String foreignKeyDefinition,
 			String[] foreignKey,
 			String referencedTable,
 			String[] primaryKey,
 			boolean referencesPrimaryKey) {
+		if( foreignKeyDefinition != null ) {
+			return " " + foreignKeyDefinition;
+		}
 		final StringBuilder res = new StringBuilder( 30 )
 				.append( " foreign key " )
 				.append( constraintName )

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
@@ -64,6 +64,7 @@ public class DenormalizedTable extends Table {
 					),
 					fk.getColumns(),
 					fk.getReferencedEntityName(),
+					fk.getKeyDefinition(),
 					fk.getReferencedColumns()
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -22,6 +22,7 @@ import org.hibernate.internal.util.StringHelper;
 public class ForeignKey extends Constraint {
 	private Table referencedTable;
 	private String referencedEntityName;
+	private String keyDefinition;
 	private boolean cascadeDeleteEnabled;
 	private List<Column> referencedColumns = new ArrayList<Column>();
 	private boolean creationEnabled = true;
@@ -79,6 +80,7 @@ public class ForeignKey extends Constraint {
 
 		final String result = dialect.getAddForeignKeyConstraintString(
 				constraintName,
+				keyDefinition,
 				columnNames,
 				referencedTable.getQualifiedName( dialect, defaultCatalog, defaultSchema ),
 				referencedColumnNames,
@@ -153,6 +155,14 @@ public class ForeignKey extends Constraint {
 		this.referencedEntityName = referencedEntityName;
 	}
 
+	public String getKeyDefinition() {
+		return keyDefinition;
+	}
+
+	public void setKeyDefinition(String keyDefinition) {
+		this.keyDefinition = keyDefinition;
+	}
+	
 	public String sqlDropString(Dialect dialect, String defaultCatalog, String defaultSchema) {
 		final StringBuilder buf = new StringBuilder( "alter table " );
 		buf.append( getTable().getQualifiedName( dialect, defaultCatalog, defaultSchema ) );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
@@ -74,6 +74,7 @@ public class ManyToOne extends ToOne {
 							getForeignKeyName(), 
 							getConstraintColumns(), 
 							( (EntityType) getType() ).getAssociatedEntityName(), 
+							getForeignKeyDefinition(), 
 							refColumns
 					);
 					fk.setCascadeDeleteEnabled(isCascadeDeleteEnabled() );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -73,6 +73,7 @@ public class SimpleValue implements KeyValue {
 	private String nullValue;
 	private Table table;
 	private String foreignKeyName;
+	private String foreignKeyDefinition;
 	private boolean alternateUniqueKey;
 	private boolean cascadeDeleteEnabled;
 
@@ -193,7 +194,7 @@ public class SimpleValue implements KeyValue {
 	@Override
 	public void createForeignKeyOfEntity(String entityName) {
 		if ( !hasFormula() && !"none".equals(getForeignKeyName())) {
-			ForeignKey fk = table.createForeignKey( getForeignKeyName(), getConstraintColumns(), entityName );
+			ForeignKey fk = table.createForeignKey( getForeignKeyName(), getConstraintColumns(), entityName, getForeignKeyDefinition() );
 			fk.setCascadeDeleteEnabled(cascadeDeleteEnabled);
 		}
 	}
@@ -346,6 +347,14 @@ public class SimpleValue implements KeyValue {
 
 	public void setForeignKeyName(String foreignKeyName) {
 		this.foreignKeyName = foreignKeyName;
+	}
+	
+	public String getForeignKeyDefinition() {
+		return foreignKeyDefinition;
+	}
+
+	public void setForeignKeyDefinition(String foreignKeyDefinition) {
+		this.foreignKeyDefinition = foreignKeyDefinition;
 	}
 
 	public boolean isAlternateUniqueKey() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -681,14 +681,15 @@ public class Table implements RelationalModel, Serializable, Exportable {
 	public void createForeignKeys() {
 	}
 
-	public ForeignKey createForeignKey(String keyName, List keyColumns, String referencedEntityName) {
-		return createForeignKey( keyName, keyColumns, referencedEntityName, null );
+	public ForeignKey createForeignKey(String keyName, List keyColumns, String referencedEntityName, String keyDefinition) {
+		return createForeignKey( keyName, keyColumns, referencedEntityName, keyDefinition, null );
 	}
 
 	public ForeignKey createForeignKey(
 			String keyName,
 			List keyColumns,
 			String referencedEntityName,
+			String keyDefinition,
 			List referencedColumns) {
 		final ForeignKeyKey key = new ForeignKeyKey( keyColumns, referencedEntityName, referencedColumns );
 
@@ -697,6 +698,7 @@ public class Table implements RelationalModel, Serializable, Exportable {
 			fk = new ForeignKey();
 			fk.setTable( this );
 			fk.setReferencedEntityName( referencedEntityName );
+			fk.setKeyDefinition(keyDefinition);
 			fk.addColumns( keyColumns.iterator() );
 			if ( referencedColumns != null ) {
 				fk.addReferencedColumns( referencedColumns.iterator() );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardForeignKeyExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardForeignKeyExporter.java
@@ -105,6 +105,7 @@ public class StandardForeignKeyExporter implements Exporter<ForeignKey> {
 				.append(
 						dialect.getAddForeignKeyConstraintString(
 								foreignKey.getName(),
+								foreignKey.getKeyDefinition(),
 								columnNames,
 								targetTableName,
 								targetColumnNames,


### PR DESCRIPTION
I am pretty sure this pull request is not perfect and also probably still misses a few things.
However I would like to see support for the `@javax.persistence.ForeignKey(foreignKeyDefinition=...)` attribute within Hibernate.


**Could someone of the more experienced hibernate team take my pull request and finish it?** I am not too comfortable with the codebase and also very short on time right now so I would like to leave the remaining work that needs to be done to the core team.
I justed wanted to **kick start** the implementation work by showing what's kind of necessary to add support for this feature.

**A few notes on this pull request**
Probably the most interrupting change is that `getAddForeignKeyConstraintString` now takes the `foreignKeyDefinition` as second argument. This means each dialect now has to choose if to use the `foreignKeyDefinition` or generate the foreign key. Please look closely on all the overriden `getAddForeignKeyConstraintString` methods why I implemented this that way: Some dialects handle the "add constraint <constraintname>" statement differently - e.g. there is a case where the constraintname is set at the end; another case is that the "add constraint" is not even part of the sql. So I think that the decision if to use the `foreignKeyDefinition` of `@ForeinKeyDefiniton` should be done within the `getAddForeignKeyConstraintString` method. Feel free do change that if you can find another solution :smile: 

**What still needs to be done (at least that's what I think):**
For all occurences of `setForeignKeyName` in
`hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java`
we also have to call `setForeignKeyDefinition`
Which means for all the `*Sources` we also need a `.getExplicitForeignKeyDefinition()` method - like we have with `Source.getExplicitForeignKeyName()`.