### PR TITLE
HHH-10934: Check ForeignKey on function instead of only the name

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -444,37 +444,40 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 	}
 
 	/**
-	 * Check if the ForeignKey already exists. First check based on definition and if that is not matched check if a key with the exact 
-	 * same name exists. Keys with the same name are presumed to be functional equal.
+	 * Check if the ForeignKey already exists. First check based on definition and if that is not matched check if a key
+	 * with the exact same name exists. Keys with the same name are presumed to be functional equal.
 	 * 
 	 * @param foreignKey - ForeignKey, new key to be created
 	 * @param tableInformation - TableInformation, information of existing keys
 	 * @return boolean, true if key already exists
 	 */
 	private boolean checkForExistingForeignKey(ForeignKey foreignKey, TableInformation tableInformation) {
-		if (foreignKey.getName() == null || tableInformation == null) {
+		if ( foreignKey.getName() == null || tableInformation == null ) {
 			return false;
 		}
 
-		final String referencingColumn = foreignKey.getColumn(0).getName();
+		final String referencingColumn = foreignKey.getColumn( 0 ).getName();
 		final String referencedTable = foreignKey.getReferencedTable().getName();
 
 		/*
-		 * Find existing keys based on referencing column and referencedTable. "referencedColumnName" is not checked because that always is the
-		 * primary key of the "referencedTable".
+		 * Find existing keys based on referencing column and referencedTable. "referencedColumnName" is not checked
+		 * because that always is the primary key of the "referencedTable".
 		 */
 		Predicate<ColumnReferenceMapping> mappingPredicate = m -> {
 			String existingReferencingColumn = m.getReferencingColumnMetadata().getColumnIdentifier().getText();
 			String existingReferencedTable = m.getReferencedColumnMetadata().getContainingTableInformation().getName().getTableName().getCanonicalName();
-			return referencingColumn.equals(existingReferencingColumn) && referencedTable.equals(existingReferencedTable);
+			return referencingColumn.equals( existingReferencingColumn ) && referencedTable.equals( existingReferencedTable );
 		};
-		Stream<ForeignKeyInformation> keyStream = StreamSupport.stream(tableInformation.getForeignKeys().spliterator(), false);
-		Stream<ColumnReferenceMapping> mappingStream = keyStream.flatMap(key -> StreamSupport.stream(key.getColumnReferenceMappings().spliterator(), false));
-		boolean found = mappingStream.anyMatch(mappingPredicate);
-		if (found) return true;
+		Stream<ForeignKeyInformation> keyStream = StreamSupport.stream( tableInformation.getForeignKeys().spliterator(), false );
+		Stream<ColumnReferenceMapping> mappingStream = keyStream.flatMap( k -> StreamSupport.stream( k.getColumnReferenceMappings().spliterator(), false ) );
+		boolean found = mappingStream.anyMatch( mappingPredicate );
+		if ( found ) {
+			return true;
+		}
 
-		// And at the end just compare the name of the key. If a key with the same name exists we assume the function is also the same...
-		return tableInformation.getForeignKey(Identifier.toIdentifier(foreignKey.getName())) != null;
+		// And at the end just compare the name of the key. If a key with the same name exists we assume the function is
+		// also the same...
+		return tableInformation.getForeignKey( Identifier.toIdentifier( foreignKey.getName() ) ) != null;
 	}
 
 	protected void checkExportIdentifier(Exportable exportable, Set<String> exportIdentifiers) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -11,6 +11,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
@@ -35,6 +37,7 @@ import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.hbm2ddl.UniqueConstraintSchemaUpdateStrategy;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation;
+import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation.ColumnReferenceMapping;
 import org.hibernate.tool.schema.extract.spi.IndexInformation;
 import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
 import org.hibernate.tool.schema.extract.spi.SequenceInformation;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.hibernate.boot.Metadata;
@@ -442,23 +443,38 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 		}
 	}
 
