### PR TITLE
[6.0] HHH-11573 Extended Envers Query API to create type expressions

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
@@ -306,6 +306,11 @@ public class Parameters {
 		sub2.addNullRestriction( right, false );
 	}
 
+	public void addEntityTypeRestriction(String alias, String entityName) {
+		String expression = String.format( "type(%s) = %s", alias, entityName );
+		expressions.add( expression );
+	}
+
 	private void append(StringBuilder sb, String toAppend, MutableBoolean isFirst) {
 		if ( !isFirst.isSet() ) {
 			sb.append( " " ).append( connective ).append( " " );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
@@ -182,7 +182,7 @@ public class AuditEntity {
 	/**
 	 * Adds a restriction for the type of the current entity.
 	 * 
-	 * @param the entity type to restrict the current alias to
+	 * @param type the entity type to restrict the current alias to
 	 */
 	public static AuditCriterion entityType(final Class<?> type) {
 		return entityType( null, type );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
@@ -7,12 +7,14 @@
 package org.hibernate.envers.query;
 
 import org.hibernate.envers.RevisionType;
+import org.hibernate.envers.internal.tools.EntityTools;
 import org.hibernate.envers.query.criteria.AuditConjunction;
 import org.hibernate.envers.query.criteria.AuditCriterion;
 import org.hibernate.envers.query.criteria.AuditDisjunction;
 import org.hibernate.envers.query.criteria.AuditId;
 import org.hibernate.envers.query.criteria.AuditProperty;
 import org.hibernate.envers.query.criteria.AuditRelatedId;
+import org.hibernate.envers.query.criteria.internal.EntityTypeAuditExpression;
 import org.hibernate.envers.query.criteria.internal.LogicalAuditExpression;
 import org.hibernate.envers.query.criteria.internal.NotAuditExpression;
 import org.hibernate.envers.query.internal.property.EntityPropertyName;
@@ -175,5 +177,45 @@ public class AuditEntity {
 	 */
 	public static AuditProjection selectEntity(boolean distinct) {
 		return new EntityAuditProjection( null, distinct );
+	}
+
+	/**
+	 * Adds a restriction for the type of the current entity.
+	 * 
+	 * @param the entity type to restrict the current alias to
+	 */
+	public static AuditCriterion entityType(final Class<?> type) {
+		return entityType( null, type );
+	}
+
+	/**
+	 * Adds a restriction for the type of the current entity.
+	 * 
+	 * @param entityName the entity name to restrict the current alias to
+	 */
+	public static AuditCriterion entityType(final String entityName) {
+		return entityType( null, entityName );
+	}
+
+	/**
+	 * Adds a restriction for the type of the entity of the specified alias.
+	 * 
+	 * @param alias the alias to restrict. If null is specified, the current alias is used
+	 * @param type the entity type to restrict the alias to
+	 */
+	public static AuditCriterion entityType(final String alias, final Class<?> type) {
+		Class<?> unproxiedType = EntityTools.getTargetClassIfProxied( type );
+		return entityType( alias, unproxiedType.getName() );
+	}
+
+	/**
+	 * Adds a restriction for the type of the entity of the specified alias.
+	 * 
+	 * @param alias the alias to restrict. If null is specified, the current alias is used
+	 * @param entityName the entity name to restrict the alias to
+	 * @return
+	 */
+	public static AuditCriterion entityType(final String alias, final String entityName) {
+		return new EntityTypeAuditExpression( alias, entityName );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/EntityTypeAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/EntityTypeAuditExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria.internal;
+
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class EntityTypeAuditExpression implements AuditCriterion {
+
+	private String alias;
+	private String entityName;
+
+	public EntityTypeAuditExpression(
+			String alias,
+			String entityName) {
+		this.alias = alias;
+		this.entityName = entityName;
+	}
+
+	@Override
+	public void addToQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap,
+			String baseAlias,
+			QueryBuilder qb,
+			Parameters parameters) {
+		String effectiveAlias = alias == null ? baseAlias : alias;
+		String effectiveEntityName = entityName;
+		if ( enversService.getEntitiesConfigurations().isVersioned( effectiveEntityName ) ) {
+			effectiveEntityName = enversService.getAuditEntitiesConfiguration().getAuditEntityName( effectiveEntityName );
+		}
+		parameters.addEntityTypeRestriction( effectiveAlias, effectiveEntityName );
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/EntityTypeAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/EntityTypeAuditExpression.java
@@ -37,6 +37,20 @@ public class EntityTypeAuditExpression implements AuditCriterion {
 			String baseAlias,
 			QueryBuilder qb,
 			Parameters parameters) {
+		// todo: add contextual detail about query generation
+		//
+		// Take an example situation where a non-audited entity extends an audited-entity and uses the
+		// AuditEntity#entityType method with the non-audited entity.  It would stand to reason that
+		// it makes sense that we'd throw a NotAuditedException here rather than apply the restriction
+		// anyway and return no results?
+		//
+		// Knowing whether EntityTypeAuditExpression is for an association traversal or part of the
+		// entity inheritance criteria of the root entity would drive how we'd either throw an
+		// exception or be lenient and permit adding the expression without validation.
+		//
+		// For now, we're just going to allow adding the criteria without any validation because the
+		// code needs to support both traversal paths without any clear distinction.
+		//
 		String effectiveAlias = alias == null ? baseAlias : alias;
 		String effectiveEntityName = entityName;
 		if ( enversService.getEntitiesConfigurations().isVersioned( effectiveEntityName ) ) {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/EntityTypeQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/EntityTypeQueryTest.java
@@ -104,6 +104,7 @@ public class EntityTypeQueryTest extends BaseEnversJPAFunctionalTestCase {
 		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
 				.add( AuditEntity.entityType( EntityB.class ) )
 				.addProjection( AuditEntity.property( "name" ) )
+				.addOrder( AuditEntity.property( "name" ).asc() )
 				.getResultList();
 		assertEquals( "Expected only entities of type EntityB to be selected", list( "b1", "b2" ), list );
 	}
@@ -113,6 +114,7 @@ public class EntityTypeQueryTest extends BaseEnversJPAFunctionalTestCase {
 		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
 				.add( AuditEntity.entityType( EntityA.class ) )
 				.addProjection( AuditEntity.property( "name" ) )
+				.addOrder( AuditEntity.property( "name" ).asc() )
 				.getResultList();
 		assertEquals( "Expected only entities of type EntityA to be selected", list( "a1", "a2" ), list );
 	}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/EntityTypeQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/EntityTypeQueryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class EntityTypeQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	@Entity
+	@Audited
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class EntityA {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+		private String name;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+	}
+
+	@Entity
+	@Audited
+	public static class EntityB extends EntityA {
+
+	}
+
+	private EntityA a1;
+	private EntityA a2;
+	private EntityB b1;
+	private EntityB b2;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ EntityA.class, EntityB.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+		a1 = new EntityA();
+		a1.setName( "a1" );
+		em.persist( a1 );
+		a2 = new EntityA();
+		a2.setName( "a2" );
+		em.persist( a2 );
+		b1 = new EntityB();
+		b1.setName( "b1" );
+		em.persist( b1 );
+		b2 = new EntityB();
+		b2.setName( "b2" );
+		em.persist( b2 );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testRestrictToSubType() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
+				.add( AuditEntity.entityType( EntityB.class ) ).addProjection( AuditEntity.property( "name" ) ).getResultList();
+		assertEquals( "Expected only entities of type EntityB to be selected", list( "b1", "b2" ), list );
+	}
+
+	@Test
+	public void testRestrictToSuperType() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
+				.add( AuditEntity.entityType( EntityA.class ) ).addProjection( AuditEntity.property( "name" ) ).getResultList();
+		assertEquals( "Expected only entities of type EntityA to be selected", list( "a1", "a2" ), list );
+	}
+
+	private List<String> list(final String... elements) {
+		final List<String> result = new ArrayList<>();
+		Collections.addAll( result, elements );
+		return result;
+	}
+
+}


### PR DESCRIPTION
Extended the Envers Query API to restrict an alias to a specified type.

[Link to Jira issue](https://hibernate.atlassian.net/browse/HHH-11573)