### PR TITLE
HHH-11838 : Added tests for getting the ID from a proxy for an entity…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
@@ -8,6 +8,7 @@ package org.hibernate.jpa.test.ops;
 
 import java.util.Map;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
@@ -171,6 +172,55 @@ public class GetLoadTest extends BaseEntityManagerFunctionalTestCase {
 
 		em.getTransaction().commit();
 		em.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11838")
+	public void testLoadIdNotFound() {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		Session s = ( Session ) em.getDelegate();
+
+		assertNull( s.get( Workload.class, 999 ) );
+
+		Workload proxy = s.load( Workload.class, 999 );
+		assertFalse( Hibernate.isInitialized( proxy ) );
+
+		try {
+			proxy.getId();
+			fail( "Should have failed because there is no Workload Entity with id == 999" );
+		}
+		catch (EntityNotFoundException ex) {
+			// expected
+			em.getTransaction().rollback();
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-11838")
+	public void testReferenceIdNotFound() {
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+
+		assertNull( em.find( Workload.class, 999 ) );
+
+		Workload proxy = em.getReference( Workload.class, 999 );
+		assertFalse( Hibernate.isInitialized( proxy ) );
+
+		try {
+			proxy.getId();
+			fail( "Should have failed because there is no Workload Entity with id == 999" );
+		}
+		catch (EntityNotFoundException ex) {
+			// expected
+			em.getTransaction().rollback();
+		}
+		finally {
+			em.close();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
… that does not exist

https://hibernate.atlassian.net/browse/HHH-11838

I don't think the fix is consistent with JPA.

Documentation for `EntityNotFoundException` says:

"The EntityNotFoundException is thrown by the persistence provider when an entity
reference obtained by getReference is accessed but the entity does not exist. ...
The current transaction, if one is active and the persistence context has been joined to
it, will be marked for rollback.

I've added a test that follows what is defined by JPA. It fails with the current fix. After reverting the commit, the test will pass (after resolving conflicts).