### PR TITLE
HHH-12007 : Executing JPA query results in persistence of new/unmanaged entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
@@ -14,11 +14,15 @@ import org.hibernate.Session;
 import org.hibernate.TransientObjectException;
 import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.loader.PropertyPath;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
+
+import static org.hibernate.internal.CoreLogging.logger;
+import static org.hibernate.internal.CoreLogging.messageLogger;
 
 /**
  * <b>foreign</b><br>
@@ -31,6 +35,8 @@ import org.hibernate.type.Type;
  * @author Gavin King
  */
 public class ForeignGenerator implements IdentifierGenerator, Configurable {
+	private static final CoreMessageLogger LOG = messageLogger( ForeignGenerator.class );
+
 	private String entityName;
 	private String propertyName;
 
@@ -105,6 +111,12 @@ public class ForeignGenerator implements IdentifierGenerator, Configurable {
 			);
 		}
 		catch (TransientObjectException toe) {
+			if ( LOG.isDebugEnabled() ) {
+				LOG.debugf(
+						"ForeignGenerator detected a transient entity [%s]",
+						foreignValueSourceType.getAssociatedEntityName()
+				);
+			}
 			id = session.save( foreignValueSourceType.getAssociatedEntityName(), associatedObject );
 		}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12007

The code in ```IncrediblySillyJpaMapsIdMappedIdentifierValueMarshaller#persistTransientEntity``` is getting executed when a transient entity with a transient or detached key-many-to-one is bound to a query.

This PR removes ```IncrediblySillyJpaMapsIdMappedIdentifierValueMarshaller#persistTransientEntity```.