### PR TITLE
HHH-12584 In fact, we can provide a ReflectionOptimizer, just without the fast class instantiator

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/ReflectionOptimizerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/ReflectionOptimizerTest.java
@@ -8,7 +8,6 @@ package org.hibernate.test.bytecode;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import org.hibernate.bytecode.internal.javassist.BulkAccessor;
 import org.hibernate.bytecode.spi.BytecodeProvider;
@@ -61,7 +60,7 @@ public class ReflectionOptimizerTest extends BaseUnitTestCase {
 		BytecodeProvider provider = Environment.getBytecodeProvider();
 		ReflectionOptimizer reflectionOptimizer = provider.getReflectionOptimizer( AbstractClass.class, new String[]{ "getProperty" },
 				new String[]{ "setProperty" }, new Class[]{ String.class } );
-		assertNull( reflectionOptimizer );
+		assertNotNull( reflectionOptimizer );
 	}
 
 	@Test
@@ -70,7 +69,7 @@ public class ReflectionOptimizerTest extends BaseUnitTestCase {
 		BytecodeProvider provider = Environment.getBytecodeProvider();
 		ReflectionOptimizer reflectionOptimizer = provider.getReflectionOptimizer( Interface.class, new String[]{ "getProperty" },
 				new String[]{ "setProperty" }, new Class[]{ String.class } );
-		assertNull( reflectionOptimizer );
+		assertNotNull( reflectionOptimizer );
 	}
 
 	private void assertEquivalent(Object[] checkValues, Object[] values) {


### PR DESCRIPTION
I was mistaken by a flawed test and the fact that the Javassist bytecode provider returns null instead of throwing an exception in my previous commit.

I noticed that while backporting the fix to the 5.2 branch.

It should be correct now.

Basically, we avoid creating a fast class instantiator in the case of an abstract class or an interface as it does not make sense. The rest of the code checks if the fast class instantiator is null and in any way shouldn't call it in the case of an abstract case (an exception is thrown in this case).

I reopened: https://hibernate.atlassian.net/browse/HHH-12584 .

I will backport this one and the first commit in 5.2.18.