### PR TITLE
Fixes HHH-10800 - InformixDialect: add support for current_timestamp() and current_date()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Locale;
 
+import org.hibernate.dialect.function.NoArgSQLFunction;
 import org.hibernate.dialect.function.NvlFunction;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.function.VarArgsSQLFunction;
@@ -78,6 +79,8 @@ public class InformixDialect extends Dialect {
 		registerFunction( "substr", new SQLFunctionTemplate( StandardBasicTypes.STRING, "substr(?1, ?2, ?3)"));
 		registerFunction( "coalesce", new NvlFunction());
 		registerFunction( "nvl", new NvlFunction());
+		registerFunction( "current_timestamp", new NoArgSQLFunction( "current", StandardBasicTypes.TIMESTAMP, false ) );
+		registerFunction( "current_date", new NoArgSQLFunction( "today", StandardBasicTypes.DATE, false ) );
 
 		uniqueDelegate = new InformixUniqueDelegate( this );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/dialect/InformixDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/InformixDialectTestCase.java
@@ -6,29 +6,70 @@
  */
 package org.hibernate.dialect;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 /**
- * Testing of patched support for Informix boolean type; see HHH-9894
+ * Testing of patched support for Informix boolean type; see HHH-9894, HHH-10800
  *
  * @author Greg Jones
  */
-@TestForIssue( jiraKey = "HHH-9894" )
 public class InformixDialectTestCase extends BaseUnitTestCase {
 	private final InformixDialect dialect = new InformixDialect();
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-9894")
 	public void testToBooleanValueStringTrue() {
 		assertEquals( "'t'", dialect.toBooleanValueString( true ) );
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-9894")
 	public void testToBooleanValueStringFalse() {
 		assertEquals( "'f'", dialect.toBooleanValueString( false ) );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-10800")
+	public void testCurrentTimestampFunction() {
+		Map<String, SQLFunction> functions = dialect.getFunctions();
+		SQLFunction sqlFunction = functions.get( "current_timestamp" );
+
+		Type firstArgumentType = null;
+		Mapping mapping = null;
+		assertEquals( StandardBasicTypes.TIMESTAMP, sqlFunction.getReturnType( firstArgumentType, mapping ) );
+
+		firstArgumentType = null;
+		List arguments = Collections.emptyList();
+		SessionFactoryImplementor factory = null;
+		assertEquals( "current", sqlFunction.render( firstArgumentType, arguments, factory ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10800")
+	public void testCurrentDateFunction() {
+		Map<String, SQLFunction> functions = dialect.getFunctions();
+		SQLFunction sqlFunction = functions.get( "current_date" );
+
+		Type firstArgumentType = null;
+		Mapping mapping = null;
+		assertEquals( StandardBasicTypes.DATE, sqlFunction.getReturnType( firstArgumentType, mapping ) );
+
+		firstArgumentType = null;
+		List arguments = Collections.emptyList();
+		SessionFactoryImplementor factory = null;
+		assertEquals( "today", sqlFunction.render( firstArgumentType, arguments, factory ) );
+	}
 }


### PR DESCRIPTION
Fix for HHH-10800, without the coalesce() function addition as it was already added in a previous PR.