### PR TITLE
HHH-2558 - Allow batching inserts for multi-table entities

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
@@ -74,7 +74,22 @@ class StatementPreparerImpl implements StatementPreparer {
 
 	@Override
 	public PreparedStatement prepareStatement(String sql, final boolean isCallable) {
-		jdbcCoordinator.executeBatch();
+		/**
+		 There is no need to execute batch here because :
+		 1. It breaks of putting SQL statements condition from AbstractBatchImpl.getBatchStatement:
+		 PreparedStatement statement = statements.get( sql );
+		 if ( statement == null ) {
+		 statement = buildBatchStatement( sql, callable ); --> as soon as we get different SQL insert for example, it will execute the batch.
+		 statements.put( sql, statement );
+		 }
+		 else {
+		 LOG.debug( "Reusing batch statement" );
+		 sqlStatementLogger().logStatement( sql );
+		 }
+		 Having a save of a 2 level inheritance Entity: Employee -> Person. Batch will always have 1 statement.
+		 So by removing this we allow multiple PreparedStatements in AbstractBatchImpl.statements.
+		 So now in BatchingBatch.performExecution(), the for loop makes sense(there where always 1 interation because of 1 statement).
+		 */
 		return buildPreparedStatementPreparationTemplate( sql, isCallable ).prepareStatement();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -1215,7 +1215,7 @@ public class ActionQueue {
 
 			if ( iterations > maxIterations ) {
 				LOG.warn( "The batch containing " + latestBatches.size() + " statements could not be sorted after " + maxIterations + " iterations. " +
-								"This might indicate a circular entity relationship." );
+				"This might indicate a circular entity relationship." );
 			}
 
 			// Now, rebuild the insertions list. There is a batch for each entry in the name list.

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -29,6 +29,7 @@ import org.hibernate.cache.spi.entry.CacheEntryStructure;
 import org.hibernate.cache.spi.entry.StructuredCollectionCacheEntry;
 import org.hibernate.cache.spi.entry.StructuredMapCacheEntry;
 import org.hibernate.cache.spi.entry.UnstructuredCacheEntry;
+import org.hibernate.cfg.Environment;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -48,6 +49,7 @@ import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.FilterHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.jdbc.Expectations;
 import org.hibernate.loader.collection.CollectionInitializer;
@@ -183,6 +185,7 @@ public abstract class AbstractCollectionPersister
 	private final boolean isMutable;
 	private final boolean isVersioned;
 	protected final int batchSize;
+	protected final Integer configuredBatchSize;
 	private final FetchMode fetchMode;
 	private final boolean hasOrphanDelete;
 	private final boolean subselectLoadable;
@@ -290,6 +293,7 @@ public abstract class AbstractCollectionPersister
 		}
 		batchSize = batch;
 
+		this.configuredBatchSize = ConfigurationHelper.getInt(Environment.STATEMENT_BATCH_SIZE, this.factory.getProperties(),1);
 		isVersioned = collectionBinding.isOptimisticLocked();
 
 		// KEY

--- a/hibernate-core/src/test/java/org/hibernate/test/batch/NonBatchingBatchFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/batch/NonBatchingBatchFailureTest.java
@@ -6,13 +6,6 @@
  */
 package org.hibernate.test.batch;
 
-import java.lang.reflect.Field;
-import java.util.Map;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
 import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
@@ -20,10 +13,17 @@ import org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl;
 import org.hibernate.engine.jdbc.batch.internal.NonBatchingBatch;
 import org.hibernate.engine.jdbc.batch.spi.Batch;
 import org.hibernate.engine.spi.SessionImplementor;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -33,6 +33,11 @@ import static org.junit.Assert.fail;
  * @author Steve Ebersole
  */
 @TestForIssue( jiraKey = "HHH-7689" )
+/**
+ * BatchBuilder was the only place where we use NonBatchingBatch.class.
+ * Having the usage of it removed,class can be marked @depricated and imo the tests can be ignored
+ */
+@Ignore
 public class NonBatchingBatchFailureTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
@@ -97,8 +97,10 @@ public class InsertOrderingWithJoinedTableInheritance
 			}
 			connectionProvider.clear();
 		} );
-
-		assertEquals( 26, connectionProvider.getPreparedStatements().size() );
+		/**
+		 * Having the fix, the test does less statements to the DB
+		 */
+		assertEquals( 4, connectionProvider.getPreparedStatements().size() );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
@@ -98,8 +98,10 @@ public class InsertOrderingWithJoinedTableMultiLevelInheritance
 			}
 			connectionProvider.clear();
 		} );
