### PR TITLE
HHH-11061 - Attempt to resolve foreign key metadata from JDBC metadata failed to find column mappings for foreign key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -362,7 +362,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl implements Information
 			boolean found = false;
 			TableInformation tableInformation = null;
 			while ( resultSet.next() ) {
-				if ( tableName.equals( identifierHelper().toIdentifier( resultSet.getString( "TABLE_NAME" ), tableName.isQuoted() ) ) ) {
+				if ( tableName.equals( Identifier.toIdentifier( resultSet.getString( "TABLE_NAME" ), tableName.isQuoted() ) ) ) {
 					if ( found ) {
 						log.multipleTablesFound( tableName.render() );
 						final String catalogName = catalog == null ? "" : catalog.render();

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/foreignkeys/SchemaUpdateWithKeywordAutoQuotingEnabledTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/foreignkeys/SchemaUpdateWithKeywordAutoQuotingEnabledTest.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.schemaupdate.foreignkeys;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11061")
+public class SchemaUpdateWithKeywordAutoQuotingEnabledTest extends BaseUnitTestCase {
+	private StandardServiceRegistry ssr;
+	private MetadataImplementor metadata;
+
+	@Before
+	public void setUp() throws IOException {
+		final StandardServiceRegistryBuilder standardServiceRegistryBuilder = new StandardServiceRegistryBuilder();
+		standardServiceRegistryBuilder.applySetting(
+				org.hibernate.cfg.AvailableSettings.KEYWORD_AUTO_QUOTING_ENABLED,
+				"true"
+		);
+		ssr = standardServiceRegistryBuilder.build();
+		final MetadataSources metadataSources = new MetadataSources( ssr );
+
+		metadataSources.addAnnotatedClass( Match.class );
+		metadata = (MetadataImplementor) metadataSources.buildMetadata();
+		metadata.validate();
+
+		new SchemaExport().setHaltOnError( true )
+				.setFormat( false )
+				.createOnly( EnumSet.of( TargetType.DATABASE ), metadata );
+	}
+
+	@After
+	public void tearsDown() {
+		new SchemaExport().setHaltOnError( true )
+				.setFormat( false )
+				.drop( EnumSet.of( TargetType.DATABASE ), metadata );
+		StandardServiceRegistryBuilder.destroy( ssr );
+	}
+
+	@Test
+	public void testUpdate() {
+		new SchemaUpdate().setHaltOnError( true )
+				.setFormat( false )
+				.execute( EnumSet.of( TargetType.DATABASE ), metadata );
+	}
+
+	@Entity(name = "Match")
+	@Table(name = "MATCH")
+	public static class Match {
+		@Id
+		private Long id;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		@CollectionTable
+		private Map<Integer, Integer> timeline = new TreeMap<>();
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11061

when the FK table target name is a keyword 

`tableName.equals( identifierHelper().toIdentifier( resultSet.getString( "TABLE_NAME" ), tableName.isQuoted() )`
compares `tableName` that is not quoted with the result of `identifierHelper().toIdentifier( resultSet.getString( "TABLE_NAME" ), tableName.isQuoted() `that is quoted even if `tableName.isQuoted() `is false due to a call to `normalizeQuoting(Identifier identifier)`.

