### PR TITLE
HHH-10835 The hash code calculation of the EntityKey should also include the hash code of the root entity name.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
@@ -56,6 +56,8 @@ public final class EntityKey implements Serializable {
 
 	private int generateHashCode() {
 		int result = 17;
+		final String rootEntityName = persister.getRootEntityName();
+		result = 37 * result + ( rootEntityName != null ? rootEntityName.hashCode() : 0 );
 		result = 37 * result + persister.getIdentifierType().getHashCode( identifier, persister.getFactory() );
 		return result;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10835