### PR TITLE
HHH-11718: fix various lgtm.com alerts

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ExplodedArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ExplodedArchiveDescriptor.java
@@ -145,8 +145,7 @@ public class ExplodedArchiveDescriptor extends AbstractArchiveDescriptor {
 	}
 
 	private void processZippedRoot(File rootFile, ArchiveContext context) {
-		try {
-			final JarFile jarFile = new JarFile(rootFile);
+		try (final JarFile jarFile = new JarFile(rootFile)){
 			final Enumeration<? extends ZipEntry> entries = jarFile.entries();
 			while ( entries.hasMoreElements() ) {
 				final ZipEntry zipEntry = entries.nextElement();

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
@@ -70,8 +70,8 @@ public class JarFileBasedArchiveDescriptor extends AbstractArchiveDescriptor {
 				//
 				// This algorithm assumes that the zipped file is only the URL root (including entry), not
 				// just any random entry
-				try (InputStream is = new BufferedInputStream( jarFile.getInputStream( zipEntry ) )) {
-					final JarInputStream jarInputStream = new JarInputStream( is );
+				try (InputStream is = new BufferedInputStream( jarFile.getInputStream( zipEntry ) ); 
+						final JarInputStream jarInputStream = new JarInputStream( is )) {
 					ZipEntry subZipEntry = jarInputStream.getNextEntry();
 					while ( subZipEntry != null ) {
 						if ( ! subZipEntry.isDirectory() ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/ExceptionConverterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ExceptionConverterImpl.java
@@ -59,9 +59,6 @@ public class ExceptionConverterImpl implements ExceptionConverter {
 					wrappedException = cause;
 				}
 			}
-			else if ( e instanceof HibernateException ) {
-				wrappedException = convert( (HibernateException) e );
-			}
 			else {
 				wrappedException = e;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdateTask.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdateTask.java
@@ -215,7 +215,9 @@ public class SchemaUpdateTask extends MatchingTask {
 			properties.putAll( getProject().getProperties() );
 		}
 		else {
-			properties.load( new FileInputStream( propertiesFile ) );
+			try (FileInputStream fip = new FileInputStream( propertiesFile )){
+				properties.load( fip );
+			} 
 		}
 
 		registryBuilder.applySettings( properties );


### PR DESCRIPTION
This PR fixes various alerts reported by lgtm.com (@lgtmhq). There are a good number of alerts that are well worth fixing here (including various logic errors and more potential resource leaks): https://lgtm.com/projects/g/hibernate/hibernate-orm/alerts.

Hope this is the right way to contribute! I think @sebersole may be interested.

https://lgtm.com/projects/g/hibernate/hibernate-orm/snapshot/06f0c3acb20bff63908e8310b571c53d55017998/files/hibernate-core/src/main/java/org/hibernate/internal/ExceptionConverterImpl.java#V62

https://lgtm.com/projects/g/hibernate/hibernate-orm/snapshot/06f0c3acb20bff63908e8310b571c53d55017998/files/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdateTask.java#V218

https://lgtm.com/projects/g/hibernate/hibernate-orm/snapshot/06f0c3acb20bff63908e8310b571c53d55017998/files/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ExplodedArchiveDescriptor.java#V149

https://lgtm.com/projects/g/hibernate/hibernate-orm/snapshot/06f0c3acb20bff63908e8310b571c53d55017998/files/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java#V74