### PR TITLE
HHH-11337 Incorrect SQL generated when use both left join with unrelated entity and implicit join to another entity in select-clause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/SqlGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/SqlGenerator.java
@@ -402,7 +402,7 @@ public class SqlGenerator extends SqlGeneratorBase implements ErrorReporter {
 				if ( right.getRealOrigin() == left ) {
 					// right represents a joins originating from left...
 					if ( right.getJoinSequence() != null && right.getJoinSequence().isThetaStyle() ) {
-						out( ", " );
+						writeCrossJoinSeparator();
 					}
 					else {
 						out( " " );
@@ -411,7 +411,7 @@ public class SqlGenerator extends SqlGeneratorBase implements ErrorReporter {
 				else {
 					// not so sure this is even valid subtree.  but if it was, it'd
 					// represent two unrelated table references...
-					out( ", " );
+					writeCrossJoinSeparator();
 				}
 			}
 			out( d );

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/EntityJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/EntityJoinTest.java
@@ -15,6 +15,7 @@ import javax.persistence.Table;
 
 import org.hibernate.Session;
 import org.hibernate.annotations.NaturalId;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -88,6 +89,37 @@ public class EntityJoinTest extends BaseNonConfigCoreFunctionalTestCase {
             // this should get all financial records even if their lastUpdateBy user is null
             List<Object[]> result = session.createQuery(
                     "select r.id, u.id, u.username " +
+                            "from FinancialRecord r " +
+                            "	left join User u on r.lastUpdateBy = u.username" +
+                            "   order by r.id"
+            ).list();
+            assertThat(result.size(), is(2));
+
+            Object[] stevesRecord = result.get(0);
+            assertThat(stevesRecord[0], is(1));
+            assertThat(stevesRecord[2], is("steve"));
+
+            Object[] noOnesRecord = result.get(1);
+            assertThat(noOnesRecord[0], is(2));
+            assertNull(noOnesRecord[2]);
+
+        } finally {
+            session.getTransaction().commit();
+            session.close();
+        }
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-11337")
+    @SuppressWarnings("unchecked")
+    public void testLeftOuterEntityJoinsWithImplicitInnerJoinInSelectClause() {
+        Session session = openSession();
+        session.beginTransaction();
+
+        try {
+            // this should get all financial records even if their lastUpdateBy user is null
+            List<Object[]> result = session.createQuery(
+                    "select r.id, u.id, u.username, r.customer.name " +
                             "from FinancialRecord r " +
                             "	left join User u on r.lastUpdateBy = u.username" +
                             "   order by r.id"


### PR DESCRIPTION
HHH-11337 fixed SQL query generation for query with left join and implicit join in select clause

I changed hardcoded comma ", " to getCrossJoinSeparator() call instead.

Also copied test in EntityJoinTest class and modified select section in it, so it fails with hardcoded comma in SqlGenerator.

After this changes - all tests pass