### PR TITLE
HHH-12026 Make sure that search icon is rendered correctly in TOC

### DIFF
--- a/documentation/src/main/style/asciidoctor/css/hibernate-layout.css
+++ b/documentation/src/main/style/asciidoctor/css/hibernate-layout.css
@@ -40,6 +40,9 @@ body:before {
     font-weight: bold !important;
     font-size: 1.3em !important;
 }
+#toc>#tocsearch {
+    font-family: "FontAwesome";
+}
 .subheader .title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{
     color:darkslategray;
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Sort.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Sort.java
@@ -14,7 +14,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Collection sort (in-memory sorting).  Different that ordering, which is applied during the SQL select.
+ * Collection sort (in-memory sorting).  Different than ordering, which is applied during the SQL select.
  *
  * @author Emmanuel Bernard
  *


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HHH-12026

It turned out that that search input in TOC wasn't using the FontAwesome font-family hence rendering the strange symbol instead of a search icon. I've also fixed a small typo in JavaDoc. 

As for the icon I'm not 100% sure that that's enough. Should the url for the font itself (https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/fonts/fontawesome-webfont.ttf) be added to `Hibernate_User_Guide-docinfo.html` or is it enough...