### PR TITLE
HHH-11386 Keep columns sequence align to sequence of entity fields fix

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyContainer.java
@@ -9,20 +9,6 @@
 
 package org.hibernate.cfg;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import javax.persistence.Access;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Transient;
-
 import org.hibernate.AnnotationException;
 import org.hibernate.MappingException;
 import org.hibernate.annotations.ManyToAny;
@@ -35,8 +21,10 @@ import org.hibernate.boot.jaxb.SourceType;
 import org.hibernate.cfg.annotations.HCANNHelper;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
-
 import org.jboss.logging.Logger;
+
+import javax.persistence.*;
+import java.util.*;
 
 /**
  * A helper class to keep the {@code XProperty}s of a class ordered by access type.
@@ -63,7 +51,7 @@ class PropertyContainer {
 	 */
 	private final AccessType classLevelAccessType;
 
-	private final TreeMap<String, XProperty> persistentAttributeMap;
+	private final Map<String, XProperty> persistentAttributeMap = new LinkedHashMap<>();
 
 	PropertyContainer(XClass clazz, XClass entityAtStake, AccessType defaultClassLevelAccessType) {
 		this.xClass = clazz;
@@ -83,8 +71,6 @@ class PropertyContainer {
 				: defaultClassLevelAccessType;
 		assert classLevelAccessType == AccessType.FIELD || classLevelAccessType == AccessType.PROPERTY;
 
-		this.persistentAttributeMap = new TreeMap<String, XProperty>();
-
 		final List<XProperty> fields = xClass.getDeclaredProperties( AccessType.FIELD.getType() );
 		final List<XProperty> getters = xClass.getDeclaredProperties( AccessType.PROPERTY.getType() );
 
@@ -93,13 +79,11 @@ class PropertyContainer {
 		final Map<String,XProperty> persistentAttributesFromGetters = new HashMap<String, XProperty>();
 
 		collectPersistentAttributesUsingLocalAccessType(
-				persistentAttributeMap,
 				persistentAttributesFromGetters,
 				fields,
 				getters
 		);
 		collectPersistentAttributesUsingClassLevelAccessType(
-				persistentAttributeMap,
 				persistentAttributesFromGetters,
 				fields,
 				getters
@@ -125,8 +109,7 @@ class PropertyContainer {
 	}
 
 	private void collectPersistentAttributesUsingLocalAccessType(
-			TreeMap<String, XProperty> persistentAttributeMap,
-			Map<String,XProperty> persistentAttributesFromGetters,
+			Map<String, XProperty> persistentAttributesFromGetters,
 			List<XProperty> fields,
 			List<XProperty> getters) {
 
@@ -177,8 +160,7 @@ class PropertyContainer {
 	}
 
 	private void collectPersistentAttributesUsingClassLevelAccessType(
-			TreeMap<String, XProperty> persistentAttributeMap,
-			Map<String,XProperty> persistentAttributesFromGetters,
+			Map<String, XProperty> persistentAttributesFromGetters,
 			List<XProperty> fields,
 			List<XProperty> getters) {
 		if ( classLevelAccessType == AccessType.FIELD ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/ColumnSequenceMatchesEntityFieldsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/ColumnSequenceMatchesEntityFieldsTest.java
@@ -1,0 +1,49 @@
+package org.hibernate.test.cfg;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColumnSequenceMatchesEntityFieldsTest extends BaseEntityManagerFunctionalTestCase {
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{ExampleEntity.class};
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-11386")
+    public void testColumnOrderMatchesAttributeOrder() throws SQLException {
+        AbstractEntityPersister entityPersister = (AbstractEntityPersister) entityManagerFactory().getMetamodel().entityPersister(ExampleEntity.class);
+        String second = entityPersister.getPropertyColumnNames(0)[0];
+        String first = entityPersister.getPropertyColumnNames(1)[0];
+        String third = entityPersister.getPropertyColumnNames(2)[0];
+        assertEquals("second", second);
+        assertEquals("first", first);
+        assertEquals("third", third);
+    }
+
+    @Entity
+    @Table(name = "example")
+    private static class ExampleEntity {
+        @Id
+        private Integer id;
+
+        @Column
+        private Integer second;
+
+        @Column
+        private Integer first;
+
+        @Column
+        private Integer third;
+    }
+}


### PR DESCRIPTION
One test introduced to verify that the fix works properly. 

Also I did some cleanup in the PropertyContainer class as one of the fields was passed as an argument to private methods which in this case was totally unnecessary.