### PR TITLE
HHH-12033 README.md links should use Markdown notation instead of AsciiDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Resources
 
 The build requires a Java 8 JDK as JAVA_HOME.
 
-You will need http://git-scm.com/[git] to obtain the http://github.com/hibernate/hibernate-orm/[source].
+You will need [git](https://git-scm.com/) to obtain the [source](https://github.com/hibernate/hibernate-orm/).
 
-Hibernate uses [Gradle](http://gradle.org) as its build tool.  See the _Gradle Primer_ section below if you are new to
+Hibernate uses [Gradle](https://gradle.org) as its build tool.  See the _Gradle Primer_ section below if you are new to
 Gradle.
 
-Contributors should read the [Contributing Guide](CONTRIBUTING.md)
+Contributors should read the [Contributing Guide](CONTRIBUTING.md).
 
 See the guides for setting up [IntelliJ](https://developer.jboss.org/wiki/ContributingToHibernateUsingIntelliJ) or
 [Eclipse](https://developer.jboss.org/wiki/ContributingToHibernateUsingEclipse) as your development environment.


### PR DESCRIPTION
This PR fixes a small typo in the links in README.md's markdown.

Before:

![grafik](https://user-images.githubusercontent.com/1366654/31531003-6c1eceec-afe4-11e7-9ed3-b6b7c576b732.png)

After:

![grafik](https://user-images.githubusercontent.com/1366654/31531012-817b9522-afe4-11e7-8cfe-d1310513afae.png)

Also http is replaced by https in that area.
