### PR TITLE
HHH-11071 : Add UtcTimestampType

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/guides/tutorial_native.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/tutorial_native.adoc
@@ -129,6 +129,9 @@ In some cases this automatic detection might not chose the default you expect or
 `date` property.  Hibernate cannot know if the property, which is of type `java.util.Date`, should map to a SQL
 _DATE_, _TIME_, or _TIMESTAMP_ datatype.  Full date and time information is preserved by mapping the property to
 the _timestamp_ converter, which identifies the converter class `org.hibernate.type.TimestampType`.
+If the `java.util.Date` field should be persisted in the database as UTC instead of local time, when the database
+does not persist time zone information, the converter must be manually overridden with an
+`@org.hibernate.annotations.Type( type = "org.hibernate.type.UtcTimestampType" )` annotation.
 
 TIP: Hibernate determines the mapping type using reflection when the mapping files are processed. This process adds
 overhead in terms of time and resources. If startup performance is important, consider explicitly defining the type

--- a/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
@@ -33,6 +33,7 @@ Internally Hibernate uses a registry of basic types when it needs to resolve a s
 |BigIntegerType |NUMERIC |java.math.BigInteger |big_integer, java.math.BigInteger
 |BigDecimalType |NUMERIC |java.math.BigDecimal |big_decimal, java.math.bigDecimal
 |TimestampType |TIMESTAMP |java.sql.Timestamp |timestamp, java.sql.Timestamp
+|UtcTimestampType |TIMESTAMP |java.sql.Timestamp |timestamp, java.sql.Timestamp
 |TimeType |TIME |java.sql.Time |time, java.sql.Time
 |DateType |DATE |java.sql.Date |date, java.sql.Date
 |CalendarType |TIMESTAMP |java.util.Calendar |calendar, java.util.Calendar
@@ -227,6 +228,10 @@ This tells Hibernate to store the Strings as nationalized data.
 This is just for illustration purposes; for better ways to indicate nationalized character data see <<basic-nationalized>> section.
 
 Additionally, the description is to be handled as a LOB. Again, for better ways to indicate LOBs see <<basic-lob>> section.
+
+Another use case for this is handling timestamps that are stored in the database without time zone as UTC instead of
+local time; this is most useful when mapping a `java.util.Date` field as milliseconds since the Unix epoch, UTC time.
+This can be achieved with an `@org.hibernate.annotations.Type( type = "org.hibernate.type.UtcTimestampType" )` annotation.
 
 The `org.hibernate.annotations.Type#type` attribute can name any of the following:
 

