### PR TITLE
HHH-12140 Allow session scoped interceptors to be managed by DI providers (e.g Spring)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.boot;
 
-import java.util.Map;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -27,6 +25,9 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * The contract for building a {@link org.hibernate.SessionFactory} given a number of options.
@@ -128,16 +129,16 @@ public interface SessionFactoryBuilder {
 	SessionFactoryBuilder applyInterceptor(Interceptor interceptor);
 
 	/**
-	 * Names an interceptor Class to be applied to the SessionFactory, which in turn means it will be used by all
+	 * Names an interceptor Supplier to be applied to the SessionFactory, which in turn means it will be used by all
 	 * Sessions unless one is explicitly specified in {@link org.hibernate.SessionBuilder#interceptor}
 	 *
-	 * @param statelessInterceptorClass The interceptor class
+	 * @param statelessInterceptorSupplier The interceptor supplier
 	 *
 	 * @return {@code this}, for method chaining
 	 *
 	 * @see org.hibernate.cfg.AvailableSettings#SESSION_SCOPED_INTERCEPTOR
 	 */
-	SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass);
+	SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier);
 
 	/**
 	 * Names a StatementInspector to be applied to the SessionFactory, which in turn means it will be used by all

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -129,7 +129,19 @@ public interface SessionFactoryBuilder {
 	SessionFactoryBuilder applyInterceptor(Interceptor interceptor);
 
 	/**
-	 * Names an interceptor Supplier to be applied to the SessionFactory, which in turn means it will be used by all
+	 * Names an interceptor Class to be applied to the SessionFactory, which in turn means it will be used by all
+	 * Sessions unless one is explicitly specified in {@link org.hibernate.SessionBuilder#interceptor}
+	 *
+	 * @param statelessInterceptorClass The interceptor class
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @see org.hibernate.cfg.AvailableSettings#SESSION_SCOPED_INTERCEPTOR
+	 */
+	SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass);
+
+	/**
+	 * Names an interceptor Class to be applied to the SessionFactory, which in turn means it will be used by all
 	 * Sessions unless one is explicitly specified in {@link org.hibernate.SessionBuilder#interceptor}
 	 *
 	 * @param statelessInterceptorSupplier The interceptor supplier

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -6,21 +6,13 @@
  */
 package org.hibernate.boot.internal;
 
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.EntityMode;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.NullPrecedence;
@@ -59,8 +51,17 @@ import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
-
 import org.jboss.logging.Logger;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 import static org.hibernate.cfg.AvailableSettings.*;
 import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
@@ -154,8 +155,8 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
-	public SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass) {
-		this.options.statelessInterceptorClass = statelessInterceptorClass;
+	public SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier) {
+		this.options.statelessInterceptorSupplier = statelessInterceptorSupplier;
 		return this;
 	}
 
@@ -503,7 +504,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		// Statistics/Interceptor/observers
 		private boolean statisticsEnabled;
 		private Interceptor interceptor;
-		private Class<? extends Interceptor> statelessInterceptorClass;
+		private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 		private StatementInspector statementInspector;
 		private List<SessionFactoryObserver> sessionFactoryObserverList = new ArrayList<>();
 		private BaselineSessionEventsListenerBuilder baselineSessionEventsListenerBuilder;	// not exposed on builder atm
@@ -609,7 +610,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 
 			this.statisticsEnabled = cfgService.getSetting( GENERATE_STATISTICS, BOOLEAN, false );
 			this.interceptor = determineInterceptor( configurationSettings, strategySelector );
-			this.statelessInterceptorClass = determineStatelessInterceptorClass( configurationSettings, strategySelector );
+			this.statelessInterceptorSupplier = determineStatelessInterceptor( configurationSettings, strategySelector );
 			this.statementInspector = strategySelector.resolveStrategy(
 					StatementInspector.class,
 					configurationSettings.get( STATEMENT_INSPECTOR )
@@ -803,7 +804,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		}
 
 		@SuppressWarnings("unchecked")
-		private static Class<? extends Interceptor> determineStatelessInterceptorClass(
+		private static Supplier<? extends Interceptor> determineStatelessInterceptor(
 				Map configurationSettings,
 				StrategySelector strategySelector) {
 			Object setting = configurationSettings.get( SESSION_SCOPED_INTERCEPTOR );
@@ -821,14 +822,18 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 			if ( setting == null ) {
 				return null;
 			}
+			else if( setting instanceof Supplier) {
+				return (Supplier<? extends Interceptor>) setting;
+			}
 			else if ( setting instanceof Class ) {
-				return (Class<? extends Interceptor>) setting;
+				Class<? extends Interceptor> clazz = (Class<? extends Interceptor>) setting;
+				return supplierOf(clazz);
 			}
 			else {
-				return strategySelector.selectStrategyImplementor(
+				return supplierOf(strategySelector.selectStrategyImplementor(
 						Interceptor.class,
 						setting.toString()
-				);
+				));
 			}
 
 		}
@@ -965,8 +970,8 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		}
 
 		@Override
