### PR TITLE
HHH-11838 - Id retrieving from proxy with FK leads to query execution

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -542,6 +542,24 @@ public final class ReflectHelper {
 		}
 	}
 
+	public static Method getterMethodOrNull(Class containerJavaType, String propertyName) {
+		try {
+			return findGetterMethod( containerJavaType, propertyName );
+		}
+		catch (PropertyNotFoundException e) {
+			return null;
+		}
+	}
+
+	public static Method setterMethodOrNull(Class containerJavaType, String propertyName, Class propertyJavaType) {
+		try {
+			return findSetterMethod( containerJavaType, propertyName, propertyJavaType );
+		}
+		catch (PropertyNotFoundException e) {
+			return null;
+		}
+	}
+
 	public static Method findSetterMethod(Class containerClass, String propertyName, Class propertyType) {
 		Class checkClass = containerClass;
 		Method setter = null;

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/AbstractFieldSerialForm.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/AbstractFieldSerialForm.java
@@ -8,6 +8,7 @@ package org.hibernate.property.access.internal;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import org.hibernate.property.access.spi.PropertyAccessSerializationException;
 
@@ -19,14 +20,16 @@ import org.hibernate.property.access.spi.PropertyAccessSerializationException;
 public abstract class AbstractFieldSerialForm implements Serializable {
 	private final Class declaringClass;
 	private final String fieldName;
+	private final String methodName;
 
-	protected AbstractFieldSerialForm(Field field) {
-		this( field.getDeclaringClass(), field.getName() );
+	protected AbstractFieldSerialForm(Field field, String methodName) {
+		this( field.getDeclaringClass(), field.getName(), methodName );
 	}
 
-	protected AbstractFieldSerialForm(Class declaringClass, String fieldName) {
+	protected AbstractFieldSerialForm(Class declaringClass, String fieldName, String methodName ) {
 		this.declaringClass = declaringClass;
 		this.fieldName = fieldName;
+		this.methodName = methodName;
 	}
 
 	protected Field resolveField() {
@@ -38,6 +41,20 @@ public abstract class AbstractFieldSerialForm implements Serializable {
 		catch (NoSuchFieldException e) {
 			throw new PropertyAccessSerializationException(
 					"Unable to resolve field on deserialization : " + declaringClass.getName() + "#" + fieldName
+			);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected Method resolveMethod() {
+		try {
+			final Method method = declaringClass.getDeclaredMethod( methodName );
+			method.setAccessible( true );
+			return method;
+		}
+		catch (NoSuchMethodException e) {
+			throw new PropertyAccessSerializationException(
+					"Unable to resolve method on deserialization : " + declaringClass.getName() + "#" + methodName
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/AbstractFieldSerialForm.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/AbstractFieldSerialForm.java
@@ -8,7 +8,6 @@ package org.hibernate.property.access.internal;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 import org.hibernate.property.access.spi.PropertyAccessSerializationException;
 
@@ -18,18 +17,16 @@ import org.hibernate.property.access.spi.PropertyAccessSerializationException;
  * @author Steve Ebersole
  */
 public abstract class AbstractFieldSerialForm implements Serializable {
-	private final Class declaringClass;
+	protected final Class declaringClass;
 	private final String fieldName;
-	private final String methodName;
 
-	protected AbstractFieldSerialForm(Field field, String methodName) {
-		this( field.getDeclaringClass(), field.getName(), methodName );
+	protected AbstractFieldSerialForm(Field field) {
+		this( field.getDeclaringClass(), field.getName() );
 	}
 
-	protected AbstractFieldSerialForm(Class declaringClass, String fieldName, String methodName ) {
+	protected AbstractFieldSerialForm(Class declaringClass, String fieldName ) {
 		this.declaringClass = declaringClass;
 		this.fieldName = fieldName;
-		this.methodName = methodName;
 	}
 
 	protected Field resolveField() {
@@ -41,20 +38,6 @@ public abstract class AbstractFieldSerialForm implements Serializable {
 		catch (NoSuchFieldException e) {
 			throw new PropertyAccessSerializationException(
 					"Unable to resolve field on deserialization : " + declaringClass.getName() + "#" + fieldName
-			);
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	protected Method resolveMethod() {
-		try {
-			final Method method = declaringClass.getDeclaredMethod( methodName );
-			method.setAccessible( true );
-			return method;
-		}
-		catch (NoSuchMethodException e) {
-			throw new PropertyAccessSerializationException(
-					"Unable to resolve method on deserialization : " + declaringClass.getName() + "#" + methodName
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
@@ -31,11 +31,11 @@ public class PropertyAccessEnhancedImpl extends PropertyAccessMixedImpl {
 	}
 
 	@Override
-	protected Setter fieldSetter(Class<?> containerJavaType, String propertyName, Field field) {
-		return resolveEnhancedSetterForField( containerJavaType, propertyName, field );
+	protected Setter fieldSetter(Class<?> containerJavaType, String propertyName, Field field, Method method ) {
+		return resolveEnhancedSetterForField( containerJavaType, propertyName, field, method );
 	}
 
-	private static Setter resolveEnhancedSetterForField(Class<?> containerClass, String propertyName, Field field) {
+	private static Setter resolveEnhancedSetterForField(Class<?> containerClass, String propertyName, Field field, Method method ) {
 		try {
 			String enhancedSetterName = EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX + propertyName;
 			Method enhancedSetter = containerClass.getDeclaredMethod( enhancedSetterName, field.getType() );
@@ -44,7 +44,7 @@ public class PropertyAccessEnhancedImpl extends PropertyAccessMixedImpl {
 		}
 		catch (NoSuchMethodException e) {
 			// enhancedSetter = null --- field not enhanced: fallback to reflection using the field
-			return new SetterFieldImpl( containerClass, propertyName, field );
+			return new SetterFieldImpl( containerClass, propertyName, field, method );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessFieldImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.property.access.internal;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.property.access.spi.Getter;
@@ -32,8 +33,10 @@ public class PropertyAccessFieldImpl implements PropertyAccess {
 		this.strategy = strategy;
 
 		final Field field = ReflectHelper.findField( containerJavaType, propertyName );
-		this.getter = new GetterFieldImpl( containerJavaType, propertyName, field );
-		this.setter = new SetterFieldImpl( containerJavaType, propertyName, field );
+		final Method getterMethod = ReflectHelper.getterMethodOrNull(containerJavaType, propertyName);
+		final Method setterMethod = getterMethod != null ? ReflectHelper.setterMethodOrNull(containerJavaType, propertyName, getterMethod.getReturnType()) : null;
+		this.getter = new GetterFieldImpl( containerJavaType, propertyName, field, getterMethod );
+		this.setter = new SetterFieldImpl( containerJavaType, propertyName, field, setterMethod );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/GetterFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/GetterFieldImpl.java
@@ -26,11 +26,13 @@ public class GetterFieldImpl implements Getter {
 	private final Class containerClass;
 	private final String propertyName;
 	private final Field field;
+	private final Method getterMethod;
 
-	public GetterFieldImpl(Class containerClass, String propertyName, Field field) {
+	public GetterFieldImpl(Class containerClass, String propertyName, Field field, Method getterMethod) {
 		this.containerClass = containerClass;
 		this.propertyName = propertyName;
 		this.field = field;
+		this.getterMethod = getterMethod;
 	}
 
 	@Override
@@ -98,30 +100,30 @@ public class GetterFieldImpl implements Getter {
 
 	@Override
 	public String getMethodName() {
-		return null;
+		return getterMethod != null ? getterMethod.getName() : null;
 	}
 
 	@Override
 	public Method getMethod() {
-		return null;
+		return getterMethod;
 	}
 
 	private Object writeReplace() throws ObjectStreamException {
-		return new SerialForm( containerClass, propertyName, field );
+		return new SerialForm( containerClass, propertyName, field, getterMethod != null ? getterMethod.getName() : "" );
 	}
 
 	private static class SerialForm extends AbstractFieldSerialForm implements Serializable {
 		private final Class containerClass;
 		private final String propertyName;
 
-		private SerialForm(Class containerClass, String propertyName, Field field) {
-			super( field );
+		private SerialForm(Class containerClass, String propertyName, Field field, String methodName) {
+			super( field, methodName );
 			this.containerClass = containerClass;
 			this.propertyName = propertyName;
 		}
 
 		private Object readResolve() {
-			return new GetterFieldImpl( containerClass, propertyName, resolveField() );
+			return new GetterFieldImpl( containerClass, propertyName, resolveField(), resolveMethod() );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/SetterFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/SetterFieldImpl.java
@@ -25,11 +25,13 @@ public class SetterFieldImpl implements Setter {
 	private final Class containerClass;
 	private final String propertyName;
 	private final Field field;
+	private final Method setterMethod;
 
-	public SetterFieldImpl(Class containerClass, String propertyName, Field field) {
+	public SetterFieldImpl(Class containerClass, String propertyName, Field field, Method method) {
 		this.containerClass = containerClass;
 		this.propertyName = propertyName;
 		this.field = field;
+		this.setterMethod = method;
 	}
 
 	@Override
@@ -72,30 +74,30 @@ public class SetterFieldImpl implements Setter {
 
 	@Override
 	public String getMethodName() {
-		return null;
+		return setterMethod != null ? setterMethod.getName() : null;
 	}
 
 	@Override
 	public Method getMethod() {
-		return null;
+		return setterMethod;
 	}
 
 	private Object writeReplace() throws ObjectStreamException {
-		return new SerialForm( containerClass, propertyName, field );
+		return new SerialForm( containerClass, propertyName, field, setterMethod != null ? setterMethod.getName() : "" );
 	}
 
 	private static class SerialForm extends AbstractFieldSerialForm implements Serializable {
 		private final Class containerClass;
 		private final String propertyName;
 
-		private SerialForm(Class containerClass, String propertyName, Field field) {
-			super( field );
+		private SerialForm(Class containerClass, String propertyName, Field field, String methodName) {
+			super( field, methodName);
 			this.containerClass = containerClass;
 			this.propertyName = propertyName;
 		}
 
 		private Object readResolve() {
-			return new SetterFieldImpl( containerClass, propertyName, resolveField() );
+			return new SetterFieldImpl( containerClass, propertyName, resolveField(), resolveMethod() );
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/Workload.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/Workload.java
@@ -23,4 +23,12 @@ public class Workload {
 	public String name;
 	@Column(name="load_")
 	public Integer load;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/property/DirectPropertyAccessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/property/DirectPropertyAccessorTest.java
@@ -38,7 +38,9 @@ public class DirectPropertyAccessorTest extends BaseCoreFunctionalTestCase {
 		o = ( Order ) s.load( Order.class, 1 );
 		assertFalse( Hibernate.isInitialized( o ) );
 		o.getOrderNumber();
-		// If you mapped with field access, any method call initializes the proxy
+		// If you mapped with field access, any method, except id, call initializes the proxy
+		assertFalse( Hibernate.isInitialized( o ) );
+		o.getName();
 		assertTrue( Hibernate.isInitialized( o ) );
 		s.close();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/property/Order.java
+++ b/hibernate-core/src/test/java/org/hibernate/property/Order.java
@@ -27,6 +27,8 @@ public class Order implements Serializable {
 	@Id
 	private int orderNumber;
 
+	private String name;
+
 	@OneToMany( fetch = FetchType.LAZY )
 	private Set<Item> items = new HashSet<Item>();
 	
@@ -40,5 +42,13 @@ public class Order implements Serializable {
 	
 	public Set<Item> getItems() {
 		return items;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/property/access/spi/GetterFieldImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/property/access/spi/GetterFieldImplTest.java
@@ -45,7 +45,7 @@ public class GetterFieldImplTest {
 		try {
 			Field field = Target.class.getDeclaredField( property );
 			field.setAccessible( true );
-			return new GetterFieldImpl( Target.class, property, field );
+			return new GetterFieldImpl( Target.class, property, field, null );
 		}
 		catch (NoSuchFieldException e) {
 			throw new IllegalArgumentException( e );

--- a/hibernate-core/src/test/java/org/hibernate/serialization/GetterSetterSerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/serialization/GetterSetterSerializationTest.java
@@ -39,10 +39,12 @@ public class GetterSetterSerializationTest {
 	public void testPrivateFieldGetter() throws Exception {
 		final AnEntity entity = new AnEntity( new PK( 1L ) );
 
+		final String propertyName = "pk";
 		final Getter getter = new GetterFieldImpl(
 				AnEntity.class,
-				"pk",
-				ReflectHelper.findField( AnEntity.class, "pk")
+				propertyName,
+				ReflectHelper.findField( AnEntity.class, propertyName),
+				ReflectHelper.findGetterMethod(AnEntity.class, propertyName)
 		);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		final ObjectOutputStream oos = new ObjectOutputStream(baos);
@@ -60,15 +62,18 @@ public class GetterSetterSerializationTest {
 	public void testPrivateFieldSetter() throws Exception {
 		AnEntity entity = new AnEntity( new PK( 1L ) );
 
+		final String propertyName = "pk";
 		final Getter getter = new GetterFieldImpl(
 				AnEntity.class,
-				"pk",
-				ReflectHelper.findField( AnEntity.class, "pk")
+				propertyName,
+				ReflectHelper.findField( AnEntity.class, propertyName),
+				ReflectHelper.findGetterMethod(AnEntity.class, propertyName)
 		);
 		final Setter setter = new SetterFieldImpl(
 				AnEntity.class,
-				"pk",
-				ReflectHelper.findField( AnEntity.class, "pk")
+				propertyName,
+				ReflectHelper.findField( AnEntity.class, propertyName),
+				ReflectHelper.findSetterMethod(AnEntity.class, propertyName, PK.class)
 		);
 
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/Account.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/Account.java
@@ -1,0 +1,39 @@
+package org.hibernate.test.lazyload;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+/**
+ * @author Igor Dmitriev
+ */
+
+@Entity
+public class Account {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "id_client")
+  private Client client;
+
+  public Client getClient() {
+    return client;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public void setClient(Client client) {
+    this.client = client;
+  }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/Address.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/Address.java
@@ -1,0 +1,52 @@
+package org.hibernate.test.lazyload;
+
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Igor Dmitriev
+ */
+
+@Entity
+public class Address {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @Column
+  private String street;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "id_client")
+  private Client client;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Client getClient() {
+    return client;
+  }
+
+  public void setClient(Client client) {
+    this.client = client;
+  }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/Client.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/Client.java
@@ -1,0 +1,65 @@
+package org.hibernate.test.lazyload;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Igor Dmitriev
+ */
+
+@Entity
+public class Client {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @Column
+  private String name;
+
+  @OneToMany(mappedBy = "client")
+  private List<Account> accounts = new ArrayList<>();
+
+  @OneToOne(mappedBy = "client", fetch = FetchType.LAZY)
+  private Address address;
+
+  public Client() {
+  }
+
+  public Client(Address address) {
+    this.address = address;
+    address.setClient(this);
+  }
+
+  public void addAccount(Account account) {
+    accounts.add(account);
+    account.setClient(this);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Address getAddress() {
+    return address;
+  }
+
+  public void setAddress(Address address) {
+    this.address = address;
+  }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingTest.java
@@ -155,7 +155,7 @@ public class LazyLoadingTest
 			client.getId();
 			assertThat(Hibernate.isInitialized(client), is(false));
 			client.getName();
-			assertThat(Hibernate.isInitialized(client), is(false));
+			assertThat(Hibernate.isInitialized(client), is(true));
 		});
 
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lazyload/LazyLoadingTest.java
@@ -6,8 +6,7 @@
  */
 package org.hibernate.test.lazyload;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.Serializable;
 
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
@@ -18,9 +17,12 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Oleksander Dukhno
@@ -42,7 +44,10 @@ public class LazyLoadingTest
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 				Parent.class,
-				Child.class
+				Child.class,
+				Client.class,
+				Address.class,
+				Account.class
 		};
 	}
 
@@ -100,4 +105,58 @@ public class LazyLoadingTest
 		assertEquals( CHILDREN_SIZE, j );
 	}
 
+	@Test
+	@TestForIssue( jiraKey = "HHH-11838")
+	public void testGetIdOneToOne() {
+		Serializable clientId = doInHibernate(this::sessionFactory, s -> {
+			Address address = new Address();
+			s.save(address);
+			Client client = new Client(address);
+			return s.save(client);
+		});
+
+		Serializable addressId = doInHibernate(this::sessionFactory, s -> {
+			Client client = s.get(Client.class, clientId);
+			Address address = client.getAddress();
+			address.getId();
+			assertThat(Hibernate.isInitialized(address), is(true));
+			address.getStreet();
+			assertThat(Hibernate.isInitialized(address), is(true));
+			return address.getId();
+		});
+
+		doInHibernate(this::sessionFactory, s -> {
+			Address address = s.get(Address.class, addressId);
+			Client client = address.getClient();
+			client.getId();
+			assertThat(Hibernate.isInitialized(client), is(false));
+			client.getName();
+			assertThat(Hibernate.isInitialized(client), is(true));
+		});
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11838")
+	public void testGetIdManyToOne() {
+		Serializable accountId = doInHibernate(this::sessionFactory, s -> {
+			Address address = new Address();
+			s.save(address);
+			Client client = new Client(address);
+			Account account = new Account();
+			client.addAccount(account);
+			s.save(account);
+			s.save(client);
+			return account.getId();
+		});
+
+		doInHibernate(this::sessionFactory, s -> {
+			Account account = s.load(Account.class, accountId);
+			Client client = account.getClient();
+			client.getId();
+			assertThat(Hibernate.isInitialized(client), is(false));
+			client.getName();
+			assertThat(Hibernate.isInitialized(client), is(false));
+		});
+
+	}
 }


### PR DESCRIPTION
## **Description of changes**
Fix - https://hibernate.atlassian.net/browse/HHH-11838
This issue is reproducible for field-based mapping, for property-based everything works fine.
https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java#L65

for ``property`` ``getIdentifierMethod`` is not null
for ``field`` ``getIdentifierMethod`` is null

## **Value being added**
getId on proxy will not load proxy (won't trigger sql query to fetch entity from db)