### PR TITLE
HHH-8955 - added HSQL dialect support for database trunc function

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -240,6 +240,7 @@ public class HSQLDialect extends Dialect {
 		registerFunction( "round", new StandardSQLFunction( "round" ) );
 		registerFunction( "roundmagic", new StandardSQLFunction( "roundmagic" ) );
 		registerFunction( "truncate", new StandardSQLFunction( "truncate" ) );
+		registerFunction( "trunc", new StandardSQLFunction( "trunc" ) );
 
 		registerFunction( "ceiling", new StandardSQLFunction( "ceiling" ) );
 		registerFunction( "floor", new StandardSQLFunction( "floor" ) );


### PR DESCRIPTION
Hi!

In HSQLDialect, I added support for trunc function.
For HSQL database, trunc function is documented [here](http://hsqldb.org/doc/2.0/guide/builtinfunctions-chapt.html) .