### PR TITLE
HHH-11769: mariadb 10.0 - 10.3 dialects

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
@@ -257,7 +257,7 @@ public enum Database {
 	MARIADB {
 		@Override
 		public Class<? extends Dialect> latestDialect() {
-			return MariaDB53Dialect.class;
+			return MariaDB103Dialect.class;
 		}
 
 		@Override
@@ -267,11 +267,22 @@ public enum Database {
 				final int majorVersion = info.getDatabaseMajorVersion();
 				final int minorVersion = info.getDatabaseMinorVersion();
 
-				if ( majorVersion < 5 || ( majorVersion == 5 && minorVersion < 3 ) ) {
-					return new MariaDBDialect();
+				if ( majorVersion == 10 ) {
+					if ( minorVersion >= 3 ) {
+						return new MariaDB103Dialect();
+					}
+					else if ( minorVersion == 2 ) {
+						return new MariaDB102Dialect();
+					}
+					else if ( minorVersion >= 0 ) {
+						return new MariaDB100Dialect();
+					}
+					return new MariaDB53Dialect();
 				}
-
-				return latestDialectInstance( this );
+				else if ( majorVersion > 5 || ( majorVersion == 5 && minorVersion >= 3 ) ) {
+					return new MariaDB53Dialect();
+				}
+				return new MariaDBDialect();
 			}
 
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB100Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB100Dialect.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MariaDB100Dialect extends MariaDB53Dialect {
+
+	public MariaDB100Dialect() {
+		super();
+
+		registerFunction( "regexp_replace", new StandardSQLFunction( "regexp_replace", StandardBasicTypes.STRING ) );
+		registerFunction( "regexp_instr", new StandardSQLFunction( "regexp_instr", StandardBasicTypes.INTEGER ) );
+		registerFunction( "regexp_substr", new StandardSQLFunction( "regexp_substr", StandardBasicTypes.STRING ) );
+		registerFunction( "weight_string", new StandardSQLFunction( "weight_string", StandardBasicTypes.STRING ) );
+		registerFunction( "to_base64", new StandardSQLFunction( "to_base64", StandardBasicTypes.STRING ) );
+		registerFunction( "from_base64", new StandardSQLFunction( "from_base64", StandardBasicTypes.STRING ) );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB102Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB102Dialect.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+import java.sql.Types;
+
+public class MariaDB102Dialect extends MariaDB100Dialect {
+
+	public MariaDB102Dialect() {
+		super();
+
+		this.registerColumnType( Types.JAVA_OBJECT, "json" );
+
+		registerFunction( "json_valid", new StandardSQLFunction( "json_valid", StandardBasicTypes.NUMERIC_BOOLEAN ) );
+
+	}
+
+	@Override
+	public boolean supportsColumnCheck() {
+		return true;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+
+/**
+ * An SQL dialect for MariaDB 10.3 and later, provides sequence support.
+ * 
+ * @author Philippe Marschall
+ */
+public class MariaDB103Dialect extends MariaDB53Dialect {
+
+	@Override
+	public boolean supportsSequences() {
+		return true;
+	}
+
+	@Override
+	public String getSelectSequenceNextValString(String sequenceName) {
+		return "next value for " + sequenceName;
+	}
+
+	@Override
+	public String getSequenceNextValString(String sequenceName) {
+		return "select " + getSelectSequenceNextValString( sequenceName );
+	}
+
+	@Override
+	public String getCreateSequenceString(String sequenceName) {
+		return "create sequence " + sequenceName;
+	}
+
+	@Override
+	public String getDropSequenceString(String sequenceName) {
+		return "drop sequence " + sequenceName;
+	}
+
+	@Override
+	public boolean supportsPooledSequences() {
+		return true;
+	}
+
+	@Override
+	protected String getCreateSequenceString(String sequenceName, int initialValue, int incrementSize) {
+		return getCreateSequenceString( sequenceName ) + " start " + initialValue + " increment " + incrementSize;
+	}
+
+	@Override
+	public String getQuerySequencesString() {
+		return "show full tables where Table_type = 'SEQUENCE'";
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
@@ -7,12 +7,21 @@
 package org.hibernate.dialect;
 
 
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
 /**
  * An SQL dialect for MariaDB 10.3 and later, provides sequence support.
  * 
  * @author Philippe Marschall
  */
-public class MariaDB103Dialect extends MariaDB53Dialect {
+public class MariaDB103Dialect extends MariaDB102Dialect {
+
+	public MariaDB103Dialect() {
+		super();
+
+		registerFunction( "chr", new StandardSQLFunction( "chr", StandardBasicTypes.CHARACTER) );
+	}
 
 	@Override
 	public boolean supportsSequences() {
@@ -20,13 +29,8 @@ public class MariaDB103Dialect extends MariaDB53Dialect {
 	}
 
 	@Override
-	public String getSelectSequenceNextValString(String sequenceName) {
-		return "next value for " + sequenceName;
-	}
-
-	@Override
-	public String getSequenceNextValString(String sequenceName) {
-		return "select " + getSelectSequenceNextValString( sequenceName );
+	public boolean supportsPooledSequences() {
+		return true;
 	}
 
 	@Override
@@ -40,18 +44,18 @@ public class MariaDB103Dialect extends MariaDB53Dialect {
 	}
 
 	@Override
-	public boolean supportsPooledSequences() {
-		return true;
+	public String getSequenceNextValString(String sequenceName) {
+		return "select " + getSelectSequenceNextValString( sequenceName );
 	}
 
 	@Override
-	protected String getCreateSequenceString(String sequenceName, int initialValue, int incrementSize) {
-		return getCreateSequenceString( sequenceName ) + " start " + initialValue + " increment " + incrementSize;
+	public String getSelectSequenceNextValString(String sequenceName) {
+		return "nextval(" + sequenceName + ")";
 	}
 
 	@Override
 	public String getQuerySequencesString() {
-		return "show full tables where Table_type = 'SEQUENCE'";
+		return "select table_name from information_schema.TABLES where table_type='SEQUENCE'";
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/resolver/DialectFactoryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/resolver/DialectFactoryTest.java
@@ -6,11 +6,6 @@
  */
 package org.hibernate.dialect.resolver;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
 import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
@@ -18,36 +13,7 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.selector.spi.StrategySelectionException;
 import org.hibernate.cfg.Environment;
-import org.hibernate.dialect.DB2400Dialect;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
-import org.hibernate.dialect.DerbyTenFiveDialect;
-import org.hibernate.dialect.DerbyTenSevenDialect;
-import org.hibernate.dialect.DerbyTenSixDialect;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.Informix10Dialect;
-import org.hibernate.dialect.InformixDialect;
-import org.hibernate.dialect.IngresDialect;
-import org.hibernate.dialect.MySQL55Dialect;
-import org.hibernate.dialect.MySQL57Dialect;
-import org.hibernate.dialect.MySQL5Dialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle10gDialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.Oracle9iDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQL82Dialect;
-import org.hibernate.dialect.PostgreSQL92Dialect;
-import org.hibernate.dialect.PostgreSQL94Dialect;
-import org.hibernate.dialect.PostgreSQL95Dialect;
-import org.hibernate.dialect.PostgreSQL9Dialect;
-import org.hibernate.dialect.PostgresPlusDialect;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.SybaseASE15Dialect;
-import org.hibernate.dialect.SybaseAnywhereDialect;
-import org.hibernate.dialect.TestingDialects;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl;
 import org.hibernate.engine.jdbc.dialect.internal.DialectResolverSet;
 import org.hibernate.engine.jdbc.dialect.internal.StandardDialectResolver;
@@ -55,14 +21,16 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfoSource;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolver;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
-
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Steve Ebersole
@@ -146,6 +114,12 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 		testDetermination( "MySQL", 5, 6, MySQL55Dialect.class, resolver );
 		testDetermination( "MySQL", 5, 7, MySQL57Dialect.class, resolver );
 		testDetermination( "MySQL", 8, 0, MySQL57Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 10, 3, MariaDB103Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 10, 2, MariaDB102Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 10, 1, MariaDB100Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 10, 0, MariaDB100Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 5, 5, MariaDB53Dialect.class, resolver );
+		testDetermination( "MariaDB", "MariaDB connector/J", 5, 2, MariaDBDialect.class, resolver );
 		testDetermination( "PostgreSQL", PostgreSQL81Dialect.class, resolver );
 		testDetermination( "PostgreSQL", 8, 2, PostgreSQL82Dialect.class, resolver );
 		testDetermination( "PostgreSQL", 8, 3, PostgreSQL82Dialect.class, resolver );
@@ -250,13 +224,23 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 			final int minorVersion,
 			Class expected,
 			DialectResolver resolver) {
+		testDetermination( databaseName, null, majorVersion, minorVersion, expected, resolver );
+	}
+
+	private void testDetermination(
+			final String databaseName,
+			final String driverName,
+			final int majorVersion,
+			final int minorVersion,
+			Class expected,
+			DialectResolver resolver) {
 		dialectFactory.setDialectResolver( resolver );
 		Dialect resolved = dialectFactory.buildDialect(
 				new Properties(),
 				new DialectResolutionInfoSource() {
 					@Override
 					public DialectResolutionInfo getDialectResolutionInfo() {
-						return TestingDialectResolutionInfo.forDatabaseInfo( databaseName, majorVersion, minorVersion );
+						return TestingDialectResolutionInfo.forDatabaseInfo( databaseName, driverName, majorVersion, minorVersion );
 					}
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/dialect/resolver/TestingDialectResolutionInfo.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/resolver/TestingDialectResolutionInfo.java
@@ -47,6 +47,10 @@ public class TestingDialectResolutionInfo implements DialectResolutionInfo {
 		return new TestingDialectResolutionInfo( name, majorVersion, minorVersion, null, NO_VERSION, NO_VERSION );
 	}
 
+	public static TestingDialectResolutionInfo forDatabaseInfo(String databaseName, String driverName, int majorVersion, int minorVersion) {
+		return new TestingDialectResolutionInfo( databaseName, majorVersion, minorVersion, driverName, NO_VERSION, NO_VERSION );
+	}
+
 	@Override
 	public String getDatabaseName() {
 		return databaseName;

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/dialect/internal/StandardDialectResolverTest.java
@@ -6,23 +6,15 @@
  */
 package org.hibernate.engine.jdbc.dialect.internal;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.hibernate.dialect.*;
+import org.hibernate.dialect.resolver.TestingDialectResolutionInfo;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
 
 import java.sql.SQLException;
 
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQL82Dialect;
-import org.hibernate.dialect.PostgreSQL9Dialect;
-import org.hibernate.dialect.SQLServer2005Dialect;
-import org.hibernate.dialect.SQLServer2008Dialect;
-import org.hibernate.dialect.SQLServer2012Dialect;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.resolver.TestingDialectResolutionInfo;
-
-import org.hibernate.testing.junit4.BaseUnitTestCase;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test of the {@link StandardDialectResolver} class.
@@ -104,6 +96,43 @@ public class StandardDialectResolverTest extends BaseUnitTestCase {
 		runPostgresDialectTest( 9, 2, PostgreSQL9Dialect.class );
 	}
 
+	@Test
+	public void testResolveDialectInternalForMariaDB103() throws SQLException {
+		runMariaDBDialectTest( 10, 3, MariaDB103Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForMariaDB102() throws SQLException {
+		runMariaDBDialectTest( 10, 2, MariaDB102Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForMariaDB101() throws SQLException {
+		runMariaDBDialectTest( 10, 1, MariaDB100Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForMariaDB100() throws SQLException {
+		runMariaDBDialectTest( 10, 0, MariaDB100Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForMariaDB55() throws SQLException {
+		runMariaDBDialectTest( 5, 5, MariaDB53Dialect.class );
+	}
+
+	@Test
+	public void testResolveDialectInternalForMariaDB52() throws SQLException {
+		runMariaDBDialectTest( 5, 2, MariaDBDialect.class );
+	}
+
+	private static void runMariaDBDialectTest(
+			int majorVersion, int minorVersion, Class<? extends MariaDBDialect> expectedDialect)
+			throws SQLException {
+		runDialectTest( "MariaDB", "MariaDB connector/J", majorVersion, minorVersion, expectedDialect );
+	}
+
+
 	private static void runSQLServerDialectTest(
 			int version, Class<? extends SQLServerDialect> expectedDialect)
 			throws SQLException {
@@ -123,7 +152,16 @@ public class StandardDialectResolverTest extends BaseUnitTestCase {
 			int majorVersion,
 			int minorVersion,
 			Class<? extends Dialect> expectedDialect) {
-		TestingDialectResolutionInfo info = TestingDialectResolutionInfo.forDatabaseInfo( productName, majorVersion, minorVersion );
+		runDialectTest( productName, null, majorVersion, minorVersion, expectedDialect );
+	}
+
+	private static void runDialectTest(
+			String productName,
+			String driverName,
+			int majorVersion,
+			int minorVersion,
+			Class<? extends Dialect> expectedDialect) {
+		TestingDialectResolutionInfo info = TestingDialectResolutionInfo.forDatabaseInfo( productName, driverName, majorVersion, minorVersion );
 
 		Dialect dialect = StandardDialectResolver.INSTANCE.resolveDialect( info );
 


### PR DESCRIPTION
I hope that i haven't missed any features that appeared in these version.

Also i have a question regarding json functions in 10.2: https://mariadb.com/kb/en/library/json-functions/. Lot's of them return and work with arrays. How should i define these functions correctly.  There's a nice article by @vladmihalcea https://vladmihalcea.com/the-hibernate-types-open-source-project-is-born/, which describes how user should work with it. But isn't it done in hibernate yet? Should we do it in this commit or in the other? And what's better to do with these array\json functions in 10.2?