### PR TITLE
HHH-11083 WrongClassException using Infinispan and sharing cache regions

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
@@ -65,6 +65,16 @@ Besides specific provider configuration, there are a number of configurations op
 	the alternative is to have stale data in that collection cache.
 `hibernate.cache.use_reference_entries`::
 	Enable direct storage of entity references into the second level cache for read-only or immutable entities.
+`hibernate.cache.keys_factory`::
+    When storing entries into second-level cache as key-value pair, the identifiers can be wrapped into tuples
+    <entity type, tenant, identifier> to guarantee uniqueness in case that second-level cache stores all entities
+    in single space. These tuples are then used as keys in the cache. When the second-level cache implementation
+    (incl. its configuration) guarantees that different entity types are stored separately and multi-tenancy is not
+    used, you can omit this wrapping to achieve better performance. This hint can be ignored by the second-level
+    cache implementation, though. Valid values are:
+* `default` (wraps identitifers in the tuple)
+* `simple` (uses identifiers as keys without any wrapping)
+* fully qualified class name that implements `org.hibernate.cache.spi.CacheKeysFactory`
 
 [[caching-mappings]]
 === Configuring second-level cache mappings

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
@@ -20,6 +20,9 @@ import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
 import org.hibernate.boot.registry.selector.spi.StrategySelectionException;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.internal.SimpleCacheKeysFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.dialect.CUBRIDDialect;
 import org.hibernate.dialect.Cache71Dialect;
 import org.hibernate.dialect.DB2390Dialect;
