### PR TITLE
HHH-11245 - new setting "hibernate.classloader.tccl_lookup"

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TCCLLookupBehavior;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TcclLookupPrecedence;
 import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -40,7 +40,7 @@ public class BootstrapServiceRegistryBuilder {
 	private List<ClassLoader> providedClassLoaders;
 	private ClassLoaderService providedClassLoaderService;
 	private StrategySelectorBuilder strategySelectorBuilder = new StrategySelectorBuilder();
-	private TCCLLookupBehavior tcclLookupBehaviour = TCCLLookupBehavior.AFTER;
+	private TcclLookupPrecedence tcclLookupPrecedence = TcclLookupPrecedence.AFTER;
 
 	private boolean autoCloseRegistry = true;
 
@@ -88,12 +88,12 @@ public class BootstrapServiceRegistryBuilder {
 	}
 
 	/**
-	 * Defines when the lookup in the thread context {@code ClassLoader} is done.
+	 * Defines when the lookup in the thread context {@code ClassLoader} is done
 	 * 
-	 * @param behavior The behavior.
+	 * @param precedence The lookup precedence
 	 */
-	public void applyTCCLBehavior(TCCLLookupBehavior behavior) {
-		tcclLookupBehaviour = behavior;
+	public void applyTcclLookupPrecedence(TcclLookupPrecedence precedence) {
+		tcclLookupPrecedence = precedence;
 	}
 
 	/**
@@ -215,8 +215,7 @@ public class BootstrapServiceRegistryBuilder {
 				classLoaders.addAll( providedClassLoaders );
 			}
 			
-			classLoaderService = new ClassLoaderServiceImpl( classLoaders );
-			classLoaderService.setTCCLLookupBehavior( tcclLookupBehaviour );
+			classLoaderService = new ClassLoaderServiceImpl( classLoaders,tcclLookupPrecedence );
 		}
 		else {
 			classLoaderService = providedClassLoaderService;

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TcclLookupPrecedence;
 import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/BootstrapServiceRegistryBuilder.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TCCLLookupBehavior;
 import org.hibernate.boot.registry.internal.BootstrapServiceRegistryImpl;
 import org.hibernate.boot.registry.selector.StrategyRegistration;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
@@ -39,6 +40,7 @@ public class BootstrapServiceRegistryBuilder {
 	private List<ClassLoader> providedClassLoaders;
 	private ClassLoaderService providedClassLoaderService;
 	private StrategySelectorBuilder strategySelectorBuilder = new StrategySelectorBuilder();
+	private TCCLLookupBehavior tcclLookupBehaviour = TCCLLookupBehavior.AFTER;
 
 	private boolean autoCloseRegistry = true;
 
@@ -83,6 +85,15 @@ public class BootstrapServiceRegistryBuilder {
 		}
 		providedClassLoaders.add( classLoader );
 		return this;
+	}
+
+	/**
+	 * Defines when the lookup in the thread context {@code ClassLoader} is done.
+	 * 
+	 * @param behavior The behavior.
+	 */
+	public void applyTCCLBehavior(TCCLLookupBehavior behavior) {
+		tcclLookupBehaviour = behavior;
 	}
 
 	/**
@@ -205,6 +216,7 @@ public class BootstrapServiceRegistryBuilder {
 			}
 			
 			classLoaderService = new ClassLoaderServiceImpl( classLoaders );
+			classLoaderService.setTCCLLookupBehavior( tcclLookupBehaviour );
 		}
 		else {
 			classLoaderService = providedClassLoaderService;
@@ -214,7 +226,6 @@ public class BootstrapServiceRegistryBuilder {
 				providedIntegrators,
 				classLoaderService
 		);
-
 
 		return new BootstrapServiceRegistryImpl(
 				autoCloseRegistry,

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/TcclLookupPrecedence.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/TcclLookupPrecedence.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+/**
+ * Defines when the lookup in the current thread context {@link ClassLoader} should be
+ * done according to the other ones.
+ * 
+ * @author Cédric Tabin
+ */
+public enum TcclLookupPrecedence {
+	/**
+	 * The current thread context {@link ClassLoader} will never be used during
+	 * the class lookup.
+	 */
+	NEVER,
+
+	/**
+	 * The class lookup will be done in the thread context {@link ClassLoader} prior
+	 * to the other {@code ClassLoader}s.
+	 */
+	BEFORE,
+
+	/**
+	 * The class lookup will be done in the thread context {@link ClassLoader} if
+	 * the former hasn't been found in the other {@code ClassLoader}s.
+	 * This is the default value.
+	 */
+	AFTER
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
@@ -80,4 +80,33 @@ public interface ClassLoaderService extends Service, Stoppable {
 	}
 
 	<T> T workWithClassLoader(Work<T> work);
+        
+	/**
+	 * Defines of the lookup in the current thread context {@link ClassLoader} should be
+	 * used.
+	 */
+	enum TCCLLookupBehavior {
+    
+		/**
+		 * The current thread context {@link ClassLoader} will never be used during
+		 * the class lookup.
+		 */
+		NEVER,
+
+		/**
+		 * The class lookup will be done in the thread context {@link ClassLoader} prior
+		 * to the other {@code ClassLoader}s.
+		 */
+		BEFORE,
+            
+		/**
+		 * The class lookup will be done in the thread context {@link ClassLoader} if
+		 * the former hasn't been found in the other {@code ClassLoader}s.
+		 * This is the default value.
+		 */
+		AFTER
+	}
+        
+	TCCLLookupBehavior getTTCLLookupBehavior();
+	void setTCCLLookupBehavior(TCCLLookupBehavior behavior);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
@@ -80,30 +80,4 @@ public interface ClassLoaderService extends Service, Stoppable {
 	}
 
 	<T> T workWithClassLoader(Work<T> work);
-        
-	/**
-	 * Defines when the lookup in the current thread context {@link ClassLoader} should be
-	 * done according to the other ones.
-	 */
-	enum TcclLookupPrecedence {
-    
-		/**
-		 * The current thread context {@link ClassLoader} will never be used during
-		 * the class lookup.
-		 */
-		NEVER,
-
-		/**
-		 * The class lookup will be done in the thread context {@link ClassLoader} prior
-		 * to the other {@code ClassLoader}s.
-		 */
-		BEFORE,
-            
-		/**
-		 * The class lookup will be done in the thread context {@link ClassLoader} if
-		 * the former hasn't been found in the other {@code ClassLoader}s.
-		 * This is the default value.
-		 */
-		AFTER
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
@@ -82,10 +82,10 @@ public interface ClassLoaderService extends Service, Stoppable {
 	<T> T workWithClassLoader(Work<T> work);
         
 	/**
-	 * Defines of the lookup in the current thread context {@link ClassLoader} should be
-	 * used.
+	 * Defines when the lookup in the current thread context {@link ClassLoader} should be
+	 * done according to the other ones.
 	 */
-	enum TCCLLookupBehavior {
+	enum TcclLookupPrecedence {
     
 		/**
 		 * The current thread context {@link ClassLoader} will never be used during
@@ -106,7 +106,4 @@ public interface ClassLoaderService extends Service, Stoppable {
 		 */
 		AFTER
 	}
-        
-	TCCLLookupBehavior getTTCLLookupBehavior();
-	void setTCCLLookupBehavior(TCCLLookupBehavior behavior);
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -197,7 +197,7 @@ public interface AvailableSettings {
 	 * 
 	 * @see ClassLoaderService#TCCLLookupBehavior
 	 */
-	String TC_CLASSLOADER = "hibernate.classloader.tccl_lookup";
+	String TC_CLASSLOADER = "hibernate.classloader.tccl_lookup_precedence";
         
 	/**
 	 * Names the {@link ClassLoader} used to load user application classes.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -7,7 +7,7 @@
 package org.hibernate.cfg;
 
 import org.hibernate.boot.MetadataBuilder;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.query.internal.ParameterMetadataImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
@@ -195,9 +195,9 @@ public interface AvailableSettings {
 	 * Used to define how the current thread context {@link ClassLoader} must be used
 	 * for class lookup.
 	 * 
-	 * @see ClassLoaderService#TCCLLookupBehavior
+	 * @see TcclLookupPrecedence
 	 */
-	String TC_CLASSLOADER = "hibernate.classloader.tccl_lookup_precedence";
+	String TC_CLASSLOADER = "hibernate.classLoader.tccl_lookup_precedence";
         
 	/**
 	 * Names the {@link ClassLoader} used to load user application classes.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -7,6 +7,7 @@
 package org.hibernate.cfg;
 
 import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.query.internal.ParameterMetadataImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
@@ -190,6 +191,14 @@ public interface AvailableSettings {
 	 */
 	String CLASSLOADERS = "hibernate.classLoaders";
 
+	/**
+	 * Used to define how the current thread context {@link ClassLoader} must be used
+	 * for class lookup.
+	 * 
+	 * @see ClassLoaderService#TCCLLookupBehavior
+	 */
+	String TC_CLASSLOADER = "hibernate.classloader.tccl_lookup";
+        
 	/**
 	 * Names the {@link ClassLoader} used to load user application classes.
 	 * @since 4.0

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -23,8 +23,6 @@ import javax.persistence.PersistenceException;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 import javax.sql.DataSource;
 
-import javassist.CtClass;
-import javassist.CtField;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
@@ -44,8 +42,8 @@ import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TcclLookupPrecedence;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -396,7 +397,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 			if( puProperties != null ) {
 				final String tcclLookupPrecedence = puProperties.getProperty( org.hibernate.cfg.AvailableSettings.TC_CLASSLOADER );
 				if( tcclLookupPrecedence != null ) {
-					bsrBuilder.applyTcclLookupPrecedence( TcclLookupPrecedence.valueOf( tcclLookupPrecedence.toUpperCase() ) );
+					bsrBuilder.applyTcclLookupPrecedence( TcclLookupPrecedence.valueOf( tcclLookupPrecedence.toUpperCase( Locale.ROOT ) ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.persistence.AttributeConverter;
@@ -44,6 +45,7 @@ import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TCCLLookupBehavior;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;
@@ -388,6 +390,15 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 				}
 				else if ( ClassLoader.class.isInstance( classLoadersSetting ) ) {
 					bsrBuilder.applyClassLoader( (ClassLoader) classLoadersSetting );
+				}
+			}
+                        
+			//configurationValues not assigned yet, using directly the properties of the PU
+			Properties puProperties = persistenceUnit.getProperties();
+			if( puProperties != null ) {
+				final String tcclBehavior = puProperties.getProperty( org.hibernate.cfg.AvailableSettings.TC_CLASSLOADER );
+				if( tcclBehavior != null ) {
+					bsrBuilder.applyTCCLBehavior( TCCLLookupBehavior.valueOf( tcclBehavior.toUpperCase() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -45,7 +45,7 @@ import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TCCLLookupBehavior;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService.TcclLookupPrecedence;
 import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.boot.spi.MetadataBuilderImplementor;
@@ -396,9 +396,9 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 			//configurationValues not assigned yet, using directly the properties of the PU
 			Properties puProperties = persistenceUnit.getProperties();
 			if( puProperties != null ) {
-				final String tcclBehavior = puProperties.getProperty( org.hibernate.cfg.AvailableSettings.TC_CLASSLOADER );
-				if( tcclBehavior != null ) {
-					bsrBuilder.applyTCCLBehavior( TCCLLookupBehavior.valueOf( tcclBehavior.toUpperCase() ) );
+				final String tcclLookupPrecedence = puProperties.getProperty( org.hibernate.cfg.AvailableSettings.TC_CLASSLOADER );
+				if( tcclLookupPrecedence != null ) {
+					bsrBuilder.applyTcclLookupPrecedence( TcclLookupPrecedence.valueOf( tcclLookupPrecedence.toUpperCase() ) );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
@@ -12,29 +12,27 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author Cedric Tabin
+ * @author Cédric Tabin
  */
 public class ClassLoaderServiceImplTest {
     @Test
     public void testNullTCCL() {
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
 	Thread.currentThread().setContextClassLoader(null);
 	
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE);
-	Class<ClassLoaderServiceImplTest> clazz1 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	ClassLoaderServiceImpl csi1 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
+	Class<ClassLoaderServiceImplTest> clazz1 = csi1.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz1);
+	csi1.stop();
 	
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
-	Class<ClassLoaderServiceImplTest> clazz2 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	ClassLoaderServiceImpl csi2 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
+	Class<ClassLoaderServiceImplTest> clazz2 = csi2.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz2);
+	csi2.stop();
 	
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.NEVER);
-	Class<ClassLoaderServiceImplTest> clazz3 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	ClassLoaderServiceImpl csi3 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.NEVER);
+	Class<ClassLoaderServiceImplTest> clazz3 = csi3.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz3);
-	
-	csi.stop();
-	try { csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE); assertTrue(false); } catch (Exception e) { }
-	try { csi.getTTCLLookupBehavior(); assertTrue(false); } catch (Exception e) { }
+	csi3.stop();
     }
     
     @Test
@@ -42,11 +40,11 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
 	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz);
 	assertEquals(1, icl.accessCount);
