### PR TITLE
HHH-10489 : DB2400Dialect could use the same LimitHandler as DB2Dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
@@ -25,7 +25,10 @@ public class DB2400Dialect extends DB2Dialect {
 		@Override
 		public String processSql(String sql, RowSelection selection) {
 			if (LimitHelper.hasFirstRow( selection )) {
-				throw new UnsupportedOperationException( "query result offset is not supported" );
+				//nest the main query in an outer select
+				return "select * from ( select inner2_.*, rownumber() over(order by order of inner2_) as rownumber_ from ( "
+						+ sql + " fetch first " + getMaxOrLimit(selection) + " rows only ) as inner2_ ) as inner1_ where rownumber_ > "
+						+ selection.getFirstRow() + " order by rownumber_";
 			}
 			return sql + " fetch first " + getMaxOrLimit( selection ) + " rows only";
 		}


### PR DESCRIPTION
HHH-10489 : DB2400Dialect could use the same LimitHandler as DB2Dialect
HHH-11150 : DB2 on AS400 (DB2400 Dialect) fails to paginate.
Leveraged code from the DB2 Dialect and placed in DB2400Dialect. This was then tested on an AS400 successfully.