### PR TITLE
HHH-11520 HHH-11517 Cloud friendliness and connection to DBs not yet present

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/jdbc/Database_Access.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/jdbc/Database_Access.adoc
@@ -121,7 +121,7 @@ Note that Hikari only supports JDBC standard isolation levels (apparently).
 
 [IMPORTANT]
 ====
-The built-in connection pool is not supported supported for use.
+The built-in connection pool is not supported for use.
 ====
 
 This section is here just for completeness.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1646,4 +1646,20 @@ public interface AvailableSettings {
 	 * @since 5.2.5
 	 */
 	String USE_LEGACY_LIMIT_HANDLERS = "hibernate.legacy_limit_handler";
+
+	/**
+	 * Start Hibernate ORM even if the database is not (yet) present.
+	 * <p>
+	 * Useful in cloud environment where the database bootstrap might be out of order with the application.
+	 *
+	 * There are a few things con consider:
+	 * <ul>
+	 *     <li>schema generation will be delayed until the first successful connection</li>
+	 *     <li>you must set {@link AvailableSettings#DIALECT} explicitly as we cannot guess the database if it's not there</li>
+	 *     <li>some JDBC specific settings set based on the JDBC metadata will not be set and best effort defaults will apply
+	 *     if the database is not present at Hibernate boot time</li>
+	 * </ul>
+	 * @since 6.0
+	 */
+	String TOLERATE_DATABASE_NOT_PRESENT = "hibernate.tolerate_database_not_present";
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DelayerConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DelayerConnectionProvider.java
@@ -1,0 +1,190 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.jdbc.connections.internal;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.jboss.logging.Logger;
+
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.Service;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.spi.Configurable;
+import org.hibernate.service.spi.ServiceRegistryAwareService;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.spi.Stoppable;
+
+/**
+ * {@link ConnectionProvider} delegating work to a real connection provider
+ * and executing some operations when the first connection request returns a valid
+ * connection.
+ *
+ * Useful to make sure an application can start even if the database is nto yet ready or present
+ * while still be able to execute schema generation orders.
+ *
+ * @author Emmanuel Bernard emmanuel@hibernate.org
+ */
+public class DelayerConnectionProvider implements
+		ConnectionProvider,
+		Configurable,
+		ServiceRegistryAwareService,
+		Stoppable {
+
+	private static final Logger LOGGER = Logger.getLogger( DelayerConnectionProvider.class );
+
+	private final ConnectionProvider connectionProvider;
+	private ServiceRegistry serviceRegistry;
+	// volatile due to the double checked lock
+	private volatile List<Runnable> operations = new ArrayList<>();
+	private final ReentrantLock lock = new ReentrantLock();
+
+	public DelayerConnectionProvider(ConnectionProvider connectionProvider) {
+		this.connectionProvider = connectionProvider;
+	}
+
+	/**
+	 * Operations can only be added before the {@code SessionFactory} is fully built.
+	 * This is to prevent concurrent additions of operations.
+	 * The operation must use the {@link ServiceRegistry} provided to retrieve
+	 * {@link ConnectionProvider} to get a connection.
+	 *
+	 * The operation will try and be executed eagerly, we might be lucky.
+	 *
+	 * @param operation on a connection ready database
+	 */
+	public void addOperation(Runnable operation) {
+		operations.add( operation );
+		tryAndExecuteOperations();
+	}
+
+	/**
+	 * Try to eagerly flush the operations if a connection is available
+	 */
+	private void tryAndExecuteOperations() {
+		// It would be more elegant to refactor the operation lock from getConnection is a shared method
+		// but I prefer the JVM to have more chances to keep getConnection() inlined
+		try {
+			Connection c = getConnection();
+			closeConnection( c );
+			if (operations == null) {
+				// operation execution has succeeded, but subsequent ones might happen
+				// remember, we are not multi-threaded here as we are bootstrapping Hibernate ORM
+				operations = new ArrayList<>();
+			}
+		}
+		catch (Exception e) {
+			// we don't care if there is a failure
+		}
+	}
+
+	@Override
+	public void injectServices(ServiceRegistryImplementor serviceRegistry) {
+		this.serviceRegistry = serviceRegistry;
+		if ( connectionProvider instanceof ServiceRegistryAwareService ) {
+			( (ServiceRegistryAwareService) connectionProvider ).injectServices( serviceRegistry );
+		}
+	}
+
+	@Override
+	public void configure(Map configurationValues) {
+		if ( connectionProvider instanceof Configurable ) {
+			Configurable configurableConnectionProvider = (Configurable) connectionProvider;
+			configurableConnectionProvider.configure( configurationValues );
+		}
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		Connection connection;
+		try {
+			connection = connectionProvider.getConnection();
+		}
+		catch (Exception e) {
+			throw e;
+		}
+
+		// protect operation execution behind a double checked lock
+		// we don't want them to be applied multiple times
+		if ( operations != null ) {
+			// if lock is already held, we are reentering and acquiring a connection for the an operation execution
+			// so we need to ignore operations here
+			if ( ! lock.isHeldByCurrentThread() ) {
+				lock.lock();
+				try {
+					if ( operations != null ) {
+						// get a service registry bypassing the DelayerConnectionProvider for the action calls
+						//ServiceRegistry sr = buildServiceRegistryDelegator();
+						operations.forEach( Runnable::run );
+						// if an operation fails, the list is not cleared but operations are
+						// catastrophic events and further use should not happen
+						operations = null;
+					}
+				}
+				finally {
+					lock.unlock();
+				}
+			}
+		}
+
+		return connection;
+	}
+
+	private ServiceRegistry buildServiceRegistryDelegator() {
+		return new ServiceRegistry() {
+			@Override
+			public ServiceRegistry getParentServiceRegistry() {
+				return DelayerConnectionProvider.this.serviceRegistry.getParentServiceRegistry();
+			}
+
+			@Override
+			public <R extends Service> R getService(Class<R> serviceRole) {
+				if ( ConnectionProvider.class.equals( serviceRole ) ) {
+					return (R) DelayerConnectionProvider.this.connectionProvider;
+				}
+				return DelayerConnectionProvider.this.serviceRegistry.getService(serviceRole);
+			}
+		};
+	}
+
+	@Override
+	public void closeConnection(Connection conn) throws SQLException {
+		connectionProvider.closeConnection( conn );
+	}
+
+	@Override
+	public boolean supportsAggressiveRelease() {
+		return connectionProvider.supportsAggressiveRelease();
+	}
+
+	@Override
+	public boolean isUnwrappableAs(Class unwrapType) {
+		if ( DelayerConnectionProvider.class.equals( unwrapType ) ) {
+			return true;
+		}
+		return connectionProvider.isUnwrappableAs( unwrapType );
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> unwrapType) {
+		if ( DelayerConnectionProvider.class.equals( unwrapType ) ) {
+			return (T) this;
+		}
+		return connectionProvider.unwrap( unwrapType );
+	}
+
+	@Override
+	public void stop() {
+		if ( connectionProvider instanceof Stoppable ) {
+			( (Stoppable) connectionProvider ).stop();
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
@@ -30,7 +30,7 @@ public interface Wrapped {
 	 *
 	 * @return The unwrapped reference
 	 *
-	 * @throws UnknownUnwrapTypeException if the servicebe unwrapped as the indicated type
+	 * @throws UnknownUnwrapTypeException if the service cannot be unwrapped as the indicated type
 	 */
 	public <T> T unwrap(Class<T> unwrapType);
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/connections/DelayerConnectionProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/connections/DelayerConnectionProviderTest.java
@@ -1,0 +1,174 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.connections;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.PersistenceException;
+
+import org.junit.Test;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.exception.GenericJDBCException;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Emmanuel Bernard emmanuel@hibernate.org
+ */
+public class DelayerConnectionProviderTest extends BaseUnitTestCase {
+
+	@Test(expected = GenericJDBCException.class)
+	public void testNonDelayedConnectionProvider() {
+		doTestSessionFactoryCreation(
+				b -> {
+					b.applySetting( AvailableSettings.CONNECTION_PROVIDER, DBNotPresentSimulatorConnectionProvider.class )
+						.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+				},
+				metadataSources -> metadataSources.addAnnotatedClass( DCPTEntity.class ),
+				Metadata::buildSessionFactory,
+				(sessionFactory, serviceRegistry) -> {}
+		);
+	}
+
+	@Test
+	public void testDelayedConnectionProvider() {
+		doTestSessionFactoryCreation(
+				b -> {
+					b.applySetting( AvailableSettings.CONNECTION_PROVIDER, DBNotPresentSimulatorConnectionProvider.class )
+							.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" )
+							.applySetting( AvailableSettings.TOLERATE_DATABASE_NOT_PRESENT, "true" );
+				},
+				metadataSources -> metadataSources.addAnnotatedClass( DCPTEntity.class ),
+				Metadata::buildSessionFactory,
+				DelayerConnectionProviderTest::checkDelayedInitializationIsCorrect
+		);
+	}
+
+	private static void checkDelayedInitializationIsCorrect(SessionFactory sf, ServiceRegistry sr) {
+		boolean exceptionRaised = false;
+		try ( Session s = sf.openSession() ) {
+			Transaction tx = s.beginTransaction();
+			s.persist( new DCPTEntity() );
+			s.flush();
+			tx.commit();
+		}
+		catch (PersistenceException e) {
+			//expected exception as the database is not present
+			exceptionRaised = true;
+		}
+		finally {
+			assertTrue( "A JDBC exception should have been raised as the DB is not accessible yet", exceptionRaised );
+		}
+		ConnectionProvider service = sr.getService( ConnectionProvider.class );
+		if ( service.isUnwrappableAs( DBNotPresentSimulatorConnectionProvider.class  ) ) {
+			DBNotPresentSimulatorConnectionProvider simulator = service.unwrap( DBNotPresentSimulatorConnectionProvider.class );
+			// database is present now
+			simulator.delay = false;
+
+		}
+		else {
+			assertTrue("Test fails to configure itself with a DBNotPresentSimulatorConnectionProvider", false);
+		}
+		try ( Session s = sf.openSession() ) {
+			Transaction tx = s.beginTransaction();
+			DCPTEntity myEntity = new DCPTEntity();
+			s.persist( myEntity );
+			s.flush();
+			s.delete( myEntity );
+			tx.commit();
+		}
+	}
+
+	private void doTestSessionFactoryCreation(
+			Consumer<StandardServiceRegistryBuilder> configureSettings,
+			Consumer<MetadataSources> configureEntities,
+			Function<Metadata, SessionFactory> buildSessionFactory,
+			BiConsumer<SessionFactory, ServiceRegistry> useSessionFactory) {
+		ServiceRegistryImplementor serviceRegistry = null;
+		try {
+			StandardServiceRegistryBuilder standardServiceRegistryBuilder = new StandardServiceRegistryBuilder();
+			configureSettings.accept( standardServiceRegistryBuilder );
+			serviceRegistry	= (ServiceRegistryImplementor) standardServiceRegistryBuilder.build();
+			MetadataSources metadataSources = new MetadataSources( serviceRegistry );
+			configureEntities.accept( metadataSources );
+
+			Metadata metadata = metadataSources.buildMetadata();
+			//need consumer and producer
+			try (SessionFactory sessionFactory = buildSessionFactory.apply( metadata )) {
+				useSessionFactory.accept( sessionFactory, serviceRegistry );
+			}
+		}
+		finally {
+			if ( serviceRegistry != null ) {
+				try {
+					StandardServiceRegistryBuilder.destroy( serviceRegistry );
+				}
+				catch (Exception ignore) {
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Throw exceptions during #getConnection() calls when the delay flag is set to true.
+	 * The connection provider starts with the delay flag set to true.
+	 *
+	 * This is used ot simulate a database that is not ready.
+	 */
+	public static class DBNotPresentSimulatorConnectionProvider extends DriverManagerConnectionProviderImpl {
+		public volatile boolean delay = true;
+
+		public DBNotPresentSimulatorConnectionProvider() {
+		}
+
+		@Override
+		public Connection getConnection() throws SQLException {
+			if ( delay ) {
+				throw new SQLException( "Database not present" );
+			}
+			return super.getConnection();
+		}
+
+		@Override
+		public boolean isUnwrappableAs(Class unwrapType) {
+			return DBNotPresentSimulatorConnectionProvider.class.equals( unwrapType ) || super.isUnwrappableAs( unwrapType );
+		}
+
+		@Override
+		public <T> T unwrap(Class<T> unwrapType) {
+			if ( DBNotPresentSimulatorConnectionProvider.class.equals( unwrapType ) ) {
+				return (T) this;
+			}
+			return super.unwrap( unwrapType );
+		}
+	}
+
+	@Entity
+	static class DCPTEntity {
+		@Id @GeneratedValue
+		public Integer id;
+	}
+}

--- a/hibernate-hikaricp/src/test/resources/hibernate.properties
+++ b/hibernate-hikaricp/src/test/resources/hibernate.properties
@@ -18,3 +18,11 @@ hibernate.hikari.poolName testPool
 hibernate.hikari.maximumPoolSize 2
 hibernate.hikari.connectionTimeout 1000
 hibernate.hikari.idleTimeout 3000
+# don't break when starting the pool if the DB is unavailable
+# see https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby
+# note that in future versions of HikariCP the variable is
+# hibernate.hikari.initializationFailTimeout 0
+hibernate.hikari.initializationFailFast false
+
+
+HHH-11517 Add HikariCP setting to not fail fast when pool starts and the DB is unavailable


### PR DESCRIPTION
The goal is to help people deploying Hibernate ORM apps when their database might be started after the Hibernate app. Cloud providers might offer some solution but this work helps users even if cloud providers are not very cooperative.

See http://in.relation.to/2017/02/16/hibernate-connections-cloud/ for more context.

## What has been done

HHH-11517:
I've fixed a few issues in particular from the built-in connection pool that was not reactive well to the DB not being present during configuration time. This means the work on `JDBCEnvironmentInitiator` falling back to default if the connection is not available now works in more situations

I've added the ability to delay some bootstrap operations needing connections to the first time a valid connection is retrieved.
I've added the ability for the schema generation tools to run as delayed operation.

## What is planned

More at https://hibernate.atlassian.net/browse/HHH-11520

Allow the connection provider to circuit break when the database is not present or verify that all connection pools offer such options.

Consider enforcing specific connection pool options to be friendly toward booting with no database available (e.g. Hikari) when the hibernate.tolerate_database_not_present option is set to true.

Create a specific how-to documentation explaining how to work in environments where the DB might not be present at boot time. Update the reference doc as well.

Consider adding an API for a user or health check implement to know our current DB status (delayed vs ready)

Explore ability to extract JDBC environment information from DB connection in a delayed fashion: that's going to be the hardest most likely and we could start without this option.

## Feedback on general approach

What I want to know is whether you think I'm going in the right direction and whether I'm doing idiomatic Hibernate ORM development (it's been a while so I might be misusing some APIs or using wrong patterns.

Don't integrate it yet as I want to do some of what is planned but comments and feedback are welcome.

Feedback on the planned tasks would be useful too.