### PR TITLE
HHH-9834: Fix Audit table creation fails for ElementCollection Map with CLOB/NCLOB element column

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/strategy/ValidityAuditStrategy.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/strategy/ValidityAuditStrategy.java
@@ -36,6 +36,9 @@ import org.hibernate.property.access.spi.Getter;
 import org.hibernate.sql.Update;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
+import org.hibernate.type.MapType;
+import org.hibernate.type.MaterializedClobType;
+import org.hibernate.type.MaterializedNClobType;
 import org.hibernate.type.Type;
 
 import static org.hibernate.envers.internal.entities.mapper.relation.query.QueryConstants.MIDDLE_ENTITY_ALIAS;
@@ -260,25 +263,8 @@ public class ValidityAuditStrategy implements AuditStrategy {
 			}
 		}
 
-		final SessionFactoryImplementor sessionFactory = ( (SessionImplementor) session ).getFactory();
-		final Type propertyType = sessionFactory.getMetamodel().entityPersister( entityName ).getPropertyType( propertyName );
-		if ( propertyType.isCollectionType() ) {
-			CollectionType collectionPropertyType = (CollectionType) propertyType;
-			// Handling collection of components.
-			if ( collectionPropertyType.getElementType( sessionFactory ) instanceof ComponentType ) {
-				// Adding restrictions to compare data outside of primary key.
-				// todo: is it necessary that non-primary key attributes be compared?
-				for ( Map.Entry<String, Object> dataEntry : persistentCollectionChangeData.getData().entrySet() ) {
-					if ( !originalIdPropName.equals( dataEntry.getKey() ) ) {
-						if ( dataEntry.getValue() != null ) {
-							qb.getRootParameters().addWhereWithParam( dataEntry.getKey(), true, "=", dataEntry.getValue() );
-						}
-						else {
-							qb.getRootParameters().addNullRestriction( dataEntry.getKey(), true );
-						}
-					}
-				}
-			}
+		if ( isNonIdentifierWhereConditionsRequired( entityName, propertyName, (SessionImplementor) session ) ) {
+			addNonIdentifierWhereConditions( qb, persistentCollectionChangeData.getData(), originalIdPropName );
 		}
 
 		addEndRevisionNullRestriction( auditEntitiesConfiguration, qb.getRootParameters() );
@@ -297,6 +283,37 @@ public class ValidityAuditStrategy implements AuditStrategy {
 		// Save the audit data
 		session.save( persistentCollectionChangeData.getEntityName(), persistentCollectionChangeData.getData() );
 		sessionCacheCleaner.scheduleAuditDataRemoval( session, persistentCollectionChangeData.getData() );
+	}
+
+	private boolean isNonIdentifierWhereConditionsRequired(String entityName, String propertyName, SessionImplementor session) {
+		final Type propertyType = session.getSessionFactory().getMetamodel().entityPersister( entityName ).getPropertyType( propertyName );
+		if ( propertyType.isCollectionType() ) {
+			final CollectionType collectionType = (CollectionType) propertyType;
+			final Type collectionElementType = collectionType.getElementType( session.getSessionFactory() );
+			if ( collectionElementType instanceof ComponentType ) {
+				// required for Embeddables
+				return true;
+			}
+			else if ( collectionElementType instanceof MaterializedClobType || collectionElementType instanceof MaterializedNClobType ) {
+				// for Map<> using @Lob annotations
+				return collectionType instanceof MapType;
+			}
+		}
+		return false;
+	}
+
+	private void addNonIdentifierWhereConditions(QueryBuilder qb, Map<String, Object> data, String originalIdPropertyName) {
+		final Parameters parameters = qb.getRootParameters();
+		for ( Map.Entry<String, Object> entry : data.entrySet() ) {
+			if ( !originalIdPropertyName.equals( entry.getKey() ) ) {
+				if ( entry.getValue() != null ) {
+					parameters.addWhereWithParam( entry.getKey(), true, "=", entry.getValue() );
+				}
+				else {
+					parameters.addNullRestriction( entry.getKey(), true );
+				}
+			}
+		}
 	}
 
 	private void addEndRevisionNullRestriction(AuditEntitiesConfiguration auditEntitiesConfiguration, Parameters rootParameters) {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/StringMapLobTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/StringMapLobTest.java
@@ -19,6 +19,7 @@ import org.hibernate.envers.Audited;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.tools.TestTools;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Chris Cranford
  */
+@TestForIssue(jiraKey = "HHH-9834")
 public class StringMapLobTest extends BaseEnversJPAFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
@@ -42,37 +44,81 @@ public class StringMapLobTest extends BaseEnversJPAFunctionalTestCase {
 			simple.getEmbeddedMap().put( "2", "Two" );
 			entityManager.persist( simple );
 		} );
+
 		TransactionUtil.doInJPA( this::entityManagerFactory, entityManager -> {
 			final Simple simple = entityManager.find( Simple.class, 1 );
 			simple.getEmbeddedMap().put( "3", "Three" );
 			entityManager.merge( simple );
 		} );
+
 		TransactionUtil.doInJPA( this::entityManagerFactory, entityManager -> {
 			final Simple simple = entityManager.find( Simple.class, 1 );
 			simple.getEmbeddedMap().remove( "1" );
 			simple.getEmbeddedMap().remove( "2" );
 			entityManager.merge( simple );
 		} );
+
+		TransactionUtil.doInJPA( this::entityManagerFactory, entityManager -> {
+			final Simple simple = entityManager.find( Simple.class, 1 );
+			simple.getEmbeddedMap().remove( "3" );
+			simple.getEmbeddedMap().put( "3", "Three-New" );
+			entityManager.merge( simple );
+		} );
+
+		TransactionUtil.doInJPA( this::entityManagerFactory, entityManager -> {
+			final Simple simple = entityManager.find( Simple.class, 1 );
+			simple.getEmbeddedMap().clear();
+			entityManager.merge( simple );
+		} );
 	}
 
 	@Test
 	public void testRevisionCounts() {
-		assertEquals( Arrays.asList( 1, 2, 3 ), getAuditReader().getRevisions( Simple.class, 1 ) );
+		assertEquals( Arrays.asList( 1, 2, 3, 4, 5 ), getAuditReader().getRevisions( Simple.class, 1 ) );
 	}
 
 	@Test
 	public void testRevisionHistory() {
 		final Simple rev1 = getAuditReader().find( Simple.class, 1, 1 );
 		assertEquals( 2, rev1.getEmbeddedMap().entrySet().size() );
-		assertEquals( TestTools.makeSet( "1", "2" ), rev1.getEmbeddedMap().keySet() );
+		TestTools.assertCollectionsEqual(
+				TestTools.<String, String>mapBuilder()
+						.add( "1", "One" )
+						.add( "2", "Two" )
+						.entries(),
+				rev1.getEmbeddedMap().entrySet()
+		);
 
 		final Simple rev2 = getAuditReader().find( Simple.class, 1, 2 );
 		assertEquals( 3, rev2.getEmbeddedMap().entrySet().size() );
-		assertEquals( TestTools.makeSet( "1", "2", "3" ), rev2.getEmbeddedMap().keySet() );
+		TestTools.assertCollectionsEqual(
+				TestTools.<String,String>mapBuilder()
+						.add( "1", "One" )
+						.add( "2", "Two" )
+						.add( "3", "Three" )
+						.entries(),
+				rev2.getEmbeddedMap().entrySet()
+		);
 
 		final Simple rev3 = getAuditReader().find( Simple.class, 1, 3 );
 		assertEquals( 1, rev3.getEmbeddedMap().entrySet().size() );
-		assertEquals( TestTools.makeSet( "3" ), rev3.getEmbeddedMap().keySet() );
+		TestTools.assertCollectionsEqual(
+				TestTools.<String,String>mapBuilder()
+						.add( "3", "Three" )
+						.entries(),
+				rev3.getEmbeddedMap().entrySet()
+		);
+
+		final Simple rev4 = getAuditReader().find( Simple.class, 1, 4 );
+		TestTools.assertCollectionsEqual(
+				TestTools.<String,String>mapBuilder()
+						.add( "3", "Three-New" )
+						.entries(),
+				rev4.getEmbeddedMap().entrySet()
+		);
+
+		final Simple rev5 = getAuditReader().find( Simple.class, 1, 5 );
+		assertEquals( 0, rev5.getEmbeddedMap().size() );
 	}
 
 	@Entity(name = "Simple")

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/tools/TestTools.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/tools/TestTools.java
@@ -20,6 +20,8 @@ import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Adam Warski (adam at warski dot org)
  */
