### PR TITLE
Wrong handling of parameter for TOP clause fixed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/TopLimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/TopLimitHandler.java
@@ -53,9 +53,15 @@ public class TopLimitHandler extends AbstractLimitHandler {
 		final int selectDistinctIndex = sql.toLowerCase(Locale.ROOT).indexOf( "select distinct" );
 		final int insertionPoint = selectIndex + (selectDistinctIndex == selectIndex ? 15 : 6);
 
-		return new StringBuilder( sql.length() + 8 )
-				.append( sql )
-				.insert( insertionPoint, " TOP ? " )
-				.toString();
+		StringBuilder sb = new StringBuilder( sql.length() + 8 )
+				.append( sql );
+		
+		if ( supportsVariableLimit ) {
+			sb.insert( insertionPoint, " TOP ? " );
+		} else {
+			sb.insert( insertionPoint, " TOP " + getMaxOrLimit( selection ) + " " );
+		}
+		
+		return sb.toString();
 	}
 }


### PR DESCRIPTION
I encountered this because the dialect resolver apparently couldn't figure out the dialect for SQL-Server 2016.