### PR TITLE
Use correct logger.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/PooledConnections.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/PooledConnections.java
@@ -22,7 +22,7 @@ public class PooledConnections {
 	private final ConcurrentLinkedQueue<Connection> allConnections = new ConcurrentLinkedQueue<Connection>();
 	private final ConcurrentLinkedQueue<Connection> availableConnections = new ConcurrentLinkedQueue<Connection>();
 
-	private static final CoreMessageLogger log = CoreLogging.messageLogger( DriverManagerConnectionProviderImpl.class );
+	private static final CoreMessageLogger log = CoreLogging.messageLogger( PooledConnections .class );
 
 	private final ConnectionCreator connectionCreator;
 	private final boolean autoCommit;


### PR DESCRIPTION
This class was using the logger for DriverManagerConnectionProviderImpl, which causes confusion when debugging log messages.