### PR TITLE
HHH-11179 fix NPE on lazy load of non-existed entity outside transaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -155,11 +155,11 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			else {
 				target = session.immediateLoad( entityName, id );
 				initialized = true;
-				checkTargetState();
+				checkTargetState(session);
 			}
 		}
 		else {
-			checkTargetState();
+			checkTargetState(session);
 		}
 	}
 
@@ -189,6 +189,8 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 
 				try {
 					target = session.immediateLoad( entityName, id );
+					initialized = true;
+					checkTargetState(session);
 				}
 				finally {
 					// make sure the just opened temp session gets closed!
@@ -202,8 +204,6 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 						log.warn( "Unable to close temporary session used to load lazy proxy associated to no session" );
 					}
 				}
-				initialized = true;
-				checkTargetState();
 			}
 			catch (Exception e) {
 				e.printStackTrace();
@@ -213,7 +213,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 		else if ( session.isOpen() && session.isConnected() ) {
 			target = session.immediateLoad( entityName, id );
 			initialized = true;
-			checkTargetState();
+			checkTargetState(session);
 		}
 		else {
 			throw new LazyInitializationException( "could not initialize proxy - Session was closed or disced" );
@@ -230,10 +230,10 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 		}
 	}
 
-	private void checkTargetState() {
+	private void checkTargetState(SharedSessionContractImplementor sharedSession) {
 		if ( !unwrap ) {
 			if ( target == null ) {
-				getSession().getFactory().getEntityNotFoundDelegate().handleEntityNotFound( entityName, id );
+				sharedSession.getFactory().getEntityNotFoundDelegate().handleEntityNotFound( entityName, id );
 			}
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingNotFoundTest.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.lazyload;
+
+import org.hibernate.LazyInitializationException;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Nikolay Golubev
+ */
+public class LazyLoadingNotFoundTest extends BaseCoreFunctionalTestCase {
+
+    protected void configure(Configuration cfg) {
+        super.configure(cfg);
+        cfg.setProperty(Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true");
+    }
+
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{
+                Parent.class,
+                Child.class
+        };
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-11179")
+    public void testNonExistentLazyInitOutsideTransaction() {
+        Session s = openSession();
+        s.beginTransaction();
+        Child loadedChild = (Child) s.load(Child.class, new Long(-1));
+        s.getTransaction().commit();
+        s.close();
+
+        try {
+            loadedChild.getParent();
+            fail("lazy init did not fail on non-existent proxy");
+        } catch (LazyInitializationException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
NullPointerException occurs when I try to access a lazy-loading field on non-existent entity outside the transaction (ENABLE_LAZY_LOAD_NO_TRANS=true). As the result, I get LazyInitializationException with null message. If the same is done inside the transaction then the correct exception will be thrown (ObjectNotFoundException) and the correct message will be given (No row with the given identifier exists).