### PR TITLE
HHH-11470 - Schema update should not try to query sequences for Dialects not supporting them (DB2400Dialect, DerbyDialect, DB2390Dialect)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2390Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2390Dialect.java
@@ -75,6 +75,11 @@ public class DB2390Dialect extends DB2Dialect {
 	}
 
 	@Override
+	public String getQuerySequencesString() {
+		return null;
+	}
+
+	@Override
 	public boolean supportsLimit() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2400Dialect.java
@@ -60,6 +60,11 @@ public class DB2400Dialect extends DB2Dialect {
 	}
 
 	@Override
+	public String getQuerySequencesString() {
+		return null;
+	}
+
+	@Override
 	@SuppressWarnings("deprecation")
 	public boolean supportsLimitOffset() {
 		return false;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -133,7 +133,7 @@ public class DerbyDialect extends DB2Dialect {
 			return "select SEQUENCENAME from SYS.SYSSEQUENCES";
 		}
 		else {
-			throw new MappingException( "Derby does not support sequence prior to release 10.6.1.0" );
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/AbstractSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/AbstractSequenceInformationExtractorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public abstract class AbstractSequenceInformationExtractorTest {
+
+	@Test
+	public void testSequenceGenerationExtractor() {
+		final Dialect dialect = getDialect();
+		assertThat(
+				dialect.getQuerySequencesString(),
+				is( expectedQuerySequencesString() )
+		);
+		assertThat(
+				dialect.getSequenceInformationExtractor(),
+				instanceOf( expectedSequenceInformationExtractor() )
+		);
+	}
+
+	public abstract Dialect getDialect();
+
+	public abstract String expectedQuerySequencesString();
+
+	public abstract Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor();
+
+	@Entity(name = "MyEntity")
+	@Table(name = "my_entity")
+	public static class MyEntity {
+		@Id
+		public Integer id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DB2390SequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DB2390SequenceInformationExtractorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import org.hibernate.dialect.DB2390Dialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11470")
+public class DB2390SequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
+
+	@Override
+	public Dialect getDialect() {
+		return new DB2390Dialect();
+	}
+
+	@Override
+	public String expectedQuerySequencesString() {
+		return null;
+	}
+
+	@Override
+	public Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor() {
+		return SequenceInformationExtractorNoOpImpl.class;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DB2400SequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DB2400SequenceInformationExtractorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import org.hibernate.dialect.DB2400Dialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11470")
+public class DB2400SequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
+
+	@Override
+	public Dialect getDialect() {
+		return new DB2400Dialect();
+	}
+
+	@Override
+	public String expectedQuerySequencesString() {
+		return null;
+	}
+
+	@Override
+	public Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor() {
+		return SequenceInformationExtractorNoOpImpl.class;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenFiveDialectSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenFiveDialectSequenceInformationExtractorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import org.hibernate.dialect.DerbyTenFiveDialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11470")
+public class DerbyTenFiveDialectSequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
+
+	@Override
+	public Dialect getDialect() {
+		return new DerbyTenFiveDialect();
+	}
+
+	@Override
+	public String expectedQuerySequencesString() {
+		return null;
+	}
+
+	@Override
+	public Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor() {
+		return SequenceInformationExtractorNoOpImpl.class;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenSevenDialectSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenSevenDialectSequenceInformationExtractorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import org.hibernate.dialect.DerbyTenSevenDialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11470")
+public class DerbyTenSevenDialectSequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
+	@Override
+	public Dialect getDialect() {
+		return new DerbyTenSevenDialect();
+	}
+
+	@Override
+	public String expectedQuerySequencesString() {
+		return "select SEQUENCENAME from SYS.SYSSEQUENCES";
+	}
+
+	@Override
+	public Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor() {
+		return SequenceInformationExtractorLegacyImpl.class;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenSixDialectSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/sequence/DerbyTenSixDialectSequenceInformationExtractorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.sequence;
+
+import org.hibernate.dialect.DerbyTenSixDialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11470")
+public class DerbyTenSixDialectSequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
+	@Override
+	public Dialect getDialect() {
+		return new DerbyTenSixDialect();
+	}
+
+	@Override
+	public String expectedQuerySequencesString() {
+		return "select SEQUENCENAME from SYS.SYSSEQUENCES";
+	}
+
+	@Override
+	public Class<? extends SequenceInformationExtractor> expectedSequenceInformationExtractor() {
+		return SequenceInformationExtractorLegacyImpl.class;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11470