### PR TITLE
HHH-11895 Support traversal of components in audit queries

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
@@ -813,7 +813,7 @@ public final class CollectionMetadataGenerator {
 	}
 
 	private void storeMiddleEntityRelationInformation(String mappedBy, MiddleIdData referencingIdData, String referencedPrefix, String auditMiddleEntityName) {
-		// Only if this is a relation (when there is a referenced entity).
+		// Only if this is a relation (when there is a referenced entity or a component).
 		if ( referencedEntityName != null ) {
 			final IdMappingData referencedIdMapping = mainGenerator.getReferencedIdMappingData(
 					referencingEntityName,
@@ -842,6 +842,9 @@ public final class CollectionMetadataGenerator {
 						referencedIdData,
 						auditMiddleEntityName );
 			}
+		}
+		else {
+			referencingEntityConfiguration.addToManyComponent( propertyName, auditMiddleEntityName, referencingIdData );
 		}
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
@@ -499,7 +499,7 @@ public final class CollectionMetadataGenerator {
 		// ******
 		// Storing information about this relation.
 		// ******
-		storeMiddleEntityRelationInformation( mappedBy );
+		storeMiddleEntityRelationInformation( mappedBy, referencingIdData, referencedPrefix, auditMiddleEntityName );
 	}
 
 	private MiddleComponentData addIndex(Element middleEntityXml, QueryGeneratorBuilder queryGeneratorBuilder) {
@@ -812,18 +812,35 @@ public final class CollectionMetadataGenerator {
 		}
 	}
 
-	private void storeMiddleEntityRelationInformation(String mappedBy) {
+	private void storeMiddleEntityRelationInformation(String mappedBy, MiddleIdData referencingIdData, String referencedPrefix, String auditMiddleEntityName) {
 		// Only if this is a relation (when there is a referenced entity).
 		if ( referencedEntityName != null ) {
+			final IdMappingData referencedIdMapping = mainGenerator.getReferencedIdMappingData(
+					referencingEntityName,
+					referencedEntityName,
+					propertyAuditingData,
+					true );
+			final MiddleIdData referencedIdData = createMiddleIdData(
+					referencedIdMapping,
+					referencedPrefix + "_",
+					referencedEntityName );
 			if ( propertyValue.isInverse() ) {
 				referencingEntityConfiguration.addToManyMiddleNotOwningRelation(
 						propertyName,
 						mappedBy,
-						referencedEntityName
+						referencedEntityName,
+						referencingIdData,
+						referencedIdData,
+						auditMiddleEntityName
 				);
 			}
 			else {
-				referencingEntityConfiguration.addToManyMiddleRelation( propertyName, referencedEntityName );
+				referencingEntityConfiguration.addToManyMiddleRelation(
+						propertyName,
+						referencedEntityName,
+						referencingIdData,
+						referencedIdData,
+						auditMiddleEntityName );
 			}
 		}
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.envers.configuration.internal.metadata.reader.ComponentAuditingData;
 import org.hibernate.envers.configuration.internal.metadata.reader.PropertyAuditingData;
+import org.hibernate.envers.internal.entities.EntityConfiguration;
 import org.hibernate.envers.internal.entities.mapper.CompositeMapperBuilder;
 import org.hibernate.envers.internal.tools.ReflectionTools;
 import org.hibernate.mapping.Component;
@@ -76,6 +77,11 @@ public final class ComponentMetadataGenerator {
 						componentPropertyAuditingData, property.isInsertable(), firstPass, false
 				);
 			}
+		}
+
+		if ( !firstPass ) {
+			final EntityConfiguration owningEntityConfiguration = mainGenerator.getEntitiesConfigurations().get( entityName );
+			owningEntityConfiguration.addToOneComponent( propertyAuditingData.getName(), componentAuditingData );
 		}
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/ComponentDescription.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/ComponentDescription.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities;
+
+import org.hibernate.envers.configuration.internal.metadata.reader.ComponentAuditingData;
+import org.hibernate.envers.internal.entities.mapper.relation.MiddleIdData;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class ComponentDescription {
+
+	private final ComponentType type;
+	private final String propertyName;
+	private final String auditMiddleEntityName;
+	private final MiddleIdData middleIdData;
+	private final ComponentAuditingData auditingData;
+
+	private ComponentDescription(ComponentType type,
+			String propertyName,
+			String auditMiddleEntityName,
+			MiddleIdData middleIdData,
+			ComponentAuditingData componentAuditingData) {
+		this.type = type;
+		this.propertyName = propertyName;
+		this.auditMiddleEntityName = auditMiddleEntityName;
+		this.middleIdData = middleIdData;
+		this.auditingData = componentAuditingData;
+	}
+
+	public static ComponentDescription many(final String propertyName, final String auditMiddleEntityName, final MiddleIdData middleIdData) {
+		return new ComponentDescription( ComponentType.MANY, propertyName, auditMiddleEntityName, middleIdData, null );
+	}
+
+	public static ComponentDescription one(final String propertyName, final ComponentAuditingData componentAuditingData) {
+		return new ComponentDescription( ComponentType.ONE, propertyName, null, null, componentAuditingData );
+	}
+
+	public ComponentType getType() {
+		return type;
+	}
+
+	public String getPropertyName() {
+		return propertyName;
+	}
+
+	public String getAuditMiddleEntityName() {
+		return auditMiddleEntityName;
+	}
+
+	public MiddleIdData getMiddleIdData() {
+		return middleIdData;
+	}
+
+	public ComponentAuditingData getAuditingData() {
+		return auditingData;
+	}
+
+	public enum ComponentType {
+		ONE, MANY
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntitiesConfigurations.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntitiesConfigurations.java
@@ -124,6 +124,27 @@ public class EntitiesConfigurations {
 		return descriptions;
 	}
 
+	public ComponentDescription getComponentDescription(final String entityName, final String propertyName) {
+		final EntityConfiguration entCfg;
+		if ( isVersioned( entityName ) ) {
+			entCfg = get( entityName );
+		}
+		else {
+			entCfg = getNotVersionEntityConfiguration( entityName );
+		}
+		final ComponentDescription relDesc = entCfg.getComponentDescription( propertyName );
+		if ( relDesc != null ) {
+			return relDesc;
+		}
+		else if ( entCfg.getParentEntityName() != null ) {
+			// The field may be declared in a superclass ...
+			return getComponentDescription( entCfg.getParentEntityName(), propertyName );
+		}
+		else {
+			return null;
+		}
+	}
+
 	private void addWithParentEntityNames(String entityName, Set<String> entityNames) {
 		entityNames.add( entityName );
 		final EntityConfiguration entCfg = entitiesConfigurations.get( entityName );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntityConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntityConfiguration.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.hibernate.envers.internal.entities.mapper.ExtendedPropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.PropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.id.IdMapper;
+import org.hibernate.envers.internal.entities.mapper.relation.MiddleIdData;
 
 /**
  * @author Adam Warski (adam at warski dot org)
@@ -87,26 +88,29 @@ public class EntityConfiguration {
 				fromPropertyName,
 				RelationDescription.toMany(
 						fromPropertyName, RelationType.TO_MANY_NOT_OWNING, toEntityName, mappedByPropertyName,
-						idMapper, fakeBidirectionalRelationMapper, fakeBidirectionalRelationIndexMapper, true, indexed
+						idMapper, fakeBidirectionalRelationMapper, fakeBidirectionalRelationIndexMapper, null, null, null, true, indexed
 				)
 		);
 	}
 
-	public void addToManyMiddleRelation(String fromPropertyName, String toEntityName) {
+	public void addToManyMiddleRelation(String fromPropertyName, String toEntityName, MiddleIdData referencingIdData, MiddleIdData referencedIdData,
+			String auditMiddleEntityName) {
 		relations.put(
 				fromPropertyName,
 				RelationDescription.toMany(
-						fromPropertyName, RelationType.TO_MANY_MIDDLE, toEntityName, null, null, null, null, true, false
+						fromPropertyName, RelationType.TO_MANY_MIDDLE, toEntityName, null, null, null, null, referencingIdData, referencedIdData,
+						auditMiddleEntityName, true, false
 				)
 		);
 	}
 
-	public void addToManyMiddleNotOwningRelation(String fromPropertyName, String mappedByPropertyName, String toEntityName) {
+	public void addToManyMiddleNotOwningRelation(String fromPropertyName, String mappedByPropertyName, String toEntityName, MiddleIdData referencingIdData,
+			MiddleIdData referencedIdData, String auditMiddleEntityName) {
 		relations.put(
 				fromPropertyName,
 				RelationDescription.toMany(
 						fromPropertyName, RelationType.TO_MANY_MIDDLE_NOT_OWNING, toEntityName, mappedByPropertyName,
-						null, null, null, true, false
+						null, null, null, referencingIdData, referencedIdData, auditMiddleEntityName, true, false
 				)
 		);
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntityConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/EntityConfiguration.java
@@ -9,6 +9,7 @@ package org.hibernate.envers.internal.entities;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.envers.configuration.internal.metadata.reader.ComponentAuditingData;
 import org.hibernate.envers.internal.entities.mapper.ExtendedPropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.PropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.id.IdMapper;
@@ -29,6 +30,7 @@ public class EntityConfiguration {
 	private ExtendedPropertyMapper propertyMapper;
 	// Maps from property name
 	private Map<String, RelationDescription> relations;
+	private Map<String, ComponentDescription> components;
 	private String parentEntityName;
 
 	public EntityConfiguration(
@@ -44,6 +46,7 @@ public class EntityConfiguration {
 		this.parentEntityName = parentEntityName;
 
 		this.relations = new HashMap<>();
+		this.components = new HashMap<>();
 	}
 
 	public void addToOneRelation(
@@ -115,12 +118,24 @@ public class EntityConfiguration {
 		);
 	}
 
+	public void addToManyComponent(String propertyName, String auditMiddleEntityName, MiddleIdData middleIdData) {
+		components.put( propertyName, ComponentDescription.many( propertyName, auditMiddleEntityName, middleIdData ) );
+	}
+
+	public void addToOneComponent(String propertyName, ComponentAuditingData auditingData) {
+		components.put( propertyName, ComponentDescription.one( propertyName, auditingData ) );
+	}
+
 	public boolean isRelation(String propertyName) {
 		return relations.get( propertyName ) != null;
 	}
 
 	public RelationDescription getRelationDescription(String propertyName) {
 		return relations.get( propertyName );
+	}
+
+	public ComponentDescription getComponentDescription(String propertyName) {
+		return components.get( propertyName );
 	}
 
 	public IdMappingData getIdMappingData() {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RelationDescription.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RelationDescription.java
@@ -8,6 +8,7 @@ package org.hibernate.envers.internal.entities;
 
 import org.hibernate.envers.internal.entities.mapper.PropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.id.IdMapper;
+import org.hibernate.envers.internal.entities.mapper.relation.MiddleIdData;
 
 /**
  * @author Adam Warski (adam at warski dot org)
@@ -22,6 +23,9 @@ public class RelationDescription {
 	private final IdMapper idMapper;
 	private final PropertyMapper fakeBidirectionalRelationMapper;
 	private final PropertyMapper fakeBidirectionalRelationIndexMapper;
+	private final MiddleIdData referencingIdData;
+	private final MiddleIdData referencedIdData;
+	private final String auditMiddleEntityName;
 	private final boolean insertable;
 	private final boolean indexed;
 	private boolean bidirectional;
@@ -38,7 +42,7 @@ public class RelationDescription {
 			boolean ignoreNotFound) {
 		return new RelationDescription(
 				fromPropertyName, relationType, toEntityName, mappedByPropertyName, idMapper,
-				fakeBidirectionalRelationMapper, fakeBidirectionalRelationIndexMapper, insertable, ignoreNotFound, false
+				fakeBidirectionalRelationMapper, fakeBidirectionalRelationIndexMapper, null, null, null, insertable, ignoreNotFound, false
 		);
 	}
 
@@ -50,6 +54,9 @@ public class RelationDescription {
 			IdMapper idMapper,
 			PropertyMapper fakeBidirectionalRelationMapper,
 			PropertyMapper fakeBidirectionalRelationIndexMapper,
+			MiddleIdData referencingIdData,
+			MiddleIdData referencedIdData,
+			String auditMiddleEntityName,
 			boolean insertable,
 			boolean indexed) {
 		// Envers populates collections by executing dedicated queries. Special handling of
@@ -58,7 +65,7 @@ public class RelationDescription {
 		// Therefore assigning false to ignoreNotFound.
 		return new RelationDescription(
 				fromPropertyName, relationType, toEntityName, mappedByPropertyName, idMapper, fakeBidirectionalRelationMapper,
-				fakeBidirectionalRelationIndexMapper, insertable, false, indexed
+				fakeBidirectionalRelationIndexMapper, referencingIdData, referencedIdData, auditMiddleEntityName, insertable, false, indexed
 		);
 	}
 
@@ -70,6 +77,9 @@ public class RelationDescription {
 			IdMapper idMapper,
 			PropertyMapper fakeBidirectionalRelationMapper,
 			PropertyMapper fakeBidirectionalRelationIndexMapper,
+			MiddleIdData referencingIdData,
+			MiddleIdData referencedIdData,
+			String auditMiddleEntityName,
 			boolean insertable,
 			boolean ignoreNotFound,
 			boolean indexed) {
@@ -81,6 +91,9 @@ public class RelationDescription {
 		this.idMapper = idMapper;
 		this.fakeBidirectionalRelationMapper = fakeBidirectionalRelationMapper;
 		this.fakeBidirectionalRelationIndexMapper = fakeBidirectionalRelationIndexMapper;
+		this.referencingIdData = referencingIdData;
+		this.referencedIdData = referencedIdData;
+		this.auditMiddleEntityName = auditMiddleEntityName;
 		this.insertable = insertable;
 		this.indexed = indexed;
 		this.bidirectional = false;
@@ -116,6 +129,18 @@ public class RelationDescription {
 
 	public PropertyMapper getFakeBidirectionalRelationIndexMapper() {
 		return fakeBidirectionalRelationIndexMapper;
+	}
+
+	public MiddleIdData getReferencingIdData() {
+		return referencingIdData;
+	}
+
+	public MiddleIdData getReferencedIdData() {
+		return referencedIdData;
+	}
+
+	public String getAuditMiddleEntityName() {
+		return auditMiddleEntityName;
 	}
 
 	public boolean isInsertable() {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
@@ -308,10 +308,10 @@ public class Parameters {
 		sub2.addNullRestriction( right, false );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, AuditFunction function, String op, Object value) {
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function, String op, Object value) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
 
 		expression.append( ' ' ).append( op );
 
@@ -322,10 +322,11 @@ public class Parameters {
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, AuditFunction function, String op, String aliasRight, String right) {
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function, String op,
+			String aliasRight, String right) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
@@ -337,7 +338,8 @@ public class Parameters {
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, String aliasLeft, String left, String op, AuditFunction function) {
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, String aliasLeft, String left, String op,
+			AuditFunction function) {
 		final StringBuilder expression = new StringBuilder();
 
 		if ( aliasLeft != null ) {
@@ -347,19 +349,20 @@ public class Parameters {
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
-		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
 
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, AuditFunction left, String op, AuditFunction right) {
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction left, String op,
+			AuditFunction right) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, left );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, left );
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
-		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, right );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, right );
 
 		expressions.add( expression.toString() );
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
@@ -11,8 +11,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.tools.MutableBoolean;
 import org.hibernate.envers.internal.tools.MutableInteger;
+import org.hibernate.envers.query.criteria.AuditFunction;
 
 /**
  * Parameters of a query, built using {@link QueryBuilder}.
@@ -304,6 +306,62 @@ public class Parameters {
 		final Parameters sub2 = sub1.addSubParameters( "and" );
 		sub2.addNullRestriction( left, false );
 		sub2.addNullRestriction( right, false );
+	}
+
+	public void addWhereWithFunction(EnversService enversService, AuditFunction function, String op, Object value) {
+		final StringBuilder expression = new StringBuilder();
+
+		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+
+		expression.append( ' ' ).append( op );
+
+		String queryParam = generateQueryParam();
+		localQueryParamValues.put( queryParam, value );
+		expression.append( ' ' ).append( ':' ).append( queryParam );
+
+		expressions.add( expression.toString() );
+	}
+
+	public void addWhereWithFunction(EnversService enversService, AuditFunction function, String op, String aliasRight, String right) {
+		final StringBuilder expression = new StringBuilder();
+
+		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+
+		expression.append( ' ' ).append( op ).append( ' ' );
+
+		if ( aliasRight != null ) {
+			expression.append( aliasRight ).append( '.' );
+		}
+		expression.append( right );
+
+		expressions.add( expression.toString() );
+	}
+
+	public void addWhereWithFunction(EnversService enversService, String aliasLeft, String left, String op, AuditFunction function) {
+		final StringBuilder expression = new StringBuilder();
+
+		if ( aliasLeft != null ) {
+			expression.append( aliasLeft ).append( '.' );
+		}
+		expression.append( left );
+
+		expression.append( ' ' ).append( op ).append( ' ' );
+
+		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, function );
+
+		expressions.add( expression.toString() );
+	}
+
+	public void addWhereWithFunction(EnversService enversService, AuditFunction left, String op, AuditFunction right) {
+		final StringBuilder expression = new StringBuilder();
+
+		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, left );
+
+		expression.append( ' ' ).append( op ).append( ' ' );
+
+		QueryBuilder.appendFunctionArgument( enversService, queryParamCounter, localQueryParamValues, alias, expression, right );
+
+		expressions.add( expression.toString() );
 	}
 
 	private void append(StringBuilder sb, String toAppend, MutableBoolean isFirst) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/Parameters.java
@@ -308,10 +308,12 @@ public class Parameters {
 		sub2.addNullRestriction( right, false );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function, String op, Object value) {
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap,
+			AuditFunction function, String op, Object value) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, queryParamCounter, localQueryParamValues,
+				alias, expression, function );
 
 		expression.append( ' ' ).append( op );
 
@@ -322,11 +324,13 @@ public class Parameters {
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function, String op,
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap,
+			AuditFunction function, String op,
 			String aliasRight, String right) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, queryParamCounter, localQueryParamValues,
+				alias, expression, function );
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
@@ -338,7 +342,8 @@ public class Parameters {
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, String aliasLeft, String left, String op,
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap,
+			String aliasLeft, String left, String op,
 			AuditFunction function) {
 		final StringBuilder expression = new StringBuilder();
 
@@ -349,20 +354,24 @@ public class Parameters {
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
-		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, function );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, queryParamCounter, localQueryParamValues,
+				alias, expression, function );
 
 		expressions.add( expression.toString() );
 	}
 
-	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction left, String op,
+	public void addWhereWithFunction(EnversService enversService, Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap,
+			AuditFunction left, String op,
 			AuditFunction right) {
 		final StringBuilder expression = new StringBuilder();
 
-		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, left );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, queryParamCounter, localQueryParamValues,
+				alias, expression, left );
 
 		expression.append( ' ' ).append( op ).append( ' ' );
 
-		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, queryParamCounter, localQueryParamValues, alias, expression, right );
+		QueryBuilder.appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, queryParamCounter, localQueryParamValues,
+				alias, expression, right );
 
 		expressions.add( expression.toString() );
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
@@ -26,6 +26,7 @@ import org.hibernate.envers.internal.tools.Triple;
 import org.hibernate.envers.query.criteria.AuditFunction;
 import org.hibernate.envers.query.criteria.AuditId;
 import org.hibernate.envers.query.criteria.AuditProperty;
+import org.hibernate.envers.query.criteria.internal.CriteriaTools;
 import org.hibernate.query.Query;
 import org.hibernate.type.CustomType;
 
@@ -182,13 +183,16 @@ public class QueryBuilder {
 		}
 	}
 
-	public void addProjection(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function) {
+	public void addProjection(EnversService enversService, Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap,
+			AuditFunction function) {
 		final StringBuilder expression = new StringBuilder();
-		appendFunctionArgument( enversService, aliasToEntityNameMap, paramCounter, projectionQueryParamValues, alias, expression, function );
+		appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, paramCounter, projectionQueryParamValues, alias,
+				expression, function );
 		projections.add( expression.toString() );
 	}
 
-	protected static void appendFunctionArgument(EnversService enversService, Map<String, String> aliasToEntityNameMap, MutableInteger paramCounter,
+	protected static void appendFunctionArgument(EnversService enversService, Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap, MutableInteger paramCounter,
 			Map<String, Object> queryParamValues, String alias,
 			StringBuilder expression, Object argument) {
 		if ( argument instanceof AuditFunction ) {
@@ -199,7 +203,8 @@ public class QueryBuilder {
 				if ( !first ) {
 					expression.append( ',' );
 				}
-				appendFunctionArgument( enversService, aliasToEntityNameMap, paramCounter, queryParamValues, alias, expression, innerArg );
+				appendFunctionArgument( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, paramCounter, queryParamValues, alias, expression,
+						innerArg );
 				first = false;
 			}
 			expression.append( ')' );
@@ -232,8 +237,10 @@ public class QueryBuilder {
 			if ( propertyAlias != null ) {
 				expression.append( propertyAlias ).append( '.' );
 			}
+			String propertyPrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+					propertyAlias );
 			String propertyName = property.getPropertyNameGetter().get( enversService );
-			expression.append( propertyName );
+			expression.append( propertyPrefix.concat( propertyName ) );
 		}
 		else {
 			String queryParam = "_p" + paramCounter.getAndIncrease();

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
@@ -14,14 +14,17 @@ import java.util.Map;
 
 import javax.persistence.criteria.JoinType;
 
+import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.RevisionTypeType;
+import org.hibernate.envers.internal.entities.mapper.id.QueryParameterData;
 import org.hibernate.envers.internal.tools.MutableInteger;
 import org.hibernate.envers.internal.tools.StringTools;
 import org.hibernate.envers.internal.tools.Triple;
 import org.hibernate.envers.query.criteria.AuditFunction;
+import org.hibernate.envers.query.criteria.AuditId;
 import org.hibernate.envers.query.criteria.AuditProperty;
 import org.hibernate.query.Query;
 import org.hibernate.type.CustomType;
@@ -179,13 +182,14 @@ public class QueryBuilder {
 		}
 	}
 
-	public void addProjection(EnversService enversService, AuditFunction function) {
+	public void addProjection(EnversService enversService, Map<String, String> aliasToEntityNameMap, AuditFunction function) {
 		final StringBuilder expression = new StringBuilder();
-		appendFunctionArgument( enversService, paramCounter, projectionQueryParamValues, alias, expression, function );
+		appendFunctionArgument( enversService, aliasToEntityNameMap, paramCounter, projectionQueryParamValues, alias, expression, function );
 		projections.add( expression.toString() );
 	}
 
-	protected static void appendFunctionArgument(EnversService enversService, MutableInteger paramCounter, Map<String, Object> queryParamValues, String alias,
+	protected static void appendFunctionArgument(EnversService enversService, Map<String, String> aliasToEntityNameMap, MutableInteger paramCounter,
+			Map<String, Object> queryParamValues, String alias,
 			StringBuilder expression, Object argument) {
 		if ( argument instanceof AuditFunction ) {
 			AuditFunction function = (AuditFunction) argument;
@@ -195,10 +199,32 @@ public class QueryBuilder {
 				if ( !first ) {
 					expression.append( ',' );
 				}
-				appendFunctionArgument( enversService, paramCounter, queryParamValues, alias, expression, innerArg );
+				appendFunctionArgument( enversService, aliasToEntityNameMap, paramCounter, queryParamValues, alias, expression, innerArg );
 				first = false;
 			}
 			expression.append( ')' );
+		}
+		else if ( argument instanceof AuditId ) {
+			AuditId<?> id = (AuditId<?>) argument;
+			String prefix = enversService.getAuditEntitiesConfiguration().getOriginalIdPropName();
+			String idAlias = id.getAlias( alias );
+			String entityName = aliasToEntityNameMap.get( idAlias );
+			/*
+			 * Resolve the name of the id property by reusing the IdMapper.mapToQueryParametersFromId() method. Null is
+			 * passed as value because only the name of the property is of interest. TODO: is there a better way to
+			 * obtain the name of the id property?
+			 */
+			List<QueryParameterData> parameters = enversService.getEntitiesConfigurations().get( entityName )
+					.getIdMapper()
+					.mapToQueryParametersFromId( null );
+			if ( parameters.size() != 1 ) {
+				throw new HibernateException( "Cannot add id property as function argument when id property is not a single column property" );
+			}
+			String propertyName = parameters.get( 0 ).getProperty( prefix );
+			if ( idAlias != null ) {
+				expression.append( idAlias ).append( '.' );
+			}
+			expression.append( propertyName );
 		}
 		else if ( argument instanceof AuditProperty ) {
 			AuditProperty<?> property = (AuditProperty<?>) argument;

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/query/QueryBuilder.java
@@ -16,10 +16,13 @@ import javax.persistence.criteria.JoinType;
 
 import org.hibernate.Session;
 import org.hibernate.envers.RevisionType;
+import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.RevisionTypeType;
 import org.hibernate.envers.internal.tools.MutableInteger;
 import org.hibernate.envers.internal.tools.StringTools;
 import org.hibernate.envers.internal.tools.Triple;
+import org.hibernate.envers.query.criteria.AuditFunction;
+import org.hibernate.envers.query.criteria.AuditProperty;
 import org.hibernate.query.Query;
 import org.hibernate.type.CustomType;
 
@@ -58,6 +61,10 @@ public class QueryBuilder {
 	 * A list of complete projection definitions: either a sole property name, or a function(property name).
 	 */
 	private final List<String> projections;
+	/**
+	 * Values of parameters used in projections.
+	 */
+	private final Map<String, Object> projectionQueryParamValues;
 
 	/**
 	 * @param entityName Main entity which should be selected.
@@ -79,6 +86,7 @@ public class QueryBuilder {
 		froms = new ArrayList<>();
 		orders = new ArrayList<>();
 		projections = new ArrayList<>();
+		projectionQueryParamValues = new HashMap<>();
 
 		addFrom( entityName, alias, true );
 	}
@@ -96,6 +104,7 @@ public class QueryBuilder {
 		froms = new ArrayList<>( other.froms );
 		orders = new ArrayList<>( other.orders );
 		projections = new ArrayList<>( other.projections );
+		projectionQueryParamValues = new HashMap<>( other.projectionQueryParamValues );
 	}
 
 	public QueryBuilder deepCopy() {
@@ -170,6 +179,43 @@ public class QueryBuilder {
 		}
 	}
 
+	public void addProjection(EnversService enversService, AuditFunction function) {
+		final StringBuilder expression = new StringBuilder();
+		appendFunctionArgument( enversService, paramCounter, projectionQueryParamValues, alias, expression, function );
+		projections.add( expression.toString() );
+	}
+
+	protected static void appendFunctionArgument(EnversService enversService, MutableInteger paramCounter, Map<String, Object> queryParamValues, String alias,
+			StringBuilder expression, Object argument) {
+		if ( argument instanceof AuditFunction ) {
+			AuditFunction function = (AuditFunction) argument;
+			expression.append( function.getFunction() ).append( '(' );
+			boolean first = true;
+			for ( final Object innerArg : function.getArguments() ) {
+				if ( !first ) {
+					expression.append( ',' );
+				}
+				appendFunctionArgument( enversService, paramCounter, queryParamValues, alias, expression, innerArg );
+				first = false;
+			}
+			expression.append( ')' );
+		}
+		else if ( argument instanceof AuditProperty ) {
+			AuditProperty<?> property = (AuditProperty<?>) argument;
+			String propertyAlias = property.getAlias( alias );
+			if ( propertyAlias != null ) {
+				expression.append( propertyAlias ).append( '.' );
+			}
+			String propertyName = property.getPropertyNameGetter().get( enversService );
+			expression.append( propertyName );
+		}
+		else {
+			String queryParam = "_p" + paramCounter.getAndIncrease();
+			queryParamValues.put( queryParam, argument );
+			expression.append( ':' ).append( queryParam );
+		}
+	}
+
 	/**
 	 * Builds the given query, appending results to the given string buffer, and adding all query parameter values
 	 * that are used to the map provided.
@@ -187,6 +233,7 @@ public class QueryBuilder {
 			// all aliases separated with commas
 			StringTools.append( sb, getSelectAliasList().iterator(), ", " );
 		}
+		queryParamValues.putAll( projectionQueryParamValues );
 		sb.append( " from " );
 		// all from entities with aliases
 		boolean first = true;

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditEntity.java
@@ -6,10 +6,15 @@
  */
 package org.hibernate.envers.query;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.query.criteria.AuditConjunction;
 import org.hibernate.envers.query.criteria.AuditCriterion;
 import org.hibernate.envers.query.criteria.AuditDisjunction;
+import org.hibernate.envers.query.criteria.AuditFunction;
 import org.hibernate.envers.query.criteria.AuditId;
 import org.hibernate.envers.query.criteria.AuditProperty;
 import org.hibernate.envers.query.criteria.AuditRelatedId;
@@ -175,5 +180,31 @@ public class AuditEntity {
 	 */
 	public static AuditProjection selectEntity(boolean distinct) {
 		return new EntityAuditProjection( null, distinct );
+	}
+
+	/**
+	 * Create restrictions or projections using a function.
+	 * <p>
+	 * Examples:
+	 * <ul>
+	 * <li>AuditEntity.function("upper", AuditEntity.property("prop"))</li>
+	 * <li>AuditEntity.function("substring", AuditEntity.property("prop"), 3, 2)</li>
+	 * <li>AuditEntity.function("concat", AuditEntity.function("upper", AuditEntity.property("prop1")),
+	 * AuditEntity.function("substring", AuditEntity.property("prop2"), 1, 2))</li>
+	 * </ul>
+	 * 
+	 * @param function the name of the function
+	 * @param arguments the arguments of the function. A function argument can either be
+	 * <ul>
+	 * <li>a primitive value like a Number or a String</li>
+	 * <li>an AuditProperty (see {@link #property(String)})</li>
+	 * <li>an other AuditFunction</li>
+	 * </ul>
+	 * @return
+	 */
+	public static AuditFunction function(final String function, final Object... arguments) {
+		List<Object> argumentList = new ArrayList<>();
+		Collections.addAll( argumentList, arguments );
+		return new AuditFunction( function, argumentList );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditConjunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditConjunction.java
@@ -36,6 +36,7 @@ public class AuditConjunction implements AuditCriterion, ExtendableCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String alias,
 			QueryBuilder qb,
 			Parameters parameters) {
@@ -46,7 +47,7 @@ public class AuditConjunction implements AuditCriterion, ExtendableCriterion {
 		}
 		else {
 			for ( AuditCriterion criterion : criterions ) {
-				criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, alias, qb, andParameters );
+				criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, alias, qb, andParameters );
 			}
 		}
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditCriterion.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditCriterion.java
@@ -21,6 +21,7 @@ public interface AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder qb,
 			Parameters parameters);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditDisjunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditDisjunction.java
@@ -36,6 +36,7 @@ public class AuditDisjunction implements AuditCriterion, ExtendableCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String alias,
 			QueryBuilder qb,
 			Parameters parameters) {
@@ -46,7 +47,7 @@ public class AuditDisjunction implements AuditCriterion, ExtendableCriterion {
 		}
 		else {
 			for ( AuditCriterion criterion : criterions ) {
-				criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, alias, qb, orParameters );
+				criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, alias, qb, orParameters );
 			}
 		}
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
@@ -9,6 +9,7 @@ package org.hibernate.envers.query.criteria;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.criterion.MatchMode;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.EntityInstantiator;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
@@ -53,6 +54,20 @@ public class AuditFunction implements AuditProjection {
 	 */
 	public AuditCriterion ne(Object value) {
 		return new SimpleFunctionAuditExpression( this, value, "<>" );
+	}
+
+	/**
+	 * Apply a "like" constraint
+	 */
+	public AuditCriterion like(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, " like " );
+	}
+
+	/**
+	 * Apply a "like" constraint
+	 */
+	public AuditCriterion like(String value, MatchMode matchMode) {
+		return new SimpleFunctionAuditExpression( this, matchMode.toMatchString( value ), " like " );
 	}
 
 	/**
@@ -224,7 +239,7 @@ public class AuditFunction implements AuditProjection {
 	@Override
 	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
 			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
-		queryBuilder.addProjection( enversService, this );
+		queryBuilder.addProjection( enversService, aliasToEntityNameMap, this );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
@@ -238,8 +238,8 @@ public class AuditFunction implements AuditProjection {
 
 	@Override
 	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
-			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
-		queryBuilder.addProjection( enversService, aliasToEntityNameMap, this );
+			Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap, String baseAlias, QueryBuilder queryBuilder) {
+		queryBuilder.addProjection( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, this );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditFunction.java
@@ -1,0 +1,241 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.entities.EntityInstantiator;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.internal.FunctionFunctionAuditExpression;
+import org.hibernate.envers.query.criteria.internal.PropertyFunctionAuditExpression;
+import org.hibernate.envers.query.criteria.internal.SimpleFunctionAuditExpression;
+import org.hibernate.envers.query.projection.AuditProjection;
+
+/**
+ * Create restrictions or projections using a function.
+ * 
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class AuditFunction implements AuditProjection {
+
+	private final String function;
+	private final List<Object> arguments;
+
+	public AuditFunction(String function, List<Object> arguments) {
+		this.function = function;
+		this.arguments = arguments;
+	}
+
+	public String getFunction() {
+		return function;
+	}
+
+	public List<Object> getArguments() {
+		return arguments;
+	}
+
+	/**
+	 * Apply an "equal" constraint
+	 */
+	public AuditCriterion eq(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, "=" );
+	}
+
+	/**
+	 * Apply a "not equal" constraint
+	 */
+	public AuditCriterion ne(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, "<>" );
+	}
+
+	/**
+	 * Apply a "greater than" constraint
+	 */
+	public AuditCriterion gt(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, ">" );
+	}
+
+	/**
+	 * Apply a "less than" constraint
+	 */
+	public AuditCriterion lt(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, "<" );
+	}
+
+	/**
+	 * Apply a "less than or equal" constraint
+	 */
+	public AuditCriterion le(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, "<=" );
+	}
+
+	/**
+	 * Apply a "greater than or equal" constraint
+	 */
+	public AuditCriterion ge(Object value) {
+		return new SimpleFunctionAuditExpression( this, value, ">=" );
+	}
+
+	/**
+	 * Apply an "equal" constraint to a property
+	 */
+	public AuditCriterion eqProperty(String propertyName) {
+		return eqProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply an "equal" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion eqProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, "=" );
+	}
+
+	/**
+	 * Apply a "not equal" constraint to a property
+	 */
+	public AuditCriterion neProperty(String propertyName) {
+		return neProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply a "not equal" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion neProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, "<>" );
+	}
+
+	/**
+	 * Apply a "less than" constraint to a property
+	 */
+	public AuditCriterion ltProperty(String propertyName) {
+		return ltProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply a "less than" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion ltProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, "<" );
+	}
+
+	/**
+	 * Apply a "less than or equal" constraint to a property
+	 */
+	public AuditCriterion leProperty(String propertyName) {
+		return leProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply a "less than or equal" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion leProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, "<=" );
+	}
+
+	/**
+	 * Apply a "greater than" constraint to a property
+	 */
+	public AuditCriterion gtProperty(String propertyName) {
+		return gtProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply a "greater than" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion gtProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, ">" );
+	}
+
+	/**
+	 * Apply a "greater than or equal" constraint to a property
+	 */
+	public AuditCriterion geProperty(String propertyName) {
+		return geProperty( null, propertyName );
+	}
+
+	/**
+	 * Apply a "greater than or equal" constraint to a property
+	 *
+	 * @param alias the alias of the entity which owns the property.
+	 */
+	public AuditCriterion geProperty(String alias, String propertyName) {
+		return new PropertyFunctionAuditExpression( this, alias, propertyName, ">=" );
+	}
+
+	/**
+	 * Apply an "equal" constraint to another function
+	 */
+	public AuditCriterion eqFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, "=" );
+	}
+
+	/**
+	 * Apply a "not equal" constraint to another function
+	 */
+	public AuditCriterion neFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, "<>" );
+	}
+
+	/**
+	 * Apply a "less than" constraint to another function
+	 */
+	public AuditCriterion ltFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, "<" );
+	}
+
+	/**
+	 * Apply a "less than or equal" constraint to another function
+	 */
+	public AuditCriterion leFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, "<=" );
+	}
+
+	/**
+	 * Apply a "greater than" constraint to another function
+	 */
+	public AuditCriterion gtFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, ">" );
+	}
+
+	/**
+	 * Apply a "greater than or equal" constraint to another function
+	 */
+	public AuditCriterion geFunction(AuditFunction otherFunction) {
+		return new FunctionFunctionAuditExpression( this, otherFunction, ">=" );
+	}
+
+	@Override
+	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+		queryBuilder.addProjection( enversService, this );
+	}
+
+	@Override
+	public Object convertQueryResult(EnversService enversService, EntityInstantiator entityInstantiator,
+			String entityName, Number revision, Object value) {
+		return value;
+	}
+
+	@Override
+	public String getAlias(String baseAlias) {
+		return baseAlias;
+	}
+
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditProperty.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/AuditProperty.java
@@ -425,7 +425,7 @@ public class AuditProperty<T> implements AuditProjection {
 
 	@Override
 	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
-			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+			Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap, String baseAlias, QueryBuilder queryBuilder) {
 		String projectionEntityAlias = getAlias( baseAlias );
 		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -433,10 +433,12 @@ public class AuditProperty<T> implements AuditProjection {
 				auditReader,
 				projectionEntityName,
 				propertyNameGetter );
+		String propertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				projectionEntityAlias );
 		queryBuilder.addProjection(
 				null,
 				projectionEntityAlias,
-				propertyName,
+				propertyNamePrefix.concat( propertyName ),
 				false );
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/AbstractAtomicExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/AbstractAtomicExpression.java
@@ -40,12 +40,15 @@ abstract class AbstractAtomicExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder qb,
 			Parameters parameters) {
 		final String effectiveAlias = alias == null ? baseAlias : alias;
 		final String entityName = aliasToEntityNameMap.get( effectiveAlias );
-		addToQuery(enversService, versionsReader, entityName, effectiveAlias, qb, parameters);
+		final String componentPrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				effectiveAlias );
+		addToQuery(enversService, versionsReader, entityName, effectiveAlias, componentPrefix, qb, parameters);
 	}
 
 	protected abstract void addToQuery(
@@ -53,6 +56,7 @@ abstract class AbstractAtomicExpression implements AuditCriterion {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters);
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/BetweenAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/BetweenAuditExpression.java
@@ -33,6 +33,7 @@ public class BetweenAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -41,10 +42,11 @@ public class BetweenAuditExpression extends AbstractAtomicExpression {
 				entityName,
 				propertyNameGetter
 		);
-		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
+		String prefixedPropertyName = componentPrefix.concat( propertyName );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, prefixedPropertyName );
 
 		Parameters subParams = parameters.addSubParameters( Parameters.AND );
