### PR TITLE
HHH-11582 - Fix inconsistent envers behavior with modified flags

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/synchronization/work/AddWorkUnit.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/synchronization/work/AddWorkUnit.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.entities.PropertyData;
+import org.hibernate.envers.internal.entities.mapper.ExtendedPropertyMapper;
 import org.hibernate.envers.internal.tools.ArraysTools;
 import org.hibernate.persister.entity.EntityPersister;
 
@@ -79,7 +81,13 @@ public class AddWorkUnit extends AbstractAuditWorkUnit implements AuditWorkUnit 
 
 	@Override
 	public AuditWorkUnit merge(ModWorkUnit second) {
-		return new AddWorkUnit( sessionImplementor, entityName, enversService, id, second.getData() );
+		return new AddWorkUnit(
+				sessionImplementor,
+				entityName,
+				enversService,
+				id,
+				mergeModifiedFlags( data, second.getData() )
+		);
 	}
 
 	@Override
@@ -101,5 +109,24 @@ public class AddWorkUnit extends AbstractAuditWorkUnit implements AuditWorkUnit 
 	@Override
 	public AuditWorkUnit dispatch(WorkUnitMergeVisitor first) {
 		return first.merge( this );
+	}
+
+	private Map<String, Object> mergeModifiedFlags(Map<String, Object> lhs, Map<String, Object> rhs) {
+		final ExtendedPropertyMapper mapper = enversService.getEntitiesConfigurations().get( getEntityName() ).getPropertyMapper();
+		// Designed to take any lhs modified flag values of true and merge those into the data set for the rhs
+		// This makes sure that when merging ModAuditWork with AddWorkUnit within the same transaction for the
+		// same entity that the modified flags are tracked correctly.
+		for ( PropertyData propertyData : mapper.getProperties().keySet() ) {
+			if ( propertyData.isUsingModifiedFlag() && !propertyData.isSynthetic() ) {
+				Boolean lhsValue = (Boolean) lhs.get( propertyData.getModifiedFlagPropertyName() );
+				if ( lhsValue != null && lhsValue ) {
+					Boolean rhsValue = (Boolean) rhs.get( propertyData.getModifiedFlagPropertyName() );
+					if ( rhsValue == null || !rhsValue ) {
+						rhs.put( propertyData.getModifiedFlagPropertyName(), true );
+					}
+				}
+			}
+		}
+		return rhs;
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/modifiedflags/HasChangedInsertUpdateSameTransactionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/modifiedflags/HasChangedInsertUpdateSameTransactionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.modifiedflags;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.envers.test.Priority;
+import org.hibernate.envers.test.integration.basic.BasicTestEntity1;
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-11582")
+public class HasChangedInsertUpdateSameTransactionTest extends AbstractModifiedFlagsEntityTest {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { BasicTestEntity1.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager entityManager = getEntityManager();
+		try {
+			// Revision 1
+			entityManager.getTransaction().begin();
+			BasicTestEntity1 entity = new BasicTestEntity1( "str1", 1 );
+			entityManager.persist( entity );
+			entity.setStr1( "str2" );
+			entityManager.merge( entity );
+			entityManager.getTransaction().commit();
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+
+	@Test
+	public void testPropertyChangedInsrtUpdateSameTransaction() {
+		// this was only flagged as changed as part of the persist
+		List list = queryForPropertyHasChanged( BasicTestEntity1.class, 1, "long1" );
+		assertEquals( 1, list.size() );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11582

Fixes Envers inconsistent behavior when modified flags is enabled and an entity is persisted and merged within the same transaction boundary.