### PR TITLE
HHH-11914 : SchemaUpdate.setHaltOnError(true) does nothing

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaMigratorHaltOnErrorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaMigratorHaltOnErrorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.schemaupdate;
+
+import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.tool.schema.spi.SchemaManagementException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Vlad Mihalcea
+ */
+public class SchemaMigratorHaltOnErrorTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+			From.class
+		};
+	}
+
+	@Override
+	protected Map buildSettings() {
+		Map settings = super.buildSettings();
+		settings.put( AvailableSettings.HBM2DDL_AUTO, "update" );
+		settings.put( AvailableSettings.HBM2DDL_HALT_ON_ERROR, true );
+		return settings;
+	}
+
+	@Override
+	public void buildEntityManagerFactory() throws Exception {
+		try {
+			super.buildEntityManagerFactory();
+			fail("Should halt on error!");
+		}
+		catch ( Exception e ) {
+			SchemaManagementException cause = (SchemaManagementException) e.getCause();
+			assertEquals("Halting on error : Error executing DDL via JDBC Statement", cause.getMessage());
+		}
+	}
+
+	@Test
+	public void testHaltOnError() {
+	}
+
+	@Entity(name = "From")
+	public class From {
+
+		@Id
+		private Integer id;
+
+		private String table;
+
+		private String select;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateHaltOnErrorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateHaltOnErrorTest.java
@@ -6,14 +6,24 @@
  */
 package org.hibernate.test.schemaupdate;
 
-import java.util.Map;
+import java.io.File;
+import java.io.IOException;
+import java.util.EnumSet;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tool.schema.spi.SchemaManagementException;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -21,38 +31,42 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Vlad Mihalcea
+ * @author Gail Badner
  */
-public class SchemaUpdateHaltOnErrorTest extends BaseEntityManagerFunctionalTestCase {
+public class SchemaUpdateHaltOnErrorTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-			From.class
-		};
+	private File output;
+	private StandardServiceRegistry ssr;
+	private MetadataImplementor metadata;
+
+	@Before
+	public void setUp() throws IOException {
+		output = File.createTempFile( "update_script", ".sql" );
+		output.deleteOnExit();
+		ssr = new StandardServiceRegistryBuilder().build();
+
+		final MetadataSources metadataSources = new MetadataSources( ssr )
+				.addAnnotatedClass( From.class );
+		metadata = (MetadataImplementor) metadataSources.buildMetadata();
 	}
 
-	@Override
-	protected Map buildSettings() {
-		Map settings = super.buildSettings();
-		settings.put( AvailableSettings.HBM2DDL_AUTO, "update" );
-		settings.put( AvailableSettings.HBM2DDL_HALT_ON_ERROR, true );
-		return settings;
-	}
-
-	@Override
-	public void buildEntityManagerFactory() throws Exception {
-		try {
-			super.buildEntityManagerFactory();
-			fail("Should halt on error!");
-		}
-		catch ( Exception e ) {
-			SchemaManagementException cause = (SchemaManagementException) e.getCause();
-			assertEquals("Halting on error : Error executing DDL via JDBC Statement", cause.getMessage());
-		}
+	@After
+	public void tearsDown() {
+		// there shouldn't be anything to clean up
+		StandardServiceRegistryBuilder.destroy( ssr );
 	}
 
 	@Test
 	public void testHaltOnError() {
+		try {
+			new SchemaUpdate().setHaltOnError( true )
+					.execute( EnumSet.of( TargetType.DATABASE ), metadata );
+			fail( "Should halt on error!" );
+		}
+		catch ( Exception e ) {
+			SchemaManagementException cause = (SchemaManagementException) e;
+			assertEquals("Halting on error : Error executing DDL via JDBC Statement", cause.getMessage());
+		}
 	}
 
 	@Entity(name = "From")


### PR DESCRIPTION
I renamed the existing `SchemaUpdateHaltOnErrorTest` to `SchemaMigratorHaltOnErrorTest`, since it uses `SchemaMigrator`, not `SchemaUpdate`.

I added a new test named `SchemaUpdateHaltOnErrorTest`  that tests `SchemaUpdate.setHaltOnError(true) `.

I noticed that `hibernate.hbm2ddl.halt_on_error` applies to `SchemaMigrator`, but not `SchemaUpdate`.

Is `SchemaUpdate` considered deprecated? If not should  `hibernate.hbm2ddl.halt_on_error` apply to `SchemaUpdate` as well?