### PR TITLE
HHH-11897: Fix support for Tuple results for native queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
@@ -1222,11 +1222,15 @@ public class QueryTranslatorImpl extends BasicLoader implements FilterTranslator
 	public ScrollableResultsImplementor scroll(
 			final QueryParameters queryParameters,
 			final SharedSessionContractImplementor session) throws HibernateException {
-		HolderInstantiator hi = HolderInstantiator.createClassicHolderInstantiator(
+		return scroll( queryParameters, returnTypes, session );
+	}
+
+	@Override
+	protected HolderInstantiator getHolderInstantiator(QueryParameters queryParameters) {
+		return HolderInstantiator.createClassicHolderInstantiator(
 				holderConstructor,
 				queryParameters.getResultTransformer()
 		);
-		return scroll( queryParameters, returnTypes, hi, session );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryTupleTransformer.java
@@ -51,7 +51,13 @@ public class NativeQueryTupleTransformer extends BasicTransformerAdapter {
 		private Map<String, Object> aliasToValue = new LinkedHashMap<>();
 
 		public NativeTupleImpl(Object[] tuple, String[] aliases) {
-			if ( tuple == null || aliases == null || tuple.length != aliases.length ) {
+			if ( tuple == null ) {
+			    throw new HibernateException( "Tuple must not be null" );
+			}
+			if ( aliases == null ) {
+			    throw new HibernateException( "Aliases must not be null" );
+            }
+			if ( tuple.length != aliases.length ) {
 				throw new HibernateException( "Got different size of tuples and aliases" );
 			}
 			this.tuple = tuple;
@@ -106,12 +112,20 @@ public class NativeQueryTupleTransformer extends BasicTransformerAdapter {
 			List<TupleElement<?>> elements = new ArrayList<>( aliasToValue.size() );
 
 			for ( Map.Entry<String, Object> entry : aliasToValue.entrySet() ) {
-				elements.add( new NativeTupleElementImpl<>( entry.getValue().getClass(), entry.getKey() ) );
+				elements.add( new NativeTupleElementImpl<>(getValueClass(entry.getValue()), entry.getKey() ) );
 			}
 			return elements;
 		}
 
-		@Override
+        private Class<?> getValueClass(Object value) {
+            Class<?> valueClass = Object.class;
+            if ( value != null ) {
+                valueClass = value.getClass();
+            }
+            return valueClass;
+        }
+
+        @Override
 		public <X> X get(TupleElement<X> tupleElement) {
 			return get( tupleElement.getAlias(), tupleElement.getJavaType() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -2735,8 +2735,6 @@ public abstract class Loader {
 	 *
 	 * @param queryParameters The parameters with which the query should be executed.
 	 * @param returnTypes The expected return types of the query
-	 * @param holderInstantiator If the return values are expected to be wrapped
-	 * in a holder, this is the thing that knows how to wrap them.
 	 * @param session The session from which the scroll request originated.
 	 *
 	 * @return The ScrollableResults instance.
@@ -2747,7 +2745,6 @@ public abstract class Loader {
 	protected ScrollableResultsImplementor scroll(
 			final QueryParameters queryParameters,
 			final Type[] returnTypes,
-			final HolderInstantiator holderInstantiator,
 			final SharedSessionContractImplementor session) throws HibernateException {
 		checkScrollability();
 
@@ -2788,7 +2785,7 @@ public abstract class Loader {
 						this,
 						queryParameters,
 						returnTypes,
-						holderInstantiator
+						getHolderInstantiator(queryParameters)
 				);
 			}
 			else {
@@ -2799,7 +2796,7 @@ public abstract class Loader {
 						this,
 						queryParameters,
 						returnTypes,
-						holderInstantiator
+						getHolderInstantiator(queryParameters)
 				);
 			}
 
@@ -2812,6 +2809,10 @@ public abstract class Loader {
 			);
 		}
 
+	}
+
+	protected HolderInstantiator getHolderInstantiator(QueryParameters queryParameters) {
+		return null;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaLoader.java
@@ -101,7 +101,7 @@ public class CriteriaLoader extends OuterJoinLoader {
 			throws HibernateException {
 		QueryParameters qp = translator.getQueryParameters();
 		qp.setScrollMode( scrollMode );
-		return scroll( qp, resultTypes, null, session );
+		return scroll( qp, resultTypes, session );
 	}
 
 	public List list(SharedSessionContractImplementor session)

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/CustomLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/CustomLoader.java
@@ -373,9 +373,13 @@ public class CustomLoader extends Loader {
 		return scroll(
 				queryParameters,
 				resultTypes,
-				getHolderInstantiator( queryParameters.getResultTransformer(), getReturnAliasesForTransformer() ),
 				session
 		);
+	}
+
+	@Override
+	protected HolderInstantiator getHolderInstantiator(QueryParameters queryParameters) {
+		return getHolderInstantiator( queryParameters.getResultTransformer(), getReturnAliasesForTransformer() );
 	}
 
 	static private HolderInstantiator getHolderInstantiator(

--- a/hibernate-core/src/main/java/org/hibernate/loader/hql/QueryLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/hql/QueryLoader.java
@@ -571,9 +571,13 @@ public class QueryLoader extends BasicLoader {
 		return scroll(
 				queryParameters,
 				queryReturnTypes,
-				buildHolderInstantiator( queryParameters.getResultTransformer() ),
 				session
 		);
+	}
+
+	@Override
+	protected HolderInstantiator getHolderInstantiator(QueryParameters queryParameters) {
+		return buildHolderInstantiator( queryParameters.getResultTransformer() );
 	}
 
 	// -- Implementation private methods --

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TupleNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TupleNativeQueryTest.java
@@ -2,7 +2,9 @@ package org.hibernate.jpa.test.query;
 
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.query.spi.NativeQueryImplementor;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +13,7 @@ import javax.persistence.*;
 import javax.persistence.criteria.CriteriaDelete;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertArrayEquals;
@@ -131,7 +134,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
         });
     }
 
-
+    @Test
     public void testAliasGetterShouldWorkWithoutExplicitAliasWhenLowerCaseAliasGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
             List<Tuple> result = getTupleResult(entityManager);
@@ -205,7 +208,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testPositionalGetterWithNamedNativeQueryShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get(0));
             assertEquals("Arnold", tuple.get(1));
@@ -215,7 +218,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testPositionalGetterWithNamedNativeQueryWithClassShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get(0, BigInteger.class));
             assertEquals("Arnold", tuple.get(1, String.class));
@@ -226,7 +229,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenLessThanZeroGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(-1);
         });
@@ -236,7 +239,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenLessThanZeroGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(-1);
         });
@@ -246,7 +249,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenTupleSizePositionGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(2);
         });
