### PR TITLE
HHH-10238 : Derby MultiTableBulkIdStrategy uses non-existant temporary tables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -21,6 +21,10 @@ import org.hibernate.dialect.pagination.LimitHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.spi.RowSelection;
+import org.hibernate.hql.spi.id.IdTableSupportStandardImpl;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.local.AfterUseAction;
+import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.sql.CaseFragment;
@@ -557,5 +561,38 @@ public class DerbyDialect extends DB2Dialect {
 		registerKeyword( "XMLPARSE" );
 		registerKeyword( "XMLSERIALIZE" );
 		registerKeyword( "YEAR" );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * From Derby docs:
+	 * <pre>
+	 *     The DECLARE GLOBAL TEMPORARY TABLE statement defines a temporary table for the current connection.
+	 * </pre>
+	 *
+	 * {@link DB2Dialect} returns a {@link org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy} that
+	 * will make temporary tables created at startup and hence unavailable for subsequent connections.<br/>
+	 * see HHH-10238.
+	 * </p>
+     */
+	@Override
+	public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+		return new LocalTemporaryTableBulkIdStrategy(new IdTableSupportStandardImpl() {
+			@Override
+			public String generateIdTableName(String baseName) {
+				return "session." + super.generateIdTableName( baseName );
+			}
+
+			@Override
+			public String getCreateIdTableCommand() {
+				return "declare global temporary table";
+			}
+
+			@Override
+			public String getCreateIdTableStatementOptions() {
+				return "not logged";
+			}
+		}, AfterUseAction.CLEAN, null);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/DerbyDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/DerbyDialectTestCase.java
@@ -6,18 +6,22 @@
  */
 package org.hibernate.dialect;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Testing of patched support for Derby limit and offset queries; see HHH-3972
  *
  * @author Evan Leonard
  */
-@TestForIssue( jiraKey = "HHH-3972" )
 public class DerbyDialectTestCase extends BaseUnitTestCase {
 
 	private static class LocalDerbyDialect extends DerbyDialect {
@@ -27,6 +31,7 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-3972" )
 	public void testInsertLimitClause() {
 		final int limit = 50;
 		final String input = "select * from tablename t where t.cat = 5";
@@ -37,6 +42,7 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-3972" )
 	public void testInsertLimitWithOffsetClause() {
 		final int limit = 50;
 		final int offset = 200;
@@ -48,6 +54,7 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-3972" )
 	public void testInsertLimitWithForUpdateClause() {
 		final int limit = 50;
 		final int offset = 200;
@@ -60,6 +67,7 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-3972" )
 	public void testInsertLimitWithWithClause() {
 		final int limit = 50;
 		final int offset = 200;
@@ -72,6 +80,7 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-3972" )
 	public void testInsertLimitWithForUpdateAndWithClauses() {
 		final int limit = 50;
 		final int offset = 200;
@@ -81,5 +90,12 @@ public class DerbyDialectTestCase extends BaseUnitTestCase {
 
 		final String actual = new LocalDerbyDialect().getLimitString( input, offset, limit );
 		assertEquals( expected, actual );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10238")
+	public void testDefaultMultiTableBulkIdStrategyIsLocal() {
+		MultiTableBulkIdStrategy actual = new LocalDerbyDialect().getDefaultMultiTableBulkIdStrategy();
+		assertThat(actual, is(instanceOf(LocalTemporaryTableBulkIdStrategy.class)));
 	}
 }


### PR DESCRIPTION
getDefaultMultiTableBulkIdStrategy() returns a LocalTemporaryTableBulkIdStrategy instead of a GlobalTemporaryTableBulkIdStrategy