### PR TITLE
HHH-11743 - Fix for streaming of Tuple query

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ScrollableResultsIterator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ScrollableResultsIterator.java
@@ -36,11 +36,12 @@ class ScrollableResultsIterator<T> implements CloseableIterator {
 	@Override
 	@SuppressWarnings("unchecked")
 	public T next() {
-		if ( scrollableResults.getNumberOfTypes() == 1 ) {
-			return (T) scrollableResults.get()[0];
+		Object[] next = scrollableResults.get();
+		if ( next.length == 1 ) {
+			return (T) next[0];
 		}
 		else {
-			return (T) scrollableResults.get();
+			return (T) next;
 		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11743

In case of Tuple values `scrollableResults` has `getNumberOfTypes` the same as number of tuple elements. That is why tuple result was treated as array.