### PR TITLE
HHH-12640: Update to JBossStandAloneJtaPlatform should be backward compatible attempting old names as well and revert HHH-12620

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JBossStandAloneJtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JBossStandAloneJtaPlatform.java
@@ -13,16 +13,15 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatformException;
 
 /**
- * Return a standalone JTA transaction manager for WildFly transaction client
- * Known to work for WildFly 13
+ * Return a standalone JTA transaction manager for JBoss Transactions
+ * Known to work for org.jboss.jbossts:jbossjta:4.9.0.GA
  *
  * @author Emmanuel Bernard
  * @author Steve Ebersole
- * @author Scott Marlow
  */
 public class JBossStandAloneJtaPlatform extends AbstractJtaPlatform {
-	public static final String JBOSS_TM_CLASS_NAME = "org.wildfly.transaction.client.ContextTransactionManager";
-	public static final String JBOSS_UT_CLASS_NAME = "org.wildfly.transaction.client.LocalUserTransaction";
+	public static final String JBOSS_TM_CLASS_NAME = "com.arjuna.ats.jta.TransactionManager";
+	public static final String JBOSS_UT_CLASS_NAME = "com.arjuna.ats.jta.UserTransaction";
 
 	@Override
 	protected TransactionManager locateTransactionManager() {
@@ -30,10 +29,10 @@ public class JBossStandAloneJtaPlatform extends AbstractJtaPlatform {
 			final Class jbossTmClass = serviceRegistry()
 					.getService( ClassLoaderService.class )
 					.classForName( JBOSS_TM_CLASS_NAME );
-			return (TransactionManager) jbossTmClass.getMethod( "getInstance" ).invoke( null );
+			return (TransactionManager) jbossTmClass.getMethod( "transactionManager" ).invoke( null );
 		}
 		catch ( Exception e ) {
-			throw new JtaPlatformException( "Could not obtain WildFly Transaction Client transaction manager instance", e );
+			throw new JtaPlatformException( "Could not obtain JBoss Transactions transaction manager instance", e );
 		}
 	}
 
@@ -43,10 +42,10 @@ public class JBossStandAloneJtaPlatform extends AbstractJtaPlatform {
 			final Class jbossUtClass = serviceRegistry()
 					.getService( ClassLoaderService.class )
 					.classForName( JBOSS_UT_CLASS_NAME );
-			return (UserTransaction) jbossUtClass.getMethod( "getInstance" ).invoke( null );
+			return (UserTransaction) jbossUtClass.getMethod( "userTransaction" ).invoke( null );
 		}
 		catch ( Exception e ) {
-			throw new JtaPlatformException( "Could not obtain WildFly Transaction Client user transaction instance", e );
+			throw new JtaPlatformException( "Could not obtain JBoss Transactions user transaction instance", e );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/StandardJtaPlatformResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/StandardJtaPlatformResolver.java
@@ -45,6 +45,25 @@ public class StandardJtaPlatformResolver implements JtaPlatformResolver {
 		// IMPL NOTE : essentially we attempt Class lookups and use the exceptions from the class(es) not
 		// being found as the indicator
 
+		// first try loading WildFly Transaction Client
+		try {
+			classLoaderService.classForName( WildFlyStandAloneJtaPlatform.WILDFLY_TM_CLASS_NAME );
+			classLoaderService.classForName( WildFlyStandAloneJtaPlatform.WILDFLY_UT_CLASS_NAME );
+
+			// we know that the WildFly Transaction Client TM classes are available
+			// if neither of these look-ups resulted in an error (no such class), then WildFly Transaction Client TM available on
+			// the classpath.
+			//
+			// todo : we cannot really distinguish between the need for JBossStandAloneJtaPlatform versus JBossApServerJtaPlatform
+			// but discussions with David led to the JtaPlatformProvider solution above, so inside JBoss AS we
+			// should be relying on that.
+			// Note that on WF13+, we can expect org.jboss.as.jpa.hibernate5.service.WildFlyCustomJtaPlatformInitiator to choose
+			// the WildFlyCustomJtaPlatform, unless the application has disabled WildFlyCustomJtaPlatformInitiator.
+			return new WildFlyStandAloneJtaPlatform();
+		}
+		catch (ClassLoadingException ignore) {
+		}
+
 
 		// JBoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/WildFlyStandAloneJtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/WildFlyStandAloneJtaPlatform.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.transaction.jta.platform.internal;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatformException;
+
+/**
+ * Return a standalone JTA transaction manager for WildFly transaction client
+ * Known to work for WildFly 13+
+ *
+ * @author Scott Marlow
+ */
+public class WildFlyStandAloneJtaPlatform extends AbstractJtaPlatform {
+	public static final String WILDFLY_TM_CLASS_NAME = "org.wildfly.transaction.client.ContextTransactionManager";
+	public static final String WILDFLY_UT_CLASS_NAME = "org.wildfly.transaction.client.LocalUserTransaction";
+
+	@Override
+	protected TransactionManager locateTransactionManager() {
+		try {
+			final Class wildflyTmClass = serviceRegistry()
+					.getService( ClassLoaderService.class )
+					.classForName( WILDFLY_TM_CLASS_NAME );
+			return (TransactionManager) wildflyTmClass.getMethod( "getInstance" ).invoke( null );
+		}
+		catch (Exception e) {
+			throw new JtaPlatformException(
+					"Could not obtain WildFly Transaction Client transaction manager instance",
+					e
+			);
+		}
+	}
+
+	@Override
+	protected UserTransaction locateUserTransaction() {
+		try {
+			final Class jbossUtClass = serviceRegistry()
+					.getService( ClassLoaderService.class )
+					.classForName( WILDFLY_UT_CLASS_NAME );
+			return (UserTransaction) jbossUtClass.getMethod( "getInstance" ).invoke( null );
+		}
+		catch (Exception e) {
+			throw new JtaPlatformException(
+					"Could not obtain WildFly Transaction Client user transaction instance",
+					e
+			);
+		}
+	}
+}


### PR DESCRIPTION
First attempt setup of WildFlyStandAloneJtaPlatform using org.wildfly.transaction.client.ContextTransactionManager + org.wildfly.transaction.client.LocalUserTransaction, if those classes are not found, then try JBossStandAloneJtaPlatform using com.arjuna.ats.jta.TransactionManager + com.arjuna.ats.jta.UserTransaction.