### PR TITLE
HHH-10964 - Fix missing currentTenantIdentifierResolver

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -697,11 +697,14 @@ public class Configuration {
 		if ( getSessionFactoryObserver() != null ) {
 			sessionFactoryBuilder.addSessionFactoryObservers( getSessionFactoryObserver() );
 		}
-		if ( entityNotFoundDelegate != null ) {
-			sessionFactoryBuilder.applyEntityNotFoundDelegate( entityNotFoundDelegate );
+		if ( getCurrentTenantIdentifierResolver() != null ) {
+			sessionFactoryBuilder.applyCurrentTenantIdentifierResolver( getCurrentTenantIdentifierResolver() );
 		}
-		if ( entityTuplizerFactory != null ) {
-			sessionFactoryBuilder.applyEntityTuplizerFactory( entityTuplizerFactory );
+		if ( getEntityNotFoundDelegate() != null ) {
+			sessionFactoryBuilder.applyEntityNotFoundDelegate( getEntityNotFoundDelegate() );
+		}
+		if ( getEntityTuplizerFactory() != null ) {
+			sessionFactoryBuilder.applyEntityTuplizerFactory( getEntityTuplizerFactory() );
 		}
 
 		return sessionFactoryBuilder.build();


### PR DESCRIPTION
1. Add missing sessionFactoryBuilder.applyCurrentTenantIdentifierResolver() .
2. Use getter instead of field for consistency .