### PR TITLE
[5.1] HHH-11254 Timestamps cache fails validation if eviction strategy = MANUAL

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/InfinispanRegionFactory.java
@@ -132,7 +132,7 @@ public class InfinispanRegionFactory implements RegionFactory {
 			if ( c.clustering().cacheMode().isInvalidation() ) {
 				throw log.timestampsMustNotUseInvalidation();
 			}
-			if (c.eviction().strategy() != EvictionStrategy.NONE) {
+			if (c.eviction().strategy().isEnabled()) {
 				throw log.timestampsMustNotUseEviction();
 			}
 		}),


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11254

Backport of PR #1629