### PR TITLE
HHH-11484 - Fix LocaleTypeDescriptor to handle Locale.ROOT

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleTypeDescriptor.java
@@ -13,7 +13,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * Descriptor for {@link Locale} handling.
- * 
+ *
  * @author Steve Ebersole
  */
 public class LocaleTypeDescriptor extends AbstractTypeDescriptor<Locale> {
@@ -43,8 +43,12 @@ public class LocaleTypeDescriptor extends AbstractTypeDescriptor<Locale> {
 	public Locale fromString(String string) {
 		// TODO : Ultimately switch to Locale.Builder for this. However, Locale.Builder is Java 7
 
-		if ( string == null || string.isEmpty() ) {
+		if ( string == null ) {
 			return null;
+		}
+
+		if( string.isEmpty() ) {
+			return Locale.ROOT;
 		}
 
 		boolean separatorFound = false;

--- a/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocaleTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/descriptor/java/LocaleTypeDescriptorTest.java
@@ -32,6 +32,8 @@ public class LocaleTypeDescriptorTest extends BaseUnitTestCase {
 		assertEquals( toLocale( null, "DE", "ch123" ), LocaleTypeDescriptor.INSTANCE.fromString( "_DE_ch123" ) );
 		assertEquals( toLocale( "de", null, "ch123" ), LocaleTypeDescriptor.INSTANCE.fromString( "de__ch123" ) );
 		assertEquals( toLocale( "de", "DE", "ch123" ), LocaleTypeDescriptor.INSTANCE.fromString( "de_DE_ch123" ) );
+		assertEquals( toLocale( "", "", "" ), LocaleTypeDescriptor.INSTANCE.fromString( "" ) );
+		assertEquals( Locale.ROOT, LocaleTypeDescriptor.INSTANCE.fromString( "" ) );
 	}
 
 	public Locale toLocale(String lang, String region, String variant) {


### PR DESCRIPTION
Bug [HHH-11484](https://hibernate.atlassian.net/browse/HHH-11484)

`Locale.ROOT` is stored as an empty String in the database, but when the [LocaleTypeDescriptor](url) is ready the empty String from the database it is returning a `null` value instead of `Locale.ROOT`