### PR TITLE
HHH-5409: Implement PersistentBad.equals as intended in Collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -515,67 +515,56 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	@Override
 	public boolean equals(Object obj) {
 		read();
-		
-		if (!obj.getClass().equals(PersistentBag.class))
-		{
-			return false;
-		}
-		
-		PersistentBag other = (PersistentBag)obj;
-		
-		if (this.bag.size() != other.bag.size())
-		{
+
+		if ( !obj.getClass().equals( PersistentBag.class ) ) {
 			return false;
 		}
 
-		Map<Object, Integer> elementCounts = new HashMap<>(this.bag.size());
+		PersistentBag other = (PersistentBag) obj;
 
-		for (Object element : this.bag)
-		{
-			if (!elementCounts.containsKey(element))
-			{
-				elementCounts.put(element, 1);
+		if ( this.bag.size() != other.bag.size() ) {
+			return false;
+		}
+
+		Map<Object, Integer> elementCounts = new HashMap<>( this.bag.size() );
+
+		for ( Object element : this.bag ) {
+			if ( !elementCounts.containsKey( element ) ) {
+				elementCounts.put( element, 1 );
 			}
-			else
-			{
-				elementCounts.put(element, elementCounts.get(element) + 1);
+			else {
+				elementCounts.put( element, elementCounts.get( element ) + 1 );
 			}
 		}
 
-		for (Object element : other.bag)
-		{
-			if (!elementCounts.containsKey(element))
-			{
+		for ( Object element : other.bag ) {
+			if ( !elementCounts.containsKey( element ) ) {
 				return false;
 			}
-			else
-			{
-				elementCounts.put(element, elementCounts.get(element) - 1);
+			else {
+				elementCounts.put( element, elementCounts.get( element ) - 1 );
 			}
 		}
 
-		for (Integer count : elementCounts.values())
-		{
-			if (count != 0)
-			{
+		for ( Integer count : elementCounts.values() ) {
+			if ( count != 0 ) {
 				return false;
 			}
 		}
-		
+
 		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		
+
 		int code = 0;
-		
-		for (Object element : bag)
-		{
+
+		for ( Object element : bag ) {
 			// Any commutative operation will be order independent
 			code += element.hashCode();
 		}
-		
+
 		return code;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -567,7 +567,16 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 	@Override
 	public int hashCode() {
-		return super.hashCode();
+		
+		int code = 0;
+		
+		for (Object element : bag)
+		{
+			// Any commutative operation will be order independent
+			code += element.hashCode();
+		}
+		
+		return code;
 	}
 
 	final class Clear implements DelayedOperation {

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
@@ -5,118 +5,114 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 
 import org.hibernate.collection.internal.PersistentBag;
-import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Tests collection equals behavior given the semantic meaning of a bag
  *
  * @author Jasper Horn
  */
-@TestForIssue( jiraKey="HHH-5409" )
+@TestForIssue(jiraKey = "HHH-5409")
 public class PersistentBagEqualsTest {
-	
+
 	@Test
-	public void testTwoEmptyBags()
-	{
+	public void testTwoEmptyBags() {
 		PersistentBag bag1 = createBag();
 		PersistentBag bag2 = createBag();
-		
-		assertEquals(bag1.equals(bag2), true);
+
+		assertEquals( bag1.equals( bag2 ), true );
 	}
-	
+
 	@Test
 	public void testTwoBagsWithDifferentContents() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		
+		bag1.add( "item1" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item2");
-		
-		System.out.println("Added items");
-		
-		assertEquals(bag1.equals(bag2), false);
+		bag2.add( "item2" );
+
+		System.out.println( "Added items" );
+
+		assertEquals( bag1.equals( bag2 ), false );
 	}
 
 	@Test
 	public void testTwoBagsWithSameContents() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item");
-		
+		bag1.add( "item" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item");
-		
-		assertEquals(bag1.equals(bag2), true);
+		bag2.add( "item" );
+
+		assertEquals( bag1.equals( bag2 ), true );
 	}
 
 	@Test
 	public void testBagWithSubsetOfOtherBag() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		
+		bag1.add( "item1" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item1");
-		bag2.add("item2");
-		
-		assertEquals(bag1.equals(bag2), false);
+		bag2.add( "item1" );
+		bag2.add( "item2" );
+
+		assertEquals( bag1.equals( bag2 ), false );
 	}
 
 	@Test
 	public void testBagWithSupersetOfOtherBag() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		bag1.add("item2");
-		
+		bag1.add( "item1" );
+		bag1.add( "item2" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item1");
-		
-		assertEquals(bag1.equals(bag2), false);
+		bag2.add( "item1" );
+
+		assertEquals( bag1.equals( bag2 ), false );
 	}
 
 	@Test
 	public void testTwoBagsWithItemsInDifferentOrder() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		bag1.add("item2");
-		
+		bag1.add( "item1" );
+		bag1.add( "item2" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item2");
-		bag2.add("item1");
-		
-		assertEquals(bag1.equals(bag2), true);
+		bag2.add( "item2" );
+		bag2.add( "item1" );
+
+		assertEquals( bag1.equals( bag2 ), true );
 	}
 
 	@Test
 	public void testTwoBagsWithItemsInDifferentQuantities() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		bag1.add("item1");
-		
+		bag1.add( "item1" );
+		bag1.add( "item1" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item1");
-		
-		assertEquals(bag1.equals(bag2), false);
+		bag2.add( "item1" );
+
+		assertEquals( bag1.equals( bag2 ), false );
 	}
 
 	@Test
 	public void testTwoBagsWithItemsInSameQuantity() {
 		PersistentBag bag1 = createBag();
-		bag1.add("item1");
-		bag1.add("item1");
-		
+		bag1.add( "item1" );
+		bag1.add( "item1" );
+
 		PersistentBag bag2 = createBag();
-		bag2.add("item1");
-		bag2.add("item1");
-		
-		assertEquals(bag1.equals(bag2), true);
+		bag2.add( "item1" );
+		bag2.add( "item1" );
+
+		assertEquals( bag1.equals( bag2 ), true );
 	}
 
 	private PersistentBag createBag() {
-		return new PersistentBag(Mockito.mock(SharedSessionContractImplementor.class), new ArrayList());
+		return new PersistentBag( Mockito.mock( SharedSessionContractImplementor.class ), new ArrayList() );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
@@ -1,0 +1,122 @@
+package org.hibernate.test.collection.bag;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.hibernate.collection.internal.PersistentBag;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Tests collection equals behavior given the semantic meaning of a bag
+ *
+ * @author Jasper Horn
+ */
+@TestForIssue( jiraKey="HHH-5409" )
+public class PersistentBagEqualsTest {
+	
+	@Test
+	public void testTwoEmptyBags()
+	{
+		PersistentBag bag1 = createBag();
+		PersistentBag bag2 = createBag();
+		
+		assertEquals(bag1.equals(bag2), true);
+	}
+	
+	@Test
+	public void testTwoBagsWithDifferentContents() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item2");
+		
+		System.out.println("Added items");
+		
+		assertEquals(bag1.equals(bag2), false);
+	}
+
+	@Test
+	public void testTwoBagsWithSameContents() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item");
+		
+		assertEquals(bag1.equals(bag2), true);
+	}
+
+	@Test
+	public void testBagWithSubsetOfOtherBag() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item1");
+		bag2.add("item2");
+		
+		assertEquals(bag1.equals(bag2), false);
+	}
+
+	@Test
+	public void testBagWithSupersetOfOtherBag() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		bag1.add("item2");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item1");
+		
+		assertEquals(bag1.equals(bag2), false);
+	}
+
+	@Test
+	public void testTwoBagsWithItemsInDifferentOrder() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		bag1.add("item2");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item2");
+		bag2.add("item1");
+		
+		assertEquals(bag1.equals(bag2), true);
+	}
+
+	@Test
+	public void testTwoBagsWithItemsInDifferentQuantities() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		bag1.add("item1");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item1");
+		
+		assertEquals(bag1.equals(bag2), false);
+	}
+
+	@Test
+	public void testTwoBagsWithItemsInSameQuantity() {
+		PersistentBag bag1 = createBag();
+		bag1.add("item1");
+		bag1.add("item1");
+		
+		PersistentBag bag2 = createBag();
+		bag2.add("item1");
+		bag2.add("item1");
+		
+		assertEquals(bag1.equals(bag2), true);
+	}
+
+	private PersistentBag createBag() {
+		return new PersistentBag(Mockito.mock(SharedSessionContractImplementor.class), new ArrayList());
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagEqualsTest.java
@@ -92,9 +92,12 @@ public class PersistentBagEqualsTest {
 		PersistentBag bag1 = createBag();
 		bag1.add( "item1" );
 		bag1.add( "item1" );
+		bag1.add( "item2" );
 
 		PersistentBag bag2 = createBag();
 		bag2.add( "item1" );
+		bag2.add( "item2" );
+		bag2.add( "item2" );
 
 		assertEquals( bag1.equals( bag2 ), false );
 	}


### PR DESCRIPTION
Implements an equals with bag semantics.

I have some tests in org.hibernate.jpa.test.cdi are failing, but they are also failing on master, so I think those are false positives (or would that be false negatives?).