### PR TITLE
Fix for HHH-11280 - Proxy Narrowing breaks polymorphic query

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -684,6 +684,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 			// Otherwise, create the narrowed proxy
 			final HibernateProxy narrowedProxy = (HibernateProxy) persister.createProxy( key.getIdentifier(), session );
+			this.addProxy(key, narrowedProxy);
 
 			// set the read-only/modifiable mode in the new proxy to what it was in the original proxy
 			final boolean readOnlyOrig = originalHibernateProxy.getHibernateLazyInitializer().isReadOnly();

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -684,16 +684,16 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			// Otherwise, create the narrowed proxy
 			final HibernateProxy narrowedProxy = (HibernateProxy) persister.createProxy( key.getIdentifier(), session );
 			
-            final Object proxyOrig = proxiesByKey.put(key, narrowedProxy); //overwrite old proxy
-            if ( proxyOrig != null ) {
-                if ( ! ( proxyOrig instanceof HibernateProxy ) ) {
-                    throw new AssertionFailure(
-                            "proxy not of type HibernateProxy; it is " + proxyOrig.getClass()
-                    );
-                }
-                originalHibernateProxy = (HibernateProxy)proxyOrig;
-            }
-            
+			final Object proxyOrig = proxiesByKey.put(key, narrowedProxy); //overwrite old proxy
+			if ( proxyOrig != null ) {
+				if ( ! ( proxyOrig instanceof HibernateProxy ) ) {
+					throw new AssertionFailure(
+							"proxy not of type HibernateProxy; it is " + proxyOrig.getClass()
+					);
+				}
+				originalHibernateProxy = (HibernateProxy)proxyOrig;
+			}
+			
 			// set the read-only/modifiable mode in the new proxy to what it was in the original proxy
 			final boolean readOnlyOrig = originalHibernateProxy.getHibernateLazyInitializer().isReadOnly();
 			narrowedProxy.getHibernateLazyInitializer().setReadOnly( readOnlyOrig );

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUser.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUser.java
@@ -3,36 +3,31 @@ package org.hibernate.test.proxy.narrow;
 /**
  * @author jlandin
  */
