### PR TITLE
HHH-12285 - DB connection exception on rollback causes connection leak

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
@@ -118,6 +118,7 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 			log.trace( "Transaction rolled-back via JDBC Connection.rollback()" );
 		}
 		catch( SQLException e ) {
+			status = TransactionStatus.FAILED_ROLLBACK;
 			throw new TransactionException( "Unable to rollback against JDBC Connection", e );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
@@ -37,6 +37,10 @@ public enum TransactionStatus {
 	 */
 	FAILED_COMMIT,
 	/**
+	 * The transaction attempted to rollback, but failed.
+	 */
+	FAILED_ROLLBACK,
+	/**
 	 * Status code indicating a transaction that has begun the second
 	 * phase of the two-phase commit protocol, but not yet completed
 	 * this phase.

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/TransactionCommitFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/TransactionCommitFailureTest.java
@@ -25,86 +25,136 @@ import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.hibernate.jpa.test.PersistenceUnitDescriptorAdapter;
 import org.hibernate.jpa.test.SettingsGenerator;
 
+import org.hibernate.testing.TestForIssue;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Vlad Mihalcea
  */
 public class TransactionCommitFailureTest {
 
-    public static final String COMMIT_FAILURE = "Commit failed!";
+	public static final String COMMIT_FAILURE = "Error while committing the transaction";
 
-    private static final AtomicBoolean transactionFailureTrigger = new AtomicBoolean( false );
+	private static AtomicBoolean transactionFailureTrigger;
+	private static AtomicBoolean connectionIsOpen;
 
-    @Test
-    public void testConfiguredInterceptor() {
-		Map settings = basicSettings();
-		EntityManagerFactory emf = Bootstrap.getEntityManagerFactoryBuilder( new PersistenceUnitDescriptorAdapter(), settings ).build();
-        EntityManager em = emf.createEntityManager();
+	private EntityManagerFactory emf;
 
-        try {
-            em.getTransaction().begin();
-            transactionFailureTrigger.set( true );
-            em.getTransaction().commit();
-        }
+	@Before
+	public void setUo() {
+		final Map settings = basicSettings();
+		emf = Bootstrap.getEntityManagerFactoryBuilder( new PersistenceUnitDescriptorAdapter(), settings ).build();
+		transactionFailureTrigger = new AtomicBoolean( false );
+		connectionIsOpen = new AtomicBoolean( false );
+	}
+
+	@After
+	public void tearDown() {
+		emf.close();
+		transactionFailureTrigger = new AtomicBoolean( false );
+		connectionIsOpen = new AtomicBoolean( false );
+	}
+
+	@Test
+	public void testConfiguredInterceptor() {
+		EntityManager em = emf.createEntityManager();
+
+		try {
+			em.getTransaction().begin();
+			transactionFailureTrigger.set( true );
+			em.getTransaction().commit();
+		}
 		catch (RollbackException e) {
-			assertEquals( COMMIT_FAILURE, e.getCause().getMessage() );
+			assertEquals( COMMIT_FAILURE, e.getLocalizedMessage());
 		}
 		finally {
-            if ( em.getTransaction() != null && em.getTransaction().isActive() ) {
-                em.getTransaction().rollback();
-            }
-            em.close();
-            emf.close();
-        }
-    }
+			if ( em.getTransaction() != null && em.getTransaction().isActive() ) {
+				em.getTransaction().rollback();
+			}
+			em.close();
+			emf.close();
+		}
+	}
 
-    protected Map basicSettings() {
+	@Test
+	@TestForIssue(jiraKey = "HHH-12285")
+	public void assertConnecitonIsRelased() {
+		EntityManager em = emf.createEntityManager();
+		try {
+			em.getTransaction().begin();
+			Assert.assertEquals( true, connectionIsOpen.get() );
+			transactionFailureTrigger.set( true );
+			em.getTransaction().rollback();
+			fail( "Rollback failure, Exception expected" );
+		}
+		catch (Exception pe) {
+			//expected
+		}
+		finally {
+			em.close();
+		}
+
+		Assert.assertEquals( "The connection was no released", false, connectionIsOpen.get() );
+	}
+
+	protected Map basicSettings() {
 		return SettingsGenerator.generateSettings(
 				Environment.HBM2DDL_AUTO, "create-drop",
 				Environment.USE_NEW_ID_GENERATOR_MAPPINGS, "true",
 				Environment.DIALECT, Dialect.getDialect().getClass().getName(),
-                Environment.CONNECTION_PROVIDER, ProxyConnectionProvider.class.getName()
+				Environment.CONNECTION_PROVIDER, ProxyConnectionProvider.class.getName()
 		);
-    }
+	}
 
 	public static class ProxyConnectionProvider extends DriverManagerConnectionProviderImpl {
 
 		@Override
 		public Connection getConnection() throws SQLException {
 			Connection delegate = super.getConnection();
+			connectionIsOpen.set( true );
 			return (Connection) Proxy.newProxyInstance(
 					this.getClass().getClassLoader(),
-					new Class[]{Connection.class},
-					new ConnectionInvocationHandler(delegate));
+					new Class[] { Connection.class },
+					new ConnectionInvocationHandler( delegate )
+			);
+		}
+
+		@Override
+		public void closeConnection(Connection conn) throws SQLException {
+			super.closeConnection( conn );
+			connectionIsOpen.set( false );
 		}
 	}
 
-    private static class ConnectionInvocationHandler implements InvocationHandler {
+	private static class ConnectionInvocationHandler implements InvocationHandler {
 
-        private final Connection delegate;
+		private final Connection delegate;
 
-        public ConnectionInvocationHandler(Connection delegate) {
-            this.delegate = delegate;
-        }
+		public ConnectionInvocationHandler(Connection delegate) {
+			this.delegate = delegate;
+		}
 
-        @Override
-        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            if("commit".equals( method.getName() )) {
-                if ( transactionFailureTrigger.get() ) {
-                    throw new PersistenceException( COMMIT_FAILURE );
-                }
-            }
-            else if("rollback".equals( method.getName() )) {
-                if ( transactionFailureTrigger.get() ) {
-                    transactionFailureTrigger.set( false );
-                    throw new PersistenceException( "Rollback failed!" );
-                }
-            }
-            return method.invoke(delegate, args);
-        }
-    }
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ( "commit".equals( method.getName() ) ) {
+				if ( transactionFailureTrigger.get() ) {
+					throw new SQLException( COMMIT_FAILURE );
+				}
+			}
+			else if ( "rollback".equals( method.getName() ) ) {
+				if ( transactionFailureTrigger.get() ) {
+					transactionFailureTrigger.set( false );
+					throw new SQLException( "Rollback failed!" );
+				}
+			}
+			return method.invoke( delegate, args );
+		}
+	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12285

The db connection is not released because when the `EntityManager#close() `method is called the transaction status results active.
`SessionImpl#close() `method executes the following code:
```
if ( discardOnClose || !isTransactionInProgress( false ) ) {
  super.close();
}
else {
 //Otherwise, session auto-close will be enabled by shouldAutoCloseSession().
 waitingForAutoClose = true;
 closed = true;
}
```
and  `isTransactionInProgress( false )` is true then the super.close() method is not called .

The patch introduces the `TransactionStatus.FAILED_ROLLBACK` value that is set when a rollback fails.