-		subParams.addWhereWithParam( alias, propertyName, ">=", lo );
-		subParams.addWhereWithParam( alias, propertyName, "<=", hi );
+		subParams.addWhereWithParam( alias, prefixedPropertyName, ">=", lo );
+		subParams.addWhereWithParam( alias, prefixedPropertyName, "<=", hi );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/CriteriaTools.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/CriteriaTools.java
@@ -47,7 +47,10 @@ public abstract class CriteriaTools {
 			return null;
 		}
 
-		if ( relationDesc.getRelationType() == RelationType.TO_ONE ) {
+		if ( relationDesc.getRelationType() == RelationType.TO_ONE
+				|| relationDesc.getRelationType() == RelationType.TO_MANY_MIDDLE
+				|| relationDesc.getRelationType() == RelationType.TO_MANY_NOT_OWNING
+				|| relationDesc.getRelationType() == RelationType.TO_MANY_MIDDLE_NOT_OWNING ) {
 			return relationDesc;
 		}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
@@ -41,6 +41,6 @@ public class FunctionFunctionAuditExpression implements AuditCriterion {
 			String baseAlias,
 			QueryBuilder queryBuilder,
 			Parameters parameters) {
-		parameters.addWhereWithFunction( enversService, leftFunction, op, rightFunction );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, leftFunction, op, rightFunction );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
@@ -38,9 +38,10 @@ public class FunctionFunctionAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor auditReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder queryBuilder,
 			Parameters parameters) {
-		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, leftFunction, op, rightFunction );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, leftFunction, op, rightFunction );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionFunctionAuditExpression.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria.internal;
+
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+import org.hibernate.envers.query.criteria.AuditFunction;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class FunctionFunctionAuditExpression implements AuditCriterion {
+
+	private AuditFunction leftFunction;
+	private AuditFunction rightFunction;
+	private String op;
+
+	public FunctionFunctionAuditExpression(
+			AuditFunction leftFunction,
+			AuditFunction rightFunction,
+			String op) {
+		this.leftFunction = leftFunction;
+		this.rightFunction = rightFunction;
+		this.op = op;
+	}
+
+	@Override
+	public void addToQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap,
+			String baseAlias,
+			QueryBuilder queryBuilder,
+			Parameters parameters) {
+		parameters.addWhereWithFunction( enversService, leftFunction, op, rightFunction );
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
@@ -53,6 +53,6 @@ public class FunctionPropertyAuditExpression implements AuditCriterion {
 				entityName,
 				propertyNameGetter );
 		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
-		parameters.addWhereWithFunction( enversService, effectiveAlias, propertyName, op, function );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, effectiveAlias, propertyName, op, function );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
@@ -42,6 +42,7 @@ public class FunctionPropertyAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor auditReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder queryBuilder,
 			Parameters parameters) {
@@ -52,7 +53,11 @@ public class FunctionPropertyAuditExpression implements AuditCriterion {
 				auditReader,
 				entityName,
 				propertyNameGetter );
-		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
-		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, effectiveAlias, propertyName, op, function );
+		String propertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				effectiveAlias );
+		String prefixedPropertyName = propertyNamePrefix.concat( propertyName );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, prefixedPropertyName );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, effectiveAlias, prefixedPropertyName, op,
+				function );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/FunctionPropertyAuditExpression.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria.internal;
+
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+import org.hibernate.envers.query.criteria.AuditFunction;
+import org.hibernate.envers.query.internal.property.PropertyNameGetter;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class FunctionPropertyAuditExpression implements AuditCriterion {
+
+	private String alias;
+	private PropertyNameGetter propertyNameGetter;
+	private AuditFunction function;
+	private String op;
+
+	public FunctionPropertyAuditExpression(
+			String alias,
+			PropertyNameGetter propertyNameGetter,
+			AuditFunction function,
+			String op) {
+		this.alias = alias;
+		this.propertyNameGetter = propertyNameGetter;
+		this.function = function;
+		this.op = op;
+	}
+
+	@Override
+	public void addToQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap,
+			String baseAlias,
+			QueryBuilder queryBuilder,
+			Parameters parameters) {
+		String effectiveAlias = alias == null ? baseAlias : alias;
+		String entityName = aliasToEntityNameMap.get( effectiveAlias );
+		String propertyName = CriteriaTools.determinePropertyName(
+				enversService,
+				auditReader,
+				entityName,
+				propertyNameGetter );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
+		parameters.addWhereWithFunction( enversService, effectiveAlias, propertyName, op, function );
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/IdentifierEqAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/IdentifierEqAuditExpression.java
@@ -32,6 +32,7 @@ public class IdentifierEqAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String prefix = enversService.getAuditEntitiesConfiguration().getOriginalIdPropName();

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/IlikeAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/IlikeAuditExpression.java
@@ -28,17 +28,17 @@ public class IlikeAuditExpression extends AbstractAtomicExpression {
 	protected void addToQuery(
 			EnversService enversService,
 			AuditReaderImplementor versionsReader, String entityName,
-			String alias, QueryBuilder qb, Parameters parameters) {
+			String alias, String componentPrefix, QueryBuilder qb, Parameters parameters) {
 
 		String propertyName = CriteriaTools.determinePropertyName(
 				enversService,
 				versionsReader,
 				entityName,
-				propertyNameGetter
-		);
-		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
+				propertyNameGetter );
+		String prefixedPropertyName = componentPrefix.concat( propertyName );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, prefixedPropertyName );
 
-		parameters.addWhereWithFunction( alias, propertyName, " lower ", " like ", value.toLowerCase( Locale.ROOT ) );
+		parameters.addWhereWithFunction( alias, prefixedPropertyName, " lower ", " like ", value.toLowerCase( Locale.ROOT ) );
 	}
 
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/InAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/InAuditExpression.java
@@ -31,15 +31,16 @@ public class InAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
 				enversService,
 				versionsReader,
 				entityName,
