### PR TITLE
HHH-11171 Fixes for Java 8 time descriptors

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/InstantType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/InstantType.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Comparator;
 import java.util.Locale;
 
@@ -32,7 +33,7 @@ public class InstantType
 	 */
 	public static final InstantType INSTANCE = new InstantType();
 
-	public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss.S 'Z'", Locale.ENGLISH );
+	public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss.n ZZZZ", Locale.ENGLISH );
 
 	public InstantType() {
 		super( TimestampTypeDescriptor.INSTANCE, InstantJavaDescriptor.INSTANCE );
@@ -40,7 +41,8 @@ public class InstantType
 
 	@Override
 	public String objectToSQLString(Instant value, Dialect dialect) throws Exception {
-		return "{ts '" + FORMATTER.format( ZonedDateTime.ofInstant( value, ZoneId.of( "UTC" ) ) ) + "'}";
+		// SQL 9075-2:2003 5.3 <timestamp literal>
+		return "TIMESTAMP '" + FORMATTER.format( ZonedDateTime.ofInstant( value, ZoneId.of( "UTC" ) ) ) + "'";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaDescriptor.java
@@ -11,11 +11,11 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.hibernate.type.InstantType;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -36,12 +36,12 @@ public class InstantJavaDescriptor extends AbstractTypeDescriptor<Instant> {
 
 	@Override
 	public String toString(Instant value) {
-		return InstantType.FORMATTER.format( ZonedDateTime.ofInstant( value, ZoneId.of( "UTC" ) ) );
+		return DateTimeFormatter.ISO_INSTANT.format( value );
 	}
 
 	@Override
 	public Instant fromString(String string) {
-		return (Instant) InstantType.FORMATTER.parse( string );
+		return Instant.from( DateTimeFormatter.ISO_INSTANT.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaDescriptor.java
@@ -42,7 +42,7 @@ public class LocalDateJavaDescriptor extends AbstractTypeDescriptor<LocalDate> {
 
 	@Override
 	public LocalDate fromString(String string) {
-		return (LocalDate) LocalDateType.FORMATTER.parse( string );
+		return LocalDate.from( LocalDateType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaDescriptor.java
@@ -40,7 +40,7 @@ public class LocalDateTimeJavaDescriptor extends AbstractTypeDescriptor<LocalDat
 
 	@Override
 	public LocalDateTime fromString(String string) {
-		return (LocalDateTime) LocalDateTimeType.FORMATTER.parse( string );
+		return LocalDateTime.from( LocalDateTimeType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
@@ -44,7 +44,7 @@ public class LocalTimeJavaDescriptor extends AbstractTypeDescriptor<LocalTime> {
 
 	@Override
 	public LocalTime fromString(String string) {
-		return (LocalTime) LocalTimeType.FORMATTER.parse( string );
+		return LocalTime.from( LocalTimeType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
@@ -40,7 +40,7 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 
 	@Override
 	public OffsetDateTime fromString(String string) {
-		return (OffsetDateTime) OffsetDateTimeType.FORMATTER.parse( string );
+		return OffsetDateTime.from( OffsetDateTimeType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaDescriptor.java
@@ -44,7 +44,7 @@ public class OffsetTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetTime>
 
 	@Override
 	public OffsetTime fromString(String string) {
-		return (OffsetTime) OffsetTimeType.FORMATTER.parse( string );
+		return OffsetTime.from( OffsetTimeType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaDescriptor.java
@@ -40,7 +40,7 @@ public class ZonedDateTimeJavaDescriptor extends AbstractTypeDescriptor<ZonedDat
 
 	@Override
 	public ZonedDateTime fromString(String string) {
-		return (ZonedDateTime) ZonedDateTimeType.FORMATTER.parse( string );
+		return ZonedDateTime.from( ZonedDateTimeType.FORMATTER.parse( string ) );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/DurationDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/DurationDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.Duration;
+import org.hibernate.type.descriptor.java.DurationJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class DurationDescriptorTest extends AbstractDescriptorTest<Duration> {
+	final Duration original = Duration.ofSeconds( 3621, 256);
+	final Duration copy = Duration.ofSeconds( 3621, 256);
+	final Duration different = Duration.ofSeconds( 1621, 156);
+
+	public DurationDescriptorTest() {
+		super(DurationJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<Duration> getTestData() {
+		return new Data<Duration>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/InstantDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/InstantDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.Instant;
+import org.hibernate.type.descriptor.java.InstantJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class InstantDescriptorTest extends AbstractDescriptorTest<Instant> {
+	final Instant original = Instant.ofEpochMilli( 1476340818745L );
+	final Instant copy = Instant.ofEpochMilli( 1476340818745L );
+	final Instant different = Instant.ofEpochMilli( 1476340818746L );
+
+	public InstantDescriptorTest() {
+		super(InstantJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<Instant> getTestData() {
+		return new Data<Instant>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalDateDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalDateDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalDate;
+import org.hibernate.type.descriptor.java.LocalDateJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class LocalDateDescriptorTest extends AbstractDescriptorTest<LocalDate> {
+	final LocalDate original = LocalDate.of( 2016, 10, 8 );
+	final LocalDate copy = LocalDate.of( 2016, 10, 8 );
+	final LocalDate different = LocalDate.of( 2013,  8, 8 );
+
+	public LocalDateDescriptorTest() {
+		super(LocalDateJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<LocalDate> getTestData() {
+		return new Data<LocalDate>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalDateTimeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalDateTimeDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalDateTime;
+import org.hibernate.type.descriptor.java.LocalDateTimeJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class LocalDateTimeDescriptorTest extends AbstractDescriptorTest<LocalDateTime> {
+	final LocalDateTime original = LocalDateTime.of( 2016, 10, 8, 10, 15, 0 );
+	final LocalDateTime copy = LocalDateTime.of( 2016, 10, 8, 10, 15, 0 );
+	final LocalDateTime different = LocalDateTime.of( 2013,  8, 8, 15, 12 );
+
+	public LocalDateTimeDescriptorTest() {
+		super(LocalDateTimeJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<LocalDateTime> getTestData() {
+		return new Data<LocalDateTime>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalTimeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocalTimeDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalDate;
+import org.hibernate.type.descriptor.java.LocalDateJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class LocalTimeDescriptorTest extends AbstractDescriptorTest<LocalDate> {
+	final LocalDate original = LocalDate.of( 2016, 10, 8 );
+	final LocalDate copy = LocalDate.of( 2016, 10, 8 );
+	final LocalDate different = LocalDate.of( 2013,  8, 8 );
+
+	public LocalTimeDescriptorTest() {
+		super(LocalDateJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<LocalDate> getTestData() {
+		return new Data<LocalDate>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/OffsetDateTimeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/OffsetDateTimeDescriptorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.hibernate.type.descriptor.java.OffsetDateTimeJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class OffsetDateTimeDescriptorTest extends AbstractDescriptorTest<OffsetDateTime> {
+	final OffsetDateTime original = OffsetDateTime.of(LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneOffset.ofHoursMinutes( 2, 0));
+	final OffsetDateTime copy = OffsetDateTime.of(LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneOffset.ofHoursMinutes( 2, 0));
+	final OffsetDateTime different = OffsetDateTime.of(LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneOffset.ofHoursMinutes( 4, 30));
+
+	public OffsetDateTimeDescriptorTest() {
+		super(OffsetDateTimeJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<OffsetDateTime> getTestData() {
+		return new Data<OffsetDateTime>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/OffsetTimeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/OffsetTimeDescriptorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import org.hibernate.type.descriptor.java.OffsetTimeJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class OffsetTimeDescriptorTest extends AbstractDescriptorTest<OffsetTime> {
+	final OffsetTime original = OffsetTime.of(LocalTime.of( 15, 13 ), ZoneOffset.ofHoursMinutes( -6, 0));
+	final OffsetTime copy = OffsetTime.of(LocalTime.of( 15, 13 ), ZoneOffset.ofHoursMinutes( -6, 0));
+	final OffsetTime different = OffsetTime.of(LocalTime.of( 15, 13 ), ZoneOffset.ofHoursMinutes( 4, 30));
+
+	public OffsetTimeDescriptorTest() {
+		super(OffsetTimeJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<OffsetTime> getTestData() {
+		return new Data<OffsetTime>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/ZonedDateTimeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/ZonedDateTimeDescriptorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.hibernate.type.descriptor.java.ZonedDateTimeJavaDescriptor;
+
+/**
+ * @author Jordan Gigov
+ */
+public class ZonedDateTimeDescriptorTest extends AbstractDescriptorTest<ZonedDateTime> {
+	final ZonedDateTime original = ZonedDateTime.of( LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneId.of( "UTC" ));
+	final ZonedDateTime copy = ZonedDateTime.of( LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneId.of( "UTC" ) );
+	final ZonedDateTime different = ZonedDateTime.of( LocalDateTime.of( 2016, 10, 8, 15, 13 ), ZoneId.of( "EET" ) );
+
+	public ZonedDateTimeDescriptorTest() {
+		super(ZonedDateTimeJavaDescriptor.INSTANCE);
+	}
+
+	@Override
+	protected Data<ZonedDateTime> getTestData() {
+		return new Data<ZonedDateTime>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return false;
+	}
+	
+}


### PR DESCRIPTION
If you're worried that I'm changing InstantJavaDescriptor to use a different format, the original code never worked in the first place.

Tests included.