### PR TITLE
HHH-10813 Remove confusing exception message when collection is not processed by flush

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Guidelines for Contributing
+
 Contributions from the community are essential in keeping Hibernate (any Open Source
 project really) strong and successful.  While we try to keep requirements for
 contributing to a minimum, there are a few guidelines we ask that you mind.
 
 ## Getting Started
+
 If you are just getting started with Git, GitHub and/or contributing to Hibernate via
 GitHub there are a few pre-requisite steps.
 
@@ -18,6 +20,7 @@ the linked page, this also includes:
 or [Eclipse](https://community.jboss.org/wiki/ContributingToHibernateUsingEclipse).
 
 ## Create the working (topic) branch
+
 Create a [topic branch](http://git-scm.com/book/en/Git-Branching-Branching-Workflows#Topic-Branches) on which you
 will work.  The convention is to name the branch using the JIRA issue key.  If there is not already a JIRA issue
 covering the work you want to do, create one.  Assuming you will be working from the master branch and working
@@ -25,6 +28,7 @@ on the JIRA HHH-123 : `git checkout -b HHH-123 master`
 
 
 ## Code
+
 Do yo thing!
 
 ## Commit
@@ -41,6 +45,7 @@ appreciated btw), please use rebasing rather than merging.  Merging creates
 "merge commits" that really muck up the project timeline._
 
 ## Submit
+
 * If you have not already, sign the [Contributor License Agreement](https://cla.jboss.org).
 * Push your changes to the topic branch in your fork of the repository.
 * Initiate a [pull request](http://help.github.com/send-pull-requests/)

--- a/hibernate-core/src/main/java/org/hibernate/AssertionFailure.java
+++ b/hibernate-core/src/main/java/org/hibernate/AssertionFailure.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate;
 
+import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 
 import org.jboss.logging.Logger;
@@ -18,10 +19,7 @@ import org.jboss.logging.Logger;
 public class AssertionFailure extends RuntimeException {
 	private static final long serialVersionUID = 1L;
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
-			CoreMessageLogger.class,
-			AssertionFailure.class.getName()
-	);
+	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( AssertionFailure.class );
 
 	/**
 	 * Creates an instance of AssertionFailure using the given message.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
@@ -18,10 +18,9 @@ import org.hibernate.MappingException;
 import org.hibernate.collection.internal.AbstractPersistentCollection;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.pretty.MessageHelper;
-
-import org.jboss.logging.Logger;
 
 /**
  * We need an entry to tell us all about the current state
@@ -30,7 +29,7 @@ import org.jboss.logging.Logger;
  * @author Gavin King
  */
 public final class CollectionEntry implements Serializable {
-	private static final Logger LOG = CoreLogging.logger( CollectionEntry.class );
+	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( CollectionEntry.class );
 
 	//ATTRIBUTES MAINTAINED BETWEEN FLUSH CYCLES
 
@@ -217,7 +216,7 @@ public final class CollectionEntry implements Serializable {
 			ignore = false;
 		}
 		else if ( !isProcessed() ) {
-			throw new AssertionFailure( "collection [" + collection.getRole() + "] was not processed by flush()" );
+			throw new HibernateException( LOG.collectionNotProcessedByFlush( collection.getRole() ) );
 		}
 		collection.setSnapshot(loadedKey, role, snapshot);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1744,4 +1744,11 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = ERROR)
 	@Message(value = "Unsuccessful: %s", id = 478)
 	void unsuccessfulSchemaManagementCommand(String command);
+
+	@Message(
+			value = "Collection [%s] was not processed by flush()."
+			+ " This is likely due to unsafe use of the session (e.g. used in multiple threads concurrently, updates during entity lifecycle hooks).",
+			id = 479
+	)
+	String collectionNotProcessedByFlush(String role);
 }


### PR DESCRIPTION
I elected to not change the `AssertionFailure` message itself but instead create a specific message and exception for cases we know it is not a Hibernate ORM bug. That's a more conservative strategy. Starting with this collection case.