### PR TITLE
HHH-11014 - Switch to native identifier strategy even when using the …

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/IdGeneratorInterpreterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/IdGeneratorInterpreterImpl.java
@@ -222,7 +222,7 @@ public class IdGeneratorInterpreterImpl implements IdGeneratorStrategyInterprete
 						return UUIDGenerator.class.getName();
 					}
 					else {
-						return org.hibernate.id.enhanced.SequenceStyleGenerator.class.getName();
+						return "auto";
 					}
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/DefaultIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/DefaultIdentifierGeneratorFactory.java
@@ -130,8 +130,22 @@ public class DefaultIdentifierGeneratorFactory
 		if ( "hilo".equals( strategy ) ) {
 			throw new UnsupportedOperationException( "Support for 'hilo' generator has been removed" );
 		}
-		String resolvedStrategy = "native".equals( strategy ) ?
-				getDialect().getNativeIdentifierGeneratorStrategy() : strategy;
+		String resolvedStrategy = strategy;
+		if ( "auto".equals( strategy ) ) {
+			if ( getDialect().supportsSequences() ) {
+				resolvedStrategy = "sequence";
+			}
+			else if ( getDialect().getIdentityColumnSupport()
+					.supportsIdentityColumns() ) {
+				resolvedStrategy = "identity";
+			}
+			else {
+				resolvedStrategy = SequenceStyleGenerator.class.getName();
+			}
+		}
+		else if ( "native".equals( strategy ) ) {
+			resolvedStrategy = getDialect().getNativeIdentifierGeneratorStrategy();
+		}
 
 		Class generatorClass = generatorStrategyToClassNameMap.get( resolvedStrategy );
 		try {

--- a/hibernate-core/src/test/java/org/hibernate/id/AutoToNativeForIdentityColumnsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/AutoToNativeForIdentityColumnsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id;
+
+import java.sql.PreparedStatement;
+import java.util.Map;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Vlad Mihalcea
+ */
+@RequiresDialectFeature(DialectChecks.SupportsOnlyIdentityColumns.class)
+public class AutoToNativeForIdentityColumnsTest extends
+		BaseNonConfigCoreFunctionalTestCase {
+
+	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider();
+
+	@Override
+	protected void addSettings(Map settings) {
+		settings.put(
+				AvailableSettings.CONNECTION_PROVIDER, connectionProvider
+		);
+	}
+
+	@Override
+	protected void releaseResources() {
+		super.releaseResources();
+		connectionProvider.stop();
+	}
+
+	@Test
+	public void test() throws Exception {
+		doInHibernate( this::sessionFactory, session -> {
+			IdHolder holder = new IdHolder();
+			session.persist( holder );
+		} );
+		PreparedStatement preparedStatement = connectionProvider.getPreparedStatement(
+				"insert into IdHolder values ( )" );
+		verify( preparedStatement, times( 1 ) ).executeUpdate();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				IdHolder.class
+		};
+	}
+
+	@Entity(name = "IdHolder")
+	public static class IdHolder {
+
+		@Id
+		@Column(name = "id")
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		private Integer id;
+	}
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -39,6 +39,14 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class SupportsOnlyIdentityColumns implements DialectCheck {
+		public boolean isMatch(Dialect dialect) {
+			return dialect.getIdentityColumnSupport()
+					.supportsIdentityColumns() &&
+					!dialect.supportsSequences();
+		}
+	}
+
 	public static class SupportsColumnCheck implements DialectCheck {
 		public boolean isMatch(Dialect dialect) {
 			return dialect.supportsColumnCheck();


### PR DESCRIPTION
…new identifier generators

Basically, this is what has changed. For the new generators, which are used by default on 5.x, whenever we use AUTO identifier generators, this is how we are going to resolve the actual strategy:
- if the DB supports sequences, we use them.
- otherwise, if the DB supports identity column,s we use those.
- we fallback to `SequencesTyleGenerator`, which is going to use a table generator (this was also the default setting prior to this change)
