### PR TITLE
HHH-11871 - during metamodel generation, verify if methods respect JavaBeans conventions

### DIFF
--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTest.java
@@ -12,10 +12,12 @@ import org.hibernate.jpamodelgen.test.util.WithClasses;
 import org.hibernate.jpamodelgen.test.util.WithMappingFiles;
 import org.junit.Test;
 
-import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMapAttributesInMetaModelFor;
+import javax.persistence.metamodel.ListAttribute;
+
 import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 import static org.hibernate.jpamodelgen.test.util.TestUtil.assertNoSourceFileGeneratedFor;
-import static org.hibernate.jpamodelgen.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMapAttributesInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertAttributeTypeInMetaModelHasRawType;
 
 /**
  * @author Hardy Ferentschik
@@ -69,5 +71,12 @@ public class ElementCollectionTest extends CompilationTest {
 		assertMapAttributesInMetaModelFor(
 				OfficeBuilding.class, "doorCodes", Integer.class, byte[].class, "Wrong type in map attribute."
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11871")
+	@WithClasses({ Homework.class})
+	public void testJavaBeanAttributeNotOverwritten() {
+		assertAttributeTypeInMetaModelHasRawType( Homework.class, "paths", ListAttribute.class, "attribute type should be ListAttribute" );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/Homework.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.elementcollection;
+
+import javax.persistence.Entity;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Bogdan Știrbăț
+ */
+@Entity
+public class Homework {
+
+    private List<String> paths;
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public Set<String> getPaths(String startPath) {
+        TreeSet<String> result = new TreeSet<>();
+
+        if (paths == null) {
+            return result;
+        }
+
+        for (String path: paths) {
+            if (path.startsWith(startPath)) {
+                result.add(path);
+            }
+        }
+        return result;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
@@ -98,6 +98,18 @@ public class TestUtil {
 		);
 	}
 
+	public static void assertAttributeTypeInMetaModelHasRawType(Class<?> clazz, String fieldName, Class<?> expectedType, String errorString) {
+		Field field = getFieldFromMetamodelFor( clazz, fieldName );
+		assertNotNull( "Cannot find field '" + fieldName + "' in " + clazz.getName(), field );
+		ParameterizedType type = (ParameterizedType) field.getGenericType();
+		Type actualType = type.getRawType();
+		assertEquals(
+				"Types do not match: " + buildErrorString( errorString, clazz ),
+				expectedType,
+				actualType
+		);
+	}
+
 	public static void assertMapAttributesInMetaModelFor(Class<?> clazz, String fieldName, Class<?> expectedMapKey, Class<?> expectedMapValue, String errorString) {
 		Field field = getFieldFromMetamodelFor( clazz, fieldName );
 		assertNotNull( field );


### PR DESCRIPTION
In method `AnnotationMetaEntity.init()`, function call `ElementFilter.methodsIn( element.getEnclosedElements() );` returns all methods the Entity has. One method might not respect JavaBeans convention; but, if it's listed after an other one, with the same name, following the JavaBeans convention, will overwrite the 'good' function in the `members` map (method call `addPersistentMembers`)

I fixed the issue, by checking if a method respects the convention prior to it's addition to the map. I followed the JavaBeans conventions explained in [this document](http://docs.oracle.com/javaee/7/tutorial/persistence-intro001.htm#BNBQA) .