### PR TITLE
HHH-11929 Improve Performance of SQLServer2012LimitHandler.hasOrderBy()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2012LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2012LimitHandler.java
@@ -110,8 +110,11 @@ public class SQLServer2012LimitHandler extends SQLServer2005LimitHandler {
 
 	private boolean hasOrderBy(String sql) {
 		int depth = 0;
-		for ( int i = 0; i < sql.length(); ++i ) {
-			char ch = sql.charAt( i );
+
+		String lowerCaseSQL = sql.toLowerCase();
+
+		for ( int i = lowerCaseSQL.length() - 1; i >= 0; --i ) {
+			char ch = lowerCaseSQL.charAt( i );
 			if ( ch == '(' ) {
 				depth++;
 			}
@@ -119,7 +122,7 @@ public class SQLServer2012LimitHandler extends SQLServer2005LimitHandler {
 				depth--;
 			}
 			if ( depth == 0 ) {
-				if ( sql.substring( i ).toLowerCase().startsWith( "order by " ) ) {
+				if ( lowerCaseSQL.startsWith( "order by ", i ) ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11929

HHH-11929 removed excessive toLowerCase() and substring() from SQLServer2012LimitHandler.hasOrderBy(). Also reversed the direction for scanning the sql string for "order by " to start at the end of the string