### PR TITLE
HHH-6382 - Allow to use OnDelete annotation on unidirectional OneToMany associations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -46,6 +46,7 @@ import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.annotations.Loader;
 import org.hibernate.annotations.ManyToAny;
+import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OptimisticLock;
 import org.hibernate.annotations.OrderBy;
 import org.hibernate.annotations.Parameter;
@@ -476,6 +477,15 @@ public abstract class CollectionBinder {
 					|| property.isAnnotationPresent( JoinColumns.class )
 					|| propertyHolder.getJoinTable( property ) != null ) ) {
 			String message = "Associations marked as mappedBy must not define database mappings like @JoinTable or @JoinColumn: ";
+			message += StringHelper.qualify( propertyHolder.getPath(), propertyName );
+			throw new AnnotationException( message );
+		}
+
+		if (!isMappedBy
+				&& oneToMany
+				&& property.isAnnotationPresent( OnDelete.class )
+				&& !property.isAnnotationPresent( JoinColumn.class )) {
+			String message = "Unidirectional one to many associations annotated with @OnDelete must define @JoinColumn: ";
 			message += StringHelper.qualify( propertyHolder.getPath(), propertyName );
 			throw new AnnotationException( message );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -293,12 +293,6 @@ public abstract class Collection implements Fetchable, Value, Filterable {
 		assert getKey() != null : "Collection key not bound : " + getRole();
 		assert getElement() != null : "Collection element not bound : " + getRole();
 
-		if ( getKey().isCascadeDeleteEnabled() && ( !isInverse() || !isOneToMany() ) ) {
-			throw new MappingException(
-					"only inverse one-to-many associations may use on-delete=\"cascade\": "
-							+ getRole()
-			);
-		}
 		if ( !getKey().isValid( mapping ) ) {
 			throw new MappingException(
 					"collection foreign key mapping has wrong number of columns: "

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/D.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/D.java
@@ -1,0 +1,18 @@
+package org.hibernate.test.annotations.onetomany;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+public class D {
+    @Id
+    Long id;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "a_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    List<E> listOfEs;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/E.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/E.java
@@ -1,0 +1,10 @@
+package org.hibernate.test.annotations.onetomany;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class E {
+    @Id
+    Long id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/F.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/F.java
@@ -4,19 +4,18 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
-public class D {
-    @Id
-    Long id;
+public class F {
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "a_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    List<E> listOfEs;
+	@Id
+	Long id;
+
+	@OneToMany(cascade = CascadeType.ALL)
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	List<E> listOfEs;
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.test.annotations.onetomany;
 
-import javax.persistence.PersistenceException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -15,11 +14,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import javax.persistence.PersistenceException;
 
+import org.hibernate.AnnotationException;
 import org.hibernate.Hibernate;
-import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.boot.MetadataSources;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
@@ -370,6 +371,16 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 		assertNull( "delete cascade should work", e1 );
 		tx.commit();
 		s.close();
+	}
+
+	@Test(expected = AnnotationException.class)
+	public void testOnDeleteWithoutJoinColumn() throws Exception {
+		new MetadataSources()
+				.addAnnotatedClass( F.class )
+				.addAnnotatedClass( E.class )
+				.buildMetadata()
+				.buildSessionFactory()
+				.close();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
@@ -346,6 +346,33 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
+	public void testCascadeDeleteWithUnidirectionalAssociation() throws Exception {
+		Session s;
+		Transaction tx;
+		s = openSession();
+		tx = s.beginTransaction();
+		E e = new E();
+		e.id = 1L;
+		D d = new D();
+		d.id = 1L;
+		d.listOfEs = java.util.Collections.singletonList(e);
+		s.persist( d );
+		tx.commit();
+		s.close();
+		s = openSession();
+		tx = s.beginTransaction();
+		s.createQuery("delete from D").executeUpdate();
+		tx.commit();
+		s.close();
+		s = openSession();
+		tx = s.beginTransaction();
+		E e1 = ( E ) s.get( E.class, e.id );
+		assertNull( "delete cascade should work", e1 );
+		tx.commit();
+		s.close();
+	}
+
+	@Test
 	public void testSimpleOneToManySet() throws Exception {
 		Session s;
 		Transaction tx;
@@ -503,7 +530,9 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 				Person.class,
 				Organisation.class,
 				OrganisationUser.class,
-				Model.class
+				Model.class,
+				D.class,
+				E.class
 		};
 	}
 


### PR DESCRIPTION
This is a reworked https://github.com/hibernate/hibernate-orm/pull/1977.

Changes made: reword commit message to include JIRA reference, add validation for `@JoinColumn` annotation when `@OnDelete` applied. 