### PR TITLE
[Discussion] Batching entity loader memory issue

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/BatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/BatchingEntityLoaderBuilder.java
@@ -54,11 +54,21 @@ public abstract class BatchingEntityLoaderBuilder {
 			LockMode lockMode,
 			SessionFactoryImplementor factory,
 			LoadQueryInfluencers influencers) {
+		return buildLoader( persister, null, batchSize, lockMode, factory, influencers );
+	}
+
+	public UniqueEntityLoader buildLoader(
+			OuterJoinLoadable persister,
+			UniqueEntityLoader entityLoaderTemplate,
+			int batchSize,
+			LockMode lockMode,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers influencers) {
 		if ( batchSize <= 1 ) {
 			// no batching
 			return buildNonBatchingLoader( persister, lockMode, factory, influencers );
 		}
-		return buildBatchingLoader( persister, batchSize, lockMode, factory, influencers );
+		return buildBatchingLoader( persister, entityLoaderTemplate, batchSize, lockMode, factory, influencers );
 	}
 
 	protected UniqueEntityLoader buildNonBatchingLoader(
@@ -75,6 +85,16 @@ public abstract class BatchingEntityLoaderBuilder {
 			LockMode lockMode,
 			SessionFactoryImplementor factory,
 			LoadQueryInfluencers influencers);
+
+	protected UniqueEntityLoader buildBatchingLoader(
+			OuterJoinLoadable persister,
+			UniqueEntityLoader entityLoaderTemplate,
+			int batchSize,
+			LockMode lockMode,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers influencers) {
+		return buildBatchingLoader( persister, batchSize, lockMode, factory, influencers );
+	}
 
 	/**
 	 * Builds a batch-fetch capable loader based on the given persister, lock-options, etc.
@@ -93,11 +113,21 @@ public abstract class BatchingEntityLoaderBuilder {
 			LockOptions lockOptions,
 			SessionFactoryImplementor factory,
 			LoadQueryInfluencers influencers) {
+		return buildLoader( persister, null, batchSize, lockOptions, factory, influencers );
+	}
+
+	public UniqueEntityLoader buildLoader(
+			OuterJoinLoadable persister,
+			UniqueEntityLoader entityLoaderTemplate,
+			int batchSize,
+			LockOptions lockOptions,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers influencers) {
 		if ( batchSize <= 1 ) {
 			// no batching
 			return buildNonBatchingLoader( persister, lockOptions, factory, influencers );
 		}
-		return buildBatchingLoader( persister, batchSize, lockOptions, factory, influencers );
+		return buildBatchingLoader( persister, entityLoaderTemplate, batchSize, lockOptions, factory, influencers );
 	}
 
 	protected UniqueEntityLoader buildNonBatchingLoader(
@@ -114,4 +144,14 @@ public abstract class BatchingEntityLoaderBuilder {
 			LockOptions lockOptions,
 			SessionFactoryImplementor factory,
 			LoadQueryInfluencers influencers);
+
+	protected UniqueEntityLoader buildBatchingLoader(
+			OuterJoinLoadable persister,
+			UniqueEntityLoader initialEntityLoader,
+			int batchSize,
+			LockOptions lockOptions,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers influencers) {
+		return buildBatchingLoader( persister, batchSize, lockOptions, factory, influencers );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/AbstractLoadPlanBasedEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/AbstractLoadPlanBasedEntityLoader.java
@@ -28,6 +28,7 @@ import org.hibernate.loader.plan.build.spi.LoadPlanBuildingAssociationVisitation
 import org.hibernate.loader.plan.build.spi.MetamodelDrivenLoadPlanBuilder;
 import org.hibernate.loader.plan.exec.internal.AbstractLoadPlanBasedLoader;
 import org.hibernate.loader.plan.exec.internal.BatchingLoadQueryDetailsFactory;
+import org.hibernate.loader.plan.exec.internal.EntityLoadQueryDetails;
 import org.hibernate.loader.plan.exec.query.spi.QueryBuildingParameters;
 import org.hibernate.loader.plan.exec.spi.LoadQueryDetails;
 import org.hibernate.loader.plan.spi.LoadPlan;
@@ -84,6 +85,23 @@ public abstract class AbstractLoadPlanBasedEntityLoader extends AbstractLoadPlan
 				uniqueKeyColumnNames,
 				buildingParameters,
 				factory
+		);
+	}
+
+	protected AbstractLoadPlanBasedEntityLoader(
+			OuterJoinLoadable entityPersister,
+			SessionFactoryImplementor factory,
+			EntityLoadQueryDetails entityLoaderQueryDetailsTemplate,
+			Type uniqueKeyType,
+			QueryBuildingParameters buildingParameters) {
+		super( factory );
+		this.entityPersister = entityPersister;
+		this.uniqueKeyType = uniqueKeyType;
+		this.entityName = entityPersister.getEntityName();
+
+		this.staticLoadQuery = BatchingLoadQueryDetailsFactory.INSTANCE.makeEntityLoadQueryDetails(
+				entityLoaderQueryDetailsTemplate,
+				buildingParameters
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/EntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/EntityLoader.java
@@ -12,11 +12,11 @@ import org.hibernate.MappingException;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.loader.plan.exec.internal.EntityLoadQueryDetails;
 import org.hibernate.loader.plan.exec.query.internal.QueryBuildingParametersImpl;
 import org.hibernate.loader.plan.exec.query.spi.QueryBuildingParameters;
 import org.hibernate.persister.entity.OuterJoinLoadable;
 import org.hibernate.type.Type;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -44,6 +44,7 @@ public class EntityLoader extends AbstractLoadPlanBasedEntityLoader  {
 
 	public static class Builder {
 		private final OuterJoinLoadable persister;
+		private EntityLoader entityLoaderTemplate;
 		private int batchSize = 1;
 		private LoadQueryInfluencers influencers = LoadQueryInfluencers.NONE;
 		private LockMode lockMode = LockMode.NONE;
@@ -51,6 +52,11 @@ public class EntityLoader extends AbstractLoadPlanBasedEntityLoader  {
 
 		public Builder(OuterJoinLoadable persister) {
 			this.persister = persister;
+		}
+
+		public Builder withEntityLoaderTemplate(EntityLoader entityLoaderTemplate) {
+			this.entityLoaderTemplate = entityLoaderTemplate;
+			return this;
 		}
 
 		public Builder withBatchSize(int batchSize) {
@@ -79,18 +85,34 @@ public class EntityLoader extends AbstractLoadPlanBasedEntityLoader  {
 
 		public EntityLoader byUniqueKey(String[] keyColumnNames, Type keyType) {
 			// capture current values in a new instance of QueryBuildingParametersImpl
-			return new EntityLoader(
-					persister.getFactory(),
-					persister,
-					keyColumnNames,
-					keyType,
-					new QueryBuildingParametersImpl(
-							influencers,
-							batchSize,
-							lockMode,
-							lockOptions
-					)
-			);
+			if ( entityLoaderTemplate == null ) {
+				return new EntityLoader(
+						persister.getFactory(),
+						persister,
+						keyColumnNames,
+						keyType,
+						new QueryBuildingParametersImpl(
+								influencers,
+								batchSize,
+								lockMode,
+								lockOptions
+						)
+				);
+			}
+			else {
+				return new EntityLoader(
+						persister.getFactory(),
+						persister,
+						entityLoaderTemplate,
+						keyType,
+						new QueryBuildingParametersImpl(
+								influencers,
+								batchSize,
+								lockMode,
+								lockOptions
+						)
+				);
+			}
 		}
 	}
 
@@ -120,5 +142,38 @@ public class EntityLoader extends AbstractLoadPlanBasedEntityLoader  {
 				);
 			}
 		}
+	}
+
+	private EntityLoader(
+			SessionFactoryImplementor factory,
+			OuterJoinLoadable persister,
+			EntityLoader entityLoaderTemplate,
+			Type uniqueKeyType,
+			QueryBuildingParameters buildingParameters) throws MappingException {
+		super( persister, factory, entityLoaderTemplate.getStaticLoadQuery(), uniqueKeyType, buildingParameters );
+		if ( log.isDebugEnabled() ) {
+			if ( buildingParameters.getLockOptions() != null ) {
+				log.debugf(
+						"Static select for entity %s [%s:%s]: %s",
+						getEntityName(),
+						buildingParameters.getLockOptions().getLockMode(),
+						buildingParameters.getLockOptions().getTimeOut(),
+						getStaticLoadQuery().getSqlStatement()
+				);
+			}
+			else if ( buildingParameters.getLockMode() != null ) {
+				log.debugf(
+						"Static select for entity %s [%s]: %s",
+						getEntityName(),
+						buildingParameters.getLockMode(),
+						getStaticLoadQuery().getSqlStatement()
+				);
+			}
+		}
+	}
+
+	@Override
+	protected EntityLoadQueryDetails getStaticLoadQuery() {
+		return (EntityLoadQueryDetails) super.getStaticLoadQuery();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/LegacyBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/LegacyBatchingEntityLoaderBuilder.java
@@ -20,7 +20,7 @@ import org.hibernate.loader.entity.UniqueEntityLoader;
 import org.hibernate.persister.entity.OuterJoinLoadable;
 
 /**
- * LoadPlan-based implementation of the the legacy batch loading strategy
+ * LoadPlan-based implementation of the legacy batch loading strategy
  *
  * @author Steve Ebersole
  */
@@ -57,15 +57,7 @@ public class LegacyBatchingEntityLoaderBuilder extends AbstractBatchingEntityLoa
 				LockMode lockMode,
 				SessionFactoryImplementor factory,
 				LoadQueryInfluencers loadQueryInfluencers) {
-			super( persister );
-			this.batchSizes = ArrayHelper.getBatchSizes( maxBatchSize );
-			this.loaders = new EntityLoader[ batchSizes.length ];
-			final EntityLoader.Builder entityLoaderBuilder = EntityLoader.forEntity( persister )
-					.withInfluencers( loadQueryInfluencers )
-					.withLockMode( lockMode );
-			for ( int i = 0; i < batchSizes.length; i++ ) {
-				this.loaders[i] = entityLoaderBuilder.withBatchSize( batchSizes[i] ).byPrimaryKey();
-			}
+			this( persister, maxBatchSize, lockMode, null, factory, loadQueryInfluencers );
 		}
 
 		public LegacyBatchingEntityLoader(
@@ -74,14 +66,29 @@ public class LegacyBatchingEntityLoaderBuilder extends AbstractBatchingEntityLoa
 				LockOptions lockOptions,
 				SessionFactoryImplementor factory,
 				LoadQueryInfluencers loadQueryInfluencers) {
+			this( persister, maxBatchSize, null, lockOptions, factory, loadQueryInfluencers );
+		}
+
+		protected LegacyBatchingEntityLoader(
+				OuterJoinLoadable persister,
+				int maxBatchSize,
+				LockMode lockMode,
+				LockOptions lockOptions,
+				SessionFactoryImplementor factory,
+				LoadQueryInfluencers loadQueryInfluencers) {
 			super( persister );
 			this.batchSizes = ArrayHelper.getBatchSizes( maxBatchSize );
 			this.loaders = new EntityLoader[ batchSizes.length ];
 			final EntityLoader.Builder entityLoaderBuilder = EntityLoader.forEntity( persister )
 					.withInfluencers( loadQueryInfluencers )
+					.withLockMode( lockMode )
 					.withLockOptions( lockOptions );
-			for ( int i = 0; i < batchSizes.length; i++ ) {
-				this.loaders[i] = entityLoaderBuilder.withBatchSize( batchSizes[i] ).byPrimaryKey();
+
+			// we create a first entity loader to use it as a template for the others
+			this.loaders[0] = entityLoaderBuilder.withBatchSize( batchSizes[0] ).byPrimaryKey();
+
+			for ( int i = 1; i < batchSizes.length; i++ ) {
+				this.loaders[i] = entityLoaderBuilder.withEntityLoaderTemplate( this.loaders[0] ).withBatchSize( batchSizes[i] ).byPrimaryKey();
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadQueryDetails.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadQueryDetails.java
@@ -90,6 +90,15 @@ public abstract class AbstractLoadQueryDetails implements LoadQueryDetails {
 	protected final SessionFactoryImplementor getSessionFactory() {
 		return queryProcessor.getSessionFactory();
 	}
+
+	protected LoadPlan getLoadPlan() {
+		return loadPlan;
+	}
+
+	protected String[] getKeyColumnNames() {
+		return keyColumnNames;
+	}
+
 	/**
 	 * Main entry point for properly handling the FROM clause and and joins and restrictions
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BatchingLoadQueryDetailsFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BatchingLoadQueryDetailsFactory.java
@@ -69,6 +69,23 @@ public class BatchingLoadQueryDetailsFactory {
 	}
 
 	/**
+	 * Returns a EntityLoadQueryDetails object based on an existing one and additional elements specific to this one.
+	 *
+	 * @param entityLoadQueryDetailsTemplate the template
+	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * that add additional joins here)
+	 * @return The EntityLoadQueryDetails
+	 */
+	public LoadQueryDetails makeEntityLoadQueryDetails(
+			EntityLoadQueryDetails entityLoadQueryDetailsTemplate,
+			QueryBuildingParameters buildingParameters) {
+		return new EntityLoadQueryDetails(
+				entityLoadQueryDetailsTemplate,
+				buildingParameters
+		);
+	}
+
+	/**
 	 * Constructs a BasicCollectionLoadQueryDetails object from the given inputs.
 	 *
 	 * @param collectionPersister The collection persister.

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/EntityLoadQueryDetails.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/EntityLoadQueryDetails.java
@@ -10,8 +10,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
 
-import org.hibernate.LockOptions;
-import org.hibernate.Session;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -20,7 +18,6 @@ import org.hibernate.loader.plan.exec.process.internal.AbstractRowReader;
 import org.hibernate.loader.plan.exec.process.internal.EntityReferenceInitializerImpl;
 import org.hibernate.loader.plan.exec.process.internal.EntityReturnReader;
 import org.hibernate.loader.plan.exec.process.internal.ResultSetProcessingContextImpl;
-import org.hibernate.loader.plan.exec.process.internal.ResultSetProcessorHelper;
 import org.hibernate.loader.plan.exec.process.spi.EntityReferenceInitializer;
 import org.hibernate.loader.plan.exec.process.spi.ReaderCollector;
 import org.hibernate.loader.plan.exec.process.spi.ResultSetProcessingContext;
@@ -31,12 +28,9 @@ import org.hibernate.loader.plan.exec.spi.EntityReferenceAliases;
 import org.hibernate.loader.plan.spi.EntityReturn;
 import org.hibernate.loader.plan.spi.LoadPlan;
 import org.hibernate.loader.plan.spi.QuerySpace;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.Joinable;
 import org.hibernate.persister.entity.OuterJoinLoadable;
 import org.hibernate.persister.entity.Queryable;
-import org.hibernate.type.CompositeType;
-import org.hibernate.type.Type;
 
 import org.jboss.logging.Logger;
 
@@ -87,6 +81,22 @@ public class EntityLoadQueryDetails extends AbstractLoadQueryDetails {
 				new EntityReturnReader( rootReturn ),
 				new EntityReferenceInitializerImpl( rootReturn, entityReferenceAliases, true )
 		);
+		generate();
+	}
+
+	protected EntityLoadQueryDetails(
+			EntityLoadQueryDetails initialEntityLoadQueryDetails,
+			QueryBuildingParameters buildingParameters) {
+		super(
+				initialEntityLoadQueryDetails.getLoadPlan(),
+				(AliasResolutionContextImpl) initialEntityLoadQueryDetails.getAliasResolutionContext(),
+				buildingParameters,
+				initialEntityLoadQueryDetails.getKeyColumnNames(),
+				initialEntityLoadQueryDetails.getRootReturn(),
+				initialEntityLoadQueryDetails.getSessionFactory()
+		);
+		this.entityReferenceAliases = initialEntityLoadQueryDetails.entityReferenceAliases;
+		this.readerCollector = initialEntityLoadQueryDetails.readerCollector;
 		generate();
 	}
 


### PR DESCRIPTION
So apart from https://github.com/hibernate/hibernate-orm/pull/2277, which seems to be pretty safe, here are another batch of changes on top of it.

1. Vanilla ORM: **1002 MB**
2. With HHH-12556: **461 MB**
3. With more template initialization (https://github.com/hibernate/hibernate-orm/pull/2278/commits/832fca76ac5d4cccd1565def44f19ed6923f9270): **420 MB**
-> these are without any lazy loading so this is the maximal memory that will be used when all the loaders are initialized
-> **UPDATE: 3/ is unsafe if `AbstractEntityPersister` is subclassed and the loader creation methods are overridden, which is the case for OGM for instance.**  Therefore, changes withdrawn.
4. With lazy loading (https://github.com/hibernate/hibernate-orm/pull/2278/commits/20ceebfc9abb8da31e84fdb88b94e40f0d18f1e0): **264MB**
-> the lazy loading is only about the loaders loaded per lock mode, we still load all the LoadPlan based entity loaders for all batch sizes. I still load eagerly the loaders for `LockMode.NONE` and `LockMode.READ`.

The issue I have with 3. is that a user might not have the same behavior if he has subclassed AbstractEntityPersister and overridden `createEntityLoader(LockMode lockMode)` as I use another method injecting a template.

The issue with 4. is:
- we lazy load so the user might get surprised he doesn't have enough memory at some point during the application lifecycle. That being said, we really have **a lot** of ``LockMode``s so for many (most?) application usage, it will be a gain as the user won't use all the ``LockMode``s.
- for now I use a `Map` as the `Map` is exposed to subclasses so I have the same doubts as for 3. as we change slightly the behavior of methods that could be overridden or used in user subclasses.

I have added GitHub comments to underline what might be an issue.

What you have in the OP's case is:
```
 \_ [LockMode 1] batching entity loader 1
     \_ [batch size 1] LoadPlan entity loader 1.1
     \_ ...
     \_ [batch size n] LoadPlan entity loader 1.n
 \_ ...
 \_ [LockMode n] batching entity loader n
     \_ [batch size 1] LoadPlan entity loader n.1
     \_ ...
     \_ [batch size n] LoadPlan entity loader n.n
```
 * Point 2. shares common data structures between the various LoadPlan entity loaders for a given lock mode
 * Point 3. reuses the common data structure of the first lock mode for the other lock modes: to be more precise, it reinjects the common data structure of LoadPlan entity loader 1.1 inside the LoadPlan entity loaders of batching entity loader n
 * Point 4. lazy loads the batching entity loader per lock mode (the LoadPlan entity loader are still eagerly loaded)

I haven't created JIRA issues for 3. and 4. as I think the approach is open to discussion.