-public class AdvancedUser 
-  extends User
-{
-  
-  private AdvancedUserDetail currentDetail;
+public class AdvancedUser extends User {
 
-  /**
-   * Constructs a new AdvancedUser.
-   */
-  public AdvancedUser()
-  {
-    super();
-  }
+	private AdvancedUserDetail currentDetail;
 
-  /**
-   * Retrieves the value of the currentDetail property.
-   * @return The value of the currentDetail property.
-   */
-  public AdvancedUserDetail getCurrentDetail()
-  {
-    return currentDetail;
-  }
+	/**
+	 * Constructs a new AdvancedUser.
+	 */
+	public AdvancedUser() {
+		super();
+	}
 
-  /**
-   * Sets the value of the currentDetail property. 
-   * @param currentDetail The value to set for the property currentDetail.
-   */
-  public void setCurrentDetail(AdvancedUserDetail currentDetail)
-  {
-    this.currentDetail = currentDetail;
-  }
+	/**
+	 * Retrieves the value of the currentDetail property.
+	 * @return The value of the currentDetail property.
+	 */
+	public AdvancedUserDetail getCurrentDetail() {
+		return currentDetail;
+	}
+
+	/**
+	 * Sets the value of the currentDetail property.
+	 * @param currentDetail The value to set for the property currentDetail.
+	 */
+	public void setCurrentDetail(AdvancedUserDetail currentDetail) {
+		this.currentDetail = currentDetail;
+	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUser.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUser.java
@@ -1,0 +1,38 @@
+package org.hibernate.test.proxy.narrow;
+
+/**
+ * @author jlandin
+ */
+public class AdvancedUser 
+  extends User
+{
+  
+  private AdvancedUserDetail currentDetail;
+
+  /**
+   * Constructs a new AdvancedUser.
+   */
+  public AdvancedUser()
+  {
+    super();
+  }
+
+  /**
+   * Retrieves the value of the currentDetail property.
+   * @return The value of the currentDetail property.
+   */
+  public AdvancedUserDetail getCurrentDetail()
+  {
+    return currentDetail;
+  }
+
+  /**
+   * Sets the value of the currentDetail property. 
+   * @param currentDetail The value to set for the property currentDetail.
+   */
+  public void setCurrentDetail(AdvancedUserDetail currentDetail)
+  {
+    this.currentDetail = currentDetail;
+  }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUserDetail.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUserDetail.java
@@ -1,0 +1,74 @@
+package org.hibernate.test.proxy.narrow;
+
+/**
+ * @author jlandin
+ */
+public class AdvancedUserDetail
+{
+  private Long id;
+  private AdvancedUser advancedUser;
+  private String statusCode;
+  
+  /**
+   * Constructs a new AdvancedUserDetail.
+   */
+  public AdvancedUserDetail()
+  {
+    super();
+  }
+
+  /**
+   * Retrieves the value of the advancedUser property.
+   * @return The value of the advancedUser property.
+   */
+  public AdvancedUser getAdvancedUser()
+  {
+    return advancedUser;
+  }
+
+  /**
+   * Sets the value of the advancedUser property. 
+   * @param advancedUser The value to set for the property advancedUser.
+   */
+  public void setAdvancedUser(AdvancedUser advancedUser)
+  {
+    this.advancedUser = advancedUser;
+  }
+
+  /**
+   * Retrieves the value of the statusCode property.
+   * @return The value of the statusCode property.
+   */
+  public String getStatusCode()
+  {
+    return statusCode;
+  }
+
+  /**
+   * Sets the value of the statusCode property. 
+   * @param statusCode The value to set for the property statusCode.
+   */
+  public void setStatusCode(String statusCode)
+  {
+    this.statusCode = statusCode;
+  }
+
+  /**
+   * Retrieves the value of the id property.
+   * @return The value of the id property.
+   */
+  public Long getId()
+  {
+    return id;
+  }
+
+  /**
+   * Sets the value of the id property. 
+   * @param id The value to set for the property id.
+   */
+  public void setId(Long id)
+  {
+    this.id = id;
+  }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUserDetail.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/AdvancedUserDetail.java
@@ -3,72 +3,64 @@ package org.hibernate.test.proxy.narrow;
 /**
  * @author jlandin
  */
-public class AdvancedUserDetail
-{
-  private Long id;
-  private AdvancedUser advancedUser;
-  private String statusCode;
-  
-  /**
-   * Constructs a new AdvancedUserDetail.
-   */
-  public AdvancedUserDetail()
-  {
-    super();
-  }
+public class AdvancedUserDetail {
+	private Long id;
+	private AdvancedUser advancedUser;
+	private String statusCode;
 
-  /**
-   * Retrieves the value of the advancedUser property.
-   * @return The value of the advancedUser property.
-   */
-  public AdvancedUser getAdvancedUser()
-  {
-    return advancedUser;
-  }
+	/**
+	 * Constructs a new AdvancedUserDetail.
+	 */
+	public AdvancedUserDetail() {
+		super();
+	}
 
-  /**
-   * Sets the value of the advancedUser property. 
-   * @param advancedUser The value to set for the property advancedUser.
-   */
-  public void setAdvancedUser(AdvancedUser advancedUser)
-  {
-    this.advancedUser = advancedUser;
-  }
+	/**
+	 * Retrieves the value of the advancedUser property.
+	 * @return The value of the advancedUser property.
+	 */
+	public AdvancedUser getAdvancedUser() {
+		return advancedUser;
+	}
 
-  /**
-   * Retrieves the value of the statusCode property.
-   * @return The value of the statusCode property.
-   */
-  public String getStatusCode()
-  {
-    return statusCode;
-  }
+	/**
+	 * Sets the value of the advancedUser property.
+	 * @param advancedUser The value to set for the property advancedUser.
+	 */
+	public void setAdvancedUser(AdvancedUser advancedUser) {
+		this.advancedUser = advancedUser;
+	}
 
-  /**
-   * Sets the value of the statusCode property. 
-   * @param statusCode The value to set for the property statusCode.
-   */
-  public void setStatusCode(String statusCode)
-  {
-    this.statusCode = statusCode;
-  }
+	/**
+	 * Retrieves the value of the statusCode property.
+	 * @return The value of the statusCode property.
+	 */
+	public String getStatusCode() {
+		return statusCode;
+	}
 
-  /**
-   * Retrieves the value of the id property.
-   * @return The value of the id property.
-   */
-  public Long getId()
-  {
-    return id;
-  }
+	/**
+	 * Sets the value of the statusCode property.
+	 * @param statusCode The value to set for the property statusCode.
+	 */
+	public void setStatusCode(String statusCode) {
+		this.statusCode = statusCode;
+	}
 
-  /**
-   * Sets the value of the id property. 
-   * @param id The value to set for the property id.
-   */
-  public void setId(Long id)
-  {
-    this.id = id;
-  }
+	/**
+	 * Retrieves the value of the id property.
+	 * @return The value of the id property.
+	 */
+	public Long getId() {
+		return id;
+	}
+
+	/**
+	 * Sets the value of the id property.
+	 * @param id The value to set for the property id.
+	 */
+	public void setId(Long id) {
+		this.id = id;
+	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/Models.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/Models.hbm.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE hibernate-mapping PUBLIC 
+    "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.test.proxy.narrow" auto-import="true">
+
+  <class name="User" table="m_user" discriminator-value="not null" lazy="true" dynamic-update="true" polymorphism="implicit">
+    <id name="id" type="java.lang.Long" column="userId"/>
+    <discriminator column="type" type="java.lang.Integer" not-null="true"/>
+    <property name="type" type="java.lang.Integer" column="type" not-null="true" insert="false" update="false"/>
+  </class>
+ 
+  <subclass name="AdvancedUser" discriminator-value="106" extends="User">
+    <one-to-one name="currentDetail" outer-join="false" foreign-key="userId" property-ref="userIdAndStatus" lazy="proxy" cascade="all">
+     <formula>userId</formula>
+     <formula>'A'</formula>
+    </one-to-one>
+  </subclass>
+ 
+  <class name="UserConfig" table="m_userConfig" lazy="true">
+    <id name="id" type="java.lang.Long" column="userConfigId"/>
+    <many-to-one name="user" foreign-key="userId" column="userId" insert="true" update="false" />
+  </class>
+ 
+  <class name="AdvancedUserDetail" table="m_advancedUserDetail" lazy="true">
+    <id name="id" type="java.lang.Long" column="advancedUserDetailId"/>
+    <properties name="userIdAndStatus">
+      <many-to-one name="advancedUser" column="userId" insert="true" update="false" not-null="false"/>
+      <property name="statusCode" column="status" type="java.lang.String"/>
+    </properties>
+  </class>
+ 
+</hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/ProxyNarrowingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/ProxyNarrowingTest.java
@@ -6,18 +6,28 @@
  */
 package org.hibernate.test.proxy.narrow;
 
+import java.util.List;
+
+import junit.framework.Assert;
+
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.Version;
+import org.hibernate.test.proxy.narrow.AdvancedUser;
+import org.hibernate.test.proxy.narrow.AdvancedUserDetail;
+import org.hibernate.test.proxy.narrow.User;
+import org.hibernate.test.proxy.narrow.UserConfig;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.proxy.HibernateProxy;
-
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Yoann Rodière
+ * @author Yoann Rodi��re
  * @author Guillaume Smet
  */
 public class ProxyNarrowingTest extends BaseCoreFunctionalTestCase {
@@ -26,6 +36,16 @@ public class ProxyNarrowingTest extends BaseCoreFunctionalTestCase {
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { AbstractEntity.class, ConcreteEntity.class, LazyAbstractEntityReference.class };
 	}
+	
+	@Override
+	protected String[] getMappings() {
+		return new String[] { "Models.hbm.xml", };
+	}
+
+	@Override
+	protected String getBaseForMappings() {
+		return "org/hibernate/test/proxy/narrow/";
+	}	
 
 	@Test
 	public void testNarrowedProxyIsInitializedIfOriginalProxyIsInitialized() {
@@ -84,4 +104,55 @@ public class ProxyNarrowingTest extends BaseCoreFunctionalTestCase {
 		}
 	}
 
+	@Test
+	public void testHHH11280() {
+		Session s = openSession();
+		try {
+			// Populate the database
+			{
+				s.beginTransaction();
+				UserConfig config = new UserConfig();
+				AdvancedUserDetail detail = new AdvancedUserDetail();
+				AdvancedUser advUser = new AdvancedUser();
+				detail.setId(9L);
+				detail.setStatusCode("A");
+				detail.setAdvancedUser(advUser);
+				advUser.setId(11L);
+				advUser.setType(106);
+				advUser.setCurrentDetail(detail);
+				config.setId(10L);
+				config.setUser(advUser);
+				s.persist(advUser);
+				s.persist(detail);
+				s.persist(config);
+				s.flush();
+				s.getTransaction().commit();
+			}
+
+			// Get on with the test.
+			s = openSession();
+			DetachedCriteria configCriteria = DetachedCriteria.forClass(UserConfig.class);
+			configCriteria.add(Restrictions.eq("id", new Long(10)));
+			final List<UserConfig> configRows = configCriteria.getExecutableCriteria(s).list();
+			UserConfig config = configRows.get(0);
+			User configUser = config.getUser();
+			Assert.assertNotNull(configUser);
+	
+			try {
+				DetachedCriteria userCriteria = DetachedCriteria.forClass(User.class);
+				userCriteria.add(Restrictions.eq("id", new Long(11)));
+				final List<User> userRows = userCriteria.getExecutableCriteria(s).list();
+				User user = userRows.get(0);
+				Assert.assertEquals(106, user.getType().intValue());
+				AdvancedUser advancedUser = (AdvancedUser)user;
+				Assert.assertNotNull(advancedUser);
+			}
+			catch(ClassCastException e) {
+				Assert.fail(String.format("The User proxy is not an AdvancedUser instance but should be (HHH-11280). Hibernate version detected as '%s'. %s", Version.getVersionString(), e.getMessage()));
+			}
+		}
+		finally {
+			s.close();
+		}
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/User.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/User.java
@@ -1,56 +1,49 @@
 package org.hibernate.test.proxy.narrow;
 
-
 /**
  * @author jlandin
  */
-public class User
-{
-  private Long id;
-  private Integer type;
-  
-  /**
-   * Constructs a new User.
-   */
-  public User()
-  {
-    super();
-  }
+public class User {
+	private Long id;
+	private Integer type;
 
-  /**
-   * Retrieves the value of the id property.
-   * @return The value of the id property.
-   */
-  public Long getId()
-  {
-    return this.id;
-  }
+	/**
+	 * Constructs a new User.
+	 */
+	public User() {
+		super();
+	}
 
-  /**
-   * Sets the value of the id property. 
-   * @param id The value to set for the property id.
-   */
-  public void setId(Long id)
-  {
-    this.id = id;
-  }
+	/**
+	 * Retrieves the value of the id property.
+	 * @return The value of the id property.
+	 */
+	public Long getId() {
+		return this.id;
+	}
 
-  /**
-   * Retrieves the value of the type property.
-   * @return The value of the type property.
-   */
-  public Integer getType()
-  {
-    return this.type;
-  }
+	/**
+	 * Sets the value of the id property.
+	 * @param id The value to set for the property id.
+	 */
+	public void setId(Long id) {
+		this.id = id;
+	}
 
-  /**
-   * Sets the value of the type property. 
-   * @param type The value to set for the property type.
-   */
-  public void setType(Integer type)
-  {
-    this.type = type;
-  }
+	/**
+	 * Retrieves the value of the type property.
+	 * @return The value of the type property.
+	 */
+	public Integer getType() {
+		return this.type;
+	}
+
+	/**
+	 * Sets the value of the type property.
+	 * @param type The value to set for the property type.
+	 */
+	public void setType(Integer type) {
+		this.type = type;
+	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/User.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/User.java
@@ -1,0 +1,56 @@
+package org.hibernate.test.proxy.narrow;
+
+
+/**
+ * @author jlandin
+ */
+public class User
+{
+  private Long id;
+  private Integer type;
+  
+  /**
+   * Constructs a new User.
+   */
+  public User()
+  {
+    super();
+  }
+
+  /**
+   * Retrieves the value of the id property.
+   * @return The value of the id property.
+   */
+  public Long getId()
+  {
+    return this.id;
+  }
+
+  /**
+   * Sets the value of the id property. 
+   * @param id The value to set for the property id.
+   */
+  public void setId(Long id)
+  {
+    this.id = id;
+  }
+
+  /**
+   * Retrieves the value of the type property.
+   * @return The value of the type property.
+   */
+  public Integer getType()
+  {
+    return this.type;
+  }
+
+  /**
+   * Sets the value of the type property. 
+   * @param type The value to set for the property type.
+   */
+  public void setType(Integer type)
+  {
+    this.type = type;
+  }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/UserConfig.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/UserConfig.java
@@ -1,0 +1,56 @@
+package org.hibernate.test.proxy.narrow;
+
+
+/**
+ * @author jlandin
+ */
+public class UserConfig
+{
+  private Long id;
+  private User user;
+  
+  /**
+   * Constructs a new UserConfig.
+   */
+  public UserConfig()
+  {
+    super();
+  }
+
+  /**
+   * Retrieves the value of the id property.
+   * @return The value of the id property.
+   */
+  public Long getId()
+  {
+    return this.id;
+  }
+
+  /**
+   * Sets the value of the id property. 
+   * @param id The value to set for the property id.
+   */
+  public void setId(Long id)
+  {
+    this.id = id;
+  }
+
+  /**
+   * Retrieves the value of the user property.
+   * @return The value of the user property.
+   */
+  public User getUser()
+  {
+    return user;
+  }
+
+  /**
+   * Sets the value of the user property. 
+   * @param user The value to set for the property user.
+   */
+  public void setUser(User user)
+  {
+    this.user = user;
+  }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/UserConfig.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/proxy/narrow/UserConfig.java
@@ -1,56 +1,49 @@
 package org.hibernate.test.proxy.narrow;
 
-
 /**
  * @author jlandin
  */
-public class UserConfig
-{
-  private Long id;
-  private User user;
-  
-  /**
-   * Constructs a new UserConfig.
-   */
-  public UserConfig()
-  {
-    super();
-  }
+public class UserConfig {
+	private Long id;
+	private User user;
 
-  /**
-   * Retrieves the value of the id property.
-   * @return The value of the id property.
-   */
-  public Long getId()
-  {
-    return this.id;
-  }
+	/**
+	 * Constructs a new UserConfig.
+	 */
+	public UserConfig() {
+		super();
+	}
 
-  /**
-   * Sets the value of the id property. 
-   * @param id The value to set for the property id.
-   */
-  public void setId(Long id)
-  {
-    this.id = id;
-  }
+	/**
+	 * Retrieves the value of the id property.
+	 * @return The value of the id property.
+	 */
+	public Long getId() {
+		return this.id;
+	}
 
-  /**
-   * Retrieves the value of the user property.
-   * @return The value of the user property.
-   */
-  public User getUser()
-  {
-    return user;
-  }
+	/**
+	 * Sets the value of the id property.
+	 * @param id The value to set for the property id.
+	 */
+	public void setId(Long id) {
+		this.id = id;
+	}
 
-  /**
-   * Sets the value of the user property. 
-   * @param user The value to set for the property user.
-   */
-  public void setUser(User user)
-  {
-    this.user = user;
-  }
+	/**
+	 * Retrieves the value of the user property.
+	 * @return The value of the user property.
+	 */
+	public User getUser() {
+		return user;
+	}
+
+	/**
+	 * Sets the value of the user property.
+	 * @param user The value to set for the property user.
+	 */
+	public void setUser(User user) {
+		this.user = user;
+	}
 
 }


### PR DESCRIPTION
The fix involves a slight adjustment in the Persistence Context to cache the newly created narrow proxy. This fix does not seem to adversely affect the original behavior of HHH-9071 and all tests are passing.