### PR TITLE
HHH-12036 Use cache.clear() for bulk removal on non-tx cache

### DIFF
--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseRegion.java
@@ -242,7 +242,7 @@ public abstract class BaseRegion implements Region {
 		// When we don't have transaction, we can do a clear operation (since we don't
 		// case about context) and can't do the one-by-one remove: remove() on tx cache
 		// requires transactional context.
-		if ( inTransaction ) {
+		if ( inTransaction && cache.getCacheConfiguration().transaction().transactionMode().isTransactional() ) {
 			log.tracef( "Transaction, clearing one element at the time" );
 			Caches.removeAll( localAndSkipLoadCache );
 		}

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractRegionAccessStrategyTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/AbstractRegionAccessStrategyTest.java
@@ -49,6 +49,7 @@ import org.hibernate.test.cache.infinispan.util.JdbcResourceTransactionMock;
 import org.hibernate.test.cache.infinispan.util.TestInfinispanRegionFactory;
 import org.hibernate.test.cache.infinispan.util.TestSynchronization;
 import org.infinispan.Cache;
+import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.test.TestingUtil;
 import org.jboss.logging.Logger;
 import org.hibernate.test.cache.infinispan.util.TestTimeService;
@@ -512,7 +513,7 @@ public abstract class AbstractRegionAccessStrategyTest<R extends BaseRegion, S e
 				});
 			} else {
 				ExpectingInterceptor.get(remoteRegion.getCache())
-					.when((ctx, cmd) -> cmd instanceof InvalidateCommand)
+					.when((ctx, cmd) -> cmd instanceof InvalidateCommand || cmd instanceof ClearCommand)
 					.countDown(endInvalidationLatch);
 				cleanup.add(() -> ExpectingInterceptor.cleanup(remoteRegion.getCache()));
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12036
https://issues.jboss.org/browse/ISPN-8411

@gbadner Should I create a fix for 5.2 as well?