### PR TITLE
HHH-11730-configurable-originalId-property

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/EnversSettings.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/EnversSettings.java
@@ -88,6 +88,11 @@ public interface EnversSettings {
 	String REVISION_TYPE_FIELD_NAME = "org.hibernate.envers.revision_type_field_name";
 
 	/**
+	 * Original id property name name. Defaults to {@literal originalId}.
+	 */
+	String ORIGINAL_ID_PROP_NAME = "org.hibernate.envers.original_id_prop_name";
+
+	/**
 	 * Column name that will hold the end revision number in audit entities. Defaults to {@literal REVEND}.
 	 */
 	String AUDIT_STRATEGY_VALIDITY_END_REV_FIELD_NAME = "org.hibernate.envers.audit_strategy_validity_end_rev_field_name";

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/AuditEntitiesConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/AuditEntitiesConfiguration.java
@@ -62,7 +62,9 @@ public class  AuditEntitiesConfiguration {
 				EnversSettings.AUDIT_STRATEGY, properties, DefaultAuditStrategy.class.getName()
 		);
 
-		originalIdPropName = "originalId";
+		originalIdPropName = ConfigurationHelper.getString(
+				EnversSettings.ORIGINAL_ID_PROP_NAME, properties, "originalId"
+		);
 
 		revisionFieldName = ConfigurationHelper.getString( EnversSettings.REVISION_FIELD_NAME, properties, "REV" );
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11730

Currently property originalId can't be audited in any entity.

Problem occurs during save, when envers try to save audit data

org.hibernate.envers.internal.synchronization.AuditProcess.doBeforeTransactionCompletion(SessionImplementor session)
	(...)
	org.hibernate.envers.internal.synchronization.work.AbstractAuditWorkUnit.fillDataWithId(Map<String, Object> data, Object revision)

where to map with all entity properties - "originalId" is added. If this property exists then it's replaced with new value (map containing entity id and revision number),
so in the end it results in exception:
	java.lang.ClassCastException: java.util.HashMap cannot be cast to java.util.UUID


This property looks like being configurable but isn't, check
org.hibernate.envers.configuration.internal.AuditEntitiesConfiguration.getOriginalIdPropName() 