@@ -256,7 +259,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenTupleSizePositionGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(2);
         });
@@ -266,7 +269,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenExceedingPositionGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(3);
         });
@@ -276,7 +279,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenExceedingPositionGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get(3);
         });
@@ -286,17 +289,17 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testAliasGetterWithNamedNativeQueryWithoutExplicitAliasShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get("ID"));
             assertEquals("Arnold", tuple.get("FIRSTNAME"));
         });
     }
 
-
+    @Test
     public void testAliasGetterWithNamedNativeQueryShouldWorkWithoutExplicitAliasWhenLowerCaseAliasGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get("id");
         });
@@ -305,7 +308,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testAliasGetterWithNamedNativeQueryShouldThrowExceptionWithoutExplicitAliasWhenWrongAliasGiven() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             tuple.get("e");
         });
@@ -314,7 +317,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testAliasGetterWithNamedNativeQueryWithClassWithoutExplicitAliasShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get("ID", BigInteger.class));
             assertEquals("Arnold", tuple.get("FIRSTNAME", String.class));
@@ -325,7 +328,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testAliasGetterWithNamedNativeQueryWithExplicitAliasShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard_with_alias", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard_with_alias");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get("ALIAS1"));
             assertEquals("Arnold", tuple.get("ALIAS2"));
@@ -335,7 +338,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testAliasGetterWithNamedNativeQueryWithClassWithExplicitAliasShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> result = entityManager.createNamedQuery("standard_with_alias", Tuple.class).getResultList();
+            List<Tuple> result = getTupleNamedResult(entityManager, "standard_with_alias");
             Tuple tuple = result.get(0);
             assertEquals(BigInteger.ONE, tuple.get("ALIAS1", BigInteger.class));
             assertEquals("Arnold", tuple.get("ALIAS2", String.class));
