### PR TITLE
HHH-12290 Expand ordinal parameters to ordinal parameters in collection parameter expansion

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
@@ -1089,9 +1089,9 @@ public class HqlSqlWalker extends HqlSqlBaseWalker implements ErrorReporter, Par
 	@Override
 	protected AST generatePositionalParameter(AST delimiterNode, AST numberNode) throws SemanticException {
 		// todo : we check this multiple times
-		if ( namedParameters != null ) {
+		if ( getSessionFactoryHelper().isStrictJPAQLComplianceEnabled() && namedParameters != null ) {
 			throw new SemanticException(
-					"Cannot define positional and named parameterSpecs : " + queryTranslatorImpl.getQueryString()
+					"Cannot mix positional and named parameters: " + queryTranslatorImpl.getQueryString()
 			);
 		}
 
@@ -1151,6 +1151,11 @@ public class HqlSqlWalker extends HqlSqlBaseWalker implements ErrorReporter, Par
 
 	@Override
 	protected AST generateNamedParameter(AST delimiterNode, AST nameNode) throws SemanticException {
+		if ( getSessionFactoryHelper().isStrictJPAQLComplianceEnabled() && positionalParameters != null ) {
+			throw new SemanticException(
+					"Cannot mix positional and named parameters: " + queryTranslatorImpl.getQueryString()
+			);
+		}
 		final String name = nameNode.getText();
 		trackNamedParameterPositions( name );
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -216,20 +216,19 @@ public final class StringHelper {
 	 * Used to find the ordinal parameters (e.g. '?1') in a string.
 	 */
 	public static int indexOfIdentifierWord(String str, String word) {
-		if ( str == null || str.length() == 0 || word == null ) {
+		if ( str == null || str.length() == 0 || word == null || word.length() == 0 ) {
 			return -1;
 		}
 
-		int position = 0;
-		while ( position < str.length() ) {
-			position = str.indexOf( word, position );
+		int position = str.indexOf( word );
+		while ( position >= 0 && position < str.length() ) {
 			if (
 					( position == 0 || !Character.isJavaIdentifierPart( str.charAt( position - 1 ) ) ) &&
 					( position + word.length() == str.length() || !Character.isJavaIdentifierPart( str.charAt( position + word.length() ) ) )
 			) {
 				return position;
 			}
-			position = position + 1;
+			position = str.indexOf( word, position + 1 );
 		}
 
 		return -1;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -212,6 +212,29 @@ public final class StringHelper {
 		return buf.toString();
 	}
 
+	/**
+	 * Used to find the ordinal parameters (e.g. '?1') in a string.
+	 */
+	public static int indexOfIdentifierWord(String str, String word) {
+		if ( str == null || str.length() == 0 || word == null ) {
+			return -1;
+		}
+
+		int position = 0;
+		while ( position < str.length() ) {
+			position = str.indexOf( word, position );
+			if (
+					( position == 0 || !Character.isJavaIdentifierPart( str.charAt( position - 1 ) ) ) &&
+					( position + word.length() == str.length() || !Character.isJavaIdentifierPart( str.charAt( position + word.length() ) ) )
+			) {
+				return position;
+			}
+			position = position + 1;
+		}
+
+		return -1;
+	}
+
 	public static char getLastNonWhitespaceCharacter(String str) {
 		if ( str != null && str.length() > 0 ) {
 			for ( int i = str.length() - 1; i >= 0; i-- ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -532,7 +532,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 				sourceToken = "?" + OrdinalParameterDescriptor.class.cast( sourceParam ).getPosition();
 			}
 
-			final int loc = queryString.indexOf( sourceToken );
+			final int loc = StringHelper.indexOfIdentifierWord( queryString, sourceToken );
 
 			if ( loc < 0 ) {
 				continue;

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
@@ -704,15 +704,11 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.close();
 		}
 	}
-	
-	/**
-	 * Collection parameters are internally rewritten to named parameters (one named parameter by
-	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
-	 */
+
 	@Test
 	@TestForIssue(jiraKey = "HHH-12290")
 	public void testParameterCollectionAndPositional() {
-		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item = new Item( "Mouse", "Microsoft mouse" );
 		final Item item2 = new Item( "Computer", "Dell computer" );
 
 		EntityManager em = getOrCreateEntityManager();
@@ -724,10 +720,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.getTransaction().commit();
 
 			em.getTransaction().begin();
-			Query q = em.createQuery( "select item from Item item where item.name in ?1 and descr = ?2" );
-			//test hint in value and string
-			q.setHint( "org.hibernate.fetchSize", 10 );
-			q.setHint( "org.hibernate.fetchSize", "10" );
+			Query q = em.createQuery( "select item from Item item where item.name in ?1 and item.descr = ?2" );
 			List params = new ArrayList();
 			params.add( item.getName() );
 			params.add( item2.getName() );
@@ -747,15 +740,11 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.close();
 		}
 	}
-	
-	/**
-	 * Collection parameters are internally rewritten to named parameters (one named parameter by
-	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
-	 */
+
 	@Test
 	@TestForIssue(jiraKey = "HHH-12290")
 	public void testParameterCollectionParenthesesAndPositional() {
-		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item = new Item( "Mouse", "Microsoft mouse" );
 		final Item item2 = new Item( "Computer", "Dell computer" );
 
 		EntityManager em = getOrCreateEntityManager();
@@ -767,13 +756,8 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.getTransaction().commit();
 
 			em.getTransaction().begin();
-			Query q = em.createQuery( "select item from Item item where item.name in (?1) and descr = ?2" );
-			//test hint in value and string
-			q.setHint( "org.hibernate.fetchSize", 10 );
-			q.setHint( "org.hibernate.fetchSize", "10" );
+			Query q = em.createQuery( "select item from Item item where item.name in (?1) and item.descr = ?2" );
 			List params = new ArrayList();
-			// for this case, 1-item collection is OK, but 2 or more is broken
-			// as 1-item collection are not "rewritten"
 			params.add( item.getName() );
 			params.add( item2.getName() );
 			q.setParameter( 1, params );
@@ -792,15 +776,11 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.close();
 		}
 	}
-	
-	/**
-	 * Collection parameters are internally rewritten to named parameters (one named parameter by
-	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
-	 */
+
 	@Test
 	@TestForIssue(jiraKey = "HHH-12290")
 	public void testParameterCollectionSingletonParenthesesAndPositional() {
-		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item = new Item( "Mouse", "Microsoft mouse" );
 		final Item item2 = new Item( "Computer", "Dell computer" );
 
 		EntityManager em = getOrCreateEntityManager();
@@ -812,13 +792,8 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.getTransaction().commit();
 
 			em.getTransaction().begin();
-			Query q = em.createQuery( "select item from Item item where item.name in (?1) and descr = ?2" );
-			//test hint in value and string
-			q.setHint( "org.hibernate.fetchSize", 10 );
-			q.setHint( "org.hibernate.fetchSize", "10" );
+			Query q = em.createQuery( "select item from Item item where item.name in (?1) and item.descr = ?2" );
 			List params = new ArrayList();
-			// for this case, 1-item collection is OK, but 2 or more is broken
-			// as 1-item collection are not "rewritten"
 			params.add( item2.getName() );
 			q.setParameter( 1, params );
 			q.setParameter( 2, item2.getDescr() );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
@@ -704,6 +704,138 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.close();
 		}
 	}
+	
+	/**
+	 * Collection parameters are internally rewritten to named parameters (one named parameter by
+	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParameterCollectionAndPositional() {
+		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item2 = new Item( "Computer", "Dell computer" );
+
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		try {
+			em.persist( item );
+			em.persist( item2 );
+			assertTrue( em.contains( item ) );
+			em.getTransaction().commit();
+
+			em.getTransaction().begin();
+			Query q = em.createQuery( "select item from Item item where item.name in ?1 and descr = ?2" );
+			//test hint in value and string
+			q.setHint( "org.hibernate.fetchSize", 10 );
+			q.setHint( "org.hibernate.fetchSize", "10" );
+			List params = new ArrayList();
+			params.add( item.getName() );
+			params.add( item2.getName() );
+			q.setParameter( 1, params );
+			q.setParameter( 2, item2.getDescr() );
+			List result = q.getResultList();
+			assertNotNull( result );
+			assertEquals( 1, result.size() );
+		}
+		catch (Exception e){
+			if ( em.getTransaction() != null && em.getTransaction().isActive() ) {
+				em.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			em.close();
+		}
+	}
+	
+	/**
+	 * Collection parameters are internally rewritten to named parameters (one named parameter by
+	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParameterCollectionParenthesesAndPositional() {
+		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item2 = new Item( "Computer", "Dell computer" );
+
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		try {
+			em.persist( item );
+			em.persist( item2 );
+			assertTrue( em.contains( item ) );
+			em.getTransaction().commit();
+
+			em.getTransaction().begin();
+			Query q = em.createQuery( "select item from Item item where item.name in (?1) and descr = ?2" );
+			//test hint in value and string
+			q.setHint( "org.hibernate.fetchSize", 10 );
+			q.setHint( "org.hibernate.fetchSize", "10" );
+			List params = new ArrayList();
+			// for this case, 1-item collection is OK, but 2 or more is broken
+			// as 1-item collection are not "rewritten"
+			params.add( item.getName() );
+			params.add( item2.getName() );
+			q.setParameter( 1, params );
+			q.setParameter( 2, item2.getDescr() );
+			List result = q.getResultList();
+			assertNotNull( result );
+			assertEquals( 1, result.size() );
+		}
+		catch (Exception e){
+			if ( em.getTransaction() != null && em.getTransaction().isActive() ) {
+				em.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			em.close();
+		}
+	}
+	
+	/**
+	 * Collection parameters are internally rewritten to named parameters (one named parameter by
+	 * collection item) and HQL parser rejects mixed positional and named parameters queries.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParameterCollectionSingletonParenthesesAndPositional() {
+		final Item item = new Item( "Mouse", "Micro$oft mouse" );
+		final Item item2 = new Item( "Computer", "Dell computer" );
+
+		EntityManager em = getOrCreateEntityManager();
+		em.getTransaction().begin();
+		try {
+			em.persist( item );
+			em.persist( item2 );
+			assertTrue( em.contains( item ) );
+			em.getTransaction().commit();
+
+			em.getTransaction().begin();
+			Query q = em.createQuery( "select item from Item item where item.name in (?1) and descr = ?2" );
+			//test hint in value and string
+			q.setHint( "org.hibernate.fetchSize", 10 );
+			q.setHint( "org.hibernate.fetchSize", "10" );
+			List params = new ArrayList();
+			// for this case, 1-item collection is OK, but 2 or more is broken
+			// as 1-item collection are not "rewritten"
+			params.add( item2.getName() );
+			q.setParameter( 1, params );
+			q.setParameter( 2, item2.getDescr() );
+			List result = q.getResultList();
+			assertNotNull( result );
+			assertEquals( 1, result.size() );
+		}
+		catch (Exception e){
+			if ( em.getTransaction() != null && em.getTransaction().isActive() ) {
+				em.getTransaction().rollback();
+			}
+			throw e;
+		}
+		finally {
+			em.close();
+		}
+	}
 
 	@Test
 	public void testParameterList() throws Exception {

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/JPAQLComplianceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/JPAQLComplianceTest.java
@@ -6,20 +6,21 @@
  */
 package org.hibernate.test.jpa.ql;
 
-import org.hibernate.hql.internal.ast.QuerySyntaxException;
-import org.hibernate.query.Query;
-import org.hibernate.testing.TestForIssue;
-import org.junit.Test;
-
-import org.hibernate.Session;
-import org.hibernate.test.jpa.AbstractJPATest;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import org.hibernate.Session;
+import org.hibernate.hql.internal.ast.QuerySyntaxException;
+import org.hibernate.query.Query;
+import org.hibernate.test.jpa.AbstractJPATest;
+import org.hibernate.test.jpa.Item;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
 
 /**
  * Tests for various JPAQL compliance issues
@@ -112,9 +113,9 @@ public class JPAQLComplianceTest extends AbstractJPATest {
 		Session s = openSession();
 		try {
 			Query q = s.createQuery( "select item from Item item where item.id in (?1) and item.name = :name" );
-			List<Integer> params = new ArrayList();
-			params.add( 0 );
-			params.add( 1 );
+			List<Long> params = new ArrayList<>();
+			params.add( 0L );
+			params.add( 1L );
 			q.setParameter( 1, params );
 			q.setParameter( "name", "name" );
 			q.list();
@@ -123,6 +124,49 @@ public class JPAQLComplianceTest extends AbstractJPATest {
 		catch (IllegalArgumentException e) {
 			assertNotNull( e.getCause() );
 			assertTyping( QuerySyntaxException.class, e.getCause() );
+		}
+		finally {
+			s.close();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParameterCollectionParenthesesAndPositional() {
+		final Item item = new Item( "Mouse" );
+		item.setId( 1L );
+		final Item item2 = new Item( "Computer" );
+		item2.setId( 2L );
+
+		Session s = openSession();
+		try {
+			s.getTransaction().begin();
+			s.save( item );
+			s.save( item2 );
+			s.getTransaction().commit();
+
+			s.getTransaction().begin();
+			Query q = s.createQuery( "select item from Item item where item.id in(?1) and item.name in (?2) and item.id in(?1)" );
+
+			List<Long> idParams = new ArrayList<>();
+			idParams.add( item.getId() );
+			idParams.add( item2.getId() );
+			q.setParameter( 1, idParams );
+
+			List<String> nameParams = new ArrayList<>();
+			nameParams.add( item.getName() );
+			nameParams.add( item2.getName() );
+			q.setParameter( 2, nameParams );
+
+			List result = q.getResultList();
+			assertNotNull( result );
+			assertEquals( 2, result.size() );
+		}
+		catch (Exception e){
+			if ( s.getTransaction() != null && s.getTransaction().isActive() ) {
+				s.getTransaction().rollback();
+			}
+			throw e;
 		}
 		finally {
 			s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/JPAQLComplianceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/ql/JPAQLComplianceTest.java
@@ -6,10 +6,20 @@
  */
 package org.hibernate.test.jpa.ql;
 
+import org.hibernate.hql.internal.ast.QuerySyntaxException;
+import org.hibernate.query.Query;
+import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
 import org.hibernate.Session;
 import org.hibernate.test.jpa.AbstractJPATest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for various JPAQL compliance issues
@@ -60,5 +70,62 @@ public class JPAQLComplianceTest extends AbstractJPATest {
 		s.createQuery( "select c.name as myname FROM Item c ORDER BY myname" ).list();
 		s.createQuery( "select p.name as name, p.stockNumber as stockNo, p.unitPrice as uPrice FROM Part p ORDER BY name, abs( p.unitPrice ), stockNo" ).list();
 		s.close();
-	}	
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParametersMixturePositionalAndNamed() {
+		Session s = openSession();
+		try {
+			s.createQuery( "select item from Item item where item.id = ?1 and item.name = :name" ).list();
+			fail( "Expecting QuerySyntaxException because of named and positional parameters mixture" );
+		} catch ( IllegalArgumentException e ) {
+			assertNotNull( e.getCause() );
+			assertTyping( QuerySyntaxException.class, e.getCause() );
+		} finally {
+			s.close();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParametersMixtureNamedAndPositional() {
+		Session s = openSession();
+		try {
+			s.createQuery( "select item from Item item where item.id = :id and item.name = ?1" ).list();
+			fail( "Expecting QuerySyntaxException because of named and positional parameters mixture" );
+		} catch ( IllegalArgumentException e ) {
+			assertNotNull( e.getCause() );
+			assertTyping( QuerySyntaxException.class, e.getCause() );
+		} finally {
+			s.close();
+		}
+	}
+
+	/**
+	 * Positional collection parameter is expanded to the list of named parameters. In spite of this fact, initial query
+	 * query is wrong in terms of JPA and exception must be thrown
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HHH-12290")
+	public void testParametersMixtureNamedCollectionAndPositional() {
+		Session s = openSession();
+		try {
+			Query q = s.createQuery( "select item from Item item where item.id in (?1) and item.name = :name" );
+			List<Integer> params = new ArrayList();
+			params.add( 0 );
+			params.add( 1 );
+			q.setParameter( 1, params );
+			q.setParameter( "name", "name" );
+			q.list();
+			fail( "Expecting QuerySyntaxException because of named and positional parameters mixture" );
+		}
+		catch (IllegalArgumentException e) {
+			assertNotNull( e.getCause() );
+			assertTyping( QuerySyntaxException.class, e.getCause() );
+		}
+		finally {
+			s.close();
+		}
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/util/StringHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/util/StringHelperTest.java
@@ -42,4 +42,16 @@ public class StringHelperTest extends BaseUnitTestCase {
 		assertEquals( STRING_HELPER_NAME, StringHelper.collapseQualifierBase( STRING_HELPER_NAME, BASE_PACKAGE ) );
 		assertEquals( "o.h.internal.util.StringHelper", StringHelper.collapseQualifierBase( STRING_HELPER_FQN, BASE_PACKAGE ) );
 	}
+
+	@Test
+	public void testFindIdentifierWord() {
+		assertEquals( StringHelper.indexOfIdentifierWord( "", "word" ), -1 );
+		assertEquals( StringHelper.indexOfIdentifierWord( null, "word" ), -1 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "sentence", null ), -1 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "where name=?13 and description=?1", "?1" ), 31 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "where name=?13 and description=?1 and category_id=?4", "?1" ), 31 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "?1", "?1" ), 0 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "no identifier here", "?1" ), -1 );
+		assertEquals( StringHelper.indexOfIdentifierWord( "some text ?", "?" ), 10 );
+	}
 }


### PR DESCRIPTION
Finally got a chance to take a look at this one today so here is my attempt to fix https://hibernate.atlassian.net/browse/HHH-12290 .

It's very similar to the new approach taken by @bdshadow in https://github.com/hibernate/hibernate-orm/pull/2158 but I think it's a bit less invasive.

We now replace ordinal parameters with ordinal parameters instead of using named parameters. It avoids gaps and should work pretty much OK.