### PR TITLE
ByteBuddy enhancement assorted fixes/improvements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
@@ -37,6 +37,8 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 			throw new AssertionFailure( "attempting to build proxy without any superclass or interfaces" );
 		}
 
+		Class<?> superClassOrMainInterface = superClass != null ? superClass : interfaces[0];
+
 		Set<Class> key = new HashSet<Class>();
 		if ( superClass != null ) {
 			key.add( superClass );
@@ -55,7 +57,7 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 			.implement( ProxyConfiguration.class )
 			.intercept( FieldAccessor.ofField( ProxyConfiguration.INTERCEPTOR_FIELD_NAME ).withAssigner( Assigner.DEFAULT, Assigner.Typing.DYNAMIC ) )
 			.make()
-			.load( BasicProxyFactory.class.getClassLoader(), ByteBuddyState.getLoadingStrategy() )
+			.load( superClassOrMainInterface.getClassLoader(), ByteBuddyState.resolveClassLoadingStrategy( superClassOrMainInterface ) )
 			.getLoaded();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
@@ -26,9 +26,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 public class BasicProxyFactoryImpl implements BasicProxyFactory {
 
 	private static final Class[] NO_INTERFACES = new Class[0];
-	private static final NamingStrategy PROXY_NAMING = Environment.useLegacyProxyClassnames() ?
-			new NamingStrategy.SuffixingRandom( "HibernateBasicProxy$" ) :
-			new NamingStrategy.SuffixingRandom( "HibernateBasicProxy" );
+	private static final String PROXY_NAMING_SUFFIX = Environment.useLegacyProxyClassnames() ? "HibernateBasicProxy$" : "HibernateBasicProxy";
 
 	private final Class proxyClass;
 
@@ -48,7 +46,7 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 		}
 
 		this.proxyClass = bytebuddy.getCurrentyByteBuddy()
-			.with( PROXY_NAMING )
+			.with( new NamingStrategy.SuffixingRandom( PROXY_NAMING_SUFFIX, new NamingStrategy.SuffixingRandom.BaseNameResolver.ForFixedValue( superClassOrMainInterface.getName() ) ) )
 			.subclass( superClass == null ? Object.class : superClass )
 			.implement( interfaces == null ? NO_INTERFACES : interfaces )
 			.defineField( ProxyConfiguration.INTERCEPTOR_FIELD_NAME, ProxyConfiguration.Interceptor.class, Visibility.PRIVATE )

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -25,11 +25,6 @@ public final class ByteBuddyState {
 	private static final ByteBuddy buddy = new ByteBuddy().with( TypeValidation.DISABLED );
 
 	/**
-	 * This will need to change depending on the runtime JDK.
-	 */
-	private static final ClassLoadingStrategy loadingStrategy = new ClassLoadingStrategy.ForUnsafeInjection();
-
-	/**
 	 * This currently needs to be static: the BytecodeProvider is a static field of Environment and
 	 * is being accessed from static methods.
 	 * It will be easier to maintain the cache and its state when it will no longer be static
@@ -81,8 +76,8 @@ public final class ByteBuddyState {
 		return buddy;
 	}
 
-	public static ClassLoadingStrategy getLoadingStrategy() {
-		return loadingStrategy;
+	public static ClassLoadingStrategy<?> resolveClassLoadingStrategy(Class<?> originalClass) {
+		return new ClassLoadingStrategy.ForUnsafeInjection( originalClass.getProtectionDomain() );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -67,7 +67,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 				.method( newInstanceMethodName )
 				.intercept( MethodCall.construct( constructor ) )
 				.make()
-				.load( clazz.getClassLoader(), ByteBuddyState.getLoadingStrategy() )
+				.load( clazz.getClassLoader(), ByteBuddyState.resolveClassLoadingStrategy( clazz ) )
 				.getLoaded();
 
 		final Class bulkAccessor = bytebuddy.getCurrentyByteBuddy()
@@ -80,7 +80,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 				.method( getPropertyNamesMethodName )
 				.intercept( MethodCall.call( new CloningPropertyCall( getterNames ) ) )
 				.make()
-				.load( clazz.getClassLoader(), ByteBuddyState.getLoadingStrategy() )
+				.load( clazz.getClassLoader(), ByteBuddyState.resolveClassLoadingStrategy( clazz ) )
 				.getLoaded();
 
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1807,4 +1807,8 @@ public interface CoreMessageLogger extends BasicLogger {
 			id = 487)
 	void immutableEntityUpdateQuery(String sourceQuery, String querySpaces);
 
+	@Message(value = "Bytecode enhancement failed for class: %1$s. It might be due to the Java module system preventing Hibernate ORM from defining an enhanced class "
+			+ "in the same package as class %1$s. In this case, the class should be opened and exported to Hibernate ORM.", id = 488)
+	String bytecodeEnhancementFailedUnableToGetPrivateLookupFor(String className);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
@@ -113,7 +113,7 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 			.implement( ProxyConfiguration.class )
 			.intercept( FieldAccessor.ofField( ProxyConfiguration.INTERCEPTOR_FIELD_NAME ).withAssigner( Assigner.DEFAULT, Assigner.Typing.DYNAMIC ) )
 			.make()
-			.load( persistentClass.getClassLoader(), ByteBuddyState.getLoadingStrategy() )
+			.load( persistentClass.getClassLoader(), ByteBuddyState.resolveClassLoadingStrategy( persistentClass ) )
 			.getLoaded(), cacheForProxies );
 	}
 


### PR DESCRIPTION
## HHH-12614

 * https://hibernate.atlassian.net/browse/HHH-12614

This one is rather safe: it's all about keeping the protection domain when proxying classes.

## HHH-12618

 * https://hibernate.atlassian.net/browse/HHH-12618

This one is open to discussion: the idea is to use `MethodHandle` lookups when available. We have to be extra careful because the generated class has to end up in the original class package, which was not always the case before to the second commit added in this PR.

Especially, when dealing with an interface, the subclass was `Object` and thus the classes ended up in a `net.bytebuddy.renamed` package.