### PR TITLE
HHH-12454 - Offer flag to consider id generator with local scope (legacy non JPA behavior)

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -71,6 +71,14 @@ hence we can save a database roundtrip.
 +
 If enabled Hibernate will initialize the entity Proxy even when accessing its identifier.
 
+`*hibernate.jpa.compliance.global_id_generators*` (e.g. `true` or `false` (default value) )::
+The JPA spec says that the scope of TableGenerator and SequenceGenerator names is global to the persistence unit (across all generator types).
++
+Traditionally, Hibernate has considered the names locally scoped.
++
+If enabled, the names used by `@TableGenerator` and `@SequenceGenerator` will be considered global so configuring two different generators
+with the same name will cause a `java.lang.IllegalArgumentException' to be thrown at boot time.
+
 [[configurations-database-connection]]
 === Database connection properties
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -19,7 +19,7 @@ import org.hibernate.cache.spi.TimestampsCacheFactory;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -36,6 +36,8 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.annotations.reflection.JPAMetadataProvider;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.jpa.internal.JpaComplianceImpl;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.jandex.IndexView;
@@ -50,6 +52,8 @@ public class BootstrapContextImpl implements BootstrapContext {
 	private static final Logger log = Logger.getLogger( BootstrapContextImpl.class );
 
 	private final StandardServiceRegistry serviceRegistry;
+
+	private final MutableJpaCompliance jpaCompliance;
 
 	private final TypeConfiguration typeConfiguration;
 
@@ -87,6 +91,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 		final StrategySelector strategySelector = serviceRegistry.getService( StrategySelector.class );
 		final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );
 
+		this.jpaCompliance = new JpaComplianceImpl( configService.getSettings(), false );
 		this.scanOptions = new StandardScanOptions(
 				(String) configService.getSettings().get( AvailableSettings.SCANNER_DISCOVERY ),
 				false
@@ -110,6 +115,11 @@ public class BootstrapContextImpl implements BootstrapContext {
 	@Override
 	public StandardServiceRegistry getServiceRegistry() {
 		return serviceRegistry;
+	}
+
+	@Override
+	public MutableJpaCompliance getJpaCompliance() {
+		return jpaCompliance;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -36,7 +36,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.annotations.reflection.JPAMetadataProvider;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.engine.config.spi.ConfigurationService;
-import org.hibernate.jpa.internal.JpaComplianceImpl;
+import org.hibernate.jpa.internal.MutableJpaComplianceImpl;
 import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -91,7 +91,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 		final StrategySelector strategySelector = serviceRegistry.getService( StrategySelector.class );
 		final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );
 
-		this.jpaCompliance = new JpaComplianceImpl( configService.getSettings(), false );
+		this.jpaCompliance = new MutableJpaComplianceImpl( configService.getSettings(), false );
 		this.scanOptions = new StandardScanOptions(
 				(String) configService.getSettings().get( AvailableSettings.SCANNER_DISCOVERY ),
 				false

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -51,7 +51,6 @@ import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedTableName;
 import org.hibernate.boot.model.source.internal.ImplicitColumnNamingSecondPass;
 import org.hibernate.boot.model.source.spi.LocalMetadataBuildingContext;
-import org.hibernate.boot.model.convert.spi.ConverterAutoApplyHandler;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -60,6 +59,7 @@ import org.hibernate.boot.spi.NaturalIdUniqueKeyBinder;
 import org.hibernate.cache.cfg.internal.DomainDataRegionConfigImpl.Builder;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.AnnotatedClassType;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.CopyIdentifierComponentSecondPass;
 import org.hibernate.cfg.CreateKeySecondPass;
 import org.hibernate.cfg.FkSecondPass;
@@ -493,11 +493,13 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 			return;
 		}
 		final IdentifierGeneratorDefinition old = idGeneratorDefinitionMap.put( generator.getName(), generator );
-		if ( old != null ) {
-			if ( !old.equals( generator ) ) {
-				throw new IllegalArgumentException( "Duplicate generator name " + old.getName() );
+		if ( old != null && !old.equals( generator ) ) {
+			if ( bootstrapContext.getJpaCompliance().isGlobalGeneratorScopeEnabled() ) {
+				throw new IllegalArgumentException( "Duplicate generator name " + old.getName() + " you will likely want to set the property " + AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE + " to false " );
 			}
-//			log.duplicateGeneratorName( old.getName() );
+			else {
+				log.duplicateGeneratorName( old.getName() );
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -975,7 +975,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	@Override
 	public JpaCompliance getJpaCompliance() {
-		return jpaCompliance;
+		return jpaCompliance.immutableCopy();
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Supplier;
 
-import org.hibernate.AssertionFailure;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
@@ -51,8 +50,8 @@ import org.hibernate.id.UUIDGenerator;
 import org.hibernate.id.uuid.LocalObjectUuidHelper;
 import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.internal.util.config.ConfigurationHelper;
-import org.hibernate.jpa.JpaCompliance;
-import org.hibernate.jpa.spi.JpaComplianceImpl;
+import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;
@@ -235,7 +234,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	private Map<String, SQLFunction> sqlFunctions;
 
-	private JpaComplianceImpl jpaCompliance;
+	private MutableJpaCompliance jpaCompliance;
 
 	private boolean failOnPaginationOverCollectionFetchEnabled;
 
@@ -465,7 +464,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		);
 
 		// added the boolean parameter in case we want to define some form of "all" as discussed
-		this.jpaCompliance = new JpaComplianceImpl( configurationSettings, false );
+		this.jpaCompliance = context.getJpaCompliance();
 
 		this.failOnPaginationOverCollectionFetchEnabled = ConfigurationHelper.getBoolean(
 				FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
@@ -978,8 +977,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	public JpaCompliance getJpaCompliance() {
 		return jpaCompliance;
 	}
-
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// In-flight mutation access

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -22,7 +22,7 @@ import org.hibernate.cfg.BaselineSessionEventsListenerBuilder;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
@@ -7,7 +7,6 @@
 package org.hibernate.boot.spi;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import org.hibernate.annotations.common.reflection.ReflectionManager;
@@ -20,6 +19,7 @@ import org.hibernate.boot.internal.ClassmateContext;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.jandex.IndexView;
@@ -33,6 +33,8 @@ import org.jboss.jandex.IndexView;
  */
 public interface BootstrapContext {
 	StandardServiceRegistry getServiceRegistry();
+
+	MutableJpaCompliance getJpaCompliance();
 
 	TypeConfiguration getTypeConfiguration();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -28,7 +28,7 @@ import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.loader.BatchFetchStyle;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -9,6 +9,7 @@ package org.hibernate.cfg;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -128,6 +129,7 @@ import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.model.IdGeneratorStrategyInterpreter;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.model.TypeDefinition;
+import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.InFlightMetadataCollector.EntityTableXref;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.annotations.CollectionBinder;
@@ -2242,20 +2244,33 @@ public final class AnnotationBinder {
 					foreignGeneratorBuilder.setName( "Hibernate-local--foreign generator" );
 					foreignGeneratorBuilder.setStrategy( "foreign" );
 					foreignGeneratorBuilder.addParam( "property", mapsIdProperty.getPropertyName() );
-
 					final IdentifierGeneratorDefinition foreignGenerator = foreignGeneratorBuilder.build();
-//					Map<String, IdentifierGeneratorDefinition> localGenerators = ( HashMap<String, IdentifierGeneratorDefinition> ) classGenerators.clone();
-//					localGenerators.put( foreignGenerator.getName(), foreignGenerator );
 
-					SecondPass secondPass = new IdGeneratorResolverSecondPass(
-							( SimpleValue ) propertyBinder.getValue(),
-							property,
-							foreignGenerator.getStrategy(),
-							foreignGenerator.getName(),
-							context,
-							foreignGenerator
-					);
-					context.getMetadataCollector().addSecondPass( secondPass );
+					if ( isGlobalGeneratorNameGlobal( context ) ) {
+						SecondPass secondPass = new IdGeneratorResolverSecondPass(
+								(SimpleValue) propertyBinder.getValue(),
+								property,
+								foreignGenerator.getStrategy(),
+								foreignGenerator.getName(),
+								context,
+								foreignGenerator
+						);
+						context.getMetadataCollector().addSecondPass( secondPass );
+					}
+					else {
+						Map<String, IdentifierGeneratorDefinition> localGenerators = (HashMap<String, IdentifierGeneratorDefinition>) classGenerators
+								.clone();
+						localGenerators.put( foreignGenerator.getName(), foreignGenerator );
+
+						BinderHelper.makeIdGenerator(
+								(SimpleValue) propertyBinder.getValue(),
+								property,
+								foreignGenerator.getStrategy(),
+								foreignGenerator.getName(),
+								context,
+								localGenerators
+						);
+					}
 				}
 				if ( isId ) {
 					//components and regular basic types create SimpleValue objects
@@ -2313,6 +2328,10 @@ public final class AnnotationBinder {
 		}
 	}
 
+	private static boolean isGlobalGeneratorNameGlobal(MetadataBuildingContext context) {
+		return context.getBootstrapContext().getJpaCompliance().isGlobalGeneratorScopeEnabled();
+	}
+
 	private static boolean isToManyAssociationWithinEmbeddableCollection(PropertyHolder propertyHolder) {
 		if(propertyHolder instanceof ComponentPropertyHolder) {
 			ComponentPropertyHolder componentPropertyHolder = (ComponentPropertyHolder) propertyHolder;
@@ -2344,10 +2363,6 @@ public final class AnnotationBinder {
 		}
 		XClass entityXClass = inferredData.getClassOrElement();
 		XProperty idXProperty = inferredData.getProperty();
-		//clone classGenerator and override with local values
-//		HashMap<String, IdentifierGeneratorDefinition> localGenerators = ( HashMap<String, IdentifierGeneratorDefinition> ) classGenerators.clone();
-//		localGenerators.putAll( buildGenerators( idXProperty, buildingContext ) );
-		buildGenerators( idXProperty, buildingContext );
 
 		//manage composite related metadata
 		//guess if its a component and find id data access (property, field etc)
@@ -2366,14 +2381,31 @@ public final class AnnotationBinder {
 			generatorType = "assigned";
 		}
 
-		SecondPass secondPass = new IdGeneratorResolverSecondPass(
-				idValue,
-				idXProperty,
-				generatorType,
-				generatorName,
-				buildingContext
-		);
-		buildingContext.getMetadataCollector().addSecondPass( secondPass );
+		if ( isGlobalGeneratorNameGlobal( buildingContext ) ) {
+			buildGenerators( idXProperty, buildingContext );
+			SecondPass secondPass = new IdGeneratorResolverSecondPass(
+					idValue,
+					idXProperty,
+					generatorType,
+					generatorName,
+					buildingContext
+			);
+			buildingContext.getMetadataCollector().addSecondPass( secondPass );
+		}
+		else {
+			//clone classGenerator and override with local values
+			HashMap<String, IdentifierGeneratorDefinition> localGenerators = (HashMap<String, IdentifierGeneratorDefinition>) classGenerators
+					.clone();
+			localGenerators.putAll( buildGenerators( idXProperty, buildingContext ) );
+			BinderHelper.makeIdGenerator(
+					idValue,
+					idXProperty,
+					generatorType,
+					generatorName,
+					buildingContext,
+					localGenerators
+			);
+		}
 
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Bind {0} on {1}", ( isComponent ? "@EmbeddedId" : "@Id" ), inferredData.getPropertyName() );
@@ -2710,27 +2742,38 @@ public final class AnnotationBinder {
 			XProperty property = propertyAnnotatedElement.getProperty();
 			if ( property.isAnnotationPresent( GeneratedValue.class ) &&
 					property.isAnnotationPresent( Id.class ) ) {
-				//clone classGenerator and override with local values
-//				Map<String, IdentifierGeneratorDefinition> localGenerators = new HashMap<>();
-//				localGenerators.putAll( buildGenerators( property, buildingContext ) );
-
-				buildGenerators( property, buildingContext );
 				GeneratedValue generatedValue = property.getAnnotation( GeneratedValue.class );
 				String generatorType = generatedValue != null
 						? generatorType( generatedValue, buildingContext, property.getType() )
 						: "assigned";
-				String generator = generatedValue != null ? generatedValue.generator() : BinderHelper.ANNOTATION_STRING_DEFAULT;
+				String generator = generatedValue != null ?
+						generatedValue.generator() :
+						BinderHelper.ANNOTATION_STRING_DEFAULT;
 
-				SecondPass secondPass = new IdGeneratorResolverSecondPass(
-						( SimpleValue ) comp.getProperty( property.getName() ).getValue(),
-						property,
-						generatorType,
-						generator,
-						buildingContext
-				);
-				buildingContext.getMetadataCollector().addSecondPass( secondPass );
+				if ( isGlobalGeneratorNameGlobal( buildingContext ) ) {
+					buildGenerators( property, buildingContext );
+					SecondPass secondPass = new IdGeneratorResolverSecondPass(
+							(SimpleValue) comp.getProperty( property.getName() ).getValue(),
+							property,
+							generatorType,
+							generator,
+							buildingContext
+					);
+					buildingContext.getMetadataCollector().addSecondPass( secondPass );
+				}
+				else {
+					Map<String, IdentifierGeneratorDefinition> localGenerators = new HashMap<>();
+					localGenerators.putAll( buildGenerators( property, buildingContext ) );
+					BinderHelper.makeIdGenerator(
+							(SimpleValue) comp.getProperty( property.getName() ).getValue(),
+							property,
+							generatorType,
+							generator,
+							buildingContext,
+							localGenerators
+					);
+				}
 			}
-
 		}
 		return comp;
 	}
@@ -2827,14 +2870,26 @@ public final class AnnotationBinder {
 			id = value.make();
 		}
 		rootClass.setIdentifier( id );
-		SecondPass secondPass = new IdGeneratorResolverSecondPass(
-				id,
-				inferredData.getProperty(),
-				generatorType,
-				generatorName,
-				buildingContext
-		);
-		buildingContext.getMetadataCollector().addSecondPass( secondPass );
+		if ( isGlobalGeneratorNameGlobal( buildingContext ) ) {
+			SecondPass secondPass = new IdGeneratorResolverSecondPass(
+					id,
+					inferredData.getProperty(),
+					generatorType,
+					generatorName,
+					buildingContext
+			);
+			buildingContext.getMetadataCollector().addSecondPass( secondPass );
+		}
+		else {
+			BinderHelper.makeIdGenerator(
+					id,
+					inferredData.getProperty(),
+					generatorType,
+					generatorName,
+					buildingContext,
+					Collections.emptyMap()
+			);
+		}
 
 		if ( isEmbedded ) {
 			rootClass.setEmbeddedIdentifier( inferredData.getPropertyClass() == null );
@@ -3331,6 +3386,7 @@ public final class AnnotationBinder {
 	}
 
 	private static HashMap<String, IdentifierGeneratorDefinition> buildGenerators(XAnnotatedElement annElt, MetadataBuildingContext context) {
+		InFlightMetadataCollector metadataCollector = context.getMetadataCollector();
 		HashMap<String, IdentifierGeneratorDefinition> generators = new HashMap<>();
 
 		TableGenerators tableGenerators = annElt.getAnnotation( TableGenerators.class );
@@ -3344,6 +3400,7 @@ public final class AnnotationBinder {
 						idGenerator.getName(),
 						idGenerator
 				);
+				metadataCollector.addIdentifierGenerator( idGenerator );
 			}
 		}
 
@@ -3358,6 +3415,7 @@ public final class AnnotationBinder {
 						idGenerator.getName(),
 						idGenerator
 				);
+				metadataCollector.addIdentifierGenerator( idGenerator );
 			}
 		}
 
@@ -3367,20 +3425,19 @@ public final class AnnotationBinder {
 		if ( tabGen != null ) {
 			IdentifierGeneratorDefinition idGen = buildIdGenerator( tabGen, context );
 			generators.put( idGen.getName(), idGen );
+			metadataCollector.addIdentifierGenerator( idGen );
+
 		}
 		if ( seqGen != null ) {
 			IdentifierGeneratorDefinition idGen = buildIdGenerator( seqGen, context );
 			generators.put( idGen.getName(), idGen );
+			metadataCollector.addIdentifierGenerator( idGen );
 		}
 		if ( genGen != null ) {
 			IdentifierGeneratorDefinition idGen = buildIdGenerator( genGen, context );
 			generators.put( idGen.getName(), idGen );
+			metadataCollector.addIdentifierGenerator( idGen );
 		}
-
-		generators.forEach( (name, idGenerator) -> {
-			context.getMetadataCollector().addIdentifierGenerator( idGenerator );
-		} );
-
 		return generators;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -16,7 +16,7 @@ import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.cache.spi.TimestampsCacheFactory;
 import org.hibernate.internal.log.DeprecationLogger;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;
 import org.hibernate.query.internal.ParameterMetadataImpl;
 import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
@@ -1845,6 +1845,18 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 * @since 5.3
 	 */
 	String JPA_CACHING_COMPLIANCE = "hibernate.jpa.compliance.caching";
+
+	/**
+	 * Determine if the scope of {@link javax.persistence.TableGenerator#name()} and {@link javax.persistence.SequenceGenerator#name()} should be
+	 * considered globally or locally defined.
+	 *
+	 * If enabled, the names will considered globally scoped so defining two different generators with the same name
+	 * will cause a name collision and an exception will be thrown during the bootstrap phase.
+	 *
+	 * @see JpaCompliance#isGlobalGeneratorScopeEnabled()
+	 * @since 5.2.17
+	 */
+	String JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE = "hibernate.jpa.compliance.global_id_generators";
 
 	/**
 	 * True/False setting indicating if the value stored in the table used by the {@link javax.persistence.TableGenerator}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -107,14 +107,26 @@ public class IdBagBinder extends BagBinder {
 				generatorType = null;
 			}
 
-			SecondPass secondPass = new IdGeneratorResolverSecondPass(
-					id,
-					property,
-					generatorType,
-					generator,
-					getBuildingContext()
-			);
-			buildingContext.getMetadataCollector().addSecondPass( secondPass );
+			if ( buildingContext.getBootstrapContext().getJpaCompliance().isGlobalGeneratorScopeEnabled() ) {
+				SecondPass secondPass = new IdGeneratorResolverSecondPass(
+						id,
+						property,
+						generatorType,
+						generator,
+						getBuildingContext()
+				);
+				buildingContext.getMetadataCollector().addSecondPass( secondPass );
+			}
+			else {
+				BinderHelper.makeIdGenerator(
+						id,
+						property,
+						generatorType,
+						generator,
+						getBuildingContext(),
+						localGenerators
+				);
+			}
 		}
 		return result;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
@@ -13,7 +13,7 @@ import org.hibernate.TransactionException;
 import org.hibernate.engine.spi.ExceptionConverter;
 import org.hibernate.engine.transaction.spi.TransactionImplementor;
 import org.hibernate.internal.CoreLogging;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
@@ -4,24 +4,25 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa.spi;
+package org.hibernate.jpa.internal;
 
 import java.util.Map;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.internal.util.config.ConfigurationHelper;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
 
 /**
  * @author Steve Ebersole
  */
-public class JpaComplianceImpl implements JpaCompliance {
+public class JpaComplianceImpl implements MutableJpaCompliance {
 	private boolean queryCompliance;
 	private boolean transactionCompliance;
 	private boolean listCompliance;
 	private boolean closedCompliance;
 	private boolean proxyCompliance;
 	private boolean cachingCompliance;
+	private final boolean globalGeneratorNameScopeCompliance;
 
 
 	@SuppressWarnings("ConstantConditions")
@@ -58,6 +59,11 @@ public class JpaComplianceImpl implements JpaCompliance {
 				configurationSettings,
 				jpaByDefault
 		);
+		globalGeneratorNameScopeCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
 	}
 
 	@Override
@@ -88,6 +94,11 @@ public class JpaComplianceImpl implements JpaCompliance {
 	@Override
 	public boolean isJpaCacheComplianceEnabled() {
 		return cachingCompliance;
+	}
+
+	@Override
+	public boolean isGlobalGeneratorScopeEnabled() {
+		return globalGeneratorNameScopeCompliance;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
@@ -6,64 +6,35 @@
  */
 package org.hibernate.jpa.internal;
 
-import java.util.Map;
-
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.internal.util.config.ConfigurationHelper;
-import org.hibernate.jpa.spi.MutableJpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 
 /**
- * @author Steve Ebersole
+ * @author Andrea Boriero
  */
-public class JpaComplianceImpl implements MutableJpaCompliance {
+public class JpaComplianceImpl implements JpaCompliance {
 	private boolean queryCompliance;
 	private boolean transactionCompliance;
 	private boolean listCompliance;
 	private boolean closedCompliance;
 	private boolean proxyCompliance;
 	private boolean cachingCompliance;
-	private final boolean globalGeneratorNameScopeCompliance;
+	private boolean globalGeneratorNameScopeCompliance;
 
-
-	@SuppressWarnings("ConstantConditions")
-	public JpaComplianceImpl(Map configurationSettings, boolean jpaByDefault) {
-		final Object legacyQueryCompliance = configurationSettings.get( AvailableSettings.JPAQL_STRICT_COMPLIANCE );
-
-		queryCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_QUERY_COMPLIANCE,
-				configurationSettings,
-				ConfigurationHelper.toBoolean( legacyQueryCompliance, jpaByDefault )
-		);
-		transactionCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_TRANSACTION_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
-		listCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_LIST_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
-		closedCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_CLOSED_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
-		proxyCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_PROXY_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
-		cachingCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_CACHING_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
-		globalGeneratorNameScopeCompliance = ConfigurationHelper.getBoolean(
-				AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE,
-				configurationSettings,
-				jpaByDefault
-		);
+	private JpaComplianceImpl(
+			boolean queryCompliance,
+			boolean transactionCompliance,
+			boolean listCompliance,
+			boolean closedCompliance,
+			boolean proxyCompliance,
+			boolean cachingCompliance,
+			boolean globalGeneratorNameScopeCompliance) {
+		this.queryCompliance = queryCompliance;
+		this.transactionCompliance = transactionCompliance;
+		this.listCompliance = listCompliance;
+		this.closedCompliance = closedCompliance;
+		this.proxyCompliance = proxyCompliance;
+		this.cachingCompliance = cachingCompliance;
+		this.globalGeneratorNameScopeCompliance = globalGeneratorNameScopeCompliance;
 	}
 
 	@Override
@@ -101,30 +72,63 @@ public class JpaComplianceImpl implements MutableJpaCompliance {
 		return globalGeneratorNameScopeCompliance;
 	}
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// Mutators
+	public static class JpaComplianceBuilder {
+		private boolean queryCompliance;
+		private boolean transactionCompliance;
+		private boolean listCompliance;
+		private boolean closedCompliance;
+		private boolean proxyCompliance;
+		private boolean cachingCompliance;
+		private boolean globalGeneratorNameScopeCompliance;
 
-	public void setQueryCompliance(boolean queryCompliance) {
-		this.queryCompliance = queryCompliance;
-	}
+		public JpaComplianceBuilder() {
+		}
 
-	public void setTransactionCompliance(boolean transactionCompliance) {
-		this.transactionCompliance = transactionCompliance;
-	}
+		public JpaComplianceBuilder setQueryCompliance(boolean queryCompliance) {
+			this.queryCompliance = queryCompliance;
+			return this;
+		}
 
-	public void setListCompliance(boolean listCompliance) {
-		this.listCompliance = listCompliance;
-	}
+		public JpaComplianceBuilder setTransactionCompliance(boolean transactionCompliance) {
+			this.transactionCompliance = transactionCompliance;
+			return this;
+		}
 
-	public void setClosedCompliance(boolean closedCompliance) {
-		this.closedCompliance = closedCompliance;
-	}
+		public JpaComplianceBuilder setListCompliance(boolean listCompliance) {
+			this.listCompliance = listCompliance;
+			return this;
+		}
 
-	public void setProxyCompliance(boolean proxyCompliance) {
-		this.proxyCompliance = proxyCompliance;
-	}
+		public JpaComplianceBuilder setClosedCompliance(boolean closedCompliance) {
+			this.closedCompliance = closedCompliance;
+			return this;
+		}
 
-	public void setCachingCompliance(boolean cachingCompliance) {
-		this.cachingCompliance = cachingCompliance;
+		public JpaComplianceBuilder setProxyCompliance(boolean proxyCompliance) {
+			this.proxyCompliance = proxyCompliance;
+			return this;
+		}
+
+		public JpaComplianceBuilder setCachingCompliance(boolean cachingCompliance) {
+			this.cachingCompliance = cachingCompliance;
+			return this;
+		}
+
+		public JpaComplianceBuilder setGlobalGeneratorNameCompliance(boolean globalGeneratorNameCompliance) {
+			this.globalGeneratorNameScopeCompliance = globalGeneratorNameCompliance;
+			return this;
+		}
+
+		JpaCompliance createJpaCompliance() {
+			return new JpaComplianceImpl(
+					queryCompliance,
+					transactionCompliance,
+					listCompliance,
+					closedCompliance,
+					proxyCompliance,
+					cachingCompliance,
+					globalGeneratorNameScopeCompliance
+			);
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/MutableJpaComplianceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/MutableJpaComplianceImpl.java
@@ -1,0 +1,143 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.internal;
+
+import java.util.Map;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
+
+/**
+ * @author Steve Ebersole
+ */
+public class MutableJpaComplianceImpl implements MutableJpaCompliance {
+	private boolean queryCompliance;
+	private boolean transactionCompliance;
+	private boolean listCompliance;
+	private boolean closedCompliance;
+	private boolean proxyCompliance;
+	private boolean cachingCompliance;
+	private final boolean globalGeneratorNameScopeCompliance;
+
+	@SuppressWarnings("ConstantConditions")
+	public MutableJpaComplianceImpl(Map configurationSettings, boolean jpaByDefault) {
+		final Object legacyQueryCompliance = configurationSettings.get( AvailableSettings.JPAQL_STRICT_COMPLIANCE );
+
+		queryCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_QUERY_COMPLIANCE,
+				configurationSettings,
+				ConfigurationHelper.toBoolean( legacyQueryCompliance, jpaByDefault )
+		);
+		transactionCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_TRANSACTION_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+		listCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_LIST_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+		closedCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_CLOSED_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+		proxyCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_PROXY_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+		cachingCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_CACHING_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+		globalGeneratorNameScopeCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+	}
+
+	@Override
+	public boolean isJpaQueryComplianceEnabled() {
+		return queryCompliance;
+	}
+
+	@Override
+	public boolean isJpaTransactionComplianceEnabled() {
+		return transactionCompliance;
+	}
+
+	@Override
+	public boolean isJpaListComplianceEnabled() {
+		return listCompliance;
+	}
+
+	@Override
+	public boolean isJpaClosedComplianceEnabled() {
+		return closedCompliance;
+	}
+
+	@Override
+	public boolean isJpaProxyComplianceEnabled() {
+		return proxyCompliance;
+	}
+
+	@Override
+	public boolean isJpaCacheComplianceEnabled() {
+		return cachingCompliance;
+	}
+
+	@Override
+	public boolean isGlobalGeneratorScopeEnabled() {
+		return globalGeneratorNameScopeCompliance;
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// Mutators
+
+	public void setQueryCompliance(boolean queryCompliance) {
+		this.queryCompliance = queryCompliance;
+	}
+
+	public void setTransactionCompliance(boolean transactionCompliance) {
+		this.transactionCompliance = transactionCompliance;
+	}
+
+	public void setListCompliance(boolean listCompliance) {
+		this.listCompliance = listCompliance;
+	}
+
+	public void setClosedCompliance(boolean closedCompliance) {
+		this.closedCompliance = closedCompliance;
+	}
+
+	public void setProxyCompliance(boolean proxyCompliance) {
+		this.proxyCompliance = proxyCompliance;
+	}
+
+	public void setCachingCompliance(boolean cachingCompliance) {
+		this.cachingCompliance = cachingCompliance;
+	}
+
+	@Override
+	public JpaCompliance immutableCopy() {
+		JpaComplianceImpl.JpaComplianceBuilder builder = new JpaComplianceImpl.JpaComplianceBuilder();
+		builder.setQueryCompliance( queryCompliance )
+				.setTransactionCompliance( transactionCompliance )
+				.setListCompliance( listCompliance )
+				.setClosedCompliance( closedCompliance )
+				.setProxyCompliance( proxyCompliance )
+				.setCachingCompliance( cachingCompliance )
+				.setGlobalGeneratorNameCompliance( globalGeneratorNameScopeCompliance );
+		return builder.createJpaCompliance();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa;
+package org.hibernate.jpa.spi;
 
 import org.hibernate.Transaction;
 
@@ -89,4 +89,12 @@ public interface JpaCompliance {
 	 * @return {@code true} says to act the spec-defined way.
 	 */
 	boolean isJpaCacheComplianceEnabled();
+
+	/**
+	 * Should the the scope of {@link javax.persistence.TableGenerator#name()} and {@link javax.persistence.SequenceGenerator#name()} be
+	 * considered globally or locally defined?
+	 *
+	 * @return {@code true} indicates the generator name scope is considered global.
+	 */
+	boolean isGlobalGeneratorScopeEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.spi;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface MutableJpaCompliance extends JpaCompliance {
+	void setQueryCompliance(boolean queryCompliance);
+
+	void setTransactionCompliance(boolean transactionCompliance);
+
+	void setListCompliance(boolean listCompliance);
+
+	void setClosedCompliance(boolean closedCompliance);
+
+	void setProxyCompliance(boolean proxyCompliance);
+
+	void setCachingCompliance(boolean cachingCompliance);
+}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
@@ -21,4 +21,6 @@ public interface MutableJpaCompliance extends JpaCompliance {
 	void setProxyCompliance(boolean proxyCompliance);
 
 	void setCachingCompliance(boolean cachingCompliance);
+
+	JpaCompliance immutableCopy();
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
@@ -15,7 +15,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.transaction.spi.IsolationDelegate;
 import org.hibernate.engine.transaction.spi.TransactionObserver;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransaction;
 import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransactionAccess;

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
@@ -19,7 +19,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.engine.transaction.spi.IsolationDelegate;
 import org.hibernate.engine.transaction.spi.TransactionObserver;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.resource.jdbc.spi.JdbcSessionContext;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.TransactionRequiredForJoinException;

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinator.java
@@ -8,7 +8,7 @@ package org.hibernate.resource.transaction.spi;
 
 import org.hibernate.engine.transaction.spi.IsolationDelegate;
 import org.hibernate.engine.transaction.spi.TransactionObserver;
-import org.hibernate.jpa.JpaCompliance;
+import org.hibernate.jpa.spi.JpaCompliance;
 
 /**
  * Models the coordination of all transaction related flows.

--- a/hibernate-core/src/test/java/org/hibernate/jpa/JpaComplianceTestingImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/JpaComplianceTestingImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.jpa;
 
+import org.hibernate.jpa.spi.JpaCompliance;
+
 /**
  * @author Steve Ebersole
  */
@@ -44,6 +46,7 @@ public class JpaComplianceTestingImpl implements JpaCompliance {
 	private boolean closedCompliance;
 	private boolean proxyCompliance;
 	private boolean cacheCompliance;
+	private boolean idGeneratorNameScopeCompliance;
 
 	@Override
 	public boolean isJpaQueryComplianceEnabled() {
@@ -73,5 +76,10 @@ public class JpaComplianceTestingImpl implements JpaCompliance {
 	@Override
 	public boolean isJpaCacheComplianceEnabled() {
 		return cacheCompliance;
+	}
+
+	@Override
+	public boolean isGlobalGeneratorScopeEnabled() {
+		return idGeneratorNameScopeCompliance;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/namescope/IdGeneratorNamesGlobalScopeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/namescope/IdGeneratorNamesGlobalScopeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.namescope;
+
+import java.util.Properties;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.TableGenerator;
+
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import org.junit.Test;
+
+/**
+ * @author Andrea Boriero
+ */
+public class IdGeneratorNamesGlobalScopeTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNoSequenceGenratorNameClash() {
+		buildSessionFactory();
+	}
+
+	@Entity(name = "FirstEntity")
+	@TableGenerator(
+			name = "table-generator",
+			table = "table_identifier_2",
+			pkColumnName = "identifier",
+			valueColumnName = "value",
+			allocationSize = 5
+	)
+	public static class FirstEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.TABLE, generator = "table-generator")
+		private Long id;
+	}
+
+	@Entity(name = "SecondEntity")
+	@TableGenerator(
+			name = "table-generator",
+			table = "table_identifier",
+			pkColumnName = "identifier",
+			valueColumnName = "value",
+			allocationSize = 5
+	)
+	public static class SecondEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.TABLE, generator = "table-generator")
+		private Long id;
+	}
+
+	private void buildSessionFactory() {
+		Configuration configuration =  new Configuration();
+		final BootstrapServiceRegistryBuilder builder = new BootstrapServiceRegistryBuilder();
+		builder.applyClassLoader( getClass().getClassLoader() );
+		BootstrapServiceRegistry bootRegistry = builder.build();
+		StandardServiceRegistryImpl serviceRegistry = buildServiceRegistry( bootRegistry, configuration );
+		configuration.addAnnotatedClass( FirstEntity.class );
+		configuration.addAnnotatedClass( SecondEntity.class );
+		configuration.buildSessionFactory( serviceRegistry );
+	}
+
+	protected StandardServiceRegistryImpl buildServiceRegistry(BootstrapServiceRegistry bootRegistry, Configuration configuration) {
+		Properties properties = new Properties();
+		properties.putAll( configuration.getProperties() );
+		properties.put( AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE, "true" );
+		ConfigurationHelper.resolvePlaceHolders( properties );
+
+		StandardServiceRegistryBuilder cfgRegistryBuilder = configuration.getStandardServiceRegistryBuilder();
+
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder( bootRegistry, cfgRegistryBuilder.getAggregatedCfgXml() )
+				.applySettings( properties );
+
+		return (StandardServiceRegistryImpl) registryBuilder.build();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/namescope/IdGeneratorNamesLocalScopeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/namescope/IdGeneratorNamesLocalScopeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.namescope;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.TableGenerator;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public class IdGeneratorNamesLocalScopeTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { FirstEntity.class, SecondEntity.class };
+	}
+
+	@Test
+	public void testNoSequenceGenratorNameClash() {
+		final FirstEntity first = new FirstEntity();
+		final SecondEntity second = new SecondEntity();
+		doInHibernate( this::sessionFactory, session -> {
+			session.persist( first );
+			session.persist( second );
+		} );
+
+		assertThat( first.getId(), is( 2L ) );
+		assertThat( second.getId(), is( 11L ) );
+	}
+
+	@Entity(name = "FirstEntity")
+	@TableGenerator(
+			name = "table-generator",
+			table = "table_identifier_2",
+			pkColumnName = "identifier",
+			valueColumnName = "value",
+			allocationSize = 5,
+			initialValue = 1
+	)
+	public static class FirstEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.TABLE, generator = "table-generator")
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "SecondEntity")
+	@TableGenerator(
+			name = "table-generator",
+			table = "table_identifier",
+			pkColumnName = "identifier",
+			valueColumnName = "value",
+			allocationSize = 5,
+			initialValue = 10
+	)
+	public static class SecondEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.TABLE, generator = "table-generator")
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/TableGeneratorMultipleDefinitionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/TableGeneratorMultipleDefinitionTest.java
@@ -13,6 +13,9 @@ import javax.persistence.Id;
 import javax.persistence.TableGenerator;
 
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -26,11 +29,18 @@ public class TableGeneratorMultipleDefinitionTest extends BaseUnitTestCase {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testDuplicateGeneratorNamesDefinition() {
-		new MetadataSources().addAnnotatedClass( TestEntity1.class )
-				.addAnnotatedClass( TestEntity2.class )
-				.buildMetadata()
-				.buildSessionFactory().close();
-
+		StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE, "true" )
+				.build();
+		try {
+			new MetadataSources( ssr )
+					.addAnnotatedClass( TestEntity2.class )
+					.addAnnotatedClass( TestEntity1.class )
+					.buildMetadata();
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
 	}
 
 	@Entity(name = "TestEntity1")

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/TableGeneratorVisibilityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/TableGeneratorVisibilityTest.java
@@ -12,6 +12,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.TableGenerator;
 
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.transaction.TransactionUtil;
@@ -22,6 +25,11 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-12157")
 public class TableGeneratorVisibilityTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE, "true" );
+	}
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.jandex.IndexView;
@@ -46,6 +47,11 @@ public class BootstrapContextImpl implements BootstrapContext {
 	@Override
 	public StandardServiceRegistry getServiceRegistry() {
 		return delegate.getServiceRegistry();
+	}
+
+	@Override
+	public MutableJpaCompliance getJpaCompliance() {
+		return delegate.getJpaCompliance();
 	}
 
 	@Override

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -42,48 +42,6 @@ For backward compatibility, a new setting called `hibernate.id.generator.stored_
 Existing applications migrating to 5.3 and using the `@TableGenerator` have to set the `hibernate.id.generator.stored_last_used` configuration property to `false`.
 ====
 
