### PR TITLE
HHH-11805 Fix JACC cannot be enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -87,6 +87,7 @@ import org.jboss.jandex.Index;
 import static org.hibernate.cfg.AvailableSettings.DATASOURCE;
 import static org.hibernate.cfg.AvailableSettings.DRIVER;
 import static org.hibernate.cfg.AvailableSettings.JACC_CONTEXT_ID;
+import static org.hibernate.cfg.AvailableSettings.JACC_ENABLED;
 import static org.hibernate.cfg.AvailableSettings.JACC_PREFIX;
 import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_DRIVER;
 import static org.hibernate.cfg.AvailableSettings.JPA_JDBC_PASSWORD;

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -483,15 +483,17 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 				final String valueString = (String) entry.getValue();
 
 				if ( keyString.startsWith( JACC_PREFIX ) ) {
-					if ( jaccContextId == null ) {
-						LOG.debug(
-								"Found JACC permission grant [%s] in properties, but no JACC context id was specified; ignoring"
-						);
-					}
-					else {
-						mergedSettings.getJaccPermissions( jaccContextId ).addPermissionDeclaration(
-								parseJaccConfigEntry( keyString, valueString )
-						);
+					if( ! JACC_CONTEXT_ID.equals( keyString ) && ! JACC_ENABLED.equals( keyString )) {
+						if ( jaccContextId == null ) {
+							LOG.debug(
+									"Found JACC permission grant [%s] in properties, but no JACC context id was specified; ignoring"
+							);
+						}
+						else {
+							mergedSettings.getJaccPermissions( jaccContextId ).addPermissionDeclaration(
+									parseJaccConfigEntry( keyString, valueString )
+							);
+						}
 					}
 				}
 				else if ( keyString.startsWith( CLASS_CACHE_PREFIX ) ) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11805

When processing JACC permission granting properties, it should be checked that the key is neither "hibernate.jacc.enabled" nor "hibernate.jacc.context_id"