### PR TITLE
HHH-11321: fixes resolution of class names via build plugins

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -6,10 +6,6 @@
  */
 package org.hibernate.bytecode.enhance.internal.bytebuddy;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -61,10 +57,8 @@ import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.StubMethod;
 import net.bytebuddy.pool.TypePool;
-import net.bytebuddy.utility.StreamDrainer;
 
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 
 public class EnhancerImpl implements Enhancer {
 
@@ -115,18 +109,6 @@ public class EnhancerImpl implements Enhancer {
 			e.printStackTrace();
 			log.unableToBuildEnhancementMetamodel( className );
 			return null;
-		}
-	}
-
-	@Override
-	public byte[] enhance(File javaClassFile) throws EnhancementException, IOException {
-		String name = javaClassFile.getName().substring( 0, javaClassFile.getName().length() - ".class".length() );
-		InputStream inputStream = new FileInputStream( javaClassFile );
-		try {
-			return enhance( name, StreamDrainer.DEFAULT.drain( inputStream ) );
-		}
-		finally {
-			inputStream.close();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/javassist/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/javassist/EnhancerImpl.java
@@ -9,12 +9,9 @@ package org.hibernate.bytecode.enhance.internal.javassist;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.LoaderClassPath;
@@ -80,18 +77,6 @@ public class EnhancerImpl implements Enhancer {
 		}
 		catch (IOException e) {
 			log.unableToBuildEnhancementMetamodel( className );
-			return null;
-		}
-	}
-
-	@Override
-	public byte[] enhance(File javaClassFile) throws EnhancementException, IOException {
-		final CtClass ctClass = classPool.makeClass( new FileInputStream( javaClassFile ) );
-		try {
-			return enhance( ctClass.getName(), ctClass.toBytecode() );
-		}
-		catch (CannotCompileException e) {
-			log.warn( "Unable to enhance class file [" + javaClassFile.getAbsolutePath() + "]", e );
 			return null;
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/Enhancer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/Enhancer.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.bytecode.enhance.spi;
 
-import java.io.File;
-import java.io.IOException;
-
 /**
  * Class responsible for performing enhancement.
  *
@@ -29,6 +26,4 @@ public interface Enhancer {
 	 * @throws EnhancementException Indicates a problem performing the enhancement
 	 */
 	byte[] enhance(String className, byte[] originalBytes) throws EnhancementException;
-
-	byte[] enhance(File javaClassFile) throws EnhancementException, IOException;
 }

--- a/tooling/hibernate-enhance-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/MavenEnhancePlugin.java
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/MavenEnhancePlugin.java
@@ -6,9 +6,10 @@
  */
 package org.hibernate.orm.tooling.maven;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileNotFoundException;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
@@ -58,6 +59,9 @@ public class MavenEnhancePlugin extends AbstractMojo {
 	@Component
 	private BuildContext buildContext;
 
+	@Parameter(property = "base", defaultValue = "${project.build.outputDirectory}")
+	private String base;
+
 	@Parameter(property = "dir", defaultValue = "${project.build.outputDirectory}")
 	private String dir;
 
@@ -86,6 +90,10 @@ public class MavenEnhancePlugin extends AbstractMojo {
 			return;
 		}
 
+		if ( !dir.startsWith( base ) ) {
+			throw new MojoExecutionException( "The enhancement directory 'dir' (" + dir + ") is no subdirectory of 'base' (" + base + ")" );
+		}
+
 		// Perform a depth first search for sourceSet
 		File root = new File( this.dir );
 		if ( !root.exists() ) {
@@ -99,7 +107,7 @@ public class MavenEnhancePlugin extends AbstractMojo {
 		}
 
 		getLog().info( "Starting Hibernate enhancement for classes on " + dir );
-		final ClassLoader classLoader = toClassLoader( Collections.singletonList( root ) );
+		final ClassLoader classLoader = toClassLoader( Collections.singletonList( new File( base ) ) );
 
 		EnhancementContext enhancementContext = new DefaultEnhancementContext() {
 			@Override
@@ -177,7 +185,7 @@ public class MavenEnhancePlugin extends AbstractMojo {
 			MavenProject executionProject = project.getExecutionProject();
 			artifacts = ( executionProject != null ? executionProject.getArtifacts() : project.getArtifacts() );
 		}
-		if ( artifacts != null) {
+		if ( artifacts != null ) {
 			for ( Artifact a : artifacts ) {
 				if ( !Artifact.SCOPE_TEST.equals( a.getScope() ) ) {
 					try {
@@ -200,7 +208,23 @@ public class MavenEnhancePlugin extends AbstractMojo {
 
 	private byte[] doEnhancement(File javaClassFile, Enhancer enhancer) throws MojoExecutionException {
 		try {
-			return enhancer.enhance(javaClassFile);
+			String className = javaClassFile.getAbsolutePath().substring(
+					base.length() + 1,
+					javaClassFile.getAbsolutePath().length() - ".class".length()
+			).replace( File.separatorChar, '.' );
+			ByteArrayOutputStream originalBytes = new ByteArrayOutputStream();
+			FileInputStream fileInputStream = new FileInputStream( javaClassFile );
+			try {
+				byte[] buffer = new byte[1024];
+				int length;
+				while ( ( length = fileInputStream.read( buffer ) ) != -1 ) {
+					originalBytes.write( buffer, 0, length );
+				}
+			}
+			finally {
+				fileInputStream.close();
+			}
+			return enhancer.enhance( className, originalBytes.toByteArray() );
 		}
 		catch (Exception e) {
 			String msg = "Unable to enhance class: " + javaClassFile.getName();
@@ -272,7 +296,7 @@ public class MavenEnhancePlugin extends AbstractMojo {
 		}
 		finally {
 			try {
-				if( outputStream != null ) {
+				if ( outputStream != null ) {
 					outputStream.close();
 				}
 			}

--- a/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/org.hibernate.orm.tooling/hibernate-enhance-maven-plugin/plugin-help.xml
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/org.hibernate.orm.tooling/hibernate-enhance-maven-plugin/plugin-help.xml
@@ -32,6 +32,13 @@
       <threadSafe>false</threadSafe>
       <parameters>
         <parameter>
+          <name>base</name>
+          <type>java.lang.String</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>The root folder for .class files</description>
+        </parameter>
+        <parameter>
           <name>dir</name>
           <type>java.lang.String</type>
           <required>false</required>
@@ -75,6 +82,7 @@
         </parameter>
       </parameters>
       <configuration>
+        <base>${project.build.outputDirectory}</base>
         <dir>${project.build.outputDirectory}</dir>
         <failOnError>true</failOnError>
         <enableLazyInitialization>false</enableLazyInitialization>

--- a/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -35,6 +35,13 @@
       <threadSafe>false</threadSafe>
       <parameters>
         <parameter>
+          <name>base</name>
+          <type>java.lang.String</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>The root folder for .class files</description>
+        </parameter>
+        <parameter>
           <name>dir</name>
           <type>java.lang.String</type>
           <required>false</required>
@@ -78,6 +85,7 @@
         </parameter>
       </parameters>
       <configuration>
+        <base>${project.build.outputDirectory}</base>
         <dir>${project.build.outputDirectory}</dir>
         <failOnError>true</failOnError>
         <enableLazyInitialization>false</enableLazyInitialization>


### PR DESCRIPTION
The `Enhancer::enhance(File)` API only worked by accident. The plugin resolves class files by the relative path of the passed instance where it is no longer possible to distinguish between a type `foo.bar.Qux` and a type `bar.Qux` residing in a base folder `foo`. The API should not be used but the plugin should resolve the name and byte array itself. When I refactored the plugin to not rely on Javassist types, this boundary broke without a test to capture the problem. A similar problem occurs when using Javassist.

This change leaves it to the build plugin to resolve the class name from a file and uses the `Enhancer::enhance(String, byte[])` API instead. Previously, the `Enhancer::enhance(File)` was already implemented as a thin delegator to this previous API.