### PR TITLE
HHH-11551 - Forward IOException in ClassFileArchiveEntryHandler::toClassFile

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/ClassFileArchiveEntryHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/ClassFileArchiveEntryHandler.java
@@ -61,7 +61,7 @@ public class ClassFileArchiveEntryHandler implements ArchiveEntryHandler {
 			return new ClassFile( dataInputStream );
 		}
 		catch (IOException e) {
-			throw new ArchiveException( "Could not build ClassFile" );
+			throw new ArchiveException( "Could not build ClassFile", e );
 		}
 		finally {
 			try {


### PR DESCRIPTION
While the exception itself might not be very helpful (Javassist, for example, can throw rather cryptic ones) including at least makes that visible.