+	csi.stop();
     }
     
     @Test
@@ -54,11 +52,11 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
 	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz);
 	assertEquals(0, icl.accessCount);
+	csi.stop();
     }
     
     @Test
@@ -66,11 +64,11 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
 	try { csi.classForName("test.class.name"); assertTrue(false); }
 	catch (Exception e) {}
 	assertEquals(1, icl.accessCount);
+	csi.stop();
     }
     
     @Test
@@ -78,11 +76,11 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
 	try { csi.classForName("test.class.not.found"); assertTrue(false); }
 	catch (Exception e) { }
 	assertEquals(1, icl.accessCount);
+	csi.stop();
     }
     
     @Test
@@ -90,15 +88,11 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
-	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.NEVER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.NEVER);
 	try { csi.classForName("test.class.name"); assertTrue(false); }
 	catch (Exception e) { }
 	assertEquals(0, icl.accessCount);
-	
 	csi.stop();
-	try { csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE); assertTrue(false); } catch (Exception e) { }
-	try { csi.getTTCLLookupBehavior(); assertTrue(false); } catch (Exception e) { }
     }
     
     private static class InternalClassLoader extends ClassLoader {

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+import java.net.URL;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Cedric Tabin
+ */
+public class ClassLoaderServiceImplTest {
+    @Test
+    public void testNullTCCL() {
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	Thread.currentThread().setContextClassLoader(null);
+	
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE);
+	Class<ClassLoaderServiceImplTest> clazz1 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	assertEquals(ClassLoaderServiceImplTest.class, clazz1);
+	
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	Class<ClassLoaderServiceImplTest> clazz2 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	assertEquals(ClassLoaderServiceImplTest.class, clazz2);
+	
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.NEVER);
+	Class<ClassLoaderServiceImplTest> clazz3 = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	assertEquals(ClassLoaderServiceImplTest.class, clazz3);
+	
+	csi.stop();
+	try { csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE); assertTrue(false); } catch (Exception e) { }
+	try { csi.getTTCLLookupBehavior(); assertTrue(false); } catch (Exception e) { }
+    }
+    
+    @Test
+    public void testLookupBefore() {
+	InternalClassLoader icl = new InternalClassLoader();
+	Thread.currentThread().setContextClassLoader(icl);
+	
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE);
+	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	assertEquals(ClassLoaderServiceImplTest.class, clazz);
+	assertEquals(1, icl.accessCount);
+    }
+    
+    @Test
+    public void testLookupAfterAvoided() {
+	InternalClassLoader icl = new InternalClassLoader();
+	Thread.currentThread().setContextClassLoader(icl);
+	
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
+	assertEquals(ClassLoaderServiceImplTest.class, clazz);
+	assertEquals(0, icl.accessCount);
+    }
+    
+    @Test
+    public void testLookupAfter() {
+	InternalClassLoader icl = new InternalClassLoader();
+	Thread.currentThread().setContextClassLoader(icl);
+	
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	try { csi.classForName("test.class.name"); assertTrue(false); }
+	catch (Exception e) {}
+	assertEquals(1, icl.accessCount);
+    }
+    
+    @Test
+    public void testLookupAfterNotFound() {
+	InternalClassLoader icl = new InternalClassLoader();
+	Thread.currentThread().setContextClassLoader(icl);
+	
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.AFTER);
+	try { csi.classForName("test.class.not.found"); assertTrue(false); }
+	catch (Exception e) { }
+	assertEquals(1, icl.accessCount);
+    }
+    
+    @Test
+    public void testLookupNever() {
+	InternalClassLoader icl = new InternalClassLoader();
+	Thread.currentThread().setContextClassLoader(icl);
+	
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl();
+	csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.NEVER);
+	try { csi.classForName("test.class.name"); assertTrue(false); }
+	catch (Exception e) { }
+	assertEquals(0, icl.accessCount);
+	
+	csi.stop();
+	try { csi.setTCCLLookupBehavior(ClassLoaderService.TCCLLookupBehavior.BEFORE); assertTrue(false); } catch (Exception e) { }
+	try { csi.getTTCLLookupBehavior(); assertTrue(false); } catch (Exception e) { }
+    }
+    
+    private static class InternalClassLoader extends ClassLoader {
+	private int accessCount = 0;
+	
+	public InternalClassLoader() { super(null); }
+
+	@Override
+	public Class<?> loadClass(String name) throws ClassNotFoundException {
+	    ++accessCount;
+	    return super.loadClass(name);
+	}
+
+	@Override
+	protected URL findResource(String name) {
+	    ++accessCount;
+	    return super.findResource(name);
+	}
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImplTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.boot.registry.classloading.internal;
 
 import java.net.URL;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -19,17 +18,17 @@ public class ClassLoaderServiceImplTest {
     public void testNullTCCL() {
 	Thread.currentThread().setContextClassLoader(null);
 	
-	ClassLoaderServiceImpl csi1 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
+	ClassLoaderServiceImpl csi1 = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.BEFORE);
 	Class<ClassLoaderServiceImplTest> clazz1 = csi1.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz1);
 	csi1.stop();
 	
-	ClassLoaderServiceImpl csi2 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
+	ClassLoaderServiceImpl csi2 = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.AFTER);
 	Class<ClassLoaderServiceImplTest> clazz2 = csi2.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz2);
 	csi2.stop();
 	
