### PR TITLE
HHH-12603 - re-enabled plugin in build.gradle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ the linked page, this also includes:
     * Clone your fork
 * See the wiki pages for setting up your IDE, whether you use 
 [IntelliJ IDEA](https://community.jboss.org/wiki/ContributingToHibernateUsingIntelliJ)
-or [Eclipse](https://community.jboss.org/wiki/ContributingToHibernateUsingEclipse).
+or [Eclipse](https://community.jboss.org/wiki/ContributingToHibernateUsingEclipse)<sup>(1)</sup>.
 
 
 ## Create the working (topic) branch
@@ -101,3 +101,6 @@ It is important that this topic branch on your fork:
 	a branch rather than specific commits.
 * remain until the PR is closed.  Once the underlying branch is deleted the corresponding
 	PR will be closed, if not already, and the changes will be lost.
+
+# Notes
+<sup>(1)</sup> Currently, there are some issues with the Gradle `eclipse` plugin due to some upgrades made by the gradle development team. If you get some error message running `./gradlew clean eclipse --refresh-dependencies` command, you can try either with `./gradlew clean --refresh-dependencies` or with the IDE tools to import gradle projects, being this last one the suggested approach

--- a/build.gradle
+++ b/build.gradle
@@ -112,10 +112,10 @@ buildScan {
 
 
 
-//allprojects {
-//	apply plugin: 'idea'
-//	apply plugin: 'eclipse'
-//}
+allprojects {
+	apply plugin: 'idea'
+	apply plugin: 'eclipse'
+}
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ allprojects {
 			name "jboss-snapshots"
 			url "http://snapshots.jboss.org/maven2/"
 		}
+		
+	apply plugin: 'idea'
+	apply plugin: 'eclipse'
 	}
 
 	// minimize changes, at least for now (gradle uses 'build' by default)..
@@ -108,14 +111,6 @@ buildScan {
 //        name = "hibernate-orm"
 //    }
 //}
-
-
-
-
-allprojects {
-	apply plugin: 'idea'
-	apply plugin: 'eclipse'
-}
 
 
 


### PR DESCRIPTION
This is my first PR. When I first cloned the repo in my local I got the reported error message. After my changes I got the following output:

```
$ ./gradlew clean eclipse --refresh-dependencies

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 7m 21s
86 actionable tasks: 68 executed, 18 up-to-date
```

I don't know if there is any way to test this fix.