### PR TITLE
[5.0] HHH-11254 Timestamps cache fails validation if eviction strategy = MANUAL

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampTypeOverrides.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampTypeOverrides.java
@@ -26,7 +26,7 @@ public class TimestampTypeOverrides extends TypeOverrides {
 			throw new CacheException( "Timestamp cache cannot be configured with invalidation" );
 		}
 		final EvictionStrategy strategy = cfg.eviction().strategy();
-		if ( !strategy.equals( EvictionStrategy.NONE ) ) {
+		if ( strategy.isEnabled() ) {
 			throw new CacheException( "Timestamp cache cannot be configured with eviction" );
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11254

Backport of PR #1629