### PR TITLE
HHH-11539 - when foreignKey is added to an @JoinColumn, and not @CollectionTable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -1134,6 +1134,11 @@ public abstract class CollectionBinder {
 					else {
 						key.setForeignKeyName( StringHelper.nullIfEmpty( collectionTableAnn.foreignKey().name() ) );
 						key.setForeignKeyDefinition( StringHelper.nullIfEmpty( collectionTableAnn.foreignKey().foreignKeyDefinition() ) );
+						if (key.getForeignKeyName() == null && key.getForeignKeyDefinition() == null
+								&& collectionTableAnn.joinColumns() != null && collectionTableAnn.joinColumns().length == 1) {
+							key.setForeignKeyName( StringHelper.nullIfEmpty( collectionTableAnn.joinColumns()[0].foreignKey().name() ) );
+							key.setForeignKeyDefinition( StringHelper.nullIfEmpty( collectionTableAnn.joinColumns()[0].foreignKey().foreignKeyDefinition() ) );
+						}
 					}
 				}
 				else {

--- a/hibernate-core/src/test/java/org/hibernate/test/constraint/ForeignKeyConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/constraint/ForeignKeyConstraintTest.java
@@ -27,6 +27,7 @@ import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
@@ -73,7 +74,9 @@ public class ForeignKeyConstraintTest extends BaseNonConfigCoreFunctionalTestCas
 				VehicleBuyInfo.class,
 				Car.class,
 				Truck.class,
-				Company.class
+				Company.class,
+				PlanItem.class,
+				Task.class
 		};
 	}
 
@@ -130,6 +133,16 @@ public class ForeignKeyConstraintTest extends BaseNonConfigCoreFunctionalTestCas
 	@Test
 	public void testMapKeyJoinColumns() {
 		assertForeignKey( "FK_VEHICLE_BUY_INFOS_VEHICLE", "VEHICLE_NR", "VEHICLE_VENDOR_NR" );
+	}
+
+	@Test
+	public void testMapForeignKeyJoinColumnColection() {
+		assertForeignKey( "FK_PROPERTIES_TASK", "task_id" );
+	}
+
+	@Test
+	public void testMapForeignKeyColection() {
+		assertForeignKey( "FK_ATTRIBUTES_TASK", "task_id" );
 	}
 
 	@Test
@@ -505,5 +518,82 @@ public class ForeignKeyConstraintTest extends BaseNonConfigCoreFunctionalTestCas
 				)
 		})
 		public CompanyInfo info;
+	}
+
+	@Entity
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	public abstract class PlanItem {
+
+		@Id
+		@GeneratedValue(strategy= GenerationType.IDENTITY)
+		private Integer id;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	@Entity
+	@SecondaryTable( name = "Task" )
+	public class Task extends PlanItem {
+		@Id
+		@GeneratedValue(strategy=GenerationType.IDENTITY)
+		private Integer id;
+
+		@ElementCollection
+		@CollectionTable(
+				name = "task_properties",
+				joinColumns = {
+						@JoinColumn(
+								name = "task_id",
+								foreignKey = @ForeignKey(
+										name = "FK_PROPERTIES_TASK",
+										foreignKeyDefinition = "FOREIGN KEY (task_id) REFERENCES Task"
+								)
+						)
+				}
+		)
+		private Set<String> properties;
+
+		@ElementCollection
+		@CollectionTable(
+				name = "task_attributes",
+				joinColumns = {@JoinColumn(name = "task_id")},
+				foreignKey = @ForeignKey(
+						name = "FK_ATTRIBUTES_TASK",
+						foreignKeyDefinition = "FOREIGN KEY (task_id) REFERENCES Task"
+				)
+		)
+		private Set<String> attributes;
+
+		@Override
+		public Integer getId() {
+			return id;
+		}
+
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Set<String> getProperties() {
+			return properties;
+		}
+
+		public void setProperties(Set<String> properties) {
+			this.properties = properties;
+		}
+
+		public Set<String> getAttributes() {
+			return attributes;
+		}
+
+		public void setAttributes(Set<String> attributes) {
+			this.attributes = attributes;
+		}
 	}
 }


### PR DESCRIPTION
Hi!

Issue [HHH-11539](https://hibernate.atlassian.net/browse/HHH-11539) links a [stackoverflow question](https://stackoverflow.com/questions/42505035/hibernate-point-foreign-key-to-secondary-table) .

In the question's example, a foreignKey is added to an JoinColumn, and not CollectionTable (please, see tests provided with this PR) . That foreignKey element was ignored; the desired behavior was reached when the foreignKey was added to the CollectionTable directly. 

I added a change, so when an CollectionTable has no foreignKey, but has an joinColumns element with one JoinColumn, that has an foreignKey, consider this element.