-				propertyNameGetter
-		);
-		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
-		parameters.addWhereWithParams( alias, propertyName, "in (", values, ")" );
+				propertyNameGetter );
+		String prefixedPropertyName = componentPrefix.concat( propertyName );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, prefixedPropertyName );
+		parameters.addWhereWithParams( alias, prefixedPropertyName, "in (", values, ")" );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/LogicalAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/LogicalAuditExpression.java
@@ -32,12 +32,15 @@ public class LogicalAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String alias,
 			QueryBuilder qb,
 			Parameters parameters) {
 		Parameters opParameters = parameters.addSubParameters( op );
 
-		lhs.addToQuery( enversService, versionsReader, aliasToEntityNameMap, alias, qb, opParameters.addSubParameters( "and" ) );
-		rhs.addToQuery( enversService, versionsReader, aliasToEntityNameMap, alias, qb, opParameters.addSubParameters( "and" ) );
+		lhs.addToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, alias, qb,
+				opParameters.addSubParameters( "and" ) );
+		rhs.addToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, alias, qb,
+				opParameters.addSubParameters( "and" ) );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotAuditExpression.java
@@ -28,9 +28,11 @@ public class NotAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String alias,
 			QueryBuilder qb,
 			Parameters parameters) {
-		criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, alias, qb, parameters.addNegatedParameters() );
+		criterion.addToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, alias, qb,
+				parameters.addNegatedParameters() );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotNullAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotNullAuditExpression.java
@@ -7,7 +7,9 @@
 package org.hibernate.envers.query.criteria.internal;
 
 import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.entities.RelationDescription;
