### PR TITLE
Updated ParameterBindImpl to fix null error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ParameterBindImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ParameterBindImpl.java
@@ -78,10 +78,12 @@ public class ParameterBindImpl<T> implements ParameterBind<T> {
 			throw new IllegalStateException( "Can only bind values for IN/INOUT parameters : " + procedureParameter );
 		}
 
-		if ( procedureParameter.getParameterType() != null ) {
-			if ( !procedureParameter.getParameterType().isInstance( value ) ) {
-				throw new IllegalArgumentException( "Bind value [" + value + "] was not of specified type [" + procedureParameter.getParameterType() );
-			}
+		if ( value == null && !procedureParameter.isPassNullsEnabled() ) {
+			throw new IllegalArgumentException( "Parameter '" + procedureParameter.getName() +  "' doesn't allow NULL value" );
+		}
+		
+		if ( value != null && !procedureParameter.getParameterType().isInstance( value ) ) {
+			throw new IllegalArgumentException( "Bind value [" + value + "] was not of specified type [" + procedureParameter.getParameterType() );
 		}
 
 		this.value = value;


### PR DESCRIPTION
Fixes the error that occurs when the value of the stored procedure parameter is set to null. 
Now when the value is null it checks if procedure's parameter allows null.