### PR TITLE
HHH-11698 Upgrade to Byte Buddy 1.6.14 for improved JDK9 compatibility

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -19,7 +19,7 @@ ext {
     cdiVersion = '1.1'
 
     javassistVersion = '3.20.0-GA'
-    byteBuddyVersion = '1.6.6'
+    byteBuddyVersion = '1.6.14' // Improved JDK9 compatibility
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
     wildflyVersion = '10.1.0.Final'


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HHH-11698