### PR TITLE
[Task #55588] Schema update error message on startup for sequences in Derby

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE5'
+    version = '4.0.1.SEE6'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/build.gradle
+++ b/build.gradle
@@ -110,8 +110,8 @@ subprojects { subProject ->
 
     defaultTasks 'build'
 
-    group = 'org.hibernate'
-    version = '4.0.1.Final'
+    group = 'com.seeburger.fork'
+    version = '4.0.1.SEE1'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"
@@ -298,8 +298,8 @@ subprojects { subProject ->
                 name = 'jbossDeployer'
                 configuration = configurations.deployerJars
                 pom.project pomConfig
-                repository(id: "jboss-releases-repository", url: "https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/")
-                snapshotRepository(id: "jboss-snapshots-repository", url: "https://repository.jboss.org/nexus/content/repositories/snapshots")
+                repository(id: "jboss-releases-repository", url: "https://repo.seeburger.de/archiva/repository/release/")
+                snapshotRepository(id: "jboss-snapshots-repository", url: "https://repo.seeburger.de/archiva/repository/snapshot/")
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE2'
+    version = '4.0.1.SEE3'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE1'
+    version = '4.0.1.SEE2'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE6'
+    version = '4.0.1.SEE7'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/build.gradle
+++ b/build.gradle
@@ -106,12 +106,12 @@ libraries = [
 
 subprojects { subProject ->
     apply plugin: 'idea'
-	apply plugin: 'eclipse'
+    apply plugin: 'eclipse'
 
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE3'
+    version = '4.0.1.SEE4'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"
@@ -141,7 +141,7 @@ subprojects { subProject ->
 
         // appropriately inject the common dependencies into each sub-project
         dependencies {
-	        compile( libraries.logging )
+            compile( libraries.logging )
             testCompile( libraries.junit )
             testRuntime( libraries.slf4j_api )
             testRuntime( libraries.slf4j_log4j12 )
@@ -194,9 +194,9 @@ subprojects { subProject ->
         // for the time being eat the annoying output from running the annotation processors
         generateMainLoggingClasses.logging.captureStandardError(LogLevel.INFO)
 
-		compileJava.dependsOn generateMainLoggingClasses
+        compileJava.dependsOn generateMainLoggingClasses
         compileJava.options.define(compilerArgs: ["-proc:none", "-encoding", "UTF-8"])
-	compileTestJava.options.define(compilerArgs: ["-proc:none", "-encoding", "UTF-8"])
+    compileTestJava.options.define(compilerArgs: ["-proc:none", "-encoding", "UTF-8"])
 
         manifest.mainAttributes(
                 provider: 'gradle',
@@ -247,9 +247,9 @@ subprojects { subProject ->
             ] as Set
         }
 
-		eclipseClasspath {
-			plusConfigurations.add( configurations.provided )
-		}
+        eclipseClasspath {
+            plusConfigurations.add( configurations.provided )
+        }
 
         // elements used to customize the generated POM used during upload
         def pomConfig = {

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE4'
+    version = '4.0.1.SEE5'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects { subProject ->
     defaultTasks 'build'
 
     group = 'com.seeburger.fork'
-    version = '4.0.1.SEE7'
+    version = '4.0.1.SEE8'
 
     // minimize changes, at least for now (gradle uses 'build' by default)..
     buildDir = "target"

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -710,6 +710,7 @@ public final class AnnotationBinder {
 		entityBinder.processComplementaryTableDefinitions( clazzToProcess.getAnnotation( org.hibernate.annotations.Table.class ) );
 		entityBinder.processComplementaryTableDefinitions( clazzToProcess.getAnnotation( org.hibernate.annotations.Tables.class ) );
 
+		LOG.infof("AnnotationBinder processed annotations for class %s - %s", clazzToProcess.getName(), entityBinder);
 	}
 
 	// parse everything discriminator column relevant in case of single table inheritance

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -967,4 +967,66 @@ public class EntityBinder {
 
 		return accessType;
 	}
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("EntityBinder [name=");
+        builder.append(name);
+        builder.append(", persistentClass=");
+        builder.append(persistentClass);
+//        builder.append(", mappings=");
+//        builder.append(mappings);
+        builder.append(", discriminatorValue=");
+        builder.append(discriminatorValue);
+        builder.append(", forceDiscriminator=");
+        builder.append(forceDiscriminator);
+        builder.append(", insertableDiscriminator=");
+        builder.append(insertableDiscriminator);
+        builder.append(", dynamicInsert=");
+        builder.append(dynamicInsert);
+        builder.append(", dynamicUpdate=");
+        builder.append(dynamicUpdate);
+        builder.append(", explicitHibernateEntityAnnotation=");
+        builder.append(explicitHibernateEntityAnnotation);
+        builder.append(", optimisticLockType=");
+        builder.append(optimisticLockType);
+        builder.append(", polymorphismType=");
+        builder.append(polymorphismType);
+        builder.append(", selectBeforeUpdate=");
+        builder.append(selectBeforeUpdate);
+        builder.append(", batchSize=");
+        builder.append(batchSize);
+        builder.append(", lazy=");
+        builder.append(lazy);
+        builder.append(", where=");
+        builder.append(where);
+//        builder.append(", secondaryTables=");
+//        builder.append(secondaryTables);
+//        builder.append(", secondaryTableJoins=");
+//        builder.append(secondaryTableJoins);
+        builder.append(", cacheConcurrentStrategy=");
+        builder.append(cacheConcurrentStrategy);
+        builder.append(", cacheRegion=");
+        builder.append(cacheRegion);
+//        builder.append(", filters=");
+//        builder.append(filters);
+//        builder.append(", inheritanceState=");
+//        builder.append(inheritanceState);
+        builder.append(", ignoreIdAnnotations=");
+        builder.append(ignoreIdAnnotations);
+        builder.append(", cacheLazyProperty=");
+        builder.append(cacheLazyProperty);
+        builder.append(", propertyAccessType=");
+        builder.append(propertyAccessType);
+        builder.append(", wrapIdsInEmbeddedComponents=");
+        builder.append(wrapIdsInEmbeddedComponents);
+        builder.append(", subselect=");
+        builder.append(subselect);
+        builder.append("]");
+        return builder.toString();
+    }
+
+
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -44,11 +44,15 @@ import org.hibernate.MappingException;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.Loader;
 import org.hibernate.annotations.OptimisticLockType;
+import org.hibernate.annotations.OptimisticLocking;
 import org.hibernate.annotations.Persister;
+import org.hibernate.annotations.Polymorphism;
 import org.hibernate.annotations.PolymorphismType;
 import org.hibernate.annotations.Proxy;
 import org.hibernate.annotations.RowId;
@@ -56,6 +60,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLDeleteAll;
 import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.annotations.SelectBeforeUpdate;
 import org.hibernate.annotations.Subselect;
 import org.hibernate.annotations.Synchronize;
 import org.hibernate.annotations.Tables;
@@ -150,23 +155,47 @@ public class EntityBinder {
 		bindHibernateAnnotation( hibAnn );
 	}
 
+	@SuppressWarnings("SimplifiableConditionalExpression")
 	private void bindHibernateAnnotation(org.hibernate.annotations.Entity hibAnn) {
+		{
+			final DynamicInsert dynamicInsertAnn = annotatedClass.getAnnotation( DynamicInsert.class );
+			this.dynamicInsert = dynamicInsertAnn == null
+					? ( hibAnn == null ? false : hibAnn.dynamicInsert() )
+					: dynamicInsertAnn.value();
+		}
+
+		{
+			final DynamicUpdate dynamicUpdateAnn = annotatedClass.getAnnotation( DynamicUpdate.class );
+			this.dynamicUpdate = dynamicUpdateAnn == null
+					? ( hibAnn == null ? false : hibAnn.dynamicUpdate() )
+					: dynamicUpdateAnn.value();
+		}
+
+		{
+			final SelectBeforeUpdate selectBeforeUpdateAnn = annotatedClass.getAnnotation( SelectBeforeUpdate.class );
+			this.selectBeforeUpdate = selectBeforeUpdateAnn == null
+					? ( hibAnn == null ? false : hibAnn.selectBeforeUpdate() )
+					: selectBeforeUpdateAnn.value();
+		}
+
+		{
+			final OptimisticLocking optimisticLockingAnn = annotatedClass.getAnnotation( OptimisticLocking.class );
+			this.optimisticLockType = optimisticLockingAnn == null
+					? ( hibAnn == null ? OptimisticLockType.VERSION : hibAnn.optimisticLock() )
+					: optimisticLockingAnn.type();
+		}
+
+		{
+			final Polymorphism polymorphismAnn = annotatedClass.getAnnotation( Polymorphism.class );
+			this.polymorphismType = polymorphismAnn == null
+					? ( hibAnn == null ? PolymorphismType.IMPLICIT : hibAnn.polymorphism() )
+					: polymorphismAnn.type();
+		}
+
 		if ( hibAnn != null ) {
-			dynamicInsert = hibAnn.dynamicInsert();
-			dynamicUpdate = hibAnn.dynamicUpdate();
-			optimisticLockType = hibAnn.optimisticLock();
-			selectBeforeUpdate = hibAnn.selectBeforeUpdate();
-			polymorphismType = hibAnn.polymorphism();
+			// used later in bind for logging
 			explicitHibernateEntityAnnotation = true;
 			//persister handled in bind
-		}
-		else {
-			//default values when the annotation is not there
-			dynamicInsert = false;
-			dynamicUpdate = false;
-			optimisticLockType = OptimisticLockType.VERSION;
-			polymorphismType = PolymorphismType.IMPLICIT;
-			selectBeforeUpdate = false;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
@@ -22,8 +22,13 @@
  * Boston, MA  02110-1301  USA
  */
 package org.hibernate.dialect;
+import java.sql.Types;
+
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.function.StandardSQLFunction;
 import org.hibernate.sql.ANSIJoinFragment;
 import org.hibernate.sql.JoinFragment;
+import org.hibernate.type.StandardBasicTypes;
 
 
 /**
@@ -31,7 +36,7 @@ import org.hibernate.sql.JoinFragment;
  * <p/>
  * The main difference between this dialect and {@link Oracle9iDialect}
  * is the use of "ANSI join syntax".  This dialect also retires the use
- * of the <tt>oracle.jdbc.driver</tt> package in favor of 
+ * of the <tt>oracle.jdbc.driver</tt> package in favor of
  * <tt>oracle.jdbc</tt>.
  *
  * @author Steve Ebersole
@@ -39,8 +44,27 @@ import org.hibernate.sql.JoinFragment;
 public class Oracle10gDialect extends Oracle9iDialect {
 
 	public Oracle10gDialect() {
-		super();
+	    super();
+        // register additional hibernate types for unicode
+        // see https://hibernate.atlassian.net/browse/HHH-9750
+        registerHibernateType( Types.NCHAR, StandardBasicTypes.CHARACTER.getName() );
+        registerHibernateType( Types.NCHAR, 1, StandardBasicTypes.CHARACTER.getName() );
+        registerHibernateType( Types.NCHAR, 255, StandardBasicTypes.STRING.getName() );
+        registerHibernateType( Types.NVARCHAR, StandardBasicTypes.STRING.getName() );
+        registerHibernateType( Types.NCLOB, StandardBasicTypes.CLOB.getName() );
 	}
+
+	@Override
+	protected void registerFunctions() {
+        super.registerFunctions();
+        registerFunction( "bitand", new StandardSQLFunction("bitand") );
+    }
+
+	@Override
+	protected void registerDefaultProperties()    {
+        super.registerDefaultProperties();
+        getDefaultProperties().setProperty( Environment.BATCH_VERSIONED_DATA, "false" );
+    }
 
 	public JoinFragment createOuterJoinFragment() {
 		return new ANSIJoinFragment();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.cfg.Environment;
+
+/**
+ * An SQL dialect for Oracle 12c.
+ *
+ * @author zhouyanming (zhouyanming@gmail.com)
+ */
+public class Oracle12cDialect extends Oracle10gDialect {
+	public static final String PREFER_LONG_RAW = "hibernate.dialect.oracle.prefer_long_raw";
+
+	public Oracle12cDialect() {
+		super();
+		getDefaultProperties().setProperty( Environment.BATCH_VERSIONED_DATA, "true" );
+	}
+
+	@Override
+	protected void registerDefaultProperties() {
+		super.registerDefaultProperties();
+		getDefaultProperties().setProperty( Environment.USE_GET_GENERATED_KEYS, "true" );
+	}
+
+// Overridden on master, but would also need changes from SequenceStyleGenerator
+//	@Override
+//    public Class getNativeIdentifierGeneratorClass()
+//    {
+//        return SequenceStyleGenerator.class;
+//    }
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+/**
+ * Microsoft SQL Server 2012 Dialect
+ *
+ * @author Brett Meyer
+ */
+public class SQLServer2012Dialect extends SQLServer2008Dialect {
+
+	@Override
+	public boolean supportsSequences() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsPooledSequences() {
+		return true;
+	}
+
+	@Override
+	public String getCreateSequenceString(String sequenceName) {
+		return "create sequence " + sequenceName;
+	}
+
+	@Override
+	public String getDropSequenceString(String sequenceName) {
+		return "drop sequence " + sequenceName;
+	}
+
+	@Override
+	public String getSelectSequenceNextValString(String sequenceName) {
+		return "next value for " + sequenceName;
+	}
+
+	@Override
+	public String getSequenceNextValString(String sequenceName) {
+		return "select " + getSelectSequenceNextValString( sequenceName );
+	}
+
+	@Override
+	public String getQuerySequencesString() {
+		return "select name from sys.sequences";
+	}
+
+	@Override
+	public boolean supportsLimitOffset() {
+		return true;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1342,8 +1342,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	void unknownOracleVersion(int databaseMajorVersion);
 
 	@LogMessage(level = WARN)
-	@Message(value = "Unknown Microsoft SQL Server major version [%s] using SQL Server 2000 dialect", id = 385)
-	void unknownSqlServerVersion(int databaseMajorVersion);
+	@Message(value = "Unknown Microsoft SQL Server major version [%s] using SQL Server [%s] dialect", id = 385)
+	void unknownSqlServerVersion(int databaseMajorVersion, int sqlServerYear);
 
 	@LogMessage(level = WARN)
 	@Message(value = "ResultSet had no statement associated with it, but was not yet registered", id = 386)

--- a/hibernate-core/src/main/java/org/hibernate/service/jdbc/dialect/internal/StandardDialectResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/jdbc/dialect/internal/StandardDialectResolver.java
@@ -43,11 +43,13 @@ import org.hibernate.dialect.Ingres9Dialect;
 import org.hibernate.dialect.IngresDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.Oracle10gDialect;
+import org.hibernate.dialect.Oracle12cDialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.Oracle9iDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 import org.hibernate.dialect.SQLServer2008Dialect;
+import org.hibernate.dialect.SQLServer2012Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.dialect.SybaseAnywhereDialect;
@@ -63,48 +65,48 @@ public class StandardDialectResolver extends AbstractDialectResolver {
     private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class,
                                                                        StandardDialectResolver.class.getName());
 
-	@Override
+    @Override
     protected Dialect resolveDialectInternal(DatabaseMetaData metaData) throws SQLException {
-		String databaseName = metaData.getDatabaseProductName();
-		int databaseMajorVersion = metaData.getDatabaseMajorVersion();
+        String databaseName = metaData.getDatabaseProductName();
+        int databaseMajorVersion = metaData.getDatabaseMajorVersion();
 
-		if ( "CUBRID".equalsIgnoreCase( databaseName ) ) {
-			return new CUBRIDDialect();
-		}
+        if ( "CUBRID".equalsIgnoreCase( databaseName ) ) {
+            return new CUBRIDDialect();
+        }
 
-		if ( "HSQL Database Engine".equals( databaseName ) ) {
-			return new HSQLDialect();
-		}
+        if ( "HSQL Database Engine".equals( databaseName ) ) {
+            return new HSQLDialect();
+        }
 
-		if ( "H2".equals( databaseName ) ) {
-			return new H2Dialect();
-		}
+        if ( "H2".equals( databaseName ) ) {
+            return new H2Dialect();
+        }
 
-		if ( "MySQL".equals( databaseName ) ) {
-			return new MySQLDialect();
-		}
+        if ( "MySQL".equals( databaseName ) ) {
+            return new MySQLDialect();
+        }
 
-		if ( "PostgreSQL".equals( databaseName ) ) {
-			return new PostgreSQLDialect();
-		}
+        if ( "PostgreSQL".equals( databaseName ) ) {
+            return new PostgreSQLDialect();
+        }
 
-		if ( "Apache Derby".equals( databaseName ) ) {
-			final int databaseMinorVersion = metaData.getDatabaseMinorVersion();
+        if ( "Apache Derby".equals( databaseName ) ) {
+            final int databaseMinorVersion = metaData.getDatabaseMinorVersion();
             if ( databaseMajorVersion > 10 || ( databaseMajorVersion == 10 && databaseMinorVersion >= 7 ) ) {
-				return new DerbyTenSevenDialect();
-			}
-			else if ( databaseMajorVersion == 10 && databaseMinorVersion == 6 ) {
-				return new DerbyTenSixDialect();
-			}
-			else if ( databaseMajorVersion == 10 && databaseMinorVersion == 5 ) {
-				return new DerbyTenFiveDialect();
-			}
-			else {
-				return new DerbyDialect();
-			}
-		}
+                return new DerbyTenSevenDialect();
+            }
+            else if ( databaseMajorVersion == 10 && databaseMinorVersion == 6 ) {
+                return new DerbyTenSixDialect();
+            }
+            else if ( databaseMajorVersion == 10 && databaseMinorVersion == 5 ) {
+                return new DerbyTenFiveDialect();
+            }
+            else {
+                return new DerbyDialect();
+            }
+        }
 
-		if ( "ingres".equalsIgnoreCase( databaseName ) ) {
+        if ( "ingres".equalsIgnoreCase( databaseName ) ) {
             switch( databaseMajorVersion ) {
                 case 9:
                     int databaseMinorVersion = metaData.getDatabaseMinorVersion();
@@ -117,54 +119,74 @@ public class StandardDialectResolver extends AbstractDialectResolver {
                 default:
                     LOG.unknownIngresVersion(databaseMajorVersion);
             }
-			return new IngresDialect();
-		}
+            return new IngresDialect();
+        }
 
-		if ( databaseName.startsWith( "Microsoft SQL Server" ) ) {
-			switch ( databaseMajorVersion ) {
+        if ( databaseName.startsWith( "Microsoft SQL Server" ) ) {
+            switch ( databaseMajorVersion ) {
                 case 8:
                     return new SQLServerDialect();
                 case 9:
                     return new SQLServer2005Dialect();
                 case 10:
                     return new SQLServer2008Dialect();
-                default:
-                    LOG.unknownSqlServerVersion(databaseMajorVersion);
-			}
-			return new SQLServerDialect();
-		}
+                case 11:
+                case 12:
+                case 13:
+                    return new SQLServer2012Dialect();
+                default: {
+                    if (databaseMajorVersion < 8 ) {
+                        LOG.unknownSqlServerVersion(databaseMajorVersion);
+                        return new SQLServerDialect();
+                    }
+                    else {
+                        // assume `majorVersion > 13`
+                        LOG.unknownSqlServerVersion(databaseMajorVersion);
+                        return new SQLServer2012Dialect();
+                    }
+                }
+            }
+        }
 
-		if ( "Sybase SQL Server".equals( databaseName ) || "Adaptive Server Enterprise".equals( databaseName ) ) {
-			return new SybaseASE15Dialect();
-		}
+        if ( "Sybase SQL Server".equals( databaseName ) || "Adaptive Server Enterprise".equals( databaseName ) ) {
+            return new SybaseASE15Dialect();
+        }
 
-		if ( databaseName.startsWith( "Adaptive Server Anywhere" ) ) {
-			return new SybaseAnywhereDialect();
-		}
+        if ( databaseName.startsWith( "Adaptive Server Anywhere" ) ) {
+            return new SybaseAnywhereDialect();
+        }
 
-		if ( "Informix Dynamic Server".equals( databaseName ) ) {
-			return new InformixDialect();
-		}
+        if ( "Informix Dynamic Server".equals( databaseName ) ) {
+            return new InformixDialect();
+        }
 
-		if ( databaseName.startsWith( "DB2/" ) ) {
-			return new DB2Dialect();
-		}
+        if ( databaseName.startsWith( "DB2/" ) ) {
+            return new DB2Dialect();
+        }
 
-		if ( "Oracle".equals( databaseName ) ) {
-			switch ( databaseMajorVersion ) {
-				case 11:
-					return new Oracle10gDialect();
-				case 10:
-					return new Oracle10gDialect();
-				case 9:
-					return new Oracle9iDialect();
-				case 8:
-					return new Oracle8iDialect();
-				default:
+        if ( "Oracle".equals( databaseName ) ) {
+            switch ( databaseMajorVersion ) {
+                case 12:
+                    return new Oracle12cDialect();
+                case 11:
+                    // fall through
+                case 10:
+                    return new Oracle10gDialect();
+                case 9:
+                    return new Oracle9iDialect();
+                case 8:
+                    return new Oracle8iDialect();
+                default: {
                     LOG.unknownOracleVersion(databaseMajorVersion);
-			}
-		}
+                    if ( databaseMajorVersion > 12 )
+                    {
+                        return new Oracle12cDialect();
+                    }
+                }
+            }
+            return new Oracle8iDialect();
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/hibernate-core/src/main/java/org/hibernate/service/jdbc/dialect/internal/StandardDialectResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/jdbc/dialect/internal/StandardDialectResolver.java
@@ -136,12 +136,12 @@ public class StandardDialectResolver extends AbstractDialectResolver {
                     return new SQLServer2012Dialect();
                 default: {
                     if (databaseMajorVersion < 8 ) {
-                        LOG.unknownSqlServerVersion(databaseMajorVersion);
+                        LOG.unknownSqlServerVersion(databaseMajorVersion, 2000);
                         return new SQLServerDialect();
                     }
                     else {
                         // assume `majorVersion > 13`
-                        LOG.unknownSqlServerVersion(databaseMajorVersion);
+                        LOG.unknownSqlServerVersion(databaseMajorVersion, 2012);
                         return new SQLServer2012Dialect();
                     }
                 }

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/entity/Forest2.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/entity/Forest2.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.OptimisticLock;
+import org.hibernate.annotations.OptimisticLockType;
+import org.hibernate.annotations.OptimisticLocking;
+import org.hibernate.annotations.Polymorphism;
+import org.hibernate.annotations.PolymorphismType;
+import org.hibernate.annotations.SelectBeforeUpdate;
+import org.hibernate.annotations.Type;
+
+/**
+ * Mapping following lines of {@link Forest}, but using the replacements for the now deprecated
+ * {@link org.hibernate.annotations.Entity} annotation.
+ *
+ * @author Steve Ebersole
+ */
+@Entity
+@DynamicInsert
+@DynamicUpdate
+@SelectBeforeUpdate
+@OptimisticLocking( type = OptimisticLockType.ALL )
+@Polymorphism( type = PolymorphismType.EXPLICIT )
+public class Forest2 {
+	private Integer id;
+	private String name;
+	private String longDescription;
+
+	@Id
+	@GeneratedValue
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@OptimisticLock(excluded=true)
+	@Type(type = "text")
+	public String getLongDescription() {
+		return longDescription;
+	}
+
+	public void setLongDescription(String longDescription) {
+		this.longDescription = longDescription;
+	}
+}

--- a/hibernate-core/src/matrix/java/org/hibernate/test/annotations/entity/NewCustomEntityMappingAnnotationsTest.java
+++ b/hibernate-core/src/matrix/java/org/hibernate/test/annotations/entity/NewCustomEntityMappingAnnotationsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2012, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.annotations.entity;
+
+import org.hibernate.mapping.RootClass;
+
+import org.junit.Test;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Steve Ebersole
+ */
+public class NewCustomEntityMappingAnnotationsTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Forest.class, Forest2.class };
+	}
+
+	@Override
+	protected String[] getAnnotatedPackages() {
+		return new String[] { Forest.class.getPackage().getName() };
+	}
+
+	@Test
+	public void testSameMappingValues() {
+		RootClass forest = (RootClass) configuration().getClassMapping( Forest.class.getName() );
+		RootClass forest2 = (RootClass) configuration().getClassMapping( Forest2.class.getName() );
+		assertEquals( forest.useDynamicInsert(), forest2.useDynamicInsert() );
+		assertEquals( forest.useDynamicUpdate(), forest2.useDynamicUpdate() );
+		assertEquals( forest.hasSelectBeforeUpdate(), forest2.hasSelectBeforeUpdate() );
+		assertEquals( forest.getOptimisticLockMode(), forest2.getOptimisticLockMode() );
+		assertEquals( forest.isExplicitPolymorphism(), forest2.isExplicitPolymorphism() );
+	}
+}

--- a/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/connection/FakeDataSource.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/ejb/test/connection/FakeDataSource.java
@@ -3,6 +3,9 @@ package org.hibernate.ejb.test.connection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
 import javax.sql.DataSource;
 
 /**
@@ -40,4 +43,9 @@ public class FakeDataSource implements DataSource {
 	public boolean isWrapperFor(Class<?> aClass) throws SQLException {
 		return false;
 	}
+
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException
+    {
+        throw new FakeDataSourceException( "getParentLogger" );
+    }
 }

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/TransactionalAccessDelegate.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/TransactionalAccessDelegate.java
@@ -154,6 +154,18 @@ public class TransactionalAccessDelegate {
          throw new CacheException("Failed to invalidate pending putFromLoad calls for key " + key + " from region " + region.getName());
       }      
       cacheAdapter.remove(key);
+
+      // added to remove the object from the pendingPuts map immediatedly.
+      // Existing mechanism is obviously not good enough to clear this queue under heavy load.
+      // Could lead to OutOfMemoryError
+      try
+      {
+          putValidator.releasePendingPut(key);
+      }
+      catch (Exception e)
+      {
+          // ignored
+      }
    }
 
    public void evictAll() throws CacheException {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/query/QueryResultsRegionImpl.java
@@ -37,6 +37,7 @@ public class QueryResultsRegionImpl extends BaseTransactionalDataRegion implemen
    public void evictAll() throws CacheException {
       Transaction tx = suspend();
       try {
+         invalidateRegion(); // Invalidate the local region and then go remote SEEBURGER backport of https://hibernate.atlassian.net/browse/HHH-7127
          cacheAdapter.broadcastEvictAll();
       } finally {
          resume(tx);

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampsRegionImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/timestamp/TimestampsRegionImpl.java
@@ -45,6 +45,7 @@ public class TimestampsRegionImpl extends BaseGeneralDataRegion implements Times
       // TODO Is this a valid operation on a timestamps cache?
       Transaction tx = suspend();
       try {
+         invalidateRegion(); // Invalidate the local region and then go remote SEEBURGER backport of https://hibernate.atlassian.net/browse/HHH-7127
          cacheAdapter.broadcastEvictAll();
       } finally {
          resume(tx);

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheAdapterImpl.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheAdapterImpl.java
@@ -219,8 +219,12 @@ public class CacheAdapterImpl implements CacheAdapter {
 
    @Override
    public void broadcastEvictAll() {
-      EvictAllCommand cmd = cacheCmdInitializer.buildEvictAllCommand(cache.getName());
-      cache.getRpcManager().broadcastRpcCommand(cmd, isSync);
+       // SEEBURGER backport of https://hibernate.atlassian.net/browse/HHH-7016
+       RpcManager rpcManager = cache.getRpcManager();
+       if (rpcManager != null) {
+         EvictAllCommand cmd = this.cacheCmdInitializer.buildEvictAllCommand(this.cache.getName());
+         rpcManager.broadcastRpcCommand(cmd, this.isSync);
+       }
    }
 
    @Override

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheHelper.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheHelper.java
@@ -29,7 +29,7 @@ import javax.transaction.TransactionManager;
 
 /**
  * Helper for dealing with Infinisan cache instances.
- * 
+ *
  * @author Galder Zamarreño
  * @since 3.5
  */
@@ -41,17 +41,32 @@ public class CacheHelper {
    private CacheHelper() {
    }
 
+
    public static <T> T withinTx(TransactionManager tm, Callable<T> c) throws Exception {
-      tm.begin();
-      try {
-         return c.call();
-      } catch (Exception e) {
-         tm.setRollbackOnly();
-         throw e;
-      } finally {
-         if (tm.getStatus() == Status.STATUS_ACTIVE) tm.commit();
-         else tm.rollback();
-      }
-   }
+        if ( tm == null ) {
+            try {
+                return c.call();
+            }
+            catch ( Exception e ) {
+                throw e;
+            }
+        }
+        else {
+            tm.begin();
+            try {
+                return c.call();
+            }
+            catch ( Exception e ) {
+                tm.setRollbackOnly();
+                throw e;
+            }
+            finally {
+                if ( tm.getStatus() == Status.STATUS_ACTIVE )
+                    tm.commit();
+                else
+                    tm.rollback();
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
DerbyDialect does not implement the method getQuerySequencesString(). 
This produces errors on startup, because Hibernate could not find the sequences and try to create them, but they already exist.

INFO  [DatabaseMetadata] table not found: XXXX
ERROR [SchemaUpdate] Unsuccessful: create sequence XXXX start with 1 increment by 1
ERROR [SchemaUpdate] Sequence 'XXXX' already exists.