### PR TITLE
Modify link of pull requests to a valid URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,5 @@ appreciated btw), please use rebasing rather than merging.  Merging creates
 
 * If you have not already, sign the [Contributor License Agreement](https://cla.jboss.org).
 * Push your changes to the topic branch in your fork of the repository.
-* Initiate a [pull request](http://help.github.com/send-pull-requests/)
+* Initiate a [pull request](http://help.github.com/articles/creating-a-pull-request)
 * Update the JIRA issue, adding a comment including a link to the created pull request


### PR DESCRIPTION
There is a link the Submit section of the file CONTRIBUTING.md that is no longer valid, which is the following:
http://help.github.com/send-pull-requests/

Therfore, I changed the previous link  to this one:
http://help.github.com/articles/creating-a-pull-request
which is the most related one to the topic of how to initiate a pull request.

