### PR TITLE
HHH-12487 - Calling getTransaction() on a closed Session

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -80,7 +80,6 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
@@ -404,13 +403,12 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public Transaction accessTransaction() {
-		if ( this.currentHibernateTransaction == null || this.currentHibernateTransaction.getStatus() != TransactionStatus.ACTIVE ) {
+		if ( this.currentHibernateTransaction == null ) {
 			this.currentHibernateTransaction = new TransactionImpl(
 					getTransactionCoordinator(),
 					getExceptionConverter(),
-					getFactory().getSessionFactoryOptions().getJpaCompliance()
+					this
 			);
-
 		}
 		if ( !isClosed() || (waitingForAutoClose && factory.isOpen()) ) {
 			getTransactionCoordinator().pulse();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/CloseEntityManagerWithActiveTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/CloseEntityManagerWithActiveTransactionTest.java
@@ -50,6 +50,7 @@ public class CloseEntityManagerWithActiveTransactionTest extends BaseEntityManag
 		super.addConfigOptions( options );
 		TestingJtaBootstrap.prepare( options );
 		options.put( AvailableSettings.TRANSACTION_TYPE, "JTA" );
+		options.put( org.hibernate.cfg.AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "true" );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/ClosedEntityManagerWithJpaTransactionComplianceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/ClosedEntityManagerWithJpaTransactionComplianceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.transaction;
+
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.Test;
+
+import org.hamcrest.CoreMatchers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public class ClosedEntityManagerWithJpaTransactionComplianceTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		options.put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "true" );
+	}
+
+	@Test
+	public void shouldReturnNotNullValueTest() {
+		EntityManager em = createEntityManager();
+		em.close();
+		assertThat( em.getTransaction(), CoreMatchers.notNullValue() );
+	}
+
+	@Test
+	public void testCallTransactionIsActive() {
+		EntityManager em = createEntityManager();
+		em.close();
+		assertFalse( em.getTransaction().isActive() );
+	}
+
+	@Test
+	public void testCallTransactionIsActive2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		assertFalse( transaction.isActive() );
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallCommit() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().commit();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallCommit2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.commit();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallBegin() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().begin();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallBegin2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.begin();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallSetRollBackOnly() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().setRollbackOnly();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallSetRollBackOnly2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.setRollbackOnly();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallRollBack() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().rollback();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallRollBack2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.rollback();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallGetRollBackOnly() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().getRollbackOnly();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallGetRollBackOnly2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.getRollbackOnly();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/ClosedEntityManagerWithoutJpaTransactionComplianceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/ClosedEntityManagerWithoutJpaTransactionComplianceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.transaction;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.Test;
+
+import org.hamcrest.CoreMatchers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public class ClosedEntityManagerWithoutJpaTransactionComplianceTest extends BaseEntityManagerFunctionalTestCase {
+	@Test
+	public void shouldReturnNotNullValueTest() {
+		EntityManager em = createEntityManager();
+		em.close();
+		assertThat( em.getTransaction(), CoreMatchers.notNullValue() );
+	}
+
+	@Test
+	public void testCallTransactionIsActive() {
+		EntityManager em = createEntityManager();
+		em.close();
+		assertFalse( em.getTransaction().isActive() );
+	}
+
+	@Test
+	public void testCallTransactionIsActive2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		assertFalse( transaction.isActive() );
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallCommit() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().commit();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallCommit2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.commit();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallBegin() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().begin();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testCallBegin2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.begin();
+	}
+
+	@Test
+	public void testCallSetRollBackOnly() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().setRollbackOnly();
+	}
+
+	@Test
+	public void testCallSetRollBackOnly2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.setRollbackOnly();
+	}
+
+	@Test
+	public void testCallRollBack() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction().rollback();
+	}
+
+	@Test
+	public void testCallRollBack2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		transaction.rollback();
+	}
+
+	@Test
+	public void testCallGetRollBackOnly() {
+		EntityManager em = createEntityManager();
+		em.close();
+		assertFalse( em.getTransaction().getRollbackOnly() );
+	}
+
+	@Test
+	public void testCallGetRollBackOnly2() {
+		EntityManager em = createEntityManager();
+		EntityTransaction transaction = em.getTransaction();
+		em.close();
+		assertFalse( transaction.getRollbackOnly() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/GetTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/GetTransactionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.transaction;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Andrea Boriero
+ */
+public class GetTransactionTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Test
+	public void testMultipleCallsReturnTheSameTransaction() {
+		EntityManager em = createEntityManager();
+		EntityTransaction t = em.getTransaction();
+		assertSame( t, em.getTransaction() );
+		assertFalse( t.isActive() );
+		t.begin();
+		assertSame( t, em.getTransaction() );
+		assertTrue( t.isActive() );
+		t.commit();
+		assertSame( t, em.getTransaction() );
+		assertFalse( t.isActive() );
+		em.close();
+		assertSame( t, em.getTransaction() );
+		assertFalse( t.isActive() );
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/JtaGetTransactionThrowsExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/JtaGetTransactionThrowsExceptionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.transaction;
+
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.jpa.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jta.TestingJtaBootstrap;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Andrea Boriero
+ */
+public class JtaGetTransactionThrowsExceptionTest extends BaseEntityManagerFunctionalTestCase {
+	@Override
+	protected void addConfigOptions(Map options) {
+		super.addConfigOptions( options );
+		TestingJtaBootstrap.prepare( options );
+		options.put( AvailableSettings.TRANSACTION_TYPE, "JTA" );
+		options.put( org.hibernate.cfg.AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "true" );
+	}
+
+	@Test(expected = IllegalStateException.class)
+	@TestForIssue( jiraKey = "HHH-12487")
+	public void onCloseEntityManagerTest() {
+		EntityManager em = createEntityManager();
+		em.close();
+		em.getTransaction();
+		fail( "Calling getTransaction on a JTA entity manager should throw an IllegalStateException" );
+	}
+
+	@Test(expected = IllegalStateException.class)
+	@TestForIssue(jiraKey = "HHH-12487")
+	public void onOpenEntityManagerTest() {
+		EntityManager em = createEntityManager();
+		try {
+			em.getTransaction();
+			fail( "Calling getTransaction on a JTA entity manager should throw an IllegalStateException" );
+		}
+		finally {
+			em.close();
+		}
+	}
+}
+


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12487

trying to create the `TransactionDriverControl` in the `TransactionImpl` constructor when 
the `EntityManager` is closed causes an Exception to be thrown because the `LogicalConnection` is closed.

