### PR TITLE
fix test failures on SAP HANA

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
@@ -75,6 +75,7 @@ public class GetLoadTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = AbstractHANADialect.class, comment = " HANA doesn't support tables consisting of only a single auto-generated column")
 	public void testLoad() {
 		clearCounts();
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/RevisionConstraintQuery.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/RevisionConstraintQuery.java
@@ -126,10 +126,9 @@ public class RevisionConstraintQuery extends BaseEnversJPAFunctionalTestCase {
 				.addProjection( AuditEntity.revisionNumber() )
 				.add( AuditEntity.revisionNumber().gt( 1 ) )
 				.add( AuditEntity.property( "number" ).lt( 10 ) )
-				.addOrder( AuditEntity.revisionNumber().asc() )
 				.getResultList();
 
-		Assert.assertEquals( Arrays.asList( 3, 4 ), result );
+		Assert.assertEquals( TestTools.makeSet( 3, 4 ), new HashSet<>( result ) );
 	}
 
 	@Test

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/RevisionConstraintQuery.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/query/RevisionConstraintQuery.java
@@ -126,6 +126,7 @@ public class RevisionConstraintQuery extends BaseEnversJPAFunctionalTestCase {
 				.addProjection( AuditEntity.revisionNumber() )
 				.add( AuditEntity.revisionNumber().gt( 1 ) )
 				.add( AuditEntity.property( "number" ).lt( 10 ) )
+				.addOrder( AuditEntity.revisionNumber().asc() )
 				.getResultList();
 
 		Assert.assertEquals( Arrays.asList( 3, 4 ), result );


### PR DESCRIPTION
- skip testLoad() of org.hibernate.jpa.test.ops.GetLoadTest
- add sort to testRevisionsGtWithPropertyQuery() of org.hibernate.envers.test.integration.query.RevisionConstraintQuery