### PR TITLE
HHH-12055 Revert to using the Javassist version included in WildFly 11

### DIFF
--- a/documentation/src/main/asciidoc/topical/wildfly/Wildfly.adoc
+++ b/documentation/src/main/asciidoc/topical/wildfly/Wildfly.adoc
@@ -18,7 +18,7 @@ can also be included in WildFly. Such a module will not replace the existing Hib
 alternative option that your application can choose to use instead of the default version it includes.
 
 Our goal is to provide a module ZIP file targeted at the WildFly version current at the time of the Hibernate release
-(e.g. WildFly 10 for Hibernate ORM 5.1.x and up until 5.2.10, as well as WildFly 11 since Hibernate ORM 5.2.11).
+(e.g. WildFly 10 for Hibernate ORM releases until 5.2.10, since Hibernate ORM 5.2.11 we provide modules for WildFly 11).
 
 == Where to download the modules from
 
@@ -138,41 +138,6 @@ persistence units, they should all make a consistent choice!
 This property is documented in the https://docs.jboss.org/author/display/WFLY10/JPA+Reference+Guide[WildFly JPA Reference Guide];
 you might want to check it out as it lists several other useful properties.
 
-== Avoiding outdated Javassist versions from WildFly
-
-Since Hibernate ORM version 5.2, it requires a more recent version of Javassist than the one provided by WildFly 10.
-Unfortunately the JPA subsystem of WildFly will expose its Javassist version to any JPA application even if you override
-the module using the above mentioned `jboss.as.jpa.providerModule` property.
-
-To avoid this problem use a `jboss-deployment-structure.xml` to explicitly demand to not get the WildFly copy of
-javassist. This will allow Hibernate ORM to use the Javassist version provided by its own module, which will contain
-the recommended versions.
-
-.WildFly configuration file to avoid the wrong Javassist version
-
-====
-[source, XML]
-[subs="verbatim,attributes"]
-----
-
-<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
-    <deployment>
-        <exclusions>
-            <module name="org.javassist" />
-        </exclusions>
-    </deployment>
-</jboss-deployment-structure>
-
-----
-====
-
-This file needs to be included in your deployment, in the top level archive.
-The exact position depends on the deployment kind: for example when deploying a `WAR` file, include it in `WEB-INF`;
-other common deployment archives will expect this resource to be found in `META-INF`.
-
-See https://docs.jboss.org/author/display/WFLY10/Class+Loading+in+WildFly[Class Loading in WildFly] for more details
-about using a custom `jboss-deployment-structure.xml`.
-
 == Limitations of using the custom WildFly modules
 
 When using these modules you're going to give up on some of the integration which the application server
@@ -181,7 +146,7 @@ normally automates.
 For example enabling an Infinispan 2nd level cache is straight forward when using the default Hibernate ORM
 module, as WildFly will automatically setup the dependency to the Infinispan and clustering components.
 When using these custom modules such integration will no longer work automatically: you can still
