### PR TITLE
CascadeMergeToChildBeforeParent object retrieval from database change…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/cascade/circle/CascadeMergeToChildBeforeParentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cascade/circle/CascadeMergeToChildBeforeParentTest.java
@@ -75,7 +75,7 @@ public class CascadeMergeToChildBeforeParentTest extends BaseCoreFunctionalTestC
 		s = openSession();
 		s.beginTransaction();
 
-		route = (Route) s.get( Route.class, new Long( 1 ) );
+		route = (Route) s.get( Route.class, route.getRouteID() );
 
 		route.setTransientField( new String( "sfnaouisrbn" ) );
 
@@ -127,7 +127,7 @@ public class CascadeMergeToChildBeforeParentTest extends BaseCoreFunctionalTestC
 		s = openSession();
 		s.beginTransaction();
 
-		route = (Route) s.get( Route.class, new Long( 1 ) );
+		route = (Route) s.get( Route.class, route.getRouteID() );
 
 		route.setTransientField( new String( "sfnaouisrbn" ) );
 
@@ -194,7 +194,7 @@ public class CascadeMergeToChildBeforeParentTest extends BaseCoreFunctionalTestC
 		s = openSession();
 		s.beginTransaction();
 
-		route = (Route) s.get( Route.class, new Long( 1 ) );
+		route = (Route) s.get( Route.class, route.getRouteID() );
 
 		route.setTransientField( new String( "sfnaouisrbn" ) );
 


### PR DESCRIPTION
CascadeMergeToChildBeforeParent object retrieval from database changed
from exact id value to value returned from .getRouteID method.