### PR TITLE
HHH-10875: added unit test to reproduce bug "Iterator.remove not calling beforeRemove on PersistentIdentifierBag"

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/collection/idbag/IdbagChild.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/idbag/IdbagChild.java
@@ -6,23 +6,25 @@
  */
 package org.hibernate.test.collection.idbag;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * {@inheritDoc}
- *
- * @author Steve Ebersole
+ * @author Daniel Strobusch
  */
-public class IdbagOwner {
+public class IdbagChild {
+	private Long id;
 	private String name;
-	private List<IdbagOwner> children = new ArrayList<>();
+	private String parent;
 
-	public IdbagOwner() {
+	public IdbagChild(String name)
+	{
+		this.name = name;
 	}
 
-	public IdbagOwner(String name) {
-		this.name = name;
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
 	}
 
 	public String getName() {
@@ -33,11 +35,11 @@ public class IdbagOwner {
 		this.name = name;
 	}
 
-	public List<IdbagOwner> getChildren() {
-		return children;
+	public String getParent() {
+		return parent;
 	}
 
-	public void setChildren(List<IdbagOwner> children) {
-		this.children = children;
+	public void setParent(String parent) {
+		this.parent = parent;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/idbag/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/idbag/Mappings.hbm.xml
@@ -24,4 +24,13 @@
         </idbag>
 	</class>
 
+    <!-- add a table to create a unique constraint on (PARENT_FK, CHILD_FK) to reproduce bug HHH-10875 -->
+    <class name="IdbagChild" table="idbag_owner_children">
+        <id name="id" column="CHILD" type="long"/>
+        <properties name="uc_parent_child" unique="true">
+            <property name="parent" column="PARENT_FK" type="string"/>
+            <property name="name" column="CHILD_FK" type="string"/>
+        </properties>
+    </class>
+
 </hibernate-mapping>


### PR DESCRIPTION
As suggested in the JIRA-Issue https://hibernate.atlassian.net/browse/HHH-10875 a unit test is implemented to reproduce the bug. The Bug itself is not fixed.
Update: added two more unit tests and provided a fix for the bug itself. 
