### PR TITLE
HHH-12474 - Make sure the JPA version is defined by a single property across build files

### DIFF
--- a/gradle/base-information.gradle
+++ b/gradle/base-information.gradle
@@ -10,7 +10,7 @@ apply plugin: 'base'
 ext {
 	hibernateVersion = '5.3.0-SNAPSHOT'
 	baselineJavaVersion = '1.8'
-	jpaVersion = '2.2'
+	jpaVersion = new JpaVersion('2.2')
 
 	final String[] hibernateVersionComponents = project.hibernateVersion.split( '\\.' )
 	hibernateMajorMinorVersion = hibernateVersionComponents[0] + '.' + hibernateVersionComponents[1]
@@ -21,3 +21,20 @@ ext {
 
 group = 'org.hibernate'
 version = project.hibernateVersion
+
+class JpaVersion {
+	/** The *normal* name (1.0, 2.0, ..) */
+	String name;
+
+	String osgiName
+
+	JpaVersion(String version){
+		name = version
+		osgiName = "${name}.0"
+	}
+
+	@Override
+	String toString() {
+		return name
+	}
+}

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -60,7 +60,7 @@ ext {
             byteBuddy:      "net.bytebuddy:byte-buddy:${byteBuddyVersion}",
 
             // javax
-            jpa:            'javax.persistence:javax.persistence-api:2.2',
+            jpa:            "javax.persistence:javax.persistence-api:${project.jpaVersion}",
             jta:            'org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.1.Final',
             validation:     "javax.validation:validation-api:${validationApiVersion}",
             jacc:           'org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.4_spec:1.0.2.Final',

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -59,7 +59,7 @@ jar {
 		instruction 'Implementation-Url', 'http://hibernate.org/orm'
 
 		instruction 'Hibernate-VersionFamily', project.hibernateMajorMinorVersion
-		instruction 'Hibernate-JpaVersion', project.jpaVersion
+		instruction 'Hibernate-JpaVersion', project.jpaVersion.name
 	}
 }
 

--- a/gradle/publishing-repos.gradle
+++ b/gradle/publishing-repos.gradle
@@ -53,7 +53,7 @@ bintray {
 				sign = true
 			}
 			attributes = [
-					'jpa': '2.2',
+					'jpa': project.jpaVersion,
 					'family': project.hibernateMajorMinorVersion
 			]
 			mavenCentralSync {

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -116,7 +116,7 @@ jar {
             'javax.validation.metadata;resolution:=optional',
             // TODO: Shouldn't have to explicitly list this, but the plugin
             // generates it with a [1.0,2) version.
-            'javax.persistence;version="2.1.0"',
+            "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
             // Temporarily support JTA 1.1 -- Karaf and other frameworks still
             // use it.  Without this, the plugin generates [1.2,2).
             // build.gradle adds javax.transaction for all modules

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -43,10 +43,10 @@ jar {
         instructionFirst 'Import-Package',
             // TODO: Shouldn't have to explicitly list the JPA packages, but
             // the plugin generates them with [1.0,2) versions.
-            'javax.persistence;version="2.1.0"',
-            'javax.persistence.criteria;version="2.1.0"',
-            'javax.persistence.metamodel;version="2.1.0"',
-            'javax.persistence.spi;version="2.1.0"',
+            "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
+            "javax.persistence.criteria;version=\"${project.jpaVersion.osgiName}\"",
+            "javax.persistence.metamodel;version=\"${project.jpaVersion.osgiName}\"",
+            "javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\"",
             // optionals
             'javax.naming;resolution:=optional',
             'org.apache.tools.ant;resolution:=optional'

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -93,7 +93,7 @@ provision {
 	override( 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api' ) {
 		groupId = 'javax.persistence'
 		artifactId = 'javax.persistence-api'
-		version = '2.2'
+		version = project.jpaVersion
 	}
 	/**TODO: explore overriding any other library we might need?
 	   Example: (not currently necessary)

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -99,8 +99,8 @@ jar {
 		instructionFirst 'Import-Package',
 			// TODO: Shouldn't have to explicitly list this, but the plugin
 			// generates it with a [1.0,2) version.
-			'javax.persistence;version="2.1.0"',
-			'javax.persistence.spi;version="2.1.0"'
+			"javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
+			"javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\""
 	}
 }
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12474

@sebersole a strange thing is the `published-java-module.gradle` where using `project.jpaVersion` cause a
"Could not find method instruction() for arguments [Hibernate-JpaVersion, 2.2] on object of type org.gradle.api.internal.plugins.osgi.DefaultOsgiManifest" exception, while using `project.jpaVersion.name` works fine, any idea of the reason? 