### PR TITLE
HHH-12592

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.hibernate.CacheMode;
 import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
+import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.cache.spi.entry.CollectionCacheEntry;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -248,6 +249,31 @@ public class CollectionLoadContext {
 //			}
 		}
 
+		// The collection has been completely initialized and added to the PersistenceContext.
+
+		if ( lce.getCollection().getOwner() != null ) {
+			// If the owner is bytecode-enhanced and the owner's collection value is uninitialized,
+			// then go ahead and set it to the newly initialized collection.
+			final BytecodeEnhancementMetadata bytecodeEnhancementMetadata =
+					persister.getOwnerEntityPersister().getInstrumentationMetadata();
+			if ( bytecodeEnhancementMetadata.isEnhancedForLazyLoading() ) {
+				// Figure out the collection property name.
+				// TODO: what if the collection is in an embeddable???
+				final String propertyName = persister.getRole().substring(
+						persister.getOwnerEntityPersister().getEntityName().length() + 1
+				);
+				if ( !bytecodeEnhancementMetadata.isAttributeLoaded( lce.getCollection().getOwner(), propertyName ) ) {
+					int propertyIndex = persister.getOwnerEntityPersister().getEntityMetamodel().getPropertyIndex(
+							propertyName
+					);
+					persister.getOwnerEntityPersister().setPropertyValue(
+							lce.getCollection().getOwner(),
+							propertyIndex,
+							lce.getCollection()
+					);
+				}
+			}
+		}
 
 		// add to cache if:
 		boolean addToCache =

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -689,15 +689,10 @@ public abstract class CollectionType extends AbstractType implements Association
 
 		// for a null target, or a target which is the same as the original, we
 		// need to put the merged elements in a new collection
-		Object result;
-		if ( target == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-			result = original;
-		}
-		else {
-			result = ( target == null || target == original ) ?
-					instantiateResult( original ) :
-					target;
-		}
+		Object result = ( target == null ||
+				target == original ||
+				target == LazyPropertyInitializer.UNFETCHED_PROPERTY ) ?
+				instantiateResult( original ) : target;
 
 		//for arrays, replaceElements() may return a different reference, since
 		//the array length might not match

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedCollectionInEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedCollectionInEmbeddableTest.java
@@ -1,0 +1,122 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.merge;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertNotSame;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue(jiraKey = "HHH-12592")
+@RunWith(BytecodeEnhancerRunner.class)
+public class MergeEnhancedDetachedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Heading.class, Grouping.class, Thing.class };
+	}
+
+	@Test
+	public void testMergeDetached() {
+		final Heading heading = doInHibernate( this::sessionFactory, session -> {
+			Heading entity = new Heading();
+			entity.name = "new";
+			entity.setGrouping( new Grouping() );
+			entity.getGrouping().getThings().add( new Thing() );
+			session.save( entity );
+			return entity;
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			heading.name = "updated";
+			Heading headingMerged = (Heading) session.merge( heading );
+			assertNotSame( heading, headingMerged );
+			assertNotSame( heading.grouping, headingMerged.grouping );
+			assertNotSame( heading.grouping.things, headingMerged.grouping.things );
+		} );
+	}
+
+	@Entity(name = "Heading")
+	public static class Heading {
+		private long id;
+		private String name;
+		private Grouping grouping;
+
+		@Id
+		@GeneratedValue
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Grouping getGrouping() {
+			return grouping;
+		}
+
+		public void setGrouping(Grouping grouping) {
+			this.grouping = grouping;
+		}
+	}
+
+	@Embeddable
+	public static class Grouping {
+		private Set<Thing> things = new HashSet<>();
+
+		@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+		public Set<Thing> getThings() {
+			return things;
+		}
+
+		public void setThings(Set<Thing> things) {
+			this.things = things;
+		}
+	}
+
+	@Entity(name = "Thing")
+	public static class Thing {
+		private long id;
+
+		@Id
+		@GeneratedValue
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
@@ -14,6 +14,7 @@ import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * @author Chris Cranford
@@ -37,7 +38,10 @@ public class MergeEnhancedDetachedOrphanRemovalTest extends BaseCoreFunctionalTe
 
 		doInHibernate( this::sessionFactory, session -> {
 			entity.setName( "updated" );
-			session.merge( entity );
+			Root entityMerged = (Root) session.merge( entity );
+			assertNotSame( entity, entityMerged );
+			assertNotSame( entity, entityMerged );
+			assertNotSame( entity.getLeaves(), entityMerged.getLeaves() );
 		} );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
@@ -40,6 +40,25 @@ public class MergeEnhancedDetachedOrphanRemovalTest extends BaseCoreFunctionalTe
 			entity.setName( "updated" );
 			Root entityMerged = (Root) session.merge( entity );
 			assertNotSame( entity, entityMerged );
+			assertNotSame( entity.getLeaves(), entityMerged.getLeaves() );
+		} );
+	}
+
+	@Test
+	public void testMergeDetachedNonEmptyCollection() {
+		final Root entity = doInHibernate( this::sessionFactory, session -> {
+			Root root = new Root();
+			root.setName( "new" );
+			Leaf leaf = new Leaf();
+			leaf.setRoot( root );
+			root.getLeaves().add( leaf );
+			session.save( root );
+			return root;
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			entity.setName( "updated" );
+			Root entityMerged = (Root) session.merge( entity );
 			assertNotSame( entity, entityMerged );
 			assertNotSame( entity.getLeaves(), entityMerged.getLeaves() );
 		} );


### PR DESCRIPTION
Add assertions to the test to ensure that the detached and merged collection are not the same, which currently fails.

I'll try reverting the fix and seeing if I can fix it a different way.

I've added a possible fix. 

The tricky bit for this use case is that, even though the collection is lazy, the collection still gets loaded when merging the entity. This happens when the operation cascades to the collection.

The code that causes the eager load on merge is: https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/loader/entity/CascadeEntityJoinWalker.java#L40-L44 .

The fix I came up with waits for the collection to be completely initialized, then set the initialized collection in the entity.

I'm not absolutely sure this is the right way to do this.

I  think it would be best if @sebersole and @barreiro both look at this.