--- a/hibernate-core/src/main/java/org/hibernate/type/UtcTimestampType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/UtcTimestampType.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type;
+
+import org.hibernate.type.descriptor.sql.UtcTimestampTypeDescriptor;
+
+/**
+ * A type that maps between {@link java.sql.Types#TIMESTAMP TIMESTAMP} and {@link java.sql.Timestamp}
+ * defaulting to UTC when no explicit time zone information is given
+ *
+ * @author Gavin King
+ * @author Steve Ebersole
+ * @author mirabilos
+ */
+public class UtcTimestampType extends TimestampType {
+	public static final UtcTimestampType INSTANCE = new UtcTimestampType();
+
+	public UtcTimestampType() {
+		super();
+		setSqlTypeDescriptor( UtcTimestampTypeDescriptor.INSTANCE );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/UtcTimestampTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/UtcTimestampTypeDescriptor.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.sql;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
+/**
+ * Descriptor for {@link Types#TIMESTAMP TIMESTAMP} handling (using UTC as default timezone).
+ *
+ * @author Steve Ebersole
+ */
+public class UtcTimestampTypeDescriptor implements SqlTypeDescriptor {
+	private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+	public static final UtcTimestampTypeDescriptor INSTANCE = new UtcTimestampTypeDescriptor();
+
+	public UtcTimestampTypeDescriptor() {
+	}
+
+	@Override
+	public int getSqlType() {
+		return Types.TIMESTAMP;
+	}
+
+	@Override
+	public boolean canBeRemapped() {
+		return true;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new BasicBinder<X>( javaTypeDescriptor, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final Timestamp timestamp = javaTypeDescriptor.unwrap( value, Timestamp.class, options );
+				if ( value instanceof Calendar ) {
+					st.setTimestamp( index, timestamp, (Calendar) value );
+				}
+				else {
+					st.setTimestamp( index, timestamp, Calendar.getInstance(UTC) );
+				}
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				final Timestamp timestamp = javaTypeDescriptor.unwrap( value, Timestamp.class, options );
+				if ( value instanceof Calendar ) {
+					st.setTimestamp( name, timestamp, (Calendar) value );
+				}
+				else {
+					st.setTimestamp( name, timestamp, Calendar.getInstance(UTC) );
+				}
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+		return new BasicExtractor<X>( javaTypeDescriptor, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, String name, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( rs.getTimestamp( name, Calendar.getInstance(UTC) ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( statement.getTimestamp( index, Calendar.getInstance(UTC) ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( statement.getTimestamp( name, Calendar.getInstance(UTC) ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/TypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/TypeTest.java
@@ -59,6 +59,7 @@ import org.hibernate.type.TimeType;
 import org.hibernate.type.TimeZoneType;
 import org.hibernate.type.TimestampType;
 import org.hibernate.type.TrueFalseType;
+import org.hibernate.type.UtcTimestampType;
 import org.hibernate.type.YesNoType;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -322,6 +323,16 @@ public class TypeTest extends BaseUnitTestCase {
 		final Timestamp different = new Timestamp( now + 9999 );
 
 		runBasicTests( TimestampType.INSTANCE, original, copy, different );
+	}
+
+	@Test
+	public void testUtcTimestampType() {
+		final long now = System.currentTimeMillis();
+		final Timestamp original = new Timestamp( now );
+		final Timestamp copy = new Timestamp( now );
+		final Timestamp different = new Timestamp( now + 9999 );
+
+		runBasicTests( UtcTimestampType.INSTANCE, original, copy, different );
 	}
 
 	@Test


### PR DESCRIPTION
This is the pull request with the patch to add a new type that can be used in place of TimestampType by an explicit `@org.hibernate.annotations.Type( type = "org.hibernate.type.UtcTimestampType" )` annotation (so existing behaviour is not affected by merging this patch). The new type explicitly uses the UTC timezone instead of the (system/JVM/…) default one when no explicit time zone is given, and is unchanged otherwise — in fact, the type descriptor class is generated by running sed(1) on the TimestampTypeDescriptor class, and the UtcTimestampType class itself is a trivial subclass of TimestampType merely changing the SQL descriptor after calling its parent’s constructor.

From a Hibernate user’s point of view, this functionality is required to be able to reliably store and retrieve data from/to SQL “TIMESTAMP WITHOUT TIME ZONE” fields; it may also positively affect “TIMESTAMP WITH TIME ZONE”, although I personally have only tested¹ the former. The only alternative to this is to store timestamps as SQL “BIGINT”, which is semantically wrong.

This ability appears to be a frequently asked-for thing (according to a WWW and StackOverflow research), and many people are willing to use a Hibernate-specific feature (with all the portability problems this involves) just to get it.

As for the patch itself, feedback is welcome; while I program since 1988, Java™ is new to me.

① “Tested” here means, added the equivalent of these classes in an internal project in that project’s namespace, added all those `@Type` annotations, and watched happily as the service *finally* gave out correct data. Also, ran “bash gradlew hibernate-core:test”. I did not test with the patched Hibernate build in the internal project, as the latter is still using version 5.1.0.Final (any chance getting this accepted into the 5.1 branch for an eventual 5.1.1 release, by the way?). We don’t wish to carry this in our application forever, due to the maintenance cost (as the descriptor has to be copied from Hibernate’s core code in each version), and because my employer ⮡ tarent is an Open Source company, and because this way we finally have an official type everyone can use instead of creating their own (or, worse, manipulating the JVM timezone, in those cases that helps).