### PR TITLE
HHH-9440 Support for Embedded value types

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -77,6 +77,7 @@ dependencies {
     testCompile( libraries.classmate )
     testCompile( libraries.mockito )
     testCompile( 'joda-time:joda-time:2.3' )
+    testCompile( 'org.assertj:assertj-core:3.6.1')
 //    testCompile( "org.jboss.weld:weld-core:2.3.4.Final" )
 //    testCompile( "org.jboss.arquillian.container:arquillian-weld-ee-embedded-1.1:1.0.0.CR9" )
     compile( "javax.enterprise:cdi-api:${cdiVersion}" ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.cfg;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1672,6 +1673,7 @@ public final class AnnotationBinder {
 		propertyBinder.setProperty( property );
 		propertyBinder.setReturnedClass( inferredData.getPropertyClass() );
 		propertyBinder.setBuildingContext( context );
+		propertyBinder.setDeclaredFinal( Modifier.isFinal( inferredData.getProperty().getModifiers() ) );
 		if ( isIdentifierMapper ) {
 			propertyBinder.setInsertable( false );
 			propertyBinder.setUpdatable( false );
@@ -2892,7 +2894,7 @@ public final class AnnotationBinder {
 				column.setUpdatable( false );
 			}
 		}
-		
+
 		final JoinColumn joinColumn = property.getAnnotation( JoinColumn.class );
 
 		//Make sure that JPA1 key-many-to-one columns are read only tooj

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -73,6 +73,7 @@ public class PropertyBinder {
 	private EntityBinder entityBinder;
 	private boolean isXToMany;
 	private String referencedEntityName;
+	private boolean declaredFinal;
 
 	public void setReferencedEntityName(String referencedEntityName) {
 		this.referencedEntityName = referencedEntityName;
@@ -150,6 +151,10 @@ public class PropertyBinder {
 	public void setDeclaringClass(XClass declaringClass) {
 		this.declaringClass = declaringClass;
 		this.declaringClassSet = true;
+	}
+
+	public void setDeclaredFinal(boolean declaredFinal) {
+		this.declaredFinal = declaredFinal;
 	}
 
 	private void validateBind() {
@@ -256,6 +261,8 @@ public class PropertyBinder {
 		else {
 			holder.addProperty( prop, columns, declaringClass );
 		}
+
+		prop.setDeclaredFinal( declaredFinal );
 		return prop;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -75,7 +75,7 @@ public class Component extends SimpleValue implements MetaAttributable {
 		return properties.size();
 	}
 
-	public Iterator getPropertyIterator() {
+	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.hibernate.EntityMode;
 import org.hibernate.MappingException;
@@ -38,7 +39,7 @@ import org.hibernate.type.TypeFactory;
  * @author Steve Ebersole
  */
 public class Component extends SimpleValue implements MetaAttributable {
-	private ArrayList<Property> properties = new ArrayList<Property>();
+	private ArrayList<Property> properties = new ArrayList<>();
 	private String componentClassName;
 	private boolean embedded;
 	private String parentProperty;
@@ -77,6 +78,10 @@ public class Component extends SimpleValue implements MetaAttributable {
 
 	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
+	}
+
+	public Stream<Property> getPropertyStream() {
+		return properties.stream();
 	}
 
 	public void addProperty(Property p) {
@@ -242,7 +247,7 @@ public class Component extends SimpleValue implements MetaAttributable {
 
 	public void addTuplizer(EntityMode entityMode, String implClassName) {
 		if ( tuplizerImpls == null ) {
-			tuplizerImpls = new HashMap<EntityMode,String>();
+			tuplizerImpls = new HashMap<>();
 		}
 		tuplizerImpls.put( entityMode, implClassName );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -49,6 +49,7 @@ public class Property implements Serializable, MetaAttributable {
 	private PersistentClass persistentClass;
 	private boolean naturalIdentifier;
 	private boolean lob;
+	private boolean declaredFinal;
 
 	public boolean isBackRef() {
 		return false;
@@ -362,4 +363,11 @@ public class Property implements Serializable, MetaAttributable {
 		this.lob = lob;
 	}
 
+	public boolean isDeclaredFinal() {
+		return declaredFinal;
+	}
+
+	public void setDeclaredFinal(boolean declaredFinal) {
+		this.declaredFinal = declaredFinal;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
@@ -40,8 +40,4 @@ public interface Instantiator extends Serializable {
 	 * entity/component.
 	 */
 	public boolean isInstance(Object object);
-
-	public default boolean canInstantiate() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
@@ -27,7 +27,7 @@ public interface Instantiator extends Serializable {
 	/**
 	 * Perform the requested instantiation.
 	 *
-	 * @return The instantiated data structure. 
+	 * @return The instantiated data structure.
 	 */
 	public Object instantiate();
 
@@ -40,4 +40,8 @@ public interface Instantiator extends Serializable {
 	 * entity/component.
 	 */
 	public boolean isInstance(Object object);
+
+	public default boolean canInstantiate() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
@@ -104,8 +104,4 @@ public class PojoInstantiator implements Instantiator, Serializable {
 	public boolean isInstance(Object object) {
 		return mappedClass.isInstance( object );
 	}
-
-	public boolean canInstantiate() {
-		return constructor != null;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
@@ -41,9 +41,9 @@ public class PojoInstantiator implements Instantiator, Serializable {
 		this.isAbstract = ReflectHelper.isAbstractClass( mappedClass );
 
 		try {
-			constructor = ReflectHelper.getDefaultConstructor(mappedClass);
+			constructor = ReflectHelper.getDefaultConstructor( mappedClass );
 		}
-		catch ( PropertyNotFoundException pnfe ) {
+		catch (PropertyNotFoundException pnfe) {
 			LOG.noDefaultConstructor( mappedClass.getName() );
 			constructor = null;
 		}
@@ -57,10 +57,10 @@ public class PojoInstantiator implements Instantiator, Serializable {
 		this.embeddedIdentifier = false;
 
 		try {
-			constructor = ReflectHelper.getDefaultConstructor(mappedClass);
+			constructor = ReflectHelper.getDefaultConstructor( mappedClass );
 		}
-		catch ( PropertyNotFoundException pnfe ) {
-			LOG.noDefaultConstructor(mappedClass.getName());
+		catch (PropertyNotFoundException pnfe) {
+			LOG.noDefaultConstructor( mappedClass.getName() );
 			constructor = null;
 		}
 	}
@@ -84,7 +84,7 @@ public class PojoInstantiator implements Instantiator, Serializable {
 			try {
 				return applyInterception( constructor.newInstance( (Object[]) null ) );
 			}
-			catch ( Exception e ) {
+			catch (Exception e) {
 				throw new InstantiationException( "Could not instantiate entity: ", mappedClass, e );
 			}
 		}
@@ -97,11 +97,15 @@ public class PojoInstantiator implements Instantiator, Serializable {
 	public Object instantiate(Serializable id) {
 		final boolean useEmbeddedIdentifierInstanceAsEntity = embeddedIdentifier &&
 				id != null &&
-				id.getClass().equals(mappedClass);
+				id.getClass().equals( mappedClass );
 		return useEmbeddedIdentifierInstanceAsEntity ? id : instantiate();
 	}
 
 	public boolean isInstance(Object object) {
 		return mappedClass.isInstance( object );
+	}
+
+	public boolean canInstantiate() {
+		return constructor != null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/PropertyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/PropertyFactory.java
@@ -287,7 +287,8 @@ public final class PropertyFactory {
 				alwaysDirtyCheck || property.isUpdateable(),
 				property.isOptimisticLocked(),
 				property.getCascadeStyle(),
-				property.getValue().getFetchMode()
+				property.getValue().getFetchMode(),
+				property.isDeclaredFinal()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/StandardProperty.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/StandardProperty.java
@@ -20,6 +20,8 @@ import org.hibernate.type.Type;
 @Deprecated
 public class StandardProperty extends AbstractNonIdentifierAttribute implements NonIdentifierAttribute {
 
+	private final boolean declaredFinal;
+
 	/**
 	 * Constructs NonIdentifierProperty instances.
 	 *
@@ -47,7 +49,8 @@ public class StandardProperty extends AbstractNonIdentifierAttribute implements 
 			boolean checkable,
 			boolean versionable,
 			CascadeStyle cascadeStyle,
-			FetchMode fetchMode) {
+			FetchMode fetchMode,
+			boolean declaredFinal) {
 		super(
 				null,
 				null,
@@ -66,5 +69,10 @@ public class StandardProperty extends AbstractNonIdentifierAttribute implements 
 						.setFetchMode( fetchMode )
 						.createInformation()
 		);
+		this.declaredFinal = declaredFinal;
+	}
+
+	public boolean isDeclaredFinal() {
+		return declaredFinal;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/ValueTypeInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/ValueTypeInstantiator.java
@@ -1,0 +1,96 @@
+package org.hibernate.tuple;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.hibernate.InstantiationException;
+import org.hibernate.mapping.Component;
+
+public class ValueTypeInstantiator {
+
+	private final Class mappedClass;
+	private final Constructor constructor;
+	private final Map<String, Integer> constructorParameterNameToIndex;
+
+	public ValueTypeInstantiator(
+			Class mappedClass,
+			Constructor constructor,
+			Map<String, Integer> constructorParameterNameToIndex) {
+		this.mappedClass = mappedClass;
+		this.constructor = constructor;
+		this.constructorParameterNameToIndex = constructorParameterNameToIndex;
+	}
+
+	public Object instantiate(String[] propertyNames, Object[] values) {
+		Object[] arguments = new Object[values.length];
+		for ( int valueIndex = 0; valueIndex < values.length; valueIndex++ ) {
+			Object value = values[valueIndex];
+			Integer argumentIndex = constructorParameterNameToIndex.get( propertyNames[valueIndex] );
+			arguments[argumentIndex] = value;
+		}
+		try {
+			return constructor.newInstance( arguments );
+		}
+		catch (Exception e) {
+			throw new InstantiationException( "Could not instantiate entity: ", mappedClass, e );
+		}
+	}
+
+	public boolean isInstance(Object object) {
+		return mappedClass.isInstance( object );
+	}
+
+	static Optional<ValueTypeInstantiator> of(Class mappedClass, Component component) {
+
+		Map<String, Class> propertyNameToType = new HashMap<>();
+		component.getPropertyIterator()
+				.forEachRemaining( property -> propertyNameToType.put(
+						property.getName(),
+						property.getType().getReturnedClass()
+				) );
+
+		Constructor constructor = Stream.of( mappedClass.getDeclaredConstructors() )
+				.filter( c -> parametersMatchProperties( c.getParameters(), propertyNameToType ) )
+				.findFirst()
+				.orElse( null );
+
+		if ( constructor == null ) {
+			return Optional.empty();
+		}
+
+		Parameter[] parameters = constructor.getParameters();
+		Map<String, Integer> constructorParameterNameToIndex = new HashMap<>();
+
+		for ( int parameterIndex = 0; parameterIndex < parameters.length; parameterIndex++ ) {
+			Parameter parameter = parameters[parameterIndex];
+			constructorParameterNameToIndex.put( parameter.getName(), parameterIndex );
+		}
+
+		if ( !constructor.isAccessible() ) {
+			constructor.setAccessible( true );
+		}
+
+		return Optional.of( new ValueTypeInstantiator( mappedClass, constructor, constructorParameterNameToIndex ) );
+	}
+
+	private static boolean parametersMatchProperties(Parameter[] parameters, Map<String, Class> propertyNameToType) {
+
+		if ( parameters.length != propertyNameToType.size() ) {
+			return false;
+		}
+
+		for ( Parameter parameter : parameters ) {
+			Class propertyType = propertyNameToType.get( parameter.getName() );
+			if ( propertyType == null || !Objects.equals( parameter.getType(), propertyType ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentMetamodel.java
@@ -42,7 +42,7 @@ public class ComponentMetamodel implements Serializable {
 
 	// cached for efficiency...
 	private final int propertySpan;
-	private final Map propertyIndexes = new HashMap();
+	private final Map<String, Integer> propertyIndexes = new HashMap<>();
 	private final boolean createEmptyCompositesEnabled;
 
 	//	public ComponentMetamodel(Component component, SessionFactoryImplementor sessionFactory) {
@@ -53,10 +53,10 @@ public class ComponentMetamodel implements Serializable {
 		this.isKey = component.isKey();
 		propertySpan = component.getPropertySpan();
 		properties = new StandardProperty[propertySpan];
-		Iterator itr = component.getPropertyIterator();
+		Iterator<Property> itr = component.getPropertyIterator();
 		int i = 0;
 		while ( itr.hasNext() ) {
-			Property property = (Property) itr.next();
+			Property property = itr.next();
 			properties[i] = PropertyFactory.buildStandardProperty( property, false );
 			propertyIndexes.put( property.getName(), i );
 			i++;

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentMetamodel.java
@@ -31,22 +31,24 @@ public class ComponentMetamodel implements Serializable {
 
 	// TODO : will need reference to session factory to fully complete HHH-1907
 
-//	private final SessionFactoryImplementor sessionFactory;
+	//	private final SessionFactoryImplementor sessionFactory;
 	private final String role;
 	private final boolean isKey;
 	private final StandardProperty[] properties;
 
 	private final EntityMode entityMode;
 	private final ComponentTuplizer componentTuplizer;
+	private final Component component;
 
 	// cached for efficiency...
 	private final int propertySpan;
 	private final Map propertyIndexes = new HashMap();
 	private final boolean createEmptyCompositesEnabled;
 
-//	public ComponentMetamodel(Component component, SessionFactoryImplementor sessionFactory) {
+	//	public ComponentMetamodel(Component component, SessionFactoryImplementor sessionFactory) {
 	public ComponentMetamodel(Component component, MetadataBuildingOptions metadataBuildingOptions) {
 //		this.sessionFactory = sessionFactory;
+		this.component = component;
 		this.role = component.getRoleName();
 		this.isKey = component.isKey();
 		propertySpan = component.getPropertySpan();
@@ -54,7 +56,7 @@ public class ComponentMetamodel implements Serializable {
 		Iterator itr = component.getPropertyIterator();
 		int i = 0;
 		while ( itr.hasNext() ) {
-			Property property = ( Property ) itr.next();
+			Property property = (Property) itr.next();
 			properties[i] = PropertyFactory.buildStandardProperty( property, false );
 			propertyIndexes.put( property.getName(), i );
 			i++;
@@ -71,7 +73,7 @@ public class ComponentMetamodel implements Serializable {
 		) : componentTuplizerFactory.constructTuplizer( tuplizerClassName, component );
 
 		final ConfigurationService cs = component.getMetadata().getMetadataBuildingOptions().getServiceRegistry()
-				.getService(ConfigurationService.class);
+				.getService( ConfigurationService.class );
 
 		this.createEmptyCompositesEnabled = ConfigurationHelper.getBoolean(
 				Environment.CREATE_EMPTY_COMPOSITES_ENABLED,
@@ -100,7 +102,7 @@ public class ComponentMetamodel implements Serializable {
 	}
 
 	public int getPropertyIndex(String propertyName) {
-		Integer index = ( Integer ) propertyIndexes.get( propertyName );
+		Integer index = (Integer) propertyIndexes.get( propertyName );
 		if ( index == null ) {
 			throw new HibernateException( "component does not contain such a property [" + propertyName + "]" );
 		}
@@ -123,4 +125,7 @@ public class ComponentMetamodel implements Serializable {
 		return createEmptyCompositesEnabled;
 	}
 
+	public Component getComponent() {
+		return component;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
@@ -16,7 +16,7 @@ import org.hibernate.tuple.Tuplizer;
  * a mapped components.
  * </p>
  * ComponentTuplizer implementations should have the following constructor signature:
- * (org.hibernate.mapping.Component)
+ *      (org.hibernate.mapping.Component)org.hibernate.mapping.Component)
  *
  * @author Gavin King
  * @author Steve Ebersole
@@ -31,13 +31,13 @@ public interface ComponentTuplizer extends Tuplizer, Serializable {
 	 */
 	public Object getParent(Object component);
 
-	/**
-	 * Set the value of the parent property.
-	 *
-	 * @param component The component instance on which to set the parent.
-	 * @param parent The parent to be set on the comonent.
-	 * @param factory The current session factory.
-	 */
+    /**
+    * Set the value of the parent property.
+    *
+    * @param component The component instance on which to set the parent.
+    * @param parent The parent to be set on the comonent.
+    * @param factory The current session factory.
+    */
 	public void setParent(Object component, Object parent, SessionFactoryImplementor factory);
 
 	/**
@@ -54,8 +54,4 @@ public interface ComponentTuplizer extends Tuplizer, Serializable {
 	 * @return True if the managed component is available from the managed component; else false.
 	 */
 	public boolean isMethodOf(Method method);
-
-	public default boolean isComponentImmutable() {
-		return false;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
@@ -16,8 +16,8 @@ import org.hibernate.tuple.Tuplizer;
  * a mapped components.
  * </p>
  * ComponentTuplizer implementations should have the following constructor signature:
- *      (org.hibernate.mapping.Component)
- * 
+ * (org.hibernate.mapping.Component)
+ *
  * @author Gavin King
  * @author Steve Ebersole
  */
@@ -31,13 +31,13 @@ public interface ComponentTuplizer extends Tuplizer, Serializable {
 	 */
 	public Object getParent(Object component);
 
-    /**
-     * Set the value of the parent property.
-     *
-     * @param component The component instance on which to set the parent.
-     * @param parent The parent to be set on the comonent.
-     * @param factory The current session factory.
-     */
+	/**
+	 * Set the value of the parent property.
+	 *
+	 * @param component The component instance on which to set the parent.
+	 * @param parent The parent to be set on the comonent.
+	 * @param factory The current session factory.
+	 */
 	public void setParent(Object component, Object parent, SessionFactoryImplementor factory);
 
 	/**
@@ -54,4 +54,8 @@ public interface ComponentTuplizer extends Tuplizer, Serializable {
 	 * @return True if the managed component is available from the managed component; else false.
 	 */
 	public boolean isMethodOf(Method method);
+
+	public default boolean isComponentImmutable() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
@@ -127,6 +127,11 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 		parentSetter.set( component, parent, factory );
 	}
 
+	@Override
+	public boolean isComponentImmutable() {
+		return !instantiator.canInstantiate();
+	}
+
 	protected Instantiator buildInstantiator(Component component) {
 		if ( component.isEmbedded() && ReflectHelper.isAbstractClass( component.getComponentClass() ) ) {
 			return new ProxiedInstantiator( component );

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
@@ -127,11 +127,6 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 		parentSetter.set( component, parent, factory );
 	}
 
-	@Override
-	public boolean isComponentImmutable() {
-		return !instantiator.canInstantiate();
-	}
-
 	protected Instantiator buildInstantiator(Component component) {
 		if ( component.isEmbedded() && ReflectHelper.isAbstractClass( component.getComponentClass() ) ) {
 			return new ProxiedInstantiator( component );

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -68,6 +68,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		this.cascade = new CascadeStyle[propertySpan];
 		this.joinedFetch = new FetchMode[propertySpan];
 
+		boolean isImmutable = true;
 		for ( int i = 0; i < propertySpan; i++ ) {
 			StandardProperty prop = metamodel.getProperty( i );
 			this.propertyNames[i] = prop.getName();
@@ -75,6 +76,9 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 			this.propertyNullability[i] = prop.isNullable();
 			this.cascade[i] = prop.getCascadeStyle();
 			this.joinedFetch[i] = prop.getFetchMode();
+			if(!prop.isDeclaredFinal()) {
+				isImmutable = false;
+			}
 			if ( !prop.isNullable() ) {
 				hasNotNullProperty = true;
 			}
@@ -85,7 +89,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		this.componentTuplizer = metamodel.getComponentTuplizer();
 		this.createEmptyCompositesEnabled = metamodel.isCreateEmptyCompositesEnabled();
 
-		if ( componentTuplizer.isComponentImmutable() ) {
+		if ( isImmutable ) {
 			valueTypeInstantiator = ValueTypeInstantiator.of( metamodel.getComponent() ).orElse( null );
 		}
 		else {
@@ -498,7 +502,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 			return null;
 		}
 
-		if ( componentTuplizer.isComponentImmutable() ) {
+		if ( isComponentImmutable() ) {
 			return component;
 		}
 
@@ -532,7 +536,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 			return null;
 		}
 
-		if ( componentTuplizer.isComponentImmutable() ) {
+		if ( isComponentImmutable() ) {
 			return original;
 		}
 
@@ -569,7 +573,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 			return null;
 		}
 
-		if ( componentTuplizer.isComponentImmutable() ) {
+		if ( isComponentImmutable() ) {
 			return original;
 		}
 		//if ( original == target ) return target;
@@ -601,7 +605,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 
 	public Object instantiate(Object[] values) throws HibernateException {
 
-		if ( valueTypeInstantiator != null && componentTuplizer.isComponentImmutable() ) {
+		if ( isComponentImmutable() ) {
 			return valueTypeInstantiator.instantiate( propertyNames, values );
 		}
 
@@ -666,7 +670,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 				assembled[i] = propertyTypes[i].assemble( (Serializable) values[i], session, owner );
 			}
 
-			if ( componentTuplizer.isComponentImmutable() ) {
+			if ( isComponentImmutable() ) {
 				return instantiate( assembled );
 			}
 
@@ -722,7 +726,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 				resolvedValues[i] = propertyTypes[i].resolve( values[i], session, owner );
 			}
 
-			if ( componentTuplizer.isComponentImmutable() ) {
+			if ( isComponentImmutable() ) {
 				return instantiate( resolvedValues );
 			}
 
@@ -878,5 +882,9 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 
 	private boolean isCreateEmptyCompositesEnabled() {
 		return createEmptyCompositesEnabled;
+	}
+
+	private boolean isComponentImmutable() {
+		return valueTypeInstantiator != null;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
@@ -64,7 +64,7 @@ public class ValueTypeInstantiatorTest {
 	}
 
 	private void givenProperties(Property... properties) {
-		given( component.getPropertyIterator() ).willReturn( Arrays.asList( properties ).iterator() );
+		given( component.getPropertyStream() ).willReturn( Arrays.stream( properties ) );
 	}
 
 	private Property givenProperty(String name, Class type) {

--- a/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
@@ -32,9 +32,10 @@ public class ValueTypeInstantiatorTest {
 				givenProperty( "firstProperty", String.class ),
 				givenProperty( "secondProperty", Integer.class )
 		);
+		given( component.getComponentClass() ).willReturn( ValueType.class );
 
 		// when
-		ValueTypeInstantiator actual = ValueTypeInstantiator.of( ValueType.class, component )
+		ValueTypeInstantiator actual = ValueTypeInstantiator.of( component )
 				.orElse( null );
 
 		// then
@@ -49,7 +50,8 @@ public class ValueTypeInstantiatorTest {
 				givenProperty( "firstProperty", String.class ),
 				givenProperty( "secondProperty", Integer.class )
 		);
-		ValueTypeInstantiator valueTypeInstantiator = ValueTypeInstantiator.of( ValueType.class, component )
+		given( component.getComponentClass() ).willReturn( ValueType.class );
+		ValueTypeInstantiator valueTypeInstantiator = ValueTypeInstantiator.of( component )
 				.orElse( null );
 		String[] propertyNames = { "firstProperty", "secondProperty" };
 		Object[] givenArgs = { "givenFirstProperty", 1 };

--- a/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/tuple/ValueTypeInstantiatorTest.java
@@ -1,0 +1,125 @@
+package org.hibernate.tuple;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.Property;
+import org.hibernate.type.Type;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValueTypeInstantiatorTest {
+
+	@Mock
+	private Component component;
+
+	@Test
+	public void shouldCreateValueTypeInstantiatorForValueType() {
+
+		// given
+		givenProperties(
+				givenProperty( "firstProperty", String.class ),
+				givenProperty( "secondProperty", Integer.class )
+		);
+
+		// when
+		ValueTypeInstantiator actual = ValueTypeInstantiator.of( ValueType.class, component )
+				.orElse( null );
+
+		// then
+		then( actual ).isNotNull();
+	}
+
+	@Test
+	public void shouldUseConstructorWithExactParameterTypeAndName() {
+
+		// given
+		givenProperties(
+				givenProperty( "firstProperty", String.class ),
+				givenProperty( "secondProperty", Integer.class )
+		);
+		ValueTypeInstantiator valueTypeInstantiator = ValueTypeInstantiator.of( ValueType.class, component )
+				.orElse( null );
+		String[] propertyNames = { "firstProperty", "secondProperty" };
+		Object[] givenArgs = { "givenFirstProperty", 1 };
+
+		// when
+		Object actual = valueTypeInstantiator.instantiate( propertyNames, givenArgs );
+
+		// then
+		then( actual ).isEqualTo( new ValueType( (String) givenArgs[0], (Integer) givenArgs[1] ) );
+	}
+
+	private void givenProperties(Property... properties) {
+		given( component.getPropertyIterator() ).willReturn( Arrays.asList( properties ).iterator() );
+	}
+
+	private Property givenProperty(String name, Class type) {
+		Property property = mock( Property.class );
+		when( property.getName() ).thenReturn( name );
+		given( property.getName() ).willReturn( name );
+		Type mockedType = mock( Type.class );
+		given( mockedType.getReturnedClass() ).willReturn( type );
+		given( property.getType() ).willReturn( mockedType );
+		return property;
+	}
+
+	static class ValueType {
+		private final String firstProperty;
+		private final Integer secondProperty;
+
+		ValueType() {
+			throw new UnsupportedOperationException();
+		}
+
+		ValueType(Integer secondProperty) {
+			throw new UnsupportedOperationException();
+		}
+
+		ValueType(String firstProperty) {
+			throw new UnsupportedOperationException();
+		}
+
+		ValueType(Integer firstProperty, Integer secondProperty) {
+			throw new UnsupportedOperationException();
+		}
+
+		ValueType(String firstProperty, Integer secondProperty) {
+			this.firstProperty = firstProperty;
+			this.secondProperty = secondProperty;
+		}
+
+		ValueType(String firstProperty, String secondProperty) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			ValueType valueType = (ValueType) o;
+			return Objects.equals( firstProperty, valueType.firstProperty ) &&
+					Objects.equals( secondProperty, valueType.secondProperty );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( firstProperty, secondProperty );
+		}
+	}
+}


### PR DESCRIPTION
POC implementation of HHH-9440 for support of value type embeddables like:

```java
@Embeddable
public class Name {

    private final String firstName;
    private final String middleName;
    private final String lastName;

    // all args constructor (no default one), getters, equals, hashcode, toString ...
}
```

Requirement: value type class has parameter names stored in bytecode (`-parameters`).