### PR TITLE
HHH-11902 - HHH000260: Exception calling user Synchronization - hibernate update indexes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -294,7 +294,15 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 					"Proxy is detached (i.e, session is null). The read-only/modifiable setting is only accessible when the proxy is associated with an open session."
 			);
 		}
-		if ( session.isClosed() ) {
+		/*
+		Replaced if ( session.isClosed() ) with if ( !session.isOpenOrWaitingForAutoClose() )
+		to fix below issue with setting index from search.
+		HHH000260: Exception calling user Synchronization 
+		[org.hibernate.search.backend.impl.EventSourceTransactionContext$BeforeCommitSynchronizationDelegator@b4884752] 
+		: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role:
+		*/
+		//if ( session.isClosed() ) {
+		if ( !session.isOpenOrWaitingForAutoClose() ) {
 			throw new SessionException(
 					"Session is closed. The read-only/modifiable setting is only accessible when the proxy is associated with an open session."
 			);


### PR DESCRIPTION
Update AbstractLazyInitializer.java to fix below issue for setting index from search in version hibernate-core 5.2.8. Below is the Exception.

HHH000260: Exception calling user Synchronization [org.hibernate.search.backend.impl.EventSourceTransactionContext$BeforeCommitSynchronizationDelegator@b4884752] : org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.myapp.loan.LoanApplication.subloans, could not initialize proxy - the owning Session was closed> 

Caused by: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.myapp.entities.LoanApplication.subloans, could not initialize proxy - the owning Session was closed

Below is the code line causing this issue.

org.hibernate.search.jpa.FullTextEntityManager fullTextEntityManager = org.hibernate.search.jpa.Search
                .getFullTextEntityManager(entityManager);

 fullTextEntityManager.index(loanApplication);

Session is marked as closed which doesn't allow the entity to update the indexes. Please see the attached testcase.

// Old Code

if ( session.isClosed() )  {
			throw new SessionException(
					"Session is closed. The read-only/modifiable setting is only accessible when the proxy is associated with an open session."
			);
		}

// Updated Code

if ( !session.isOpenOrWaitingForAutoClose() ) {
			throw new SessionException(
					"Session is closed. The read-only/modifiable setting is only accessible when the proxy is associated with an open session."
			);
		}