### PR TITLE
Allow to use @OnDelete annotation on unidirectional @OneToMany associations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -293,12 +293,6 @@ public abstract class Collection implements Fetchable, Value, Filterable {
 		assert getKey() != null : "Collection key not bound : " + getRole();
 		assert getElement() != null : "Collection element not bound : " + getRole();
 
-		if ( getKey().isCascadeDeleteEnabled() && ( !isInverse() || !isOneToMany() ) ) {
-			throw new MappingException(
-					"only inverse one-to-many associations may use on-delete=\"cascade\": "
-							+ getRole()
-			);
-		}
 		if ( !getKey().isValid( mapping ) ) {
 			throw new MappingException(
 					"collection foreign key mapping has wrong number of columns: "

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/D.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/D.java
@@ -1,0 +1,18 @@
+package org.hibernate.test.annotations.onetomany;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+public class D {
+    @Id
+    Long id;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "a_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    List<E> listOfEs;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/E.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/E.java
@@ -1,0 +1,10 @@
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class E {
+    @Id
+    Long id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
@@ -346,6 +346,33 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
+	public void testCascadeDeleteWithUnidirectionalAssociation() throws Exception {
+		Session s;
+		Transaction tx;
+		s = openSession();
+		tx = s.beginTransaction();
+		E e = new E();
+		e.id = 1L;
+		D d = new D();
+		d.id = 1L;
+		d.listOfEs = java.util.Collections.singletonList(e);
+		s.persist( d );
+		tx.commit();
+		s.close();
+		s = openSession();
+		tx = s.beginTransaction();
+		s.createQuery("delete from D").executeUpdate();
+		tx.commit();
+		s.close();
+		s = openSession();
+		tx = s.beginTransaction();
+		E e1 = ( E ) s.get( E.class, e.id );
+		assertNull( "delete cascade should work", e1 );
+		tx.commit();
+		s.close();
+	}
+
+	@Test
 	public void testSimpleOneToManySet() throws Exception {
 		Session s;
 		Transaction tx;
@@ -503,7 +530,9 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 				Person.class,
 				Organisation.class,
 				OrganisationUser.class,
-				Model.class
+				Model.class,
+				D.class,
+				E.class
 		};
 	}
 


### PR DESCRIPTION
Motivation for this change is that since JPA 2.x it is a valid configuration to have unidirectional one-to-many associations i.e. do not create many-to-one 'reverse' link back to parent.

However in order to allow DDL schema export to confiure foreign  keys properly and include ON DELETE CASCADE (for the supported dialects only) having many-to-one link is still required.

This change allow to add `@OnDelete` for `@OneToMany` association like this:

```java
@OneToMany(cascade = CascadeType.ALL)
@JoinColumn(name = "parent_id")
@OnDelete(action = OnDeleteAction.CASCADE)
List<Child> children;
```

This will automatically generate `ON CASCADE DELETE` on table for the entity `Child`.

Backward compatibility: as this change enable new configuration which wasn't allowed before it is backward compatible.

The only affected area is automatic DDL schema generation.