### PR TITLE
HHH-11514 Honor Overwrite flag on replicate action

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
@@ -124,8 +124,21 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 				);
 			}
 
-			final boolean regenerate = persister.isIdentifierAssignedByInsert(); // prefer re-generation of identity!
-			final EntityKey key = regenerate ? null : source.generateEntityKey( id, persister );
+			// We should only regenerate when the id is not there
+			// otherwise we must try to use the id of the provided entity otherwise we don't overwrite
+			final boolean regenerate = persister.isIdentifierAssignedByInsert();
+			final EntityKey key;
+			if(regenerate){
+				// We should use the provided id even with regenerate when overwrite specified and
+				// we have an id
+				if(id!=null && replicationMode==ReplicationMode.OVERWRITE){ 
+					key = source.generateEntityKey( id, persister );
+				}else{
+					key = null;
+				}
+			}else{
+				key = source.generateEntityKey( id, persister );
+			}
 
 			performSaveOrReplicate(
 					entity,


### PR DESCRIPTION
The system prefers to generate a new ID instead of using the one the programmer provides.
The replicate action doesn't say you will do that but the opposite. Use the id provided by programmer.

