### PR TITLE
HHH-11645 - HikariCP shutdown() method is deprecated, close() should be called instead

### DIFF
--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
@@ -119,6 +119,6 @@ public class HikariCPConnectionProvider implements ConnectionProvider, Configura
 
 	@Override
 	public void stop() {
-		hds.shutdown();
+		hds.close();
 	}
 }


### PR DESCRIPTION
Shutdown is deprecated in favour of close hence using close()