@@ -345,7 +348,7 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testToArrayShouldWithNamedNativeQueryWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> tuples = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> tuples = getTupleNamedResult(entityManager, "standard");
             Object[] result = tuples.get(0).toArray();
             assertArrayEquals(new Object[]{BigInteger.ONE, "Arnold"}, result);
         });
@@ -354,12 +357,354 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
     @Test
     public void testGetElementsWithNamedNativeQueryShouldWorkProperly() {
         doInJPA(this::entityManagerFactory, entityManager -> {
-            List<Tuple> tuples = entityManager.createNamedQuery("standard", Tuple.class).getResultList();
+            List<Tuple> tuples = getTupleNamedResult(entityManager, "standard");
             List<TupleElement<?>> result = tuples.get(0).getElements();
             assertEquals(2, result.size());
             assertEquals(BigInteger.class, result.get(0).getJavaType());
             assertEquals("id", result.get(0).getAlias());
             assertEquals(String.class, result.get(1).getJavaType());
+            assertEquals("firstname", result.get(1).getAlias());
+        });
+    }
+
+    @Test
+    public void testStreamedPositionalGetterShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0));
+            assertEquals("Arnold", tuple.get(1));
+        });
+    }
+
+    @Test
+    public void testStreamedPositionalGetterWithClassShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0, BigInteger.class));
+            assertEquals("Arnold", tuple.get(1, String.class));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithClassShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithClassShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithClassShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test
+    public void testStreamedAliasGetterWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID"));
+            assertEquals("Arnold", tuple.get("FIRSTNAME"));
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterShouldWorkWithoutExplicitAliasWhenLowerCaseAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get("id");
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedAliasGetterShouldThrowExceptionWithoutExplicitAliasWhenWrongAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            tuple.get("e");
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterWithClassWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedTupleResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID", BigInteger.class));
+            assertEquals("Arnold", tuple.get("FIRSTNAME", String.class));
+        });
+    }
+
+
+    @Test
+    public void testStreamedAliasGetterWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleAliasedResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1"));
+            assertEquals("Arnold", tuple.get("ALIAS2"));
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterWithClassWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getTupleAliasedResult(entityManager);
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1", BigInteger.class));
+            assertEquals("Arnold", tuple.get("ALIAS2", String.class));
+        });
+    }
+
+    @Test
+    public void testStreamedToArrayShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getStreamedTupleResult(entityManager);
+            Object[] result = tuples.get(0).toArray();
+            assertArrayEquals(new Object[]{BigInteger.ONE, "Arnold"}, result);
+        });
+    }
+
+    @Test
+    public void testStreamedGetElementsShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getStreamedTupleResult(entityManager);
+            List<TupleElement<?>> result = tuples.get(0).getElements();
+            assertEquals(2, result.size());
+            assertEquals(BigInteger.class, result.get(0).getJavaType());
+            assertEquals("id", result.get(0).getAlias());
+            assertEquals(String.class, result.get(1).getJavaType());
+            assertEquals("firstname", result.get(1).getAlias());
+        });
+    }
+
+    @Test
+    public void testStreamedPositionalGetterWithNamedNativeQueryShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0));
+            assertEquals("Arnold", tuple.get(1));
+        });
+    }
+
+    @Test
+    public void testStreamedPositionalGetterWithNamedNativeQueryWithClassShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get(0, BigInteger.class));
+            assertEquals("Arnold", tuple.get(1, String.class));
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenLessThanZeroGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(-1);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenTupleSizePositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(2);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedPositionalGetterWithNamedNativeQueryWithClassShouldThrowExceptionWhenExceedingPositionGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get(3);
+        });
+    }
+
+
+    @Test
+    public void testStreamedAliasGetterWithNamedNativeQueryWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID"));
+            assertEquals("Arnold", tuple.get("FIRSTNAME"));
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterWithNamedNativeQueryShouldWorkWithoutExplicitAliasWhenLowerCaseAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get("id");
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStreamedAliasGetterWithNamedNativeQueryShouldThrowExceptionWithoutExplicitAliasWhenWrongAliasGiven() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            tuple.get("e");
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterWithNamedNativeQueryWithClassWithoutExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ID", BigInteger.class));
+            assertEquals("Arnold", tuple.get("FIRSTNAME", String.class));
+        });
+    }
+
+
+    @Test
+    public void testStreamedAliasGetterWithNamedNativeQueryWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard_with_alias");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1"));
+            assertEquals("Arnold", tuple.get("ALIAS2"));
+        });
+    }
+
+    @Test
+    public void testStreamedAliasGetterWithNamedNativeQueryWithClassWithExplicitAliasShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> result = getStreamedNamedTupleResult(entityManager, "standard_with_alias");
+            Tuple tuple = result.get(0);
+            assertEquals(BigInteger.ONE, tuple.get("ALIAS1", BigInteger.class));
+            assertEquals("Arnold", tuple.get("ALIAS2", String.class));
+        });
+    }
+
+    @Test
+    public void testStreamedToArrayShouldWithNamedNativeQueryWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getStreamedNamedTupleResult(entityManager, "standard");
+            Object[] result = tuples.get(0).toArray();
+            assertArrayEquals(new Object[]{BigInteger.ONE, "Arnold"}, result);
+        });
+    }
+
+    @Test
+    public void testStreamedGetElementsWithNamedNativeQueryShouldWorkProperly() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getStreamedNamedTupleResult(entityManager, "standard");
+            List<TupleElement<?>> result = tuples.get(0).getElements();
+            assertEquals(2, result.size());
+            assertEquals(BigInteger.class, result.get(0).getJavaType());
+            assertEquals("id", result.get(0).getAlias());
+            assertEquals(String.class, result.get(1).getJavaType());
+            assertEquals("firstname", result.get(1).getAlias());
+        });
+    }
+
+    @Test
+    @TestForIssue(jiraKey = "HHH-11897")
+    public void testGetElementsShouldNotThrowExceptionWhenResultContainsNullValue() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            User user = entityManager.find(User.class, 1L);
+            user.firstName = null;
+        });
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            List<Tuple> tuples = getTupleResult(entityManager);
+            List<TupleElement<?>> result = tuples.get(0).getElements();
+            assertEquals(2, result.size());
+            assertEquals(BigInteger.class, result.get(0).getJavaType());
+            assertEquals("id", result.get(0).getAlias());
+            assertEquals(Object.class, result.get(1).getJavaType());
             assertEquals("firstname", result.get(1).getAlias());
         });
     }
