### PR TITLE
HHH-11640 - NamedQuery doesn't log comment when UPDATE/DELETE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeSQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeSQLQueryPlan.java
@@ -183,7 +183,9 @@ public class NativeSQLQueryPlan implements Serializable {
 		PreparedStatement ps;
 		try {
 			queryParameters.processFilters( this.customQuery.getSQL(), session );
-			final String sql = queryParameters.getFilteredSQL();
+			final String sql = (isCommentsEnabled(session))
+					? prependComment(queryParameters.getFilteredSQL(), queryParameters)
+					: queryParameters.getFilteredSQL();
 
 			ps = session.getJdbcCoordinator().getStatementPreparer().prepareStatement( sql, false );
 
@@ -209,5 +211,16 @@ public class NativeSQLQueryPlan implements Serializable {
 		}
 
 		return result;
+	}
+
+	private boolean isCommentsEnabled(SharedSessionContractImplementor session) {
+		return session.getFactory().getSessionFactoryOptions().isCommentsEnabled();
+	}
+
+	private String prependComment(String sql, QueryParameters parameters) {
+		String comment = parameters.getComment();
+		return ( comment == null )
+				? sql
+				: "/* " + comment + " */ " + sql;
 	}
 }


### PR DESCRIPTION
Prepending comment to native update, similarly as [AbstractLoadPlanBasedLoade.executeQueryStatement()#L183](https://github.com/hibernate/hibernate-orm/blob/3a813dcbb4b5cf5b13571c63ff0c66b94a83b53c/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java#L183) or [Loader.executeQueryStatement()#L1909](https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/loader/Loader.java#L1909)