### PR TITLE
HHH-12064 - Issue with unidirectional one-to-many association with a join column that references a column that is not the primary key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
@@ -86,7 +86,7 @@ public class CollectionReferenceInitializerImpl implements CollectionReferenceIn
 				ResultSetProcessingContext.EntityReferenceProcessingState ownerState = context.getOwnerProcessingState( (Fetch) collectionReference );
 
 				Serializable optionalKey = collectionReference.getCollectionPersister().getCollectionType()
-				.getKeyOfOwnerNoCast(ownerState.getEntityInstance(), context.getSession());
+				.getKeyOfOwnerNoSemiResolve(ownerState.getEntityInstance(), context.getSession());
 
 				if ( optionalKey != null ) {
 					// we did not find a collection element in the result set, so we

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
@@ -19,7 +19,6 @@ import org.hibernate.loader.plan.exec.spi.CollectionReferenceAliases;
 import org.hibernate.loader.plan.spi.CollectionReference;
 import org.hibernate.loader.plan.spi.Fetch;
 import org.hibernate.pretty.MessageHelper;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -84,7 +83,11 @@ public class CollectionReferenceInitializerImpl implements CollectionReferenceIn
 
 			}
 			else {
-				final Serializable optionalKey = findCollectionOwnerKey( context );
+				ResultSetProcessingContext.EntityReferenceProcessingState ownerState = context.getOwnerProcessingState( (Fetch) collectionReference );
+
+				Serializable optionalKey = collectionReference.getCollectionPersister().getCollectionType()
+				.getKeyOfOwnerNoCast(ownerState.getEntityInstance(), context.getSession());
+
 				if ( optionalKey != null ) {
 					// we did not find a collection element in the result set, so we
 					// ensure that a collection is created with the owner's identifier,

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -409,14 +409,13 @@ public abstract class CollectionType extends AbstractType implements Association
 	}
 
 	/**
-	 * Get the key value from the owning entity instance, usually the identifier, but might be some
-	 * other unique key, in the case of property-ref
+	 * Get the key value from the owning entity instance, without semi-resolving.
 	 *
 	 * @param owner The collection owner
 	 * @param session The session from which the request is originating.
 	 * @return The collection owner's key
 	 */
-	public Serializable getKeyOfOwnerNoCast(Object owner, SharedSessionContractImplementor session) {
+	public Serializable getKeyOfOwnerNoSemiResolve(Object owner, SharedSessionContractImplementor session) {
 
 		EntityEntry entityEntry = session.getPersistenceContext().getEntry( owner );
 		if ( entityEntry == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -46,12 +46,11 @@ import org.hibernate.persister.entity.Joinable;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
-
 import org.jboss.logging.Logger;
 
 /**
  * A type that handles Hibernate <tt>PersistentCollection</tt>s (including arrays).
- * 
+ *
  * @author Gavin King
  */
 public abstract class CollectionType extends AbstractType implements AssociationType {
@@ -107,8 +106,8 @@ public abstract class CollectionType extends AbstractType implements Association
 	@Override
 	public final boolean isEqual(Object x, Object y) {
 		return x == y
-			|| ( x instanceof PersistentCollection && ( (PersistentCollection) x ).wasInitialized() && ( (PersistentCollection) x ).isWrapper( y ) )
-			|| ( y instanceof PersistentCollection && ( (PersistentCollection) y ).wasInitialized() && ( (PersistentCollection) y ).isWrapper( x ) );
+			|| x instanceof PersistentCollection && ( (PersistentCollection) x ).wasInitialized() && ( (PersistentCollection) x ).isWrapper( y )
+			|| y instanceof PersistentCollection && ( (PersistentCollection) y ).wasInitialized() && ( (PersistentCollection) y ).isWrapper( x );
 	}
 
 	@Override
@@ -203,7 +202,7 @@ public abstract class CollectionType extends AbstractType implements Association
 			return "<uninitialized>";
 		}
 
-		final List<String> list = new ArrayList<String>();
+		final List<String> list = new ArrayList<>();
 		Type elemType = getElementType( factory );
 		Iterator itr = getElementsIterator( value );
 		while ( itr.hasNext() ) {
@@ -259,11 +258,11 @@ public abstract class CollectionType extends AbstractType implements Association
 	public Serializable disassemble(Object value, SharedSessionContractImplementor session, Object owner)
 			throws HibernateException {
 		//remember the uk value
-		
+
 		//This solution would allow us to eliminate the owner arg to disassemble(), but
 		//what if the collection was null, and then later had elements added? seems unsafe
 		//session.getPersistenceContext().getCollectionEntry( (PersistentCollection) value ).getKey();
-		
+
 		final Serializable key = getKeyOfOwner(owner, session);
 		if (key==null) {
 			return null;
@@ -278,7 +277,7 @@ public abstract class CollectionType extends AbstractType implements Association
 	@Override
 	public Object assemble(Serializable cached, SharedSessionContractImplementor session, Object owner)
 			throws HibernateException {
-		//we must use the "remembered" uk value, since it is 
+		//we must use the "remembered" uk value, since it is
 		//not available from the EntityEntry during assembly
 		if (cached==null) {
 			return null;
@@ -369,14 +368,14 @@ public abstract class CollectionType extends AbstractType implements Association
 	 * @return The collection owner's key
 	 */
 	public Serializable getKeyOfOwner(Object owner, SharedSessionContractImplementor session) {
-		
+
 		EntityEntry entityEntry = session.getPersistenceContext().getEntry( owner );
 		if ( entityEntry == null ) {
 			// This just handles a particular case of component
 			// projection, perhaps get rid of it and throw an exception
 			return null;
 		}
-		
+
 		if ( foreignKeyPropertyName == null ) {
 			return entityEntry.getId();
 		}
@@ -401,11 +400,48 @@ public abstract class CollectionType extends AbstractType implements Association
 				id = keyType.semiResolve(
 						entityEntry.getLoadedValue( foreignKeyPropertyName ),
 						session,
-						owner 
+						owner
 				);
 			}
 
 			return (Serializable) id;
+		}
+	}
+
+	/**
+	 * Get the key value from the owning entity instance, usually the identifier, but might be some
+	 * other unique key, in the case of property-ref
+	 *
+	 * @param owner The collection owner
+	 * @param session The session from which the request is originating.
+	 * @return The collection owner's key
+	 */
+	public Serializable getKeyOfOwnerNoCast(Object owner, SharedSessionContractImplementor session) {
+
+		EntityEntry entityEntry = session.getPersistenceContext().getEntry( owner );
+		if ( entityEntry == null ) {
+			// This just handles a particular case of component
+			// projection, perhaps get rid of it and throw an exception
+			return null;
+		}
+
+		if ( foreignKeyPropertyName == null ) {
+			return entityEntry.getId();
+		}
+		else {
+			// TODO: at the point where we are resolving collection references, we don't
+			// know if the uk value has been resolved (depends if it was earlier or
+			// later in the mapping document) - now, we could try and use e.getStatus()
+			// to decide to semiResolve(), trouble is that initializeEntity() reuses
+			// the same array for resolved and hydrated values
+			Object id;
+			if ( entityEntry.getLoadedState() != null ) {
+				id = entityEntry.getLoadedValue( foreignKeyPropertyName );
+			}
+			else {
+				id = entityEntry.getPersister().getPropertyValue( owner, foreignKeyPropertyName );
+			}
+			return id == null ? null : (Serializable) id;
 		}
 	}
 
@@ -450,10 +486,10 @@ public abstract class CollectionType extends AbstractType implements Association
 	@Override
 	public Object resolve(Object value, SharedSessionContractImplementor session, Object owner)
 			throws HibernateException {
-		
+
 		return resolveKey( getKeyOfOwner( owner, session ), session, owner );
 	}
-	
+
 	private Object resolveKey(Serializable key, SharedSessionContractImplementor session, Object owner) {
 		// if (key==null) throw new AssertionFailure("owner identifier unknown when re-assembling
 		// collection reference");
@@ -497,19 +533,19 @@ public abstract class CollectionType extends AbstractType implements Association
 	public String getAssociatedEntityName(SessionFactoryImplementor factory)
 			throws MappingException {
 		try {
-			
+
 			QueryableCollection collectionPersister = (QueryableCollection) factory
 					.getCollectionPersister( role );
-			
+
 			if ( !collectionPersister.getElementType().isEntityType() ) {
-				throw new MappingException( 
-						"collection was not an association: " + 
-						collectionPersister.getRole() 
+				throw new MappingException(
+						"collection was not an association: " +
+						collectionPersister.getRole()
 				);
 			}
-			
+
 			return collectionPersister.getElementPersister().getEntityName();
-			
+
 		}
 		catch (ClassCastException cce) {
 			throw new MappingException( "collection role is not queryable " + role );
@@ -599,7 +635,7 @@ public abstract class CollectionType extends AbstractType implements Association
 			for ( Map.Entry<Object, Object> entry : ( (Map<Object, Object>) originalSnapshot ).entrySet() ) {
 				Object key = entry.getKey();
 				Object value = entry.getValue();
-				Object resultSnapshotValue = ( resultSnapshot == null )
+				Object resultSnapshotValue = resultSnapshot == null
 						? null
 						: ( (Map<Object, Object>) resultSnapshot ).get( key );
 
@@ -682,7 +718,7 @@ public abstract class CollectionType extends AbstractType implements Association
 		// for a null target, or a target which is the same as the original, we
 		// need to put the merged elements in a new collection
 		Object result = target == null || target == original ? instantiateResult( original ) : target;
-		
+
 		//for arrays, replaceElements() may return a different reference, since
 		//the array length might not match
 		result = replaceElements( original, result, owner, copyCache, session );
@@ -749,12 +785,12 @@ public abstract class CollectionType extends AbstractType implements Association
 
 		// check if collection is currently being loaded
 		PersistentCollection collection = persistenceContext.getLoadContexts().locateLoadingCollection( persister, key );
-		
+
 		if ( collection == null ) {
-			
+
 			// check if it is already completely loaded, but unowned
 			collection = persistenceContext.useUnownedCollection( new CollectionKey(persister, key, entityMode) );
-			
+
 			if ( collection == null ) {
 
 				collection = persistenceContext.getCollection( new CollectionKey(persister, key, entityMode) );
@@ -781,15 +817,15 @@ public abstract class CollectionType extends AbstractType implements Association
 				}
 
 			}
-			
+
 			if ( LOG.isTraceEnabled() ) {
 				LOG.tracef( "Created collection wrapper: %s",
 						MessageHelper.collectionInfoString( persister, collection,
 								key, session ) );
 			}
-			
+
 		}
-		
+
 		collection.setOwner(owner);
 
 		return collection.getValue();
@@ -809,13 +845,13 @@ public abstract class CollectionType extends AbstractType implements Association
 	}
 
 	/**
-	 * We always need to dirty check the collection because we sometimes 
-	 * need to incremement version number of owner and also because of 
+	 * We always need to dirty check the collection because we sometimes
+	 * need to incremement version number of owner and also because of
 	 * how assemble/disassemble is implemented for uks
 	 */
 	@Override
 	public boolean isAlwaysDirtyChecked() {
-		return true; 
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
A one-to-many association is causing Hibernate to 
throw 
`INFO: HHH000327: Error performing load command : org.hibernate.property.access.spi.PropertyAccessException: 
`
when loading an entity via Session.get(domainClass, identifier), under the following conditions:
1. the association collection is annotated with @Fetch(FetchMode.JOIN)
2. the association's join column is referencing a non-primary key of the owning entity
3. the association's join column value is referencing a non-existing record of the associated table (the "many" side).

```
package org.hibernate.bugs;

import java.io.Serializable;
import java.util.List;

import javax.persistence.Basic;
import javax.persistence.Column;
import javax.persistence.Entity;
import javax.persistence.FetchType;
import javax.persistence.Id;
import javax.persistence.JoinColumn;
import javax.persistence.OneToMany;

import org.hibernate.Session;
import org.hibernate.SessionFactory;
import org.hibernate.Transaction;
import org.hibernate.annotations.Fetch;
import org.hibernate.annotations.FetchMode;
import org.hibernate.boot.Metadata;
import org.hibernate.boot.MetadataSources;
import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
import org.junit.Before;
import org.junit.Test;

/**
 * Issue with unidirectional one-to-many association with a join column that
 * references a column that is not the primary key.
 */
public class ORMStandaloneTestCase {

  private SessionFactory sf;


  @Before
  public void setup() {
    StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder().applySetting("hibernate.show_sql", "true")
        .applySetting("hibernate.format_sql", "true").applySetting("hibernate.hbm2ddl.auto", "update");

    Metadata metadata = new MetadataSources(srb.build()).addAnnotatedClass(Customer.class).addAnnotatedClass(Order.class)
        .buildMetadata();

    sf = metadata.buildSessionFactory();
  }


  @Test
  public void unidirectionalOneToManyAssociationTest() throws Exception {
    Session session = sf.openSession();
    Transaction tx = session.beginTransaction();

    try {
      // Save the entity on the One side
      Customer customer = new Customer();
      customer.idCode = "ABC";
      customer.translationId = 1L;

      session.persist(customer);
    } finally {
      tx.commit();
      session.close();
    }

    try {
      session = sf.openSession();
      tx = session.beginTransaction();

      // Attempt to load the entity saved in the previous session
      session.get(Customer.class, "ABC");

    } finally {
      tx.commit();
      session.close();
    }
  }

  @Entity
  public static class Customer implements Serializable {

    @Id
    @Basic
    public String      idCode;

    @Basic
    @Column(precision = 15, scale = 0)
    public Long        translationId;

    @Fetch(FetchMode.JOIN)
    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true)
    @JoinColumn(name = "translationId", referencedColumnName = "translationId")
    public List<Order> translations;
  }

  @Entity
  public static class Order implements Serializable {

    @Id
    @Basic
    @Column(precision = 15, scale = 0)
    public long id;

    @Basic
    @Column(precision = 15, scale = 0)
    public long translationId;
  }
}
```

