### PR TITLE
[HHH-11522] Error on empty config about missing dialect instead of no connection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -134,7 +134,17 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		}
 
 		// if we get here, either we were asked to not use JDBC metadata or accessing the JDBC metadata failed.
-		return new JdbcEnvironmentImpl( registry, dialectFactory.buildDialect( configurationValues, null ) );
+		return new JdbcEnvironmentImpl( registry, getDialect(dialectFactory, configurationValues) );
+	}
+
+	private Dialect getDialect(DialectFactory dialectFactory, Map configurationValues) {
+		try {
+			return dialectFactory.buildDialect(configurationValues, null);
+		}
+		catch (HibernateException ex) {
+			log.warn("Unable to determine dialect: " + ex.getMessage());
+			return new Dialect() { };
+		}
 	}
 
 	private JdbcConnectionAccess buildJdbcConnectionAccess(Map configValues, ServiceRegistryImplementor registry) {


### PR DESCRIPTION
JIRA: https://hibernate.atlassian.net/browse/HHH-11522

When starting a session with an empty hibernate config ([test project](https://github.com/rzymek/hibernate-minimal-project)):

    final StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
            .build();
    SessionFactory sessionFactory = new MetadataSources(registry)
            .buildMetadata()
            .buildSessionFactory();
    try(Session session = sessionFactory.openSession()){
        session.beginTransaction();
        session.getTransaction().commit();
    }

The error that gets propagated to the user contains a cryptic message about a missing dialect:

    Caused by: org.hibernate.HibernateException: Access to DialectResolutionInfo cannot be null when 'hibernate.dialect' not set
            at org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl.determineDialect(DialectFactoryImpl.java:100)
            at org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl.buildDialect(DialectFactoryImpl.java:54)
            at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.initiateService(JdbcEnvironmentInitiator.java:137)
            at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.initiateService(JdbcEnvironmentInitiator.java:35)
            at org.hibernate.boot.registry.internal.StandardServiceRegistryImpl.initiateService(StandardServiceRegistryImpl.java:88)
            at org.hibernate.service.internal.AbstractServiceRegistryImpl.createService(AbstractServiceRegistryImpl.java:259)
            ... 18 more
[(Complete output)](https://github.com/rzymek/hibernate-minimal-project/blob/5.2.8/output.txt)

A more appropriate error should inform about the main issue here - no available connection. 

I propose to change the dialect detection procedure to return a default dialect (aka `new Dialect() {}`) on failure and moving on. The exception that gets propagated to the user becomes:

    Exception in thread "main" java.lang.UnsupportedOperationException: The application must supply JDBC connections
            at org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl.getConnection(UserSuppliedConnectionProviderImpl.java:44)
            at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:35)
            at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:99)
            at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:129)
            ....
[(Complete output)](https://github.com/rzymek/hibernate-minimal-project/blob/master/output.txt)

_Instead of returning an anonymous instance of Dialect, a new `DefaultDialect` class might be a better choice._
