### PR TITLE
HHH-12083: Fix test failure in InsertOrderingWithBidirectionalOneToManyFlushProblem on SAP HANA

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToManyFlushProblem.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToManyFlushProblem.java
@@ -135,7 +135,7 @@ public class InsertOrderingWithBidirectionalOneToManyFlushProblem
 		}
 	}
 
-	@Entity(name = "Top")
+	@Entity(name = "`Top`")
 	public static class Top {
 
 		@Column(nullable = false)


### PR DESCRIPTION
- "TOP" is a reserved key word on HANA, so the name of an entity named "Top" must be quoted.