### PR TITLE
HHH-10465 Loss of precision in temporal JavaTypeDescriptor implementations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeTypeDescriptor.java
@@ -24,6 +24,8 @@ import org.hibernate.type.descriptor.WrapperOptions;
 public class JdbcTimeTypeDescriptor extends AbstractTypeDescriptor<Date> {
 	public static final JdbcTimeTypeDescriptor INSTANCE = new JdbcTimeTypeDescriptor();
 	public static final String TIME_FORMAT = "HH:mm:ss";
+	public static final String LONG_FORMAT = "HH:mm:ss.SSS";
+	public static final int LONG_FORMAT_LENGTH = LONG_FORMAT.length();
 
 	public static class TimeMutabilityPlan extends MutableMutabilityPlan<Date> {
 		public static final TimeMutabilityPlan INSTANCE = new TimeMutabilityPlan();
@@ -45,7 +47,10 @@ public class JdbcTimeTypeDescriptor extends AbstractTypeDescriptor<Date> {
 	@Override
 	public java.util.Date fromString(String string) {
 		try {
-			return new Time( new SimpleDateFormat( TIME_FORMAT ).parse( string ).getTime() );
+                        if (LONG_FORMAT_LENGTH == string.length()) {
+                            return new Time( new SimpleDateFormat( LONG_FORMAT ).parse( string ).getTime() );
+                        }
+                        return new Time( new SimpleDateFormat( TIME_FORMAT ).parse( string ).getTime() );
 		}
 		catch ( ParseException pe ) {
 			throw new HibernateException( "could not parse time string" + string, pe );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampTypeDescriptor.java
@@ -24,6 +24,8 @@ import org.hibernate.type.descriptor.WrapperOptions;
 public class JdbcTimestampTypeDescriptor extends AbstractTypeDescriptor<Date> {
 	public static final JdbcTimestampTypeDescriptor INSTANCE = new JdbcTimestampTypeDescriptor();
 	public static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+	public static final String LONG_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+	public static final int LONG_FORMAT_LENGTH = LONG_FORMAT.length();
 
 	public static class TimestampMutabilityPlan extends MutableMutabilityPlan<Date> {
 		public static final TimestampMutabilityPlan INSTANCE = new TimestampMutabilityPlan();
@@ -46,12 +48,15 @@ public class JdbcTimestampTypeDescriptor extends AbstractTypeDescriptor<Date> {
 	}
 	@Override
 	public String toString(Date value) {
-		return new SimpleDateFormat( TIMESTAMP_FORMAT ).format( value );
+		return new SimpleDateFormat( LONG_FORMAT ).format( value );
 	}
 	@Override
 	public Date fromString(String string) {
 		try {
-			return new Timestamp( new SimpleDateFormat( TIMESTAMP_FORMAT ).parse( string ).getTime() );
+                        if (LONG_FORMAT_LENGTH == string.length()) {
+                            return new Timestamp( new SimpleDateFormat( LONG_FORMAT ).parse( string ).getTime() );
+                        }
+                        return new Timestamp( new SimpleDateFormat( TIMESTAMP_FORMAT ).parse( string ).getTime() );
 		}
 		catch ( ParseException pe) {
 			throw new HibernateException( "could not parse timestamp string" + string, pe );

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/JdbcTimeTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/JdbcTimeTypeDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.util.Date;
+
+import org.hibernate.type.descriptor.java.JdbcTimeTypeDescriptor;
+
+/**
+ * @author Owen Farrell
+ */
+public class JdbcTimeTypeDescriptorTest extends AbstractDescriptorTest<Date> {
+	final Date original = new Date();
+	final Date copy = new Date( original.getTime() );
+	final Date different = new Date( original.getTime() + 500L);
+
+	public JdbcTimeTypeDescriptorTest() {
+		super( JdbcTimeTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	protected Data<Date> getTestData() {
+		return new Data<Date>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return true;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/JdbcTimestampTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/JdbcTimestampTypeDescriptorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type.descriptor.java;
+
+import java.util.Date;
+
+import org.hibernate.type.descriptor.java.JdbcTimestampTypeDescriptor;
+
+/**
+ * @author Owen Farrell
+ */
+public class JdbcTimestampTypeDescriptorTest extends AbstractDescriptorTest<Date> {
+	final Date original = new Date();
+	final Date copy = new Date( original.getTime() );
+	final Date different = new Date( original.getTime() + 500L);
+
+	public JdbcTimestampTypeDescriptorTest() {
+		super( JdbcTimestampTypeDescriptor.INSTANCE );
+	}
+
+	@Override
+	protected Data<Date> getTestData() {
+		return new Data<Date>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return true;
+	}
+}


### PR DESCRIPTION
This update provides a fix for [HHH-10465](https://hibernate.atlassian.net/browse/HHH-10465) and includes unit tests to verify the associated changes.