@@ -82,5 +84,43 @@ public class TestTools {
 			}
 		}
 		return result;
+	}
+
+	public static <T> void assertCollectionsEqual(Collection<T> expected, Collection<T> actual) {
+		assertEquals( expected.size(), actual.size() );
+		Iterator<T> it = actual.iterator();
+		for ( T obj : actual ) {
+			assertEquals( obj, it.next() );
+		}
+	}
+
+	public static <K,E> MapBuilder<K,E> mapBuilder() {
+		return new MashMapBuilderImpl<K,E>();
+	}
+
+	public interface MapBuilder<K,E> {
+		MapBuilder<K,E> add(K key, E value);
+		Set<Map.Entry<K,E>> entries();
+		Map<K,E> map();
+	}
+
+	private static class MashMapBuilderImpl<K,E> implements MapBuilder<K,E> {
+		private final Map<K,E> hashMap = new HashMap<K, E>();
+
+		@Override
+		public MapBuilder<K, E> add(K key, E value) {
+			hashMap.put( key, value );
+			return this;
+		}
+
+		@Override
+		public Set<Map.Entry<K, E>> entries() {
+			return hashMap.entrySet();
+		}
+
+		@Override
+		public Map<K, E> map() {
+			return hashMap;
+		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-9834

This PR addresses a flaw in the original PR https://github.com/hibernate/hibernate-orm/pull/1714, where we now will include the Revision Type field as part of the primary key to address uniqueness concerns.
