### PR TITLE
HHH-12692 - Modify SessionImpl.toString to be quiet by default and verbose when trace is enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2314,7 +2314,7 @@ public final class SessionImpl
 	@Override
 	public String toString() {
 		StringBuilder buf = new StringBuilder( 500 )
-				.append( "SessionImpl(" );
+				.append( "SessionImpl(" ).append(System.identityHashCode(this));
 		if ( !isClosed() ) {
 			if(TRACE_ENABLED) {
 			buf.append( persistenceContext )

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2316,9 +2316,13 @@ public final class SessionImpl
 		StringBuilder buf = new StringBuilder( 500 )
 				.append( "SessionImpl(" );
 		if ( !isClosed() ) {
+			if(TRACE_ENABLED) {
 			buf.append( persistenceContext )
 					.append( ";" )
 					.append( actionQueue );
+			}
+			else
+				buf.append("<open>");
 		}
 		else {
 			buf.append( "<closed>" );


### PR DESCRIPTION
Change default behavior to show instance id and whether it is open/closed unless TRACE_ENABLED is true.