### PR TITLE
HHH-9641 Publish JavaDoc JARs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -353,6 +353,15 @@ subprojects { subProject ->
 	sourcesJar {
 		manifest = jar.manifest
 	}
+
+	task javadocJar(type: Jar) {
+		from new File(project(":documentation").buildDir, "/javadocs")
+		classifier = 'javadoc'
+		manifest = jar.manifest
+	}
+
+	javadocJar.dependsOn(":documentation:aggregateJavadocs")
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
@@ -465,6 +474,7 @@ subprojects { subProject ->
 					artifact( sourcesJar ) {
 						classifier 'sources'
 					}
+					artifact javadocJar
 				}
 				// http://issues.gradle.org/browse/GRADLE-2966
 				// Once ^^ is resolved:

--- a/hibernate-entitymanager/hibernate-entitymanager.gradle
+++ b/hibernate-entitymanager/hibernate-entitymanager.gradle
@@ -30,3 +30,8 @@ sourcesJar {
 	manifest = null
 }
 
+javadocJar {
+	// The OSGi JAR manifest support does not like a non-existent classes dir,
+	// so make sure we dont use the OSGi one :)
+	manifest = null
+}

--- a/hibernate-java8/hibernate-java8.gradle
+++ b/hibernate-java8/hibernate-java8.gradle
@@ -22,3 +22,9 @@ sourcesJar {
     // so make sure we dont use the OSGi one :)
     manifest = null
 }
+
+javadocJar {
+    // The OSGi JAR manifest support does not like a non-existent classes dir,
+    // so make sure we dont use the OSGi one :)
+    manifest = null
+}


### PR DESCRIPTION
[HHH-9641](https://hibernate.atlassian.net/browse/HHH-9641) is an old ticket and isn't assigned to anyone, but the required changes didn't seem too hard so I gave it a shot. I tested my changes with a `./gradlew clean assemble publishToMavenLocal` (which, before my changes only created the binary and source JARs). I'd be glad to do any more required testing and make any other changes necessary.