+import org.hibernate.envers.internal.entities.RelationType;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 import org.hibernate.envers.internal.tools.query.Parameters;
 import org.hibernate.envers.internal.tools.query.QueryBuilder;
@@ -43,8 +45,13 @@ public class NotNullAuditExpression extends AbstractAtomicExpression {
 		if ( relatedEntity == null ) {
 			parameters.addNotNullRestriction( alias, propertyName );
 		}
-		else {
+		else if ( relatedEntity.getRelationType() == RelationType.TO_ONE ) {
 			relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, null, alias, null, false );
+		}
+		else {
+			throw new AuditException(
+					"This type of relation (" + entityName + "." + propertyName +
+							") can't be used with not null restrictions." );
 		}
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotNullAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NotNullAuditExpression.java
@@ -32,6 +32,7 @@ public class NotNullAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -40,10 +41,11 @@ public class NotNullAuditExpression extends AbstractAtomicExpression {
 				entityName,
 				propertyNameGetter
 		);
-		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
+		String prefixedPropertyName = componentPrefix.concat( propertyName );
+		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, prefixedPropertyName );
 
 		if ( relatedEntity == null ) {
-			parameters.addNotNullRestriction( alias, propertyName );
+			parameters.addNotNullRestriction( alias, prefixedPropertyName );
 		}
 		else if ( relatedEntity.getRelationType() == RelationType.TO_ONE ) {
 			relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, null, alias, null, false );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NullAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NullAuditExpression.java
@@ -32,6 +32,7 @@ public class NullAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -41,9 +42,10 @@ public class NullAuditExpression extends AbstractAtomicExpression {
 				propertyNameGetter
 		);
 		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
+		String prefixedPropertyName = componentPrefix.concat( propertyName );
 
 		if ( relatedEntity == null ) {
-			parameters.addNullRestriction( alias, propertyName );
+			parameters.addNullRestriction( alias, prefixedPropertyName );
 		}
 		else if ( relatedEntity.getRelationType() == RelationType.TO_ONE ) {
 			relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, null, alias, null, true );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NullAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/NullAuditExpression.java
@@ -7,7 +7,9 @@
 package org.hibernate.envers.query.criteria.internal;
 
 import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.entities.RelationDescription;
+import org.hibernate.envers.internal.entities.RelationType;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 import org.hibernate.envers.internal.tools.query.Parameters;
 import org.hibernate.envers.internal.tools.query.QueryBuilder;
@@ -43,8 +45,13 @@ public class NullAuditExpression extends AbstractAtomicExpression {
 		if ( relatedEntity == null ) {
 			parameters.addNullRestriction( alias, propertyName );
 		}
-		else {
+		else if ( relatedEntity.getRelationType() == RelationType.TO_ONE ) {
 			relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, null, alias, null, true );
+		}
+		else {
+			throw new AuditException(
+					"This type of relation (" + entityName + "." + propertyName +
+							") can't be used with null restrictions." );
 		}
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyAuditExpression.java
@@ -44,6 +44,7 @@ public class PropertyAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder qb,
 			Parameters parameters) {
@@ -57,15 +58,21 @@ public class PropertyAuditExpression implements AuditCriterion {
 				entityName,
 				propertyNameGetter
 		);
-		CriteriaTools.checkPropertyNotARelation( enversService, entityName, propertyName );
+		String propertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				effectiveAlias );
+		String otherPropertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				effectiveOtherAlias );
+		String prefixedPropertyName = propertyNamePrefix.concat( propertyName );
+		String prefixedOtherPropertyName = otherPropertyNamePrefix.concat( otherPropertyName );
+		CriteriaTools.checkPropertyNotARelation( enversService, entityName, prefixedPropertyName );
 		/*
 		 * Check that the other property name is not a relation. However, we can only
 		 * do this for audited entities. If the other property belongs to a non-audited
 		 * entity, we have to skip this check.
 		 */
 		if ( enversService.getEntitiesConfigurations().isVersioned( otherEntityName ) ) {
-			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, otherPropertyName );
+			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, prefixedOtherPropertyName );
 		}
-		parameters.addWhere( effectiveAlias, propertyName, op, effectiveOtherAlias, otherPropertyName );
+		parameters.addWhere( effectiveAlias, prefixedPropertyName, op, effectiveOtherAlias, prefixedOtherPropertyName );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
@@ -41,6 +41,7 @@ public class PropertyFunctionAuditExpression implements AuditCriterion {
 			EnversService enversService,
 			AuditReaderImplementor auditReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder queryBuilder,
 			Parameters parameters) {
@@ -51,8 +52,11 @@ public class PropertyFunctionAuditExpression implements AuditCriterion {
 		 * the other property belongs to a non-audited entity, we have to skip this check.
 		 */
 		if ( enversService.getEntitiesConfigurations().isVersioned( otherEntityName ) ) {
-			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, otherPropertyName );
+			String otherPropertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap, effectiveOtherAlias );
+			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, otherPropertyNamePrefix.concat( otherPropertyName ) );
 		}
-		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, function, op, effectiveOtherAlias, otherPropertyName );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, function, op, effectiveOtherAlias,
+				otherPropertyName );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
@@ -53,6 +53,6 @@ public class PropertyFunctionAuditExpression implements AuditCriterion {
 		if ( enversService.getEntitiesConfigurations().isVersioned( otherEntityName ) ) {
 			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, otherPropertyName );
 		}
-		parameters.addWhereWithFunction( enversService, function, op, effectiveOtherAlias, otherPropertyName );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, function, op, effectiveOtherAlias, otherPropertyName );
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/PropertyFunctionAuditExpression.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria.internal;
+
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+import org.hibernate.envers.query.criteria.AuditFunction;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class PropertyFunctionAuditExpression implements AuditCriterion {
+
+	private AuditFunction function;
+	private String otherAlias;
+	private String otherPropertyName;
+	private String op;
+
+	public PropertyFunctionAuditExpression(
+			AuditFunction function,
+			String otherAlias,
+			String otherPropertyName,
+			String op) {
+		this.function = function;
+		this.otherAlias = otherAlias;
+		this.otherPropertyName = otherPropertyName;
+		this.op = op;
+	}
+
+	@Override
+	public void addToQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap,
+			String baseAlias,
+			QueryBuilder queryBuilder,
+			Parameters parameters) {
+		String effectiveOtherAlias = otherAlias == null ? baseAlias : otherAlias;
+		String otherEntityName = aliasToEntityNameMap.get( effectiveOtherAlias );
+		/*
+		 * Check that the other property name is not a relation. However, we can only do this for audited entities. If
+		 * the other property belongs to a non-audited entity, we have to skip this check.
+		 */
+		if ( enversService.getEntitiesConfigurations().isVersioned( otherEntityName ) ) {
+			CriteriaTools.checkPropertyNotARelation( enversService, otherEntityName, otherPropertyName );
+		}
+		parameters.addWhereWithFunction( enversService, function, op, effectiveOtherAlias, otherPropertyName );
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditEqualityExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditEqualityExpression.java
@@ -9,6 +9,7 @@ package org.hibernate.envers.query.criteria.internal;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.entities.RelationDescription;
+import org.hibernate.envers.internal.entities.RelationType;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 import org.hibernate.envers.internal.tools.query.Parameters;
 import org.hibernate.envers.internal.tools.query.QueryBuilder;
@@ -49,8 +50,12 @@ public class RelatedAuditEqualityExpression extends AbstractAtomicExpression {
 		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
 		if ( relatedEntity == null ) {
 			throw new AuditException(
-					"This criterion can only be used on a property that is a relation to another property."
-			);
+					"This criterion can only be used on a property that is a relation to another property." );
+		}
+		else if ( relatedEntity.getRelationType() != RelationType.TO_ONE ) {
+			throw new AuditException(
+					"This type of relation (" + entityName + "." + propertyName +
+							") can't be used with related equality restrictions." );
 		}
 		relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, id, alias, null, equals );
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditEqualityExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditEqualityExpression.java
@@ -38,6 +38,7 @@ public class RelatedAuditEqualityExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -47,7 +48,7 @@ public class RelatedAuditEqualityExpression extends AbstractAtomicExpression {
 				propertyNameGetter
 		);
 
