### PR TITLE
HHH-12149 - Allow to use predicate operators in HQL order by clauses

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/HQL.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/HQL.adoc
@@ -1806,6 +1806,7 @@ The types of expressions considered valid as part of the `ORDER BY` clause inclu
 * state fields
 * component/embeddable attributes
 * scalar expressions such as arithmetic operations, functions, etc.
+* predicate operators
 * identification variable declared in the select clause for any of the previous expression types
 
 Additionally, JPQL says that all values referenced in the `ORDER BY` clause must be named in the `SELECT` clause.

--- a/hibernate-core/src/main/antlr/hql-sql.g
+++ b/hibernate-core/src/main/antlr/hql-sql.g
@@ -383,6 +383,7 @@ nullPrecedence
 orderExpr
 	: { isOrderExpressionResultVariableRef( _t ) }? resultVariableRef
 	| expr [ null ]
+	| logicalExpr
 	;
 
 resultVariableRef!

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
@@ -875,6 +875,12 @@ public class HQLTest extends QueryTranslatorTestCase {
 		}
 	}
 
+    @Test
+    @TestForIssue(jiraKey = "HHH-12149")
+    public void testOrderByPredicates() throws Exception {
+        assertTranslation( "from Animal an order by an.bodyWeight > 10" );
+    }
+
 	@Test
 	public void testGroupByFunction() {
 		if ( getDialect() instanceof Oracle8iDialect ) return; // the new hiearchy...


### PR DESCRIPTION
PR for [HHH-12149](https://hibernate.atlassian.net/browse/HHH-12149).