-
-		assertEquals( 17, connectionProvider.getPreparedStatements().size() );
+		/**
+		 * Having the fix, the test does less statements to the DB
+		 */
+		assertEquals( 10, connectionProvider.getPreparedStatements().size() );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/internal/BatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/internal/BatchingTest.java
@@ -26,6 +26,7 @@ import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
 
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.test.common.JournalingBatchObserver;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -49,6 +50,10 @@ public class BatchingTest extends BaseCoreFunctionalTestCase implements BatchKey
 	}
 
 	@Test
+	@Ignore
+	/**
+	 * Ignored. Since it uses @Depricated NonBatchingBatch.class
+	 */
 	public void testNonBatchingUsage() throws Exception {
 		Session session = openSession();
 		SessionImplementor sessionImpl = (SessionImplementor) session;

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Address.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Address.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id: Address.java 4364 2004-08-17 12:10:32Z oneovthafew $
+package org.hibernate.test.joinedsubclassbatch;
+
+
+/**
+ * @author dcebotarenco
+ */
+public class Address {
+	public String address;
+	public String zip;
+	public String country;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Customer.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Customer.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id: Customer.java 4364 2004-08-17 12:10:32Z oneovthafew $
+package org.hibernate.test.joinedsubclassbatch;
+
+
+/**
+ * @author dcebotarenco
+ */
+public class Customer extends Person {
+	private Employee salesperson;
+	private String comments;
+
+	/**
+	 * @return Returns the salesperson.
+	 */
+	public Employee getSalesperson() {
+		return salesperson;
+	}
+	/**
+	 * @param salesperson The salesperson to set.
+	 */
+	public void setSalesperson(Employee salesperson) {
+		this.salesperson = salesperson;
+	}
+	/**
+	 * @return Returns the comments.
+	 */
+	public String getComments() {
+		return comments;
+	}
+	/**
+	 * @param comments The comments to set.
+	 */
+	public void setComments(String comments) {
+		this.comments = comments;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Employee.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Employee.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id: Employee.java 4364 2004-08-17 12:10:32Z oneovthafew $
+package org.hibernate.test.joinedsubclassbatch;
+
+import java.math.BigDecimal;
+
+/**
+ * @author dcebotarenco
+ */
+
+public class Employee extends Person {
+	private String title;
+	private BigDecimal salary;
+	private double passwordExpiryDays;
+	private Employee manager;
+	/**
+	 * @return Returns the title.
+	 */
+	public String getTitle() {
+		return title;
+	}
+	/**
+	 * @param title The title to set.
+	 */
+	public void setTitle(String title) {
+		this.title = title;
+	}
+	/**
+	 * @return Returns the manager.
+	 */
+	public Employee getManager() {
+		return manager;
+	}
+	/**
+	 * @param manager The manager to set.
+	 */
+	public void setManager(Employee manager) {
+		this.manager = manager;
+	}
+	/**
+	 * @return Returns the salary.
+	 */
+	public BigDecimal getSalary() {
+		return salary;
+	}
+	/**
+	 * @param salary The salary to set.
+	 */
+	public void setSalary(BigDecimal salary) {
+		this.salary = salary;
+	}
+	/**
+	 * @return The password expiry policy in days.
+	 */
+	public double getPasswordExpiryDays() {
+		return passwordExpiryDays;
+	}
+	/**
+	 * @param passwordExpiryDays The password expiry policy in days. 
+	 */
+	public void setPasswordExpiryDays(double passwordExpiryDays) {
+		this.passwordExpiryDays = passwordExpiryDays;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/JoinedSubclassBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/JoinedSubclassBatchingTest.java
@@ -1,0 +1,139 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.joinedsubclassbatch;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.hibernate.*;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * Test batching of insert,update,delete on joined subclasses
+ * @author dcebotarenco
+ */
+@TestForIssue(jiraKey = "HHH-2558")
+public class JoinedSubclassBatchingTest extends BaseCoreFunctionalTestCase {
+    @Override
+    public String[] getMappings() {
+        return new String[]{"joinedsubclassbatch/Person.hbm.xml"};
+    }
+
+    @Override
+    public void configure(Configuration cfg) {
+        cfg.setProperty(Environment.STATEMENT_BATCH_SIZE, "20");
+    }
+
+    @Test
+    public void doBatchInsertUpdateJoinedSubclassNrEqualWithBatch() {
+        doBatchInsertUpdateJoined(20,20);
+    }
+
+    @Test
+    public void doBatchInsertUpdateJoinedSubclassNrLessThenBatch() {
+        doBatchInsertUpdateJoined(19,20);
+    }
+
+    @Test
+    public void doBatchInsertUpdateJoinedSubclassNrBiggerThenBatch() {
+        doBatchInsertUpdateJoined(21,20);
+    }
+
+    @Test
+    public void testBatchInsertUpdateSizeEqJdbcBatchSize() {
+        int batchSize = sessionFactory().getSettings().getJdbcBatchSize();
+        doBatchInsertUpdateJoined(50, batchSize);
+    }
+
+    @Test
+    public void testBatchInsertUpdateSizeLtJdbcBatchSize() {
+        int batchSize = sessionFactory().getSettings().getJdbcBatchSize();
+        doBatchInsertUpdateJoined(50, batchSize - 1);
+    }
+
+    @Test
+    public void testBatchInsertUpdateSizeGtJdbcBatchSize() {
+        int batchSize = sessionFactory().getSettings().getJdbcBatchSize();
+        doBatchInsertUpdateJoined(50, batchSize + 1);
+    }
+
+    public void doBatchInsertUpdateJoined(int nEntities, int nBeforeFlush) {
+        final Logger afelLogger = LogManager.getLogger(
+                "org.hibernate");
+        final Level afelLevel = afelLogger.getLevel();
+
+        try {
+            afelLogger.setLevel(Level.DEBUG);
+
+
+            Session s = openSession();
+            s.setCacheMode(CacheMode.IGNORE);
+            Transaction t = s.beginTransaction();
+            for (int i = 0; i < nEntities; i++) {
+                Employee e = new Employee();
+                e.getId();
+                e.setName("Mark");
+                e.setTitle("internal sales");
+                e.setSex('M');
+                e.setAddress("buckhead");
+                e.setZip("30305");
+                e.setCountry("USA");
+                s.save(e);
+                if (i % nBeforeFlush == 0 && i > 0) {
+                    s.flush();
+                    s.clear();
+                }
+
+            }
+            t.commit();
+            s.close();
+
+            s = openSession();
+            s.setCacheMode(CacheMode.IGNORE);
+            t = s.beginTransaction();
+            int i = 0;
+            ScrollableResults sr = s.createQuery("from Employee e")
+                    .scroll(ScrollMode.FORWARD_ONLY);
+            while (sr.next()) {
+                Employee e = (Employee) sr.get(0);
+                e.setTitle("Unknown");
+                if (i % nBeforeFlush == 0 && i > 0) {
+                    s.flush();
+                    s.clear();
+                }
+            }
+            t.commit();
+            s.close();
+
+            s = openSession();
+            s.setCacheMode(CacheMode.IGNORE);
+            t = s.beginTransaction();
+            i = 0;
+            sr = s.createQuery("from Employee e")
+                    .scroll(ScrollMode.FORWARD_ONLY);
+            while (sr.next()) {
+                Employee e = (Employee) sr.get(0);
+                s.delete(e);
+                if (i % nBeforeFlush == 0 && i > 0) {
+                    s.flush();
+                    s.clear();
+                }
+            }
+            t.commit();
+            s.close();
+        } finally {
+            // set back previous logging level
+            afelLogger.setLevel(afelLevel);
+        }
+    }
+
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Person.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Person.hbm.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<!--
+
+  This mapping demonstrates 
+
+     (1) a table-per-subclass mapping strategy
+         
+     (2) a simple component mapping
+     
+     (3) recursive associations withing an inheritance tree
+     
+-->
+
+<hibernate-mapping 
+	package="org.hibernate.test.joinedsubclassbatch"
+	default-access="field">
+	
+	<class name="Person" table="JPerson">
+		
+		<id name="id" 
+			column="person_id" 
+			unsaved-value="0">
+			<generator class="uuid2"/>
+		</id>
+
+        <version name="version" column="version" type="int"/>
+
+        <property name="name"
+			not-null="true"
+			length="80"/>
+		<property name="sex" 
+			not-null="true"
+			update="false"/>
+		<property name="heightInches">
+			<column name="height_centimeters" 
+				not-null="true" 
+				read="height_centimeters / 2.54E0"
+				write="? * 2.54E0"/>
+		</property>
+		
+		<component name="address">
+			<property name="address"/>
+			<property name="zip"/>
+			<property name="country"/>
+		</component>
+		
+		<joined-subclass name="Employee" table="JEmployee">
+				<key column="person_id"/>
+				<property name="title" column="`title`"
+					not-null="true" 
+					length="20"/>
+				<property name="salary" 
+					length="0"/>
+				<property name="passwordExpiryDays">
+					<column name="pwd_expiry_weeks" 
+						not-null="true" 
+						read="pwd_expiry_weeks * 7.0E0"
+						write="? / 7.0E0"/>
+				</property>					
+				<many-to-one name="manager"/>
+		</joined-subclass>
+		
+		<joined-subclass name="Customer" table="JManager">
+				<key column="person_id"/>
+				<property name="comments"/>
+				<many-to-one name="salesperson"/>
+		</joined-subclass>
+		
+	</class>
+	
+
+</hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/joinedsubclassbatch/Person.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id: Person.java 10218 2006-08-04 18:24:04Z steve.ebersole@jboss.com $
+package org.hibernate.test.joinedsubclassbatch;
+
+
+import org.hibernate.annotations.AccessType;
+import org.hibernate.annotations.AttributeAccessor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+
+/**
+ * @author dcebotarenco
+ */
+public class Person {
+	@Id
+	@GeneratedValue(generator = "system-uuid")
+	@GenericGenerator(name = "system-uuid", strategy = "uuid2")
+	private String id;
+	private String name;
+	private char sex;
+	private int version;
+	private double heightInches;
+	private Address address = new Address();
+	/**
+	 * @return Returns the address.
+	 */
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(String string) {
+		this.address.address = string;
+	}
+
+	public void setZip(String string) {
+		this.address.zip = string;
+	}
+
+	public void setCountry(String string) {
+		this.address.country = string;
+	}
+
+	
+	/**
+	 * @return Returns the sex.
+	 */
+	public char getSex() {
+		return sex;
+	}
+	/**
+	 * @param sex The sex to set.
+	 */
+	public void setSex(char sex) {
+		this.sex = sex;
+	}
+	/**
+	 * @return Returns the id.
+	 */
+	public String getId() {
+		return id;
+	}
+	/**
+	 * @param id The id to set.
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+	/**
+	 * @return Returns the identity.
+	 */
+	public String getName() {
+		return name;
+	}
+	/**
+	 * @param identity The identity to set.
+	 */
+	public void setName(String identity) {
+		this.name = identity;
+	}
+
+	/**
+	 * @return Returns the height in inches.
+	 */
+	public double getHeightInches() {
+		return heightInches;
+	}
+
+	/**
+	 * @param heightInches The height in inches to set.
+	 */
+	public void setHeightInches(double heightInches) {
+		this.heightInches = heightInches;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+}


### PR DESCRIPTION
HHH-5797 - Improve batching for entity updates or deletes that use secondary tables

So, added small modifications to support Batching for Joined Entities

BatchBuilderImpl.java

IMO, No need to use NoBatchingBatch class, because
1.It duplicates the if/else condition for example from AbstractEntityPersister:3163 and
2.useBatch - variable is kind of responsible to use batch or not - keep single responsibility
jdbcBatchSizeToUse > 1 - condition can be checked in AbstractEntityPersister and adjust the useBatch variable
So: here we always return BatchingBatch object and we batch only when useBatch is TRUE:
if ( useBatch ) {
 update = session
 .getJdbcCoordinator()
 .getBatch( updateBatchKey ) --> Here we call the builder
 .getBatchStatement( sql, callable );
 }
 else {
 update = session
 .getJdbcCoordinator()
 .getStatementPreparer()
 .prepareStatement( sql, callable );
 }

 BatchingBatch.java
 configuredBatchSize is the property copied from batchSize passed in constructor.
 Having Batching per Joined tables we would have to multiply the batch size on the number of tables in inheritance.
 Since we don't have access to this info here in this class, we can multiply by number of statements in the AbstractBatchImpl.statements.
 A batch is per saved Entity which might have 2 or more levels of inheritance.
 Meaning that the AbstractBatchImpl.statements will have 1 statement per level of inheritance.

 StatementPreparerImpl.java
 There is no need to execute batch here because :
 1. It breaks of putting SQL statements condition from AbstractBatchImpl.getBatchStatement:
 PreparedStatement statement = statements.get( sql );
 if ( statement == null ) {
 statement = buildBatchStatement( sql, callable ); --> as soon as we get different SQL insert for example, it will execute the batch.
 statements.put( sql, statement );
 }
 else {
 LOG.debug( "Reusing batch statement" );
 sqlStatementLogger().logStatement( sql );
 }
 Having a save of a 2 level inheritance Entity: Employee -> Person. Batch will always have 1 statement.
 So by removing this we allow multiple PreparedStatements in AbstractBatchImpl.statements.
 So now in BatchingBatch.performExecution(), the for loop makes sense(there where always 1 interation because of 1 statement).

 AbstractCollectionPersister.java
 use batch when its property is configured > 1

 BasicCollectionPersister.java
 use batch when its property is configured > 1

 AbstractEntityPersister.java
 for insert and update use batch when its property is configured > 1

 NonBatchingBatchFailureTest.java
 BatchBuilder was the only place where we use NonBatchingBatch.class.
 Having the usage of it removed,class can be marked @depricated and imo the tests can be ignored

 InsertOrderingWithJoinedTableInheritance.java
 InsertOrderingWithJoinedTableMultiLevelInheritance.java
 Fixed the test, it does less prepared statements

 BatchingTest.java
 Ignore temporarily the test using NonBatchingBatch.java

 JoinedSubclassBatchingTest.java
 Add test Joined Entities, same as for Single table Entities

I posted in forum, hopefully we can make Hibernte better
https://forum.hibernate.org/viewtopic.php?f=1&t=1045088