-		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
+		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, componentPrefix.concat( propertyName ) );
 		if ( relatedEntity == null ) {
 			throw new AuditException(
 					"This criterion can only be used on a property that is a relation to another property." );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditInExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditInExpression.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.entities.RelationDescription;
+import org.hibernate.envers.internal.entities.RelationType;
 import org.hibernate.envers.internal.entities.mapper.id.QueryParameterData;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 import org.hibernate.envers.internal.tools.query.Parameters;
@@ -51,8 +52,12 @@ public class RelatedAuditInExpression extends AbstractAtomicExpression {
 		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
 		if ( relatedEntity == null ) {
 			throw new AuditException(
-					"The criterion can only be used on a property that is a relation to another property."
-			);
+					"The criterion can only be used on a property that is a relation to another property." );
+		}
+		else if ( relatedEntity.getRelationType() != RelationType.TO_ONE ) {
+			throw new AuditException(
+					"This type of relation (" + entityName + "." + propertyName +
+							") can't be used with related in restrictions." );
 		}
 
 		// todo: should this throw an error if qpdList is null?  is it possible?

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditInExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RelatedAuditInExpression.java
@@ -40,6 +40,7 @@ public class RelatedAuditInExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -49,7 +50,7 @@ public class RelatedAuditInExpression extends AbstractAtomicExpression {
 				propertyNameGetter
 		);
 
-		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, propertyName );
+		RelationDescription relatedEntity = CriteriaTools.getRelatedEntity( enversService, entityName, componentPrefix.concat( propertyName ) );
 		if ( relatedEntity == null ) {
 			throw new AuditException(
 					"The criterion can only be used on a property that is a relation to another property." );
@@ -64,7 +65,7 @@ public class RelatedAuditInExpression extends AbstractAtomicExpression {
 		List<QueryParameterData> qpdList = relatedEntity.getIdMapper().mapToQueryParametersFromId( propertyName );
 		if ( qpdList != null ) {
 			QueryParameterData qpd = qpdList.iterator().next();
-			parameters.addWhereWithParams( alias, qpd.getQueryParameterName(), "in (", ids, ")" );
+			parameters.addWhereWithParams( alias, componentPrefix.concat( qpd.getQueryParameterName() ), "in (", ids, ")" );
 		}
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RevisionTypeAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/RevisionTypeAuditExpression.java
@@ -30,6 +30,7 @@ public class RevisionTypeAuditExpression extends AbstractAtomicExpression {
 			AuditReaderImplementor versionsReader,
 			String entityName,
 			String alias,
+			String componentPrefix,
 			QueryBuilder qb,
 			Parameters parameters) {
 		parameters.addWhereWithParam( alias, enversService.getAuditEntitiesConfiguration().getRevisionTypePropName(), op, value );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleAuditExpression.java
@@ -10,6 +10,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.entities.RelationDescription;
+import org.hibernate.envers.internal.entities.RelationType;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
 import org.hibernate.envers.internal.tools.query.Parameters;
 import org.hibernate.envers.internal.tools.query.QueryBuilder;
@@ -76,7 +77,7 @@ public class SimpleAuditExpression extends AbstractAtomicExpression {
 				parameters.addWhereWithParam( alias, propertyName, op, value );
 			}
 		}
-		else {
+		else if ( relatedEntity.getRelationType() == RelationType.TO_ONE ) {
 			if ( !"=".equals( op ) && !"<>".equals( op ) ) {
 				throw new AuditException(
 						"This type of operation: " + op + " (" + entityName + "." + propertyName +
@@ -85,6 +86,11 @@ public class SimpleAuditExpression extends AbstractAtomicExpression {
 			}
 			Object id = relatedEntity.getIdMapper().mapToIdFromEntity( value );
 			relatedEntity.getIdMapper().addIdEqualsToQuery( parameters, id, alias, null, "=".equals( op ) );
+		}
+		else {
+			throw new AuditException(
+					"This type of relation (" + entityName + "." + propertyName +
+							") can't be used in audit query restrictions." );
 		}
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
@@ -33,7 +33,7 @@ public class SimpleFunctionAuditExpression implements AuditCriterion {
 	@Override
 	public void addToQuery(EnversService enversService, AuditReaderImplementor versionsReader,
 			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder qb, Parameters parameters) {
-		parameters.addWhereWithFunction( enversService, function, op, value );
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, function, op, value );
 	}
 
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
@@ -32,8 +32,9 @@ public class SimpleFunctionAuditExpression implements AuditCriterion {
 
 	@Override
 	public void addToQuery(EnversService enversService, AuditReaderImplementor versionsReader,
-			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder qb, Parameters parameters) {
-		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, function, op, value );
+			Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap, String baseAlias, QueryBuilder qb,
+			Parameters parameters) {
+		parameters.addWhereWithFunction( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap, function, op, value );
 	}
 
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/criteria/internal/SimpleFunctionAuditExpression.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.criteria.internal;
+
+import java.util.Map;
+
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+import org.hibernate.envers.query.criteria.AuditFunction;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class SimpleFunctionAuditExpression implements AuditCriterion {
+
+	private AuditFunction function;
+	private Object value;
+	private String op;
+
+	public SimpleFunctionAuditExpression(AuditFunction function, Object value, String op) {
+		this.function = function;
+		this.value = value;
+		this.op = op;
+	}
+
+	@Override
+	public void addToQuery(EnversService enversService, AuditReaderImplementor versionsReader,
+			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder qb, Parameters parameters) {
+		parameters.addWhereWithFunction( enversService, function, op, value );
+	}
+
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
@@ -134,22 +134,10 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 	// Projection and order
 
 	public AuditQuery addProjection(AuditProjection projection) {
-		AuditProjection.ProjectionData projectionData = projection.getData( enversService );
-		String projectionEntityAlias = projectionData.getAlias( REFERENCED_ENTITY_ALIAS );
+		String projectionEntityAlias = projection.getAlias( REFERENCED_ENTITY_ALIAS );
 		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
 		registerProjection( projectionEntityName, projection );
-		String propertyName = CriteriaTools.determinePropertyName(
-				enversService,
-				versionsReader,
-				projectionEntityName,
-				projectionData.getPropertyName()
-		);
-		qb.addProjection(
-				projectionData.getFunction(),
-				projectionEntityAlias,
-				propertyName,
-				projectionData.isDistinct()
-		);
+		projection.addProjectionToQuery( enversService, versionsReader, aliasToEntityNameMap, REFERENCED_ENTITY_ALIAS, qb );
 		return this;
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
@@ -50,6 +50,7 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 	protected String versionsEntityName;
 	protected QueryBuilder qb;
 	protected final Map<String, String> aliasToEntityNameMap = new HashMap<>();
+	protected final Map<String, String> aliasToComponentPropertyNameMap = new HashMap<>();
 
 	protected boolean hasOrder;
 
@@ -137,7 +138,7 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 		String projectionEntityAlias = projection.getAlias( REFERENCED_ENTITY_ALIAS );
 		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
 		registerProjection( projectionEntityName, projection );
-		projection.addProjectionToQuery( enversService, versionsReader, aliasToEntityNameMap, REFERENCED_ENTITY_ALIAS, qb );
+		projection.addProjectionToQuery( enversService, versionsReader, aliasToEntityNameMap, aliasToComponentPropertyNameMap, REFERENCED_ENTITY_ALIAS, qb );
 		return this;
 	}
 
@@ -161,7 +162,9 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 				orderEntityName,
 				orderData.getPropertyName()
 		);
-		qb.addOrder( orderEntityAlias, propertyName, orderData.isAscending() );
+		String componentPrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				orderEntityAlias );
+		qb.addOrder( orderEntityAlias, componentPrefix.concat( propertyName ), orderData.isAscending() );
 		return this;
 	}
 
@@ -186,6 +189,7 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 					associationName,
 					joinType,
 					aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap,
 					REFERENCED_ENTITY_ALIAS,
 					alias
 			);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AuditAssociationQueryImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AuditAssociationQueryImpl.java
@@ -150,22 +150,10 @@ public class AuditAssociationQueryImpl<Q extends AuditQueryImplementor>
 
 	@Override
 	public AuditAssociationQueryImpl<Q> addProjection(AuditProjection projection) {
-		AuditProjection.ProjectionData projectionData = projection.getData( enversService );
-		String projectionEntityAlias = projectionData.getAlias( alias );
+		String projectionEntityAlias = projection.getAlias( alias );
 		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
-		String propertyName = CriteriaTools.determinePropertyName(
-				enversService,
-				auditReader,
-				projectionEntityName,
-				projectionData.getPropertyName()
-		);
-		queryBuilder.addProjection(
-				projectionData.getFunction(),
-				projectionEntityAlias,
-				propertyName,
-				projectionData.isDistinct()
-		);
 		registerProjection( projectionEntityName, projection );
+		projection.addProjectionToQuery( enversService, auditReader, aliasToEntityNameMap, alias, queryBuilder );
 		return this;
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionQuery.java
@@ -108,6 +108,7 @@ public class EntitiesAtRevisionQuery extends AbstractAuditQuery {
 					enversService,
 					versionsReader,
 					aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap,
 					QueryConstants.REFERENCED_ENTITY_ALIAS,
 					qb,
 					qb.getRootParameters()

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesModifiedAtRevisionQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesModifiedAtRevisionQuery.java
@@ -66,6 +66,7 @@ public class EntitiesModifiedAtRevisionQuery extends AbstractAuditQuery {
 					enversService,
 					versionsReader,
 					aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap,
 					QueryConstants.REFERENCED_ENTITY_ALIAS,
 					qb,
 					qb.getRootParameters()

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/RevisionsOfEntityQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/RevisionsOfEntityQuery.java
@@ -111,6 +111,7 @@ public class RevisionsOfEntityQuery extends AbstractAuditQuery {
 					enversService,
 					versionsReader,
 					aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap,
 					QueryConstants.REFERENCED_ENTITY_ALIAS,
 					qb,
 					qb.getRootParameters()

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/AuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/AuditProjection.java
@@ -22,6 +22,7 @@ public interface AuditProjection {
 			EnversService enversService,
 			AuditReaderImplementor auditReader,
 			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
 			String baseAlias,
 			QueryBuilder queryBuilder);
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/AuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/AuditProjection.java
@@ -6,19 +6,26 @@
  */
 package org.hibernate.envers.query.projection;
 
+import java.util.Map;
+
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.EntityInstantiator;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
 
 /**
  * @author Adam Warski (adam at warski dot org)
  */
 public interface AuditProjection {
-	/**
-	 * @param enversService The EnversService
-	 *
-	 * @return the projection data
-	 */
-	ProjectionData getData(EnversService enversService);
+
+	void addProjectionToQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap,
+			String baseAlias,
+			QueryBuilder queryBuilder);
+
+	public String getAlias(String baseAlias);
 
 	/**
 	 * @param enversService the Envers service
@@ -36,35 +43,4 @@ public interface AuditProjection {
 			final Object value
 	);
 
-	class ProjectionData {
-
-		private final String function;
-		private final String alias;
-		private final String propertyName;
-		private final boolean distinct;
-
-		public ProjectionData(String function, String alias, String propertyName, boolean distinct) {
-			this.function = function;
-			this.alias = alias;
-			this.propertyName = propertyName;
-			this.distinct = distinct;
-		}
-
-		public String getFunction() {
-			return function;
-		}
-
-		public String getAlias(String baseAlias) {
-			return alias == null ? baseAlias : alias;
-		}
-
-		public String getPropertyName() {
-			return propertyName;
-		}
-
-		public boolean isDistinct() {
-			return distinct;
-		}
-
-	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/EntityAuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/EntityAuditProjection.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.EntityInstantiator;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
 import org.hibernate.envers.query.projection.AuditProjection;
 
 /**
@@ -26,9 +28,19 @@ public class EntityAuditProjection implements AuditProjection {
 	}
 
 	@Override
-	public ProjectionData getData(final EnversService enversService) {
-		// no property is selected, instead the whole entity (alias) is selected
-		return new ProjectionData( null, alias, null, distinct );
+	public String getAlias(String baseAlias) {
+		return alias == null ? baseAlias : alias;
+	}
+
+	@Override
+	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+		String projectionEntityAlias = getAlias( baseAlias );
+		queryBuilder.addProjection(
+				null,
+				projectionEntityAlias,
+				null,
+				distinct );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/EntityAuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/EntityAuditProjection.java
@@ -34,7 +34,7 @@ public class EntityAuditProjection implements AuditProjection {
 
 	@Override
 	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
-			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+			Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap, String baseAlias, QueryBuilder queryBuilder) {
 		String projectionEntityAlias = getAlias( baseAlias );
 		queryBuilder.addProjection(
 				null,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/PropertyAuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/PropertyAuditProjection.java
@@ -6,8 +6,13 @@
  */
 package org.hibernate.envers.query.projection.internal;
 
+import java.util.Map;
+
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.EntityInstantiator;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.criteria.internal.CriteriaTools;
 import org.hibernate.envers.query.internal.property.PropertyNameGetter;
 import org.hibernate.envers.query.projection.AuditProjection;
 
@@ -28,10 +33,25 @@ public class PropertyAuditProjection implements AuditProjection {
 	}
 
 	@Override
-	public ProjectionData getData(EnversService enversService) {
-		String propertyName = propertyNameGetter.get( enversService );
-		
-		return new ProjectionData( function, alias, propertyName, distinct );
+	public String getAlias(String baseAlias) {
+		return alias == null ? baseAlias : alias;
+	}
+
+	@Override
+	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
+			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+		String projectionEntityAlias = getAlias( baseAlias );
+		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
+		String propertyName = CriteriaTools.determinePropertyName(
+				enversService,
+				auditReader,
+				projectionEntityName,
+				propertyNameGetter );
+		queryBuilder.addProjection(
+				function,
+				projectionEntityAlias,
+				propertyName,
+				distinct );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/PropertyAuditProjection.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/projection/internal/PropertyAuditProjection.java
@@ -39,7 +39,7 @@ public class PropertyAuditProjection implements AuditProjection {
 
 	@Override
 	public void addProjectionToQuery(EnversService enversService, AuditReaderImplementor auditReader,
-			Map<String, String> aliasToEntityNameMap, String baseAlias, QueryBuilder queryBuilder) {
+			Map<String, String> aliasToEntityNameMap, Map<String, String> aliasToComponentPropertyNameMap, String baseAlias, QueryBuilder queryBuilder) {
 		String projectionEntityAlias = getAlias( baseAlias );
 		String projectionEntityName = aliasToEntityNameMap.get( projectionEntityAlias );
 		String propertyName = CriteriaTools.determinePropertyName(
@@ -47,10 +47,12 @@ public class PropertyAuditProjection implements AuditProjection {
 				auditReader,
 				projectionEntityName,
 				propertyNameGetter );
+		String propertyNamePrefix = CriteriaTools.determineComponentPropertyPrefix( enversService, aliasToEntityNameMap, aliasToComponentPropertyNameMap,
+				projectionEntityAlias );
 		queryBuilder.addProjection(
 				function,
 				projectionEntityAlias,
-				propertyName,
+				propertyNamePrefix.concat( propertyName ),
 				distinct );
 	}
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/components/dynamic/AuditedDynamicComponentsAdvancedCasesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/components/dynamic/AuditedDynamicComponentsAdvancedCasesTest.java
@@ -366,28 +366,6 @@ public class AuditedDynamicComponentsAdvancedCasesTest extends BaseEnversFunctio
 
 			assertTyping( IllegalArgumentException.class, e );
 		}
-
-		try {
-			getAuditReader().createQuery()
-					.forEntitiesAtRevision( AdvancedEntity.class, 1 )
-					.add(
-							AuditEntity.property( "dynamicConfiguration_" + INTERNAL_MAP_WITH_MANY_TO_MANY )
-									.eq( entity.getDynamicConfiguration().get( INTERNAL_MAP_WITH_MANY_TO_MANY ) )
-					)
-					.getResultList();
-			Assert.fail();
-		}
-		catch ( Exception e ) {
-			if ( getSession().getTransaction().isActive() ) {
-				getSession().getTransaction().rollback();
-			}
-
-			assertTyping( AuditException.class, e );
-			Assert.assertEquals(
-					"This type of relation (org.hibernate.envers.test.integration.components.dynamic.AdvancedEntity.dynamicConfiguration_internalMapWithEntities) isn't supported and can't be used in queries.",
-					e.getMessage()
-			);
-		}
 	}
 
 	@Test

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/components/dynamic/SanityCheckTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/components/dynamic/SanityCheckTest.java
@@ -148,7 +148,7 @@ public class SanityCheckTest extends BaseEnversFunctionalTestCase {
 		catch ( Exception e ) {
 			assertTyping( AuditException.class, e );
 			assertEquals(
-					"This type of relation (org.hibernate.envers.test.integration.components.dynamic.PlainEntity.component_manyToManyList) isn't supported and can't be used in queries.",
+					"This type of relation (org.hibernate.envers.test.integration.components.dynamic.PlainEntity.component_manyToManyList) can't be used in audit query restrictions.",
 					e.getMessage()
 			);
 		}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AssociationToManyJoinQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AssociationToManyJoinQueryTest.java
@@ -1,0 +1,496 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.criteria.JoinType;
+
+import org.hibernate.envers.AuditJoinTable;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+@TestForIssue(jiraKey = "HHH-11735")
+public class AssociationToManyJoinQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	private EntityA aEmpty;
+	private EntityA aOneToMany;
+	private EntityA aManyToMany;
+	private EntityA aBidiOneToManyInverse;
+	private EntityA aBidiManyToManyOwning;
+	private EntityA aBidiManyToManyInverse;
+	private EntityB b1;
+	private EntityB b2;
+	private EntityB b3;
+	private EntityC c1;
+	private EntityC c2;
+	private EntityC c3;
+
+	@Entity(name = "EntityA")
+	@Audited
+	public static class EntityA {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany
+		@AuditJoinTable(name = "entitya_onetomany_entityb_aud")
+		private Set<EntityB> bOneToMany = new HashSet<>();
+
+		@ManyToMany
+		@JoinTable(name = "entitya_manytomany_entityb")
+		private Set<EntityB> bManyToMany = new HashSet<>();
+
+		@OneToMany(mappedBy = "bidiAManyToOneOwning")
+		private Set<EntityC> bidiCOneToManyInverse = new HashSet<>();
+
+		@ManyToMany
+		@AuditJoinTable(name = "entitya_entityc_bidi_aud")
+		private Set<EntityC> bidiCManyToManyOwning = new HashSet<>();
+
+		@ManyToMany(mappedBy = "bidiAManyToManyOwning")
+		private Set<EntityC> bidiCManyToManyInverse = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Set<EntityB> getbOneToMany() {
+			return bOneToMany;
+		}
+
+		public void setbOneToMany(Set<EntityB> bOneToMany) {
+			this.bOneToMany = bOneToMany;
+		}
+
+		public Set<EntityB> getbManyToMany() {
+			return bManyToMany;
+		}
+
+		public void setbManyToMany(Set<EntityB> bManyToMany) {
+			this.bManyToMany = bManyToMany;
+		}
+
+		public Set<EntityC> getBidiCOneToManyInverse() {
+			return bidiCOneToManyInverse;
+		}
+
+		public void setBidiCOneToManyInverse(Set<EntityC> bidiCOneToManyInverse) {
+			this.bidiCOneToManyInverse = bidiCOneToManyInverse;
+		}
+
+		public Set<EntityC> getBidiCManyToManyOwning() {
+			return bidiCManyToManyOwning;
+		}
+
+		public void setBidiCManyToManyOwning(Set<EntityC> bidiCManyToManyOwning) {
+			this.bidiCManyToManyOwning = bidiCManyToManyOwning;
+		}
+
+		public Set<EntityC> getBidiCManyToManyInverse() {
+			return bidiCManyToManyInverse;
+		}
+
+		public void setBidiCManyToManyInverse(Set<EntityC> bidiCManyToManyInverse) {
+			this.bidiCManyToManyInverse = bidiCManyToManyInverse;
+		}
+
+	}
+
+	@Entity(name = "EntityB")
+	@Audited
+	public static class EntityB {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "EntityC")
+	@Audited
+	public static class EntityC {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@ManyToOne
+		private EntityA bidiAManyToOneOwning;
+
+		@ManyToMany
+		@JoinTable(name = "entityc_entitya_bidi")
+		private Set<EntityA> bidiAManyToManyOwning = new HashSet<>();
+
+		@ManyToMany(mappedBy = "bidiCManyToManyOwning")
+		private Set<EntityA> bidiAManyToManyInverse = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public EntityA getBidiAManyToOneOwning() {
+			return bidiAManyToOneOwning;
+		}
+
+		public void setBidiAManyToOneOwning(EntityA bidiAManyToOneOwning) {
+			this.bidiAManyToOneOwning = bidiAManyToOneOwning;
+		}
+
+		public Set<EntityA> getBidiAManyToManyOwning() {
+			return bidiAManyToManyOwning;
+		}
+
+		public void setBidiAManyToManyOwning(Set<EntityA> bidiAManyToManyOwning) {
+			this.bidiAManyToManyOwning = bidiAManyToManyOwning;
+		}
+
+		public Set<EntityA> getBidiAManyToManyInverse() {
+			return bidiAManyToManyInverse;
+		}
+
+		public void setBidiAManyToManyInverse(Set<EntityA> bidiAManyToManyInverse) {
+			this.bidiAManyToManyInverse = bidiAManyToManyInverse;
+		}
+
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ EntityA.class, EntityB.class, EntityC.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		// revision 1:
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+		b1 = new EntityB();
+		b1.setId( 21L );
+		b1.setName( "B1" );
+		em.persist( b1 );
+		b2 = new EntityB();
+		b2.setId( 22L );
+		b2.setName( "B2" );
+		em.persist( b2 );
+		b3 = new EntityB();
+		b3.setId( 23L );
+		b3.setName( "B3" );
+		em.persist( b3 );
+		c1 = new EntityC();
+		c1.setId( 31L );
+		c1.setName( "C1" );
+		em.persist( c1 );
+		c2 = new EntityC();
+		c2.setId( 32L );
+		c2.setName( "C2" );
+		em.persist( c2 );
+		c3 = new EntityC();
+		c3.setId( 33L );
+		c3.setName( "C3" );
+		em.persist( c3 );
+		aEmpty = new EntityA();
+		aEmpty.setId( 1L );
+		aEmpty.setName( "aEmpty" );
+		em.persist( aEmpty );
+		aOneToMany = new EntityA();
+		aOneToMany.setId( 2L );
+		aOneToMany.setName( "aOneToMany" );
+		aOneToMany.getbOneToMany().add( b1 );
+		aOneToMany.getbOneToMany().add( b3 );
+		em.persist( aOneToMany );
+		aManyToMany = new EntityA();
+		aManyToMany.setId( 3L );
+		aManyToMany.setName( "aManyToMany" );
+		aManyToMany.getbManyToMany().add( b1 );
+		aManyToMany.getbManyToMany().add( b3 );
+		em.persist( aManyToMany );
+		aBidiOneToManyInverse = new EntityA();
+		aBidiOneToManyInverse.setId( 4L );
+		aBidiOneToManyInverse.setName( "aBidiOneToManyInverse" );
+		aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c1 );
+		c1.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c3 );
+		c3.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		em.persist( aBidiOneToManyInverse );
+		aBidiManyToManyOwning = new EntityA();
+		aBidiManyToManyOwning.setId( 5L );
+		aBidiManyToManyOwning.setName( "aBidiManyToManyOwning" );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c1 );
+		c1.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c3 );
+		c3.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		em.persist( aBidiManyToManyOwning );
+		aBidiManyToManyInverse = new EntityA();
+		aBidiManyToManyInverse.setId( 6L );
+		aBidiManyToManyInverse.setName( "aBidiManyToManyInverse" );
+		aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c1 );
+		c1.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c3 );
+		c3.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		em.persist( aBidiManyToManyInverse );
+		em.getTransaction().commit();
+
+		// revision 2:
+		em.getTransaction().begin();
+		aOneToMany.getbOneToMany().remove( b1 );
+		aOneToMany.getbOneToMany().add( b2 );
+		aManyToMany.getbManyToMany().remove( b1 );
+		aManyToMany.getbManyToMany().add( b2 );
+		aBidiOneToManyInverse.getBidiCOneToManyInverse().remove( c1 );
+		c1.setBidiAManyToOneOwning( null );
+		aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c2 );
+		c2.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().remove( c1 );
+		c1.getBidiAManyToManyInverse().remove( aBidiManyToManyOwning );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c2 );
+		c2.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		aBidiManyToManyInverse.getBidiCManyToManyInverse().remove( c1 );
+		c1.getBidiAManyToManyOwning().remove( aBidiManyToManyInverse );
+		aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c2 );
+		c2.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testOneToManyInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aOneToMany.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aOneToMany.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testOneToManyLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.LEFT, "b" ).up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "b", "name" ).eq( "B1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aOneToMany.getId() ) );
+	}
+
+	@Test
+	public void testManyToManyInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aManyToMany.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aManyToMany.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testManyToManyLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.LEFT, "b" ).up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "b", "name" ).eq( "B1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aManyToMany.getId() ) );
+	}
+
+	@Test
+	public void testBidiOneToManyInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCOneToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiOneToManyInverse.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCOneToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCOneToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiOneToManyInverse.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCOneToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testBidiOneToManyLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCOneToManyInverse", JoinType.LEFT, "c" )
+				.up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aBidiOneToManyInverse.getId() ) );
+	}
+
+	@Test
+	public void testBidiManyToManyOwningInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyOwning.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyOwning.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testBidiManyToManyOwningLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.LEFT, "c" )
+				.up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aBidiManyToManyOwning.getId() ) );
+	}
+
+	@Test
+	public void testBidiManyToManyInverseInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyInverse.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyInverse.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyInverse", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testBidiManyToManyInverseLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyInverse", JoinType.LEFT, "c" )
+				.up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aBidiManyToManyInverse.getId() ) );
+	}
+
+	private boolean listContainsIds(final Collection<?> entities, final long... ids) {
+		final Set<Long> idSet = new HashSet<>();
+		for ( final Object entity : entities ) {
+			idSet.add( ( (EntityA) entity ).getId() );
+		}
+		boolean result = true;
+		for ( final long id : ids ) {
+			if ( !idSet.contains( id ) ) {
+				result = false;
+				break;
+			}
+		}
+		return result;
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AssociationToNotAuditedManyJoinQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AssociationToNotAuditedManyJoinQueryTest.java
@@ -1,0 +1,508 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.persistence.criteria.JoinType;
+
+import org.hibernate.envers.AuditJoinTable;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.RelationTargetAuditMode;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+@TestForIssue(jiraKey = "HHH-11735")
+public class AssociationToNotAuditedManyJoinQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	private EntityA aEmpty;
+	private EntityA aOneToMany;
+	private EntityA aManyToMany;
+	private EntityA aBidiOneToManyInverse;
+	private EntityA aBidiManyToManyOwning;
+	private EntityA aBidiManyToManyInverse;
+	private EntityB b1;
+	private EntityB b2;
+	private EntityB b3;
+	private EntityC c1;
+	private EntityC c2;
+	private EntityC c3;
+
+	@Entity(name = "EntityA")
+	@Audited
+	public static class EntityA {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany
+		@AuditJoinTable(name = "entitya_onetomany_entityb_aud")
+		@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+		private Set<EntityB> bOneToMany = new HashSet<>();
+
+		@ManyToMany
+		@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+		@JoinTable(name = "entitya_manytomany_entityb")
+		private Set<EntityB> bManyToMany = new HashSet<>();
+
+		// @OneToMany(mappedBy="bidiAManyToOneOwning")
+		// @Audited(targetAuditMode=RelationTargetAuditMode.NOT_AUDITED)
+		// private Set<EntityC> bidiCOneToManyInverse = new HashSet<>();
+
+		@ManyToMany
+		@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+		@AuditJoinTable(name = "entitya_entityc_bidi_aud")
+		private Set<EntityC> bidiCManyToManyOwning = new HashSet<>();
+
+		// @ManyToMany(mappedBy="bidiAManyToManyOwning")
+		// @Audited(targetAuditMode=RelationTargetAuditMode.NOT_AUDITED)
+		// private Set<EntityC> bidiCManyToManyInverse = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Set<EntityB> getbOneToMany() {
+			return bOneToMany;
+		}
+
+		public void setbOneToMany(Set<EntityB> bOneToMany) {
+			this.bOneToMany = bOneToMany;
+		}
+
+		public Set<EntityB> getbManyToMany() {
+			return bManyToMany;
+		}
+
+		public void setbManyToMany(Set<EntityB> bManyToMany) {
+			this.bManyToMany = bManyToMany;
+		}
+
+		// public Set<EntityC> getBidiCOneToManyInverse() {
+		// return bidiCOneToManyInverse;
+		// }
+		//
+		//
+		//
+		// public void setBidiCOneToManyInverse(Set<EntityC> bidiCOneToManyInverse) {
+		// this.bidiCOneToManyInverse = bidiCOneToManyInverse;
+		// }
+
+		public Set<EntityC> getBidiCManyToManyOwning() {
+			return bidiCManyToManyOwning;
+		}
+
+		public void setBidiCManyToManyOwning(Set<EntityC> bidiCManyToManyOwning) {
+			this.bidiCManyToManyOwning = bidiCManyToManyOwning;
+		}
+
+		// public Set<EntityC> getBidiCManyToManyInverse() {
+		// return bidiCManyToManyInverse;
+		// }
+		//
+		//
+		// public void setBidiCManyToManyInverse(Set<EntityC> bidiCManyToManyInverse) {
+		// this.bidiCManyToManyInverse = bidiCManyToManyInverse;
+		// }
+
+	}
+
+	@Entity(name = "EntityB")
+	public static class EntityB {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "EntityC")
+	public static class EntityC {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		// @ManyToOne
+		// private EntityA bidiAManyToOneOwning;
+
+		// @ManyToMany
+		// @JoinTable(name="entityc_entitya_bidi")
+		// private Set<EntityA> bidiAManyToManyOwning = new HashSet<>();
+
+		@ManyToMany(mappedBy = "bidiCManyToManyOwning")
+		private Set<EntityA> bidiAManyToManyInverse = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		// public EntityA getBidiAManyToOneOwning() {
+		// return bidiAManyToOneOwning;
+		// }
+		//
+		//
+		// public void setBidiAManyToOneOwning(EntityA bidiAManyToOneOwning) {
+		// this.bidiAManyToOneOwning = bidiAManyToOneOwning;
+		// }
+
+		// public Set<EntityA> getBidiAManyToManyOwning() {
+		// return bidiAManyToManyOwning;
+		// }
+		//
+		//
+		// public void setBidiAManyToManyOwning(Set<EntityA> bidiAManyToManyOwning) {
+		// this.bidiAManyToManyOwning = bidiAManyToManyOwning;
+		// }
+
+		public Set<EntityA> getBidiAManyToManyInverse() {
+			return bidiAManyToManyInverse;
+		}
+
+		public void setBidiAManyToManyInverse(Set<EntityA> bidiAManyToManyInverse) {
+			this.bidiAManyToManyInverse = bidiAManyToManyInverse;
+		}
+
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ EntityA.class, EntityB.class, EntityC.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		// revision 1:
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+		b1 = new EntityB();
+		b1.setId( 21L );
+		b1.setName( "B1" );
+		em.persist( b1 );
+		b2 = new EntityB();
+		b2.setId( 22L );
+		b2.setName( "B2" );
+		em.persist( b2 );
+		b3 = new EntityB();
+		b3.setId( 23L );
+		b3.setName( "B3" );
+		em.persist( b3 );
+		c1 = new EntityC();
+		c1.setId( 31L );
+		c1.setName( "C1" );
+		em.persist( c1 );
+		c2 = new EntityC();
+		c2.setId( 32L );
+		c2.setName( "C2" );
+		em.persist( c2 );
+		c3 = new EntityC();
+		c3.setId( 33L );
+		c3.setName( "C3" );
+		em.persist( c3 );
+		aEmpty = new EntityA();
+		aEmpty.setId( 1L );
+		aEmpty.setName( "aEmpty" );
+		em.persist( aEmpty );
+		aOneToMany = new EntityA();
+		aOneToMany.setId( 2L );
+		aOneToMany.setName( "aOneToMany" );
+		aOneToMany.getbOneToMany().add( b1 );
+		aOneToMany.getbOneToMany().add( b3 );
+		em.persist( aOneToMany );
+		aManyToMany = new EntityA();
+		aManyToMany.setId( 3L );
+		aManyToMany.setName( "aManyToMany" );
+		aManyToMany.getbManyToMany().add( b1 );
+		aManyToMany.getbManyToMany().add( b3 );
+		em.persist( aManyToMany );
+		aBidiOneToManyInverse = new EntityA();
+		aBidiOneToManyInverse.setId( 4L );
+		aBidiOneToManyInverse.setName( "aBidiOneToManyInverse" );
+		// aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c1 );
+		// c1.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		// aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c3 );
+		// c3.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		em.persist( aBidiOneToManyInverse );
+		aBidiManyToManyOwning = new EntityA();
+		aBidiManyToManyOwning.setId( 5L );
+		aBidiManyToManyOwning.setName( "aBidiManyToManyOwning" );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c1 );
+		c1.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c3 );
+		c3.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		em.persist( aBidiManyToManyOwning );
+		aBidiManyToManyInverse = new EntityA();
+		aBidiManyToManyInverse.setId( 6L );
+		aBidiManyToManyInverse.setName( "aBidiManyToManyInverse" );
+		// aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c1 );
+		// c1.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		// aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c3 );
+		// c3.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		em.persist( aBidiManyToManyInverse );
+		em.getTransaction().commit();
+
+		// revision 2:
+		em.getTransaction().begin();
+		aOneToMany.getbOneToMany().remove( b1 );
+		aOneToMany.getbOneToMany().add( b2 );
+		aManyToMany.getbManyToMany().remove( b1 );
+		aManyToMany.getbManyToMany().add( b2 );
+		// aBidiOneToManyInverse.getBidiCOneToManyInverse().remove( c1 );
+		// c1.setBidiAManyToOneOwning( null );
+		// aBidiOneToManyInverse.getBidiCOneToManyInverse().add( c2 );
+		// c2.setBidiAManyToOneOwning( aBidiOneToManyInverse );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().remove( c1 );
+		c1.getBidiAManyToManyInverse().remove( aBidiManyToManyOwning );
+		aBidiManyToManyOwning.getBidiCManyToManyOwning().add( c2 );
+		c2.getBidiAManyToManyInverse().add( aBidiManyToManyOwning );
+		// aBidiManyToManyInverse.getBidiCManyToManyInverse().remove( c1 );
+		// c1.getBidiAManyToManyOwning().remove( aBidiManyToManyInverse );
+		// aBidiManyToManyInverse.getBidiCManyToManyInverse().add( c2 );
+		// c2.getBidiAManyToManyOwning().add( aBidiManyToManyInverse );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testOneToManyInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aOneToMany.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aOneToMany.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bOneToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testOneToManyLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bOneToMany", JoinType.LEFT, "b" ).up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "b", "name" ).eq( "B1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aOneToMany.getId() ) );
+	}
+
+	@Test
+	public void testManyToManyInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aManyToMany.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aManyToMany.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bManyToMany", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "B1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since B1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testManyToManyLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bManyToMany", JoinType.LEFT, "b" ).up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "b", "name" ).eq( "B1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aManyToMany.getId() ) );
+	}
+
+	// @Test
+	// public void testBidiOneToManyInnerJoin() {
+	// List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCOneToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+	// assertEquals("Expected exactly one entity", 1, list1.size());
+	// EntityA entityA1 = (EntityA) list1.get( 0 );
+	// assertEquals("Expected the correct entity to be resolved", aBidiOneToManyInverse.getId(), entityA1.getId());
+	//
+	// List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCOneToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+	// assertTrue("Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty());
+	//
+	// List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation(
+	// "bidiCOneToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+	// assertEquals("Expected exactly one entity", 1, list3.size());
+	// EntityA entityA3 = (EntityA) list3.get( 0 );
+	// assertEquals("Expected the correct entity to be resolved", aBidiOneToManyInverse.getId(), entityA3.getId());
+	//
+	// List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation(
+	// "bidiCOneToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+	// assertTrue("Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty());
+	// }
+	//
+	// @Test
+	// public void testBidiOneToManyLeftJoin() {
+	// List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCOneToManyInverse", JoinType.LEFT, "c" ).up()
+	// .add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1"
+	// ) ) )
+	// .getResultList();
+	// assertTrue("Expected the correct entities to be resolved", listContainsIds(list, aEmpty.getId(),
+	// aBidiOneToManyInverse.getId()));
+	// }
+
+	@Test
+	public void testBidiManyToManyOwningInnerJoin() {
+		List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list1.size() );
+		EntityA entityA1 = (EntityA) list1.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyOwning.getId(), entityA1.getId() );
+
+		List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty() );
+
+		List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+		assertEquals( "Expected exactly one entity", 1, list3.size() );
+		EntityA entityA3 = (EntityA) list3.get( 0 );
+		assertEquals( "Expected the correct entity to be resolved", aBidiManyToManyOwning.getId(), entityA3.getId() );
+
+		List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation( "bidiCManyToManyOwning", JoinType.INNER )
+				.add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+		assertTrue( "Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty() );
+	}
+
+	@Test
+	public void testBidiManyToManyOwningLeftJoin() {
+		List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation( "bidiCManyToManyOwning", JoinType.LEFT, "c" )
+				.up()
+				.add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1" ) ) )
+				.getResultList();
+		assertTrue( "Expected the correct entities to be resolved", listContainsIds( list, aEmpty.getId(), aBidiManyToManyOwning.getId() ) );
+	}
+
+	// @Test
+	// public void testBidiManyToManyInverseInnerJoin() {
+	// List<?> list1 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCManyToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+	// assertEquals("Expected exactly one entity", 1, list1.size());
+	// EntityA entityA1 = (EntityA) list1.get( 0 );
+	// assertEquals("Expected the correct entity to be resolved", aBidiManyToManyInverse.getId(), entityA1.getId());
+	//
+	// List<?> list2 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCManyToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+	// assertTrue("Expected no entities to be returned, since C2 has been added in revision 2", list2.isEmpty());
+	//
+	// List<?> list3 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation(
+	// "bidiCManyToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C2" ) ).getResultList();
+	// assertEquals("Expected exactly one entity", 1, list3.size());
+	// EntityA entityA3 = (EntityA) list3.get( 0 );
+	// assertEquals("Expected the correct entity to be resolved", aBidiManyToManyInverse.getId(), entityA3.getId());
+	//
+	// List<?> list4 = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 2 ).traverseRelation(
+	// "bidiCManyToManyInverse", JoinType.INNER ).add( AuditEntity.property( "name" ).eq( "C1" ) ).getResultList();
+	// assertTrue("Expected no entities to be returned, since C1 has been removed in revision 2", list4.isEmpty());
+	// }
+	//
+	// @Test
+	// public void testBidiManyToManyInverseLeftJoin() {
+	// List<?> list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 ).traverseRelation(
+	// "bidiCManyToManyInverse", JoinType.LEFT, "c" ).up()
+	// .add( AuditEntity.or( AuditEntity.property( "name" ).eq( "aEmpty" ), AuditEntity.property( "c", "name" ).eq( "C1"
+	// ) ) )
+	// .getResultList();
+	// assertTrue("Expected the correct entities to be resolved", listContainsIds(list, aEmpty.getId(),
+	// aBidiManyToManyInverse.getId()));
+	// }
+
+	private boolean listContainsIds(final Collection<?> entities, final long... ids) {
+		final Set<Long> idSet = new HashSet<>();
+		for ( final Object entity : entities ) {
+			idSet.add( ( (EntityA) entity ).getId() );
+		}
+		boolean result = true;
+		for ( final long id : ids ) {
+			if ( !idSet.contains( id ) ) {
+				result = false;
+				break;
+			}
+		}
+		return result;
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AuditFunctionQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AuditFunctionQueryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+public class AuditFunctionQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	@Entity
+	@Audited
+	public static class TestEntity {
+
+		@Id
+		private Long id;
+		private String string1;
+		private String string2;
+		private Integer int1;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getString1() {
+			return string1;
+		}
+
+		public void setString1(String string1) {
+			this.string1 = string1;
+		}
+
+		public String getString2() {
+			return string2;
+		}
+
+		public Integer getInt1() {
+			return int1;
+		}
+
+		public void setInt1(Integer int1) {
+			this.int1 = int1;
+		}
+
+		public void setString2(String string2) {
+			this.string2 = string2;
+		}
+
+	}
+
+	private TestEntity testEntity1;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ TestEntity.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+		testEntity1 = new TestEntity();
+		testEntity1.setId( 1L );
+		testEntity1.setString1( "abcdef" );
+		testEntity1.setString2( "42 - the truth" );
+		testEntity1.setInt1( 42 );
+		em.persist( testEntity1 );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testProjectionWithPropertyArgument() {
+		Object actual = getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.addProjection( AuditEntity.function( "upper", AuditEntity.property( "string1" ) ) ).getSingleResult();
+		String expected = testEntity1.getString1().toUpperCase();
+		assertEquals( "Expected the property string1 to be upper case", expected, actual );
+	}
+
+	@Test
+	public void testProjectionWithPropertyAndSimpleArguments() {
+		Object actual = getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.addProjection( AuditEntity.function( "substring", AuditEntity.property( "string1" ), 3, 2 ) ).getSingleResult();
+		// the sql substring indices are 1 based while java substring indices are 0 based
+		// the sql substring second parameter denotes the length of the substring
+		// while in java the scond argument denotes the end index
+		String expected = testEntity1.getString1().substring( 2, 4 );
+		assertEquals( "Expected the substring of the property string1", expected, actual );
+	}
+
+	@Test
+	public void testProjectionWithNestedFunction() {
+		Object actual = getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.addProjection( AuditEntity.function( "concat",
+						AuditEntity.function( "upper", AuditEntity.property( "string1" ) ),
+						AuditEntity.function( "substring", AuditEntity.property( "string2" ), 1, 2 ) ) )
+				.getSingleResult();
+		final String expected = testEntity1.getString1().toUpperCase().concat( testEntity1.getString2().substring( 0, 2 ) );
+		assertEquals( "Expected the upper cased string1 to be concat with the first two characters of string2", expected, actual );
+	}
+
+	@Test
+	public void testComparisonFunctionWithValue() {
+		TestEntity entity = (TestEntity) getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.add( AuditEntity.function( "substring", AuditEntity.property( "string1" ), 3, 2 ).eq( "cd" ) ).getSingleResult();
+		assertNotNull( "Expected the entity to be returned", entity );
+		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
+	}
+
+	@Test
+	public void testComparionFunctionWithProperty() {
+		TestEntity entity = (TestEntity) getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.add( AuditEntity.function( "length", AuditEntity.property( "string2" ) ).ltProperty( "int1" ) ).getSingleResult();
+		assertNotNull( "Expected the entity to be returned", entity );
+		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
+	}
+
+	@Test
+	public void testComparisonFunctionWithFunction() {
+		TestEntity entity = (TestEntity) getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.add( AuditEntity.function( "substring", AuditEntity.property( "string2" ), 1, 2 )
+						.eqFunction( AuditEntity.function( "str", AuditEntity.property( "int1" ) ) ) )
+				.getSingleResult();
+		assertNotNull( "Expected the entity to be returned", entity );
+		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
+	}
+
+	@Test
+	public void testComparisonPropertyWithFunction() {
+		TestEntity entity = (TestEntity) getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.add( AuditEntity.property( "int1" ).gtFunction( AuditEntity.function( "length", AuditEntity.property( "string2" ) ) ) ).getSingleResult();
+		assertNotNull( "Expected the entity to be returned", entity );
+		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AuditFunctionQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/AuditFunctionQueryTest.java
@@ -153,4 +153,12 @@ public class AuditFunctionQueryTest extends BaseEnversJPAFunctionalTestCase {
 		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
 	}
 
+	@Test
+	public void testFunctionOnIdProperty() {
+		TestEntity entity = (TestEntity) getAuditReader().createQuery().forEntitiesAtRevision( TestEntity.class, 1 )
+				.add( AuditEntity.function( "str", AuditEntity.id() ).like( "%1%" ) ).getSingleResult();
+		assertNotNull( "Expected the entity to be returned", entity );
+		assertEquals( "Expected the entity to be returned", testEntity1.getId(), entity.getId() );
+	}
+
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/ComponentQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/ComponentQueryTest.java
@@ -1,0 +1,281 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.criteria.JoinType;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+@SuppressWarnings("rawtypes")
+@TestForIssue(jiraKey = "HHH-11895")
+public class ComponentQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	@Embeddable
+	public static class Symbol {
+
+		@ManyToOne
+		private SymbolType type;
+		private String identifier;
+
+		public Symbol() {
+
+		}
+
+		public Symbol(final SymbolType type, final String identifier) {
+			this.type = type;
+			this.identifier = identifier;
+		}
+
+		public SymbolType getType() {
+			return type;
+		}
+
+		public void setType(SymbolType type) {
+			this.type = type;
+		}
+
+		public String getIdentifier() {
+			return identifier;
+		}
+
+		public void setIdentifier(String identifier) {
+			this.identifier = identifier;
+		}
+
+	}
+
+	@Entity(name = "SymbolType")
+	@Audited
+	public static class SymbolType {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Asset")
+	@Audited
+	public static class Asset {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Embedded
+		private Symbol singleSymbol;
+
+		@ElementCollection
+		private Set<Symbol> multiSymbols = new HashSet<>();
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Symbol getSingleSymbol() {
+			return singleSymbol;
+		}
+
+		public void setSingleSymbol(Symbol singleSymbol) {
+			this.singleSymbol = singleSymbol;
+		}
+
+		public Set<Symbol> getMultiSymbols() {
+			return multiSymbols;
+		}
+
+		public void setMultiSymbols(Set<Symbol> multiSymbols) {
+			this.multiSymbols = multiSymbols;
+		}
+
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Asset.class, Symbol.class, SymbolType.class };
+	}
+
+	private SymbolType type1;
+	private SymbolType type2;
+
+	private Asset asset1;
+	private Asset asset2;
+	private Asset asset3;
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		type1 = new SymbolType();
+		type1.setName( "T1" );
+		em.persist( type1 );
+
+		type2 = new SymbolType();
+		type2.setName( "T2" );
+		em.persist( type2 );
+
+		asset1 = new Asset();
+		em.persist( asset1 );
+
+		asset2 = new Asset();
+		asset2.setSingleSymbol( new Symbol( type1, "X1" ) );
+		asset2.getMultiSymbols().add( new Symbol( type1, "X" ) );
+		em.persist( asset2 );
+
+		asset3 = new Asset();
+		asset3.setSingleSymbol( new Symbol( type2, "X2" ) );
+		asset3.getMultiSymbols().add( new Symbol( type1, "Y" ) );
+		asset3.getMultiSymbols().add( new Symbol( type2, "X" ) );
+		em.persist( asset3 );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testSingleSymbolUsingIdentifier() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "singleSymbol", JoinType.INNER, "s" )
+				.add( AuditEntity.property( "s", "identifier" ).eq( "X1" ) ).up().addProjection( AuditEntity.id() ).getResultList();
+		assertEquals( "Expected only asset2 to be returned", Collections.singletonList( asset2.getId() ), actual );
+	}
+
+	@Test
+	public void testMultiSymbolUsingIdentifier() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "multiSymbols", JoinType.INNER, "s" )
+				.add( AuditEntity.property( "s", "identifier" ).like( "X%" ) ).up().addProjection( AuditEntity.id() ).addOrder( AuditEntity.id().asc() )
+				.getResultList();
+		List<Integer> expected = new ArrayList<>();
+		Collections.addAll( expected, asset2.getId(), asset3.getId() );
+		assertEquals( "Expected only the ids of the assets with symbol T1", expected, actual );
+	}
+
+	@Test
+	public void testSingleSymbolUsingType() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "singleSymbol", JoinType.INNER, "s" )
+				.add( AuditEntity.property( "s", "type" ).eq( type1 ) ).up().addProjection( AuditEntity.id() ).getResultList();
+		assertEquals( "Expected only asset2 to be returned", Collections.singletonList( asset2.getId() ), actual );
+	}
+
+	@Test
+	public void testMultiSymbolUsingType() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "multiSymbols", JoinType.INNER, "s" )
+				.add( AuditEntity.property( "s", "type" ).eq( type2 ) ).up().addProjection( AuditEntity.id() ).getResultList();
+		assertEquals( " Expected only asset3 to be returned", Collections.singletonList( asset3.getId() ), actual );
+	}
+
+	@Test
+	public void testJoinOnSingleComponentAssociation() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "singleSymbol", JoinType.INNER, "s" )
+				.traverseRelation( "type", JoinType.INNER, "t" )
+				.add( AuditEntity.property( "t", "name" ).eq( "T1" ) ).up().up().addProjection( AuditEntity.id() ).getResultList();
+		assertEquals( "Expected only asset2 to be returned", Collections.singletonList( asset2.getId() ), actual );
+	}
+
+	@Test
+	public void testJoinOnMultiComponentAssociation() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).traverseRelation( "multiSymbols", JoinType.INNER, "s" )
+				.traverseRelation( "type", JoinType.INNER, "t" )
+				.add( AuditEntity.property( "t", "name" ).eq( "T2" ) ).up().up().addProjection( AuditEntity.id() ).getResultList();
+		assertEquals( "Expected only asset3 to be returned", Collections.singletonList( asset3.getId() ), actual );
+	}
+
+	@Test
+	public void testOrderingOnSingleComponent() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).addProjection( AuditEntity.id() )
+				.traverseRelation( "singleSymbol", JoinType.LEFT, "s" ).addOrder( AuditEntity.property( "s", "identifier" ).asc() ).getResultList();
+		List<Integer> expected = new ArrayList<>();
+		Collections.addAll( expected, asset1.getId(), asset2.getId(), asset3.getId() );
+		assertEquals( "Expected all assets in correct order", expected, actual );
+	}
+
+	@Test
+	public void testOrderingOnMultiComponent() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).addProjection( AuditEntity.id() )
+				.traverseRelation( "multiSymbols", JoinType.LEFT, "s" ).traverseRelation( "type", JoinType.LEFT, "t" )
+				.addOrder( AuditEntity.property( "t", "name" ).asc() ).addOrder( AuditEntity.property( "s", "identifier" ).asc() ).getResultList();
+		List<Integer> expected = new ArrayList<>();
+		Collections.addAll( expected, asset1.getId(), asset2.getId(), asset3.getId(), asset3.getId() );
+		assertEquals( "Expected all assets in correct order", expected, actual );
+	}
+
+	@Test
+	public void testProjectionOnSingleComponentProperty() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).add( AuditEntity.id().eq( asset2.getId() ) )
+				.traverseRelation( "singleSymbol", JoinType.INNER, "s" ).addProjection( AuditEntity.property( "s", "identifier" ) ).getResultList();
+		assertEquals( "Expected the symbol identifier of asset2 to be returned", Collections.singletonList( "X1" ), actual );
+	}
+
+	@Test
+	public void testProjectionOnMultiComponentProperty() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).add( AuditEntity.id().eq( asset2.getId() ) )
+				.traverseRelation( "multiSymbols", JoinType.INNER, "s" ).addProjection( AuditEntity.property( "s", "identifier" ) ).getResultList();
+		assertEquals( "Expected the symbol identifier of asset2 to be returned", Collections.singletonList( "X" ), actual );
+	}
+
+	@Test
+	public void testFunctionOnSingleComponentProperty() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).add( AuditEntity.id().eq( asset2.getId() ) )
+				.traverseRelation( "singleSymbol", JoinType.INNER, "s" )
+				.addProjection( AuditEntity.function( "CONCAT", AuditEntity.property( "s", "identifier" ), "Z" ) ).getResultList();
+		assertEquals( "Expecte the symbol identfier of asset2 concatenated with 'Z'", Collections.singletonList( "X1Z" ), actual );
+	}
+
+	@Test
+	public void testFunctionOnMultiComponentProperty() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( Asset.class, 1 ).add( AuditEntity.id().eq( asset2.getId() ) )
+				.traverseRelation( "multiSymbols", JoinType.INNER, "s" )
+				.addProjection( AuditEntity.function( "CONCAT", AuditEntity.property( "s", "identifier" ), "Z" ) ).getResultList();
+		assertEquals( "Expecte the symbol identfier of asset2 concatenated with 'Z'", Collections.singletonList( "XZ" ), actual );
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/NestedComponentQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/NestedComponentQueryTest.java
@@ -1,0 +1,150 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.query;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.criteria.JoinType;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+@TestForIssue(jiraKey = "HHH-11895")
+public class NestedComponentQueryTest extends BaseEnversJPAFunctionalTestCase {
+
+	@Embeddable
+	public static class Component1 {
+
+		private String name1;
+
+		@Embedded
+		private Component2 component2;
+
+		public String getName1() {
+			return name1;
+		}
+
+		public void setName1(String name1) {
+			this.name1 = name1;
+		}
+
+		public Component2 getComponent2() {
+			return component2;
+		}
+
+		public void setComponent2(Component2 component2) {
+			this.component2 = component2;
+		}
+	}
+
+	@Embeddable
+	public static class Component2 {
+
+		private String name2;
+
+		public String getName2() {
+			return name2;
+		}
+
+		public void setName2(String name2) {
+			this.name2 = name2;
+		}
+	}
+
+	@Entity(name = "EntityOwner")
+	@Audited
+	public static class EntityOwner {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Embedded
+		private Component1 component1;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Component1 getComponent1() {
+			return component1;
+		}
+
+		public void setComponent1(Component1 component1) {
+			this.component1 = component1;
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ EntityOwner.class, Component1.class, Component2.class };
+	}
+
+	private EntityOwner owner1;
+	private EntityOwner owner2;
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+		owner1 = new EntityOwner();
+		Component1 component1 = new Component1();
+		component1.setName1( "X" );
+		owner1.setComponent1( component1 );
+		Component2 component2 = new Component2();
+		component2.setName2( "Y" );
+		component1.setComponent2( component2 );
+		em.persist( owner1 );
+		owner2 = new EntityOwner();
+		Component1 component12 = new Component1();
+		component12.setName1( "Z" );
+		owner2.setComponent1( component12 );
+		Component2 component22 = new Component2();
+		component22.setName2( "Z" );
+		component12.setComponent2( component22 );
+		em.persist( owner2 );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testQueryNestedComponent() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( EntityOwner.class, 1 ).addProjection( AuditEntity.id() )
+				.traverseRelation( "component1", JoinType.INNER, "c1" ).traverseRelation( "component2", JoinType.INNER, "c2" )
+				.add( AuditEntity.property( "c2", "name2" ).eq( "Y" ) ).getResultList();
+		assertEquals( "Expected owner1 to be returned", Collections.singletonList( owner1.getId() ), actual );
+	}
+
+	@Test
+	public void testQueryNestedComponentWithPropertyEquals() {
+		List actual = getAuditReader().createQuery().forEntitiesAtRevision( EntityOwner.class, 1 ).addProjection( AuditEntity.id() )
+				.traverseRelation( "component1", JoinType.INNER, "c1" ).traverseRelation( "component2", JoinType.INNER, "c2" )
+				.add( AuditEntity.property( "c1", "name1" ).eqProperty( "c2", "name2" ) ).getResultList();
+		assertEquals( "Expected owner2 to be returned", Collections.singletonList( owner2.getId() ), actual );
+	}
+
+}


### PR DESCRIPTION
This PR adds the possibility to query for properties on components in the envers query API by using the traverseRelation(..) methods.

This PR is based on the open PRs for HHH-11452 ([1849](https://github.com/hibernate/hibernate-orm/pull/1849)) and HHH-11735 ([1904](https://github.com/hibernate/hibernate-orm/pull/1904)). That means that the only the last commit is a new contribution and the other commits are part of the other PRs.

Link to Jira Issue: [HHH-11895](https://hibernate.atlassian.net/browse/HHH-11895)
