### PR TITLE
[5.1]: HHH-10968 - Skip EntityMode.MAP metadata when JpaMetaModelPopulationSetting is IGNORE_UNSUPPORTED

### DIFF
--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/internal/metamodel/MetadataContext.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/internal/metamodel/MetadataContext.java
@@ -121,7 +121,10 @@ class MetadataContext {
 	}
 
 	/*package*/ void registerEntityType(PersistentClass persistentClass, EntityTypeImpl<?> entityType) {
-		entityTypes.put( entityType.getBindableJavaType(), entityType );
+		// HHH-10968 - Skip EntityMode.MAP entities when ignore unsupported enabled.
+		if ( !( entityType.getBindableJavaType() == null && ignoreUnsupported ) ) {
+			entityTypes.put( entityType.getBindableJavaType(), entityType );
+		}
 		entityTypesByEntityName.put( persistentClass.getEntityName(), entityType );
 		entityTypesByPersistentClass.put( persistentClass, entityType );
 		orderedMappings.add( persistentClass );

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/AbstractMetamodelPopulateTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/AbstractMetamodelPopulateTest.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.xml.metamodel;
+
+import java.util.Map;
+
+import org.hibernate.jpa.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-10968")
+public abstract class AbstractMetamodelPopulateTest extends BaseEntityManagerFunctionalTestCase {
+	@Override
+	protected String[] getMappings() {
+		return new String[] { "org/hibernate/jpa/test/xml/Person.hbm.xml" };
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void addConfigOptions(Map options) {
+		super.addConfigOptions( options );
+		options.put( AvailableSettings.JPA_METAMODEL_POPULATION, getPopulationMode() );
+	}
+
+	protected abstract String getPopulationMode();
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/DisabledPopulationTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/DisabledPopulationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.xml.metamodel;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-10968")
+public class DisabledPopulationTest extends AbstractMetamodelPopulateTest {
+	@Override
+	protected String getPopulationMode() {
+		return "DISABLED";
+	}
+
+	@Test
+	public void testJpaMetaModelPopulationDisabled() {
+		EntityManager entityManager = getOrCreateEntityManager();
+		try {
+			// When 'DISABLED' is set, no metamodel data is populated.
+			// This means that the metamodel data will be null.
+			assertNull( entityManager.getMetamodel() );
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/EnabledPopulationTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/EnabledPopulationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.xml.metamodel;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-10968")
+public class EnabledPopulationTest extends AbstractMetamodelPopulateTest {
+	@Override
+	protected String getPopulationMode() {
+		return "ENABLED";
+	}
+
+	@Test
+	public void testJpaMetaModelPopulationEnabled() {
+		EntityManager entityManager = getOrCreateEntityManager();
+		try {
+			// When 'ENABLED' is set, the metamodel data is populated, including map-mode entities.
+			// This means that the mapped entity will be included in the managed types.
+			assertEquals( 1, entityManager.getMetamodel().getManagedTypes().size() );
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/IgnoreUnsupportedPopulationTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/xml/metamodel/IgnoreUnsupportedPopulationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.xml.metamodel;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-10968")
+public class IgnoreUnsupportedPopulationTest extends AbstractMetamodelPopulateTest {
+	@Override
+	protected String getPopulationMode() {
+		return "ignoreUnsupported";
+	}
+
+	@Test
+	public void testJpaMetaModelPopulationSettingUnsupported() {
+		EntityManager entityManager = getOrCreateEntityManager();
+		try {
+			// When 'ignoreUnsupported' is set, all map-mode entities are ignored.
+			// This means that the managed types collection is empty.
+			assertTrue( entityManager.getMetamodel().getManagedTypes().isEmpty() );
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+}

--- a/hibernate-entitymanager/src/test/resources/org/hibernate/jpa/test/xml/Person.hbm.xml
+++ b/hibernate-entitymanager/src/test/resources/org/hibernate/jpa/test/xml/Person.hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class entity-name="Person">
+        <id name="id" type="integer">
+            <generator class="native"/>
+        </id>
+        <property name="name" type="string">
+            <column name="NAME" length="20" not-null="true"/>
+        </property>
+    </class>
+
+</hibernate-mapping>
+


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10968