### PR TITLE
ManagedBeanRegistry CDI lifecycle fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/CdiLifecycleManagementStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/CdiLifecycleManagementStrategy.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.resource.beans.internal;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.hibernate.resource.beans.spi.ManagedBean;
+
+interface CdiLifecycleManagementStrategy {
+
+	<T> ManagedBean<T> createBean(BeanManager beanManager, Class<T> beanClass);
+
+	<T> ManagedBean<T> createBean(BeanManager beanManager, String beanName, Class<T> beanClass);
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
@@ -23,6 +23,24 @@ public class Helper {
 	}
 
 	@SuppressWarnings("unchecked")
+	public <T> Bean<T> getBean(Class<T> beanContract, BeanManager beanManager) {
+		Set<Bean<?>> beans = beanManager.getBeans( beanContract );
+
+		if ( beans.isEmpty() ) {
+			throw new IllegalArgumentException(
+					"BeanManager returned no matching beans: contract = " + beanContract.getName()
+			);
+		}
+		if ( beans.size() > 1 ) {
+			throw new IllegalArgumentException(
+					"BeanManager returned multiple matching beans: contract = " + beanContract.getName()
+			);
+		}
+
+		return (Bean<T>) beans.iterator().next();
+	}
+
+	@SuppressWarnings("unchecked")
 	public <T> Bean<T> getNamedBean(String beanName, Class<T> beanContract, BeanManager beanManager) {
 		Set<Bean<?>> beans = beanManager.getBeans( beanContract, new NamedBeanQualifier( beanName ) );
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
@@ -23,24 +23,6 @@ public class Helper {
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T> Bean<T> getBean(Class<T> beanContract, BeanManager beanManager) {
-		Set<Bean<?>> beans = beanManager.getBeans( beanContract );
-
-		if ( beans.isEmpty() ) {
-			throw new IllegalArgumentException(
-					"BeanManager returned no matching beans: contract = " + beanContract.getName()
-			);
-		}
-		if ( beans.size() > 1 ) {
-			throw new IllegalArgumentException(
-					"BeanManager returned multiple matching beans: contract = " + beanContract.getName()
-			);
-		}
-
-		return (Bean<T>) beans.iterator().next();
-	}
-
-	@SuppressWarnings("unchecked")
 	public <T> Bean<T> getNamedBean(String beanName, Class<T> beanContract, BeanManager beanManager) {
 		Set<Bean<?>> beans = beanManager.getBeans( beanContract, new NamedBeanQualifier( beanName ) );
 
@@ -56,5 +38,14 @@ public class Helper {
 		}
 
 		return (Bean<T>) beans.iterator().next();
+	}
+
+	public CdiLifecycleManagementStrategy getLifecycleManagementStrategy(boolean shouldRegistryManageLifecycle) {
+		if ( shouldRegistryManageLifecycle ) {
+			return JpaCdiLifecycleManagementStrategy.INSTANCE;
+		}
+		else {
+			return StandardCdiLifecycleManagementStrategy.INSTANCE;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
@@ -6,10 +6,6 @@
  */
 package org.hibernate.resource.beans.internal;
 
-import java.util.Set;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-
 /**
  * @author Steve Ebersole
  */
@@ -20,24 +16,6 @@ public class Helper {
 	public static final Helper INSTANCE = new Helper();
 
 	private Helper() {
-	}
-
-	@SuppressWarnings("unchecked")
-	public <T> Bean<T> getNamedBean(String beanName, Class<T> beanContract, BeanManager beanManager) {
-		Set<Bean<?>> beans = beanManager.getBeans( beanContract, new NamedBeanQualifier( beanName ) );
-
-		if ( beans.isEmpty() ) {
-			throw new IllegalArgumentException(
-					"BeanManager returned no matching beans: name = " + beanName + "; contract = " + beanContract.getName()
-			);
-		}
-		if ( beans.size() > 1 ) {
-			throw new IllegalArgumentException(
-					"BeanManager returned multiple matching beans: name = " + beanName + "; contract = " + beanContract.getName()
-			);
-		}
-
-		return (Bean<T>) beans.iterator().next();
 	}
 
 	public CdiLifecycleManagementStrategy getLifecycleManagementStrategy(boolean shouldRegistryManageLifecycle) {

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/JpaCdiLifecycleManagementStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/JpaCdiLifecycleManagementStrategy.java
@@ -1,0 +1,111 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.resource.beans.internal;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionTarget;
+
+import org.hibernate.resource.beans.spi.ManagedBean;
+
+class JpaCdiLifecycleManagementStrategy implements CdiLifecycleManagementStrategy {
+
+	static final JpaCdiLifecycleManagementStrategy INSTANCE = new JpaCdiLifecycleManagementStrategy();
+
+	private JpaCdiLifecycleManagementStrategy() {
+		// private constructor, do not use
+	}
+
+	@Override
+	public <T> ManagedBean<T> createBean(BeanManager beanManager, Class<T> beanClass) {
+		AnnotatedType<T> annotatedType = beanManager.createAnnotatedType( beanClass );
+		InjectionTarget<T> injectionTarget = beanManager.createInjectionTarget( annotatedType );
+		CreationalContext<T> creationalContext = beanManager.createCreationalContext( null );
+
+		T beanInstance = injectionTarget.produce( creationalContext );
+		injectionTarget.inject( beanInstance, creationalContext );
+
+		injectionTarget.postConstruct( beanInstance );
+
+		return new JpaManagedBeanImpl<>( beanClass, injectionTarget, creationalContext, beanInstance );
+	}
+
+	@Override
+	public <T> ManagedBean<T> createBean(BeanManager beanManager, String beanName, Class<T> beanClass) {
+		Bean<T> bean = Helper.INSTANCE.getNamedBean( beanName, beanClass, beanManager );
+
+		CreationalContext<T> creationalContext = beanManager.createCreationalContext( null );
+
+		T beanInstance = bean.create( creationalContext );
+
+		return new NamedJpaManagedBeanImpl<>( beanClass, creationalContext, beanInstance );
+	}
+
+	private static class JpaManagedBeanImpl<T> implements ManagedBean<T> {
+		private final Class<T> beanClass;
+		private final InjectionTarget<T> injectionTarget;
+		private final CreationalContext<T> creationContext;
+		private final T beanInstance;
+
+		private JpaManagedBeanImpl(
+				Class<T> beanClass,
+				InjectionTarget<T> injectionTarget, CreationalContext<T> creationContext, T beanInstance) {
+			this.beanClass = beanClass;
+			this.injectionTarget = injectionTarget;
+			this.creationContext = creationContext;
+			this.beanInstance = beanInstance;
+		}
+
+		@Override
+		public Class<T> getBeanClass() {
+			return beanClass;
+		}
+
+		@Override
+		public T getBeanInstance() {
+			return beanInstance;
+		}
+
+		@Override
+		public void release() {
+			injectionTarget.preDestroy( beanInstance );
+			injectionTarget.dispose( beanInstance );
+			creationContext.release();
+		}
+	}
+
+	private static class NamedJpaManagedBeanImpl<T> implements ManagedBean<T> {
+		private final Class<T> beanClass;
+		private final CreationalContext<T> creationContext;
+		private final T beanInstance;
+
+		private NamedJpaManagedBeanImpl(
+				Class<T> beanClass,
+				CreationalContext<T> creationContext, T beanInstance) {
+			this.beanClass = beanClass;
+			this.creationContext = creationContext;
+			this.beanInstance = beanInstance;
+		}
+
+		@Override
+		public Class<T> getBeanClass() {
+			return beanClass;
+		}
+
+		@Override
+		public T getBeanInstance() {
+			return beanInstance;
+		}
+
+		@Override
+		public void release() {
+			creationContext.release();
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/JpaCdiLifecycleManagementStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/JpaCdiLifecycleManagementStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.resource.beans.internal;
 
+import java.util.Set;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
@@ -48,9 +49,11 @@ class JpaCdiLifecycleManagementStrategy implements CdiLifecycleManagementStrateg
 		return new JpaManagedBeanImpl<>( beanClass, injectionTarget, creationalContext, beanInstance );
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public <T> ManagedBean<T> createBean(BeanManager beanManager, String beanName, Class<T> beanClass) {
-		Bean<T> bean = Helper.INSTANCE.getNamedBean( beanName, beanClass, beanManager );
+		Set<Bean<?>> beans = beanManager.getBeans( beanClass, new NamedBeanQualifier( beanName ) );
+		Bean<T> bean = (Bean<T>) beanManager.resolve( beans );
 
 		CreationalContext<T> creationalContext = beanManager.createCreationalContext( null );
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiDelayedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiDelayedImpl.java
@@ -33,13 +33,15 @@ public class ManagedBeanRegistryCdiDelayedImpl extends AbstractManagedBeanRegist
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
-		return new LazilyInitializedManagedBeanImpl<>( beanClass, JpaCdiLifecycleManagementStrategy.INSTANCE );
+	protected <T> ManagedBean<T> createBean(Class<T> beanClass, boolean shouldRegistryManageLifecycle) {
+		return new LazilyInitializedManagedBeanImpl<>( beanClass,
+				Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle ) );
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
-		return new LazilyInitializedNamedManagedBeanImpl<>( beanName, beanContract, StandardCdiLifecycleManagementStrategy.INSTANCE );
+	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract, boolean shouldRegistryManageLifecycle) {
+		return new LazilyInitializedNamedManagedBeanImpl<>( beanName, beanContract,
+				Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle ) );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiDelayedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiDelayedImpl.java
@@ -6,12 +6,7 @@
  */
 package org.hibernate.resource.beans.internal;
 
-import java.util.Set;
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.AnnotatedType;
-import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.InjectionTarget;
 
 import org.hibernate.resource.beans.spi.AbstractManagedBeanRegistry;
 import org.hibernate.resource.beans.spi.ManagedBean;
@@ -39,25 +34,29 @@ public class ManagedBeanRegistryCdiDelayedImpl extends AbstractManagedBeanRegist
 
 	@Override
 	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
-		return new ManagedBeanImpl<>( beanClass );
+		return new LazilyInitializedManagedBeanImpl<>( beanClass, JpaCdiLifecycleManagementStrategy.INSTANCE );
 	}
 
 	@Override
 	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
-		return new NamedManagedBeanImpl<>( beanName, beanContract );
+		return new LazilyInitializedNamedManagedBeanImpl<>( beanName, beanContract, StandardCdiLifecycleManagementStrategy.INSTANCE );
 	}
 
-	private class ManagedBeanImpl<T> implements ManagedBean<T> {
+	/**
+	 * A {@link ManagedBean} that is initialized upon the first call to {@link #getBeanInstance()},
+	 * relying on a {@link CdiLifecycleManagementStrategy} to initialize a delegate.
+	 *
+	 * @param <T> The type of bean instances
+	 */
+	private class LazilyInitializedManagedBeanImpl<T> implements ManagedBean<T> {
 		private final Class<T> beanClass;
+		private final CdiLifecycleManagementStrategy strategy;
 
-		private boolean initialized = false;
+		private ManagedBean<T> delegate = null;
 
-		private InjectionTarget<T> injectionTarget;
-		private CreationalContext<T> creationContext;
-		private T beanInstance;
-
-		ManagedBeanImpl(Class<T> beanClass) {
+		LazilyInitializedManagedBeanImpl(Class<T> beanClass, CdiLifecycleManagementStrategy strategy) {
 			this.beanClass = beanClass;
+			this.strategy = strategy;
 		}
 
 		@Override
@@ -67,56 +66,50 @@ public class ManagedBeanRegistryCdiDelayedImpl extends AbstractManagedBeanRegist
 
 		@Override
 		public T getBeanInstance() {
-			if ( !initialized ) {
+			if ( delegate == null ) {
 				initialize();
 			}
-			return beanInstance;
+			return delegate.getBeanInstance();
 		}
 
 		private void initialize() {
-			log.debug( "Delayed initialization of CDI bean on first use : " + beanClass );
+			log.debugf( "Delayed initialization of CDI bean on first use : %s", beanClass.getName() );
 
-			final AnnotatedType<T> annotatedType = beanManager.createAnnotatedType( beanClass );
-			this.injectionTarget = beanManager.createInjectionTarget( annotatedType );
-			this.creationContext = beanManager.createCreationalContext( null );
-
-			this.beanInstance = injectionTarget.produce( creationContext );
-			injectionTarget.inject( this.beanInstance, creationContext );
-
-			injectionTarget.postConstruct( this.beanInstance );
-
-			this.initialized = true;
+			delegate = strategy.createBean( beanManager, beanClass );
 		}
 
 		@Override
 		public void release() {
-			if ( !initialized ) {
-				log.debug( "Skipping release for (delayed) CDI bean [" + beanClass + "] as it was not initialized" );
+			if ( delegate == null ) {
+				log.debugf( "Skipping release for (delayed) CDI bean [%s] as it was not initialized", beanClass.getName() );
 				return;
 			}
 
-			log.debug( "Releasing (delayed) CDI bean : " + beanClass );
+			log.debugf( "Releasing (delayed) CDI bean : %s", beanClass.getName() );
 
-			injectionTarget.preDestroy( beanInstance );
-			injectionTarget.dispose( beanInstance );
-			creationContext.release();
-
-			initialized = false;
+			delegate.release();
+			delegate = null;
 		}
 	}
 
-	private class NamedManagedBeanImpl<T> implements ManagedBean<T> {
+	/**
+	 * A named {@link ManagedBean} that is lazily initialized upon the first call to {@link #getBeanInstance()}.
+	 *
+	 * @param <T> The type of bean instances
+	 *
+	 * @see ManagedBeanRegistryCdiExtendedImpl.LazilyInitializedManagedBeanImpl
+	 */
+	private class LazilyInitializedNamedManagedBeanImpl<T> implements ManagedBean<T> {
 		private final String beanName;
 		private final Class<T> beanContract;
+		private final CdiLifecycleManagementStrategy strategy;
 
-		private boolean initialized = false;
+		private ManagedBean<T> delegate = null;
 
-		private CreationalContext<T> creationContext;
-		private T beanInstance;
-
-		NamedManagedBeanImpl(String beanName, Class<T> beanContract) {
+		LazilyInitializedNamedManagedBeanImpl(String beanName, Class<T> beanContract, CdiLifecycleManagementStrategy strategy) {
 			this.beanName = beanName;
 			this.beanContract = beanContract;
+			this.strategy = strategy;
 		}
 
 		@Override
@@ -126,33 +119,29 @@ public class ManagedBeanRegistryCdiDelayedImpl extends AbstractManagedBeanRegist
 
 		@Override
 		public T getBeanInstance() {
-			if ( !initialized ) {
+			if ( delegate == null ) {
 				initialize();
 			}
-			return beanInstance;
+			return delegate.getBeanInstance();
 		}
 
 		private void initialize() {
-			final Bean<T> bean = Helper.INSTANCE.getNamedBean( beanName, beanContract, beanManager );
+			log.debugf( "Delayed initialization of CDI bean on first use : [%s : %s]", beanName, beanContract.getName() );
 
-			this.creationContext = beanManager.createCreationalContext( bean );
-			this.beanInstance = beanContract.cast( beanManager.getReference( bean, beanContract, creationContext ) );
-
-			this.initialized = true;
+			delegate = strategy.createBean( beanManager, beanName, beanContract );
 		}
 
 		@Override
 		public void release() {
-			if ( !initialized ) {
+			if ( delegate == null ) {
 				log.debugf( "Skipping release for (delayed) CDI bean [%s : %s] as it was not initialized", beanName, beanContract.getName() );
 				return;
 			}
 
 			log.debugf( "Releasing (delayed) CDI bean [%s : %s]", beanName, beanContract.getName() );
 
-			creationContext.release();
-
-			initialized = false;
+			delegate.release();
+			delegate = null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiExtendedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiExtendedImpl.java
@@ -39,13 +39,15 @@ public class ManagedBeanRegistryCdiExtendedImpl
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
-		return new LazilyInitializedManagedBeanImpl<>( beanClass, JpaCdiLifecycleManagementStrategy.INSTANCE );
+	protected <T> ManagedBean<T> createBean(Class<T> beanClass, boolean shouldRegistryManageLifecycle) {
+		return new LazilyInitializedManagedBeanImpl<>( beanClass,
+				Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle ) );
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
-		return new LazilyInitializedNamedManagedBeanImpl<>( beanName, beanContract, StandardCdiLifecycleManagementStrategy.INSTANCE );
+	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract, boolean shouldRegistryManageLifecycle) {
+		return new LazilyInitializedNamedManagedBeanImpl<>( beanName, beanContract,
+				Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiStandardImpl.java
@@ -6,11 +6,7 @@
  */
 package org.hibernate.resource.beans.internal;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.AnnotatedType;
-import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.InjectionTarget;
 
 import org.hibernate.resource.beans.spi.AbstractManagedBeanRegistry;
 import org.hibernate.resource.beans.spi.ManagedBean;
@@ -39,103 +35,11 @@ class ManagedBeanRegistryCdiStandardImpl extends AbstractManagedBeanRegistry {
 
 	@Override
 	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
-		return new ManagedBeanImpl<>( beanClass );
+		return JpaCdiLifecycleManagementStrategy.INSTANCE.createBean( beanManager, beanClass );
 	}
 
 	@Override
 	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
-		return new NamedManagedBeanImpl<>( beanName, beanContract );
-	}
-
-	private class ManagedBeanImpl<T> implements ManagedBean<T> {
-		private final Class<T> beanClass;
-		private final InjectionTarget<T> injectionTarget;
-
-		private boolean initialized;
-
-		private final CreationalContext<T> creationContext;
-		private final T beanInstance;
-
-		public ManagedBeanImpl(Class<T> beanClass) {
-			this.beanClass = beanClass;
-
-			AnnotatedType<T> annotatedType = beanManager.createAnnotatedType( beanClass );
-			this.injectionTarget = beanManager.createInjectionTarget( annotatedType );
-			this.creationContext = beanManager.createCreationalContext( null );
-
-			this.beanInstance = injectionTarget.produce( creationContext );
-			injectionTarget.inject( this.beanInstance, creationContext );
-
-			injectionTarget.postConstruct( this.beanInstance );
-		}
-
-		@Override
-		public Class<T> getBeanClass() {
-			return beanClass;
-		}
-
-		@Override
-		public T getBeanInstance() {
-			return beanInstance;
-		}
-
-		@Override
-		public void release() {
-			if ( !initialized ) {
-				log.debugf( "Skipping release for (standard) CDI bean [%s] as it was not initialized", beanClass.getName() );
-				return;
-			}
-
-			log.debugf( "Releasing (standard) CDI bean [%s]", beanClass.getName() );
-
-			injectionTarget.preDestroy( beanInstance );
-			injectionTarget.dispose( beanInstance );
-			creationContext.release();
-		}
-	}
-
-	private class NamedManagedBeanImpl<T> implements ManagedBean<T> {
-		private final String beanName;
-		private final Class<T> beanContract;
-
-		private boolean initialized;
-
-		private CreationalContext<T> creationContext;
-		private T beanInstance;
-
-		private NamedManagedBeanImpl(String beanName, Class<T> beanContract) {
-			this.beanName = beanName;
-			this.beanContract = beanContract;
-
-			final Bean<T> bean = Helper.INSTANCE.getNamedBean( beanName, beanContract, beanManager );
-
-			this.creationContext = beanManager.createCreationalContext( bean );
-			this.beanInstance = beanContract.cast( beanManager.getReference( bean, beanContract, creationContext ) );
-
-			this.initialized = true;
-		}
-		@Override
-		public Class<T> getBeanClass() {
-			return beanContract;
-		}
-
-		@Override
-		public T getBeanInstance() {
-			return beanInstance;
-		}
-
-		@Override
-		public void release() {
-			if ( !initialized ) {
-				log.debugf( "Skipping release for (standard) CDI bean [%s : %s] as it was not initialized", beanName, beanContract.getName() );
-				return;
-			}
-
-			log.debugf( "Releasing (standard) CDI bean [%s : %s]", beanName, beanContract.getName() );
-
-			creationContext.release();
-
-			initialized = false;
-		}
+		return StandardCdiLifecycleManagementStrategy.INSTANCE.createBean( beanManager, beanName, beanContract );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryCdiStandardImpl.java
@@ -34,12 +34,14 @@ class ManagedBeanRegistryCdiStandardImpl extends AbstractManagedBeanRegistry {
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
-		return JpaCdiLifecycleManagementStrategy.INSTANCE.createBean( beanManager, beanClass );
+	protected <T> ManagedBean<T> createBean(Class<T> beanClass, boolean shouldRegistryManageLifecycle) {
+		return Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle )
+				.createBean( beanManager, beanClass );
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
-		return StandardCdiLifecycleManagementStrategy.INSTANCE.createBean( beanManager, beanName, beanContract );
+	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract, boolean shouldRegistryManageLifecycle) {
+		return Helper.INSTANCE.getLifecycleManagementStrategy( shouldRegistryManageLifecycle )
+				.createBean( beanManager, beanName, beanContract );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryDirectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/ManagedBeanRegistryDirectImpl.java
@@ -23,12 +23,15 @@ public class ManagedBeanRegistryDirectImpl extends AbstractManagedBeanRegistry {
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(Class<T> beanClass) {
+	protected <T> ManagedBean<T> createBean(Class<T> beanClass, boolean shouldRegistryManageLifecycle) {
 		return new DirectInstantiationManagedBeanImpl<>( beanClass );
 	}
 
 	@Override
-	protected <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract) {
+	protected <T> ManagedBean<T> createBean(
+			String beanName,
+			Class<T> beanContract,
+			boolean shouldRegistryManageLifecycle) {
 		return new DirectInstantiationManagedBeanImpl<>( beanContract );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/StandardCdiLifecycleManagementStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/StandardCdiLifecycleManagementStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.resource.beans.internal;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.hibernate.resource.beans.spi.ManagedBean;
+
+class StandardCdiLifecycleManagementStrategy implements CdiLifecycleManagementStrategy {
+
+	static final StandardCdiLifecycleManagementStrategy INSTANCE = new StandardCdiLifecycleManagementStrategy();
+
+	private StandardCdiLifecycleManagementStrategy() {
+		// private constructor, do not use
+	}
+
+	@Override
+	public <T> ManagedBean<T> createBean(BeanManager beanManager, Class<T> beanClass) {
+		Bean<T> bean = Helper.INSTANCE.getBean( beanClass, beanManager );
+
+		// Pass the bean to createCreationalContext here so that an existing instance can be returned
+		CreationalContext<T> creationalContext = beanManager.createCreationalContext( bean );
+
+		T beanInstance = bean.create( creationalContext );
+
+		return new BeanManagerManagedBeanImpl<>( beanClass, creationalContext, beanInstance );
+	}
+
+	@Override
+	public <T> ManagedBean<T> createBean(BeanManager beanManager, String beanName, Class<T> beanClass) {
+		Bean<T> bean = Helper.INSTANCE.getNamedBean( beanName, beanClass, beanManager );
+
+		// Pass the bean to createCreationalContext here so that an existing instance can be returned
+		CreationalContext<T> creationalContext = beanManager.createCreationalContext( bean );
+
+		T beanInstance = bean.create( creationalContext );
+
+		return new BeanManagerManagedBeanImpl<>( beanClass, creationalContext, beanInstance );
+	}
+
+	private static class BeanManagerManagedBeanImpl<T> implements ManagedBean<T> {
+		private final Class<T> beanClass;
+		private final CreationalContext<T> creationContext;
+		private final T beanInstance;
+
+		private BeanManagerManagedBeanImpl(
+				Class<T> beanClass,
+				CreationalContext<T> creationContext, T beanInstance) {
+			this.beanClass = beanClass;
+			this.creationContext = creationContext;
+			this.beanInstance = beanInstance;
+		}
+
+		@Override
+		public Class<T> getBeanClass() {
+			return beanClass;
+		}
+
+		@Override
+		public T getBeanInstance() {
+			return beanInstance;
+		}
+
+		@Override
+		public void release() {
+			creationContext.release();
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/UnnamedRegistryScopedManagedBeanImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/UnnamedRegistryScopedManagedBeanImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.resource.beans.internal;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionTarget;
+
+import org.hibernate.resource.beans.spi.ManagedBean;
+
+class UnnamedRegistryScopedManagedBeanImpl<T> implements ManagedBean<T> {
+
+	private final Class<T> beanClass;
+
+	private final InjectionTarget<T> injectionTarget;
+	private final CreationalContext<T> creationContext;
+	private T beanInstance;
+
+	UnnamedRegistryScopedManagedBeanImpl(BeanManager beanManager, Class<T> beanClass) {
+		this.beanClass = beanClass;
+
+		final AnnotatedType<T> annotatedType = beanManager.createAnnotatedType( beanClass );
+		this.injectionTarget = beanManager.createInjectionTarget( annotatedType );
+		this.creationContext = beanManager.createCreationalContext( null );
+
+		this.beanInstance = injectionTarget.produce( creationContext );
+		injectionTarget.inject( this.beanInstance, creationContext );
+
+		injectionTarget.postConstruct( this.beanInstance );
+	}
+
+	@Override
+	public Class<T> getBeanClass() {
+		return beanClass;
+	}
+
+	@Override
+	public T getBeanInstance() {
+		return beanInstance;
+	}
+
+	@Override
+	public void release() {
+		injectionTarget.preDestroy( beanInstance );
+		injectionTarget.dispose( beanInstance );
+		creationContext.release();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/AbstractManagedBeanRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/AbstractManagedBeanRegistry.java
@@ -27,7 +27,7 @@ public abstract class AbstractManagedBeanRegistry implements ManagedBeanRegistry
 			return getCacheableBean( beanClass );
 		}
 		else {
-			return createBean( beanClass );
+			return createBean( beanClass, shouldRegistryManageLifecycle );
 		}
 	}
 
@@ -39,13 +39,13 @@ public abstract class AbstractManagedBeanRegistry implements ManagedBeanRegistry
 			return existing;
 		}
 
-		final ManagedBean<T> bean = createBean( beanClass );
+		final ManagedBean<T> bean = createBean( beanClass, true );
 		registrations.put( beanName, bean );
 		return bean;
 	}
 
 	@SuppressWarnings("WeakerAccess")
-	protected abstract <T> ManagedBean<T> createBean(Class<T> beanClass);
+	protected abstract <T> ManagedBean<T> createBean(Class<T> beanClass, boolean shouldRegistryManageLifecycle);
 
 	@Override
 	public <T> ManagedBean<T> getBean(String beanName, Class<T> beanContract, boolean shouldRegistryManageLifecycle) {
@@ -53,7 +53,7 @@ public abstract class AbstractManagedBeanRegistry implements ManagedBeanRegistry
 			return getCacheableBean( beanName, beanContract );
 		}
 		else {
-			return createBean( beanName, beanContract );
+			return createBean( beanName, beanContract, shouldRegistryManageLifecycle );
 		}
 	}
 
@@ -64,13 +64,13 @@ public abstract class AbstractManagedBeanRegistry implements ManagedBeanRegistry
 			return existing;
 		}
 
-		final ManagedBean<T> bean = createBean( beanName, beanContract );
+		final ManagedBean<T> bean = createBean( beanName, beanContract, false );
 		registrations.put( beanName, bean );
 		return bean;
 	}
 
 	@SuppressWarnings("WeakerAccess")
-	protected abstract <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract);
+	protected abstract <T> ManagedBean<T> createBean(String beanName, Class<T> beanContract, boolean shouldRegistryManageLifecycle);
 
 	@SuppressWarnings("WeakerAccess")
 	protected void forEachBean(Consumer<ManagedBean<?>> consumer) {

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/Monitor.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/Monitor.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A util used to verify injection into a {@link TheApplicationScopedBean}
+ * or a {@link TheDependentBean}.
+ * <p>
+ * Note we really need instances to be retrieved statically, and through CDI injection.
+ * If instances were injected into {@link TheApplicationScopedBean} or {@link TheDependentBean},
+ * CDI would add proxies around instances when injecting them,
+ * which may prevent us from using these instances depending on when Hibernate ORM is shut down.
+ * In particular, if Hibernate ORM is shut down after CDI, we may not be able to
+ * call methods on the proxy during {@link TheApplicationScopedBean}'s or {@link TheDependentBean}'s
+ * post-construct methods.
+ *
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+public final class Monitor {
+
+	private static final Monitor THE_APPLICATION_SCOPED_BEAN = new Monitor();
+	private static final Monitor THE_MAIN_NAMED_APPLICATION_SCOPED_BEAN = new Monitor();
+	private static final Monitor THE_ALTERNATIVE_NAMED_APPLICATION_SCOPED_BEAN = new Monitor();
+	private static final Monitor THE_SHARED_APPLICATION_SCOPED_BEAN = new Monitor();
+	private static final Monitor THE_DEPENDENT_BEAN = new Monitor();
+	private static final Monitor THE_MAIN_NAMED_DEPENDENT_BEAN = new Monitor();
+	private static final Monitor THE_ALTERNATIVE_NAMED_DEPENDENT_BEAN = new Monitor();
+	private static final Monitor THE_NESTED_DEPENDENT_BEAN = new Monitor();
+
+	private final AtomicInteger instantiationCount = new AtomicInteger( 0 );
+	private final AtomicInteger postConstructCount = new AtomicInteger( 0 );
+	private final AtomicInteger preDestroyCount = new AtomicInteger( 0 );
+
+	public static Monitor theApplicationScopedBean() {
+		return THE_APPLICATION_SCOPED_BEAN;
+	}
+
+	public static Monitor theMainNamedApplicationScopedBean() {
+		return THE_MAIN_NAMED_APPLICATION_SCOPED_BEAN;
+	}
+
+	public static Monitor theAlternativeNamedApplicationScopedBean() {
+		return THE_ALTERNATIVE_NAMED_APPLICATION_SCOPED_BEAN;
+	}
+
+	public static Monitor theSharedApplicationScopedBean() {
+		return THE_SHARED_APPLICATION_SCOPED_BEAN;
+	}
+
+	public static Monitor theDependentBean() {
+		return THE_DEPENDENT_BEAN;
+	}
+
+	public static Monitor theMainNamedDependentBean() {
+		return THE_MAIN_NAMED_DEPENDENT_BEAN;
+	}
+
+	public static Monitor theAlternativeNamedDependentBean() {
+		return THE_ALTERNATIVE_NAMED_DEPENDENT_BEAN;
+	}
+
+	public static Monitor theNestedDependentBean() {
+		return THE_NESTED_DEPENDENT_BEAN;
+	}
+
+	public static void reset() {
+		THE_APPLICATION_SCOPED_BEAN.resetInternal();
+		THE_MAIN_NAMED_APPLICATION_SCOPED_BEAN.resetInternal();
+		THE_SHARED_APPLICATION_SCOPED_BEAN.resetInternal();
+		THE_ALTERNATIVE_NAMED_APPLICATION_SCOPED_BEAN.resetInternal();
+		THE_DEPENDENT_BEAN.resetInternal();
+		THE_MAIN_NAMED_DEPENDENT_BEAN.resetInternal();
+		THE_ALTERNATIVE_NAMED_DEPENDENT_BEAN.resetInternal();
+		THE_NESTED_DEPENDENT_BEAN.resetInternal();
+	}
+
+	private Monitor() {
+		// Private constructor. Use static methods to retrieve instances.
+	}
+
+	private void resetInternal() {
+		instantiationCount.set( 0 );
+		postConstructCount.set( 0 );
+		preDestroyCount.set( 0 );
+	}
+
+	public int currentInstantiationCount() {
+		return instantiationCount.get();
+	}
+
+	public int currentPostConstructCount() {
+		return postConstructCount.get();
+	}
+
+	public int currentPreDestroyCount() {
+		return preDestroyCount.get();
+	}
+
+	public void instantiated() {
+		instantiationCount.getAndIncrement();
+	}
+
+	public void postConstructCalled() {
+		postConstructCount.getAndIncrement();
+	}
+
+	public void preDestroyCalled() {
+		preDestroyCount.getAndIncrement();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/NonRegistryManagedBeanConsumingIntegrator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/NonRegistryManagedBeanConsumingIntegrator.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.resource.beans.spi.ManagedBean;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+
+/**
+ * Simulates a Hibernate ORM integrator consuming beans whose lifecycle is not managed by the registry,
+ * but by the CDI engine only.
+ *
+ * @author Yoann Rodiere
+ */
+public class NonRegistryManagedBeanConsumingIntegrator implements Integrator {
+
+	private ManagedBean<TheApplicationScopedBean> applicationScopedBean1;
+	private ManagedBean<TheApplicationScopedBean> applicationScopedBean2;
+	private ManagedBean<TheDependentBean> dependentBean1;
+	private ManagedBean<TheDependentBean> dependentBean2;
+	private ManagedBean<TheNamedApplicationScopedBean> namedApplicationScopedBean1;
+	private ManagedBean<TheNamedApplicationScopedBean> namedApplicationScopedBean2;
+	private ManagedBean<TheNamedDependentBean> namedDependentBean1;
+	private ManagedBean<TheNamedDependentBean> namedDependentBean2;
+
+	@Override
+	public void integrate(Metadata metadata, SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+		ManagedBeanRegistry registry = sessionFactory.getServiceRegistry().getService( ManagedBeanRegistry.class );
+
+		applicationScopedBean1 = registry.getBean( TheApplicationScopedBean.class, false );
+		applicationScopedBean2 = registry.getBean( TheApplicationScopedBean.class, false );
+		dependentBean1 = registry.getBean( TheDependentBean.class, false );
+		dependentBean2 = registry.getBean( TheDependentBean.class, false );
+		namedApplicationScopedBean1 = registry.getBean( TheMainNamedApplicationScopedBeanImpl.NAME,
+				TheNamedApplicationScopedBean.class, false );
+		namedApplicationScopedBean2 = registry.getBean( TheMainNamedApplicationScopedBeanImpl.NAME,
+				TheNamedApplicationScopedBean.class, false );
+		namedDependentBean1 = registry.getBean( TheMainNamedDependentBeanImpl.NAME, TheNamedDependentBean.class,
+						false );
+		namedDependentBean2 = registry.getBean( TheMainNamedDependentBeanImpl.NAME, TheNamedDependentBean.class,
+						false );
+	}
+
+	/**
+	 * Use one instance from each ManagedBean, ensuring that any lazy initialization is executed,
+	 * be it in Hibernate ORM ({@link org.hibernate.resource.beans.spi.ExtendedBeanManager support})
+	 * or in CDI (proxies).
+	 */
+	public void ensureInstancesInitialized() {
+		applicationScopedBean1.getBeanInstance().ensureInitialized();
+		applicationScopedBean2.getBeanInstance().ensureInitialized();
+		dependentBean1.getBeanInstance().ensureInitialized();
+		dependentBean2.getBeanInstance().ensureInitialized();
+		namedApplicationScopedBean1.getBeanInstance().ensureInitialized();
+		namedApplicationScopedBean2.getBeanInstance().ensureInitialized();
+		namedDependentBean1.getBeanInstance().ensureInitialized();
+		namedDependentBean2.getBeanInstance().ensureInitialized();
+	}
+
+	@Override
+	public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+		applicationScopedBean1.release();
+		applicationScopedBean2.release();
+		dependentBean1.release();
+		dependentBean2.release();
+		namedApplicationScopedBean1.release();
+		namedApplicationScopedBean2.release();
+		namedDependentBean1.release();
+		namedDependentBean2.release();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheAlternativeNamedApplicationScopedBeanImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheAlternativeNamedApplicationScopedBeanImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+/**
+ * @author Yoann Rodiere
+ */
+@ApplicationScoped
+@Named(TheAlternativeNamedApplicationScopedBeanImpl.NAME)
+public class TheAlternativeNamedApplicationScopedBeanImpl implements TheNamedApplicationScopedBean {
+	public static final String NAME = "TheAlternativeNamedApplicationScopedBeanImpl_name";
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheAlternativeNamedApplicationScopedBeanImpl() {
+		Monitor.theAlternativeNamedApplicationScopedBean().instantiated();
+	}
+
+	@Override
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theAlternativeNamedApplicationScopedBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theAlternativeNamedApplicationScopedBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheAlternativeNamedDependentBeanImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheAlternativeNamedDependentBeanImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Named;
+
+/**
+ * @author Yoann Rodiere
+ */
+@Dependent
+@Named(TheAlternativeNamedDependentBeanImpl.NAME)
+public class TheAlternativeNamedDependentBeanImpl implements TheNamedDependentBean {
+	public static final String NAME = "TheAlternativeNamedDependentBeanImpl_name";
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheAlternativeNamedDependentBeanImpl() {
+		Monitor.theAlternativeNamedDependentBean().instantiated();
+	}
+
+	@Override
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theAlternativeNamedDependentBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theAlternativeNamedDependentBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheApplicationScopedBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheApplicationScopedBean.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * @author Yoann Rodiere
+ */
+@ApplicationScoped
+public class TheApplicationScopedBean {
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheApplicationScopedBean() {
+		Monitor.theApplicationScopedBean().instantiated();
+	}
+
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theApplicationScopedBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theApplicationScopedBean().preDestroyCalled();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheDependentBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheDependentBean.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+
+/**
+ * @author Yoann Rodiere
+ */
+@Dependent
+public class TheDependentBean {
+	@javax.inject.Inject
+	private TheNestedDependentBean dependentBean;
+
+	public TheDependentBean() {
+		Monitor.theDependentBean().instantiated();
+	}
+
+	public void ensureInitialized() {
+		dependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theDependentBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theDependentBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+@Entity
+@Table( name = "the_entity")
+public class TheEntity {
+	private Integer id;
+	private String name;
+
+	public TheEntity() {
+	}
+
+	public TheEntity(Integer id) {
+		this.id = id;
+	}
+
+	@Id
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheMainNamedApplicationScopedBeanImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheMainNamedApplicationScopedBeanImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+/**
+ * @author Yoann Rodiere
+ */
+@ApplicationScoped
+@Named(TheMainNamedApplicationScopedBeanImpl.NAME)
+public class TheMainNamedApplicationScopedBeanImpl implements TheNamedApplicationScopedBean {
+	public static final String NAME = "TheMainNamedApplicationScopedBeanImpl_name";
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheMainNamedApplicationScopedBeanImpl() {
+		Monitor.theMainNamedApplicationScopedBean().instantiated();
+	}
+
+	@Override
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theMainNamedApplicationScopedBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theMainNamedApplicationScopedBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheMainNamedDependentBeanImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheMainNamedDependentBeanImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.inject.Named;
+
+/**
+ * @author Yoann Rodiere
+ */
+@Dependent
+@Named(TheMainNamedDependentBeanImpl.NAME)
+public class TheMainNamedDependentBeanImpl implements TheNamedDependentBean {
+	public static final String NAME = "TheMainNamedDependentBeanImpl_name";
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheMainNamedDependentBeanImpl() {
+		Monitor.theMainNamedDependentBean().instantiated();
+	}
+
+	@Override
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theMainNamedDependentBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theMainNamedDependentBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNamedApplicationScopedBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNamedApplicationScopedBean.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+/**
+ * @author Yoann Rodiere
+ */
+public interface TheNamedApplicationScopedBean {
+
+	void ensureInitialized();
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNamedDependentBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNamedDependentBean.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+/**
+ * @author Yoann Rodiere
+ */
+public interface TheNamedDependentBean {
+
+	void ensureInitialized();
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNestedDependentBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNestedDependentBean.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+
+/**
+ * A dependent bean required by other beans, but never requested directly
+ * to the {@link org.hibernate.resource.beans.spi.ManagedBeanRegistry}.
+ *
+ * @author Yoann Rodiere
+ */
+@Dependent
+public class TheNestedDependentBean {
+
+	public TheNestedDependentBean() {
+		Monitor.theNestedDependentBean().instantiated();
+	}
+
+	public void ensureInitialized() {
+		// Nothing to do: if this method is called, all surrounding proxies have been initialized
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theNestedDependentBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theNestedDependentBean().preDestroyCalled();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNonHibernateBeanConsumer.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheNonHibernateBeanConsumer.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/**
+ * Simulates CDI bean consumers outside of Hibernate ORM
+ * that rely on the same beans used in Hibernate ORM.
+ *
+ * Allows us to assert that consumed beans can be shared between Hibernate ORM consumers
+ * and non-Hibernate consumers.
+ *
+ * @author Yoann Rodiere
+ */
+@Singleton
+public class TheNonHibernateBeanConsumer {
+	public static final String NAME = "TheAlternativeNamedApplicationScopedBeanImpl_name";
+
+	@javax.inject.Inject
+	private TheSharedApplicationScopedBean sharedApplicationScopedBean;
+
+	@PostConstruct
+	public void ensureInstancesInitialized() {
+		sharedApplicationScopedBean.ensureInitialized();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheSharedApplicationScopedBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/TheSharedApplicationScopedBean.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * @author Yoann Rodiere
+ */
+@ApplicationScoped
+public class TheSharedApplicationScopedBean {
+
+	@javax.inject.Inject
+	private TheNestedDependentBean nestedDependentBean;
+
+	public TheSharedApplicationScopedBean() {
+		Monitor.theSharedApplicationScopedBean().instantiated();
+	}
+
+	public void ensureInitialized() {
+		nestedDependentBean.ensureInitialized();
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		Monitor.theSharedApplicationScopedBean().postConstructCalled();
+	}
+
+	@PreDestroy
+	public void preDestroy() {
+		Monitor.theSharedApplicationScopedBean().preDestroyCalled();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/delayed/NonRegistryManagedDelayedCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/delayed/NonRegistryManagedDelayedCdiSupportTest.java
@@ -1,0 +1,185 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged.delayed;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.jpa.event.spi.JpaIntegrator;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+import org.hibernate.tool.schema.Action;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.test.cdi.nonregistrymanaged.Monitor;
+import org.hibernate.test.cdi.nonregistrymanaged.NonRegistryManagedBeanConsumingIntegrator;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheEntity;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNestedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNonHibernateBeanConsumer;
+import org.hibernate.test.cdi.nonregistrymanaged.TheSharedApplicationScopedBean;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests support for requesting CDI beans from the {@link ManagedBeanRegistry}
+ * when the CDI BeanManager access is delayed (not available during bootstrap),
+ * and when the registry should not manage the lifecycle of beans, but leave it up to CDI.
+ *
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+public class NonRegistryManagedDelayedCdiSupportTest extends BaseUnitTestCase {
+	@Test
+	public void testIt() {
+		Monitor.reset();
+
+		final NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator =
+				new NonRegistryManagedBeanConsumingIntegrator();
+
+		final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( TheApplicationScopedBean.class )
+				.addBeanClasses( TheNamedApplicationScopedBean.class, TheMainNamedApplicationScopedBeanImpl.class,
+						TheAlternativeNamedApplicationScopedBeanImpl.class )
+				.addBeanClasses( TheSharedApplicationScopedBean.class )
+				.addBeanClasses( TheDependentBean.class )
+				.addBeanClasses( TheNamedDependentBean.class, TheMainNamedDependentBeanImpl.class,
+						TheAlternativeNamedDependentBeanImpl.class )
+				.addBeanClasses( TheNestedDependentBean.class )
+				.addBeanClasses( TheNonHibernateBeanConsumer.class );
+
+		try (final SeContainer cdiContainer = cdiInitializer.initialize()) {
+			// Simulate CDI bean consumers outside of Hibernate ORM
+			Instance<TheNonHibernateBeanConsumer> nonHibernateBeanConsumerInstance =
+					cdiContainer.getBeanManager().createInstance().select( TheNonHibernateBeanConsumer.class );
+			nonHibernateBeanConsumerInstance.get();
+
+			// Expect the shared bean to have been instantiated already, but only that one
+			assertEquals( 0, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theDependentBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+			// Nested dependent bean: 1 instance per bean that depends on it
+			assertEquals( 1, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+			try (SessionFactoryImplementor sessionFactory = buildSessionFactory( cdiContainer, beanConsumingIntegrator )) {
+				// Here, the NonRegistryManagedBeanConsumingIntegrator has just been integrated and has requested beans
+				// See NonRegistryManagedBeanConsumingIntegrator for a detailed list of requested beans
+
+				beanConsumingIntegrator.ensureInstancesInitialized();
+
+				// Application scope: maximum 1 instance as soon as at least one was requested
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+
+				// Dependent scope: 1 instance per bean we requested explicitly
+				assertEquals( 2, Monitor.theDependentBean().currentInstantiationCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+
+				// Nested dependent bean: 1 instance per bean that depends on it
+				assertEquals( 7, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+				// Expect one PostConstruct call per instance
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theDependentBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 7, Monitor.theNestedDependentBean().currentPostConstructCount() );
+
+				// Expect no PreDestroy call yet
+				assertEquals( 0, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+			}
+
+			// Here, the NonRegistryManagedBeanConsumingIntegrator has just been disintegrated and has released beans
+
+			// release() should have an effect on exclusively used application-scoped beans
+			assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+
+			// release() should have no effect on shared application-scoped beans (they will be released when they are no longer used)
+			assertEquals( 0, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+
+			// release() should have an effect on dependent-scoped beans
+			assertEquals( 2, Monitor.theDependentBean().currentPreDestroyCount() );
+			assertEquals( 2, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+			// The nested dependent bean instances should have been destroyed along with the beans that depend on them
+			// (the instances used in application-scoped beans should not have been destroyed)
+			assertEquals( 6, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+		}
+
+		// After the CDI context has ended, PreDestroy should have been called on every created bean
+		// (see the assertions about instantiations above for an explanation of the expected counts)
+		assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theDependentBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 7, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+	}
+
+	private SessionFactoryImplementor buildSessionFactory(SeContainer cdiContainer,
+			NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator) {
+		BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder()
+				.applyIntegrator( new JpaIntegrator() )
+				.applyIntegrator( beanConsumingIntegrator )
+				.build();
+
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder( bsr )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
+				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, cdiContainer.getBeanManager() )
+				.applySetting( AvailableSettings.DELAY_CDI_ACCESS, "true" )
+				.build();
+
+		try {
+			return (SessionFactoryImplementor) new MetadataSources( ssr )
+					.addAnnotatedClass( TheEntity.class )
+					.buildMetadata()
+					.getSessionFactoryBuilder()
+					.build();
+		}
+		catch (Exception e) {
+			StandardServiceRegistryBuilder.destroy( ssr );
+			throw e;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/extended/NonRegistryManagedExtendedCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/extended/NonRegistryManagedExtendedCdiSupportTest.java
@@ -1,0 +1,196 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged.extended;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.jpa.event.spi.JpaIntegrator;
+import org.hibernate.resource.beans.spi.ExtendedBeanManager;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+import org.hibernate.tool.schema.Action;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.test.cdi.nonregistrymanaged.Monitor;
+import org.hibernate.test.cdi.nonregistrymanaged.NonRegistryManagedBeanConsumingIntegrator;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheEntity;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNestedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNonHibernateBeanConsumer;
+import org.hibernate.test.cdi.nonregistrymanaged.TheSharedApplicationScopedBean;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests support for requesting CDI beans from the {@link ManagedBeanRegistry}
+ * when the CDI BeanManager access is "lazy" (beans are instantiated when instances are first requested),
+ * and when the registry should not manage the lifecycle of beans, but leave it up to CDI.
+ *
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+public class NonRegistryManagedExtendedCdiSupportTest extends BaseUnitTestCase {
+	@Test
+	public void testIt() {
+		Monitor.reset();
+
+		final ExtendedBeanManagerImpl standIn = new ExtendedBeanManagerImpl();
+		final NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator =
+				new NonRegistryManagedBeanConsumingIntegrator();
+
+		try (SessionFactoryImplementor sessionFactory = buildSessionFactory( standIn, beanConsumingIntegrator )) {
+			final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+					.disableDiscovery()
+					.addBeanClasses( TheApplicationScopedBean.class )
+					.addBeanClasses( TheNamedApplicationScopedBean.class, TheMainNamedApplicationScopedBeanImpl.class,
+							TheAlternativeNamedApplicationScopedBeanImpl.class )
+					.addBeanClasses( TheSharedApplicationScopedBean.class )
+					.addBeanClasses( TheDependentBean.class )
+					.addBeanClasses( TheNamedDependentBean.class, TheMainNamedDependentBeanImpl.class,
+							TheAlternativeNamedDependentBeanImpl.class )
+					.addBeanClasses( TheNestedDependentBean.class )
+					.addBeanClasses( TheNonHibernateBeanConsumer.class );
+			try (final SeContainer cdiContainer = cdiInitializer.initialize()) {
+				// Simulate CDI bean consumers outside of Hibernate ORM
+				Instance<TheNonHibernateBeanConsumer> nonHibernateBeanConsumerInstance =
+						cdiContainer.getBeanManager().createInstance().select( TheNonHibernateBeanConsumer.class );
+				nonHibernateBeanConsumerInstance.get();
+
+				// Here, the NonRegistryManagedBeanConsumingIntegrator has just been integrated and has requested beans
+				// BUT it has not fetched instances of beans yet, so non-shared beans should not have been instantiated yet.
+				assertEquals( 0, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theDependentBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+				// Nested dependent bean: 1 instance per bean that depends on it
+				assertEquals( 1, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+				standIn.beanManagerReady( cdiContainer.getBeanManager() );
+
+				beanConsumingIntegrator.ensureInstancesInitialized();
+
+				// Here the NonRegistryManagedBeanConsumingIntegrator *did* fetch an instance of each bean,
+				// so all beans should have been instantiated.
+				// See NonRegistryManagedBeanConsumingIntegrator for a detailed list of requested beans
+
+				// Application scope: maximum 1 instance as soon as at least one was requested
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+
+				// Dependent scope: 1 instance per bean we requested explicitly
+				assertEquals( 2, Monitor.theDependentBean().currentInstantiationCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+
+				// Nested dependent bean: 1 instance per bean that depends on it
+				assertEquals( 7, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+				// Expect one PostConstruct call per instance
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theDependentBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 7, Monitor.theNestedDependentBean().currentPostConstructCount() );
+
+				// Expect no PreDestroy call yet
+				assertEquals( 0, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+			}
+
+			// After the CDI context has ended, PreDestroy should have been called on every "normal-scoped" bean
+			// (i.e. all beans excepting the dependent ones we requested explicitly and haven't released yet)
+			assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theDependentBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+			assertEquals( 3, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+		}
+
+		// Here, the NonRegistryManagedBeanConsumingIntegrator has just been disintegrated and has released beans
+		// The dependent beans should now have been released as well.
+		assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theDependentBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 7, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+	}
+
+	private SessionFactoryImplementor buildSessionFactory(ExtendedBeanManagerImpl standIn,
+			NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator) {
+		BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder()
+				.applyIntegrator( new JpaIntegrator() )
+				.applyIntegrator( beanConsumingIntegrator )
+				.build();
+
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder( bsr )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
+				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, standIn )
+				.build();
+
+		try {
+			return (SessionFactoryImplementor) new MetadataSources( ssr )
+					.addAnnotatedClass( TheEntity.class )
+					.buildMetadata()
+					.getSessionFactoryBuilder()
+					.build();
+		}
+		catch (Exception e) {
+			StandardServiceRegistryBuilder.destroy( ssr );
+			throw e;
+		}
+	}
+
+	public static class ExtendedBeanManagerImpl implements ExtendedBeanManager {
+		private LifecycleListener callback;
+
+		@Override
+		public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+			this.callback = lifecycleListener;
+		}
+
+		public void beanManagerReady(BeanManager beanManager) {
+			callback.beanManagerInitialized( beanManager );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+/**
+ * Package for testing Hibernate's support for integrating
+ * with CDI for beans whose lifecycle is  not managed by the
+ * {@link org.hibernate.resource.beans.spi.ManagedBeanRegistry}
+ * (i.e. beans retrieved with shouldRegistryManageLifecycle = false).
+ */
+package org.hibernate.test.cdi.nonregistrymanaged;

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/standard/NonRegistryManagedStandardCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/nonregistrymanaged/standard/NonRegistryManagedStandardCdiSupportTest.java
@@ -1,0 +1,185 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.nonregistrymanaged.standard;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.jpa.event.spi.JpaIntegrator;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+import org.hibernate.tool.schema.Action;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.test.cdi.nonregistrymanaged.Monitor;
+import org.hibernate.test.cdi.nonregistrymanaged.NonRegistryManagedBeanConsumingIntegrator;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheAlternativeNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheEntity;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedApplicationScopedBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheMainNamedDependentBeanImpl;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedApplicationScopedBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNamedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNestedDependentBean;
+import org.hibernate.test.cdi.nonregistrymanaged.TheNonHibernateBeanConsumer;
+import org.hibernate.test.cdi.nonregistrymanaged.TheSharedApplicationScopedBean;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests support for requesting CDI beans from the {@link ManagedBeanRegistry}
+ * when the CDI BeanManager is available right away during bootstrap,
+ * and when the registry should not manage the lifecycle of beans, but leave it up to CDI.
+ *
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+public class NonRegistryManagedStandardCdiSupportTest extends BaseUnitTestCase {
+	@Test
+	public void testIt() {
+		Monitor.reset();
+
+		final NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator =
+				new NonRegistryManagedBeanConsumingIntegrator();
+
+		final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( TheApplicationScopedBean.class )
+				.addBeanClasses( TheNamedApplicationScopedBean.class, TheMainNamedApplicationScopedBeanImpl.class,
+						TheAlternativeNamedApplicationScopedBeanImpl.class )
+				.addBeanClasses( TheSharedApplicationScopedBean.class )
+				.addBeanClasses( TheDependentBean.class )
+				.addBeanClasses( TheNamedDependentBean.class, TheMainNamedDependentBeanImpl.class,
+						TheAlternativeNamedDependentBeanImpl.class )
+				.addBeanClasses( TheNestedDependentBean.class )
+				.addBeanClasses( TheNonHibernateBeanConsumer.class );
+
+		try (final SeContainer cdiContainer = cdiInitializer.initialize()) {
+			// Simulate CDI bean consumers outside of Hibernate ORM
+			Instance<TheNonHibernateBeanConsumer> nonHibernateBeanConsumerInstance =
+					cdiContainer.getBeanManager().createInstance().select( TheNonHibernateBeanConsumer.class );
+			nonHibernateBeanConsumerInstance.get();
+
+			// Expect the shared bean to have been instantiated already, but only that one
+			assertEquals( 0, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theDependentBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+			// Nested dependent bean: 1 instance per bean that depends on it
+			assertEquals( 1, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+			try (SessionFactoryImplementor sessionFactory = buildSessionFactory( cdiContainer, beanConsumingIntegrator )) {
+				// Here, the NonRegistryManagedBeanConsumingIntegrator has just been integrated and has requested beans
+				// See NonRegistryManagedBeanConsumingIntegrator for a detailed list of requested beans
+
+				beanConsumingIntegrator.ensureInstancesInitialized();
+
+				// Application scope: maximum 1 instance as soon as at least one was requested
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentInstantiationCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentInstantiationCount() );
+
+				// Dependent scope: 1 instance per bean we requested explicitly
+				assertEquals( 2, Monitor.theDependentBean().currentInstantiationCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentInstantiationCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentInstantiationCount() );
+
+				// Nested dependent bean: 1 instance per bean that depends on it
+				assertEquals( 7, Monitor.theNestedDependentBean().currentInstantiationCount() );
+
+				// Expect one PostConstruct call per instance
+				assertEquals( 1, Monitor.theApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theDependentBean().currentPostConstructCount() );
+				assertEquals( 2, Monitor.theMainNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPostConstructCount() );
+				assertEquals( 7, Monitor.theNestedDependentBean().currentPostConstructCount() );
+
+				// Expect no PreDestroy call yet
+				assertEquals( 0, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+				assertEquals( 0, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+			}
+
+			// Here, the NonRegistryManagedBeanConsumingIntegrator has just been disintegrated and has released beans
+
+			// release() should have an effect on exclusively used application-scoped beans
+			assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+
+			// release() should have no effect on shared application-scoped beans (they will be released when they are no longer used)
+			assertEquals( 0, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+
+			// release() should have an effect on dependent-scoped beans
+			assertEquals( 2, Monitor.theDependentBean().currentPreDestroyCount() );
+			assertEquals( 2, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+			assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+			// The nested dependent bean instances should have been destroyed along with the beans that depend on them
+			// (the instances used in application-scoped beans should not have been destroyed)
+			assertEquals( 6, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+		}
+
+		// After the CDI context has ended, PreDestroy should have been called on every created bean
+		// (see the assertions about instantiations above for an explanation of the expected counts)
+		assertEquals( 1, Monitor.theApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theMainNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 1, Monitor.theSharedApplicationScopedBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theDependentBean().currentPreDestroyCount() );
+		assertEquals( 2, Monitor.theMainNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 0, Monitor.theAlternativeNamedDependentBean().currentPreDestroyCount() );
+		assertEquals( 7, Monitor.theNestedDependentBean().currentPreDestroyCount() );
+	}
+
+	private SessionFactoryImplementor buildSessionFactory(SeContainer cdiContainer,
+			NonRegistryManagedBeanConsumingIntegrator beanConsumingIntegrator) {
+		BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder()
+				.applyIntegrator( new JpaIntegrator() )
+				.applyIntegrator( beanConsumingIntegrator )
+				.build();
+
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder( bsr )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
+				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, cdiContainer.getBeanManager() )
+				.build();
+
+		try {
+			return (SessionFactoryImplementor) new MetadataSources( ssr )
+					.addAnnotatedClass( TheEntity.class )
+					.buildMetadata()
+					.getSessionFactoryBuilder()
+					.build();
+		}
+		catch ( Exception e ) {
+			StandardServiceRegistryBuilder.destroy( ssr );
+			throw e;
+		}
+	}
+
+}


### PR DESCRIPTION
@sebersole Here are the fixes I mentioned yesterday regarding the `ManagedBeanRegistry`. Mainly this is about making sure that, when `shouldRegistryManageLifecycle` is `false`, the registry really doesn't manage the CDI lifecycle at all and delegates to the CDI runtime.

All of the commits in this PR are follow-ups to already-fixed tickets:

 * https://hibernate.atlassian.net/browse/HHH-12133
 * https://hibernate.atlassian.net/browse/HHH-12171

**WARNING**: I had to use CDI 2.0 APIs, and those APIs are not available in WildFly 11. So I added a build step to patch the WildFly server.