### PR TITLE
HHH-11576 and HHH-11459

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 import org.hibernate.HibernateException;
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CascadeStyle;
@@ -94,8 +95,13 @@ public final class Cascade {
 
 					// For bytecode enhanced entities, need to fetch the attribute
 					if ( hasUninitializedLazyProperties && persister.getPropertyLaziness()[i] && action.performOnLazyProperty() ) {
-						LazyAttributeLoadingInterceptor interceptor = persister.getInstrumentationMetadata().extractInterceptor( parent );
-						child = interceptor.fetchAttribute( parent, propertyName );
+						if ( types[i].isCollectionType() ) {
+							child = types[i].resolve( LazyPropertyInitializer.UNFETCHED_PROPERTY, eventSource, parent );
+						}
+						else {
+							LazyAttributeLoadingInterceptor interceptor = persister.getInstrumentationMetadata().extractInterceptor( parent );
+							child = interceptor.fetchAttribute( parent, propertyName );
+						}
 					}
 					else {
 						child = persister.getPropertyValue( parent, i );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
@@ -7,6 +7,7 @@
 package org.hibernate.event.internal;
 
 import org.hibernate.HibernateException;
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.Collections;
 import org.hibernate.event.spi.EventSource;
@@ -35,6 +36,9 @@ public class FlushVisitor extends AbstractVisitor {
 			if ( type.hasHolder() ) {
 				coll = getSession().getPersistenceContext().getCollectionHolder(collection);
 			}
+			else if ( collection == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+				coll = (PersistentCollection) type.resolve( collection, getSession(), owner );
+			}
 			else {
 				coll = (PersistentCollection) collection;
 			}
@@ -44,6 +48,11 @@ public class FlushVisitor extends AbstractVisitor {
 
 		return null;
 
+	}
+
+	@Override
+	boolean includeEntityProperty(Object[] values, int i) {
+		return true;
 	}
 
 	FlushVisitor(EventSource session, Object owner) {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -40,6 +40,7 @@ import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteOn
 import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteThreeTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.HHH_10708.UnexpectedDeleteTwoTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyBasicFieldNotInitializedTestTask;
+import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionDeletedTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionLoadingTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyCollectionNoTransactionLoadingTestTask;
 import org.hibernate.test.bytecode.enhancement.lazy.LazyLoadingIntegrationTestTask;
@@ -125,6 +126,12 @@ public class EnhancerTest extends BaseUnitTestCase {
 
 		EnhancerTestUtils.runEnhancerTestTask( LazyBasicPropertyAccessTestTask.class );
 		EnhancerTestUtils.runEnhancerTestTask( LazyBasicFieldAccessTestTask.class );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11576")
+	public void testLazyCollectionDeleted() {
+		EnhancerTestUtils.runEnhancerTestTask( LazyCollectionDeletedTestTask.class );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/EnhancerTest.java
@@ -8,6 +8,9 @@ package org.hibernate.test.bytecode.enhancement;
 
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
 
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
+import org.hibernate.test.bytecode.enhancement.merge.MergeEnhancedEntityTestTask;
+import org.hibernate.test.bytecode.enhancement.merge.RefreshEnhancedEntityTestTask;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.RequiresDialectFeature;
@@ -93,6 +96,13 @@ public class EnhancerTest extends BaseUnitTestCase {
 	@TestForIssue( jiraKey = "HHH-11426" )
 	public void testDetached() {
 		EnhancerTestUtils.runEnhancerTestTask( DetachedGetIdentifierTestTask.class );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11459" )
+	public void testMergeRefresh() {
+		EnhancerTestUtils.runEnhancerTestTask( MergeEnhancedEntityTestTask.class );
+		EnhancerTestUtils.runEnhancerTestTask( RefreshEnhancedEntityTestTask.class );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionDeletedTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionDeletedTestTask.java
@@ -1,0 +1,137 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Query;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Luis Barreiro
+ */
+public class LazyCollectionDeletedTestTask extends AbstractEnhancerTestTask {
+    private static final int CHILDREN_SIZE = 10;
+    private Long postId;
+
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{Post.class, Tag.class, AdditionalDetails.class};
+    }
+
+    public void prepare() {
+        Configuration cfg = new Configuration();
+        cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+        cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+        super.prepare( cfg );
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Post post = new Post();
+
+            Tag tag1 = new Tag();
+            tag1.name = "tag1";
+            Tag tag2 = new Tag();
+            tag1.name = "tag2";
+
+            Set<Tag> tagSet = new HashSet<>();
+            tagSet.add( tag1 );
+            tagSet.add( tag2 );
+            post.tags = tagSet;
+
+            AdditionalDetails details = new AdditionalDetails();
+            details.post = post;
+            details.details = "Some data";
+            post.additionalDetails = details;
+
+            postId = (Long) s.save( post );
+            s.getTransaction().commit();
+        }
+    }
+
+    public void execute() {
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Query query = s.createQuery( "from AdditionalDetails where id=" + postId );
+            AdditionalDetails additionalDetails = (AdditionalDetails) query.getSingleResult();
+            additionalDetails.details = "New data";
+            s.persist( additionalDetails );
+
+            // additionalDetais.post.tags get deleted on commit
+            s.getTransaction().commit();
+        }
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            Query query = s.createQuery( "from Post where id=" + postId );
+            Post retrievedPost = (Post) query.getSingleResult();
+
+            assertFalse( "No tags found", retrievedPost.tags.isEmpty() );
+            retrievedPost.tags.forEach( tag -> System.out.println( "Found tag: " + tag ) );
+
+            s.getTransaction().commit();
+        }
+    }
+
+    protected void cleanup() {
+    }
+
+    // --- //
+
+    @Entity( name = "Tag" )
+    public static class Tag {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String name;
+    }
+
+    @Entity( name = "Post" )
+    public static class Post {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @ManyToMany( cascade = CascadeType.ALL )
+        private Set<Tag> tags;
+
+        @OneToOne( fetch = FetchType.LAZY, mappedBy = "post", cascade = CascadeType.ALL )
+        private AdditionalDetails additionalDetails;
+    }
+
+    @Entity( name = "AdditionalDetails" )
+    public static class AdditionalDetails {
+
+        @Id
+        private Long id;
+
+        private String details;
+
+        @OneToOne( optional = false )
+        @MapsId
+        private Post post;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedEntityTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedEntityTestTask.java
@@ -1,0 +1,97 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.merge;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.junit.Assert;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Luis Barreiro
+ */
+public class MergeEnhancedEntityTestTask extends AbstractEnhancerTestTask {
+
+    private long entityId;
+
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{Person.class, PersonAddress.class};
+    }
+
+    public void prepare() {
+        Configuration cfg = new Configuration();
+        cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+        cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+        super.prepare( cfg );
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            s.persist( new Person( 1L, "Sam" ) );
+            s.getTransaction().commit();
+        }
+    }
+
+    public void execute() {
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+            Person entity = s.find( Person.class, 1L );
+            entity.name = "Jhon";
+            try {
+                s.merge( entity );
+                s.getTransaction().commit();
+            } catch ( RuntimeException e ) {
+                Assert.fail( "Enhanced entity can't be refreshed: " + e.getMessage() );
+            }
+        }
+    }
+
+    protected void cleanup() {
+    }
+
+    @Entity
+    public static class Person {
+
+        @Id
+        private Long id;
+
+        @Column( name = "name", length = 10, nullable = false )
+        private String name;
+
+        @OneToMany( fetch = FetchType.LAZY, mappedBy = "parent", orphanRemoval = true, cascade = CascadeType.ALL )
+        private List<PersonAddress> details = new ArrayList<>();
+
+        protected Person() {
+        }
+
+        public Person(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @Entity
+    public static class PersonAddress {
+
+        @Id
+        private Long id;
+
+        @ManyToOne( optional = false, fetch = FetchType.LAZY )
+        private Person parent;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedEntityTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedEntityTestTask.java
@@ -64,7 +64,7 @@ public class MergeEnhancedEntityTestTask extends AbstractEnhancerTestTask {
     protected void cleanup() {
     }
 
-    @Entity
+    @Entity( name = "Person" )
     public static class Person {
 
         @Id
@@ -85,7 +85,7 @@ public class MergeEnhancedEntityTestTask extends AbstractEnhancerTestTask {
         }
     }
 
-    @Entity
+    @Entity( name = "PersonAddress" )
     public static class PersonAddress {
 
         @Id

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/RefreshEnhancedEntityTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/RefreshEnhancedEntityTestTask.java
@@ -1,0 +1,97 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.merge;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.test.bytecode.enhancement.AbstractEnhancerTestTask;
+import org.junit.Assert;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Luis Barreiro
+ */
+public class RefreshEnhancedEntityTestTask extends AbstractEnhancerTestTask {
+
+    private long entityId;
+
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{Person.class, PersonAddress.class};
+    }
+
+    public void prepare() {
+        Configuration cfg = new Configuration();
+        cfg.setProperty( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+        cfg.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
+        super.prepare( cfg );
+
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+
+            s.persist( new Person( 1L, "Sam" ) );
+            s.getTransaction().commit();
+        }
+    }
+
+    public void execute() {
+        try ( Session s = getFactory().openSession() ) {
+            s.beginTransaction();
+            Person entity = s.find( Person.class, 1L );
+            entity.name = "Jhon";
+            try {
+                s.refresh( entity );
+                s.getTransaction().commit();
+            } catch ( RuntimeException e ) {
+                Assert.fail( "Enhanced entity can't be refreshed: " + e.getMessage() );
+            }
+        }
+    }
+
+    protected void cleanup() {
+    }
+
+    @Entity
+    public static class Person {
+
+        @Id
+        private Long id;
+
+        @Column( name = "name", length = 10, nullable = false )
+        private String name;
+
+        @OneToMany( fetch = FetchType.LAZY, mappedBy = "parent", orphanRemoval = true, cascade = CascadeType.ALL )
+        private List<PersonAddress> details = new ArrayList<>();
+
+        protected Person() {
+        }
+
+        public Person(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @Entity
+    public static class PersonAddress {
+
+        @Id
+        private Long id;
+
+        @ManyToOne( optional = false, fetch = FetchType.LAZY )
+        private Person parent;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/RefreshEnhancedEntityTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/RefreshEnhancedEntityTestTask.java
@@ -64,7 +64,7 @@ public class RefreshEnhancedEntityTestTask extends AbstractEnhancerTestTask {
     protected void cleanup() {
     }
 
-    @Entity
+    @Entity(name = "Person")
     public static class Person {
 
         @Id
@@ -85,7 +85,7 @@ public class RefreshEnhancedEntityTestTask extends AbstractEnhancerTestTask {
         }
     }
 
-    @Entity
+    @Entity(name = "PersonAddress")
     public static class PersonAddress {
 
         @Id


### PR DESCRIPTION
This supersedes https://github.com/hibernate/hibernate-orm/pull/1854 with a small change and added comments.

It also avoids cascading the entity field value (e.g, null or some other value initialized by entity constructor) from the enhanced entity when `CascadingAction#performOnLazyProperty` returns `false`.