-		public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
-			return statelessInterceptorClass;
+		public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+			return statelessInterceptorSupplier;
 		}
 
 		@Override
@@ -1228,6 +1233,16 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		}
 	}
 
+	private static Supplier<? extends Interceptor> supplierOf(Class<? extends Interceptor> clazz) {
+		return () -> {
+            try {
+                return clazz.newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new HibernateException( "Could not supplierOf session-scoped SessionFactory Interceptor", e );
+            }
+        };
+	}
+
 	@Override
 	public StandardServiceRegistry getServiceRegistry() {
 		return options.getServiceRegistry();
@@ -1297,7 +1312,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
-	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
+	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
 		return options.getStatelessInterceptorImplementor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -155,6 +155,12 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
+	public SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass) {
+		this.options.statelessInterceptorClass = statelessInterceptorClass;
+		return this;
+	}
+
+	@Override
 	public SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier) {
 		this.options.statelessInterceptorSupplier = statelessInterceptorSupplier;
 		return this;
@@ -504,6 +510,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		// Statistics/Interceptor/observers
 		private boolean statisticsEnabled;
 		private Interceptor interceptor;
+		private Class<? extends Interceptor> statelessInterceptorClass;
 		private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 		private StatementInspector statementInspector;
 		private List<SessionFactoryObserver> sessionFactoryObserverList = new ArrayList<>();
@@ -970,7 +977,12 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		}
 
 		@Override
-		public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+		public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
+			return statelessInterceptorClass;
+		}
+
+		@Override
+		public Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
 			return statelessInterceptorSupplier;
 		}
 
@@ -1238,7 +1250,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
             try {
                 return clazz.newInstance();
             } catch (InstantiationException | IllegalAccessException e) {
-                throw new HibernateException( "Could not supplierOf session-scoped SessionFactory Interceptor", e );
+                throw new HibernateException( "Could not supply session-scoped SessionFactory Interceptor", e );
             }
         };
 	}
@@ -1312,8 +1324,13 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
-	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
 		return options.getStatelessInterceptorImplementor();
