### PR TITLE
HHH-11420 - Update Byte Buddy and use more granular locks on type caches

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -10,8 +10,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import net.bytebuddy.TypeCache;
 import org.hibernate.HibernateException;
@@ -73,7 +71,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 						.load(clazz.getClassLoader())
 						.getLoaded();
 			}
-		}, clazz);
+		}, FAST_CLASSES);
 
 		fastClass = FAST_CLASSES.insert( clazz.getClassLoader(), clazz.getName(), fastClass );
 
@@ -94,7 +92,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 						.load(clazz.getClassLoader())
 						.getLoaded();
 			}
-		}, clazz);
+		}, BULK_ACCESSORS);
 
 		try {
 			return new ReflectionOptimizerImpl(

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
@@ -114,7 +114,7 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 						.load(persistentClass.getClassLoader())
 						.getLoaded();
 			}
-		}, persistentClass);
+		}, CACHE);
 	}
 
 	@Override

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -19,7 +19,7 @@ ext {
     cdiVersion = '1.1'
 
     javassistVersion = '3.20.0-GA'
-    byteBuddyVersion = '1.6.4'
+    byteBuddyVersion = '1.6.6'
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
     wildflyVersion = '10.1.0.Final'


### PR DESCRIPTION
Updates Byte Buddy to version 1.6.5 with better handling of raw types and uses more granular locks to avoid dead-locks if classes are loaded during proxy creation where a proxy is created from another thread simultaneously.