### PR TITLE
HHH-12369 Fix for integer overflow in limit handler when using Integer.MAX_VALUE for maxResults on DB2

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/AbstractLimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/AbstractLimitHandler.java
@@ -169,6 +169,13 @@ public abstract class AbstractLimitHandler implements LimitHandler {
 	protected final int getMaxOrLimit(RowSelection selection) {
 		final int firstRow = convertToFirstRowValue( LimitHelper.getFirstRow( selection ) );
 		final int lastRow = selection.getMaxRows();
-		return useMaxForLimit() ? lastRow + firstRow : lastRow;
+		final int maxRows = useMaxForLimit() ? lastRow + firstRow : lastRow;
+		// Use Integer.MAX_VALUE on overflow
+		if ( maxRows < 0 ) {
+			return Integer.MAX_VALUE;
+		}
+		else {
+			return maxRows;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/NoopLimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/NoopLimitHandler.java
@@ -42,7 +42,14 @@ public class NoopLimitHandler extends AbstractLimitHandler {
 	@Override
 	public void setMaxRows(RowSelection selection, PreparedStatement statement) throws SQLException {
 		if ( LimitHelper.hasMaxRows( selection ) ) {
-			statement.setMaxRows( selection.getMaxRows() + convertToFirstRowValue( LimitHelper.getFirstRow( selection ) ) );
+			int maxRows = selection.getMaxRows() + convertToFirstRowValue( LimitHelper.getFirstRow( selection ) );
+			// Use Integer.MAX_VALUE on overflow
+			if ( maxRows < 0 ) {
+				statement.setMaxRows( Integer.MAX_VALUE );
+			}
+			else {
+				statement.setMaxRows( maxRows );
+			}
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/DB2DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/DB2DialectTestCase.java
@@ -8,6 +8,7 @@ package org.hibernate.dialect;
 
 import java.sql.Types;
 
+import org.hibernate.engine.spi.RowSelection;
 import org.junit.Test;
 
 import org.hibernate.mapping.Column;
@@ -15,6 +16,7 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * DB2 dialect related test cases
@@ -61,6 +63,19 @@ public class DB2DialectTestCase extends BaseUnitTestCase {
 				"Wrong binary type. Should be varchar for length > 254",
 				"varchar(255) for bit data",
 				actual
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12369")
+	public void testIntegerOverflowForMaxResults() {
+		RowSelection rowSelection = new RowSelection();
+		rowSelection.setFirstRow(1);
+		rowSelection.setMaxRows(Integer.MAX_VALUE);
+		String sql = dialect.getLimitHandler().processSql( "select a.id from tbl_a a order by a.id", rowSelection );
+		assertTrue(
+				"Integer overflow for max rows in: " + sql,
+				sql.contains("fetch first 2147483647 rows only")
 		);
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12369