### PR TITLE
Remove reference to EntityManager in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Common Java related tasks
 -------------------------
 
 * _build_ - Assembles (jars) and tests this project
-* _buildDependents_ - Assembles and tests this project and all projects that depend on it.  So think of running this in hibernate-entitymanager, Gradle would assemble and test hibernate-entitymanager as well as hibernate-envers (because envers depends on entitymanager)
+* _buildDependents_ - Assembles and tests this project and all projects that depend on it.  So think of running this in hibernate-core, Gradle would assemble and test hibernate-core as well as hibernate-envers (because envers depends on core)
 * _classes_ - Compiles the main classes
 * _testClasses_ - Compiles the test classes
 * _compile_ (Hibernate addition) - Performs all compilation tasks including staging resources from both main and test


### PR DESCRIPTION
Hibernate EntityManager was merged into Core and no longer exists as a sub-project.