### PR TITLE
HHH-11394 Custom WildFly modules include a duplicate dependency on Ja…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/BasicCdiTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/BasicCdiTest.java
@@ -51,6 +51,7 @@ public class BasicCdiTest {
 				.addClass( EventQueue.class )
 				.addClass( Event.class )
 				.addClass( Monitor.class )
+				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ConversationalPersistenceContextExtendedTest.java
@@ -37,6 +37,7 @@ public class ConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( ConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ManualFlushConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ManualFlushConversationalPersistenceContextExtendedTest.java
@@ -38,6 +38,7 @@ public class ManualFlushConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( ManualFlushConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/NonConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/NonConversationalPersistenceContextExtendedTest.java
@@ -37,6 +37,7 @@ public class NonConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( NonConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/bmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/bmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
@@ -54,6 +54,7 @@ public class DdlInWildFlyUsingBmtAndEmfTest {
 				.setManifest( "org/hibernate/test/wf/ddl/manifest.mf" )
 				.addClass( WildFlyDdlEntity.class )
 //				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml")
+				.addAsWebInfResource( "jboss-deployment-structure.xml" ) //Add as "web-inf" resource on Web archives
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), PERSISTENCE_XML_RESOURCE_NAME )
 				.addAsResource( "org/hibernate/test/wf/ddl/log4j.properties", "log4j.properties" );
 		System.out.println( war.toString(true) );

--- a/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/cmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/cmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
@@ -52,6 +52,7 @@ public class DdlInWildFlyUsingBmtAndEmfTest {
 				.setManifest( "org/hibernate/test/wf/ddl/manifest.mf" )
 				.addClass( WildFlyDdlEntity.class )
 //				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml")
+				.addAsWebInfResource( "jboss-deployment-structure.xml" ) //Add as "web-inf" resource on Web archives
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), PERSISTENCE_XML_RESOURCE_NAME )
 				.addAsResource( "org/hibernate/test/wf/ddl/log4j.properties", "log4j.properties" );
 		System.out.println( war.toString(true) );

--- a/hibernate-core/src/test/resources/jboss-deployment-structure.xml
+++ b/hibernate-core/src/test/resources/jboss-deployment-structure.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+    <deployment>
+        <exclusions>
+            <!--
+            The org.javassist:main module is automatically injected by the current WildFly JPADependencyProcessor;
+            this module is necessary for users of the standard Hibernate ORM version included in WildFly,
+            but when testing the very latest Hibernate ORM it could be the wrong version.
+            We therefore exclude it here from the deployment, and have the custom ORM modules bring their own version.
+            See also: http://lists.jboss.org/pipermail/wildfly-dev/2017-January/005681.html
+            -->
+            <module name="org.javassist" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
+++ b/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
@@ -14,7 +14,6 @@
     </resources>
 
     <dependencies>
-        <module name="asm.asm"/>
         <module name="com.fasterxml.classmate"/>
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
@@ -25,10 +24,6 @@
         <module name="javax.xml.bind.api"/>
         <module name="org.antlr"/>
         <module name="org.dom4j"/>
-        <!-- Javassist is handled directly as a resource in order to account for
-        the likely conflict in Javassist versions
-        -->
-        <module name="org.javassist"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/hibernate-orm-modules/src/main/modules/org/hibernate/jipijapa-hibernate5/module.xml
+++ b/hibernate-orm-modules/src/main/modules/org/hibernate/jipijapa-hibernate5/module.xml
@@ -16,8 +16,6 @@
 
     <dependencies>
         <module name="org.hibernate" slot="${slot}"/>
-        <module name="asm.asm"/>
-        <module name="com.fasterxml.classmate"/>
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
@@ -25,9 +23,6 @@
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="javax.xml.bind.api"/>
-        <module name="org.antlr"/>
-        <module name="org.dom4j"/>
-        <module name="org.javassist"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateEnversOnWildflyTest.java
+++ b/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateEnversOnWildflyTest.java
@@ -44,6 +44,7 @@ public class HibernateEnversOnWildflyTest {
 		return ShrinkWrap.create( WebArchive.class )
 				.addClass( AuditedEntity.class )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsWebInfResource( "jboss-deployment-structure.xml" )
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), "META-INF/persistence.xml" );
 	}
 

--- a/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateModulesOnWildflyTest.java
+++ b/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateModulesOnWildflyTest.java
@@ -45,6 +45,7 @@ public class HibernateModulesOnWildflyTest {
 		return ShrinkWrap.create( WebArchive.class )
 				.addClass( Kryptonite.class )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsWebInfResource( "jboss-deployment-structure.xml" )
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), "META-INF/persistence.xml" );
 	}
 

--- a/hibernate-orm-modules/src/test/resources/jboss-deployment-structure.xml
+++ b/hibernate-orm-modules/src/test/resources/jboss-deployment-structure.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+    <deployment>
+        <exclusions>
+            <!--
+            The org.javassist:main module is automatically injected by the current WildFly JPADependencyProcessor;
+            this module is necessary for users of the standard Hibernate ORM version included in WildFly,
+            but when testing the very latest Hibernate ORM it could be the wrong version.
+            We therefore exclude it here from the deployment, and have the custom ORM modules bring their own version.
+            See also: http://lists.jboss.org/pipermail/wildfly-dev/2017-January/005681.html
+            -->
+            <module name="org.javassist" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
…vassist

 - https://hibernate.atlassian.net/browse/HHH-11394

And removed some more unnecessary dependencies.

The Arquillian tests need to make sure they explicitly exclude the default javassist instance, so that we can use our own (exclusively and consistently); before this, it was not deterministic which one would be used.