### PR TITLE
Fix for HHH-10256

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
@@ -55,7 +55,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 	@Override
 	public ResultSet extract(PreparedStatement statement) {
 		// IMPL NOTE : SQL logged by caller
-		if ( isTypeOf( statement, CallableStatement.class ) ) {
+		if ( isTypeOf( statement, CallableStatement.class ) && statement instanceof CallableStatement ) {
 			// We actually need to extract from Callable statement.  Although
 			// this seems needless, Oracle can return an
 			// OracleCallableStatementWrapper that finds its way to this method,


### PR DESCRIPTION
The problem was, that the type is checked with
statement.isWrapperFor(type), which returns true because the wrapped
class is of type CallableStatement. In the next step, the checked class
(the statement or wrapper) is casted to CallableStatement resulting in a
ClassCastException if the wrapper doesn't implement CallableStatement. I
got the ClassCastException when trying to use the SAP HANA jdbc driver
because the inner class was a CallableStatement, but the wrapper was
not.