### PR TITLE
HHH-12216 - Improve logging for when Hibernate throws the "illegally attempted to associate a proxy with two open Sessions" Exception

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -102,6 +102,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			}
 			else if ( isConnectedToSession() ) {
 				//TODO: perhaps this should be some other RuntimeException...
+				log.debug("Illegally attempted to associate a proxy for entity with name " + entityName + " and ID " + id + " with two open sessions.");
 				throw new HibernateException( "illegally attempted to associate a proxy with two open Sessions" );
 			}
 			else {


### PR DESCRIPTION
Update AbstractLazyInitializer.java to include debugging information regarding the entity being proxied when illegally attempting to associate it with two open sessions. Right now the stack trace of the exception does not give any information on the entity itself which makes debugging this issue cumbersome.