### PR TITLE
HHH-11467 Replace incorrect use of StringHelper.WHITESPACE with single space.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -960,9 +960,9 @@ public abstract class CollectionBinder {
 			String clause = whereOnCollection.clause();
 			if ( StringHelper.isNotEmpty( clause ) ) {
 				if ( whereBuffer.length() > 0 ) {
-					whereBuffer.append( StringHelper.WHITESPACE );
+					whereBuffer.append( ' ' );
 					whereBuffer.append( Junction.Nature.AND.getOperator() );
-					whereBuffer.append( StringHelper.WHITESPACE );
+					whereBuffer.append( ' ' );
 				}
 				whereBuffer.append( clause );
 			}


### PR DESCRIPTION
This prevents an issue with Firebird where formfeed (\f or 0x0c) is not considered valid whitespace in a query.