### PR TITLE
Log failing SQL when batched execution fails with RTE like StaleStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
@@ -102,6 +102,7 @@ public class BatchingBatch extends AbstractBatchImpl {
 		LOG.debugf( "Executing batch size: %s", batchPosition );
 		try {
 			for ( Map.Entry<String,PreparedStatement> entry : getStatements().entrySet() ) {
+				String sql = entry.getKey();
 				try {
 					final PreparedStatement statement = entry.getValue();
 					final int[] rowCounts;
@@ -116,13 +117,14 @@ public class BatchingBatch extends AbstractBatchImpl {
 				}
 				catch ( SQLException e ) {
 					abortBatch();
-					throw sqlExceptionHelper().convert( e, "could not execute batch", entry.getKey() );
+					LOG.unableToExecuteBatch( e, sql );
+					throw sqlExceptionHelper().convert( e, "could not execute batch", sql );
+				}
+				catch ( RuntimeException re ) {
+					LOG.unableToExecuteBatch( re, sql );
+					throw re;
 				}
 			}
-		}
-		catch ( RuntimeException re ) {
-			LOG.unableToExecuteBatch( re.getMessage() );
-			throw re;
 		}
 		finally {
 			batchPosition = 0;

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1066,8 +1066,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	void unableToDropTemporaryIdTable(String message);
 
 	@LogMessage(level = ERROR)
-	@Message(value = "Exception executing batch [%s]", id = 315)
-	void unableToExecuteBatch(String message);
+	@Message(value = "Exception executing batch [%s], SQL: %s", id = 315)
+	void unableToExecuteBatch(Exception e, String sql );
 
 	@LogMessage(level = WARN)
 	@Message(value = "Error executing resolver [%s] : %s", id = 316)


### PR DESCRIPTION
Currently, when using batched updates and Hibernate detects stale state (e.g. data row concurrently deleted or deleted by JPQL executed with NO_FLUSH), failing SQL is not logged. However, when SQLException occurs, the failing SQL is logged (and that's so much convenient!).

This patch changes how we handle non-SQLException exception when executing batch, so that current SQL is logged for them as well.