### PR TITLE
HHH-11510 - NativeQuery#iterate throws QuerySyntaxException instead of UnsupportedOperationException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/Query.java
@@ -369,7 +369,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 
 	/**
 	 * Return the query results as an <tt>Iterator</tt>. If the query
-	 * contains multiple results pre row, the results are returned in
+	 * contains multiple results per row, the results are returned in
 	 * an instance of <tt>Object[]</tt>.<br>
 	 * <br>
 	 * Entities returned as results are initialized on demand. The first

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/NativeQueryImpl.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.persistence.FlushModeType;
@@ -237,6 +238,11 @@ public class NativeQueryImpl<T> extends AbstractProducedQuery<T> implements Nati
 		if ( shouldFlush() ) {
 			getProducer().flush();
 		}
+	}
+
+	@Override
+	public Iterator<T> iterate() {
+		throw new UnsupportedOperationException( "SQL queries do not currently support iteration" );
 	}
 
 	private boolean shouldFlush() {

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/NativeQueryDoesNotSupportIterationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/NativeQueryDoesNotSupportIterationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.sql;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.Session;
+import org.hibernate.query.NativeQuery;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Andrea Boriero
+ */
+public class NativeQueryDoesNotSupportIterationTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {TestEntity.class};
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void iterateShouldThrowAnUnsupportedOperationException() {
+		try (Session session = openSession();) {
+			final NativeQuery sqlQuery = session.createNativeQuery( "select * from TEST_ENTITY" );
+			sqlQuery.iterate();
+		}
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "TEST_ENTITY")
+	public static class TestEntity {
+		@Id
+		public Long id;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11510