### PR TITLE
HHH-11756 - Typo in public API method name: requiresPostCommitHanding…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -204,7 +204,7 @@ public class EntityDeleteAction extends EntityAction {
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostDeleteEventListener> group = listenerGroup( EventType.POST_COMMIT_DELETE );
 		for ( PostDeleteEventListener listener : group.listeners() ) {
-			if ( listener.requiresPostCommitHanding( getPersister() ) ) {
+			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -118,7 +118,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostInsertEventListener> group = listenerGroup( EventType.POST_COMMIT_INSERT );
 		for ( PostInsertEventListener listener : group.listeners() ) {
-			if ( listener.requiresPostCommitHanding( getPersister() ) ) {
+			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -240,7 +240,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostInsertEventListener> group = listenerGroup( EventType.POST_COMMIT_INSERT );
 		for ( PostInsertEventListener listener : group.listeners() ) {
-			if ( listener.requiresPostCommitHanding( getPersister() ) ) {
+			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -299,7 +299,7 @@ public final class EntityUpdateAction extends EntityAction {
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostUpdateEventListener> group = listenerGroup( EventType.POST_COMMIT_UPDATE );
 		for ( PostUpdateEventListener listener : group.listeners() ) {
-			if ( listener.requiresPostCommitHanding( getPersister() ) ) {
+			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostActionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostActionEventListener.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.event.spi;
+
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * @author Andrea Boriero
+ */
+interface PostActionEventListener {
+
+	/**
+	 * Does this listener require that after transaction hooks be registered?
+	 *
+	 * @param persister The persister for the entity in question.
+	 *
+	 * @return {@code true} if after transaction callbacks should be added.
+	 *
+	 * @deprecated use {@link #requiresPostCommitHandling(EntityPersister)}
+	 */
+	@Deprecated
+	boolean requiresPostCommitHanding(EntityPersister persister);
+
+	/**
+	 * Does this listener require that after transaction hooks be registered?
+	 *
+	 * @param persister The persister for the entity in question.
+	 *
+	 * @return {@code true} if after transaction callbacks should be added.
+	 */
+	default boolean requiresPostCommitHandling(EntityPersister persister) {
+		return requiresPostCommitHanding( persister );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostDeleteEventListener.java
@@ -8,15 +8,11 @@ package org.hibernate.event.spi;
 
 import java.io.Serializable;
 
-import org.hibernate.persister.entity.EntityPersister;
-
 /**
  * Called after deleting an item from the datastore
  * 
  * @author Gavin King
  */
-public interface PostDeleteEventListener extends Serializable {
-	public void onPostDelete(PostDeleteEvent event);
-
-	public boolean requiresPostCommitHanding(EntityPersister persister);
+public interface PostDeleteEventListener extends Serializable, PostActionEventListener {
+	void onPostDelete(PostDeleteEvent event);
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostInsertEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostInsertEventListener.java
@@ -8,25 +8,12 @@ package org.hibernate.event.spi;
 
 import java.io.Serializable;
 
-import org.hibernate.persister.entity.EntityPersister;
-
 /**
  * Called after insterting an item in the datastore
  * 
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface PostInsertEventListener extends Serializable {
-	public void onPostInsert(PostInsertEvent event);
-
-	/**
-	 * Does this listener require that after transaction hooks be registered?   Typically this is {@code true}
-	 * for post-insert event listeners, but may not be, for example, in JPA cases where there are no callbacks defined
-	 * for the particular entity.
-	 *
-	 * @param persister The persister for the entity in question.
-	 *
-	 * @return {@code true} if after transaction callbacks should be added.
-	 */
-	public boolean requiresPostCommitHanding(EntityPersister persister);
+public interface PostInsertEventListener extends Serializable, PostActionEventListener {
+	void onPostInsert(PostInsertEvent event);
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostUpdateEventListener.java
@@ -8,15 +8,11 @@ package org.hibernate.event.spi;
 
 import java.io.Serializable;
 
-import org.hibernate.persister.entity.EntityPersister;
-
 /**
  * Called after updating the datastore
  * 
  * @author Gavin King
  */
-public interface PostUpdateEventListener extends Serializable {
-	public void onPostUpdate(PostUpdateEvent event);
-
-	public boolean requiresPostCommitHanding(EntityPersister persister);
+public interface PostUpdateEventListener extends Serializable, PostActionEventListener {
+	void onPostUpdate(PostUpdateEvent event);
 }


### PR DESCRIPTION
… on PostInsertEventListener
https://hibernate.atlassian.net/browse/HHH-11756

I had to introduce the `PostActionEventListener` interface in order to avoid compilation errors for classes implementing all the 3 interfaces affected by the typo due to the 3 default methods with the same name (
aN example is  `org.hibernate.cache.internal.CollectionCacheInvalidator`).