### PR TITLE
Update to Byte Buddy 1.6.4: fixes handling of bridge methods when encountering raw types

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -19,7 +19,7 @@ ext {
     cdiVersion = '1.1'
 
     javassistVersion = '3.20.0-GA'
-    byteBuddyVersion = '1.6.0'
+    byteBuddyVersion = '1.6.4'
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
     wildflyVersion = '10.1.0.Final'


### PR DESCRIPTION
Byte Buddy did previously not compute the correct bridge methods upon encountering a raw type within a type hierarchy when creating a proxy. This update resolves this problem.