-	ClassLoaderServiceImpl csi3 = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.NEVER);
+	ClassLoaderServiceImpl csi3 = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.NEVER);
 	Class<ClassLoaderServiceImplTest> clazz3 = csi3.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz3);
 	csi3.stop();
@@ -40,7 +39,7 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.BEFORE);
 	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz);
 	assertEquals(1, icl.accessCount);
@@ -52,7 +51,7 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.AFTER);
 	Class<ClassLoaderServiceImplTest> clazz = csi.classForName(ClassLoaderServiceImplTest.class.getName());
 	assertEquals(ClassLoaderServiceImplTest.class, clazz);
 	assertEquals(0, icl.accessCount);
@@ -64,7 +63,7 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.AFTER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.AFTER);
 	try { csi.classForName("test.class.name"); assertTrue(false); }
 	catch (Exception e) {}
 	assertEquals(1, icl.accessCount);
@@ -76,7 +75,7 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.BEFORE);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.BEFORE);
 	try { csi.classForName("test.class.not.found"); assertTrue(false); }
 	catch (Exception e) { }
 	assertEquals(1, icl.accessCount);
@@ -88,7 +87,7 @@ public class ClassLoaderServiceImplTest {
 	InternalClassLoader icl = new InternalClassLoader();
 	Thread.currentThread().setContextClassLoader(icl);
 	
-	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,ClassLoaderService.TcclLookupPrecedence.NEVER);
+	ClassLoaderServiceImpl csi = new ClassLoaderServiceImpl(null,TcclLookupPrecedence.NEVER);
 	try { csi.classForName("test.class.name"); assertTrue(false); }
 	catch (Exception e) { }
 	assertEquals(0, icl.accessCount);


### PR DESCRIPTION
New setting "hibernate.classloader.tccl_lookup" to allow the configuration of the thread context classloader lookup.

The bootstrap classloader context is not stored anymore in the ClassLoaderService because on Glassfish 4.1.1, the former will be closed after bootstrap, causing huge warning and stacktraces occurs in the log each time a HQL query has to be compiled. Looking at the source code of the [ASURLClassLoader](http://grepcode.com/file/repo1.maven.org/maven2/org.glassfish.common/common-util/3.1.1/com/sun/enterprise/loader/ASURLClassLoader.java#ASURLClassLoader.findClassData%28java.lang.String%29), this has also some performance impact if there are many HQL queries to compile.

See ticket HHH-11245 for details.