### PR TITLE
toString - remove overly verbose output

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2316,9 +2316,13 @@ public final class SessionImpl
 		StringBuilder buf = new StringBuilder( 500 )
 				.append( "SessionImpl(" );
 		if ( !isClosed() ) {
+			if(TRACE_ENABLED) {
 			buf.append( persistenceContext )
 					.append( ";" )
 					.append( actionQueue );
+			}
+			else
+				buf.append("<open>");
 		}
 		else {
 			buf.append( "<closed>" );


### PR DESCRIPTION
Is toString used, if so, when do we need to see the actionQueue or persistenceContext?
TRACE?