### PR TITLE
Minor fixes for SAP HANA

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1025,7 +1025,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getCurrentTimestampSelectString() {
-		return "select current_timestamp from dummy";
+		return "select current_timestamp from sys.dummy";
 	}
 
 	@Override
@@ -1099,7 +1099,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getSequenceNextValString(final String sequenceName) {
-		return "select " + getSelectSequenceNextValString( sequenceName ) + " from dummy";
+		return "select " + getSelectSequenceNextValString( sequenceName ) + " from sys.dummy";
 	}
 
 	@Override
@@ -1219,12 +1219,6 @@ public abstract class AbstractHANADialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsCircularCascadeDeleteConstraints() {
-		// HANA does not support circular constraints
-		return false;
-	}
-
-	@Override
 	public ScrollMode defaultScrollMode() {
 		return ScrollMode.FORWARD_ONLY;
 	}
@@ -1320,7 +1314,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getSelectGUIDString() {
-		return "select sysuuid from dummy";
+		return "select sysuuid from sys.dummy";
 	}
 
 	@Override
@@ -1410,7 +1404,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getCurrentSchemaCommand() {
-		return "select current_schema from dummy";
+		return "select current_schema from sys.dummy";
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/id/SequenceValueExtractor.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/SequenceValueExtractor.java
@@ -52,7 +52,7 @@ public class SequenceValueExtractor {
 		}
 		else if ( dialect instanceof AbstractHANADialect ) {
 
-			queryString = "select " + sequenceName + ".currval from dummy";
+			queryString = "select " + sequenceName + ".currval from sys.dummy";
 		}
 		else {
 			queryString = "select currval('" + sequenceName + "');";

--- a/hibernate-core/src/test/java/org/hibernate/test/procedure/HANAStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/procedure/HANAStoredProcedureTest.java
@@ -144,7 +144,7 @@ public class HANAStoredProcedureTest extends BaseEntityManagerFunctionalTestCase
 									"  BEGIN " +
 									"    p_recordset = " +
 									"    SELECT 1 as id " +
-									"    FROM DUMMY; " +
+									"    FROM SYS.DUMMY; " +
 									"  END; " );
 					statement.executeUpdate(
 							"CREATE OR REPLACE " +
@@ -152,8 +152,8 @@ public class HANAStoredProcedureTest extends BaseEntityManagerFunctionalTestCase
 									"  BEGIN " +
 									"    p_recordset = " +
 									"    SELECT 1 as id " +
-									"    FROM DUMMY; " +
-									"	 SELECT 1 INTO p_value FROM DUMMY; " +
+									"    FROM SYS.DUMMY; " +
+									"	 SELECT 1 INTO p_value FROM SYS.DUMMY; " +
 									"  END; " );
 				}
 				finally {
@@ -365,7 +365,7 @@ public class HANAStoredProcedureTest extends BaseEntityManagerFunctionalTestCase
 
 		try {
 			Integer phoneCount = (Integer) entityManager
-					.createNativeQuery( "SELECT fn_count_phones(:personId) FROM DUMMY" )
+					.createNativeQuery( "SELECT fn_count_phones(:personId) FROM SYS.DUMMY" )
 					.setParameter( "personId", 1 )
 					.getSingleResult();
 			assertEquals( Integer.valueOf( 2 ), phoneCount );


### PR DESCRIPTION
- Use "SYS.DUMMY" instead of "DUMMY" in queries to avoid errors due to a table
  named dummy in the current schema
- Remove override for Dialect#supportsCircularCascadeDeleteConstraints from
  AbstractHANADialect