### PR TITLE
Fix and testcase for HHH-12657

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -307,7 +307,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				);
 			}
 
-			if ( persistentClass.hasNaturalId() && persistentClass.getNaturalIdCacheRegionName() != null ) {
+			if ( persistentClass.hasNaturalId() && persistentClass instanceof RootClass && persistentClass.getNaturalIdCacheRegionName() != null ) {
 				locateCacheRegionConfigBuilder( persistentClass.getNaturalIdCacheRegionName() ).addNaturalIdConfig(
 						(RootClass) persistentClass,
 						accessType

--- a/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
@@ -6,17 +6,16 @@
  */
 package org.hibernate.test.naturalid.mutable.cached;
 
-import org.hibernate.Session;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.stat.NaturalIdCacheStatistics;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.cache.CachingRegionFactory;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.NaturalIdCacheStatistics;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.cache.CachingRegionFactory;
+import org.junit.Test;
 
 public class CachedMutableNaturalIdStrictReadWriteTest extends
 		CachedMutableNaturalIdTest {

--- a/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/CachedMutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/CachedMutableNaturalIdTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public abstract class CachedMutableNaturalIdTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {A.class, Another.class, AllCached.class, B.class};
+		return new Class[] {A.class, Another.class, AllCached.class, B.class, SubClass.class};
 	}
 
 	@Override
@@ -161,6 +161,33 @@ public abstract class CachedMutableNaturalIdTest extends BaseCoreFunctionalTestC
 			assertNull( it );
 			it = (AllCached) session.bySimpleNaturalId( AllCached.class ).load( "it2" );
 			assertNotNull( it );
+			session.delete( it );
+			session.getTransaction().commit();
+			session.close();
+	}
+	
+	@Test
+	@TestForIssue( jiraKey = "HHH-12657" )
+	public void testbySimpleNaturalIdResolveEntityFrom2LCacheSubClass() {
+			Session session = openSession();
+			session.beginTransaction();
+			SubClass it = new SubClass( "it" );
+			
+			session.save( it );
+			session.getTransaction().commit();
+			session.close();
+
+			session = openSession();
+			session.beginTransaction();
+			
+			// verify instance can be retrieved by bySimpleNaturalId called on superclass 
+			it = (SubClass) session.bySimpleNaturalId( AllCached.class ).load( "it" );
+			assertNotNull( it );
+			
+			// verify instance can be retrieved by bySimpleNaturalId called on concrete sub class too 
+			it = session.bySimpleNaturalId( SubClass.class ).load( "it" );
+			assertNotNull( it );
+					
 			session.delete( it );
 			session.getTransaction().commit();
 			session.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/SubClass.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/naturalid/mutable/cached/SubClass.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.naturalid.mutable.cached;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Guenther Demetz
+ */
+@Entity
+public class SubClass extends AllCached {
+
+	public SubClass() {
+		super();
+	}
+	
+	public SubClass(String name) {
+		super(name);
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12657

The change in InFlightMetadataCollectorImpl.java is the fix which avoids the ClassCastException
which raises when executing CachedMutableNaturalIdStrictReadWriteTest without this fix.
The fix consists in verifying if persistentClass is an instanceof RootClass, because only in this case it is neccessary to add a NaturalIdConfig.

The new added test method  testbySimpleNaturalIdResolveEntityFrom2LCacheSubClass()
 verifies that  instance can be retrieved by bySimpleNaturalId called on the declaring super class 
as well as when called on the concrete sub class. 