### PR TITLE
User Guide: fix OrderBy example

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/extras/collections/collections-customizing-ordered-by-sql-clause-fetching-example.sql
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/extras/collections/collections-customizing-ordered-by-sql-clause-fetching-example.sql
@@ -9,4 +9,4 @@ from
 where
     a.person_id = ?
 order by
-    CHAR_LENGTH(a.name) desc
+    CHAR_LENGTH(a.content) desc

--- a/documentation/src/test/java/org/hibernate/userguide/collections/OrderedBySQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/collections/OrderedBySQLTest.java
@@ -81,7 +81,7 @@ public class OrderedBySQLTest extends BaseEntityManagerFunctionalTestCase {
 		private String name;
 
 		@OneToMany(mappedBy = "person", cascade = CascadeType.ALL)
-		@org.hibernate.annotations.OrderBy(clause = "CHAR_LENGTH(name) DESC")
+		@org.hibernate.annotations.OrderBy(clause = "CHAR_LENGTH(content) DESC")
 		private List<Article> articles = new ArrayList<>();
 
 		//Getters and setters are omitted for brevity


### PR DESCRIPTION
Since the relative lengths of the article's name and its content are
the same, this bug could go unnoticed.