### PR TITLE
[5.1]: HHH-4712 - Fix missing column failures when non-identifier properties named id.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
@@ -339,14 +339,7 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 			throw new IllegalStateException( "No table alias for node " + this );
 		}
 
-		final String propertyName;
-		if ( getEntityPersister() != null && getEntityPersister().getEntityMetamodel() != null
-				&& getEntityPersister().getEntityMetamodel().hasNonIdentifierPropertyNamedId() ) {
-			propertyName = getEntityPersister().getIdentifierPropertyName();
-		}
-		else {
-			propertyName = EntityPersister.ENTITY_ID;
-		}
+		final String propertyName = getIdentifierPropertyName();
 
 		if ( getWalker().getStatementType() == HqlSqlTokenTypes.SELECT ) {
 			return getPropertyMapping( propertyName ).toColumns( table, propertyName );
@@ -519,6 +512,10 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 
 	public CollectionPropertyReference getCollectionPropertyReference(String propertyName) {
 		return elementType.getCollectionPropertyReference( propertyName );
+	}
+
+	public String getIdentifierPropertyName() {
+		return elementType.getIdentifierPropertyName();
 	}
 
 	public void setFetch(boolean fetch) {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
@@ -129,10 +129,10 @@ class FromElementType {
 	 */
 	String renderScalarIdentifierSelect(int i) {
 		checkInitialized();
-		String[] cols = getPropertyMapping( EntityPersister.ENTITY_ID ).toColumns(
-				getTableAlias(),
-				EntityPersister.ENTITY_ID
-		);
+
+		final String idPropertyName = getIdentifierPropertyName();
+		String[] cols = getPropertyMapping( idPropertyName ).toColumns( getTableAlias(), idPropertyName );
+
 		StringBuilder buf = new StringBuilder();
 		// For property references generate <tablealias>.<columnname> as <projectionalias>
 		for ( int j = 0; j < cols.length; j++ ) {
@@ -675,6 +675,16 @@ class FromElementType {
 		public String[] toColumns(String propertyName) throws QueryException, UnsupportedOperationException {
 			validate( propertyName );
 			return queryableCollection.toColumns( propertyName );
+		}
+	}
+
+	public String getIdentifierPropertyName() {
+		if ( getEntityPersister() != null && getEntityPersister().getEntityMetamodel() != null
+				&& getEntityPersister().getEntityMetamodel().hasNonIdentifierPropertyNamedId() ) {
+			return getEntityPersister().getIdentifierPropertyName();
+		}
+		else {
+			return EntityPersister.ENTITY_ID;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/SelectNewEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/SelectNewEmbeddedIdTest.java
@@ -1,0 +1,139 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.hql;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test entities with a non-identifier property named 'id' with an EmbeddedId using
+ * the constructor new syntax.
+ *
+ * @author Chris Cranford
+ */
+public class SelectNewEmbeddedIdTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Simple.class };
+	}
+
+	private void assertQueryRowCount(String queryString, int rowCount) {
+		EntityManager entityManager = getOrCreateEntityManager();
+		try {
+			// persist the data
+			entityManager.getTransaction().begin();
+			entityManager.persist( new Simple( new SimpleId( 1, 1 ), 1 ) );
+			entityManager.getTransaction().commit();
+
+			Query query = entityManager.createQuery( queryString );
+			assertEquals( rowCount, query.getResultList().size() );
+		}
+		catch ( Exception e ) {
+			if ( entityManager.getTransaction().isActive() ) {
+				entityManager.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewListEntity() {
+		assertQueryRowCount( "select new list(e) FROM Simple e", 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewListEmbeddedIdValue() {
+		assertQueryRowCount( "select new list(e.simpleId) FROM Simple e", 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewMapEntity() {
+		assertQueryRowCount( "select new map(e.id, e) FROM Simple e", 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewMapEmbeddedIdValue() {
+		assertQueryRowCount( "select new map(e.simpleId, e.simpleId) FROM Simple e", 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewObjectEntity() {
+		assertQueryRowCount( "select new " + Wrapper.class.getName() + "(e) FROM Simple e", 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-4712")
+	public void testSelectNewObjectEmbeddedIdValue() {
+		assertQueryRowCount( "select new " + Wrapper.class.getName() + "(e.simpleId) FROM Simple e", 1 );
+	}
+
+	@Entity(name = "Simple")
+	public static class Simple {
+		@EmbeddedId
+		private SimpleId simpleId;
+		private int id;
+
+		public Simple() {
+
+		}
+
+		public Simple(SimpleId simpleId, int id) {
+			this.simpleId = simpleId;
+			this.id = id;
+		}
+	}
+
+	@Embeddable
+	public static class SimpleId implements Serializable {
+		private int realId;
+		private int otherId;
+
+		public SimpleId() {
+		}
+
+		public SimpleId(int realId, int otherId) {
+			this.realId = realId;
+			this.otherId = otherId;
+		}
+	}
+
+	public static class Wrapper {
+		private Simple simple;
+
+		public Wrapper() {
+
+		}
+
+		public Wrapper(Simple simple) {
+			this.simple = simple;
+		}
+
+		public Wrapper(SimpleId simpleId) {
+
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-4712

In circumstances where an entity's identifier was an Embeddable but also contained a non-identifier property named id would result in failure to generate the proper column aliases for the query.

This fix makes sure the same logic is used in several places to avoid the incorrect SQL generated.