### PR TITLE
HHH-11712 - PostgreSQL does not support negative initial sequence values for ascending sequences unless MINVALUE is defined as well

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -487,7 +487,35 @@ public class PostgreSQL81Dialect extends Dialect {
 	 */
 	@Override
 	protected String getCreateSequenceString(String sequenceName, int initialValue, int incrementSize) {
-		return getCreateSequenceString( sequenceName ) + " start " + initialValue + " increment " + incrementSize;
+		if ( initialValue < 0 && incrementSize > 0 ) {
+			return
+					String.format(
+							"%s minvalue %d start %d increment %d",
+							getCreateSequenceString( sequenceName ),
+							initialValue,
+							initialValue,
+							incrementSize
+					);
+		}
+		else if ( initialValue > 0 && incrementSize < 0 ) {
+			return
+					String.format(
+							"%s maxvalue %d start %d increment %d",
+							getCreateSequenceString( sequenceName ),
+							initialValue,
+							initialValue,
+							incrementSize
+					);
+		}
+		else {
+			return
+					String.format(
+							"%s start %d increment %d",
+							getCreateSequenceString( sequenceName ),
+							initialValue,
+							incrementSize
+					);
+		}
 	}
 	
 	// Overridden informational metadata ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11712