### PR TITLE
Remove unnecessary equals/hashCode from ManyToMany test case

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/associations/ManyToManyBidirectionalWithLinkEntityTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/associations/ManyToManyBidirectionalWithLinkEntityTest.java
@@ -113,22 +113,6 @@ public class ManyToManyBidirectionalWithLinkEntityTest extends BaseEntityManager
 			personAddress.setAddress( null );
 		}
 
-		@Override
-		public boolean equals(Object o) {
-			if ( this == o ) {
-				return true;
-			}
-			if ( o == null || getClass() != o.getClass() ) {
-				return false;
-			}
-			Person person = (Person) o;
-			return Objects.equals( registrationNumber, person.registrationNumber );
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash( registrationNumber );
-		}
 	}
 
 	@Entity(name = "PersonAddress")
@@ -231,24 +215,6 @@ public class ManyToManyBidirectionalWithLinkEntityTest extends BaseEntityManager
 			return owners;
 		}
 
-		@Override
-		public boolean equals(Object o) {
-			if ( this == o ) {
-				return true;
-			}
-			if ( o == null || getClass() != o.getClass() ) {
-				return false;
-			}
-			Address address = (Address) o;
-			return Objects.equals( street, address.street ) &&
-					Objects.equals( number, address.number ) &&
-					Objects.equals( postalCode, address.postalCode );
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash( street, number, postalCode );
-		}
 	}
 	//end::associations-many-to-many-bidirectional-with-link-entity-example[]
 }


### PR DESCRIPTION
Since the PersonAddress is the only class that is used inside a
collection, only that class needs to implement equals and hashCode.