### PR TITLE
HHH-12346: Replace StringHelper#join by Java's String#join

### DIFF
--- a/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/C3P0ConnectionProvider.java
+++ b/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/C3P0ConnectionProvider.java
@@ -21,7 +21,6 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.service.UnknownUnwrapTypeException;
 import org.hibernate.service.spi.Configurable;

--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
@@ -39,7 +39,6 @@ import org.hibernate.boot.spi.MetadataBuilderFactory;
 import org.hibernate.boot.spi.XmlMappingBinderAccess;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.SerializationException;
 import org.w3c.dom.Document;
@@ -161,7 +160,7 @@ public class MetadataSources implements Serializable {
 		if ( activeFactoryNames != null && activeFactoryNames.size() > 1 ) {
 			throw new HibernateException(
 					"Multiple active MetadataBuilder definitions were discovered : " +
-							StringHelper.join( ", ", activeFactoryNames )
+							String.join(", ", activeFactoryNames)
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -38,7 +38,6 @@ import org.hibernate.engine.spi.NamedSQLQueryDefinition;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.id.factory.spi.MutableIdentifierGeneratorFactory;
 import org.hibernate.internal.SessionFactoryImpl;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.FetchProfile;
 import org.hibernate.mapping.MappedSuperclass;
@@ -154,7 +153,7 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 		if ( activeFactoryNames != null && activeFactoryNames.size() > 1 ) {
 			throw new HibernateException(
 					"Multiple active SessionFactoryBuilderFactory definitions were discovered : " +
-							StringHelper.join( ", ", activeFactoryNames )
+							String.join(", ", activeFactoryNames)
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/criterion/BetweenExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/BetweenExpression.java
@@ -31,7 +31,7 @@ public class BetweenExpression implements Criterion {
 	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
 		final String[] columns = criteriaQuery.findColumns( propertyName, criteria );
 		final String[] expressions = StringHelper.suffix( columns, " between ? and ?" );
-		return StringHelper.join( " and ", expressions );
+		return String.join( " and ", expressions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/criterion/IdentifierEqExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/IdentifierEqExpression.java
@@ -33,7 +33,7 @@ public class IdentifierEqExpression implements Criterion {
 	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) {
 		final String[] columns = criteriaQuery.getIdentifierColumns( criteria );
 
-		String result = StringHelper.join( " and ", StringHelper.suffix( columns, " = ?" ) );
+		String result = String.join( " and ", StringHelper.suffix( columns, " = ?" ) );
 		if ( columns.length > 1) {
 			result = '(' + result + ')';
 		}

--- a/hibernate-core/src/main/java/org/hibernate/criterion/IdentifierProjection.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/IdentifierProjection.java
@@ -7,7 +7,6 @@
 package org.hibernate.criterion;
 
 import org.hibernate.Criteria;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.type.Type;
 
 /**
@@ -67,7 +66,7 @@ public class IdentifierProjection extends SimpleProjection {
 			return super.toGroupSqlString( criteria, criteriaQuery );
 		}
 		else {
-			return StringHelper.join( ", ", criteriaQuery.getIdentifierColumns( criteria ) );
+			return String.join( ", ", criteriaQuery.getIdentifierColumns( criteria ) );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/criterion/InExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/InExpression.java
@@ -49,14 +49,14 @@ public class InExpression implements Criterion {
 			final String params = values.length > 0
 					? StringHelper.repeat( singleValueParam + ", ", values.length - 1 ) + singleValueParam
 					: "";
-			String cols = StringHelper.join( ", ", columns );
+			String cols = String.join( ", ", columns );
 			if ( columns.length > 1 ) {
 				cols = '(' + cols + ')';
 			}
 			return cols + " in (" + params + ')';
 		}
 		else {
-			String cols = " ( " + StringHelper.join( " = ? and ", columns ) + "= ? ) ";
+			String cols = " ( " + String.join( " = ? and ", columns ) + "= ? ) ";
 			cols = values.length > 0
 					? StringHelper.repeat( cols + "or ", values.length - 1 ) + cols
 					: "";

--- a/hibernate-core/src/main/java/org/hibernate/criterion/NotNullExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/NotNullExpression.java
@@ -28,7 +28,7 @@ public class NotNullExpression implements Criterion {
 	@Override
 	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
 		final String[] columns = criteriaQuery.findColumns( propertyName, criteria );
-		String result = StringHelper.join(
+		String result = String.join(
 				" or ",
 				StringHelper.suffix( columns, " is not null" )
 		);

--- a/hibernate-core/src/main/java/org/hibernate/criterion/NullExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/NullExpression.java
@@ -34,7 +34,7 @@ public class NullExpression implements Criterion {
 	@Override
 	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
 		final String[] columns = criteriaQuery.findColumns( propertyName, criteria );
-		String result = StringHelper.join(
+		String result = String.join(
 				" and ",
 				StringHelper.suffix( columns, " is null" )
 		);

--- a/hibernate-core/src/main/java/org/hibernate/criterion/PropertiesSubqueryExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/PropertiesSubqueryExpression.java
@@ -7,7 +7,6 @@
 package org.hibernate.criterion;
 
 import org.hibernate.Criteria;
-import org.hibernate.internal.util.StringHelper;
 
 /**
  * A comparison between several properties value in the outer query and the result of a multicolumn subquery.
@@ -29,7 +28,7 @@ public class PropertiesSubqueryExpression extends SubqueryExpression {
 		for ( int i = 0; i < sqlColumnNames.length; ++i ) {
 			sqlColumnNames[i] = outerQuery.getColumn( criteria, propertyNames[i] );
 		}
-		left.append( StringHelper.join( ", ", sqlColumnNames ) );
+		left.append( String.join( ", ", sqlColumnNames ) );
 		return left.append( ")" ).toString();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/criterion/PropertyExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/PropertyExpression.java
@@ -40,7 +40,7 @@ public class PropertyExpression implements Criterion {
 
 		final String[] comparisons = StringHelper.add( lhsColumns, getOp(), rhsColumns );
 		if ( comparisons.length > 1 ) {
-			return '(' + StringHelper.join( " and ", comparisons ) + ')';
+			return '(' + String.join( " and ", comparisons ) + ')';
 		}
 		else {
 			return comparisons[0];

--- a/hibernate-core/src/main/java/org/hibernate/criterion/PropertyProjection.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/PropertyProjection.java
@@ -7,7 +7,6 @@
 package org.hibernate.criterion;
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.type.Type;
 
 /**
@@ -65,7 +64,7 @@ public class PropertyProjection extends SimpleProjection {
 			return super.toGroupSqlString( criteria, criteriaQuery );
 		}
 		else {
-			return StringHelper.join( ", ", criteriaQuery.getColumns( propertyName, criteria ) );
+			return String.join( ", ", criteriaQuery.getColumns( propertyName, criteria ) );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -75,7 +75,6 @@ import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
@@ -1457,7 +1456,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getQueryHintString(String query, List<String> hints) {
-		return query + " with hint (" + StringHelper.join( ",", hints ) + ")";
+		return query + " with hint (" + String.join( ",", hints ) + ")";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -41,7 +41,6 @@ import org.hibernate.hql.spi.id.IdTableSupportStandardImpl;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.local.AfterUseAction;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.persister.entity.Lockable;
 import org.hibernate.sql.CacheJoinFragment;
 import org.hibernate.sql.JoinFragment;
@@ -398,11 +397,11 @@ public class Cache71Dialect extends Dialect {
 				.append( " FOREIGN KEY " )
 				.append( constraintName )
 				.append( " (" )
-				.append( StringHelper.join( ", ", foreignKey ) )
+				.append( String.join( ", ", foreignKey ) )
 				.append( ") REFERENCES " )
 				.append( referencedTable )
 				.append( " (" )
-				.append( StringHelper.join( ", ", primaryKey ) )
+				.append( String.join( ", ", primaryKey ) )
 				.append( ") " )
 				.toString();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2130,13 +2130,13 @@ public abstract class Dialect implements ConversionContext {
 		res.append( " add constraint " )
 				.append( quote( constraintName ) )
 				.append( " foreign key (" )
-				.append( StringHelper.join( ", ", foreignKey ) )
+				.append( String.join( ", ", foreignKey ) )
 				.append( ") references " )
 				.append( referencedTable );
 
 		if ( !referencesPrimaryKey ) {
 			res.append( " (" )
-					.append( StringHelper.join( ", ", primaryKey ) )
+					.append( String.join( ", ", primaryKey ) )
 					.append( ')' );
 		}
 
@@ -2797,7 +2797,7 @@ public abstract class Dialect implements ConversionContext {
 	 * @return The modified SQL
 	 */
 	public String getQueryHintString(String query, List<String> hintList) {
-		final String hints = StringHelper.join( ", ", hintList.iterator() );
+		final String hints = String.join( ", ", hintList );
 
 		if ( StringHelper.isEmpty( hints ) ) {
 			return query;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -28,7 +28,6 @@ import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.local.AfterUseAction;
 import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.type.StandardBasicTypes;
 
 /**
@@ -106,13 +105,13 @@ public class InformixDialect extends Dialect {
 		final StringBuilder result = new StringBuilder( 30 )
 				.append( " add constraint " )
 				.append( " foreign key (" )
-				.append( StringHelper.join( ", ", foreignKey ) )
+				.append( String.join( ", ", foreignKey ) )
 				.append( ") references " )
 				.append( referencedTable );
 
 		if ( !referencesPrimaryKey ) {
 			result.append( " (" )
-					.append( StringHelper.join( ", ", primaryKey ) )
+					.append( String.join( ", ", primaryKey ) )
 					.append( ')' );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -33,7 +33,6 @@ import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.local.AfterUseAction;
 import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.type.StandardBasicTypes;
 
@@ -248,8 +247,8 @@ public class MySQLDialect extends Dialect {
 			String referencedTable,
 			String[] primaryKey,
 			boolean referencesPrimaryKey) {
-		final String cols = StringHelper.join( ", ", foreignKey );
-		final String referencedCols = StringHelper.join( ", ", primaryKey );
+		final String cols = String.join( ", ", foreignKey );
+		final String referencedCols = String.join( ", ", primaryKey );
 		return String.format(
 				" add constraint %s foreign key (%s) references %s (%s)",
 				constraintName,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -17,7 +17,6 @@ import java.util.regex.Pattern;
 
 import org.hibernate.JDBCException;
 import org.hibernate.QueryTimeoutException;
-import org.hibernate.annotations.common.util.StringHelper;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.NoArgSQLFunction;
 import org.hibernate.dialect.function.NvlFunction;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
@@ -17,7 +17,6 @@ import org.hibernate.hql.spi.id.IdTableSupportStandardImpl;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.local.AfterUseAction;
 import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.sql.CaseFragment;
 import org.hibernate.sql.DecodeCaseFragment;
 import org.hibernate.type.StandardBasicTypes;
@@ -148,13 +147,13 @@ public class SAPDBDialect extends Dialect {
 				.append( " foreign key " )
 				.append( constraintName )
 				.append( " (" )
-				.append( StringHelper.join( ", ", foreignKey ) )
+				.append( String.join( ", ", foreignKey ) )
 				.append( ") references " )
 				.append( referencedTable );
 
 		if ( !referencesPrimaryKey ) {
 			res.append( " (" )
-					.append( StringHelper.join( ", ", primaryKey ) )
+					.append( String.join( ", ", primaryKey ) )
 					.append( ')' );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.SQLServer2012LimitHandler;
-import org.hibernate.internal.util.StringHelper;
 
 /**
  * Microsoft SQL Server 2012 Dialect

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -221,7 +221,7 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 		}
 
 		// In case of '*' or '{table}.*' expressions adding an alias breaks SQL syntax, returning '*'.
-		return selectsMultipleColumns ? "*" : StringHelper.join( ", ", aliases.iterator() );
+		return selectsMultipleColumns ? "*" : String.join( ", ", aliases );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
@@ -177,7 +177,7 @@ public class SubselectFetch {
 				? StringHelper.qualify( alias, loadable.getIdentifierColumnNames() )
 				: ( (PropertyMapping) loadable ).toColumns( alias, ukname );
 
-		return "select " + StringHelper.join( ", ", joinColumns ) + queryString;
+		return "select " + String.join( ", ", joinColumns ) + queryString;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/CollectionSubqueryFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/CollectionSubqueryFactory.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import org.hibernate.MappingException;
 import org.hibernate.QueryException;
 import org.hibernate.engine.internal.JoinSequence;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.sql.JoinFragment;
 
 /**
@@ -31,7 +30,7 @@ public final class CollectionSubqueryFactory {
 			String[] columns) {
 		try {
 			JoinFragment join = joinSequence.toJoinFragment( enabledFilters, true );
-			return "select " + StringHelper.join( ", ", columns )
+			return "select " + String.join( ", ", columns )
 					+ " from " + join.toFromFragmentString().substring( 2 )
 					+ " where " + join.toWhereFragmentString().substring( 5 );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/QueryTranslatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/QueryTranslatorImpl.java
@@ -551,7 +551,7 @@ public class QueryTranslatorImpl implements FilterTranslator {
 		if ( primaryOrdering != null ) {
 			// TODO : this is a bit dodgy, come up with a better way to check this (plus see above comment)
 			String [] idColNames = owner.getQueryable().getIdentifierColumnNames();
-			String expectedPrimaryOrderSeq = StringHelper.join(
+			String expectedPrimaryOrderSeq = String.join(
 					", ",
 					StringHelper.qualify( owner.getTableAlias(), idColNames )
 			);

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/exec/DeleteExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/exec/DeleteExecutor.java
@@ -17,7 +17,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.hql.internal.ast.HqlSqlWalker;
 import org.hibernate.hql.internal.ast.SqlGenerator;
 import org.hibernate.hql.internal.ast.tree.DeleteStatement;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.collection.AbstractCollectionPersister;
 import org.hibernate.persister.entity.Queryable;
@@ -81,9 +80,9 @@ public class DeleteExecutor extends BasicExecutor {
 						}
 						else {
 							final String idSubselect = "(select "
-									+ StringHelper.join( ", ", persister.getIdentifierColumnNames() ) + " from "
+									+ String.join( ", ", persister.getIdentifierColumnNames() ) + " from "
 									+ persister.getTableName() + idSubselectWhere + ")";
-							final String where = "(" + StringHelper.join( ", ", cPersister.getKeyColumnNames() )
+							final String where = "(" + String.join( ", ", cPersister.getKeyColumnNames() )
 									+ ") in " + idSubselect;
 							final Delete delete = new Delete().setTableName( cPersister.getTableName() ).setWhere( where );
 							if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/AbstractMapComponentNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/AbstractMapComponentNode.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import org.hibernate.hql.internal.antlr.HqlSqlTokenTypes;
 import org.hibernate.hql.internal.ast.util.ColumnHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.persister.collection.QueryableCollection;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
@@ -90,7 +89,7 @@ public abstract class AbstractMapComponentNode extends FromReferenceNode impleme
 	}
 
 	private void initText(String[] columns) {
-		String text = StringHelper.join( ", ", columns );
+		String text = String.join( ", ", columns );
 		if ( columns.length > 1 && getWalker().isComparativeExpressionClause() ) {
 			text = "(" + text + ")";
 		}

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ConstructorNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ConstructorNode.java
@@ -191,7 +191,7 @@ public class ConstructorNode extends SelectExpressionList implements AggregatedS
 					? ( (PrimitiveType) constructorArgumentTypes[j] ).getPrimitiveClass().getName()
 					: constructorArgumentTypes[j].getReturnedClass().getName();
 		}
-		String formattedList = params.length == 0 ? "no arguments constructor" : StringHelper.join( ", ", params );
+		String formattedList = params.length == 0 ? "no arguments constructor" : String.join( ", ", params );
 		return String.format(
 				"Unable to locate appropriate constructor on class [%s]. Expected arguments are: %s",
 				className, formattedList

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
@@ -254,7 +254,7 @@ public class DotNode extends FromReferenceNode implements DisplayableNode, Selec
 
 	private void initText() {
 		String[] cols = getColumns();
-		String text = StringHelper.join( ", ", cols );
+		String text = String.join( ", ", cols );
 		boolean countDistinct = getWalker().isInCountDistinct()
 				&& getWalker().getSessionFactoryHelper().getFactory().getDialect().requiresParensForTupleDistinctCounts();
 		if ( cols.length > 1 &&

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
@@ -23,7 +23,6 @@ import org.hibernate.hql.internal.ast.util.ASTUtil;
 import org.hibernate.hql.spi.QueryTranslator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.param.DynamicFilterParameterSpecification;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.collection.QueryableCollection;
@@ -329,7 +328,7 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 			return cols[0];
 		}
 		else {
-			return "(" + StringHelper.join( ", ", cols ) + ")";
+			return "(" + String.join( ", ", cols ) + ")";
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
@@ -95,7 +95,7 @@ public class IdentNode extends FromReferenceNode implements SelectExpression {
 	}
 	
 	private void initText(String[] columns) {
-		String text = StringHelper.join( ", ", columns );
+		String text = String.join( ", ", columns );
 		if ( columns.length > 1 && getWalker().isComparativeExpressionClause() ) {
 			text = "(" + text + ")";
 		}
@@ -216,7 +216,7 @@ public class IdentNode extends FromReferenceNode implements SelectExpression {
 				setText( columnExpressions[0] );
 			}
 			else {
-				String joinedFragment = StringHelper.join( ", ", columnExpressions );
+				String joinedFragment = String.join( ", ", columnExpressions );
 				// avoid wrapping in parenthesis (explicit tuple treatment) if possible due to varied support for
 				// tuple syntax across databases..
 				final boolean shouldSkipWrappingInParenthesis =
@@ -277,7 +277,7 @@ public class IdentNode extends FromReferenceNode implements SelectExpression {
 		String[] columns = getWalker().isSelectStatement()
 				? persister.toColumns(fromElement.getTableAlias(), property)
 				: persister.toColumns(property);
-		String text = StringHelper.join(", ", columns);
+		String text = String.join(", ", columns);
 		setText(columns.length == 1 ? text : "(" + text + ")");
 		setType(SqlTokenTypes.SQL_TOKEN);
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ResultVariableRefNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ResultVariableRefNode.java
@@ -7,7 +7,6 @@
 package org.hibernate.hql.internal.ast.tree;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.util.StringHelper;
 
 import antlr.SemanticException;
 
@@ -69,6 +68,6 @@ public class ResultVariableRefNode extends HqlSqlWalkerNode {
 	}
 
 	private String getColumnNamesString(int scalarColumnIndex) {
-		return StringHelper.join( ", ", getWalker().getSelectClause().getColumnNames()[scalarColumnIndex] );
+		return String.join( ", ", getWalker().getSelectClause().getColumnNames()[scalarColumnIndex] );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/JoinProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/JoinProcessor.java
@@ -238,7 +238,7 @@ public class JoinProcessor implements SqlTokenTypes {
 				final FilterImpl filter = (FilterImpl) walker.getEnabledFilters().get( parts[0] );
 				final Object value = filter.getParameter( parts[1] );
 				final Type type = filter.getFilterDefinition().getParameterType( parts[1] );
-				final String typeBindFragment = StringHelper.join(
+				final String typeBindFragment = String.join(
 						",",
 						ArrayHelper.fillArray(
 								"?",
@@ -247,7 +247,7 @@ public class JoinProcessor implements SqlTokenTypes {
 				);
 				final String bindFragment;
 				if ( value != null && Collection.class.isInstance( value ) ) {
-					bindFragment = StringHelper.join(
+					bindFragment = String.join(
 							",",
 							ArrayHelper.fillArray( typeBindFragment, ( (Collection) value ).size() )
 					);

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/AbstractTableBasedBulkIdHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/AbstractTableBasedBulkIdHandler.java
@@ -15,7 +15,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.hql.internal.ast.HqlSqlWalker;
 import org.hibernate.hql.internal.ast.SqlGenerator;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.entity.Queryable;
 import org.hibernate.sql.InsertSelect;
@@ -190,7 +189,7 @@ public abstract class AbstractTableBasedBulkIdHandler {
 	}
 
 	protected String generateIdSubselect(Queryable persister, IdTableInfo idTableInfo) {
-		return "select " + StringHelper.join( ", ", persister.getIdentifierColumnNames() ) +
+		return "select " + String.join( ", ", persister.getIdentifierColumnNames() ) +
 				" from " + idTableInfo.getQualifiedIdTableName();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/TableBasedDeleteHandlerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/TableBasedDeleteHandlerImpl.java
@@ -17,7 +17,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.hql.internal.ast.HqlSqlWalker;
 import org.hibernate.hql.internal.ast.tree.DeleteStatement;
 import org.hibernate.hql.internal.ast.tree.FromElement;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.collection.AbstractCollectionPersister;
 import org.hibernate.persister.entity.Queryable;
@@ -88,7 +87,7 @@ public class TableBasedDeleteHandlerImpl
 	private String generateDelete(String tableName, String[] columnNames, String idSubselect, String comment) {
 		final Delete delete = new Delete()
 				.setTableName( tableName )
-				.setWhere( "(" + StringHelper.join( ", ", columnNames ) + ") IN (" + idSubselect + ")" );
+				.setWhere( "(" + String.join( ", ", columnNames ) + ") IN (" + idSubselect + ")" );
 		if ( factory().getSessionFactoryOptions().isCommentsEnabled() ) {
 			delete.setComment( comment );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/TableBasedUpdateHandlerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/TableBasedUpdateHandlerImpl.java
@@ -20,7 +20,6 @@ import org.hibernate.hql.internal.ast.HqlSqlWalker;
 import org.hibernate.hql.internal.ast.tree.AssignmentSpecification;
 import org.hibernate.hql.internal.ast.tree.FromElement;
 import org.hibernate.hql.internal.ast.tree.UpdateStatement;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.entity.Queryable;
 import org.hibernate.sql.Update;
@@ -75,7 +74,7 @@ public class TableBasedUpdateHandlerImpl
 			final List<ParameterSpecification> parameterList = new ArrayList<>();
 			final Update update = new Update( dialect )
 					.setTableName( tableNames[tableIndex] )
-					.setWhere( "(" + StringHelper.join( ", ", columnNames[tableIndex] ) + ") IN (" + idSubselect + ")" );
+					.setWhere( "(" + String.join( ", ", columnNames[tableIndex] ) + ") IN (" + idSubselect + ")" );
 			if ( factory().getSessionFactoryOptions().isCommentsEnabled() ) {
 				update.setComment( "bulk update" );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -39,23 +39,6 @@ public final class StringHelper {
 		return string.length() - 1;
 	}
 
-	public static String join(String seperator, String[] strings) {
-		int length = strings.length;
-		if ( length == 0 ) {
-			return "";
-		}
-		// Allocate space for length * firstStringLength;
-		// If strings[0] is null, then its length is defined as 4, since that's the
-		// length of "null".
-		final int firstStringLength = strings[0] != null ? strings[0].length() : 4;
-		StringBuilder buf = new StringBuilder( length * firstStringLength )
-				.append( strings[0] );
-		for ( int i = 1; i < length; i++ ) {
-			buf.append( seperator ).append( strings[i] );
-		}
-		return buf.toString();
-	}
-
 	public static String joinWithQualifierAndSuffix(
 			String[] values,
 			String qualifier,
@@ -73,7 +56,7 @@ public final class StringHelper {
 		return buf.toString();
 	}
 
-	public static String join(String seperator, Iterator objects) {
+	public static String join(String seperator, Iterator<?> objects) {
 		StringBuilder buf = new StringBuilder();
 		if ( objects.hasNext() ) {
 			buf.append( objects.next() );
@@ -82,10 +65,6 @@ public final class StringHelper {
 			buf.append( seperator ).append( objects.next() );
 		}
 		return buf.toString();
-	}
-
-	public static String join(String separator, Iterable objects) {
-		return join( separator, objects.iterator() );
 	}
 
 	public static String[] add(String[] x, String sep, String[] y) {
@@ -838,18 +817,9 @@ public final class StringHelper {
 
 	public static <T> String join(Collection<T> values, Renderer<T> renderer) {
 		final StringBuilder buffer = new StringBuilder();
-		boolean firstPass = true;
 		for ( T value : values ) {
-			if ( firstPass ) {
-				firstPass = false;
-			}
-			else {
-				buffer.append( ", " );
-			}
-
-			buffer.append( renderer.render( value ) );
+			buffer.append( String.join(", ", renderer.render( value )) );
 		}
-
 		return buffer.toString();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -82,7 +82,7 @@ public final class ConfigurationHelper {
 		if ( !defaultValue.equals( value ) && ArrayHelper.indexOf( otherSupportedValues, value ) == -1 ) {
 			throw new ConfigurationException(
 					"Unsupported configuration [name=" + name + ", value=" + value + "]. " +
-							"Choose value between: '" + defaultValue + "', '" + StringHelper.join( "', '", otherSupportedValues ) + "'."
+							"Choose value between: '" + defaultValue + "', '" + String.join( "', '", otherSupportedValues ) + "'."
 			);
 		}
 		return value;

--- a/hibernate-core/src/main/java/org/hibernate/loader/GeneratedCollectionAliases.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/GeneratedCollectionAliases.java
@@ -9,7 +9,6 @@ package org.hibernate.loader;
 import java.util.Collections;
 import java.util.Map;
 
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.persister.collection.CollectionPersister;
 
 /**
@@ -116,7 +115,7 @@ public class GeneratedCollectionAliases implements CollectionAliases {
 			return null;
 		}
 
-		return StringHelper.join( ", ", aliases );
+		return String.join( ", ", aliases );
 	}
 
 	private String[] getUserProvidedAliases(String propertyPath, String[] defaultAliases) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/CollectionJoinWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/CollectionJoinWalker.java
@@ -32,7 +32,7 @@ public abstract class CollectionJoinWalker extends JoinWalker {
 			if (columnNames.length>1) {
 				buf.append('(');
 			}
-			buf.append( StringHelper.join(", ", StringHelper.qualify(alias, columnNames) ) );
+			buf.append( String.join(", ", StringHelper.qualify(alias, columnNames) ) );
 			if (columnNames.length>1) {
 				buf.append(')');
 			}

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/ColumnCollectionAliases.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/ColumnCollectionAliases.java
@@ -8,7 +8,6 @@ package org.hibernate.loader.custom;
 
 import java.util.Map;
 
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.loader.CollectionAliases;
 import org.hibernate.persister.collection.SQLLoadableCollection;
 
@@ -111,7 +110,7 @@ public class ColumnCollectionAliases implements CollectionAliases {
 			return null;
 		}
 
-		return StringHelper.join( ", ", aliases );
+		return String.join( ", ", aliases );
 	}
 
 	private String[] getUserProvidedAliases(String propertyPath, String[] defaultAliases) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/spi/QuerySpaceTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/spi/QuerySpaceTreePrinter.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.loader.EntityAliases;
 import org.hibernate.loader.plan.exec.spi.AliasResolutionContext;
 import org.hibernate.loader.plan.exec.spi.CollectionReferenceAliases;
@@ -180,7 +179,7 @@ public class QuerySpaceTreePrinter {
 			printWriter.println(
 					TreePrinterHelper.INSTANCE.generateNodePrefix( depth + detailDepthOffset )
 							+ "suffixed key columns - {"
-							+ StringHelper.join( ", ", entityAliases.getColumnAliases().getSuffixedKeyAliases() )
+							+ String.join( ", ", entityAliases.getColumnAliases().getSuffixedKeyAliases() )
 							+ "}"
 			);
 		}
@@ -193,7 +192,7 @@ public class QuerySpaceTreePrinter {
 			printWriter.println(
 					TreePrinterHelper.INSTANCE.generateNodePrefix( depth + detailDepthOffset )
 							+ "suffixed key columns - {"
-							+ StringHelper.join( ", ", collectionReferenceAliases.getCollectionColumnAliases().getSuffixedKeyAliases() )
+							+ String.join( ", ", collectionReferenceAliases.getCollectionColumnAliases().getSuffixedKeyAliases() )
 							+ "}"
 			);
 			final EntityAliases elementAliases =
@@ -209,7 +208,7 @@ public class QuerySpaceTreePrinter {
 						TreePrinterHelper.INSTANCE.generateNodePrefix( depth + detailDepthOffset )
 								+ elementAliases.getSuffix()
 								+ "entity-element suffixed key columns - "
-								+ StringHelper.join( ", ", elementAliases.getSuffixedKeyAliases() )
+								+ String.join( ", ", elementAliases.getSuffixedKeyAliases() )
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AliasResolutionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AliasResolutionContextImpl.java
@@ -346,7 +346,7 @@ public class AliasResolutionContextImpl implements AliasResolutionContext {
 			printWriter.println(
 					TreePrinterHelper.INSTANCE.generateNodePrefix( depth+3 )
 							+ "suffixed key columns - "
-							+ StringHelper.join( ", ", entityAliases.getColumnAliases().getSuffixedKeyAliases() )
+							+ String.join( ", ", entityAliases.getColumnAliases().getSuffixedKeyAliases() )
 			);
 		}
 
@@ -358,7 +358,7 @@ public class AliasResolutionContextImpl implements AliasResolutionContext {
 			printWriter.println(
 					TreePrinterHelper.INSTANCE.generateNodePrefix( depth+3 )
 							+ "suffixed key columns - "
-							+ StringHelper.join( ", ", collectionReferenceAliases.getCollectionColumnAliases().getSuffixedKeyAliases() )
+							+ String.join( ", ", collectionReferenceAliases.getCollectionColumnAliases().getSuffixedKeyAliases() )
 			);
 			final EntityReferenceAliases elementAliases = collectionReferenceAliases.getEntityElementAliases();
 			if ( elementAliases != null ) {
@@ -370,7 +370,7 @@ public class AliasResolutionContextImpl implements AliasResolutionContext {
 						TreePrinterHelper.INSTANCE.generateNodePrefix( depth+3 )
 								+ elementAliases.getColumnAliases().getSuffix()
 								+ "entity-element suffixed key columns - "
-								+ StringHelper.join( ", ", elementAliases.getColumnAliases().getSuffixedKeyAliases() )
+								+ String.join( ", ", elementAliases.getColumnAliases().getSuffixedKeyAliases() )
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -27,7 +27,6 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter;
 import org.hibernate.engine.spi.Mapping;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.tool.hbm2ddl.ColumnMetadata;
 import org.hibernate.tool.hbm2ddl.TableMetadata;
 import org.hibernate.tool.schema.extract.spi.ColumnInformation;
@@ -901,9 +900,9 @@ public class Table implements RelationalModel, Serializable, Exportable {
 		@Override
 		public String toString() {
 			return "ForeignKeyKey{" +
-					"columns=" + StringHelper.join( ",", columns ) +
+					"columns=" + String.join( ",", columns ) +
 					", referencedClassName='" + referencedClassName + '\'' +
-					", referencedColumns=" + StringHelper.join( ",", referencedColumns ) +
+					", referencedColumns=" + String.join( ",", referencedColumns ) +
 					'}';
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1642,7 +1642,7 @@ public abstract class AbstractEntityPersister
 				fromJoinFragment( getRootAlias(), true, false );
 
 		String whereClause = new StringBuilder()
-				.append( StringHelper.join( "=? and ", aliasedIdColumns ) )
+				.append( String.join( "=? and ", aliasedIdColumns ) )
 				.append( "=?" )
 				.append( whereJoinFragment( getRootAlias(), true, false ) )
 				.toString();
@@ -1701,7 +1701,7 @@ public abstract class AbstractEntityPersister
 		}
 
 		String[] aliasedIdColumns = StringHelper.qualify( getRootAlias(), getIdentifierColumnNames() );
-		String selectClause = StringHelper.join( ", ", aliasedIdColumns ) +
+		String selectClause = String.join( ", ", aliasedIdColumns ) +
 				concretePropertySelectFragment( getRootAlias(), getPropertyUpdateability() );
 
 		String fromClause = fromTableFragment( getRootAlias() ) +
@@ -1709,7 +1709,7 @@ public abstract class AbstractEntityPersister
 
 		String whereClause = new StringBuilder()
 				.append(
-						StringHelper.join(
+						String.join(
 								"=? and ",
 								aliasedIdColumns
 						)
@@ -3927,7 +3927,7 @@ public abstract class AbstractEntityPersister
 
 	protected String createWhereByKey(int tableNumber, String alias) {
 		//TODO: move to .sql package, and refactor with similar things!
-		return StringHelper.join(
+		return String.join(
 				"=? and ",
 				StringHelper.qualify( alias, getSubclassTableKeyColumns( tableNumber ) )
 		) + "=?";
@@ -5084,7 +5084,7 @@ public abstract class AbstractEntityPersister
 		String[] aliasedIdColumns = StringHelper.qualify( getRootAlias(), getIdentifierColumnNames() );
 		String whereClause = new StringBuilder()
 				.append(
-						StringHelper.join(
+						String.join(
 								"=? and ",
 								aliasedIdColumns
 						)
@@ -5295,10 +5295,10 @@ public abstract class AbstractEntityPersister
 			final String[] aliasedPropertyColumns = StringHelper.qualify( tableAlias, propertyColumnNames );
 
 			if ( valueNullness != null && valueNullness[valuesIndex] ) {
-				whereClause.append( StringHelper.join( " is null and ", aliasedPropertyColumns ) ).append( " is null" );
+				whereClause.append( String.join( " is null and ", aliasedPropertyColumns ) ).append( " is null" );
 			}
 			else {
-				whereClause.append( StringHelper.join( "=? and ", aliasedPropertyColumns ) ).append( "=?" );
+				whereClause.append( String.join( "=? and ", aliasedPropertyColumns ) ).append( "=?" );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/AssociationKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/AssociationKey.java
@@ -8,7 +8,6 @@ package org.hibernate.persister.walking.spi;
 
 import java.util.Arrays;
 
-import org.hibernate.internal.util.StringHelper;
 
 /**
  * Used to uniquely identify a foreign key, so that we don't join it more than once creating circularities.  Note
@@ -63,7 +62,7 @@ public class AssociationKey {
 	@Override
 	public String toString() {
 		if ( str == null ) {
-			str = "AssociationKey(table=" + table + ", columns={" + StringHelper.join( ",", columns ) + "})";
+			str = "AssociationKey(table=" + table + ", columns={" + String.join( ",", columns ) + "})";
 		}
 		return str;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+
 import javax.persistence.Parameter;
 
 import org.hibernate.QueryException;
@@ -64,7 +65,7 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 									"Unexpected gap in ordinal parameter labels [%s -> %s] : [%s]",
 									lastPosition,
 									sortedPosition,
-									StringHelper.join( ",", sortedPositions )
+									StringHelper.join( ",", sortedPositions.iterator() )
 							)
 					);
 				}
@@ -143,7 +144,7 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 							Locale.ROOT,
 							"Could not locate ordinal parameter [%s], expecting one of [%s]",
 							position,
-							StringHelper.join( ", ", ordinalDescriptorMap.keySet() )
+							StringHelper.join( ", ", ordinalDescriptorMap.keySet().iterator())
 					)
 			);
 		}
@@ -218,7 +219,7 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 							Locale.ROOT,
 							"Could not locate named parameter [%s], expecting one of [%s]",
 							name,
-							StringHelper.join( ", ", namedDescriptorMap.keySet() )
+							String.join( ", ", namedDescriptorMap.keySet() )
 					)
 			);
 		}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/BaseEntityManagerFunctionalTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/BaseEntityManagerFunctionalTestCase.java
@@ -24,7 +24,6 @@ import org.hibernate.bytecode.enhance.spi.EnhancementContext;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.hibernate.jpa.boot.spi.Bootstrap;
@@ -196,7 +195,7 @@ public abstract class BaseEntityManagerFunctionalTestCase extends BaseUnitTestCa
 	protected void addMappings(Map settings) {
 		String[] mappings = getMappings();
 		if ( mappings != null ) {
-			settings.put( AvailableSettings.HBXML_FILES, StringHelper.join( ",", mappings ) );
+			settings.put( AvailableSettings.HBXML_FILES, String.join( ",", mappings ) );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/generics/ParameterizedAttributeConverterParameterTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/generics/ParameterizedAttributeConverterParameterTypeTest.java
@@ -9,6 +9,7 @@ package org.hibernate.test.converter.generics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 import javax.persistence.Entity;
@@ -126,7 +127,7 @@ public class ParameterizedAttributeConverterParameterTypeTest extends BaseUnitTe
 				return null;
 			}
 			else {
-				return StringHelper.join( ", ", attribute );
+				return StringHelper.join( ", ", attribute.iterator() );
 			}
 		}
 
@@ -160,7 +161,7 @@ public class ParameterizedAttributeConverterParameterTypeTest extends BaseUnitTe
 				return null;
 			}
 			else {
-				return StringHelper.join( ", ", attribute );
+				return String.join( ", ", attribute );
 			}
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/plans/LoadPlanStructureAssertionHelper.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/plans/LoadPlanStructureAssertionHelper.java
@@ -10,7 +10,6 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.loader.JoinWalker;
 import org.hibernate.loader.entity.EntityJoinWalker;
 import org.hibernate.loader.plan.build.internal.FetchStyleLoadPlanBuildingAssociationVisitationStrategy;
@@ -104,8 +103,8 @@ public class LoadPlanStructureAssertionHelper {
 		System.out.println( "----------------------------------------------------------------------------" );
 		System.out.println( );
 		System.out.println( "------ SUFFIXES ------------------------------------------------------------" );
-		System.out.println( "WALKER    : " + StringHelper.join( ", ",  walker.getSuffixes() ) + " : "
-									+ StringHelper.join( ", ", walker.getCollectionSuffixes() ) );
+		System.out.println( "WALKER    : " + String.join( ", ",  walker.getSuffixes() ) + " : "
+									+ String.join( ", ", walker.getCollectionSuffixes() ) );
 		System.out.println( "----------------------------------------------------------------------------" );
 		System.out.println( );
 	}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/BaseEnversJPAFunctionalTestCase.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/BaseEnversJPAFunctionalTestCase.java
@@ -148,7 +148,7 @@ public abstract class BaseEnversJPAFunctionalTestCase extends AbstractEnversTest
 	protected void addMappings(Map settings) {
 		String[] mappings = getMappings();
 		if ( mappings != null ) {
-			settings.put( AvailableSettings.HBXML_FILES, StringHelper.join( ",", mappings ) );
+			settings.put( AvailableSettings.HBXML_FILES, String.join( ",", mappings ) );
 		}
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/JdbcMocks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/JdbcMocks.java
@@ -37,7 +37,7 @@ public class JdbcMocks {
 		private boolean supportsBatchUpdates = true;
 		private boolean dataDefinitionIgnoredInTransactions = false;
 		private boolean dataDefinitionCausesTransactionCommit = false;
-		private String sqlKeywords = StringHelper.join( ",", AnsiSqlKeywords.INSTANCE.sql2003() );
+		private String sqlKeywords = String.join( ",", AnsiSqlKeywords.INSTANCE.sql2003() );
 		private int sqlStateType = DatabaseMetaData.sqlStateXOpen;
 		private boolean locatorsUpdateCopy = false;
 		private boolean storesLowerCaseIdentifiers = true;


### PR DESCRIPTION
This pull request replaces a couple of `StringHelper#join` methods and its occurrences by Java 8's `String#join`.

As I mentioned in the JIRA ticket, this is a left-over after I submitted another pull request. I had noted this class methods, and noticed at least the join could be replaced.

Had to use streams in three places to convert from `Integer` to `String`.

Not a problem if it is decided not to touch this method for being in core module, or because it just works :-) Otherwise, let me know if further testing, syntax, formatting, etc, is necessary. Happy to update the ticket with new commits, squash, rebase, etc.

Cheers
Bruno