@@ -157,6 +160,7 @@ public class StrategySelectorBuilder {
 		addMultiTableBulkIdStrategies( strategySelector );
 		addEntityCopyObserverStrategies( strategySelector );
 		addImplicitNamingStrategies( strategySelector );
+		addCacheKeysFactories( strategySelector );
 
 		// apply auto-discovered registrations
 		for ( StrategyRegistrationProvider provider : classLoaderService.loadJavaServices( StrategyRegistrationProvider.class ) ) {
@@ -434,6 +438,19 @@ public class StrategySelectorBuilder {
 				ImplicitNamingStrategy.class,
 				"component-path",
 				ImplicitNamingStrategyComponentPathImpl.class
+		);
+	}
+
+	private void addCacheKeysFactories(StrategySelectorImpl strategySelector) {
+		strategySelector.registerStrategyImplementor(
+			CacheKeysFactory.class,
+			DefaultCacheKeysFactory.SHORT_NAME,
+			DefaultCacheKeysFactory.class
+		);
+		strategySelector.registerStrategyImplementor(
+			CacheKeysFactory.class,
+			SimpleCacheKeysFactory.SHORT_NAME,
+			SimpleCacheKeysFactory.class
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
@@ -21,11 +21,8 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  * @author Steve Ebersole
- *
- * @deprecated In optimized implementations, wrapping the id is not necessary.
  */
-@Deprecated
-final class OldCacheKeyImplementation implements Serializable {
+final class CacheKeyImplementation implements Serializable {
 	private final Object id;
 	private final Type type;
 	private final String entityOrRoleName;
@@ -43,7 +40,7 @@ final class OldCacheKeyImplementation implements Serializable {
 	 * @param tenantId The tenant identifier associated this data.
 	 * @param factory The session factory for which we are caching
 	 */
-	OldCacheKeyImplementation(
+	CacheKeyImplementation(
 			final Object id,
 			final Type type,
 			final String entityOrRoleName,
@@ -74,11 +71,11 @@ final class OldCacheKeyImplementation implements Serializable {
 		if ( this == other ) {
 			return true;
 		}
-		if ( hashCode != other.hashCode() || !( other instanceof OldCacheKeyImplementation ) ) {
+		if ( hashCode != other.hashCode() || !( other instanceof CacheKeyImplementation) ) {
 			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
 			return false;
 		}
-		final OldCacheKeyImplementation that = (OldCacheKeyImplementation) other;
+		final CacheKeyImplementation that = (CacheKeyImplementation) other;
 		return EqualsHelper.equals( entityOrRoleName, that.entityOrRoleName )
 				&& type.isEqual( id, that.id)
 				&& EqualsHelper.equals( tenantId, that.tenantId );

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
@@ -38,61 +38,61 @@ import org.hibernate.persister.entity.EntityPersister;
  * @author Sanne Grinovero
  * @since 5.0
  */
-public class DefaultCacheKeysFactory {
+public class DefaultCacheKeysFactory implements CacheKeysFactory {
+	public static final String SHORT_NAME = "default";
+	public static final DefaultCacheKeysFactory INSTANCE = new DefaultCacheKeysFactory();
 
-	public static Object createCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+	public static Object staticCreateCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
 		return new OldCacheKeyImplementation( id, persister.getKeyType(), persister.getRole(), tenantIdentifier, factory );
 	}
 
-	public static Object createEntityKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+	public static Object staticCreateEntityKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
 		return new OldCacheKeyImplementation( id, persister.getIdentifierType(), persister.getRootEntityName(), tenantIdentifier, factory );
 	}
 
-	public static Object createNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
+	public static Object staticCreateNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
 		return new OldNaturalIdCacheKey( naturalIdValues,  persister.getPropertyTypes(), persister.getNaturalIdentifierProperties(), persister.getRootEntityName(), session );
 	}
 
-	public static Object getEntityId(Object cacheKey) {
+	public static Object staticGetEntityId(Object cacheKey) {
 		return ((OldCacheKeyImplementation) cacheKey).getId();
 	}
 
-	public static Object getCollectionId(Object cacheKey) {
+	public static Object staticGetCollectionId(Object cacheKey) {
 		return ((OldCacheKeyImplementation) cacheKey).getId();
 	}
 
-	public static Object[] getNaturalIdValues(Object cacheKey) {
+	public static Object[] staticGetNaturalIdValues(Object cacheKey) {
 		return ((OldNaturalIdCacheKey) cacheKey).getNaturalIdValues();
 	}
 
-	public static CacheKeysFactory INSTANCE = new CacheKeysFactory() {
-		@Override
-		public Object createCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-			return DefaultCacheKeysFactory.createCollectionKey(id, persister, factory, tenantIdentifier);
-		}
+	@Override
+	public Object createCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return staticCreateCollectionKey(id, persister, factory, tenantIdentifier);
+	}
 
-		@Override
-		public Object createEntityKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-			return DefaultCacheKeysFactory.createEntityKey(id, persister, factory, tenantIdentifier);
-		}
+	@Override
+	public Object createEntityKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
+		return staticCreateEntityKey(id, persister, factory, tenantIdentifier);
+	}
 
-		@Override
-		public Object createNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-			return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
-		}
+	@Override
+	public Object createNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
+		return staticCreateNaturalIdKey(naturalIdValues, persister, session);
+	}
 
-		@Override
-		public Object getEntityId(Object cacheKey) {
-			return DefaultCacheKeysFactory.getEntityId(cacheKey);
-		}
+	@Override
+	public Object getEntityId(Object cacheKey) {
+		return staticGetEntityId(cacheKey);
+	}
 
-		@Override
-		public Object getCollectionId(Object cacheKey) {
-			return DefaultCacheKeysFactory.getCollectionId(cacheKey);
-		}
+	@Override
+	public Object getCollectionId(Object cacheKey) {
+		return staticGetCollectionId(cacheKey);
+	}
 
-		@Override
-		public Object[] getNaturalIdValues(Object cacheKey) {
-			return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
-		}
-	};
+	@Override
+	public Object[] getNaturalIdValues(Object cacheKey) {
+		return staticGetNaturalIdValues(cacheKey);
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeysFactory.java
@@ -43,27 +43,27 @@ public class DefaultCacheKeysFactory implements CacheKeysFactory {
 	public static final DefaultCacheKeysFactory INSTANCE = new DefaultCacheKeysFactory();
 
 	public static Object staticCreateCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return new OldCacheKeyImplementation( id, persister.getKeyType(), persister.getRole(), tenantIdentifier, factory );
+		return new CacheKeyImplementation( id, persister.getKeyType(), persister.getRole(), tenantIdentifier, factory );
 	}
 
 	public static Object staticCreateEntityKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return new OldCacheKeyImplementation( id, persister.getIdentifierType(), persister.getRootEntityName(), tenantIdentifier, factory );
+		return new CacheKeyImplementation( id, persister.getIdentifierType(), persister.getRootEntityName(), tenantIdentifier, factory );
 	}
 
 	public static Object staticCreateNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return new OldNaturalIdCacheKey( naturalIdValues,  persister.getPropertyTypes(), persister.getNaturalIdentifierProperties(), persister.getRootEntityName(), session );
+		return new NaturalIdCacheKey( naturalIdValues,  persister.getPropertyTypes(), persister.getNaturalIdentifierProperties(), persister.getRootEntityName(), session );
 	}
 
 	public static Object staticGetEntityId(Object cacheKey) {
-		return ((OldCacheKeyImplementation) cacheKey).getId();
+		return ((CacheKeyImplementation) cacheKey).getId();
 	}
 
 	public static Object staticGetCollectionId(Object cacheKey) {
-		return ((OldCacheKeyImplementation) cacheKey).getId();
+		return ((CacheKeyImplementation) cacheKey).getId();
 	}
 
 	public static Object[] staticGetNaturalIdValues(Object cacheKey) {
-		return ((OldNaturalIdCacheKey) cacheKey).getNaturalIdValues();
+		return ((NaturalIdCacheKey) cacheKey).getNaturalIdValues();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NaturalIdCacheKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NaturalIdCacheKey.java
@@ -26,11 +26,8 @@ import org.hibernate.type.Type;
  *
  * @author Eric Dalquist
  * @author Steve Ebersole
- *
- * @deprecated Cache implementation should provide optimized key.
  */
-@Deprecated
-public class OldNaturalIdCacheKey implements Serializable {
+public class NaturalIdCacheKey implements Serializable {
 	private final Serializable[] naturalIdValues;
 	private final String entityName;
 	private final String tenantId;
@@ -45,7 +42,7 @@ public class OldNaturalIdCacheKey implements Serializable {
 	 * @param naturalIdPropertyIndexes
 	 * @param session The originating session
 	 */
-	public OldNaturalIdCacheKey(
+	public NaturalIdCacheKey(
 			final Object[] naturalIdValues,
 			Type[] propertyTypes, int[] naturalIdPropertyIndexes, final String entityName,
 			final SharedSessionContractImplementor session) {
@@ -140,12 +137,12 @@ public class OldNaturalIdCacheKey implements Serializable {
 			return true;
 		}
 
-		if ( hashCode != o.hashCode() || !( o instanceof OldNaturalIdCacheKey ) ) {
+		if ( hashCode != o.hashCode() || !( o instanceof NaturalIdCacheKey) ) {
 			//hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
 			return false;
 		}
 
-		final OldNaturalIdCacheKey other = (OldNaturalIdCacheKey) o;
+		final NaturalIdCacheKey other = (NaturalIdCacheKey) o;
 		return EqualsHelper.equals( entityName, other.entityName )
 				&& EqualsHelper.equals( tenantId, other.tenantId )
 				&& Arrays.deepEquals( this.naturalIdValues, other.naturalIdValues );

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/SimpleCacheKeysFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/SimpleCacheKeysFactory.java
@@ -34,7 +34,7 @@ public class SimpleCacheKeysFactory implements CacheKeysFactory {
 	@Override
 	public Object createNaturalIdKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
 		// natural ids always need to be wrapped
-		return new OldNaturalIdCacheKey(naturalIdValues, persister.getPropertyTypes(), persister.getNaturalIdentifierProperties(), null, session);
+		return new NaturalIdCacheKey(naturalIdValues, persister.getPropertyTypes(), persister.getNaturalIdentifierProperties(), null, session);
 	}
 
 	@Override
@@ -49,6 +49,6 @@ public class SimpleCacheKeysFactory implements CacheKeysFactory {
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return ((OldNaturalIdCacheKey) cacheKey).getNaturalIdValues();
+		return ((NaturalIdCacheKey) cacheKey).getNaturalIdValues();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/SimpleCacheKeysFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/SimpleCacheKeysFactory.java
@@ -18,8 +18,8 @@ import org.hibernate.persister.entity.EntityPersister;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class SimpleCacheKeysFactory implements CacheKeysFactory {
-
-public static CacheKeysFactory INSTANCE = new SimpleCacheKeysFactory();
+	public static final String SHORT_NAME = "simple";
+	public static CacheKeysFactory INSTANCE = new SimpleCacheKeysFactory();
 
 	@Override
 	public Object createCollectionKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -932,6 +932,8 @@ public interface AvailableSettings {
 	 *     <li>an Object implementing {@link org.hibernate.cache.spi.CacheKeysFactory}</li>
 	 *     <li>a Class implementing {@link org.hibernate.cache.spi.CacheKeysFactory}</li>
 	 *     <li>FQN of a Class implementing {@link org.hibernate.cache.spi.CacheKeysFactory}</li>
+	 *     <li>'default' as a short name for {@link org.hibernate.cache.internal.DefaultCacheKeysFactory}</li>
+	 *     <li>'simple' as a short name for {@link org.hibernate.cache.internal.SimpleCacheKeysFactory}</li>
 	 * </ul>
 	 *
 	 * @since 5.2 - note that currently this is only honored for hibernate-infinispan

--- a/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
@@ -61,7 +61,7 @@ public class NaturalIdCacheKeyTest {
             }
         });
 
-        final OldNaturalIdCacheKey key = (OldNaturalIdCacheKey) DefaultCacheKeysFactory.createNaturalIdKey( new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor );
+        final OldNaturalIdCacheKey key = (OldNaturalIdCacheKey) DefaultCacheKeysFactory.staticCreateNaturalIdKey( new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor );
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(baos);

--- a/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cache/spi/NaturalIdCacheKeyTest.java
@@ -12,7 +12,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import org.hibernate.cache.internal.DefaultCacheKeysFactory;
-import org.hibernate.cache.internal.OldNaturalIdCacheKey;
+import org.hibernate.cache.internal.NaturalIdCacheKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.persister.entity.EntityPersister;
@@ -61,14 +61,14 @@ public class NaturalIdCacheKeyTest {
             }
         });
 
-        final OldNaturalIdCacheKey key = (OldNaturalIdCacheKey) DefaultCacheKeysFactory.staticCreateNaturalIdKey( new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor );
+        final NaturalIdCacheKey key = (NaturalIdCacheKey) DefaultCacheKeysFactory.staticCreateNaturalIdKey( new Object[] {"a", "b", "c"}, entityPersister, sessionImplementor );
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(key);
         
         final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        final OldNaturalIdCacheKey keyClone = (OldNaturalIdCacheKey) ois.readObject();
+        final NaturalIdCacheKey keyClone = (NaturalIdCacheKey) ois.readObject();
         
         assertEquals(key, keyClone);
         assertEquals(key.hashCode(), keyClone.hashCode());

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareCollectionRegionAccessStrategy.java
@@ -164,11 +164,11 @@ public class NonstopAwareCollectionRegionAccessStrategy implements CollectionReg
 
 	@Override
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareEntityRegionAccessStrategy.java
@@ -210,11 +210,11 @@ public class NonstopAwareEntityRegionAccessStrategy implements EntityRegionAcces
 
 	@Override
 	public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateEntityKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getEntityId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/nonstop/NonstopAwareNaturalIdRegionAccessStrategy.java
@@ -207,11 +207,11 @@ public class NonstopAwareNaturalIdRegionAccessStrategy implements NaturalIdRegio
 
 	@Override
 	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return DefaultCacheKeysFactory.createNaturalIdKey( naturalIdValues, persister, session );
+		return DefaultCacheKeysFactory.staticCreateNaturalIdKey( naturalIdValues, persister, session );
 	}
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+		return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheCollectionRegionAccessStrategy.java
@@ -86,11 +86,11 @@ public class NonStrictReadWriteEhcacheCollectionRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getCollectionId( cacheKey );
+		return DefaultCacheKeysFactory.staticGetCollectionId( cacheKey );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheEntityRegionAccessStrategy.java
@@ -125,11 +125,11 @@ public class NonStrictReadWriteEhcacheEntityRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateEntityKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getEntityId( cacheKey );
+		return DefaultCacheKeysFactory.staticGetEntityId( cacheKey );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -122,11 +122,11 @@ public class NonStrictReadWriteEhcacheNaturalIdRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+		return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
 	}
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return DefaultCacheKeysFactory.getNaturalIdValues( cacheKey );
+		return DefaultCacheKeysFactory.staticGetNaturalIdValues( cacheKey );
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheCollectionRegionAccessStrategy.java
@@ -75,11 +75,11 @@ public class ReadOnlyEhcacheCollectionRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheEntityRegionAccessStrategy.java
@@ -117,11 +117,11 @@ public class ReadOnlyEhcacheEntityRegionAccessStrategy extends AbstractEhcacheAc
 
 	@Override
 	public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createEntityKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateEntityKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getEntityId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadOnlyEhcacheNaturalIdRegionAccessStrategy.java
@@ -115,11 +115,11 @@ public class ReadOnlyEhcacheNaturalIdRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+		return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
 	}
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+		return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheCollectionRegionAccessStrategy.java
@@ -42,11 +42,11 @@ public class ReadWriteEhcacheCollectionRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheEntityRegionAccessStrategy.java
@@ -124,11 +124,11 @@ public class ReadWriteEhcacheEntityRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createEntityKey(id, persister, factory, tenantIdentifier);
+		return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getEntityId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/ReadWriteEhcacheNaturalIdRegionAccessStrategy.java
@@ -121,11 +121,11 @@ public class ReadWriteEhcacheNaturalIdRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+		return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
 	}
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+		return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheCollectionRegionAccessStrategy.java
@@ -107,11 +107,11 @@ public class TransactionalEhcacheCollectionRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createCollectionKey( id, persister, factory, tenantIdentifier );
+		return DefaultCacheKeysFactory.staticCreateCollectionKey( id, persister, factory, tenantIdentifier );
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetCollectionId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheEntityRegionAccessStrategy.java
@@ -145,11 +145,11 @@ public class TransactionalEhcacheEntityRegionAccessStrategy extends AbstractEhca
 
 	@Override
 	public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory, String tenantIdentifier) {
-		return DefaultCacheKeysFactory.createEntityKey(id, persister, factory, tenantIdentifier);
+		return DefaultCacheKeysFactory.staticCreateEntityKey(id, persister, factory, tenantIdentifier);
 	}
 
 	@Override
 	public Object getCacheKeyId(Object cacheKey) {
-		return DefaultCacheKeysFactory.getEntityId(cacheKey);
+		return DefaultCacheKeysFactory.staticGetEntityId(cacheKey);
 	}
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/strategy/TransactionalEhcacheNaturalIdRegionAccessStrategy.java
@@ -138,11 +138,11 @@ public class TransactionalEhcacheNaturalIdRegionAccessStrategy
 
 	@Override
 	public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor session) {
-		return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+		return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, session);
 	}
 
 	@Override
 	public Object[] getNaturalIdValues(Object cacheKey) {
-		return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+		return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
 	}
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
@@ -478,14 +478,10 @@ public class InfinispanRegionFactory implements RegionFactory {
 	}
 
 	private CacheKeysFactory determineCacheKeysFactory(SessionFactoryOptions settings, Properties properties) {
-		final CacheKeysFactory implicitFactory = settings.getMultiTenancyStrategy() != MultiTenancyStrategy.NONE
-				? DefaultCacheKeysFactory.INSTANCE
-				: SimpleCacheKeysFactory.INSTANCE;
-
 		return settings.getServiceRegistry().getService( StrategySelector.class ).resolveDefaultableStrategy(
 				CacheKeysFactory.class,
 				properties.get( AvailableSettings.CACHE_KEYS_FACTORY ),
-				implicitFactory
+				DefaultCacheKeysFactory.INSTANCE
 		);
 	}
 
@@ -711,8 +707,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 				log.debugf("Region '%s' has additional configuration set through properties.", regionName);
 				builder.read(override.build(false));
 			}
-			// with multi-tenancy the keys will be wrapped
-			if (settings.getMultiTenancyStrategy() == MultiTenancyStrategy.NONE) {
+			if (getCacheKeysFactory() instanceof SimpleCacheKeysFactory) {
 				// the keys may not define hashCode/equals correctly (e.g. arrays)
 				if (metadata != null && metadata.getKeyType() != null) {
 					builder.dataContainer().keyEquivalence(new TypeEquivalance(metadata.getKeyType()));

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/CacheKeysFactoryTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/CacheKeysFactoryTest.java
@@ -1,0 +1,86 @@
+package org.hibernate.test.cache.infinispan;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.internal.SimpleCacheKeysFactory;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.spi.CacheImplementor;
+import org.hibernate.test.cache.infinispan.functional.entities.Name;
+import org.hibernate.test.cache.infinispan.functional.entities.Person;
+import org.hibernate.test.cache.infinispan.util.InfinispanTestingSetup;
+import org.hibernate.test.cache.infinispan.util.TestInfinispanRegionFactory;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.infinispan.Cache;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.hibernate.test.cache.infinispan.util.TxUtil.withTxSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CacheKeysFactoryTest extends BaseUnitTestCase {
+   @Rule
+   public InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+
+   private SessionFactory getSessionFactory(String cacheKeysFactory) {
+      Configuration configuration = new Configuration()
+         .setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
+         .setProperty(Environment.CACHE_REGION_FACTORY, TestInfinispanRegionFactory.class.getName())
+         .setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
+         .setProperty(Environment.JPA_SHARED_CACHE_MODE, "ALL")
+         .setProperty(Environment.HBM2DDL_AUTO, "create-drop");
+      if (cacheKeysFactory != null) {
+         configuration.setProperty(Environment.CACHE_KEYS_FACTORY, cacheKeysFactory);
+      }
+      configuration.addAnnotatedClass(Person.class);
+      return configuration.buildSessionFactory();
+   }
+
+   @Test
+   public void testNotSet() throws Exception {
+      test(null, "OldCacheKeyImplementation");
+   }
+
+   @Test
+   public void testDefault() throws Exception {
+      test(DefaultCacheKeysFactory.SHORT_NAME, "OldCacheKeyImplementation");
+   }
+
+   @Test
+   public void testDefaultClass() throws Exception {
+      test(DefaultCacheKeysFactory.class.getName(), "OldCacheKeyImplementation");
+   }
+
+   @Test
+   public void testSimple() throws Exception {
+      test(SimpleCacheKeysFactory.SHORT_NAME, Name.class.getSimpleName());
+   }
+
+   @Test
+   public void testSimpleClass() throws Exception {
+      test(SimpleCacheKeysFactory.class.getName(), Name.class.getSimpleName());
+   }
+
+   private void test(String cacheKeysFactory, String keyClassName) throws Exception {
+      SessionFactory sessionFactory = getSessionFactory(cacheKeysFactory);
+      withTxSession(false, sessionFactory, s -> {
+         Person person = new Person("John", "Black", 39);
+         s.persist(person);
+      });
+
+      TestInfinispanRegionFactory regionFactory = (TestInfinispanRegionFactory) ((CacheImplementor) sessionFactory.getCache()).getRegionFactory();
+      Cache<Object, Object> cache = regionFactory.getCacheManager().getCache(Person.class.getName());
+      Iterator<Object> iterator = cache.getAdvancedCache().getDataContainer().keySet().iterator();
+      assertTrue(iterator.hasNext());
+      Object key = iterator.next();
+      assertEquals(keyClassName, key.getClass().getSimpleName());
+
+      withTxSession(false, sessionFactory, s -> {
+         Person person = s.load(Person.class, new Name("John", "Black"));
+         assertEquals(39, person.getAge());
+      });
+   }
+}

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/AbstractFunctionalTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/AbstractFunctionalTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cache.internal.SimpleCacheKeysFactory;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.AvailableSettings;
@@ -181,6 +182,7 @@ public abstract class AbstractFunctionalTest extends BaseNonConfigCoreFunctional
 		settings.put( Environment.GENERATE_STATISTICS, "true" );
 		settings.put( Environment.USE_QUERY_CACHE, String.valueOf( getUseQueryCache() ) );
 		settings.put( Environment.CACHE_REGION_FACTORY, getRegionFactoryClass().getName() );
+		settings.put( Environment.CACHE_KEYS_FACTORY, SimpleCacheKeysFactory.SHORT_NAME );
 		settings.put( TestInfinispanRegionFactory.TRANSACTIONAL, useTransactionalCache );
 		settings.put( TestInfinispanRegionFactory.CACHE_MODE, cacheMode);
 

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/entities/Person.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/entities/Person.java
@@ -1,5 +1,6 @@
 package org.hibernate.test.cache.infinispan.functional.entities;
 
+import javax.persistence.Cacheable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -12,6 +13,7 @@ import java.io.Serializable;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 @Entity
+@Cacheable
 public class Person implements Serializable {
     @EmbeddedId
     Name name;


### PR DESCRIPTION
* DefaultCacheKeysFactory implements CacheKeysFactory, therefore it can be used in hibernate.cache.keys_factory
* Use DefaultCacheKeysFactory by default
* Add "default" and "simple" as short names for those factories