### PR TITLE
HHH-10294 EntityGraph improvement: For each jpa attribute, generate also a String constant holding the attribute field name

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/Student.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/Student.java
@@ -31,7 +31,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 	@NamedEntityGraph(
 		name = "Student.Full",
 		attributeNodes = {
-			@NamedAttributeNode(value = "courses")
+			@NamedAttributeNode(value = Student_.COURSES)
 		}
 	)
 })

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
@@ -111,7 +111,11 @@ public final class ClassWriter {
 
 			List<MetaAttribute> members = entity.getMembers();
 			for ( MetaAttribute metaMember : members ) {
-				pw.println( "	" + metaMember.getDeclarationString() );
+				pw.println( "	" + metaMember.getAttributeDeclarationString() );
+			}
+			pw.println();
+			for ( MetaAttribute metaMember : members ) {
+				pw.println( "	" + metaMember.getAttributeNameDeclarationString() );
 			}
 
 			pw.println();

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaAttribute.java
@@ -7,12 +7,15 @@
 package org.hibernate.jpamodelgen.annotation;
 
 import java.beans.Introspector;
+import java.util.ArrayList;
+import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.util.Elements;
 
 import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.MetaEntity;
+import org.hibernate.jpamodelgen.util.StringUtil;
 
 /**
  * Captures all information about an annotated persistent attribute.
@@ -33,7 +36,8 @@ public abstract class AnnotationMetaAttribute implements MetaAttribute {
 		this.type = type;
 	}
 
-	public String getDeclarationString() {
+	@Override
+	public String getAttributeDeclarationString() {
 		return new StringBuilder().append( "public static volatile " )
 				.append( parent.importType( getMetaType() ) )
 				.append( "<" )
@@ -43,6 +47,20 @@ public abstract class AnnotationMetaAttribute implements MetaAttribute {
 				.append( "> " )
 				.append( getPropertyName() )
 				.append( ";" )
+				.toString();
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString(){
+		return new StringBuilder().append("public static final ")
+				.append(parent.importType(String.class.getName()))
+				.append(" ")
+				.append(StringUtil.getUpperUnderscoreCaseFromLowerCamelCase(getPropertyName()))
+				.append(" = ")
+				.append("\"")
+				.append(getPropertyName())
+				.append("\"")
+				.append(";")
 				.toString();
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaMap.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaMap.java
@@ -23,7 +23,8 @@ public class AnnotationMetaMap extends AnnotationMetaCollection {
 		this.keyType = keyType;
 	}
 
-	public String getDeclarationString() {
+	@Override
+	public String getAttributeDeclarationString() {
 		return "public static volatile " + getHostingEntity().importType( getMetaType() )
 				+ "<" + getHostingEntity().importType( getHostingEntity().getQualifiedName() )
 				+ ", " + getHostingEntity().importType( keyType ) + ", "

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/model/MetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/model/MetaAttribute.java
@@ -10,7 +10,9 @@ package org.hibernate.jpamodelgen.model;
  * @author Hardy Ferentschik
  */
 public interface MetaAttribute {
-	String getDeclarationString();
+    String getAttributeDeclarationString();
+
+    String getAttributeNameDeclarationString();
 
 	String getMetaType();
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/StringUtil.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/StringUtil.java
@@ -93,6 +93,10 @@ public final class StringUtil {
 		}
 	}
 
+	public static String getUpperUnderscoreCaseFromLowerCamelCase(String lowerCamelCaseString){
+		return lowerCamelCaseString.replaceAll("(.)(\\p{Upper})", "$1_$2").toUpperCase();
+	}
+
 	private static boolean startsWithSeveralUpperCaseLetters(String string) {
 		return string.length() > 1 &&
 				Character.isUpperCase( string.charAt( 0 ) ) &&

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaAttribute.java
@@ -8,6 +8,10 @@ package org.hibernate.jpamodelgen.xml;
 
 import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.MetaEntity;
+import org.hibernate.jpamodelgen.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Hardy Ferentschik
@@ -24,12 +28,26 @@ public abstract class XmlMetaAttribute implements MetaAttribute {
 		this.type = type;
 	}
 
-	@Override
-	public String getDeclarationString() {
+    @Override
+	public String getAttributeDeclarationString() {
 		return "public static volatile " + hostingEntity.importType( getMetaType() )
 				+ "<" + hostingEntity.importType( hostingEntity.getQualifiedName() )
 				+ ", " + hostingEntity.importType( getTypeDeclaration() )
 				+ "> " + getPropertyName() + ";";
+	}
+
+    @Override
+    public String getAttributeNameDeclarationString(){
+		return new StringBuilder().append("public static final ")
+				.append(hostingEntity.importType(String.class.getName()))
+				.append(" ")
+				.append(StringUtil.getUpperUnderscoreCaseFromLowerCamelCase(getPropertyName()))
+				.append(" = ")
+				.append("\"")
+				.append(getPropertyName())
+				.append("\"")
+				.append(";")
+				.toString();
 	}
 
 	public String getPropertyName() {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaMap.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaMap.java
@@ -20,7 +20,8 @@ public class XmlMetaMap extends XmlMetaCollection {
 		this.keyType = keyType;
 	}
 
-	public String getDeclarationString() {
+	@Override
+	public String getAttributeDeclarationString() {
 		final MetaEntity hostingEntity = getHostingEntity();
 		return new StringBuilder().append( "public static volatile " )
 				.append( hostingEntity.importType( getMetaType() ) )

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/StringUtilTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/StringUtilTest.java
@@ -10,6 +10,7 @@ import org.hibernate.jpamodelgen.test.util.TestForIssue;
 import org.hibernate.jpamodelgen.util.StringUtil;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -34,5 +35,10 @@ public class StringUtilTest {
 	@TestForIssue(jiraKey = "METAGEN-76")
 	public void testHashCodeNotAProperty() {
 		assertFalse( StringUtil.isProperty( "hashCode", "Integer" ) );
+	}
+
+	@Test
+	public void testGetUpperUnderscoreCaseFromLowerCamelCase(){
+		assertEquals("USER_PARENT_NAME", StringUtil.getUpperUnderscoreCaseFromLowerCamelCase("userParentName"));
 	}
 }


### PR DESCRIPTION
Fix for https://hibernate.atlassian.net/browse/HHH-10294
Replaces https://github.com/hibernate/hibernate-orm/pull/1152.

Attributes are not interweaved anymore.
A use case has been added to `Student.java`