-=== Change in the `@TableGenerator` and `@SequenceGenerator` name scope
-
-In order to be compliant with the JPA specification, generators names are now considered global (e.g. https://hibernate.atlassian.net/browse/HHH-12157[HHH-12157]) .
-Configuring two generators, even if with different types but with the same name will now cause a `java.lang.IllegalArgumentException' to be thrown at boot time.
-
-For example, the following mappings are no longer valid:
-
-[source,java]
-----
-@Entity
-@TableGenerator(name = "ID_GENERATOR", ... )
-public class FirstEntity {
-    ....
-}
-
-@Entity
-@TableGenerator(name = "ID_GENERATOR", ... )
-public class SecondEntity {
-    ....
-}
-----
-
-or
-
-[source,java]
-----
-@Entity
-@TableGenerator(name = "ID_GENERATOR", ... )
-public class FirstEntity {
-    ....
-}
-
-@Entity
-@SequenceGenerator(name="ID_GENERATOR", ... )
-public class SecondEntity {
-    ....
-}
-----
-
-The solution is to make all generators unique so that there are no two generators with the same name.
-
-
 === Drop hibernate-infinispan module
 
 Support for using Infinispan as a Hibernate 2nd-level cache provider has been moved to the Infinispan project so


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12454

@sebersole any idea for a better name than ID_GENERATOR_NAMES_GLOBAL_SCOPE = "hibernate.id.generator.global_scope_name";?

Backporting to 5.2 do we have to keep the default value to true?