### PR TITLE
HHH-11135 - TableGenerator.registerExportables should be optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ allprojects {
 }
 
 ext {
-	hibernateTargetVersion = '5.2.2.Final'
+	hibernateTargetVersion = '5.2.2.Fixed'
 	expectedGradleVersion = '3.0-milestone-1'
 	baselineJavaVersion = '1.8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ allprojects {
 }
 
 ext {
-	hibernateTargetVersion = '5.2.2.Fixed'
+	hibernateTargetVersion = '5.2.2.Final'
 	expectedGradleVersion = '3.0-milestone-1'
 	baselineJavaVersion = '1.8'
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -350,6 +350,7 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 		final JdbcEnvironment jdbcEnvironment = serviceRegistry.getService( JdbcEnvironment.class );
 
 		qualifiedTableName = determineGeneratorTableName( params, jdbcEnvironment );
+		renderedTableName = qualifiedTableName.render();
 		segmentColumnName = determineSegmentColumnName( params, jdbcEnvironment );
 		valueColumnName = determineValueColumnName( params, jdbcEnvironment );
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -351,6 +351,10 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 
 		qualifiedTableName = determineGeneratorTableName( params, jdbcEnvironment );
 		renderedTableName = qualifiedTableName.render();
+		selectQuery = buildSelectQuery( jdbcEnvironment.getDialect() );
+		updateQuery = buildUpdateQuery();
+		insertQuery = buildInsertQuery();
+
 		segmentColumnName = determineSegmentColumnName( params, jdbcEnvironment );
 		valueColumnName = determineValueColumnName( params, jdbcEnvironment );
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -351,9 +351,6 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 
 		qualifiedTableName = determineGeneratorTableName( params, jdbcEnvironment );
 		renderedTableName = qualifiedTableName.render();
-		selectQuery = buildSelectQuery( jdbcEnvironment.getDialect() );
-		updateQuery = buildUpdateQuery();
-		insertQuery = buildInsertQuery();
 
 		segmentColumnName = determineSegmentColumnName( params, jdbcEnvironment );
 		valueColumnName = determineValueColumnName( params, jdbcEnvironment );
@@ -375,6 +372,9 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 				incrementSize,
 				ConfigurationHelper.getInt( INITIAL_PARAM, params, -1 )
 		);
+		selectQuery = buildSelectQuery( jdbcEnvironment.getDialect() );
+		updateQuery = buildUpdateQuery();
+		insertQuery = buildInsertQuery();
 	}
 
 	/**


### PR DESCRIPTION
Currently TableGenerator only works if registerExportables is called. registerExportables is a narrow use case, and should not be in the critical path. Configure should be the only initialization method that must be called. This patch sets critical class variables in the configure method, so if we never registerExportables, it will still work. Example: if I manually call MyIdGenerator.generate(..) rather than using JPA annotations, registerExportables is never called and the 5.2.2.Final release breaks.
