### PR TITLE
HHH-11529 fix NPE in ScanningCoordinator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
@@ -271,7 +271,7 @@ public class ScanningCoordinator {
 			log.debugf(
 					"Unable to resolve class [%s] named in persistence unit [%s]",
 					unresolvedListedClassName,
-					scanEnvironment.getRootUrl().toExternalForm()
+					scanEnvironment.getRootUrl()
 			);
 		}
 	}


### PR DESCRIPTION
Actually URL.toString() calls toExternalForm(), so it has exactly the same effect, but without NPE.
