### PR TITLE
HHH-11389 - Update Byte Buddy to v1.6.0

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/FieldAccessEnhancer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/FieldAccessEnhancer.java
@@ -8,12 +8,12 @@ package org.hibernate.bytecode.enhance.internal.bytebuddy;
 
 import javax.persistence.Id;
 
+import net.bytebuddy.description.method.MethodList;
 import org.hibernate.bytecode.enhance.spi.EnhancementException;
 import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 
-import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.AsmVisitorWrapper;
 import net.bytebuddy.description.field.FieldDescription;
 import net.bytebuddy.description.field.FieldList;
@@ -47,7 +47,7 @@ class FieldAccessEnhancer implements AsmVisitorWrapper.ForDeclaredMethods.Method
 	@Override
 	public MethodVisitor wrap(
 			TypeDescription instrumentedType,
-			MethodDescription.InDefinedShape instrumentedMethod,
+			MethodDescription instrumentedMethod,
 			MethodVisitor methodVisitor,
 			Implementation.Context implementationContext,
 			TypePool typePool,

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import javax.persistence.Embedded;
 
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
 import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
 import org.hibernate.engine.spi.CompositeOwner;
 import org.hibernate.internal.CoreLogging;
@@ -116,7 +118,7 @@ class PersistentAttributeTransformer implements AsmVisitorWrapper.ForDeclaredMet
 	@Override
 	public MethodVisitor wrap(
 			TypeDescription instrumentedType,
-			MethodDescription.InDefinedShape instrumentedMethod,
+			MethodDescription instrumentedMethod,
 			MethodVisitor methodVisitor,
 			Implementation.Context implementationContext,
 			TypePool typePool,

--- a/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
@@ -262,7 +262,7 @@ public final class MessageHelper {
 				ownerKey = collectionKey;
 			}
 			else {
-            Object collectionOwner = collection == null ? null : collection.getOwner();
+			Object collectionOwner = collection == null ? null : collection.getOwner();
 				EntityEntry entry = collectionOwner == null ? null : session.getPersistenceContext().getEntry(collectionOwner);
 				ownerKey = entry == null ? null : entry.getId();
 			}

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -19,7 +19,7 @@ ext {
     cdiVersion = '1.1'
 
     javassistVersion = '3.20.0-GA'
-    byteBuddyVersion = '1.5.4'
+    byteBuddyVersion = '1.6.0'
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
     wildflyVersion = '10.0.0.Final'


### PR DESCRIPTION
Byte Buddy 1.6.0 fixes proxy support on Java 9 after latest EA update. Also, it fixes the Karaf OSGi descriptor according to https://hibernate.atlassian.net/browse/HHH-11309