### PR TITLE
HHH-10745

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1437,8 +1437,8 @@ public final class AnnotationBinder {
 	private static void bindFetchProfile(FetchProfile fetchProfileAnnotation, MetadataBuildingContext context) {
 		for ( FetchProfile.FetchOverride fetch : fetchProfileAnnotation.fetchOverrides() ) {
 			org.hibernate.annotations.FetchMode mode = fetch.mode();
-			if ( !mode.equals( org.hibernate.annotations.FetchMode.JOIN ) ) {
-				throw new MappingException( "Only FetchMode.JOIN is currently supported" );
+			if ( !(mode.equals( org.hibernate.annotations.FetchMode.JOIN ) || mode.equals( org.hibernate.annotations.FetchMode.SELECT ))) {
+				throw new MappingException( "Only FetchMode.JOIN or FetchMode.SELECT is currently supported" );
 			}
 
 			context.getMetadataCollector().addSecondPass(

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1137,7 +1137,7 @@ public abstract class Loader {
 			int hydratedObjectsSize = hydratedObjects.size();
 			LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
 			for ( Object hydratedObject : hydratedObjects ) {
-				TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre );
+				TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, null );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/AbstractRowReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/AbstractRowReader.java
@@ -239,7 +239,7 @@ public abstract class AbstractRowReader implements RowReader {
 					registration.getInstance(),
 					context.isReadOnly(),
 					context.getSession(),
-					preLoadEvent
+					preLoadEvent, context.getSession().getLoadQueryInfluencers()
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -635,11 +635,11 @@ public abstract class EntityType extends AbstractType implements AssociationType
 		boolean isProxyUnwrapEnabled = unwrapProxy &&
 				getAssociatedEntityPersister( session.getFactory() )
 						.isInstrumented();
-
+		boolean fetchOverride = FetchOverrideThreadLocal.hasFetchOverride(this);
 		Object proxyOrEntity = session.internalLoad(
 				getAssociatedEntityName(),
 				id,
-				eager,
+				eager | fetchOverride,
 				isNullable() && !isProxyUnwrapEnabled
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/type/FetchOverrideThreadLocal.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/FetchOverrideThreadLocal.java
@@ -1,3 +1,10 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
 package org.hibernate.type;
 
 import java.util.HashSet;
@@ -6,25 +13,22 @@ import java.util.Set;
 public class FetchOverrideThreadLocal extends ThreadLocal<Boolean>{
 
 	private static ThreadLocal<Set<Type>> tlocal = new ThreadLocal<Set<Type>>();
-	public static void addFetchOverride(Type type)
-	{
+	public static void addFetchOverride(Type type)	{
 		ensureSet();
 		tlocal.get().add(type);
 	}
-	public static void removeFetchOverride(Type type)
-	{
+	public static void removeFetchOverride(Type type)	{
 		ensureSet();
 		tlocal.get().remove(type);
 	}
 
-	public static boolean hasFetchOverride(Type t)
-	{
+	public static boolean hasFetchOverride(Type t)	{
 		ensureSet();
 		return tlocal.get().contains(t);
 	}
-	private static void ensureSet()
-	{
-		if (tlocal.get() == null)
+	private static void ensureSet()	{
+		if (tlocal.get() == null) {
 			tlocal.set(new HashSet<Type>());
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/FetchOverrideThreadLocal.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/FetchOverrideThreadLocal.java
@@ -1,0 +1,30 @@
+package org.hibernate.type;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FetchOverrideThreadLocal extends ThreadLocal<Boolean>{
+
+	private static ThreadLocal<Set<Type>> tlocal = new ThreadLocal<Set<Type>>();
+	public static void addFetchOverride(Type type)
+	{
+		ensureSet();
+		tlocal.get().add(type);
+	}
+	public static void removeFetchOverride(Type type)
+	{
+		ensureSet();
+		tlocal.get().remove(type);
+	}
+
+	public static boolean hasFetchOverride(Type t)
+	{
+		ensureSet();
+		return tlocal.get().contains(t);
+	}
+	private static void ensureSet()
+	{
+		if (tlocal.get() == null)
+			tlocal.set(new HashSet<Type>());
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/fetchprofile/Customer4.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/fetchprofile/Customer4.java
@@ -23,7 +23,7 @@ import org.hibernate.annotations.FetchProfile;
  */
 @Entity
 @FetchProfile(name = "unsupported-fetch-mode", fetchOverrides = {
-		@FetchProfile.FetchOverride(entity = Customer4.class, association = "orders", mode = FetchMode.SELECT)
+		@FetchProfile.FetchOverride(entity = Customer4.class, association = "orders", mode = FetchMode.SUBSELECT)
 })
 public class Customer4 {
 	@Id

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/FetchProfileCycleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/FetchProfileCycleTest.java
@@ -1,0 +1,117 @@
+package org.hibernate.test.fetchprofiles.cycle;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hibernate.LazyInitializationException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.test.annotations.fetch.Branch;
+import org.hibernate.test.annotations.fetch.Leaf;
+import org.hibernate.test.annotations.fetch.Person;
+import org.hibernate.test.annotations.fetch.Stay;
+import org.hibernate.test.annotations.fetchprofile.FetchProfileTest;
+import org.hibernate.testing.ServiceRegistryBuilder;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+@TestForIssue( jiraKey = "HHH-10745" )
+public class FetchProfileCycleTest extends BaseCoreFunctionalTestCase {
+
+	private static final Logger log = Logger.getLogger( FetchProfileCycleTest.class );
+//	private ServiceRegistry serviceRegistry;
+//	private SessionFactory sessionFactory;
+//
+//	@Before
+//    public void setUp() {
+//		serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( Environment.getProperties() );
+//		Configuration config = new Configuration();
+//		config.addAnnotatedClass(Start.class);
+//		config.addAnnotatedClass(Via1.class);
+//		config.addAnnotatedClass(Via2.class);
+//		config.addAnnotatedClass(Mid.class);
+//		config.addAnnotatedClass(Finish.class);
+//		this.sessionFactory = (SessionFactoryImplementor) config.buildSessionFactory(serviceRegistry);
+//	}
+//
+//	@After
+//    public void tearDown() {
+//		this.sessionFactory.close();
+//        if (serviceRegistry != null) ServiceRegistryBuilder.destroy(serviceRegistry);
+//	}
+
+	@Test
+	public void testFetchProfileConfigured() {
+
+		long start1Id = this.createSampleData(true);
+		long start2Id = this.createSampleData(false);
+		Start[] starts = this.fetchLoad(start1Id, start2Id);
+		log.info("Start 0:" + starts[0]);
+		log.info("Start 1:" + starts[1]);
+		starts[0].getVia1().getMid().getFinish().getSumdumattr();
+		starts[1].getVia2().getMid().getFinish().getSumdumattr();
+	}
+
+	public long createSampleData(boolean path1)
+	{
+		Session ss = this.openSession( );
+		ss.getTransaction().begin();
+		Finish f = new Finish();
+		f.setSumdumattr("sumdumval");
+		ss.persist(f);
+		Mid m = new Mid();
+		m.setFinish(f);
+		ss.persist(m);
+		Start s = new Start();
+		ss.persist(s);
+		if (path1)
+		{
+			Via1 v1 = new Via1();
+			ss.persist(v1);
+			s.setVia1(v1);
+			v1.setMid(m);
+		} else
+		{
+			Via2 v2 = new Via2();
+			ss.persist(v2);
+			s.setVia2(v2);
+			v2.setMid(m);
+		}
+		ss.flush();
+		ss.getTransaction().commit();
+		ss.close();
+		return s.getId();
+	}
+	public Start[] fetchLoad(long id1, long id2)
+	{
+		Session s = this.openSession( );
+		s.enableFetchProfile("fp");
+		Start s1 = s.get(Start.class, id1);
+		Start s2 = s.get(Start.class, id2);
+		s.disableFetchProfile("fp");
+		s.close();
+		return new Start[] {s1, s2};
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{
+				Start.class,
+				Mid.class,
+				Finish.class,
+				Via1.class,
+				Via2.class
+		};
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Finish.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Finish.java
@@ -1,0 +1,31 @@
+package org.hibernate.test.fetchprofiles.cycle;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+@Entity
+public class Finish {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@Column(name="sumdumattr", nullable=false)
+	private String sumdumattr;
+	
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getSumdumattr() {
+		return sumdumattr;
+	}
+
+	public void setSumdumattr(String sumdumattr) {
+		this.sumdumattr = sumdumattr;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Mid.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Mid.java
@@ -1,0 +1,40 @@
+package org.hibernate.test.fetchprofiles.cycle;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.FetchProfile;
+import org.hibernate.annotations.FetchProfile.FetchOverride;
+@Entity
+@FetchProfile(name="fp", fetchOverrides={@FetchOverride(entity=Mid.class, association="finish", mode=FetchMode.JOIN)})
+public class Mid {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	
+	@ManyToOne(optional=false, fetch=FetchType.LAZY)
+	private Finish finish;
+
+	
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Finish getFinish() {
+		return finish;
+	}
+
+	public void setFinish(Finish finish) {
+		this.finish = finish;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Start.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Start.java
@@ -1,0 +1,54 @@
+package org.hibernate.test.fetchprofiles.cycle;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.FetchProfile;
+import org.hibernate.annotations.FetchProfile.FetchOverride;
+
+@Entity
+@FetchProfile(name="fp", fetchOverrides=
+	{@FetchOverride(entity=Start.class, association="via1", mode=FetchMode.JOIN),
+	@FetchOverride(entity=Start.class, association="via2", mode=FetchMode.JOIN)}
+)
+public class Start {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@ManyToOne(optional=true, fetch=FetchType.LAZY)
+	private Via1 via1;
+	
+	@ManyToOne(optional=true, fetch=FetchType.LAZY)
+	private Via2 via2;
+	
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Via1 getVia1() {
+		return via1;
+	}
+
+	public void setVia1(Via1 via1) {
+		this.via1 = via1;
+	}
+
+	public Via2 getVia2() {
+		return via2;
+	}
+
+	public void setVia2(Via2 via2) {
+		this.via2 = via2;
+	}
+	
+	
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Via1.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Via1.java
@@ -1,0 +1,41 @@
+package org.hibernate.test.fetchprofiles.cycle;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.FetchProfile;
+import org.hibernate.annotations.FetchProfile.FetchOverride;
+
+@Entity
+@FetchProfile(name="fp", fetchOverrides={@FetchOverride(entity=Via1.class, association="mid", mode=FetchMode.JOIN)})
+
+public class Via1 {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@ManyToOne(optional=true, fetch=FetchType.LAZY)
+	private Mid mid;
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Mid getMid() {
+		return mid;
+	}
+
+	public void setMid(Mid mid) {
+		this.mid = mid;
+	}
+	
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Via2.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fetchprofiles/cycle/Via2.java
@@ -1,0 +1,40 @@
+package org.hibernate.test.fetchprofiles.cycle;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.FetchProfile;
+import org.hibernate.annotations.FetchProfile.FetchOverride;
+
+@Entity
+@FetchProfile(name="fp", fetchOverrides={@FetchOverride(entity=Via2.class, association="mid", mode=FetchMode.JOIN)})
+public class Via2 {
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@ManyToOne(optional=true, fetch=FetchType.LAZY)
+	private Mid mid;
+
+	
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public Mid getMid() {
+		return mid;
+	}
+
+	public void setMid(Mid mid) {
+		this.mid = mid;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
@@ -348,7 +348,7 @@ public class CustomPersister implements EntityPersister {
 					clone,
 					false,
 					session,
-					new PreLoadEvent( (EventSource) session )
+					new PreLoadEvent( (EventSource) session ), null
 			);
 			TwoPhaseLoad.postLoad( clone, session, new PostLoadEvent( (EventSource) session ) );
 		}


### PR DESCRIPTION
Hello,
I think the MatamodelGraphWalker fix means major redesign. Therefore I studied hoe EAGER relations work and made the fix to FetchProfile loading so that it behaves the same way, i.e. the relations that fail to load because of the MetamodelGraphWalker problem are loaded in subsequent select in TwoPhaseLoad. As a side effect this also implements the FetchStyle.SELECT.

I was unable to get the FetchProfile information to EntityType as parameter without major changes to the system, so I've fallen back to the use of ThreadLocal - I don't like it much, but haven't found any better way. Please advice if you know better way.
