### PR TITLE
HHH-11369 Fix nonFatalCheckstyle task blocking 'tasks' listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,8 +358,9 @@ subprojects { subProject ->
 	checkstyleMain.source = 'src/main/java'
 	
 	// define a second checkstyle task for checking non-fatal violations
-	task nonFatalCheckstyle(type:Checkstyle, dependsOn: checkstyle) {
-		source subProject.sourceSets.main
+	task nonFatalCheckstyle(type:Checkstyle) {
+		source = subProject.sourceSets.main.java
+		classpath = subProject.configurations.checkstyle
 		showViolations = false
 		configFile = rootProject.file( 'shared/config/checkstyle/checkstyle-non-fatal.xml' )
 	}


### PR DESCRIPTION
Additionally, I noticed the task had the regular `checkstyle` task listed as a dependency, making it so that the fatal checkstyle is run before the non-fatal one. This is fixed as well.