### PR TITLE
updated description.

### DIFF
--- a/documentation/src/main/docbook/manual/pot/content/query_hql.pot
+++ b/documentation/src/main/docbook/manual/pot/content/query_hql.pot
@@ -339,7 +339,7 @@ msgstr ""
 
 #. Tag: para
 #, no-c-format
-msgid "would result in a query that would require four table joins in SQL."
+msgid "would result in a query that would require four table joins in SQL (assuming the tables are foo, bar, baz, customer and address)."
 msgstr ""
 
 #. Tag: para


### PR DESCRIPTION
Making it clear how "four" joins are required in the example showing where clause with compound path expressions.