### PR TITLE
Test case and proposed fix for HHH-12011

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
@@ -77,7 +77,23 @@ public class MetaAttributeGenerationVisitor extends SimpleTypeVisitor6<Annotatio
 //				}
 //			}
 //			return attribute;
-		return new AnnotationMetaSingleAttribute( entity, element, TypeUtils.toTypeString( t ) );
+
+		String typeName = null;
+
+		TypeMirror type = t.getComponentType();
+
+		if ( type instanceof com.sun.tools.javac.code.Type.AnnotatedType ) {
+			type = ((com.sun.tools.javac.code.Type.AnnotatedType) type).unannotatedType();
+			if ( type.getKind().isPrimitive() ) {
+				typeName = context.getTypeUtils().getPrimitiveType(type.getKind()).toString();
+			}
+		}
+
+		if ( typeName == null ) {
+			typeName = type.toString();
+		}
+
+		return new AnnotationMetaSingleAttribute( entity, element, typeName + "[]" );
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotation.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Valentin Rentschler
+ */
+@Target({ FIELD, TYPE_USE })
+@Retention(RUNTIME)
+@Documented
+public @interface TypeUseAnnotation {
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotationEntity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotationEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.annotation;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.sql.Blob;
+
+/**
+ * @author Valentin Rentschler
+ */
+@Entity
+@Table
+public class TypeUseAnnotationEntity {
+
+	@Id
+	private String id;
+
+	@TypeUseAnnotation
+	private String string;
+
+	@TypeUseAnnotation
+	private Blob blob;
+
+	@TypeUseAnnotation
+	private byte[] bytes;
+
+	private byte[] bytesWoAnnotation;
+
+	@TypeUseAnnotation
+	private Byte[] bytesAlt;
+
+	private Byte[] bytesAltWoAnnotation;
+
+}
+
+

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotationTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/annotation/TypeUseAnnotationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.annotation;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+import org.junit.Test;
+
+import java.sql.Blob;
+
+import static java.lang.String.format;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.*;
+
+/**
+ * @author Valentin Rentschler
+ */
+public class TypeUseAnnotationTest extends CompilationTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12011")
+	@WithClasses(TypeUseAnnotationEntity.class)
+	public void testTypeUseAnnotation() {
+		assertMetamodelClassGeneratedFor( TypeUseAnnotationEntity.class );
+		assertPresenceOfFieldFor( "blob", Blob.class );
+		assertPresenceOfFieldFor( "string", String.class );
+		assertPresenceOfFieldFor( "id", String.class );
+		assertPresenceOfFieldFor( "bytes", byte[].class );
+		assertPresenceOfFieldFor( "bytesWoAnnotation", byte[].class );
+		assertPresenceOfFieldFor( "bytesAlt", Byte[].class );
+		assertPresenceOfFieldFor( "bytesAltWoAnnotation", Byte[].class );
+	}
+
+	private void assertPresenceOfFieldFor(String fieldName, Class<?> expectedType) {
+		assertPresenceOfFieldInMetamodelFor( TypeUseAnnotationEntity.class, fieldName,
+				format("the metamodel should have a member '%s'", fieldName) );
+		assertAttributeTypeInMetaModelFor( TypeUseAnnotationEntity.class,
+				fieldName, expectedType, format("the metamodel should have a member '%s' of type '%s'", fieldName, expectedType)
+		);
+	}
+}


### PR DESCRIPTION
Test case and proposed fix for HHH-12011 - Field annotated with target TYPE_USE break metamodel generation, see https://hibernate.atlassian.net/browse/HHH-12011

We probably shouldn't use com.sun.tools.javac.code.Type.AnnotatedType, but I found no other solution short of parsing the output of toString().