### PR TITLE
HHH-12072 BasicFormatterImpl throws a NPE if native SQL begins with a parentheses

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -356,14 +356,18 @@ public class BasicFormatterImpl implements Formatter {
 		}
 
 		private static boolean isFunctionName(String tok) {
-			final char begin = tok.charAt( 0 );
-			final boolean isIdentifier = Character.isJavaIdentifierStart( begin ) || '"' == begin;
-			return isIdentifier &&
-					!LOGICAL.contains( tok ) &&
-					!END_CLAUSES.contains( tok ) &&
-					!QUANTIFIERS.contains( tok ) &&
-					!DML.contains( tok ) &&
-					!MISC.contains( tok );
+			if (tok != null && tok.length() > 0) {
+				final char begin = tok.charAt( 0 );
+				final boolean isIdentifier = Character.isJavaIdentifierStart( begin ) || '"' == begin;
+				return isIdentifier &&
+						!LOGICAL.contains( tok ) &&
+						!END_CLAUSES.contains( tok ) &&
+						!QUANTIFIERS.contains( tok ) &&
+						!DML.contains( tok ) &&
+						!MISC.contains( tok );
+			} else {
+				return false;
+			}
 		}
 
 		private static boolean isWhitespace(String token) {

--- a/hibernate-core/src/test/java/org/hibernate/jdbc/util/BasicFormatterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jdbc/util/BasicFormatterTest.java
@@ -43,6 +43,9 @@ public class BasicFormatterTest extends BaseUnitTestCase {
 		assertNoLoss(
 				"/* Here we' go! */ select case when p.age > 50 then 'old' when p.age > 18 then 'adult' else 'child' end from Person p where ( case when p.age > 50 then 'old' when p.age > 18 then 'adult' else 'child' end ) like ?"
 		);
+		assertNoLoss(
+				"(select p.pid from Address where city = 'Boston') union (select p.pid from Address where city = 'Taipei')"
+		);
 	}
 
 	private void assertNoLoss(String query) {


### PR DESCRIPTION
This can happen, for example, where there are two select statements
being union'ed together and the select statements are placed in
parentheses for readability.