### PR TITLE
HHH-12233: Fix NPE in CacheImpl.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
@@ -406,11 +406,9 @@ public class CacheImpl implements CacheImplementor {
 		if ( settings.isQueryCacheEnabled() ) {
 			allCacheRegions.put( updateTimestampsCache.getRegion().getName(), updateTimestampsCache.getRegion() );
 			allCacheRegions.put( queryCache.getRegion().getName(), queryCache.getRegion() );
-		}
-		// keys in queryCaches may not be equal to the Region names
-		// obtained from queryCaches values; we need to be sure we are adding
-		// the actual QueryCache region name as the key in allCacheRegions.
-		if ( settings.isQueryCacheEnabled() ) {
+			// keys in queryCaches may not be equal to the Region names
+			// obtained from queryCaches values; we need to be sure we are adding
+			// the actual QueryCache region name as the key in allCacheRegions.
 			for ( QueryCache queryCacheValue : queryCaches.values() ) {
 				allCacheRegions.put( queryCacheValue.getRegion().getName(), queryCacheValue.getRegion() );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CacheImpl.java
@@ -402,17 +402,18 @@ public class CacheImpl implements CacheImplementor {
 		// which Map contents are added to getAllSecondLevelCacheRegions.
 		// In addition, if there is a CollectionRegion and an EntityRegion with the same name, then we
 		// want the EntityRegion to be in the Map that gets returned.
-		final Map<String, Region> allCacheRegions = new HashMap<String, Region>(
-				2 + queryCaches.size() + otherRegionMap.size() + naturalIdRegionMap.size()
-						+ collectionRegionMap.size() + entityRegionMap.size()
-		);
-		allCacheRegions.put( updateTimestampsCache.getRegion().getName(), updateTimestampsCache.getRegion() );
-		allCacheRegions.put( queryCache.getRegion().getName(), queryCache.getRegion() );
+		final Map<String, Region> allCacheRegions = new HashMap<String, Region>();
+		if ( settings.isQueryCacheEnabled() ) {
+			allCacheRegions.put( updateTimestampsCache.getRegion().getName(), updateTimestampsCache.getRegion() );
+			allCacheRegions.put( queryCache.getRegion().getName(), queryCache.getRegion() );
+		}
 		// keys in queryCaches may not be equal to the Region names
 		// obtained from queryCaches values; we need to be sure we are adding
 		// the actual QueryCache region name as the key in allCacheRegions.
-		for ( QueryCache queryCacheValue : queryCaches.values() ) {
-			allCacheRegions.put( queryCacheValue.getRegion().getName(), queryCacheValue.getRegion() );
+		if ( settings.isQueryCacheEnabled() ) {
+			for ( QueryCache queryCacheValue : queryCaches.values() ) {
+				allCacheRegions.put( queryCacheValue.getRegion().getName(), queryCacheValue.getRegion() );
+			}
 		}
 		allCacheRegions.putAll( otherRegionMap );
 		allCacheRegions.putAll( naturalIdRegionMap );


### PR DESCRIPTION
Fix NPEs in CacheImpl.java seen when using Hibernate 5.1.11 with Wildfly 11.x.
Varaibles queryCache, queryCaches and updateTimestampsCache can be null.

Simply omitted the calculation of the exact HashMap size.
Protected the use of the possibly null regions like done at other places in this source.