### PR TITLE
[5.1]: HHH-11324 - Fix LimitHandler parsing of select-clause subqueries for SQLServer2005Dialect.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -8,6 +8,7 @@ package org.hibernate.dialect.pagination;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -316,11 +317,28 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 			return -1;
 		}
 
+		List<IgnoreRange> ignoreRangeList = generateIgnoreRanges( matchString );
+
 		Matcher matcher = pattern.matcher( matchString );
 		matcher.region( fromIndex, matchString.length() );
 
-		if ( matcher.find() && matcher.groupCount() > 0 ) {
-			index = matcher.start();
+		if ( ignoreRangeList.isEmpty() ) {
+			// old behavior where the first match is used if no ignorable ranges
+			// were deduced from the matchString.
+			if ( matcher.find() && matcher.groupCount() > 0 ) {
+				index = matcher.start();
+			}
+		}
+		else {
+			// rather than taking the first match, we now iterate all matches
+			// until we determine a match that isn't considered "ignorable'.
+			while ( matcher.find() && matcher.groupCount() > 0 ) {
+				final int position = matcher.start();
+				if ( !isPositionIgnorable( ignoreRangeList, position ) ) {
+					index = position;
+					break;
+				}
+			}
 		}
 		return index;
 	}
@@ -341,5 +359,76 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 				")(?![^\\(]*\\))",
 				Pattern.CASE_INSENSITIVE
 		);
+	}
+
+	/**
+	 * Geneartes a list of {@code IgnoreRange} objects that represent nested sections of the
+	 * provided SQL buffer that should be ignored when performing regular expression matches.
+	 *
+	 * @param sql The SQL buffer.
+	 * @return list of {@code IgnoreRange} objects, never {@code null}.
+	 */
+	private static List<IgnoreRange> generateIgnoreRanges(String sql) {
+		List<IgnoreRange> ignoreRangeList = new ArrayList<IgnoreRange>();
+
+		int depth = 0;
+		int start = -1;
+		for ( int i = 0; i < sql.length(); ++i ) {
+			final char ch = sql.charAt( i );
+			if ( ch == '(' ) {
+				depth++;
+				if ( depth == 1 ) {
+					start = i;
+				}
+			}
+			else if ( ch == ')' ) {
+				if ( depth > 0 ) {
+					if ( depth == 1 ) {
+						ignoreRangeList.add( new IgnoreRange( start, i ) );
+						start = -1;
+					}
+					depth--;
+				}
+				else {
+					throw new IllegalStateException( "Found an unmatched ')' at position " + i + ": " + sql );
+				}
+			}
+		}
+
+		if ( depth != 0 ) {
+			throw new IllegalStateException( "Unmatched parenthesis in rendered SQL (" + depth + " depth): " + sql );
+		}
+
+		return ignoreRangeList;
+	}
+
+	/**
+	 * Returns whether the specified {@code position} is within the ranges of the {@code ignoreRangeList}.
+	 *
+	 * @param ignoreRangeList list of {@code IgnoreRange} objects deduced from the SQL buffer.
+	 * @param position the position to determine whether is ignorable.
+	 * @return {@code true} if the position is to ignored/skipped, {@code false} otherwise.
+	 */
+	private static boolean isPositionIgnorable(List<IgnoreRange> ignoreRangeList, int position) {
+		for ( IgnoreRange ignoreRange : ignoreRangeList ) {
+			if ( ignoreRange.isWithinRange( position ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static class IgnoreRange {
+		private int start;
+		private int end;
+
+		IgnoreRange(int start, int end) {
+			this.start = start;
+			this.end = end;
+		}
+
+		boolean isWithinRange(int position) {
+			return position >= start && position <= end;
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
@@ -362,6 +362,31 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11324")
+	public void testGetLimitStringWithSelectClauseNestedQueryUsingParenthesis() {
+		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC";
+
+		assertEquals(
+				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+						"select TOP(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC ) inner_query ) " +
+						"SELECT col_0_0, col_1_0 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11324")
+	public void testGetLimitStringWithSelectClauseNestedQueryUsingParenthesisOnlyTop() {
+		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC";
+
+		assertEquals(
+				"select TOP(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC",
+				dialect.getLimitHandler().processSql( query, toRowSelection( 0, 5 ) )
+		);
+	}
+
 	@Test
 	@TestForIssue(jiraKey = "HHH-9635")
 	public void testAppendLockHintReadPastLocking() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11324

This PR also includes test case fixes for HHH-11084 which included invalid SQL which were identified as a part of this code fix.