### PR TITLE
HHH-11826: ImplicitNamingStrategyComponentPathImpl generates invalid SQL for entity with embedded Elementcollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
@@ -148,7 +148,12 @@ public class ImplicitNamingStrategyJpaCompliantImpl implements ImplicitNamingStr
 					+ source.getReferencedColumnName().getText();
 		}
 		else {
-			name = transformAttributePath( source.getAttributePath() )
+			//HHH-11826: ImplicitNamingStrategyComponentPathImpl generates invalid SQL for Entity with Embedded ElementCollection
+			String attributePath = transformAttributePath( source.getAttributePath() );
+			if(attributePath.contains( "_collection&&element_" )) {
+				attributePath = attributePath.replace( "_collection&&element_", "_" );
+			}
+			name = attributePath
 					+ '_'
 					+ source.getReferencedColumnName().getText();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -891,7 +891,8 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private void handleNativeQueryResult(NativeQueryImplementor query, Class resultClass) {
 		if (Tuple.class.equals(resultClass)) {
 			query.setResultTransformer(new NativeQueryTupleTransformer());
-		} else {
+		} 
+		else {
 			query.addEntity( "alias1", resultClass.getName(), LockMode.READ );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
@@ -1,3 +1,9 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
 package org.hibernate.jpa.spi;
 
 import java.util.ArrayList;


### PR DESCRIPTION
https://hibernate.atlassian.net/projects/HHH/issues/HHH-11826

The changeset of file ImplicitNamingStrategyJpaCompliantImpl.java is to fix HHH-11826.

The changeset of file AbstractSharedSessionContract.java and NativeQueryTupleTransformer.java is to fix the checkstyle failure.

And all UT cases passed.