### PR TITLE
HHH-10863 Be consistent in the parameter passed to ImplicitNamingStrategy#determineBasicColumnName

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/AbstractAttributeKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/AbstractAttributeKey.java
@@ -12,6 +12,8 @@ import org.hibernate.internal.util.StringHelper;
  * @author Steve Ebersole
  */
 public abstract class AbstractAttributeKey {
+	private static final String COLLECTION_ELEMENT = "collection&&element";
+
 	private final AbstractAttributeKey parent;
 	private final String property;
 	private final String fullPath;
@@ -76,6 +78,13 @@ public abstract class AbstractAttributeKey {
 
 	public boolean isRoot() {
 		return parent == null;
+	}
+
+	/**
+	 * @return true if the current property is a collection element marker
+	 */
+	public boolean isCollectionElement() {
+		return COLLECTION_ELEMENT.equals( property );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3Column.java
@@ -269,13 +269,9 @@ public class Ejb3Column {
 		if ( applyNamingStrategy ) {
 			if ( StringHelper.isEmpty( columnName ) ) {
 				if ( propertyName != null ) {
-					/// HHH-6005 magic
-					if ( propertyName.contains( ".collection&&element." ) ) {
-						propertyName = propertyName.replace( "collection&&element.", "" );
-					}
 					final AttributePath attributePath = AttributePath.parse( propertyName );
 
-					final Identifier implicitName = normalizer.normalizeIdentifierQuoting(
+					Identifier implicitName = normalizer.normalizeIdentifierQuoting(
 							implicitNamingStrategy.determineBasicColumnName(
 									new ImplicitBasicColumnNameSource() {
 										@Override
@@ -298,6 +294,12 @@ public class Ejb3Column {
 									}
 							)
 					);
+
+					// HHH-6005 magic
+					if ( implicitName.getText().contains( "_collection&&element_" ) ) {
+						implicitName = Identifier.toIdentifier( implicitName.getText().replace( "_collection&&element_", "_" ),
+								implicitName.isQuoted() );
+					}
 
 					final Identifier physicalName = physicalNamingStrategy.toPhysicalColumnName( implicitName, database.getJdbcEnvironment() );
 					mappingColumn.setName( physicalName.render( database.getDialect() ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/boot/model/source/AttributePathTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/model/source/AttributePathTest.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.boot.model.source;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hibernate.boot.model.source.spi.AttributePath;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+public class AttributePathTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10863")
+	public void testCollectionElement() {
+		AttributePath attributePath = AttributePath.parse( "items.collection&&element.name" );
+
+		assertFalse( attributePath.isCollectionElement() );
+		assertTrue( attributePath.getParent().isCollectionElement() );
+		assertFalse( attributePath.getParent().getParent().isCollectionElement() );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/components/ComponentNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/namingstrategy/components/ComponentNamingStrategyTest.java
@@ -73,7 +73,7 @@ public class ComponentNamingStrategyTest extends BaseUnitTestCase {
 			SimpleValue elementValue = assertTyping(  SimpleValue.class, value.getElement() );
 			assertEquals( 1, elementValue.getColumnSpan() );
 			Column column = assertTyping( Column.class, elementValue.getColumnIterator().next() );
-			assertEquals( column.getName(), "items_name" );
+			assertEquals( "items_name", column.getName() );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( ssr );


### PR DESCRIPTION
When dealing with an element collection (say items.name),
ImplicitNamingStrategy#determineBasicColumnName is sometimes called
with items.collection&&element.name and sometimes with items.name.

This is due to HHH-6005 which removes the "collection&&element."
part before calling determineBasicColumnName.

With this patch, we only remove the "collection&&element." part before
calling the physical naming strategy, thus allowing us to be consistent
in the way we call ImplicitNamingStrategy#determineBasicColumnName.