### PR TITLE
HHH-11845 - Warn user when multiple persistence-units use the same name

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/persistenceunit/DuplicatePersistenceUnitNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/persistenceunit/DuplicatePersistenceUnitNameTest.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.persistenceunit;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
+import org.hibernate.loader.Loader;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.jboss.logging.Logger;
+
+import static org.hibernate.internal.util.ConfigHelper.findAsResource;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11845")
+@RunWith(BMUnitRunner.class)
+public class DuplicatePersistenceUnitNameTest extends BaseUnitTestCase {
+	private Triggerable triggerable;
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
+			Logger.getMessageLogger( CoreMessageLogger.class, PersistenceXmlParser.class.getName() )
+	);
+
+	@Before
+	public void setUp() {
+		final Set messagesPrefixes = new HashSet<>();
+		messagesPrefixes.add( "HHH015018" );
+		triggerable = logInspection.watchForLogMessages( messagesPrefixes );
+	}
+
+	@After
+	public void tearDown() {
+		triggerable.reset();
+	}
+
+	@Test
+	public void testDuplicatePersistenceUnitNameLogAWarnMessage() {
+		final Map<String, Object> properties = new HashMap<String, Object>();
+		properties.put( AvailableSettings.RESOURCES_CLASSLOADER, new TestClassLoader() );
+		PersistenceXmlParser.locatePersistenceUnits( properties );
+		assertTrue( "The warn HHH015018 has not been logged ", triggerable.wasTriggered() );
+	}
+
+	private static class TestClassLoader extends ClassLoader {
+		private final Iterator<URL> persistenceUnitUrlsIterator;
+
+		public TestClassLoader() {
+			final List<URL> urls = Arrays.asList(
+					findAsResource(
+							"org/hibernate/jpa/test/persistenceunit/META-INF/persistence.xml"
+					)
+					,
+					findAsResource(
+							"org/hibernate/jpa/test/persistenceunit/META-INF/persistenceUnitForNameDuplicationTest.xml"
+					)
+			);
+			persistenceUnitUrlsIterator = urls.iterator();
+		}
+
+		@Override
+		protected Enumeration<URL> findResources(String name) throws IOException {
+			if ( name.equals( "META-INF/persistence.xml" ) ) {
+				return new Enumeration<URL>() {
+					@Override
+					public boolean hasMoreElements() {
+						return persistenceUnitUrlsIterator.hasNext();
+					}
+
+					@Override
+					public URL nextElement() {
+						return persistenceUnitUrlsIterator.next();
+					}
+				};
+			}
+			else {
+				return java.util.Collections.emptyEnumeration();
+			}
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/jpa/test/persistenceunit/META-INF/persistenceUnitForNameDuplicationTest.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/jpa/test/persistenceunit/META-INF/persistenceUnitForNameDuplicationTest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <!--
+        The PU name is also present in the persistence.xml located in the same folder,
+        this should cause a warn message to be logged.
+
+        See org.hibernate.jpa.test.persistenceunit.DuplicatePersistenceUnitNameTest
+    -->
+    <persistence-unit name="ExcludeUnlistedClassesTest1" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>org.hibernate.jpa.test.persistenceunit.DataPoint</class>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11845

The PU names clash was performed for names belonging to the same persistence.xml file but  if  the same PU name is present in two different files, like in case of testing, the clash does not produce any warning.  The a solution is to have a  class `private final Map<String,ParsedPersistenceXmlDescriptor> persistenceUnits; `field, so for every PU we can check if there is already one with the same name.