### PR TITLE
HHH-12535: SAP HANA dialect doesn't support circular cascade delete constraints

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1219,12 +1219,6 @@ public abstract class AbstractHANADialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsCircularCascadeDeleteConstraints() {
-		// HANA does not support circular constraints
-		return false;
-	}
-
-	@Override
 	public ScrollMode defaultScrollMode() {
 		return ScrollMode.FORWARD_ONLY;
 	}


### PR DESCRIPTION
Fix for [HHH-12535](https://hibernate.atlassian.net/browse/HHH-12535)