### PR TITLE
HHH-11915 : DatabaseMetaData#getIndexInfo can return column names enc…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/DatabaseIdentifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/DatabaseIdentifier.java
@@ -27,6 +27,11 @@ public class DatabaseIdentifier extends Identifier {
 		if ( StringHelper.isEmpty( text ) ) {
 			return null;
 		}
-		return new DatabaseIdentifier( text );
+		String textToUse = text;
+		if ( isQuoted( text ) ) {
+			// exclude the quotes from text
+			textToUse = Identifier.toIdentifier( text ).getText();
+		}
+		return new DatabaseIdentifier( textToUse );
 	}
 }


### PR DESCRIPTION
…losed in quotes on PostgresPlus

Should column names in the `ResultSet` returned by  `DatabaseMetaData#getIndexInfo` be stripped of quotes, even if the actual column in the index has quotes? It appears that is the case for all dialects except PostgresPlus.

Is this is bug in PostgresPlus?

Would this PR be a reasonable bugfix or workaround?

The bug is reproduced by `SchemaUpdateTest` on PostgresPlus.