+	/**
+	 * Check if the ForeignKey already exists. First check based on definition and if that is not matched check if a key with the exact 
+	 * same name exists. Keys with the same name are presumed to be functional equal.
+	 * 
+	 * @param foreignKey - ForeignKey, new key to be created
+	 * @param tableInformation - TableInformation, information of existing keys
+	 * @return boolean, true if key already exists
+	 */
 	private boolean checkForExistingForeignKey(ForeignKey foreignKey, TableInformation tableInformation) {
-		if ( foreignKey.getName() == null ) {
+		if (foreignKey.getName() == null || tableInformation == null) {
 			return false;
 		}
-		
+
+		final String referencingColumn = foreignKey.getColumn(0).getName();
+		final String referencedTable = foreignKey.getReferencedTable().getName();
+
 		/*
-		 * Find existing keys based on referencing column and referencedTable
+		 * Find existing keys based on referencing column and referencedTable. "referencedColumnName" is not checked because that always is the
+		 * primary key of the "referencedTable".
 		 */
-		String referencingColumn = foreignKey.getColumn(0).getName();
-		String referencedTableName = foreignKey.getReferencedTable().getName();
-		Predicate<ColumnReferenceMapping> mappingPredicate = m -> referencingColumn.equals(m.getReferencingColumnMetadata().getColumnIdentifier().getText())
-				&& referencedTableName.equals(m.getReferencedColumnMetadata().getContainingTableInformation().getName().getTableName().getCanonicalName());
-		boolean found = StreamSupport.stream(tableInformation.getForeignKeys().spliterator(), false)
-				.flatMap(key -> StreamSupport.stream(key.getColumnReferenceMappings().spliterator(), false)).anyMatch(mappingPredicate);
+		Predicate<ColumnReferenceMapping> mappingPredicate = m -> {
+			String existingReferencingColumn = m.getReferencingColumnMetadata().getColumnIdentifier().getText();
+			String existingReferencedTable = m.getReferencedColumnMetadata().getContainingTableInformation().getName().getTableName().getCanonicalName();
+			return referencingColumn.equals(existingReferencingColumn) && referencedTable.equals(existingReferencedTable);
+		};
+		Stream<ForeignKeyInformation> keyStream = StreamSupport.stream(tableInformation.getForeignKeys().spliterator(), false);
+		Stream<ColumnReferenceMapping> mappingStream = keyStream.flatMap(key -> StreamSupport.stream(key.getColumnReferenceMappings().spliterator(), false));
+		boolean found = mappingStream.anyMatch(mappingPredicate);
 		if (found) return true;
-		
-		return tableInformation.getForeignKey( Identifier.toIdentifier( foreignKey.getName() ) ) != null;
+
+		// And at the end just compare the name of the key. If a key with the same name exists we assume the function is also the same...
+		return tableInformation.getForeignKey(Identifier.toIdentifier(foreignKey.getName())) != null;
 	}
 
 	protected void checkExportIdentifier(Exportable exportable, Set<String> exportIdentifiers) {

--- a/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
@@ -37,29 +37,32 @@ import org.mockito.Mockito;
 
 /**
  * @author Milo van der Zee
- *
  */
 public class CheckForExistingForeignKeyTest {
+
 	private class SchemaMigrator extends AbstractSchemaMigrator {
+
 		/**
 		 * Needed constructor.
 		 */
 		public SchemaMigrator() {
-			super(null, null);
+			super( null, null );
 		}
 
 		/**
 		 * Needed implementation. Not used in test.
 		 */
 		@Override
-		protected NameSpaceTablesInformation performTablesMigration(Metadata metadata, DatabaseInformation existingDatabase, ExecutionOptions options, Dialect dialect,
-																	Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs, boolean tryToCreateSchemas,
-																	Set<Identifier> exportedCatalogs, Namespace namespace, GenerationTarget[] targets) {
+		protected NameSpaceTablesInformation performTablesMigration(Metadata metadata, DatabaseInformation existingDatabase, ExecutionOptions options,
+				Dialect dialect,
+				Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs, boolean tryToCreateSchemas,
+				Set<Identifier> exportedCatalogs, Namespace namespace, GenerationTarget[] targets) {
 			return null;
 		}
 	}
 
 	private class ColumnReferenceMappingImpl implements ColumnReferenceMapping {
+
 		private ColumnInformation referencingColumnMetadata;
 		private ColumnInformation referencedColumnMetadata;
 
@@ -80,6 +83,7 @@ public class CheckForExistingForeignKeyTest {
 	}
 
 	private class IdentifierHelperImpl implements IdentifierHelper {
+
 		@Override
 		public Identifier normalizeQuoting(Identifier identifier) {
 			return null;
@@ -122,7 +126,8 @@ public class CheckForExistingForeignKeyTest {
 	}
 
 	/**
-	 * If the key has no name it should never be found. Result is that those keys are always recreated. But keys always have a name so this is no problem.
+	 * If the key has no name it should never be found. Result is that those keys are always recreated. But keys always
+	 * have a name so this is no problem.
 	 * 
 	 * @throws NoSuchMethodException - error
 	 * @throws SecurityException - error
@@ -131,16 +136,17 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws InvocationTargetException - error
 	 */
 	@Test
-	public void testForeignKeyWithoutName() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+	public void testForeignKeyWithoutName()
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		// foreignKey name with same name should match
 		ForeignKey foreignKey = new ForeignKey();
-		TableInformation tableInformation = new TableInformationImpl(null, null, null, false, null);
-		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
-		Assert.assertFalse("Key should not be found", found);
+		TableInformation tableInformation = new TableInformationImpl( null, null, null, false, null );
+		boolean found = (boolean) method.invoke( new SchemaMigrator(), foreignKey, tableInformation );
+		Assert.assertFalse( "Key should not be found", found );
 	}
 
 	/**
@@ -153,22 +159,23 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws InvocationTargetException - error
 	 */
 	@Test
-	public void testMissingTableInformation() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+	public void testMissingTableInformation()
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		// foreignKey name with same name should match
 		ForeignKey foreignKey = new ForeignKey();
-		foreignKey.setName("objectId2id");
-		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, null);
-		Assert.assertFalse("Key should not be found", found);
+		foreignKey.setName( "objectId2id" );
+		boolean found = (boolean) method.invoke( new SchemaMigrator(), foreignKey, null );
+		Assert.assertFalse( "Key should not be found", found );
 	}
 
 	/**
 	 * Check detection of existing foreign keys with the same name exists.
 	 * 
-	 * @throws SecurityException - error 
+	 * @throws SecurityException - error
 	 * @throws NoSuchMethodException - error
 	 * @throws InvocationTargetException - error
 	 * @throws IllegalArgumentException - error
@@ -176,35 +183,36 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws NoSuchFieldException - error
 	 */
 	@Test
-	public void testKeyWithSameNameExists()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
-											NoSuchFieldException {
+	public void testKeyWithSameNameExists()
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+			NoSuchFieldException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		ForeignKey foreignKey = new ForeignKey();
-		foreignKey.setName("objectId2id");
-		foreignKey.addColumn(new Column("id"));
-		foreignKey.setReferencedTable(new Table("table2"));
+		foreignKey.setName( "objectId2id" );
+		foreignKey.addColumn( new Column( "id" ) );
+		foreignKey.setReferencedTable( new Table( "table2" ) );
 
-		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		InformationExtractor informationExtractor = Mockito.mock( InformationExtractor.class );
 		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
 		List<ForeignKeyInformation> fks = new ArrayList<>();
-		fks.add(new ForeignKeyInformationImpl(new Identifier("objectId2id", false), new ArrayList<>()));
-		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
-		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
-		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
-		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		fks.add( new ForeignKeyInformationImpl( new Identifier( "objectId2id", false ), new ArrayList<>() ) );
+		Mockito.when( informationExtractor.getForeignKeys( Mockito.any() ) ).thenReturn( fks );
+		Name schemaName = new Name( new Identifier( "-", false ), new Identifier( "-", false ) );
+		QualifiedTableName tableName = new QualifiedTableName( schemaName, new Identifier( "-", false ) );
+		TableInformation tableInformation = new TableInformationImpl( informationExtractor, identifierHelper, tableName, false, null );
 
 		// foreignKey name with same name should match
-		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
-		Assert.assertTrue("Key should be found", found);
+		boolean found = (boolean) method.invoke( new SchemaMigrator(), foreignKey, tableInformation );
+		Assert.assertTrue( "Key should be found", found );
 	}
 
 	/**
 	 * Check detection of existing foreign keys with the same name exists.
 	 * 
-	 * @throws SecurityException - error 
+	 * @throws SecurityException - error
 	 * @throws NoSuchMethodException - error
 	 * @throws InvocationTargetException - error
 	 * @throws IllegalArgumentException - error
@@ -212,35 +220,37 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws NoSuchFieldException - error
 	 */
 	@Test
-	public void testKeyWithSameNameNotExists()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
-												NoSuchFieldException {
+	public void testKeyWithSameNameNotExists()
+			throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+			NoSuchFieldException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		ForeignKey foreignKey = new ForeignKey();
-		foreignKey.setName("objectId2id_1");
-		foreignKey.addColumn(new Column("id"));
-		foreignKey.setReferencedTable(new Table("table2"));
+		foreignKey.setName( "objectId2id_1" );
+		foreignKey.addColumn( new Column( "id" ) );
+		foreignKey.setReferencedTable( new Table( "table2" ) );
 
-		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		InformationExtractor informationExtractor = Mockito.mock( InformationExtractor.class );
 		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
 		List<ForeignKeyInformation> fks = new ArrayList<>();
-		fks.add(new ForeignKeyInformationImpl(new Identifier("objectId2id_2", false), new ArrayList<>()));
-		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
-		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
-		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
-		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		fks.add( new ForeignKeyInformationImpl( new Identifier( "objectId2id_2", false ), new ArrayList<>() ) );
+		Mockito.when( informationExtractor.getForeignKeys( Mockito.any() ) ).thenReturn( fks );
+		Name schemaName = new Name( new Identifier( "-", false ), new Identifier( "-", false ) );
+		QualifiedTableName tableName = new QualifiedTableName( schemaName, new Identifier( "-", false ) );
+		TableInformation tableInformation = new TableInformationImpl( informationExtractor, identifierHelper, tableName, false, null );
 
 		// foreignKey name with same name should match
-		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
-		Assert.assertFalse("Key should not be found", found);
+		boolean found = (boolean) method.invoke( new SchemaMigrator(), foreignKey, tableInformation );
+		Assert.assertFalse( "Key should not be found", found );
 	}
 
 	/**
-	 * Check detection of existing foreign key with the same mappings for a simple mapping (table1.objectId => table2.id).
+	 * Check detection of existing foreign key with the same mappings for a simple mapping (table1.objectId =>
+	 * table2.id).
 	 * 
-	 * @throws SecurityException - error 
+	 * @throws SecurityException - error
 	 * @throws NoSuchMethodException - error
 	 * @throws InvocationTargetException - error
 	 * @throws IllegalArgumentException - error
@@ -248,36 +258,37 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws NoSuchFieldException - error
 	 */
 	@Test
-	public void testCheckForExistingForeignKeyOne2One()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
-														InvocationTargetException, NoSuchFieldException {
+	public void testCheckForExistingForeignKeyOne2One() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
+			InvocationTargetException, NoSuchFieldException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		ForeignKey foreignKey = new ForeignKey();
-		foreignKey.setName("objectId2id_1"); // Make sure the match is not successful based on key name
-		foreignKey.addColumn(new Column("id"));
-		foreignKey.setReferencedTable(new Table("table2"));
+		foreignKey.setName( "objectId2id_1" ); // Make sure the match is not successful based on key name
+		foreignKey.addColumn( new Column( "id" ) );
+		foreignKey.setReferencedTable( new Table( "table2" ) );
 
-		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
-		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		Name schemaName = new Name( new Identifier( "-", false ), new Identifier( "-", false ) );
+		InformationExtractor informationExtractor = Mockito.mock( InformationExtractor.class );
 		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
 		List<ForeignKeyInformation> fks = new ArrayList<>();
-		fks.add(getForeignKeyInformation("table2", "id", "object2Id_2"));
-		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
-		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
-		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		fks.add( getForeignKeyInformation( "table2", "id", "object2Id_2" ) );
+		Mockito.when( informationExtractor.getForeignKeys( Mockito.any() ) ).thenReturn( fks );
+		QualifiedTableName tableName = new QualifiedTableName( schemaName, new Identifier( "-", false ) );
+		TableInformation tableInformation = new TableInformationImpl( informationExtractor, identifierHelper, tableName, false, null );
 		AbstractSchemaMigrator schemaMigrator = new SchemaMigrator();
 
 		// Check single-column-key to single-column-key, existing (table1.objectId => table2.id)
-		boolean found = (boolean)method.invoke(schemaMigrator, foreignKey, tableInformation);
-		Assert.assertTrue("Key should be found", found);
+		boolean found = (boolean) method.invoke( schemaMigrator, foreignKey, tableInformation );
+		Assert.assertTrue( "Key should be found", found );
 	}
 
 	/**
-	 * Check detection of not existing foreign key with the same mappings for a simple mapping (table1.objectId => table2.id).
+	 * Check detection of not existing foreign key with the same mappings for a simple mapping (table1.objectId =>
+	 * table2.id).
 	 * 
-	 * @throws SecurityException - error 
+	 * @throws SecurityException - error
 	 * @throws NoSuchMethodException - error
 	 * @throws InvocationTargetException - error
 	 * @throws IllegalArgumentException - error
@@ -285,32 +296,32 @@ public class CheckForExistingForeignKeyTest {
 	 * @throws NoSuchFieldException - error
 	 */
 	@Test
-	public void testCheckForNotExistingForeignKeyOne2One()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
-															InvocationTargetException, NoSuchFieldException {
+	public void testCheckForNotExistingForeignKeyOne2One() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
+			InvocationTargetException, NoSuchFieldException {
 		// Get the private method
-		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
-		method.setAccessible(true);
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod( "checkForExistingForeignKey", ForeignKey.class, TableInformation.class );
+		method.setAccessible( true );
 
 		ForeignKey foreignKey = new ForeignKey();
-		foreignKey.setName("objectId2id_1"); // Make sure the match is not successful based on key name
-		foreignKey.addColumn(new Column("id"));
-		foreignKey.setReferencedTable(new Table("table2"));
+		foreignKey.setName( "objectId2id_1" ); // Make sure the match is not successful based on key name
+		foreignKey.addColumn( new Column( "id" ) );
+		foreignKey.setReferencedTable( new Table( "table2" ) );
 
-		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
-		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		Name schemaName = new Name( new Identifier( "-", false ), new Identifier( "-", false ) );
+		InformationExtractor informationExtractor = Mockito.mock( InformationExtractor.class );
 		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
 		List<ForeignKeyInformation> fks = new ArrayList<>();
-		fks.add(getForeignKeyInformation("table2", "blah", "blahKey_001"));
-		fks.add(getForeignKeyInformation("table3", "id", "blahKey_002"));
-		fks.add(getForeignKeyInformation("table3", "blah", "blahKey_003"));
-		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
-		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
-		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		fks.add( getForeignKeyInformation( "table2", "blah", "blahKey_001" ) );
+		fks.add( getForeignKeyInformation( "table3", "id", "blahKey_002" ) );
+		fks.add( getForeignKeyInformation( "table3", "blah", "blahKey_003" ) );
+		Mockito.when( informationExtractor.getForeignKeys( Mockito.any() ) ).thenReturn( fks );
+		QualifiedTableName tableName = new QualifiedTableName( schemaName, new Identifier( "-", false ) );
+		TableInformation tableInformation = new TableInformationImpl( informationExtractor, identifierHelper, tableName, false, null );
 		AbstractSchemaMigrator schemaMigrator = new SchemaMigrator();
 
 		// Check single-column-key to single-column-key, existing (table1.objectId => table2.id)
-		boolean found = (boolean)method.invoke(schemaMigrator, foreignKey, tableInformation);
-		Assert.assertFalse("Key should not be found", found);
+		boolean found = (boolean) method.invoke( schemaMigrator, foreignKey, tableInformation );
+		Assert.assertFalse( "Key should not be found", found );
 	}
 
 	/**
@@ -321,24 +332,26 @@ public class CheckForExistingForeignKeyTest {
 	 */
 	private ForeignKeyInformation getForeignKeyInformation(String referencedTableName, String referencingColumnName, String keyName) {
 		List<ColumnReferenceMapping> columnMappingList = new ArrayList<>();
-		ColumnInformation referencingColumnMetadata = getColumnInformation("-", referencingColumnName);
-		ColumnInformation referencedColumnMetadata = getColumnInformation(referencedTableName, "-");
-		ColumnReferenceMapping columnReferenceMapping = new ColumnReferenceMappingImpl(referencingColumnMetadata, referencedColumnMetadata);
-		columnMappingList.add(columnReferenceMapping);
-		ForeignKeyInformationImpl foreignKeyInformation = new ForeignKeyInformationImpl(new Identifier(keyName, false), columnMappingList);
+		ColumnInformation referencingColumnMetadata = getColumnInformation( "-", referencingColumnName );
+		ColumnInformation referencedColumnMetadata = getColumnInformation( referencedTableName, "-" );
+		ColumnReferenceMapping columnReferenceMapping = new ColumnReferenceMappingImpl( referencingColumnMetadata, referencedColumnMetadata );
+		columnMappingList.add( columnReferenceMapping );
+		ForeignKeyInformationImpl foreignKeyInformation = new ForeignKeyInformationImpl( new Identifier( keyName, false ), columnMappingList );
 		return foreignKeyInformation;
 	}
 
 	private ColumnInformation getColumnInformation(String tableName, String columnName) {
-		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
-		TableInformation containingTableInformation = new TableInformationImpl(null, null, new QualifiedTableName(schemaName, new Identifier(tableName, false)), false, null);
-		Identifier columnIdentifier = new Identifier(columnName, false);
+		Name schemaName = new Name( new Identifier( "-", false ), new Identifier( "-", false ) );
+		TableInformation containingTableInformation = new TableInformationImpl( null, null,
+				new QualifiedTableName( schemaName, new Identifier( tableName, false ) ), false, null );
+		Identifier columnIdentifier = new Identifier( columnName, false );
 		int typeCode = 0;
 		String typeName = null;
 		int columnSize = 0;
 		int decimalDigits = 0;
 		TruthValue nullable = null;
-		ColumnInformationImpl columnInformation = new ColumnInformationImpl(containingTableInformation, columnIdentifier, typeCode, typeName, columnSize, decimalDigits, nullable);
+		ColumnInformationImpl columnInformation = new ColumnInformationImpl( containingTableInformation, columnIdentifier, typeCode, typeName, columnSize,
+				decimalDigits, nullable );
 		return columnInformation;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
@@ -1,0 +1,344 @@
+package org.hibernate.test.tool.schema.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.TruthValue;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.Namespace.Name;
+import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.engine.jdbc.internal.Formatter;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.schema.extract.internal.ColumnInformationImpl;
+import org.hibernate.tool.schema.extract.internal.ForeignKeyInformationImpl;
+import org.hibernate.tool.schema.extract.internal.TableInformationImpl;
+import org.hibernate.tool.schema.extract.spi.ColumnInformation;
+import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
+import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation;
+import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation.ColumnReferenceMapping;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
+import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
+import org.hibernate.tool.schema.internal.AbstractSchemaMigrator;
+import org.hibernate.tool.schema.internal.exec.GenerationTarget;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Milo van der Zee
+ *
+ */
+public class CheckForExistingForeignKeyTest {
+	private class SchemaMigrator extends AbstractSchemaMigrator {
+		/**
+		 * Needed constructor.
+		 */
+		public SchemaMigrator() {
+			super(null, null);
+		}
+
+		/**
+		 * Needed implementation. Not used in test.
+		 */
+		@Override
+		protected NameSpaceTablesInformation performTablesMigration(Metadata metadata, DatabaseInformation existingDatabase, ExecutionOptions options, Dialect dialect,
+																	Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs, boolean tryToCreateSchemas,
+																	Set<Identifier> exportedCatalogs, Namespace namespace, GenerationTarget[] targets) {
+			return null;
+		}
+	}
+
+	private class ColumnReferenceMappingImpl implements ColumnReferenceMapping {
+		private ColumnInformation referencingColumnMetadata;
+		private ColumnInformation referencedColumnMetadata;
+
+		public ColumnReferenceMappingImpl(ColumnInformation referencingColumnMetadata, ColumnInformation referencedColumnMetadata) {
+			this.referencingColumnMetadata = referencingColumnMetadata;
+			this.referencedColumnMetadata = referencedColumnMetadata;
+		}
+
+		@Override
+		public ColumnInformation getReferencingColumnMetadata() {
+			return referencingColumnMetadata;
+		}
+
+		@Override
+		public ColumnInformation getReferencedColumnMetadata() {
+			return referencedColumnMetadata;
+		}
+	}
+
+	private class IdentifierHelperImpl implements IdentifierHelper {
+		@Override
+		public Identifier normalizeQuoting(Identifier identifier) {
+			return null;
+		}
+
+		@Override
+		public Identifier toIdentifier(String text) {
+			return null;
+		}
+
+		@Override
+		public Identifier toIdentifier(String text, boolean quoted) {
+			return null;
+		}
+
+		@Override
+		public Identifier applyGlobalQuoting(String text) {
+			return null;
+		}
+
+		@Override
+		public boolean isReservedWord(String word) {
+			return false;
+		}
+
+		@Override
+		public String toMetaDataCatalogName(Identifier catalogIdentifier) {
+			return null;
+		}
+
+		@Override
+		public String toMetaDataSchemaName(Identifier schemaIdentifier) {
+			return null;
+		}
+
+		@Override
+		public String toMetaDataObjectName(Identifier identifier) {
+			return identifier.getText();
+		}
+	}
+
+	/**
+	 * If the key has no name it should never be found. Result is that those keys are always recreated. But keys always have a name so this is no problem.
+	 * 
+	 * @throws NoSuchMethodException - error
+	 * @throws SecurityException - error
+	 * @throws IllegalAccessException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws InvocationTargetException - error
+	 */
+	@Test
+	public void testForeignKeyWithoutName() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		// foreignKey name with same name should match
+		ForeignKey foreignKey = new ForeignKey();
+		TableInformation tableInformation = new TableInformationImpl(null, null, null, false, null);
+		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
+		Assert.assertFalse("Key should not be found", found);
+	}
+
+	/**
+	 * Test key not found if tableinformation is missing.
+	 * 
+	 * @throws NoSuchMethodException - error
+	 * @throws SecurityException - error
+	 * @throws IllegalAccessException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws InvocationTargetException - error
+	 */
+	@Test
+	public void testMissingTableInformation() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		// foreignKey name with same name should match
+		ForeignKey foreignKey = new ForeignKey();
+		foreignKey.setName("objectId2id");
+		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, null);
+		Assert.assertFalse("Key should not be found", found);
+	}
+
+	/**
+	 * Check detection of existing foreign keys with the same name exists.
+	 * 
+	 * @throws SecurityException - error 
+	 * @throws NoSuchMethodException - error
+	 * @throws InvocationTargetException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws IllegalAccessException - error
+	 * @throws NoSuchFieldException - error
+	 */
+	@Test
+	public void testKeyWithSameNameExists()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+											NoSuchFieldException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		ForeignKey foreignKey = new ForeignKey();
+		foreignKey.setName("objectId2id");
+		foreignKey.addColumn(new Column("id"));
+		foreignKey.setReferencedTable(new Table("table2"));
+
+		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
+		List<ForeignKeyInformation> fks = new ArrayList<>();
+		fks.add(new ForeignKeyInformationImpl(new Identifier("objectId2id", false), new ArrayList<>()));
+		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
+		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
+		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
+		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+
+		// foreignKey name with same name should match
+		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
+		Assert.assertTrue("Key should be found", found);
+	}
+
+	/**
+	 * Check detection of existing foreign keys with the same name exists.
+	 * 
+	 * @throws SecurityException - error 
+	 * @throws NoSuchMethodException - error
+	 * @throws InvocationTargetException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws IllegalAccessException - error
+	 * @throws NoSuchFieldException - error
+	 */
+	@Test
+	public void testKeyWithSameNameNotExists()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+												NoSuchFieldException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		ForeignKey foreignKey = new ForeignKey();
+		foreignKey.setName("objectId2id_1");
+		foreignKey.addColumn(new Column("id"));
+		foreignKey.setReferencedTable(new Table("table2"));
+
+		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
+		List<ForeignKeyInformation> fks = new ArrayList<>();
+		fks.add(new ForeignKeyInformationImpl(new Identifier("objectId2id_2", false), new ArrayList<>()));
+		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
+		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
+		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
+		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+
+		// foreignKey name with same name should match
+		boolean found = (boolean)method.invoke(new SchemaMigrator(), foreignKey, tableInformation);
+		Assert.assertFalse("Key should not be found", found);
+	}
+
+	/**
+	 * Check detection of existing foreign key with the same mappings for a simple mapping (table1.objectId => table2.id).
+	 * 
+	 * @throws SecurityException - error 
+	 * @throws NoSuchMethodException - error
+	 * @throws InvocationTargetException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws IllegalAccessException - error
+	 * @throws NoSuchFieldException - error
+	 */
+	@Test
+	public void testCheckForExistingForeignKeyOne2One()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
+														InvocationTargetException, NoSuchFieldException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		ForeignKey foreignKey = new ForeignKey();
+		foreignKey.setName("objectId2id_1"); // Make sure the match is not successful based on key name
+		foreignKey.addColumn(new Column("id"));
+		foreignKey.setReferencedTable(new Table("table2"));
+
+		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
+		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
+		List<ForeignKeyInformation> fks = new ArrayList<>();
+		fks.add(getForeignKeyInformation("table2", "id", "object2Id_2"));
+		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
+		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
+		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		AbstractSchemaMigrator schemaMigrator = new SchemaMigrator();
+
+		// Check single-column-key to single-column-key, existing (table1.objectId => table2.id)
+		boolean found = (boolean)method.invoke(schemaMigrator, foreignKey, tableInformation);
+		Assert.assertTrue("Key should be found", found);
+	}
+
+	/**
+	 * Check detection of not existing foreign key with the same mappings for a simple mapping (table1.objectId => table2.id).
+	 * 
+	 * @throws SecurityException - error 
+	 * @throws NoSuchMethodException - error
+	 * @throws InvocationTargetException - error
+	 * @throws IllegalArgumentException - error
+	 * @throws IllegalAccessException - error
+	 * @throws NoSuchFieldException - error
+	 */
+	@Test
+	public void testCheckForNotExistingForeignKeyOne2One()	throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
+															InvocationTargetException, NoSuchFieldException {
+		// Get the private method
+		Method method = AbstractSchemaMigrator.class.getDeclaredMethod("checkForExistingForeignKey", ForeignKey.class, TableInformation.class);
+		method.setAccessible(true);
+
+		ForeignKey foreignKey = new ForeignKey();
+		foreignKey.setName("objectId2id_1"); // Make sure the match is not successful based on key name
+		foreignKey.addColumn(new Column("id"));
+		foreignKey.setReferencedTable(new Table("table2"));
+
+		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
+		InformationExtractor informationExtractor = Mockito.mock(InformationExtractor.class);
+		IdentifierHelper identifierHelper = new IdentifierHelperImpl();
+		List<ForeignKeyInformation> fks = new ArrayList<>();
+		fks.add(getForeignKeyInformation("table2", "blah", "blahKey_001"));
+		fks.add(getForeignKeyInformation("table3", "id", "blahKey_002"));
+		fks.add(getForeignKeyInformation("table3", "blah", "blahKey_003"));
+		Mockito.when(informationExtractor.getForeignKeys(Mockito.any())).thenReturn(fks);
+		QualifiedTableName tableName = new QualifiedTableName(schemaName, new Identifier("-", false));
+		TableInformation tableInformation = new TableInformationImpl(informationExtractor, identifierHelper, tableName, false, null);
+		AbstractSchemaMigrator schemaMigrator = new SchemaMigrator();
+
+		// Check single-column-key to single-column-key, existing (table1.objectId => table2.id)
+		boolean found = (boolean)method.invoke(schemaMigrator, foreignKey, tableInformation);
+		Assert.assertFalse("Key should not be found", found);
+	}
+
+	/**
+	 * @param referencedTableName - String
+	 * @param referencingColumnName - String
+	 * @param keyName - String
+	 * @return ForeignKeyInformation
+	 */
+	private ForeignKeyInformation getForeignKeyInformation(String referencedTableName, String referencingColumnName, String keyName) {
+		List<ColumnReferenceMapping> columnMappingList = new ArrayList<>();
+		ColumnInformation referencingColumnMetadata = getColumnInformation("-", referencingColumnName);
+		ColumnInformation referencedColumnMetadata = getColumnInformation(referencedTableName, "-");
+		ColumnReferenceMapping columnReferenceMapping = new ColumnReferenceMappingImpl(referencingColumnMetadata, referencedColumnMetadata);
+		columnMappingList.add(columnReferenceMapping);
+		ForeignKeyInformationImpl foreignKeyInformation = new ForeignKeyInformationImpl(new Identifier(keyName, false), columnMappingList);
+		return foreignKeyInformation;
+	}
+
+	private ColumnInformation getColumnInformation(String tableName, String columnName) {
+		Name schemaName = new Name(new Identifier("-", false), new Identifier("-", false));
+		TableInformation containingTableInformation = new TableInformationImpl(null, null, new QualifiedTableName(schemaName, new Identifier(tableName, false)), false, null);
+		Identifier columnIdentifier = new Identifier(columnName, false);
+		int typeCode = 0;
+		String typeName = null;
+		int columnSize = 0;
+		int decimalDigits = 0;
+		TruthValue nullable = null;
+		ColumnInformationImpl columnInformation = new ColumnInformationImpl(containingTableInformation, columnIdentifier, typeCode, typeName, columnSize, decimalDigits, nullable);
+		return columnInformation;
+	}
+}


### PR DESCRIPTION
The naming of ForeignKeys changed during previous versions. The result is that when using the update function (in dev environment) that there are a lot of updates to the keys. This results in double keys and also a very long delay in large databases.

I changed the code so that it checks the function of the key and not only the name.

Also see https://hibernate.atlassian.net/browse/HHH-10934