### PR TITLE
HHH-12116 - Positional parameters report position as name HHH-12101 - Remove support for legacy HQL-style positional parameters

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/ParameterTranslationsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/ParameterTranslationsImpl.java
@@ -64,6 +64,19 @@ public class ParameterTranslationsImpl implements ParameterTranslations {
 						namedSpecification.getName(),
 						k -> new NamedParameterInformationImpl( k, namedSpecification.getExpectedType() )
 				);
+
+				/*
+					If a previous reference to the NamedParameter already exists with expected type null and the new
+					reference expected type is not null then we add the type to the NamedParameterInformation.
+
+					This situation may occur when the same name parameter is used twice in the same query,
+					an example is ".... where :name is null or name.last = :name"
+
+					If info.getExpectedType() != null and also != namedSpecification.getExpectedType(), should an exception be thrown?
+				*/
+				if ( info.getExpectedType() == null && namedSpecification.getExpectedType() != null ) {
+					info.setExpectedType( namedSpecification.getExpectedType() );
+				}
 				info.addSourceLocation( i++ );
 			}
 		}


### PR DESCRIPTION
HHH-12116 and HHH-12101 introduced a regression when in a query a named parameter is used twice and the first reference does not permit to determine the expected type of the parameter.
This on PostgresSQL causes the failure of org.hibernate.test.hql.ASTParserLoadingTest#testMultipleRefsToSameParam() test.



