### PR TITLE
HHH-12637 : Improvement to fix for HHH-12592

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/Leaf.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/Leaf.java
@@ -11,11 +11,9 @@ import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.SequenceGenerator;
 
 /**
  * @author Chris Cranford
@@ -24,8 +22,7 @@ import javax.persistence.SequenceGenerator;
 @Access(AccessType.FIELD)
 public class Leaf {
 	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator="LEAF_SEQ")
-	@SequenceGenerator(name = "LEAF_SEQ", sequenceName = "LEAF_SEQ")
+	@GeneratedValue
 	private Long id;
 
 	@ManyToOne(optional = false)

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeDetachedCascadedCollectionInEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeDetachedCascadedCollectionInEmbeddableTest.java
@@ -9,13 +9,12 @@ package org.hibernate.test.bytecode.enhancement.merge;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.CascadeType;
-import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 
 import org.hibernate.testing.TestForIssue;
@@ -32,7 +31,7 @@ import static org.junit.Assert.assertNotSame;
  */
 @TestForIssue(jiraKey = "HHH-12592")
 @RunWith(BytecodeEnhancerRunner.class)
-public class MergeEnhancedDetachedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
+public class MergeDetachedCascadedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Heading.class, Grouping.class, Thing.class };
@@ -96,6 +95,7 @@ public class MergeEnhancedDetachedCollectionInEmbeddableTest extends BaseCoreFun
 		private Set<Thing> things = new HashSet<>();
 
 		@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+		@JoinColumn
 		public Set<Thing> getThings() {
 			return things;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeDetachedNonCascadedCollectionInEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/MergeDetachedNonCascadedCollectionInEmbeddableTest.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.merge;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertNotSame;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue(jiraKey = "HHH-12637")
+@RunWith(BytecodeEnhancerRunner.class)
+public class MergeDetachedNonCascadedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Heading.class, Grouping.class, Thing.class };
+	}
+
+	@Test
+	public void testMergeDetached() {
+		final Heading heading = doInHibernate( this::sessionFactory, session -> {
+			Heading entity = new Heading();
+			entity.name = "new";
+			entity.setGrouping( new Grouping() );
+			Thing thing = new Thing();
+			entity.getGrouping().getThings().add( thing );
+			session.save( thing );
+			session.save( entity );
+			return entity;
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			heading.name = "updated";
+			Heading headingMerged = (Heading) session.merge( heading );
+			assertNotSame( heading, headingMerged );
+			assertNotSame( heading.grouping, headingMerged.grouping );
+			assertNotSame( heading.grouping.things, headingMerged.grouping.things );
+		} );
+	}
+
+	@Entity(name = "Heading")
+	public static class Heading {
+		private long id;
+		private String name;
+		private Grouping grouping;
+
+		@Id
+		@GeneratedValue
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Grouping getGrouping() {
+			return grouping;
+		}
+
+		public void setGrouping(Grouping grouping) {
+			this.grouping = grouping;
+		}
+	}
+
+	@Embeddable
+	public static class Grouping {
+		private Set<Thing> things = new HashSet<>();
+
+		@OneToMany(fetch = FetchType.LAZY)
+		@JoinColumn
+		public Set<Thing> getThings() {
+			return things;
+		}
+
+		public void setThings(Set<Thing> things) {
+			this.things = things;
+		}
+	}
+
+	@Entity(name = "Thing")
+	public static class Thing {
+		private long id;
+
+		@Id
+		@GeneratedValue
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/Root.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/merge/Root.java
@@ -15,12 +15,11 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import javax.persistence.SequenceGenerator;
 
 /**
+ *
  * @author Chris Cranford
  */
 @Entity
@@ -31,8 +30,7 @@ public class Root {
 	private Set<Leaf> leaves = new HashSet<>();
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ROOT_SEQ")
-	@SequenceGenerator(name = "ROOT_SEQ", sequenceName = "ROOT_SEQ")
+	@GeneratedValue
 	public Long getId() {
 		return id;
 	}


### PR DESCRIPTION
The fix for HHH-12592 will call the owning entity {{BytecodeEnhancementMetadata#isAttributeLoaded}} for a collection contained within an embeddable, using a property name that is qualified by the embeddable (e.g., grouping.things). The method simply returns {{false}} in this case, because there is no lazy property with this (qualified) name.

Depending on how HHH-10480 is fixed, Hibernate may need to be changed to call {{BytecodeEnhancementMetadata#isAttributeLoaded}} for the embeddable (not the entity) with an unqualified property name.

I made a small change to the fix for HHH-12592 so that Hibernate does not bother calling {{BytecodeEnhancementMetadata#isAttributeLoaded}}  if the collection is in an embeddable.
I will also mention this code needs to be revisited when HHH-10480 is fixed.

I also added a couple of tests involving lazy collections in embeddables that shows that things work properly currently, before HHH-10480 is fixed.