### PR TITLE
HHH-12332 Fix for NPE in AbstractPropertyMapping.getSuperCollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
@@ -135,6 +135,11 @@ public class ExportableColumn extends Column {
 		}
 
 		@Override
+		public boolean isSame(Value value) {
+			return false;
+		}
+
+		@Override
 		public ServiceRegistry getServiceRegistry() {
 			return database.getBuildingOptions().getServiceRegistry();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Any.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Any.java
@@ -7,6 +7,7 @@
 package org.hibernate.mapping;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -68,5 +69,17 @@ public class Any extends SimpleValue {
 
 	public Object accept(ValueVisitor visitor) {
 		return visitor.accept(this);
+	}
+
+	@Override
+	public boolean isSame(SimpleValue other) {
+		return other instanceof Any && isSame( (Any) other );
+	}
+
+	public boolean isSame(Any other) {
+		return super.isSame( other )
+				&& Objects.equals( identifierTypeName, other.identifierTypeName )
+				&& Objects.equals( metaTypeName, other.metaTypeName )
+				&& Objects.equals( metaValues, other.metaValues );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.Objects;
 
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
@@ -402,6 +403,27 @@ public abstract class Collection implements Fetchable, Value, Filterable {
 
 	public boolean isValid(Mapping mapping) throws MappingException {
 		return true;
+	}
+
+	@Override
+	public boolean isSame(Value other) {
+		return this == other || other instanceof Collection && isSame( (Collection) other );
+	}
+
+	protected static boolean isSame(Value v1, Value v2) {
+		return v1 == v2 || v1 != null && v2 != null && v1.isSame( v2 );
+	}
+
+	public boolean isSame(Collection other) {
+		return this == other || isSame( key, other.key )
+				&& isSame( element, other.element )
+				&& Objects.equals( collectionTable, other.collectionTable )
+				&& Objects.equals( where, other.where )
+				&& Objects.equals( manyToManyWhere, other.manyToManyWhere )
+				&& Objects.equals( referencedPropertyName, other.referencedPropertyName )
+				&& Objects.equals( mappedByProperty, other.mappedByProperty )
+				&& Objects.equals( typeName, other.typeName )
+				&& Objects.equals( typeParameters, other.typeParameters );
 	}
 
 	private void createForeignKeys() throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Map;
 
 import org.hibernate.EntityMode;
@@ -194,6 +195,20 @@ public class Component extends SimpleValue implements MetaAttributable {
 	@Override
 	public Object accept(ValueVisitor visitor) {
 		return visitor.accept(this);
+	}
+
+	@Override
+	public boolean isSame(SimpleValue other) {
+		return other instanceof Component && isSame( (Component) other );
+	}
+
+	public boolean isSame(Component other) {
+		return super.isSame( other )
+				&& Objects.equals( properties, other.properties )
+				&& Objects.equals( componentClassName, other.componentClassName )
+				&& embedded == other.embedded
+				&& Objects.equals( parentProperty, other.parentProperty )
+				&& Objects.equals( metaAttributes, other.metaAttributes );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DependantValue.java
@@ -53,4 +53,15 @@ public class DependantValue extends SimpleValue {
 	public void setUpdateable(boolean updateable) {
 		this.updateable = updateable;
 	}
+
+	@Override
+	public boolean isSame(SimpleValue other) {
+		return other instanceof DependantValue && isSame( (DependantValue) other );
+	}
+
+	public boolean isSame(DependantValue other) {
+		return super.isSame( other )
+				&& isSame( wrappedValue, other.wrappedValue );
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IdentifierCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IdentifierCollection.java
@@ -33,6 +33,17 @@ public abstract class IdentifierCollection extends Collection {
 		return true;
 	}
 
+	@Override
+	public boolean isSame(Collection other) {
+		return other instanceof IdentifierCollection
+				&& isSame( (IdentifierCollection) other );
+	}
+
+	public boolean isSame(IdentifierCollection other) {
+		return super.isSame( other )
+				&& isSame( identifier, other.identifier );
+	}
+
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
@@ -37,6 +37,17 @@ public abstract class IndexedCollection extends Collection {
 		return true;
 	}
 
+	@Override
+	public boolean isSame(Collection other) {
+		return other instanceof IndexedCollection
+				&& isSame( (IndexedCollection) other );
+	}
+
+	public boolean isSame(IndexedCollection other) {
+		 return super.isSame( other )
+				 && isSame( index, other.index );
+	}
+
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
@@ -44,15 +44,15 @@ public abstract class IndexedCollection extends Collection {
 	}
 
 	public boolean isSame(IndexedCollection other) {
-		 return super.isSame( other )
-				 && isSame( index, other.index );
+		return super.isSame( other )
+				&& isSame( index, other.index );
 	}
 
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );
 			pk.addColumns( getKey().getColumnIterator() );
-			
+
 			// index should be last column listed
 			boolean isFormula = false;
 			Iterator iter = getIndex().getColumnIterator();
@@ -66,7 +66,7 @@ public abstract class IndexedCollection extends Collection {
 				pk.addColumns( getElement().getColumnIterator() );
 			}
 			else {
-				pk.addColumns( getIndex().getColumnIterator() ); 
+				pk.addColumns( getIndex().getColumnIterator() );
 			}
 			getCollectionTable().setPrimaryKey(pk);
 		}
@@ -95,7 +95,7 @@ public abstract class IndexedCollection extends Collection {
 			);
 		}
 	}
-	
+
 	public boolean isList() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -7,6 +7,7 @@
 package org.hibernate.mapping;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
@@ -131,6 +132,16 @@ public class OneToMany implements Value {
 		return visitor.accept( this );
 	}
 
+	@Override
+	public boolean isSame(Value other) {
+		return this == other || other instanceof OneToMany && isSame( (OneToMany) other );
+	}
+
+	public boolean isSame(OneToMany other) {
+		return Objects.equals( referencingTable, other.referencingTable )
+				&& Objects.equals( referencedEntityName, other.referencedEntityName )
+				&& Objects.equals( associatedClass, other.associatedClass );
+	}
 
 	public boolean[] getColumnInsertability() {
 		//TODO: we could just return all false...

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
@@ -8,6 +8,7 @@ package org.hibernate.mapping;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -145,6 +146,20 @@ public class OneToOne extends ToOne {
 
 	public Object accept(ValueVisitor visitor) {
 		return visitor.accept(this);
+	}
+
+	@Override
+	public boolean isSame(ToOne other) {
+		return other instanceof OneToOne && isSame( (OneToOne) other );
+	}
+
+	public boolean isSame(OneToOne other) {
+		return super.isSame( other )
+				&& Objects.equals( foreignKeyType, other.foreignKeyType )
+				&& isSame( identifier, other.identifier )
+				&& Objects.equals( propertyName, other.propertyName )
+				&& Objects.equals( entityName, other.entityName )
+				&& constrained == other.constrained;
 	}
 	
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -446,7 +446,7 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 
 	public Property getRecursiveProperty(String propertyPath) throws MappingException {
 		try {
-			return getRecursiveProperty( propertyPath, getPropertyIterator() );
+			return getRecursiveProperty( propertyPath, getPropertyClosureIterator() );
 		}
 		catch (MappingException e) {
 			throw new MappingException(

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Objects;
 import javax.persistence.AttributeConverter;
 
 import org.hibernate.FetchMode;
@@ -637,6 +638,24 @@ public class SimpleValue implements KeyValue {
 
 		type = sourceValue.type;
 		attributeConverterDescriptor = sourceValue.attributeConverterDescriptor;
+	}
+
+	@Override
+	public boolean isSame(Value other) {
+		return this == other || other instanceof SimpleValue && isSame( (SimpleValue) other );
+	}
+
+	protected static boolean isSame(Value v1, Value v2) {
+		return v1 == v2 || v1 != null && v2 != null && v1.isSame( v2 );
+	}
+
+	public boolean isSame(SimpleValue other) {
+		return Objects.equals( columns, other.columns )
+				&& Objects.equals( typeName, other.typeName )
+				&& Objects.equals( typeParameters, other.typeParameters )
+				&& Objects.equals( table, other.table )
+				&& Objects.equals( foreignKeyName, other.foreignKeyName )
+				&& Objects.equals( foreignKeyDefinition, other.foreignKeyDefinition );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
@@ -14,6 +14,8 @@ import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.type.Type;
 
+import java.util.Objects;
+
 /**
  * A simple-point association (ie. a reference to another entity).
  * @author Gavin King
@@ -75,6 +77,18 @@ public abstract class ToOne extends SimpleValue implements Fetchable {
 	
 	public Object accept(ValueVisitor visitor) {
 		return visitor.accept(this);
+	}
+
+	@Override
+	public boolean isSame(SimpleValue other) {
+		return other instanceof ToOne && isSame( (ToOne) other );
+	}
+
+	public boolean isSame(ToOne other) {
+		return super.isSame( other )
+				&& Objects.equals( referencedPropertyName, other.referencedPropertyName )
+				&& Objects.equals( referencedEntityName, other.referencedEntityName )
+				&& embedded == other.embedded;
 	}
 
 	public boolean isValid(Mapping mapping) throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
@@ -40,6 +40,7 @@ public interface Value extends Serializable {
 	public boolean isValid(Mapping mapping) throws MappingException;
 	public void setTypeUsingReflection(String className, String propertyName) throws MappingException;
 	public Object accept(ValueVisitor visitor);
+	public boolean isSame(Value other);
 
 	ServiceRegistry getServiceRegistry();
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -193,8 +193,17 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 					return;
 				}
 
-				throw new IllegalStateException( "Collection mapping in abstract entity type with a type variable is unsupported! Couldn't add property '"
-						+ path + "' with type: " + type );
+				// When we discover incompatible types, we register "null" as property type to signal that the property is not resolvable on the parent type
+				newType = null;
+				if ( LOG.isTraceEnabled() ) {
+					LOG.tracev(
+							"Skipped adding same named type incompatible property to base type [{0}] for property [{1}], existing type = [{2}], incoming type = [{3}]",
+							getEntityName(),
+							path,
+							existingType,
+							type
+					);
+				}
 			}
 			else if ( type instanceof EntityType ) {
 				EntityType entityType1 = (EntityType) existingType;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -250,6 +250,10 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 		PersistentClass otherClass = metadata.getEntityBinding( entityType2.getAssociatedEntityName() );
 		PersistentClass commonClass = getCommonPersistentClass( thisClass, otherClass );
 
+		if ( commonClass == null ) {
+			return null;
+		}
+
 		// Create a copy of the type but with the common class
 		if ( entityType1 instanceof ManyToOneType ) {
 			ManyToOneType t = (ManyToOneType) entityType1;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -193,7 +193,8 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 					return;
 				}
 
-                throw new IllegalStateException( "Collection mapping in abstract entity type with a type variable is unsupported! Couldn't add property '" + path + "' with type: " + type );
+				throw new IllegalStateException( "Collection mapping in abstract entity type with a type variable is unsupported! Couldn't add property '"
+						+ path + "' with type: " + type );
 			}
 			else if ( type instanceof EntityType ) {
 				EntityType entityType1 = (EntityType) existingType;

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/JoinedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/JoinedInheritanceTest.java
@@ -104,12 +104,16 @@ public class JoinedInheritanceTest extends BaseCoreFunctionalTestCase {
 	public static class EntityA extends BaseEntity {
 		@OneToMany(fetch = FetchType.LAZY)
 		private Set<EntityC> attributes;
+		@ManyToOne(fetch = FetchType.LAZY)
+		private EntityC relation;
 	}
 
 	@Entity(name = "EntityB")
 	public static class EntityB extends BaseEntity {
 		@OneToMany(fetch = FetchType.LAZY)
 		private Set<EntityD> attributes;
+		@ManyToOne(fetch = FetchType.LAZY)
+		private EntityD relation;
 	}
 
 	@Entity(name = "EntityC")

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
@@ -1,0 +1,136 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2014, Red Hat Inc. or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.test.inheritance.discriminator;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.List;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * Originally from https://github.com/mkaletka/hibernate-test-case-templates/commit/2b3c075cacd07474d5565fa3bd5a6d0a48683dc0
+ *
+ * @author Christian Beikov
+ */
+public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				TestEntity.class,
+				GrandParent.class,
+				Parent.class,
+				Child1.class,
+				Child2.class
+		};
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12332")
+	public void testQueryingSingle() {
+		doInHibernate( this::sessionFactory, s -> {
+			s.createQuery( "from TestEntity p" ).getResultList();
+		} );
+	}
+
+	@Entity(name = "GrandParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@DiscriminatorColumn(name = "discriminator")
+	public static abstract class GrandParent implements Serializable {
+		private static final long serialVersionUID = 1L;
+
+        @Id
+        @GeneratedValue
+		private Long id;
+
+		public GrandParent() {
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class Parent extends GrandParent {
+
+		@ManyToMany(mappedBy = "parents")
+		private List<TestEntity> entities;
+
+		public List<TestEntity> getEntities() {
+			return entities;
+		}
+
+		public void setEntities(List<TestEntity> entities) {
+			this.entities = entities;
+		}
+
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+		@ManyToMany
+		private List<GrandParent> parents;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<GrandParent> getParents() {
+			return parents;
+		}
+
+		public void setParents(List<GrandParent> parents) {
+			this.parents = parents;
+		}
+
+	}
+
+	@Entity(name = "Child1")
+	@DiscriminatorValue("CHILD1")
+	public static class Child1 extends Parent {
+	}
+
+	@Entity(name = "Child2")
+	@DiscriminatorValue("CHILD2")
+	public static class Child2 extends Parent {
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
@@ -54,13 +54,14 @@ public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCas
 	@Test
 	@TestForIssue(jiraKey = "HHH-12332")
 	public void testQueryingSingle() {
+		// Make sure that the produced query for th
 		doInHibernate( this::sessionFactory, s -> {
-			s.createQuery( "from TestEntity p" ).getResultList();
+			s.createQuery( "FROM TestEntity e JOIN e.parents p1 JOIN p1.entities JOIN p1.entities2 JOIN e.parents2 p2 JOIN p2.entities JOIN p2.entities2" ).getResultList();
 		} );
 	}
 
 	@Entity(name = "GrandParent")
-	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Inheritance
 	@DiscriminatorColumn(name = "discriminator")
 	public static abstract class GrandParent implements Serializable {
 		private static final long serialVersionUID = 1L;
@@ -68,6 +69,8 @@ public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCas
         @Id
         @GeneratedValue
 		private Long id;
+		@ManyToMany(mappedBy = "parents2")
+		private List<TestEntity> entities2;
 
 		public GrandParent() {
 		}
@@ -78,6 +81,14 @@ public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCas
 
 		public void setId(Long id) {
 			this.id = id;
+		}
+
+		public List<TestEntity> getEntities2() {
+			return entities2;
+		}
+
+		public void setEntities2(List<TestEntity> entities2) {
+			this.entities2 = entities2;
 		}
 	}
 
@@ -105,6 +116,8 @@ public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCas
 		private Long id;
 		@ManyToMany
 		private List<GrandParent> parents;
+		@ManyToMany
+		private List<GrandParent> parents2;
 
 		public Long getId() {
 			return id;
@@ -122,6 +135,13 @@ public class MappedSuperclassExtendsEntityTest extends BaseCoreFunctionalTestCas
 			this.parents = parents;
 		}
 
+		public List<GrandParent> getParents2() {
+			return parents2;
+		}
+
+		public void setParents2(List<GrandParent> parents2) {
+			this.parents2 = parents2;
+		}
 	}
 
 	@Entity(name = "Child1")


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12332

Still running tests locally, but this should do it. Essentially, I compare the element types for "equality" to determine whether a collection was defined with a type variable on an abstract entity base type and if it is, I bail out. I was sketching a proper fix for type variable use with collections as well here: https://github.com/beikov/hibernate-orm/tree/HHH-12332-2

but it's not so easy since there is no `CollectionBinding` for type variable defined collections on abstract entity types.