### PR TITLE
HHH-11089 - pass foreign keys through the implicitNamingStrategy.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitForeignKeyNameSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitForeignKeyNameSource.java
@@ -14,4 +14,5 @@ import java.util.List;
 public interface ImplicitForeignKeyNameSource extends ImplicitConstraintNameSource {
 	public Identifier getReferencedTableName();
 	public List<Identifier> getReferencedColumnNames();
+	public Identifier getUserProvidedIdentifier();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
@@ -198,7 +198,7 @@ public class ImplicitNamingStrategyJpaCompliantImpl implements ImplicitNamingStr
 
 	@Override
 	public Identifier determineForeignKeyName(ImplicitForeignKeyNameSource source) {
-		return toIdentifier(
+		return source.getUserProvidedIdentifier() != null ? source.getUserProvidedIdentifier() : toIdentifier(
 				NamingHelper.INSTANCE.generateHashedFkName(
 						"FK",
 						source.getTableName(),


### PR DESCRIPTION
Call the implicit naming strategy regardless if the client has specified foreign key name
or not.