### PR TITLE
HHH-11546 Add support for SAP NetWeaver as JTA Platform

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/transactions/Transactions.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/transactions/Transactions.adoc
@@ -81,6 +81,7 @@ Hibernate provides many implementations of the `JtaPlatform` contract, all with 
 `OC4J`:: `JtaPlatform` for Oracle's OC4J container.
 `Orion`:: `JtaPlatform` for the Orion Application Server.
 `Resin`:: `JtaPlatform` for the Resin Application Server.
+`SapNetWeaver`:: `JtaPlatform` for the SAP NetWeaver Application Server.
 `SunOne`:: `JtaPlatform` for the SunOne Application Server.
 `Weblogic`:: `JtaPlatform` for the Weblogic Application Server.
 `WebSphere`:: `JtaPlatform` for older versions of the WebSphere Application Server.

--- a/documentation/src/main/docbook/devguide-old/en-US/chapters/services/Services.xml
+++ b/documentation/src/main/docbook/devguide-old/en-US/chapters/services/Services.xml
@@ -507,6 +507,13 @@
                             </listitem>
                             <listitem>
                                 <para>
+                                    <classname>org.hibernate.engine.transaction.jta.platform.internal.SapNetWeaverJtaPlatform</classname> -
+                                    Integration with transaction manager as deployed in a SAP NetWeaver application server.
+                                    Can also be referenced using the <property>SapNetWeaver</property> configuration short name
+                                </para>
+                            </listitem>
+                            <listitem>
+                                <para>
                                     <classname>org.hibernate.engine.transaction.jta.platform.internal.SunOneJtaPlatform</classname> -
                                     Integration with transaction manager as deployed in a Sun ONE (7 and above)
                                     application server.  Can also be referenced using the <property>SunOne</property>

--- a/documentation/src/main/docbook/manual-old/en-US/content/bootstrap.xml
+++ b/documentation/src/main/docbook/manual-old/en-US/content/bootstrap.xml
@@ -507,6 +507,11 @@
             </listitem>
             <listitem>
                 <para>
+                    <literal>SapNetWeaver</literal> - JtaPlatform for the SAP NetWeaver Application Server.
+                </para>
+            </listitem>
+            <listitem>
+                <para>
                     <literal>SunOne</literal> - JtaPlatform for the SunOne Application Server.
                 </para>
             </listitem>

--- a/documentation/src/main/docbook/userGuide/en-US/chapters/transactions/Transactions.xml
+++ b/documentation/src/main/docbook/userGuide/en-US/chapters/transactions/Transactions.xml
@@ -179,6 +179,11 @@
                 </listitem>
                 <listitem>
                     <para>
+                        <literal>SapNetWeaver</literal> - JtaPlatform for the SAP NetWeaver Application Server.
+                    </para>
+                </listitem>
+                <listitem>
+                    <para>
                         <literal>SunOne</literal> - JtaPlatform for the SunOne Application Server.
                     </para>
                 </listitem>

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
@@ -77,6 +77,7 @@ import org.hibernate.engine.transaction.jta.platform.internal.JRun4JtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.OC4JJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.OrionJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.ResinJtaPlatform;
+import org.hibernate.engine.transaction.jta.platform.internal.SapNetWeaverJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.SunOneJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.WebSphereExtendedJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.WebSphereJtaPlatform;
@@ -312,6 +313,13 @@ public class StrategySelectorBuilder {
 				ResinJtaPlatform.class,
 				"Resin",
 				"org.hibernate.service.jta.platform.internal.ResinJtaPlatform"
+		);
+
+		addJtaPlatforms(
+				strategySelector,
+				SapNetWeaverJtaPlatform.class,
+				"SapNetWeaver",
+				"org.hibernate.service.jta.platform.internal.SapNetWeaverJtaPlatform"
 		);
 
 		addJtaPlatforms(

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/SapNetWeaverJtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/SapNetWeaverJtaPlatform.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.transaction.jta.platform.internal;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+/**
+ * {@link org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform} implementation for SAP NetWeaver
+ *
+ * @author Lukas Pradel
+ */
+public class SapNetWeaverJtaPlatform extends AbstractJtaPlatform {
+	public static final String TM_NAME = "TransactionManager";
+	public static final String UT_NAME = "UserTransaction";
+
+	@Override
+	protected TransactionManager locateTransactionManager() {
+		return (TransactionManager) jndiService().locate( TM_NAME );
+	}
+
+	@Override
+	protected UserTransaction locateUserTransaction() {
+		return (UserTransaction) jndiService().locate( UT_NAME );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11546

We added support for SAP NetWeaver as a JTA Platform to Hibernate. We successfully tested and used this JtaPlatform to deploy a JPA 2 application to SAP NetWeaver 7.5 SP06.

Note that the JNDI names for `TransactionManager` and `UserTransaction` have been the same since forever in all JEE5-compliant NetWeaver versions as far as we can tell.

Please advise on any tests you want to see for this change as we were unable to locate any tests for the JtaPlatforms for other application servers such as WebLogic or WebSphere.