### PR TITLE
HHH-8973 - Fix tracking entity changes to detached entities with modified-flags feature.

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
@@ -18,6 +18,7 @@ import org.hibernate.envers.event.spi.EnversPostInsertEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPostUpdateEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionRemoveEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionUpdateEventListenerImpl;
+import org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
@@ -29,6 +30,7 @@ import org.jboss.logging.Logger;
  * Hooks up Envers event listeners.
  *
  * @author Steve Ebersole
+ * @author Chris Cranford
  */
 public class EnversIntegrator implements Integrator {
 	private static final Logger log = Logger.getLogger( EnversIntegrator.class );
@@ -88,6 +90,10 @@ public class EnversIntegrator implements Integrator {
 			listenerRegistry.appendListeners(
 					EventType.POST_INSERT,
 					new EnversPostInsertEventListenerImpl( enversService )
+			);
+			listenerRegistry.appendListeners(
+					EventType.PRE_UPDATE,
+					new EnversPreUpdateEventListenerImpl( enversService )
 			);
 			listenerRegistry.appendListeners(
 					EventType.POST_UPDATE,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversUpdateEventListener.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversUpdateEventListener.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.event.spi;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.entities.EntityConfiguration;
+
+/**
+ * @author Chris Cranford
+ */
+public abstract class BaseEnversUpdateEventListener extends BaseEnversEventListener {
+	public BaseEnversUpdateEventListener(EnversService enversService) {
+		super( enversService );
+	}
+
+	/**
+	 * Returns whether the entity has {@code withModifiedFlag} features and has no old state, most likely implying
+	 * it was updated in a detached entity state.
+	 *
+	 * @param entityName The associated entity name.
+	 * @param oldState The event old (likely detached) entity state.
+	 * @return {@code true} if the entity is/has been updated in detached state, otherwise {@code false}.
+	 */
+	protected boolean isDetachedEntityUpdate(String entityName, Object[] oldState) {
+		final EntityConfiguration configuration = getEnversService().getEntitiesConfigurations().get( entityName );
+		if ( configuration.getPropertyMapper() != null && oldState == null ) {
+			return configuration.getPropertyMapper().hasPropertiesWithModifiedFlag();
+		}
+		return false;
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/EnversPreUpdateEventListenerImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/EnversPreUpdateEventListenerImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.event.spi;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.synchronization.AuditProcess;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+
+/**
+ * Envers-specific entity (pre) update event listener.
+ *
+ * @author Chris Cranford
+ */
+public class EnversPreUpdateEventListenerImpl extends BaseEnversUpdateEventListener implements PreUpdateEventListener {
+	public EnversPreUpdateEventListenerImpl(EnversService enversService) {
+		super( enversService );
+	}
+
+	@Override
+	public boolean onPreUpdate(PreUpdateEvent event) {
+		final String entityName = event.getPersister().getEntityName();
+		if ( getEnversService().getEntitiesConfigurations().isVersioned( entityName ) ) {
+			checkIfTransactionInProgress( event.getSession() );
+			if ( isDetachedEntityUpdate( entityName, event.getOldState() ) ) {
+				final AuditProcess auditProcess = getEnversService().getAuditProcessManager().get( event.getSession() );
+				auditProcess.cacheEntityState(
+						event.getId(),
+						entityName,
+						event.getPersister().getDatabaseSnapshot( event.getId(), event.getSession() )
+				);
+			}
+		}
+		return false;
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/ComponentPropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/ComponentPropertyMapper.java
@@ -25,6 +25,7 @@ import org.hibernate.property.access.spi.Setter;
  * @author Adam Warski (adam at warski dot org)
  * @author Michal Skowronek (mskowr at o2 dot pl)
  * @author Lukasz Zuchowski (author at zuchos dot com)
+ * @author Chris Cranford
  */
 public class ComponentPropertyMapper implements PropertyMapper, CompositeMapperBuilder {
 	private final PropertyData propertyData;
@@ -157,5 +158,10 @@ public class ComponentPropertyMapper implements PropertyMapper, CompositeMapperB
 	@Override
 	public Map<PropertyData, PropertyMapper> getProperties() {
 		return delegate.getProperties();
+	}
+
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		return delegate.hasPropertiesWithModifiedFlag();
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/ModifiedFlagMapperSupport.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/ModifiedFlagMapperSupport.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities.mapper;
+
+/**
+ * Contract for {@link PropertyMapper} implementations to expose whether they contain any property
+ * that uses {@link org.hibernate.envers.internal.entities.PropertyData#isUsingModifiedFlag()}.
+ *
+ * @author Chris Cranford
+ */
+public interface ModifiedFlagMapperSupport {
+	/**
+	 * Returns whether the associated {@link PropertyMapper} has any properties that use
+	 * the {@code witModifiedFlag} feature.
+	 *
+	 * @return {@code true} if a property uses {@code withModifiedFlag}, otherwise {@code false}.
+	 */
+	boolean hasPropertiesWithModifiedFlag();
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiPropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiPropertyMapper.java
@@ -233,4 +233,14 @@ public class MultiPropertyMapper implements ExtendedPropertyMapper {
 	public Map<String, PropertyData> getPropertyDatas() {
 		return propertyDatas;
 	}
+
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		for ( PropertyData property : getProperties().keySet() ) {
+			if ( property.isUsingModifiedFlag() ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/PropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/PropertyMapper.java
@@ -18,8 +18,9 @@ import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 /**
  * @author Adam Warski (adam at warski dot org)
  * @author Michal Skowronek (mskowr at o2 dot pl)
+ * @author Chris Cranford
  */
-public interface PropertyMapper {
+public interface PropertyMapper extends ModifiedFlagMapperSupport {
 	/**
 	 * Maps properties to the given map, basing on differences between properties of new and old objects.
 	 *

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SinglePropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SinglePropertyMapper.java
@@ -133,4 +133,8 @@ public class SinglePropertyMapper implements PropertyMapper, SimpleMapperBuilder
 		return null;
 	}
 
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		return propertyData != null && propertyData.isUsingModifiedFlag();
+	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SubclassPropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SubclassPropertyMapper.java
@@ -23,6 +23,7 @@ import org.hibernate.envers.internal.reader.AuditReaderImplementor;
  *
  * @author Adam Warski (adam at warski dot org)
  * @author Michal Skowronek (mskowr at o2 dot pl)
+ * @author Chris Cranford
  */
 public class SubclassPropertyMapper implements ExtendedPropertyMapper {
 	private ExtendedPropertyMapper main;
@@ -140,4 +141,16 @@ public class SubclassPropertyMapper implements ExtendedPropertyMapper {
 		joinedProperties.putAll( main.getProperties() );
 		return joinedProperties;
 	}
+
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		// checks all properties, exposed both by the main mapper and parent mapper.
+		for ( PropertyData property : getProperties().keySet() ) {
+			if ( property.isUsingModifiedFlag() ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
@@ -38,6 +38,7 @@ import org.hibernate.property.access.spi.Setter;
 /**
  * @author Adam Warski (adam at warski dot org)
  * @author Michal Skowronek (mskowr at o2 dot pl)
+ * @author Chris Cranford
  */
 public abstract class AbstractCollectionMapper<T> implements PropertyMapper {
 	protected final CommonCollectionMapperData commonCollectionMapperData;
@@ -394,5 +395,14 @@ public abstract class AbstractCollectionMapper<T> implements PropertyMapper {
 		addCollectionChanges( session, collectionChanges, deleted, RevisionType.DEL, id );
 
 		return collectionChanges;
+	}
+
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		if ( commonCollectionMapperData != null ) {
+			final PropertyData propertyData = commonCollectionMapperData.getCollectionReferencingPropertyData();
+			return propertyData != null && propertyData.isUsingModifiedFlag();
+		}
+		return false;
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractToOneMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractToOneMapper.java
@@ -26,6 +26,7 @@ import org.hibernate.service.ServiceRegistry;
  * Base class for property mappers that manage to-one relation.
  *
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
+ * @author Chris Cranford
  */
 public abstract class AbstractToOneMapper implements PropertyMapper {
 	private final ServiceRegistry serviceRegistry;
@@ -134,5 +135,10 @@ public abstract class AbstractToOneMapper implements PropertyMapper {
 		public boolean isAudited() {
 			return audited;
 		}
+	}
+
+	@Override
+	public boolean hasPropertiesWithModifiedFlag() {
+		return propertyData != null && propertyData.isUsingModifiedFlag();
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/modifiedflags/DetachedEntityTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/modifiedflags/DetachedEntityTest.java
@@ -1,0 +1,186 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.modifiedflags;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test that an updated detached entity will still properly track {@code withModifiedFlag}
+ * values correctly rather than always triggering that a field was modified so that both a
+ * detached and attached entity result in the same {@code withModifiedFlag} settings.
+ *
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-8973")
+public class DetachedEntityTest extends BaseEnversFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class<?>[] { Project.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		final Session s = openSession();
+		try {
+			// revision 1 - persist the project entity
+			s.getTransaction().begin();
+			final Project project = new Project( 1, "fooName" );
+			s.persist( project );
+			s.getTransaction().commit();
+
+			// detach the project entity
+			s.clear();
+
+			// revision 2 to 6 - update the detached project entity.
+			for( int i = 0; i < 5; ++i ) {
+				s.getTransaction().begin();
+				project.setName( "fooName" + ( i + 2 ) );
+				s.update( project );
+				s.getTransaction().commit();
+				s.clear();
+			}
+		}
+		catch ( Throwable t ) {
+			if ( s.getTransaction().isActive() ) {
+				s.getTransaction().rollback();
+			}
+			throw t;
+		}
+		finally {
+			s.close();
+		}
+	}
+
+	@Test
+	public void testRevisionCounts() {
+		assertEquals( Arrays.asList( 1, 2, 3, 4, 5, 6 ), getAuditReader().getRevisions( Project.class, 1 ) );
+	}
+
+	@Test
+	public void testRevisionHistory() {
+		for ( Integer revision : Arrays.asList( 1, 2, 3, 4, 5, 6 ) ) {
+			final Project project = getAuditReader().find( Project.class, 1, revision );
+			if ( revision == 1 ) {
+				assertEquals( new Project( 1, "fooName" ), project );
+			}
+			else {
+				assertEquals( new Project( 1, "fooName" + revision ), project );
+			}
+		}
+	}
+
+	@Test
+	public void testModifiedFlagChangesForProjectType() {
+		final List results = getAuditReader().createQuery()
+				.forRevisionsOfEntity( Project.class, false, true )
+				.add( AuditEntity.property( "type" ).hasChanged() )
+				.addProjection( AuditEntity.revisionNumber() )
+				.getResultList();
+		assertEquals( Arrays.asList( 1 ), results );
+	}
+
+	@Test
+	public void testModifiedFlagChangesForProjectName() {
+		final List results = getAuditReader().createQuery()
+				.forRevisionsOfEntity( Project.class, false, true )
+				.add( AuditEntity.property( "name" ).hasChanged() )
+				.addProjection( AuditEntity.revisionNumber() )
+				.getResultList();
+		assertEquals( Arrays.asList( 1, 2, 3, 4, 5, 6 ), results );
+	}
+
+	@Entity(name = "Project")
+	@Audited(withModifiedFlag = true)
+	public static class Project {
+		@Id
+		private Integer id;
+		private String name;
+		private String type;
+
+		Project() {
+
+		}
+
+		Project(Integer id, String name) {
+			this( id, name, "fooType" );
+		}
+
+		Project(Integer id, String name, String type) {
+			this.id = id;
+			this.name = name;
+			this.type = type;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			Project project = (Project) o;
+
+			if ( id != null ? !id.equals( project.id ) : project.id != null ) {
+				return false;
+			}
+			if ( name != null ? !name.equals( project.name ) : project.name != null ) {
+				return false;
+			}
+			return type != null ? type.equals( project.type ) : project.type == null;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = id != null ? id.hashCode() : 0;
+			result = 31 * result + ( name != null ? name.hashCode() : 0 );
+			result = 31 * result + ( type != null ? type.hashCode() : 0 );
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-8973

This PR solves the problem when an entity uses the `withModifiedFlag` feature either set specifically on an entity, entity property or the global property and the entity is updated in a detached state to make sure that modified flags columns represent the state changes just as if the entity was attached.