### PR TITLE
HHH-11037 - fix tests on Oracle

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/JoinedSubclassWithEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/JoinedSubclassWithEmbeddableTest.java
@@ -68,7 +68,7 @@ public class JoinedSubclassWithEmbeddableTest extends BaseCoreFunctionalTestCase
 		} );
 	}
 
-	@Entity
+	@Entity(name = "Person")
 	@Inheritance(strategy = InheritanceType.JOINED)
 	public static abstract class Person implements Serializable {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/SingleTableWithEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/SingleTableWithEmbeddableTest.java
@@ -69,7 +69,7 @@ public class SingleTableWithEmbeddableTest extends BaseCoreFunctionalTestCase {
 		} );
 	}
 
-	@Entity
+	@Entity(name = "Person")
 	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 	public static abstract class Person implements Serializable {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/TablePerClassWithEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritancediscriminator/embeddable/TablePerClassWithEmbeddableTest.java
@@ -68,7 +68,7 @@ public class TablePerClassWithEmbeddableTest extends BaseCoreFunctionalTestCase 
 		} );
 	}
 
-	@Entity
+	@Entity(name = "Person")
 	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 	public static abstract class Person implements Serializable {
 


### PR DESCRIPTION
fixes ORA-00972: identifier is too long on Oracle databases

https://hibernate.atlassian.net/browse/HHH-11037

I didn't create Jira for this simple test fix and only referenced original Jira in commit message

@gbadner Can you please also cherry-pick this to 5.0 and 5.1? 