### PR TITLE
HHH-11587 - Reordering items in List throws a constraint violation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -69,6 +69,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	// collections detect changes made via their public interface and mark
 	// themselves as dirty as a performance optimization
 	private boolean dirty;
+	protected boolean elementRemoved;
 	private Serializable storedSnapshot;
 
 	private String sessionFactoryUuid;
@@ -106,8 +107,14 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	}
 
 	@Override
+	public boolean isElementRemoved() {
+		return elementRemoved;
+	}
+
+	@Override
 	public final void clearDirty() {
 		dirty = false;
+		elementRemoved = false;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -307,6 +307,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	public boolean remove(Object o) {
 		initialize( true );
 		if ( bag.remove( o ) ) {
+			elementRemoved = true;
 			dirty();
 			return true;
 		}
@@ -346,6 +347,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 		if ( c.size()>0 ) {
 			initialize( true );
 			if ( bag.removeAll( c ) ) {
+				elementRemoved = true;
 				dirty();
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
@@ -150,6 +150,7 @@ public class PersistentIdentifierBag extends AbstractPersistentCollection implem
 		if ( index >= 0 ) {
 			beforeRemove( index );
 			values.remove( index );
+			elementRemoved = true;
 			dirty();
 			return true;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentList.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentList.java
@@ -163,6 +163,7 @@ public class PersistentList extends AbstractPersistentCollection implements List
 		if ( exists == null ) {
 			initialize( true );
 			if ( list.remove( value ) ) {
+				elementRemoved = true;
 				dirty();
 				return true;
 			}
@@ -171,6 +172,7 @@ public class PersistentList extends AbstractPersistentCollection implements List
 			}
 		}
 		else if ( exists ) {
+			elementRemoved = true;
 			queueOperation( new SimpleRemove( value ) );
 			return true;
 		}
@@ -222,6 +224,7 @@ public class PersistentList extends AbstractPersistentCollection implements List
 		if ( coll.size()>0 ) {
 			initialize( true );
 			if ( list.removeAll( coll ) ) {
+				elementRemoved = true;
 				dirty();
 				return true;
 			}
@@ -298,8 +301,10 @@ public class PersistentList extends AbstractPersistentCollection implements List
 			throw new ArrayIndexOutOfBoundsException( "negative index" );
 		}
 		final Object old = isPutQueueEnabled() ? readElementByIndex( index ) : UNKNOWN;
+		elementRemoved = true;
 		if ( old == UNKNOWN ) {
 			write();
+			dirty();
 			return list.remove( index );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
@@ -178,6 +178,7 @@ public class PersistentMap extends AbstractPersistentCollection implements Map {
 		if ( isPutQueueEnabled() ) {
 			final Object old = readElementByIndex( key );
 			if ( old != UNKNOWN ) {
+				elementRemoved = true;
 				queueOperation( new Remove( key, old ) );
 				return old;
 			}
@@ -185,6 +186,7 @@ public class PersistentMap extends AbstractPersistentCollection implements Map {
 		// TODO : safe to interpret "map.remove(key) == null" as non-dirty?
 		initialize( true );
 		if ( map.containsKey( key ) ) {
+			elementRemoved = true;
 			dirty();
 		}
 		return map.remove( key );

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSet.java
@@ -206,6 +206,7 @@ public class PersistentSet extends AbstractPersistentCollection implements java.
 		if ( exists == null ) {
 			initialize( true );
 			if ( set.remove( value ) ) {
+				elementRemoved = true;
 				dirty();
 				return true;
 			}
@@ -214,6 +215,7 @@ public class PersistentSet extends AbstractPersistentCollection implements java.
 			}
 		}
 		else if ( exists ) {
+			elementRemoved = true;
 			queueOperation( new SimpleRemove( value ) );
 			return true;
 		}
@@ -266,6 +268,7 @@ public class PersistentSet extends AbstractPersistentCollection implements java.
 		if ( coll.size() > 0 ) {
 			initialize( true );
 			if ( set.removeAll( coll ) ) {
+				elementRemoved = true;
 				dirty();
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -395,7 +395,11 @@ public interface PersistentCollection {
 	 * @return {@code true} if the collection is dirty
 	 */
 	boolean isDirty();
-	
+
+	default boolean isElementRemoved(){
+		return false;
+	}
+
 	/**
 	 * Clear the dirty flag, afterQuery flushing changes
 	 * to the database.

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -9,7 +9,9 @@ package org.hibernate.persister.collection;
 import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
@@ -193,82 +195,50 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 		}
 
 		try {
-			PreparedStatement st = null;
-			Expectation expectation = Expectations.appropriateExpectation( getUpdateCheckStyle() );
-			boolean callable = isUpdateCallable();
-			boolean useBatch = expectation.canBeBatched();
-			Iterator entries = collection.entries( this );
-			String sql = getSQLUpdateRowString();
-			int i = 0;
-			int count = 0;
+			final Expectation expectation = Expectations.appropriateExpectation( getUpdateCheckStyle() );
+			final boolean callable = isUpdateCallable();
+			final boolean useBatch = expectation.canBeBatched();
+			final Iterator entries = collection.entries( this );
+
+			final List elements = new ArrayList();
 			while ( entries.hasNext() ) {
-				Object entry = entries.next();
-				if ( collection.needsUpdating( entry, i, elementType ) ) {
-					int offset = 1;
+				elements.add( entries.next() );
+			}
 
-					if ( useBatch ) {
-						if ( updateBatchKey == null ) {
-							updateBatchKey = new BasicBatchKey(
-									getRole() + "#UPDATE",
-									expectation
-							);
-						}
-						st = session
-								.getJdbcCoordinator()
-								.getBatch( updateBatchKey )
-								.getBatchStatement( sql, callable );
-					}
-					else {
-						st = session
-								.getJdbcCoordinator()
-								.getStatementPreparer()
-								.prepareStatement( sql, callable );
-					}
-
-					try {
-						offset += expectation.prepare( st );
-						int loc = writeElement( st, collection.getElement( entry ), offset, session );
-						if ( hasIdentifier ) {
-							writeIdentifier( st, collection.getIdentifier( entry, i ), loc, session );
-						}
-						else {
-							loc = writeKey( st, id, loc, session );
-							if ( hasIndex && !indexContainsFormula ) {
-								writeIndexToWhere( st, collection.getIndex( entry, i, this ), loc, session );
-							}
-							else {
-								writeElementToWhere( st, collection.getSnapshotElement( entry, i ), loc, session );
-							}
-						}
-
-						if ( useBatch ) {
-							session.getJdbcCoordinator()
-									.getBatch( updateBatchKey )
-									.addToBatch();
-						}
-						else {
-							expectation.verifyOutcome(
-									session.getJdbcCoordinator().getResultSetReturn().executeUpdate(
-											st
-									), st, -1
-							);
-						}
-					}
-					catch (SQLException sqle) {
-						if ( useBatch ) {
-							session.getJdbcCoordinator().abortBatch();
-						}
-						throw sqle;
-					}
-					finally {
-						if ( !useBatch ) {
-							session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( st );
-							session.getJdbcCoordinator().afterStatementExecution();
-						}
-					}
-					count++;
+			final String sql = getSQLUpdateRowString();
+			int count = 0;
+			if ( collection.isElementRemoved() ) {
+				// the update should be done starting from the end to the list
+				for ( int i = elements.size() - 1; i >= 0; i-- ) {
+					count = doUpdateRow(
+							id,
+							collection,
+							session,
+							expectation,
+							callable,
+							useBatch,
+							elements,
+							sql,
+							count,
+							i
+					);
 				}
-				i++;
+			}
+			else {
+				for ( int i = 0; i < elements.size(); i++ ) {
+					count = doUpdateRow(
+							id,
+							collection,
+							session,
+							expectation,
+							callable,
+							useBatch,
+							elements,
+							sql,
+							count,
+							i
+					);
+				}
 			}
 			return count;
 		}
@@ -284,6 +254,82 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 					getSQLUpdateRowString()
 			);
 		}
+	}
+
+	private int doUpdateRow(
+			Serializable id,
+			PersistentCollection collection,
+			SharedSessionContractImplementor session,
+			Expectation expectation, boolean callable, boolean useBatch, List elements, String sql, int count, int i)
+			throws SQLException {
+		PreparedStatement st;
+		Object entry = elements.get( i );
+		if ( collection.needsUpdating( entry, i, elementType ) ) {
+			int offset = 1;
+
+			if ( useBatch ) {
+				if ( updateBatchKey == null ) {
+					updateBatchKey = new BasicBatchKey(
+							getRole() + "#UPDATE",
+							expectation
+					);
+				}
+				st = session
+						.getJdbcCoordinator()
+						.getBatch( updateBatchKey )
+						.getBatchStatement( sql, callable );
+			}
+			else {
+				st = session
+						.getJdbcCoordinator()
+						.getStatementPreparer()
+						.prepareStatement( sql, callable );
+			}
+
+			try {
+				offset += expectation.prepare( st );
+				int loc = writeElement( st, collection.getElement( entry ), offset, session );
+				if ( hasIdentifier ) {
+					writeIdentifier( st, collection.getIdentifier( entry, i ), loc, session );
+				}
+				else {
+					loc = writeKey( st, id, loc, session );
+					if ( hasIndex && !indexContainsFormula ) {
+						writeIndexToWhere( st, collection.getIndex( entry, i, this ), loc, session );
+					}
+					else {
+						writeElementToWhere( st, collection.getSnapshotElement( entry, i ), loc, session );
+					}
+				}
+
+				if ( useBatch ) {
+					session.getJdbcCoordinator()
+							.getBatch( updateBatchKey )
+							.addToBatch();
+				}
+				else {
+					expectation.verifyOutcome(
+							session.getJdbcCoordinator().getResultSetReturn().executeUpdate(
+									st
+							), st, -1
+					);
+				}
+			}
+			catch (SQLException sqle) {
+				if ( useBatch ) {
+					session.getJdbcCoordinator().abortBatch();
+				}
+				throw sqle;
+			}
+			finally {
+				if ( !useBatch ) {
+					session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( st );
+					session.getJdbcCoordinator().afterStatementExecution();
+				}
+			}
+			count++;
+		}
+		return count;
 	}
 
 	public String selectFragment(

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/mapping/UnidirectionalOneToManyOrderColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/mapping/UnidirectionalOneToManyOrderColumnTest.java
@@ -7,32 +7,37 @@
 package org.hibernate.jpa.test.mapping;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
+import javax.persistence.Table;
 
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
 
+@TestForIssue(jiraKey = "HHH-11587")
 public class UnidirectionalOneToManyOrderColumnTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-11587" )
-	public void testQuote() {
+	public void testRemovingAnElement() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 
 			ParentData parent = new ParentData();
 			entityManager.persist( parent );
 
-			String[] childrenStr = new String[] { "One", "Two", "Three", "Four", "Five" };
+			String[] childrenStr = new String[] {"One", "Two", "Three"};
 			for ( String str : childrenStr ) {
 				ChildData child = new ChildData( str );
 				entityManager.persist( child );
@@ -46,6 +51,57 @@ public class UnidirectionalOneToManyOrderColumnTest extends BaseEntityManagerFun
 		} );
 	}
 
+	@Test
+	public void testAddingAnElement() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+
+			ParentData parent = new ParentData();
+			entityManager.persist( parent );
+
+			String[] childrenStr = new String[] {"One", "Two", "Three"};
+			for ( String str : childrenStr ) {
+				ChildData child = new ChildData( str );
+				entityManager.persist( child );
+				parent.getChildren().add( child );
+			}
+
+			entityManager.flush();
+
+			List<ChildData> children = parent.getChildren();
+			children.add( 1, new ChildData( "Another" ) );
+		} );
+	}
+
+	@Test
+	public void testRemovingAndAddingAnElement() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+
+			ParentData parent = new ParentData();
+			entityManager.persist( parent );
+
+			String[] childrenStr = new String[] {"One", "Two", "Three"};
+			for ( String str : childrenStr ) {
+				ChildData child = new ChildData( str );
+				entityManager.persist( child );
+				parent.getChildren().add( child );
+			}
+
+			entityManager.flush();
+
+			List<ChildData> children = parent.getChildren();
+			children.remove( 0 );
+			children.add( 1, new ChildData( "Another" ) );
+		} );
+		doInJPA( this::entityManagerFactory, entityManager -> {
+
+			ParentData parent = entityManager.find( ParentData.class, 1L );
+			List<String> childIds = parent.getChildren().stream().map( ChildData::toString ).collect( Collectors.toList() );
+			int i = 0;
+			assertEquals( "Two", childIds.get( i++ ));
+			assertEquals( "Another", childIds.get( i++ ));
+			assertEquals( "Three", childIds.get( i++ ));
+		} );
+	}
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
@@ -55,7 +111,8 @@ public class UnidirectionalOneToManyOrderColumnTest extends BaseEntityManagerFun
 		};
 	}
 
-	@Entity
+	@Entity(name = "ParentData")
+	@Table(name = "PARENT")
 	public static class ParentData {
 		@Id
 		@GeneratedValue
@@ -70,7 +127,8 @@ public class UnidirectionalOneToManyOrderColumnTest extends BaseEntityManagerFun
 		}
 	}
 
-	@Entity
+	@Entity(name = "ChildData")
+	@Table(name = "CHILD")
 	public static class ChildData {
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/mapping/UnidirectionalOneToManyOrderColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/mapping/UnidirectionalOneToManyOrderColumnTest.java
@@ -7,9 +7,7 @@
 package org.hibernate.jpa.test.mapping;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -101,6 +99,39 @@ public class UnidirectionalOneToManyOrderColumnTest extends BaseEntityManagerFun
 			assertEquals( "Another", childIds.get( i++ ));
 			assertEquals( "Three", childIds.get( i++ ));
 		} );
+	}
+
+	@Test
+	public void testRemovingOneAndAddingTwoElements() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+
+					 ParentData parent = new ParentData();
+					 entityManager.persist( parent );
+
+					 String[] childrenStr = new String[] {"One", "Two", "Three"};
+					 for ( String str : childrenStr ) {
+						 ChildData child = new ChildData( str );
+						 entityManager.persist( child );
+						 parent.getChildren().add( child );
+					 }
+
+					 entityManager.flush();
+
+					 List<ChildData> children = parent.getChildren();
+					 children.remove( 0 );
+					 children.add( 1, new ChildData( "Another" ) );
+				   	 children.add( new ChildData( "Another Another" ) );
+				 } );
+		doInJPA( this::entityManagerFactory, entityManager -> {
+
+					 ParentData parent = entityManager.find( ParentData.class, 1L );
+					 List<String> childIds = parent.getChildren().stream().map( ChildData::toString ).collect( Collectors.toList() );
+					 int i = 0;
+					 assertEquals( "Two", childIds.get( i++ ));
+					 assertEquals( "Another", childIds.get( i++ ));
+					 assertEquals( "Three", childIds.get( i++ ));
+					 assertEquals( "Another Another", childIds.get( i++ ));
+				 } );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11587

this PR fix the failure highlighted by @gbadner with the UnidirectionalOneToManyOrderColumnTest#testRemovingOneAndAddingTwoElements() test.

This fix changes an spi interface, this is not a problem for 5.2 thanks to the default but a problem for backporting 5.1 and 5.0.