### PR TITLE
Build script changes for Javassist version workig on Java 9

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -216,25 +216,6 @@ artifacts {
     tests testJar
 }
 
-if ( JavaVersion.current().isJava9Compatible() ) {
-    logger.warn( '[WARN] Skipping Javassist-related tests for hibernate-core due to Javassist JDK 9 incompatibility' )
-
-    // we need to exclude tests using Javassist enhancement, which does not properly support
-    // Java 9 yet - https://issues.jboss.org/browse/JASSIST-261
-    test {
-        // rather than wild-cards, keep an explicit list
-        exclude 'org/hibernate/jpa/test/enhancement/InterceptFieldClassFileTransformerTest.class'
-        exclude 'org/hibernate/jpa/test/enhancement/runtime/JpaRuntimeEnhancementTest.class'
-        exclude 'org/hibernate/test/bytecode/enhancement/EnhancerTest.class'
-        exclude 'org/hibernate/test/bytecode/enhancement/basic/BasicInSessionTest.class'
-
-        // also, any tests using Arquillian for in-container testing with WildFly currently
-        // need to be excluded because WildFly does not yet work with Java 9
-        exclude 'org/hibernate/test/wf/ddl/**'
-        exclude 'org/hibernate/jpa/test/cdi/**'
-    }
-}
-
 processTestResources {
     doLast {
         copy {

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -87,16 +87,3 @@ tasks."matrix_mariadb" {
         println "Starting test: " + descriptor
     }
 }
-
-if ( JavaVersion.current().isJava9Compatible() ) {
-    logger.warn( '[WARN] Skipping Javassist-related tests for hibernate-envers due to Javassist JDK 9 incompatibility' )
-
-    // we need to exclude tests using Javassist enhancement, which does not properly support
-    // Java 9 yet - https://issues.jboss.org/browse/JASSIST-261
-    test {
-        // rather than wild-cards, keep an explicit list
-        exclude 'org/hibernate/envers/internal/tools/MapProxyTest.class'
-        exclude 'org/hibernate/envers/test/integration/components/dynamic/AuditedDynamicComponentTest.class'
-        exclude 'org/hibernate/envers/test/integration/components/dynamic/AuditedDynamicComponentsAdvancedCasesTest.class'
-    }
-}

--- a/hibernate-hikaricp/hibernate-hikaricp.gradle
+++ b/hibernate-hikaricp/hibernate-hikaricp.gradle
@@ -43,10 +43,3 @@ mavenPom {
 def osgiDescription() {
 	return mavenPom.description
 }
-
-if ( JavaVersion.current().isJava9Compatible() ) {
-    logger.warn( '[WARN] Skipping all tests for hibernate-hikaricp due to Javassist JDK 9 incompatibility' )
-
-    // Hikari CP relies on Javassist which we know has issues with Java 9
-    test.enabled = false
-}

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -149,12 +149,6 @@ build.dependsOn createModulesZip
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // tasks related to in-container (Arquillian + WF) testing
 
-if ( JavaVersion.current().isJava9Compatible() ) {
-    logger.lifecycle( "WARNING - Skipping hibernate-orm-modules tests for Java 9" )
-    // WildFly has problems booting in Java 9
-    test.enabled = false
-}
-
 task installWildFly(type: Copy) {
     description = 'Downloads the WildFly distribution and installs it into a local directory (if needed)'
 

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -399,8 +399,3 @@ publishing {
 		}
 	}
 }
-
-if ( JavaVersion.current().isJava9Compatible() ) {
-	// Hikari CP relies on Javassist which we know has issues with Java 9
-	test.enabled = false
-}

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -18,10 +18,10 @@ ext {
     elVersion = '2.2.4'
     cdiVersion = '1.1'
 
-    javassistVersion = '3.20.0-GA'
+    javassistVersion = '3.22.0-CR1'
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
-    wildflyVersion = '10.0.0.Final'
+    wildflyVersion = '10.1.0.Final'
     arquillianVersion = '1.1.10.Final'
     shrinkwrapVersion = '1.2.6'
     shrinkwrapDescriptorsVersion = '2.0.0-alpha-8'


### PR DESCRIPTION
Changes to build scripts based on Javassist version now supporting Java 9