### PR TITLE
HHH-12059 HHH-11440 HHH-11286 HHH-10333 - 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -744,6 +744,11 @@ public class Oracle8iDialect extends Dialect {
 	}
 
 	@Override
+	public String getCurrentSchemaCommand() {
+		return "SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM DUAL";
+	}
+
+	@Override
 	public boolean supportsPartitionBy() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -121,6 +121,11 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
+	public String getCurrentSchemaCommand() {
+		return "SELECT SCHEMA_NAME()";
+	}
+
+	@Override
 	public char openQuote() {
 		return '[';
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -298,7 +298,7 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 			return schemaNameResolver.resolveSchemaName( databaseMetaData.getConnection(), dialect );
 		}
 		catch (Exception e) {
-			// for now, just ignore the exception.
+			log.debugf( "Unable to resolve connection default schema : " + e.getMessage() );
 			return null;
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/SchemaNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/SchemaNameResolver.java
@@ -25,5 +25,5 @@ public interface SchemaNameResolver {
 	 *
 	 * @return The name of the schema (may be null).
 	 */
-	public String resolveSchemaName(Connection connection, Dialect dialect) throws SQLException;
+	String resolveSchemaName(Connection connection, Dialect dialect) throws SQLException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/JdbcMetadaAccessStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/JdbcMetadaAccessStrategy.java
@@ -6,8 +6,11 @@
  */
 package org.hibernate.tool.schema;
 
+import java.util.Map;
+
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationHelper;
 
 /**
  * @author Andrea Boriero
@@ -24,7 +27,7 @@ public enum JdbcMetadaAccessStrategy {
 	 * The {@link org.hibernate.tool.schema.spi.SchemaMigrator} and {@link org.hibernate.tool.schema.spi.SchemaValidator}
 	 * execute a single {@link java.sql.DatabaseMetaData#getTables(String, String, String, String[])} call
 	 * to retrieve all the database table in order to determine all the {@link javax.persistence.Entity} have a mapped database tables.
-	 *
+	 * <p>
 	 * This strategy is the default one and it may require {@link AvailableSettings#DEFAULT_CATALOG} and/or
 	 * {@link AvailableSettings#DEFAULT_SCHEMA} values to be provided.
 	 */
@@ -41,20 +44,34 @@ public enum JdbcMetadaAccessStrategy {
 		return strategy;
 	}
 
-	public static JdbcMetadaAccessStrategy interpretHbm2ddlSetting(Object value) {
-		if(value == null){
-			return GROUPED;
+	public static JdbcMetadaAccessStrategy interpretSetting(Map options) {
+		if ( options == null ) {
+			return interpretHbm2ddlSetting( null );
 		}
-		String name = value.toString();
-		if ( StringHelper.isEmpty( name ) || GROUPED.strategy.equals( name ) ) {
-			return GROUPED;
-		}
-		else if ( INDIVIDUALLY.strategy.equals( name ) ) {
+		else if ( ConfigurationHelper.getBoolean( AvailableSettings.ENABLE_SYNONYMS, options, false ) ) {
+			// Use of synonyms can cause issues during schema validation or schema update when GROUPED strategy is used (especially in Oracle)
 			return INDIVIDUALLY;
 		}
 		else {
-			throw new IllegalArgumentException( "Unrecognized `" + AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY + "` value : " + name );
+			return interpretHbm2ddlSetting( options.get( AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY ) );
 		}
+	}
 
+	public static JdbcMetadaAccessStrategy interpretHbm2ddlSetting(Object value) {
+		if ( value == null ) {
+			return GROUPED;
+		}
+		else {
+			final String name = value.toString();
+			if ( StringHelper.isEmpty( name ) || GROUPED.strategy.equals( name ) ) {
+				return GROUPED;
+			}
+			else if ( INDIVIDUALLY.strategy.equals( name ) ) {
+				return INDIVIDUALLY;
+			}
+			else {
+				throw new IllegalArgumentException( "Unrecognized `" + AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY + "` value : " + name );
+			}
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -104,10 +104,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	}
 
 	private JdbcMetadaAccessStrategy determineJdbcMetadaAccessStrategy(Map options) {
-		if ( options == null ) {
-			return JdbcMetadaAccessStrategy.interpretHbm2ddlSetting( null );
-		}
-		return JdbcMetadaAccessStrategy.interpretHbm2ddlSetting( options.get( AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY ) );
+		return JdbcMetadaAccessStrategy.interpretSetting( options );
 	}
 
 	GenerationTarget[] buildGenerationTargets(


### PR DESCRIPTION
bm2ddl.auto=update and update do not work with Oracle and SQLServer when Jdbc driver Connection implementation does not implement getSchema()

The issue is related with the `SchemaNameResolver`, if the `Connection` implementation does not implement the `getSchema()` method introduced with Java 7, but at runtime the `jdbcConnectionClass.getMethod( "getSchema" );`  may return not null ( I think depends on the JRE version used) and then when the 
`getSchemaMethod.invoke( connection )` is later executed an exception is thrown.

This is causing issues with the` InformationExtractorJdbcDatabaseMetaDataImpl#getTables()` method, due to the previous behaviour the value of the `schemaFilter` in 
```
extractionContext.getJdbcDatabaseMetaData().getTables(
					catalogFilter,
					schemaFilter,
					"%",
					tableTypes
			);
```
is an empty string causing the search to be limited to tables with no schema.


.

