### PR TITLE
HHH-12612 - Fix metamodel generation with TYPE_USE based annotations.

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
@@ -121,7 +121,14 @@ public final class TypeUtils {
 			return extractClosestRealTypeAsString( compositeUpperBound, context );
 		}
 		else {
-			return context.getTypeUtils().erasure( type ).toString();
+			final TypeMirror erasureType = context.getTypeUtils().erasure( type );
+			if ( TypeKind.ARRAY.equals( erasureType.getKind() ) ) {
+				// keep old behavior here for arrays since #asElement returns null for them.
+				return erasureType.toString();
+			}
+			else {
+				return context.getTypeUtils().asElement( erasureType ).toString();
+			}
 		}
 	}
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/arraytype/ArrayTestWithTypeUseTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/arraytype/ArrayTestWithTypeUseTest.java
@@ -7,13 +7,12 @@
 package org.hibernate.jpamodelgen.test.arraytype;
 
 import org.hibernate.jpamodelgen.test.util.CompilationTest;
-import org.hibernate.jpamodelgen.test.util.IgnoreCompilationErrors;
 import org.hibernate.jpamodelgen.test.util.TestForIssue;
-import org.hibernate.jpamodelgen.test.util.TestUtil;
 import org.hibernate.jpamodelgen.test.util.WithClasses;
 import org.junit.Test;
 
 import static org.hibernate.jpamodelgen.test.util.TestUtil.assertAttributeTypeInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 
 /**
  * @author Chris Cranford
@@ -22,9 +21,8 @@ public class ArrayTestWithTypeUseTest extends CompilationTest {
 	@Test
 	@TestForIssue(jiraKey = "HHH-12011")
 	@WithClasses(TestEntity.class)
-	@IgnoreCompilationErrors
 	public void testArrayWithBeanValidation() {
-		System.out.println( TestUtil.getMetaModelSourceAsString( TestEntity.class ) );
+		assertMetamodelClassGeneratedFor(  TestEntity.class );
 
 		// Primitive Arrays
 		assertAttributeTypeInMetaModelFor( TestEntity.class, "primitiveAnnotatedArray", byte[].class, "Wrong type for field." );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTypeUseTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/ElementCollectionTypeUseTest.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.elementcollection;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertListAttributeTypeInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMapAttributesInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertSetAttributeTypeInMetaModelFor;
+
+/**
+ * @author Chris Cranford
+ */
+public class ElementCollectionTypeUseTest extends CompilationTest {
+	@Test
+	@TestForIssue(jiraKey = "HHH-12612")
+	@WithClasses(OfficeBuildingValidated.class)
+	public void testAnnotatedCollectionElements() {
+		assertMetamodelClassGeneratedFor( OfficeBuildingValidated.class );
+
+		assertMapAttributesInMetaModelFor(
+				OfficeBuildingValidated.class,
+				"doorCodes",
+				Integer.class,
+				byte[].class,
+				"Wrong type in map attributes."
+		);
+
+		assertSetAttributeTypeInMetaModelFor(
+				OfficeBuildingValidated.class,
+				"computerSerialNumbers",
+				String.class,
+				"Wrong type in set attribute."
+		);
+
+		assertListAttributeTypeInMetaModelFor(
+				OfficeBuildingValidated.class,
+				"employeeNames",
+				String.class,
+				"Wrong type in list attributes."
+		);
+
+		assertListAttributeTypeInMetaModelFor(
+				OfficeBuildingValidated.class,
+				"rooms",
+				Room.class,
+				"Wrong type in list attributes."
+		);
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/OfficeBuildingValidated.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/elementcollection/OfficeBuildingValidated.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.elementcollection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+
+/**
+ * @author Chris Cranford
+ */
+@Entity
+public class OfficeBuildingValidated {
+
+	// mock a bean validation annotation using TYPE_USE
+	@Target({ ElementType.TYPE_USE })
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface NotNullAllowed {
+
+	}
+
+	@ElementCollection
+	@NotNullAllowed
+	private Map<@NotNullAllowed Integer, @NotNullAllowed byte[]> doorCodes;
+
+	@ElementCollection
+	@NotNullAllowed
+	private Set<@NotNullAllowed String> computerSerialNumbers;
+
+	@ElementCollection
+	@NotNullAllowed
+	private List<@NotNullAllowed String> employeeNames;
+
+	@ElementCollection
+	@NotNullAllowed
+	private List<@NotNullAllowed Room> rooms;
+
+	public Map<Integer, byte[]> getDoorCodes() {
+		return doorCodes;
+	}
+
+	public void setDoorCodes(Map<Integer, byte[]> doorCodes) {
+		this.doorCodes = doorCodes;
+	}
+
+	public Set<String> getComputerSerialNumbers() {
+		return computerSerialNumbers;
+	}
+
+	public void setComputerSerialNumbers(Set<String> computerSerialNumbers) {
+		this.computerSerialNumbers = computerSerialNumbers;
+	}
+
+	public List<String> getEmployeeNames() {
+		return employeeNames;
+	}
+
+	public void setEmployeeNames(List<String> employeeNames) {
+		this.employeeNames = employeeNames;
+	}
+
+	public List<Room> getRooms() {
+		return rooms;
+	}
+
+	public void setRooms(List<Room> rooms) {
+		this.rooms = rooms;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
 import javax.persistence.metamodel.ListAttribute;
+import javax.persistence.metamodel.SetAttribute;
 import javax.tools.Diagnostic;
 
 import org.jboss.logging.Logger;
@@ -110,6 +111,27 @@ public class TestUtil {
 				"Types do not match: " + buildErrorString( errorString, clazz ),
 				expectedType,
 				actualType
+		);
+	}
+
+	public static void assertSetAttributeTypeInMetaModelFor(Class<?> clazz, String fieldName, Class<?> expectedType, String errorString) {
+		Field field = getFieldFromMetamodelFor( clazz, fieldName );
+		assertNotNull( "Cannot find field '" + fieldName + "' in " + clazz.getName(), field );
+		ParameterizedType type = (ParameterizedType) field.getGenericType();
+		Type rawType = type.getRawType();
+
+		assertEquals(
+				"Types do not match: " + buildErrorString( errorString, clazz ),
+				SetAttribute.class,
+				rawType
+		);
+
+		Type genericType = type.getActualTypeArguments()[1];
+
+		assertEquals(
+				"Types do not match: " + buildErrorString( errorString, clazz ),
+				expectedType,
+				genericType
 		);
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12612

While this addresses issues with collections that are annotated with TYPE_USE targeted annotations, this PR is still a WIP until we've determined all TYPE_USE scenarios are covered.