### PR TITLE
HHH-11971 - QueryParameterBindingValidator does not handle primitive types

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
@@ -86,11 +86,37 @@ public class QueryParameterBindingValidator {
 	}
 
 	private static boolean isValidBindValue(Class expectedType, Object value, TemporalType temporalType) {
-		if ( expectedType.isInstance( value ) ) {
+		if ( expectedType.isPrimitive() ) {
+			if ( expectedType == boolean.class ) {
+				return Boolean.class.isInstance( value );
+			}
+			else if ( expectedType == char.class ) {
+				return Character.class.isInstance( value );
+			}
+			else if ( expectedType == byte.class ) {
+				return Byte.class.isInstance( value );
+			}
+			else if ( expectedType == short.class ) {
+				return Short.class.isInstance( value );
+			}
+			else if ( expectedType == int.class ) {
+				return Integer.class.isInstance( value );
+			}
+			else if ( expectedType == long.class ) {
+				return Long.class.isInstance( value );
+			}
+			else if ( expectedType == float.class ) {
+				return Float.class.isInstance( value );
+			}
+			else if ( expectedType == double.class ) {
+				return Double.class.isInstance( value );
+			}
+			return false;
+		}
+		else if ( expectedType.isInstance( value ) ) {
 			return true;
 		}
-
-		if ( temporalType != null ) {
+		else if ( temporalType != null ) {
 			final boolean parameterDeclarationIsTemporal = Date.class.isAssignableFrom( expectedType )
 					|| Calendar.class.isAssignableFrom( expectedType );
 			final boolean bindIsTemporal = Date.class.isInstance( value )

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryParametersValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryParametersValidationTest.java
@@ -6,15 +6,25 @@
  */
 package org.hibernate.jpa.test.query;
 
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
+import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Type;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.usertype.UserType;
 
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
@@ -66,11 +76,107 @@ public class QueryParametersValidationTest extends BaseEntityManagerFunctionalTe
 		}
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-11971")
+	public void setPrimitiveParameterShouldNotThrowExceptions() {
+		final EntityManager entityManager = entityManagerFactory().createEntityManager();
+		try {
+			entityManager.createQuery( "select e from TestEntity e where e.active = :active" ).setParameter(
+					"active",
+					true
+			);
+			entityManager.createQuery( "select e from TestEntity e where e.active = :active" ).setParameter(
+					"active",
+					Boolean.TRUE
+			);
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	@TestForIssue( jiraKey = "HHH-11971")
+	public void setWrongPrimitiveParameterShouldThrowIllegalArgumentException() {
+		final EntityManager entityManager = entityManagerFactory().createEntityManager();
+		try {
+			entityManager.createQuery( "select e from TestEntity e where e.active = :active" ).setParameter( "active", 'c' );
+		}
+		finally {
+			entityManager.close();
+		}
+	}
+
 	@Entity(name = "TestEntity")
 	public class TestEntity {
 
 		@Id
 		@GeneratedValue(strategy = GenerationType.AUTO)
 		private Long id;
+
+		@Type(type = "org.hibernate.jpa.test.query.QueryParametersValidationTest$BooleanUserType")
+		private boolean active;
+	}
+
+	public static class BooleanUserType implements UserType {
+
+		@Override
+		public int[] sqlTypes() {
+			return new int[] { Types.CHAR };
+		}
+
+		@Override
+		public Class returnedClass() {
+			return boolean.class;
+		}
+
+		@Override
+		public boolean equals(Object x, Object y) throws HibernateException {
+			return Objects.equals( x, y);
+		}
+
+		@Override
+		public int hashCode(Object x) throws HibernateException {
+			return Objects.hashCode(x);
+		}
+
+		@Override
+		public Object nullSafeGet(
+				ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+				throws HibernateException, SQLException {
+			return "Y".equals(rs.getString(names[0]));
+		}
+
+		@Override
+		public void nullSafeSet(
+				PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+				throws HibernateException, SQLException {
+			st.setString(index, ((Boolean) value).booleanValue() ? "Y" : "N");
+		}
+
+		@Override
+		public Object deepCopy(Object value) throws HibernateException {
+			return value;
+		}
+
+		@Override
+		public boolean isMutable() {
+			return false;
+		}
+
+		@Override
+		public Serializable disassemble(Object value) throws HibernateException {
+			return null;
+		}
+
+		@Override
+		public Object assemble(Serializable cached, Object owner) throws HibernateException {
+			return null;
+		}
+
+		@Override
+		public Object replace(Object original, Object target, Object owner) throws HibernateException {
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11971

The check is needed because the primitive parameter is automatically boxed, so by example true become an instance of `Boolean` while the expected type is a `boolean` this cause the `expectedType.isInstance( value )` returning false.