-enable all normally available features but these will require manual configuration, as if you were
+enable all normally available features but these will require explicit configuration, as if you were
 running Hibernate in a different container, or in no container.
 
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/BasicCdiTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/BasicCdiTest.java
@@ -51,7 +51,6 @@ public class BasicCdiTest {
 				.addClass( EventQueue.class )
 				.addClass( Event.class )
 				.addClass( Monitor.class )
-				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ConversationalPersistenceContextExtendedTest.java
@@ -37,7 +37,6 @@ public class ConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( ConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
-				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ManualFlushConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/ManualFlushConversationalPersistenceContextExtendedTest.java
@@ -38,7 +38,6 @@ public class ManualFlushConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( ManualFlushConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
-				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/NonConversationalPersistenceContextExtendedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cdi/extended/NonConversationalPersistenceContextExtendedTest.java
@@ -37,7 +37,6 @@ public class NonConversationalPersistenceContextExtendedTest {
 				.addClass( Event.class )
 				.addClass( NonConversationalEventManager.class )
 				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
-				.addAsManifestResource( "jboss-deployment-structure.xml" )
 				.addAsManifestResource( new StringAsset( persistenceXml().exportAsString() ), "persistence.xml" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/bmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/bmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
@@ -54,7 +54,6 @@ public class DdlInWildFlyUsingBmtAndEmfTest {
 				.setManifest( "org/hibernate/test/wf/ddl/manifest.mf" )
 				.addClass( WildFlyDdlEntity.class )
 //				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml")
-				.addAsWebInfResource( "jboss-deployment-structure.xml" ) //Add as "web-inf" resource on Web archives
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), PERSISTENCE_XML_RESOURCE_NAME )
 				.addAsResource( "org/hibernate/test/wf/ddl/log4j.properties", "log4j.properties" );
 		System.out.println( war.toString(true) );

--- a/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/cmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/wf/ddl/cmt/emf/DdlInWildFlyUsingBmtAndEmfTest.java
@@ -52,7 +52,6 @@ public class DdlInWildFlyUsingBmtAndEmfTest {
 				.setManifest( "org/hibernate/test/wf/ddl/manifest.mf" )
 				.addClass( WildFlyDdlEntity.class )
 //				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml")
-				.addAsWebInfResource( "jboss-deployment-structure.xml" ) //Add as "web-inf" resource on Web archives
 				.addAsResource( new StringAsset( persistenceXml().exportAsString() ), PERSISTENCE_XML_RESOURCE_NAME )
 				.addAsResource( "org/hibernate/test/wf/ddl/log4j.properties", "log4j.properties" );
 		System.out.println( war.toString(true) );

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -37,7 +37,6 @@ ext {
             minorSlot: minorSlot,
             version: rootProject.hibernateTargetVersion,
             wildflyVersion: wildflyVersion,
-            javassistVersion: javassistVersion,
             byteBuddyVersion: byteBuddyVersion
     ];
 }
@@ -53,15 +52,12 @@ configurations {
     }
 
     wildflyDist
-
-    javassist
     byteBuddy
 }
 
 dependencies {
     jipijapa "org.wildfly:jipijapa-hibernate5:${wildflyVersion}"
     wildflyDist "org.wildfly:wildfly-dist:${wildflyVersion}@zip"
-    javassist libraries.javassist
     byteBuddy libraries.byteBuddy
 
     testCompile project( ":hibernate-core" )
@@ -144,9 +140,6 @@ task createModulesZip(type: Zip, dependsOn: [copyAndExpandModuleXml]) {
     into( 'org/hibernate/' + slot ) {
         from parent.project( 'hibernate-core' ).configurations.archives.allArtifacts.files
         from parent.project( 'hibernate-envers' ).configurations.archives.allArtifacts.files
-
-        // also need Javassist's jar
-        from configurations.javassist
         // also need Byte Buddy's jar
         from configurations.byteBuddy
     }

--- a/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
+++ b/hibernate-orm-modules/src/main/modules/org/hibernate/core/module.xml
@@ -9,7 +9,6 @@
     <resources>
         <resource-root path="hibernate-core-${version}.jar"/>
         <resource-root path="hibernate-envers-${version}.jar"/>
-        <resource-root path="javassist-${javassistVersion}.jar"/>
         <resource-root path="byte-buddy-${byteBuddyVersion}.jar"/>
     </resources>
 
@@ -28,6 +27,7 @@
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.javassist" export="true"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.hibernate.infinispan" services="import" optional="true" slot="${slot}"/>
         <module name="org.hibernate.jipijapa-hibernate5" services="import" slot="${slot}"/>


### PR DESCRIPTION
This is a small step but it also simplifies the packaging needs for end users.

I originally started looking at this as apparently the JDK9 CI build started failing after we upgraded Javassist; it only failed on WildFly so this is kinda of a workaround: don't use our "latest" on WildFly tests yet.

Incidentally, I tried to switch the integration tests to ByteBuddy but the Javassist supporting code is still killing the test, so we'll have to work on making Javassist truely optional.