### PR TITLE
HHH-9188 - Testcase for one-to-one jointable with selfjoin and table per class

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/ABlockableEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/ABlockableEntity.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.jointable;
+
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Christian Beikov
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public abstract class ABlockableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.TABLE)
+	@Column(name = "id")
+	private Long id;
+
+	// We have two one-to-one associations to make sure parent_id isn't considered as part of this table regarding duplicate mappings
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinTable(
+			name = "TBL_QUEUE",
+			joinColumns = @JoinColumn(name = "child_id", referencedColumnName = "id"),
+			inverseJoinColumns = @JoinColumn(name = "parent_id", referencedColumnName = "id")
+	)
+	private OtherEntity other;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinTable(
+			name = "TBL_QUEUE2",
+			joinColumns = @JoinColumn(name = "child_id", referencedColumnName = "id"),
+			inverseJoinColumns = @JoinColumn(name = "parent_id", referencedColumnName = "id")
+	)
+	private ABlockableEntity other2;
+
+	// Two many-to-ones to make sure that still works in this scenario
+	@ManyToOne(fetch = FetchType.LAZY)
+	private OtherEntity manyToOne1;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private ABlockableEntity manyToOne2;
+
+	// Two one-to-manys to make sure that considering one-to-one joins in the entity persister doesn't break this
+	@OneToMany
+	private Set<OtherEntity> oneToMany1;
+
+	@OneToMany
+	private Set<ABlockableEntity> oneToMany2;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public OtherEntity getOther() {
+		return other;
+	}
+
+	public void setOther(OtherEntity other) {
+		this.other = other;
+	}
+
+	public ABlockableEntity getOther2() {
+		return other2;
+	}
+
+	public void setOther2(ABlockableEntity other2) {
+		this.other2 = other2;
+	}
+
+	public OtherEntity getManyToOne1() {
+		return manyToOne1;
+	}
+
+	public void setManyToOne1(OtherEntity manyToOne1) {
+		this.manyToOne1 = manyToOne1;
+	}
+
+	public ABlockableEntity getManyToOne2() {
+		return manyToOne2;
+	}
+
+	public void setManyToOne2(ABlockableEntity manyToOne2) {
+		this.manyToOne2 = manyToOne2;
+	}
+
+	public Set<OtherEntity> getOneToMany1() {
+		return oneToMany1;
+	}
+
+	public void setOneToMany1(Set<OtherEntity> oneToMany1) {
+		this.oneToMany1 = oneToMany1;
+	}
+
+	public Set<ABlockableEntity> getOneToMany2() {
+		return oneToMany2;
+	}
+
+	public void setOneToMany2(Set<ABlockableEntity> oneToMany2) {
+		this.oneToMany2 = oneToMany2;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/Event.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/Event.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.jointable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+/**
+ * @author Christian Beikov
+ */
+@Entity
+public class Event extends ABlockableEntity {
+	@Column(name = "description")
+	private String description;
+
+	public Event() {
+	}
+
+	public Event(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/Message.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/Message.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.jointable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+/**
+ * @author Christian Beikov
+ */
+@Entity
+public class Message extends ABlockableEntity {
+	@Column(name = "description")
+	private String description;
+
+	public Message() {
+	}
+
+	public Message(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/OneToOneJoinTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/OneToOneJoinTableTest.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.jointable;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Christian Beikov
+ */
+public class OneToOneJoinTableTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Event.class,
+				Message.class,
+				ABlockableEntity.class,
+				OtherEntity.class
+		};
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-9188")
+	public void test() throws Exception {
+		Long id = doInHibernate( this::sessionFactory, s -> {
+			Event childEvent = new Event();
+			childEvent.setDescription( "childEvent" );
+			s.save( childEvent );
+
+			Event parentEvent = new Event();
+			parentEvent.setDescription( "parentEvent" );
+			s.save( parentEvent );
+
+			OtherEntity otherEntity = new OtherEntity();
+			otherEntity.setId( "123" );
+			s.save( otherEntity );
+
+			childEvent.setOther( otherEntity );
+			s.save( childEvent );
+			s.flush();
+
+			// Test updates and deletes
+			childEvent.setOther( new OtherEntity( "456" ) );
+			childEvent.setOther2( new Event( "randomEvent" ) );
+			s.flush();
+
+			s.remove( otherEntity );
+			s.remove( parentEvent );
+
+			s.createQuery( "DELETE FROM OtherEntity e WHERE e.id IS NULL" ).executeUpdate();
+			s.createQuery( "DELETE FROM ABlockableEntity e WHERE e.description IS NULL" ).executeUpdate();
+			s.createQuery( "DELETE FROM ABlockableEntity e WHERE e.other IS NULL AND e.description <> 'randomEvent'" )
+					.executeUpdate();
+			s.createQuery( "DELETE FROM Event e WHERE e.description IS NULL" ).executeUpdate();
+			s.createQuery( "DELETE FROM Event e WHERE e.other IS NULL AND e.description <> 'randomEvent'" )
+					.executeUpdate();
+
+			s.createQuery( "UPDATE OtherEntity e SET id = 'test' WHERE e.id IS NULL" ).executeUpdate();
+			s.createQuery( "UPDATE ABlockableEntity  e SET description = 'test' WHERE e.description IS NULL" )
+					.executeUpdate();
+			s.createQuery( "UPDATE ABlockableEntity e SET description = 'test' WHERE e.other IS NULL" ).executeUpdate();
+			s.createQuery( "UPDATE Event e SET description = 'test' WHERE e.description IS NULL" ).executeUpdate();
+			s.createQuery( "UPDATE Event e SET description = 'test' WHERE e.other IS NULL" ).executeUpdate();
+
+			return childEvent.getId();
+		} );
+		doInHibernate( this::sessionFactory, s -> {
+			Event saved = s.find( Event.class, id );
+			assertNotNull( saved );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/OtherEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/jointable/OtherEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.jointable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Christian Beikov
+ */
+@Entity
+public class OtherEntity {
+	@Id
+	private String id;
+
+	public OtherEntity() {
+	}
+
+	public OtherEntity(String id) {
+		this.id = id;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-9188

Tried to implement a fix, but this requires touching so many parts that I gave up. One of the main problems as far as I understood is that the `UnionSubclassEntityPersister` doesn't implement support for _secondary tables_ and using a join table apparently is like using a secondary table. The persister also wrongly thinks that the column against which to join for the join table reside on the tables of the table per class hierarchy.