### PR TITLE
[HHH-11557] DB2 gets confused with numerical parameters in nullif function of DB2Dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -6,12 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.util.Locale;
-
 import org.hibernate.JDBCException;
 import org.hibernate.MappingException;
 import org.hibernate.NullPrecedence;
@@ -41,6 +35,12 @@ import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.sql.SmallIntTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
 
 /**
  * An SQL dialect for DB2.
@@ -348,7 +348,7 @@ public class DB2Dialect extends Dialect {
 			default:
 				literal = "0";
 		}
-		return "nullif(" + literal + ',' + literal + ')';
+		return "nullif(" + literal + ", " + literal + ')';
 	}
 
 	@Override


### PR DESCRIPTION
The function getSelectClauseNullString is called with other sqlType than the explicitly specified in switch statement. So the default case returns nullif(0,0). This leads to the following error: 
Error: DB2 SQL Error: SQLCODE=-170, SQLSTATE=42605, SQLERRMC=NULLIF, DRIVER=4.13.80
SQLState:  42605
ErrorCode: -170

The meaning of SQLCODE -170 is: THE NUMBER OF ARGUMENTS SPECIFIED FOR function-name IS INVALID

The solution is to insert a trailing space after the comma. Inserting the space is syntactically correct in general. So this has no negativ impact on the other sqlTypes.