### PR TITLE
[master branch] HHH-10972 Use UTF-8 charset for reading file content of scripts for initializing the databases

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromFile.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromFile.java
@@ -7,8 +7,10 @@
 package org.hibernate.tool.schema.internal.exec;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 
 import org.hibernate.tool.schema.spi.SchemaManagementException;
@@ -48,11 +50,11 @@ public class ScriptSourceInputFromFile extends AbstractScriptSourceInput impleme
 	@Override
 	public void prepare() {
 		super.prepare();
-		this.reader = toFileReader( file );
+		this.reader = toReader( file );
 	}
 
 	@SuppressWarnings("ResultOfMethodCallIgnored")
-	private static Reader toFileReader(File file) {
+	private static Reader toReader(File file) {
 		if ( ! file.exists() ) {
 			log.warnf( "Specified schema generation script file [%s] did not exist for reading", file );
 			return new Reader() {
@@ -68,7 +70,7 @@ public class ScriptSourceInputFromFile extends AbstractScriptSourceInput impleme
 		}
 
 		try {
-			return new FileReader( file );
+			return new InputStreamReader( new FileInputStream(file), "UTF-8" );
 		}
 		catch (IOException e) {
 			throw new SchemaManagementException(


### PR DESCRIPTION
The commit here adds support for UTF-8 character encoding of script files that are configured to be used to populate/initialize the databases of an application. More details in the JIRA https://hibernate.atlassian.net/browse/HHH-10972 and the original forum thread https://developer.jboss.org/thread/271498

P.S: I haven't added any new test case for this since I couldn't narrow down whether this functionality already has any testcases that I can use but I have ensured that after this change, the existing test cases continue to pass.