@@ -370,11 +715,32 @@ public class TupleNativeQueryTest extends BaseEntityManagerFunctionalTestCase {
         return (List<Tuple>) query.getResultList();
     }
 
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getStreamedTupleAliasedResult(EntityManager entityManager) {
+        NativeQueryImplementor query = (NativeQueryImplementor) entityManager.createNativeQuery("SELECT id AS alias1, firstname AS alias2 FROM users", Tuple.class);
+        return (List<Tuple>) query.stream().collect(Collectors.toList());
+    }
 
     @SuppressWarnings("unchecked")
     private List<Tuple> getTupleResult(EntityManager entityManager) {
         Query query = entityManager.createNativeQuery("SELECT id, firstname FROM users", Tuple.class);
         return (List<Tuple>) query.getResultList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getTupleNamedResult(EntityManager entityManager, String name) {
+        return entityManager.createNamedQuery(name, Tuple.class).getResultList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getStreamedTupleResult(EntityManager entityManager) {
+        NativeQueryImplementor query = (NativeQueryImplementor) entityManager.createNativeQuery("SELECT id, firstname FROM users", Tuple.class);
+        return (List<Tuple>) query.stream().collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Tuple> getStreamedNamedTupleResult(EntityManager entityManager, String name) {
+        return (List<Tuple>)((NativeQueryImplementor) entityManager.createNamedQuery(name, Tuple.class)).stream().collect(Collectors.toList());
     }
 
     @Entity


### PR DESCRIPTION
Added couple more tests to verify the stream() behavior as well as the NPE bug.

I'm a bit unsure if the change in the Loader class (removing a method parameter and introducing the protected method) is appropriate or not, I'm open for discussion on that area. 