### PR TITLE
HHH-11571 - JTA platform for WebSphere Liberty and OpenLiberty

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
@@ -84,6 +84,7 @@ import org.hibernate.engine.transaction.jta.platform.internal.SapNetWeaverJtaPla
 import org.hibernate.engine.transaction.jta.platform.internal.SunOneJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.WebSphereExtendedJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.WebSphereJtaPlatform;
+import org.hibernate.engine.transaction.jta.platform.internal.WebSphereLibertyJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.internal.WeblogicJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.event.internal.EntityCopyAllowedLoggedObserver;
@@ -340,6 +341,13 @@ public class StrategySelectorBuilder {
 				WeblogicJtaPlatform.class,
 				"Weblogic",
 				"org.hibernate.service.jta.platform.internal.WeblogicJtaPlatform"
+		);
+		
+		addJtaPlatforms(
+				strategySelector,
+				WebSphereLibertyJtaPlatform.class,
+				"WebSphereLiberty",
+				"org.hibernate.engine.transaction.jta.platform.internal.WebSphereLibertyJtaPlatform"
 		);
 
 		addJtaPlatforms(

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/StandardJtaPlatformResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/StandardJtaPlatformResolver.java
@@ -86,8 +86,16 @@ public class StandardJtaPlatformResolver implements JtaPlatformResolver {
 		}
 		catch (ClassLoadingException ignore) {
 		}
-
-		// WebSphere ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		
+		// WebSphere Liberty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		try {
+			classLoaderService.classForName(WebSphereLibertyJtaPlatform.TMF_CLASS_NAME);
+			return new WebSphereLibertyJtaPlatform();
+		}
+		catch (ClassLoadingException ignore) {
+		}
+		
+		// WebSphere traditional ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		for ( WebSphereJtaPlatform.WebSphereEnvironment webSphereEnvironment
 				: WebSphereJtaPlatform.WebSphereEnvironment.values() ) {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/WebSphereLibertyJtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/WebSphereLibertyJtaPlatform.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.transaction.jta.platform.internal;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatformException;
+
+/**
+ * JTA platform implementation intended for use with WebSphere Liberty and OpenLiberty
+ *
+ * @author Andrew Guibert
+ * @author Nathan Rauh
+ */
+@SuppressWarnings("serial")
+public class WebSphereLibertyJtaPlatform extends AbstractJtaPlatform {
+	
+	public static final String TMF_CLASS_NAME = "com.ibm.tx.jta.TransactionManagerFactory";
+	
+	public static final String UT_NAME = "java:comp/UserTransaction";
+	
+	@Override
+	protected TransactionManager locateTransactionManager() {
+		try {
+			final Class<?> TransactionManagerFactory = serviceRegistry()
+					.getService( ClassLoaderService.class )
+					.classForName( TMF_CLASS_NAME );
+			return (TransactionManager) TransactionManagerFactory.getMethod("getTransactionManager").invoke(null);
+		}
+		catch ( Exception e ) {
+			throw new JtaPlatformException( "Could not obtain WebSphere Liberty transaction manager instance", e );
+		}
+	}
+
+	@Override
+	protected UserTransaction locateUserTransaction() {
+		return (UserTransaction) jndiService().locate( UT_NAME );
+	}
+
+	public boolean canRegisterSynchronization() {
+		try {
+			return getCurrentStatus() == Status.STATUS_ACTIVE;
+		} 
+		catch (SystemException x) {
+			throw new RuntimeException(x);
+		}
+	}
+
+	public int getCurrentStatus() throws SystemException {
+		return retrieveTransactionManager().getStatus();
+	}
+
+	public Object getTransactionIdentifier(Transaction transaction) {
+		return transaction;
+	}
+
+	public void registerSynchronization(Synchronization synchronization) {
+		try {
+			retrieveTransactionManager().getTransaction().registerSynchronization(synchronization);
+		} 
+		catch (IllegalStateException x) {
+			throw new RuntimeException(x);
+		} 
+		catch (RollbackException x) {
+			throw new RuntimeException(x);
+		} 
+		catch (SystemException x) {
+			throw new RuntimeException(x);
+		}
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/spi/JtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/spi/JtaPlatform.java
@@ -39,8 +39,7 @@ public interface JtaPlatform extends Service {
 	 * Determine an identifier for the given transaction appropriate for use in caching/lookup usages.
 	 * <p/>
 	 * Generally speaking the transaction itself will be returned here.  This method was added specifically
-	 * for use in WebSphere and other unfriendly JEE containers (although WebSphere is still the only known
-	 * such brain-dead, sales-driven impl).
+	 * for use in WebSphere and other unfriendly JEE containers.
 	 *
 	 * @param transaction The transaction to be identified.
 	 * @return An appropriate identifier


### PR DESCRIPTION
This will allow Hibernate to properly interoperate with Liberty's transaction service out of the box.  

All tests for the `hibernate-core` project have been run locally (`../gradlew build`) and are passing.

Based on the precedent set by other JtaPlatforms, no documentation or unit tests will be added.