### PR TITLE
HHH-11319 Refine the dirty property names logging.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -647,7 +647,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			LOG.tracev(
 					"Found dirty properties [{0}] : {1}",
 					MessageHelper.infoString( persister.getEntityName(), id ),
-					dirtyPropertyNames
+					Arrays.toString(dirtyPropertyNames)
 			);
 		}
 	}


### PR DESCRIPTION
Using SLF4J+logback to get the dirty property names and got something like below 

    org.hibernate.event.internal.DefaultFlushEntityEventListener - Found dirty properties    [[packagenames#9742239717]] : [Ljava.lang.String;@68abb468

Which the contents of `dirtyPropertyNames` are not printed, but the type and object id.
The log statement needs to use `Arrays.toString` to print the contents of `dirtyPropertyNames`.