### PR TITLE
HHH-11938 - for not registered user defined database function calls, set type AnyType

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/MethodNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/MethodNode.java
@@ -18,6 +18,7 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.persister.collection.CollectionPropertyMapping;
 import org.hibernate.persister.collection.CollectionPropertyNames;
 import org.hibernate.persister.collection.QueryableCollection;
+import org.hibernate.type.AnyType;
 import org.hibernate.type.Type;
 
 import org.jboss.logging.Logger;
@@ -119,6 +120,11 @@ public class MethodNode extends AbstractSelectExpression implements FunctionNode
 			Type functionReturnType = getSessionFactoryHelper()
 					.findFunctionReturnType( methodName, function, firstChild );
 			setDataType( functionReturnType );
+		} else {
+			//HHH-11938:
+			// in JPA 2.1 specification, user can call any database function, even if function is not supported by the JPA standard
+			Type defaultType = new AnyType(null, null, null);
+			setDataType(defaultType);
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -276,6 +276,20 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 		em.getTransaction().commit();
 		em.close();
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11938")
+	public void testPowerFunction() {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		CriteriaBuilderImpl cb = (CriteriaBuilderImpl) em.getCriteriaBuilder();
+		CriteriaQuery<Long> criteria = cb.createQuery( Long.class );
+		criteria.from(Customer.class);
+		criteria.select(cb.function("SINH", Long.class, cb.literal(2)));
+		em.createQuery(criteria).getResultList();
+		em.getTransaction().commit();
+		em.close();
+	}
 	
 	@Test
 	@TestForIssue(jiraKey = "HHH-10737")

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -279,7 +279,7 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11938")
-	public void testPowerFunction() {
+	public void testSinhFunction() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();
 		CriteriaBuilderImpl cb = (CriteriaBuilderImpl) em.getCriteriaBuilder();


### PR DESCRIPTION
If a user calls a non-registered, non-JPA standard, database function, it's type is not known.
Thus, in SelectClause, an exception is thrown: "No data type for node: MethodNode".

An example is added in QueryBuilderTest.testSinhFunction. The 'sinh' function is supported by H2 database, as described [here](http://www.h2database.com/html/functions.html#sinh). In H2Dialect class, the sinh function is not registered. Thus, test QueryBuilderTest.testSinhFunction fails, without this fix.