+	}
+
+	@Override
+	public Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
+		return options.getStatelessInterceptorSupplier();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.boot.internal;
 
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -32,6 +29,10 @@ import org.hibernate.query.criteria.LiteralHandlingMode;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 /**
  * Standard implementation of SessionFactoryOptions
@@ -66,7 +67,7 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	// Statistics/Interceptor/observers
 	private final boolean statisticsEnabled;
 	private final Interceptor interceptor;
-	private Class<? extends Interceptor> statelessInterceptorClass;
+	private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 	private final StatementInspector statementInspector;
 	private final SessionFactoryObserver[] sessionFactoryObserverList;
 	private final BaselineSessionEventsListenerBuilder baselineSessionEventsListenerBuilder;	// not exposed on builder atm
@@ -152,7 +153,7 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 
 		this.statisticsEnabled = state.isStatisticsEnabled();
 		this.interceptor = state.getInterceptor();
-		this.statelessInterceptorClass = state.getStatelessInterceptorImplementor();
+		this.statelessInterceptorSupplier = state.getStatelessInterceptorImplementor();
 		this.statementInspector = state.getStatementInspector();
 		this.sessionFactoryObserverList = state.getSessionFactoryObservers();
 		this.baselineSessionEventsListenerBuilder = state.getBaselineSessionEventsListenerBuilder();
@@ -273,8 +274,8 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	}
 
 	@Override
-	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
-		return statelessInterceptorClass;
+	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+		return statelessInterceptorSupplier;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsImpl.java
@@ -67,6 +67,7 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	// Statistics/Interceptor/observers
 	private final boolean statisticsEnabled;
 	private final Interceptor interceptor;
+	private Class<? extends Interceptor> statelessInterceptorClass;
 	private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 	private final StatementInspector statementInspector;
 	private final SessionFactoryObserver[] sessionFactoryObserverList;
@@ -153,7 +154,8 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 
 		this.statisticsEnabled = state.isStatisticsEnabled();
 		this.interceptor = state.getInterceptor();
-		this.statelessInterceptorSupplier = state.getStatelessInterceptorImplementor();
+		this.statelessInterceptorSupplier = state.getStatelessInterceptorSupplier();
+		this.statelessInterceptorClass = state.getStatelessInterceptorImplementor();
 		this.statementInspector = state.getStatementInspector();
 		this.sessionFactoryObserverList = state.getSessionFactoryObservers();
 		this.baselineSessionEventsListenerBuilder = state.getBaselineSessionEventsListenerBuilder();
@@ -274,7 +276,12 @@ public class SessionFactoryOptionsImpl implements SessionFactoryOptions {
 	}
 
 	@Override
-	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
+		return statelessInterceptorClass;
+	}
+
+	@Override
+	public Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
 		return statelessInterceptorSupplier;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
@@ -73,7 +73,9 @@ public interface SessionFactoryOptionsState {
 
 	Interceptor getInterceptor();
 
-	Supplier<? extends Interceptor> getStatelessInterceptorImplementor();
+	Class<? extends Interceptor> getStatelessInterceptorImplementor();
+
+	Supplier<? extends Interceptor> getStatelessInterceptorSupplier();
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
@@ -10,6 +10,7 @@ import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.NullPrecedence;
@@ -75,7 +76,15 @@ public interface SessionFactoryOptionsState {
 
 	Class<? extends Interceptor> getStatelessInterceptorImplementor();
 
-	Supplier<? extends Interceptor> getStatelessInterceptorSupplier();
+	default Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
+		return () -> {
+			try {
+				return getStatelessInterceptorImplementor().newInstance();
+			} catch (InstantiationException | IllegalAccessException e) {
+				throw new HibernateException( "Could not supply session-scoped SessionFactory Interceptor", e );
+			}
+		};
+	}
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsState.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.boot.internal;
 
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -32,6 +29,10 @@ import org.hibernate.query.criteria.LiteralHandlingMode;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 /**
  * Sort of a mutable SessionFactoryOptions used during SessionFactoryBuilder calls.
@@ -72,7 +73,7 @@ public interface SessionFactoryOptionsState {
 
 	Interceptor getInterceptor();
 
-	Class<? extends Interceptor> getStatelessInterceptorImplementor();
+	Supplier<? extends Interceptor> getStatelessInterceptorImplementor();
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -402,6 +402,12 @@ public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionF
 	}
 
 	@Override
+	public T applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass) {
+		delegate.applyStatelessInterceptor(statelessInterceptorClass);
+		return getThis();
+	}
+
+	@Override
 	public T applyConnectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
 		delegate.applyConnectionHandlingMode( connectionHandlingMode );
 		return getThis();

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.boot.spi;
 
-import java.util.Map;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -29,6 +27,9 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizer;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Convenience base class for custom implementors of SessionFactoryBuilder, using delegation
@@ -395,8 +396,8 @@ public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionF
 	}
 
 	@Override
-	public T applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass) {
-		delegate.applyStatelessInterceptor( statelessInterceptorClass );
+	public T applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier) {
+		delegate.applyStatelessInterceptor(statelessInterceptorSupplier);
 		return getThis();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -372,8 +372,13 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
-	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
+	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
 		return delegate.getStatelessInterceptorImplementor();
+	}
+
+	@Override
+	public Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
+		return delegate.getStatelessInterceptorSupplier();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.boot.spi;
 
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -31,6 +28,10 @@ import org.hibernate.query.criteria.LiteralHandlingMode;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 /**
  * Convenience base class for custom implementors of SessionFactoryOptions, using delegation
@@ -371,7 +372,7 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
-	public Class<? extends Interceptor> getStatelessInterceptorImplementor() {
+	public Supplier<? extends Interceptor> getStatelessInterceptorImplementor() {
 		return delegate.getStatelessInterceptorImplementor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.boot.spi;
 
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
@@ -31,6 +28,10 @@ import org.hibernate.query.criteria.LiteralHandlingMode;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.tuple.entity.EntityTuplizerFactory;
+
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Supplier;
 
 /**
  * Aggregator of special options used to build the SessionFactory.
@@ -102,7 +103,7 @@ public interface SessionFactoryOptions {
 	 *
 	 * @return The interceptor to use factory wide.  May be {@code null}
 	 */
