### PR TITLE
Fix HHH-11352 - the Pattern at buildShallowIndexPattern where "wordBoundary==true" should wrap the pattern properly with '\b'

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -361,14 +361,15 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 	 * based on the search pattern that is not enclosed in parenthesis.
 	 *
 	 * @param pattern String search pattern.
-	 * @param wordBoundardy whether to apply a word boundary restriction.
+	 * @param wordBoundary whether to apply a word boundary restriction.
 	 * @return Compiled {@link Pattern}.
 	 */
-	private static Pattern buildShallowIndexPattern(String pattern, boolean wordBoundardy) {
+	private static Pattern buildShallowIndexPattern(String pattern, boolean wordBoundary) {
 		return Pattern.compile(
 				"(" +
-				( wordBoundardy ? "\\b" : "" ) +
+				( wordBoundary ? "\\b" : "" ) +
 				pattern +
+				( wordBoundary ? "\\b" : "" ) +
 				")(?![^\\(|\\[]*(\\)|\\]))",
 				Pattern.CASE_INSENSITIVE
 		);

--- a/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
@@ -129,6 +129,16 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-11352")
+	public void testPagingWithColumnNameStartingWithFrom() {
+		final String sql = "select column1 c1, from_column c2 from table1";
+		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"select column1 c1, from_column c2 from table1 ) inner_query ) " +
+				"SELECT c1, c2 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				dialect.getLimitHandler().processSql(sql, toRowSelection(3, 5)));
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HHH-7019")
 	public void testGetLimitStringWithSubselect() {
 		final String subselectInSelectClauseSQL = "select persistent0_.id as col_0_0_, " +


### PR DESCRIPTION
Fix HHH-11352 - the Pattern at buildShallowIndexPattern where "wordBoundary==true" should wrap the pattern properly with '\b'