### PR TITLE
HHH-11176: Add support for Tuple results for native queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
@@ -1,0 +1,131 @@
+package org.hibernate.jpa.spi;
+
+import org.hibernate.HibernateException;
+import org.hibernate.transform.BasicTransformerAdapter;
+
+import javax.persistence.Tuple;
+import javax.persistence.TupleElement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ResultTransformer adapter for handling Tuple results from Native queries
+ *
+ * @author Arnold Galovics
+ */
+public class NativeQueryTupleTransformer extends BasicTransformerAdapter  {
+    @Override
+    public Object transformTuple(Object[] tuple, String[] aliases) {
+        return new NativeTupleImpl(tuple, aliases);
+    }
+
+    private static class NativeTupleElementImpl<X> implements TupleElement<X> {
+        private final Class<? extends X> javaType;
+        private final String alias;
+
+        public NativeTupleElementImpl(Class<? extends X> javaType, String alias) {
+            this.javaType = javaType;
+            this.alias = alias;
+        }
+
+        @Override
+        public Class<? extends X> getJavaType() {
+            return javaType;
+        }
+
+        @Override
+        public String getAlias() {
+            return alias;
+        }
+    }
+
+    private static class NativeTupleImpl implements Tuple {
+        private Object[] tuple;
+        private LinkedHashMap<String, Object> aliasToValue = new LinkedHashMap<>();
+
+        public NativeTupleImpl(Object[] tuple, String[] aliases) {
+            if (tuple == null || aliases == null || tuple.length != aliases.length) {
+                throw new HibernateException("Got different size of tuples and aliases");
+            }
+            this.tuple = tuple;
+            for (int i = 0; i < tuple.length; i++) {
+                aliasToValue.put(aliases[i], tuple[i]);
+            }
+        }
+
+        @Override
+        public <X> X get(String alias, Class<X> type) {
+            final Object untyped = get( alias );
+            if ( untyped != null ) {
+                if ( !type.isInstance( untyped ) ) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Requested tuple value [alias=%s, value=%s] cannot be assigned to requested type [%s]",
+                                    alias,
+                                    untyped,
+                                    type.getName()
+                            )
+                    );
+                }
+            }
+            return (X) untyped;
+        }
+
+        @Override
+        public Object get(String alias) {
+            Object tupleElement = aliasToValue.get( alias );
+            if ( tupleElement == null ) {
+                throw new IllegalArgumentException( "Unknown alias [" + alias + "]" );
+            }
+            return tupleElement;
+        }
+
+        @Override
+        public <X> X get(int i, Class<X> type) {
+            final Object result = get( i );
+            if ( result != null && !type.isInstance( result ) ) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Requested tuple value [index=%s, realType=%s] cannot be assigned to requested type [%s]",
+                                i,
+                                result.getClass().getName(),
+                                type.getName()
+                        )
+                );
+            }
+            return (X) result;
+        }
+
+        @Override
+        public Object get(int i) {
+            if ( i < 0 ) {
+                throw new IllegalArgumentException( "requested tuple index must be greater than zero" );
+            }
+            if ( i >= aliasToValue.size() ) {
+                throw new IllegalArgumentException( "requested tuple index exceeds actual tuple size" );
+            }
+            return tuple[i];
+        }
+
+        @Override
+        public Object[] toArray() {
+            return tuple;
+        }
+
+        @Override
+        public List<TupleElement<?>> getElements() {
+            List<TupleElement<?>> elements = new ArrayList<>(aliasToValue.size());
+            for (Map.Entry<String, Object> entry : aliasToValue.entrySet()) {
+                elements.add(new NativeTupleElementImpl<>(entry.getValue().getClass(), entry.getKey()));
+            }
+            return elements;
+        }
+
+        @Override
+        public <X> X get(TupleElement<X> tupleElement) {
+            return get( tupleElement.getAlias(), tupleElement.getJavaType() );
+        }
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TupleNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TupleNativeQueryTest.java
@@ -1,0 +1,408 @@
+package org.hibernate.jpa.test.query;
+
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.RequiresDialect;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.*;
+import javax.persistence.criteria.CriteriaDelete;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RequiresDialect(H2Dialect.class)
+public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class[]{User.class};
+    }
+
+    @Before
+    public void setUp() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            User user = new User("Arnold");
+            entityManager.persist(user);
+        });
+    }
+
+    @After
+    public void tearDown() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            CriteriaDelete<User> delete = entityManager.getCriteriaBuilder().createCriteriaDelete(User.class);
+            delete.from(User.class);
+            entityManager.createQuery(delete).executeUpdate();
+        });
+    }
+
+    @Test
+    public void testPositionalGetterShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0));
+            assertEquals("Arnold", tuple.get(1));
+        });
+    }
+
+    @Test
+    public void testPositionalGetterWithClassShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0, BigInteger.class));
+            assertEquals("Arnold", tuple.get(1, String.class));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithClassShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithClassShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithClassShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test
+    public void testAliasGetterWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID"));
+            assertEquals("Arnold", tuple.get("FIRSTNAME"));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAliasGetterShouldThrowExceptionWithoutExplicitAliasWhenLowerCaseAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get("id");
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAliasGetterShouldThrowExceptionWithoutExplicitAliasWhenWrongAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get("e");
+        });
+    }
+
+    @Test
+    public void testAliasGetterWithClassWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID", BigInteger.class));
+            assertEquals("Arnold", tuple.get("FIRSTNAME", String.class));
+        });
+    }
+
+
+    @Test
+    public void testAliasGetterWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleAliasedResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1"));
+            assertEquals("Arnold", tuple.get("ALIAS2"));
+        });
+    }
+
+    @Test
+    public void testAliasGetterWithClassWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleAliasedResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1", BigInteger.class));
+            assertEquals("Arnold", tuple.get("ALIAS2", String.class));
+        });
+    }
+
+    @Test
+    public void testToArrayShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getTupleResult(entityManager);
+            Object[] result = tuples.get(0).toArray();
+            assertArrayEquals(new Object[]{BigInteger.ONE, "Arnold"}, result);
+        });
+    }
+
+    @Test
+    public void testGetElementsShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getTupleResult(entityManager);
+            List<TupleElement<?>> result = tuples.get(0).getElements();
+            assertEquals(2, result.size());
+            assertEquals(BigInteger.class, result.get(0).getJavaType());
+            assertEquals("ID", result.get(0).getAlias());
+            assertEquals(String.class, result.get(1).getJavaType());
+            assertEquals("FIRSTNAME", result.get(1).getAlias());
+        });
+    }
+
+    @Test
+    public void testPositionalGetterWithNamedNativeQueryShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0));
+            assertEquals("Arnold", tuple.get(1));
+        });
+    }
+
+    @Test
+    public void testPositionalGetterWithNamedNativeQueryWithClassShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0, BigInteger.class));
+            assertEquals("Arnold", tuple.get(1, String.class));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test
+    public void testAliasGetterWithNamedNativeQueryWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID"));
+            assertEquals("Arnold", tuple.get("FIRSTNAME"));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAliasGetterWithNamedNativeQueryShouldThrowExceptionWithoutExplicitAliasWhenLowerCaseAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get("id");
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAliasGetterWithNamedNativeQueryShouldThrowExceptionWithoutExplicitAliasWhenWrongAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            tuple.get("e");
+        });
+    }
+
+    @Test
+    public void testAliasGetterWithNamedNativeQueryWithClassWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID", BigInteger.class));
+            assertEquals("Arnold", tuple.get("FIRSTNAME", String.class));
+        });
+    }
+
+
+    @Test
+    public void testAliasGetterWithNamedNativeQueryWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard_with_alias", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1"));
+            assertEquals("Arnold", tuple.get("ALIAS2"));
+        });
+    }
+
+    @Test
+    public void testAliasGetterWithNamedNativeQueryWithClassWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = entityManager.createNamedQuery("standard_with_alias", Tuple.class).getResultList();
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1", BigInteger.class));
+            assertEquals("Arnold", tuple.get("ALIAS2", String.class));
+        });
+    }
+
+    @Test
+    public void testToArrayShouldWithNamedNativeQueryWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            Object[] result = tuples.get(0).toArray();
+            assertArrayEquals(new Object[]{BigInteger.ONE, "Arnold"}, result);
+        });
+    }
+
+    @Test
+    public void testGetElementsWithNamedNativeQueryShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<TupleElement<?>> result = tuples.get(0).getElements();
+            assertEquals(2, result.size());
+            assertEquals(BigInteger.class, result.get(0).getJavaType());
+            assertEquals("ID", result.get(0).getAlias());
+            assertEquals(String.class, result.get(1).getJavaType());
+            assertEquals("FIRSTNAME", result.get(1).getAlias());
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getTupleAliasedResult(EntityManager entityManager) {
+        Query query = entityManager.createNativeQuery("SELECT id AS alias1, firstname AS alias2 FROM users", Tuple.class);
+        return (List<Tuple>) query.getResultList();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getTupleResult(EntityManager entityManager) {
+        Query query = entityManager.createNativeQuery("SELECT id, firstname FROM users", Tuple.class);
+        return (List<Tuple>) query.getResultList();
+    }
+
+    @Entity
+    @Table(name = "users")
+    @NamedNativeQueries({
+            @NamedNativeQuery(
+                    name = "standard",
+                    query = "SELECT id, firstname FROM users"
+            ),
+            @NamedNativeQuery(
+                    name = "standard_with_alias",
+                    query = "SELECT id AS alias1, firstname AS alias2 FROM users"
+            )
+    })
+    public static class User {
+        @Id
+        private long id;
+
+        private String firstName;
+
+        public User() {
+        }
+
+        public User(String firstName) {
+            this.id = 1L;
+            this.firstName = firstName;
+        }
+    }
+}


### PR DESCRIPTION
Basic implementation and tests added.

Now the EntityManager#createNativeQuery(String, Class) and EntityManager#createNamedQuery(String, Class) are supporting Tuple results.

One thing I was unsure about is what contract do we have for the Tuple#get(String) method regarding case-sensitivity? Currently, the implementation is case-sensitive but I feel like for native queries, this might be confusing.