### PR TITLE
HHH-11798: Provide method for overriding delete statement in GlobalTemporaryTableBulkIdStrategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
@@ -6,24 +6,10 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.PreparedStatement;
-
-import org.hibernate.dialect.identity.HANAIdentityColumnSupport;
-import org.hibernate.dialect.identity.IdentityColumnSupport;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.hql.internal.ast.HqlSqlWalker;
-import org.hibernate.hql.internal.ast.tree.DeleteStatement;
-import org.hibernate.hql.internal.ast.tree.FromElement;
-import org.hibernate.hql.internal.ast.tree.UpdateStatement;
-import org.hibernate.hql.spi.id.IdTableInfo;
 import org.hibernate.hql.spi.id.IdTableSupportStandardImpl;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
-import org.hibernate.hql.spi.id.TableBasedDeleteHandlerImpl;
-import org.hibernate.hql.spi.id.TableBasedUpdateHandlerImpl;
 import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.local.AfterUseAction;
-import org.hibernate.persister.entity.Queryable;
 
 /**
  * An SQL dialect for HANA. <br/>
@@ -52,60 +38,11 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 				return "create global temporary column table";
 			}
 
-		}, AfterUseAction.CLEAN ) {
-
 			@Override
-			public DeleteHandler buildDeleteHandler(SessionFactoryImplementor factory, HqlSqlWalker walker) {
-				final DeleteStatement updateStatement = (DeleteStatement) walker.getAST();
-
-				final FromElement fromElement = updateStatement.getFromClause().getFromElement();
-				final Queryable targetedPersister = fromElement.getQueryable();
-
-				return new TableBasedDeleteHandlerImpl( factory, walker, getIdTableInfo( targetedPersister ) ) {
-
-					@Override
-					protected void releaseFromUse(Queryable persister, SharedSessionContractImplementor session) {
-						cleanUpRows( ( (IdTableInfo) getIdTableInfo( persister ) ).getQualifiedIdTableName(), session );
-					}
-				};
+			public String getTruncateIdTableCommand() {
+				return "truncate table";
 			}
 
-			@Override
-			public UpdateHandler buildUpdateHandler(SessionFactoryImplementor factory, HqlSqlWalker walker) {
-				final UpdateStatement updateStatement = (UpdateStatement) walker.getAST();
-
-				final FromElement fromElement = updateStatement.getFromClause().getFromElement();
-				final Queryable targetedPersister = fromElement.getQueryable();
-
-				return new TableBasedUpdateHandlerImpl( factory, walker, getIdTableInfo( targetedPersister ) ) {
-
-					@Override
-					protected void releaseFromUse(Queryable persister, SharedSessionContractImplementor session) {
-						// clean up our id-table rows
-						cleanUpRows( ( (IdTableInfo) getIdTableInfo( persister ) ).getQualifiedIdTableName(), session );
-					}
-				};
-			}
-
-			private void cleanUpRows(String tableName, SharedSessionContractImplementor session) {
-				// TODO: delegate to dialect
-				final String sql = "truncate table " + tableName;
-				PreparedStatement ps = null;
-				try {
-					ps = session.getJdbcCoordinator().getStatementPreparer().prepareStatement( sql, false );
-					session.getJdbcCoordinator().getResultSetReturn().executeUpdate( ps );
-				}
-				finally {
-					if ( ps != null ) {
-						try {
-							session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( ps );
-						}
-						catch (Throwable ignore) {
-							// ignore
-						}
-					}
-				}
-			}
-		};
+		}, AfterUseAction.CLEAN );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
@@ -144,6 +144,11 @@ public class TeradataDialect extends Dialect implements IdTableSupport {
 	public String getDropIdTableCommand() {
 		return "drop table";
 	}
+	
+	@Override
+	public String getTruncateIdTableCommand() {
+		return "delete from";
+	}
 
 	/**
 	 * Get the name of the database type associated with the given

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableSupport.java
@@ -14,4 +14,5 @@ public interface IdTableSupport {
 	String getCreateIdTableCommand();
 	String getCreateIdTableStatementOptions();
 	String getDropIdTableCommand();
+	String getTruncateIdTableCommand();
 }

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableSupportStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableSupportStandardImpl.java
@@ -34,4 +34,9 @@ public class IdTableSupportStandardImpl implements IdTableSupport {
 	public String getDropIdTableCommand() {
 		return "drop table";
 	}
+	
+	@Override
+	public String getTruncateIdTableCommand() {
+		return "delete from";
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/global/GlobalTemporaryTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/global/GlobalTemporaryTableBulkIdStrategy.java
@@ -165,7 +165,7 @@ public class GlobalTemporaryTableBulkIdStrategy
 	}
 
 	private void cleanUpRows(String tableName, SharedSessionContractImplementor session) {
-		final String sql = "delete from " + tableName;
+		final String sql = this.getIdTableSupport().getTruncateIdTableCommand() + " " + tableName;
 		PreparedStatement ps = null;
 		try {
 			ps = session.getJdbcCoordinator().getStatementPreparer().prepareStatement( sql, false );


### PR DESCRIPTION
I've added `org.hibernate.hql.spi.id.IdTableSupport#getTruncateIdTableCommand`, implemented it in `org.hibernate.hql.spi.id.IdTableSupportStandardImpl` and `org.hibernate.dialect.TeradataDialect`, and added a call to it to `org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy#cleanUpRows`.