-	Class<? extends Interceptor> getStatelessInterceptorImplementor();
+	Supplier<? extends Interceptor> getStatelessInterceptorImplementor();
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -10,6 +10,7 @@ import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityMode;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.NullPrecedence;
@@ -110,7 +111,15 @@ public interface SessionFactoryOptions {
 	 *
 	 * @return The interceptor to use factory wide.  May be {@code null}
 	 */
-	Supplier<? extends Interceptor> getStatelessInterceptorSupplier();
+	default Supplier<? extends Interceptor> getStatelessInterceptorSupplier() {
+		return () -> {
+			try {
+				return getStatelessInterceptorImplementor().newInstance();
+			} catch (InstantiationException | IllegalAccessException e) {
+				throw new HibernateException( "Could not supply session-scoped SessionFactory Interceptor", e );
+			}
+		};
+	}
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -103,7 +103,14 @@ public interface SessionFactoryOptions {
 	 *
 	 * @return The interceptor to use factory wide.  May be {@code null}
 	 */
-	Supplier<? extends Interceptor> getStatelessInterceptorImplementor();
+	Class<? extends Interceptor> getStatelessInterceptorImplementor();
+
+	/**
+	 * Get the interceptor to use by default for all sessions opened from this factory.
+	 *
+	 * @return The interceptor to use factory wide.  May be {@code null}
+	 */
+	Supplier<? extends Interceptor> getStatelessInterceptorSupplier();
 
 	StatementInspector getStatementInspector();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -6,49 +6,7 @@
  */
 package org.hibernate.internal;
 
-import java.io.IOException;
-import java.io.InvalidObjectException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import javax.naming.Reference;
-import javax.naming.StringRefAddr;
-import javax.persistence.EntityGraph;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceContextType;
-import javax.persistence.PersistenceException;
-import javax.persistence.PersistenceUnitUtil;
-import javax.persistence.Query;
-import javax.persistence.SynchronizationType;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.spi.PersistenceUnitTransactionType;
-
-import org.hibernate.AssertionFailure;
-import org.hibernate.ConnectionAcquisitionMode;
-import org.hibernate.ConnectionReleaseMode;
-import org.hibernate.CustomEntityDirtinessStrategy;
-import org.hibernate.EmptyInterceptor;
-import org.hibernate.FlushMode;
-import org.hibernate.HibernateException;
-import org.hibernate.Interceptor;
-import org.hibernate.MappingException;
-import org.hibernate.MultiTenancyStrategy;
-import org.hibernate.Session;
-import org.hibernate.SessionBuilder;
-import org.hibernate.SessionEventListener;
-import org.hibernate.SessionFactory;
-import org.hibernate.SessionFactoryObserver;
-import org.hibernate.StatelessSession;
-import org.hibernate.StatelessSessionBuilder;
-import org.hibernate.TypeHelper;
+import org.hibernate.*;
 import org.hibernate.boot.cfgxml.spi.CfgXmlAccessService;
 import org.hibernate.boot.cfgxml.spi.LoadedConfig;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -127,8 +85,32 @@ import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
 import org.hibernate.type.SerializableType;
 import org.hibernate.type.Type;
 import org.hibernate.type.TypeResolver;
-
 import org.jboss.logging.Logger;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContextType;
+import javax.persistence.PersistenceException;
+import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.Query;
+import javax.persistence.SynchronizationType;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.spi.PersistenceUnitTransactionType;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
 
 import static org.hibernate.metamodel.internal.JpaMetaModelPopulationSetting.determineJpaMetaModelPopulationSetting;
 
@@ -1058,12 +1040,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 
 		// then check the Session-scoped interceptor prototype
 		if ( options.getStatelessInterceptorImplementor() != null ) {
-			try {
-				return options.getStatelessInterceptorImplementor().newInstance();
-			}
-			catch (InstantiationException | IllegalAccessException e) {
-				throw new HibernateException( "Could not instantiate session-scoped SessionFactory Interceptor", e );
-			}
+			return options.getStatelessInterceptorImplementor().get();
 		}
 
 		return null;


### PR DESCRIPTION
This allows Session Scoped Interceptors to be managed by third party IOC frameworks e.g. Spring/Guice

- Instead of providing `"hibernate.session_factory.interceptor={class name}"` and the interceptor being created by `{class name}.newInstance()` in the session builder, you can now provide a `Supplier<Interceptor>` in your hibernate properties/Spring config XML/other framework configuration.

e.g. in Spring:

```
@Autowired
private Supplier<Interceptor> customSessionScopedInterceptorSupplier;

@Bean
public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
    //... 
    final Map<String, Object> properties = new HashMap<>();
    //.... Add all JPA Properties
    properties.put("hibernate.session_factory.interceptor", customSessionScopedInterceptorSupplier);
    factory.setJpaPropertyMap(properties);
    return factory;
}
```

Note: This change maintains existing functionality allowing a user to specify a `Class` name and just extends this functionality to allow an `Interceptor<Supplier>` as well.