### PR TITLE
HHH-10938 - Fix memory leak when bootstrapping EntityManagerFactory

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
@@ -118,8 +118,8 @@ public class JarFileBasedArchiveDescriptor extends AbstractArchiveDescriptor {
 				final String name = extractName( zipEntry );
 				final String relativeName = extractRelativeName( zipEntry );
 				final InputStreamAccess inputStreamAccess;
-				try {
-					inputStreamAccess = buildByteBasedInputStreamAccess( name, jarFile.getInputStream( zipEntry ) );
+				try (InputStream is = jarFile.getInputStream( zipEntry )) {
+					inputStreamAccess = buildByteBasedInputStreamAccess( name, is );
 				}
 				catch (IOException e) {
 					throw new ArchiveException(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-10938

This is simply a PR of the patch by @jbonjean found at https://hibernate.atlassian.net/secure/attachment/39001/0001-fix-HHH-10938.patch