### PR TITLE
HHH-11871 - during metamodel generation, verify if methods respect JavaBeans conventions

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -15,6 +15,8 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic;
 
@@ -170,7 +172,13 @@ public class AnnotationMetaEntity implements MetaEntity {
 		List<? extends Element> fieldsOfClass = ElementFilter.fieldsIn( element.getEnclosedElements() );
 		addPersistentMembers( fieldsOfClass, AccessType.FIELD );
 
-		List<? extends Element> methodsOfClass = ElementFilter.methodsIn( element.getEnclosedElements() );
+		List<? extends Element> rawMethodsOfClass = ElementFilter.methodsIn( element.getEnclosedElements() );
+		List<Element> methodsOfClass = new ArrayList<Element>();
+		for (Element rawMethodOfClass: rawMethodsOfClass) {
+			if (methodRespectsJavaBeansConvention(rawMethodOfClass)) {
+				methodsOfClass.add(rawMethodOfClass);
+			}
+		}
 		addPersistentMembers( methodsOfClass, AccessType.PROPERTY );
 
 		initialized = true;
@@ -195,5 +203,22 @@ public class AnnotationMetaEntity implements MetaEntity {
 				members.put( result.getPropertyName(), result );
 			}
 		}
+	}
+
+	/**
+	 * Should generate code only for persistent attributes.
+	 * Thus, methods should follow conventions of JavaBeans components.
+	 * See HHH-11871.
+	 * @param methodOfClass
+	 * @return
+	 */
+	private boolean methodRespectsJavaBeansConvention(Element methodOfClass) {
+		ExecutableType methodType = (ExecutableType) methodOfClass.asType();
+		String methodSimpleName = methodOfClass.getSimpleName().toString();
+		List<? extends TypeMirror> methodParameterTypes = methodType.getParameterTypes();
+
+		return (methodSimpleName.startsWith("set") && methodParameterTypes.size() == 1)
+				||
+				((methodSimpleName.startsWith("get") || methodSimpleName.startsWith("is")) && methodParameterTypes.isEmpty());
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
@@ -12,9 +12,9 @@ import org.hibernate.jpamodelgen.test.util.WithClasses;
 import org.hibernate.jpamodelgen.test.util.WithMappingFiles;
 import org.junit.Test;
 
-import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMapAttributesInMetaModelFor;
-import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
-import static org.hibernate.jpamodelgen.test.util.TestUtil.assertNoSourceFileGeneratedFor;
+import javax.persistence.metamodel.ListAttribute;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.*;
 
 /**
  * @author Hardy Ferentschik
@@ -58,5 +58,12 @@ public class ElementCollectionTest extends CompilationTest {
 		assertMapAttributesInMetaModelFor(
 				Hostel.class, "cleaners", Room.class, Cleaner.class, "Wrong type in map attribute."
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11871")
+	@WithClasses({ Homework.class, Room.class, Cleaner.class })
+	public void testJavaBeanAttributeNotOverwritten() {
+		assertAttributeTypeInMetaModelHasRawType( Homework.class, "paths", ListAttribute.class, "attribute type should be List" );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
@@ -62,8 +62,8 @@ public class ElementCollectionTest extends CompilationTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11871")
-	@WithClasses({ Homework.class, Room.class, Cleaner.class })
+	@WithClasses({ Homework.class})
 	public void testJavaBeanAttributeNotOverwritten() {
-		assertAttributeTypeInMetaModelHasRawType( Homework.class, "paths", ListAttribute.class, "attribute type should be List" );
+		assertAttributeTypeInMetaModelHasRawType( Homework.class, "paths", ListAttribute.class, "generated attribute type should be ListAttribute" );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
@@ -7,6 +7,7 @@
 package org.hibernate.jpamodelgen.test.elementcollection;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -17,7 +18,18 @@ import java.util.TreeSet;
 @Entity
 public class Homework {
 
+    private int id;
+
     private List<String> paths;
+
+    @Id
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
 
     public List<String> getPaths() {
         return paths;

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.elementcollection;
+
+import javax.persistence.Entity;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Bogdan Știrbăț
+ */
+@Entity
+public class Homework {
+
+    private List<String> paths;
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public Set<String> getPaths(String startPath) {
+        TreeSet<String> result = new TreeSet<>();
+
+        if (paths == null) {
+            return result;
+        }
+
+        for (String path: paths) {
+            if (path.startsWith(startPath)) {
+                result.add(path);
+            }
+        }
+        return result;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
@@ -99,6 +99,18 @@ public class TestUtil {
 		);
 	}
 
+	public static void assertAttributeTypeInMetaModelHasRawType(Class<?> clazz, String fieldName, Class<?> expectedType, String errorString) {
+		Field field = getFieldFromMetamodelFor( clazz, fieldName );
+		assertNotNull( "Cannot find field '" + fieldName + "' in " + clazz.getName(), field );
+		ParameterizedType type = (ParameterizedType) field.getGenericType();
+		Type actualType = type.getRawType();
+		assertEquals(
+				"Types do not match: " + buildErrorString( errorString, clazz ),
+				expectedType,
+				actualType
+		);
+	}
+
 	public static void assertMapAttributesInMetaModelFor(Class<?> clazz, String fieldName, Class<?> expectedMapKey, Class<?> expectedMapValue, String errorString) {
 		Field field = getFieldFromMetamodelFor( clazz, fieldName );
 		assertNotNull( field );


### PR DESCRIPTION
When the JPAMetaModelEntityProcessor is executed, a new AnnotationMetaEntity is created for each Entity.
When the AnnotationMetaEntity is created, for a specific entity (Java class), each member of the class was registered as a persistent member. In this pull request, only members of class that respects the JavaBeans convention are added as persistent members.

I was thinking about this fix, by reading the [Java API specification](http://docs.oracle.com/javaee/7/tutorial/persistence-intro001.htm#BNBQA) : "If the entity uses persistent properties, the entity must follow the method conventions of JavaBeans components.". 
The same specification describes the [metamodel generation](https://docs.oracle.com/javaee/7/tutorial/persistence-criteria002.htm#GJIUP) : "For each entity class in a particular package, a metamodel class is created with a trailing underscore and with attributes that correspond to the persistent fields or properties of the entity class."
