### PR TITLE
HHH-11576

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -147,21 +147,7 @@ public final class TwoPhaseLoad {
 		final Type[] types = persister.getPropertyTypes();
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
-			if ( value == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-				// IMPLEMENTATION NOTE: This is a lazy property on a bytecode-enhanced entity.
-				// hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY so that
-				// setPropertyValues() below (ultimately AbstractEntityTuplizer#setPropertyValues) works properly
-				// No resolution is necessary, unless the lazy property is a collection.
-				if ( types[i].isCollectionType() ) {
-					// IMPLEMENTATION NOTE: this is a lazy collection property on a bytecode-enhanced entity.
-					// HHH-10989: We need to resolve the collection so that a CollectionReference is added to StatefulPersistentContext.
-					// As mentioned above, hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY
-					// so do not assign the resolved, unitialized PersistentCollection back to hydratedState[i].
-					types[i].resolve( value, session, entity );
-				}
-			}
-			else if ( value!= PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
-				// we know value != LazyPropertyInitializer.UNFETCHED_PROPERTY
+			if ( value!=LazyPropertyInitializer.UNFETCHED_PROPERTY && value!= PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				hydratedState[i] = types[i].resolve( value, session, entity );
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -40,6 +40,7 @@ import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteOn
 import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteThreeTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteTwoTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
+import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionDeletedTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionLoadingTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionNoTransactionLoadingTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingIntegrationTestTask;
@@ -125,6 +126,12 @@ public class EnhancerTest extends BaseUnitTestCase {
 
 		EnhancerTestUtils.runEnhancerTestTask( LazyBasicPropertyAccessTestTask.class );
 		EnhancerTestUtils.runEnhancerTestTask( LazyBasicFieldAccessTestTask.class );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11576")
+	public void testLazyCollectionDeleted() {
+		EnhancerTestUtils.runEnhancerTestTask( LazyCollectionDeletedTestTask.class );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionDeletedTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionDeletedTestTask.java
@@ -1,0 +1,137 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Query;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Luis Barreiro
+ */
+public class LazyCollectionDeletedTestTask extends AbstractEnhancerTestTask {
+    private static final int CHILDREN_SIZE = 10;
+    private Long postId;
+
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{Post.class, Tag.class, AdditionalDetails.class};
+    }
+
+    public void prepare() {
+        Configuration cfg = new Configuration();
+        cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+        cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+        super.prepare( cfg );
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Post post = new Post();
+
+            Tag tag1 = new Tag();
+            tag1.name = "tag1";
+            Tag tag2 = new Tag();
+            tag1.name = "tag2";
+
+            Set<Tag> tagSet = new HashSet<>();
+            tagSet.add( tag1 );
+            tagSet.add( tag2 );
+            post.tags = tagSet;
+
+            AdditionalDetails details = new AdditionalDetails();
+            details.post = post;
+            details.details = "Some data";
+            post.additionalDetails = details;
+
+            postId = (Long) s.save( post );
+            s.getTransaction().commit();
+        }
+    }
+
+    public void execute() {
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Query query = s.createQuery( "from AdditionalDetails where id=" + postId );
+            AdditionalDetails additionalDetails = (AdditionalDetails) query.getSingleResult();
+            additionalDetails.details = "New data";
+            s.persist( additionalDetails );
+
+            // additionalDetais.post.tags get deleted on commit
+            s.getTransaction().commit();
+        }
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Query query = s.createQuery( "from Post where id=" + postId );
+            Post retrievedPost = (Post) query.getSingleResult();
+
+            assertFalse( "No tags found", retrievedPost.tags.isEmpty() );
+            retrievedPost.tags.forEach( tag -> System.out.println( "Found tag: " + tag ) );
+
+            s.getTransaction().commit();
+        }
+    }
+
+    protected void cleanup() {
+    }
+
+    // --- //
+
+    @Entity( name = "Tag" )
+    public static class Tag {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String name;
+    }
+
+    @Entity( name = "Post" )
+    public static class Post {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @ManyToMany( cascade = CascadeType.ALL )
+        private Set<Tag> tags;
+
+        @OneToOne( fetch = FetchType.LAZY, mappedBy = "post", cascade = CascadeType.ALL )
+        private AdditionalDetails additionalDetails;
+    }
+
+    @Entity( name = "AdditionalDetails" )
+    public static class AdditionalDetails {
+
+        @Id
+        private Long id;
+
+        private String details;
+
+        @OneToOne( optional = false )
+        @MapsId
+        private Post post;
+    }
+}


### PR DESCRIPTION
This is an alternative to https://github.com/hibernate/hibernate-orm/pull/1854 for fixing HHH-11576.

It reverts the fix from HHH-10989. Instead, it resolves the collection  during flush, but only when the owner is (or was) deleted. This will fix both HHH-10989 and HHH-11576.

After flush, the CollectionEntry for the deleted collection is removed from the PersistenceContext.
