### PR TITLE
 HHH-12676 - Initial draft for SecondaryTable support on UnionSubclassPersister

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/Pool.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/Pool.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id$
+package org.hibernate.test.annotations.inheritance.union;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+
+public class Pool {
+	@Id @GeneratedValue 
+	private Integer id;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/PoolAddress.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/PoolAddress.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.inheritance.union;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class PoolAddress {
+    @Column(table = "POOL_ADDRESS")
+    private String address;
+    
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/SwimmingPool.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/SwimmingPool.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id$
+package org.hibernate.test.annotations.inheritance.union;
+
+import org.hibernate.annotations.Tables;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.SecondaryTable;
+import javax.persistence.SecondaryTables;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+@SecondaryTables({
+    @SecondaryTable(name="POOL_ADDRESS"),
+//	@SecondaryTable(name="POOL_ADDRESS_2")
+})
+@Tables({
+    @org.hibernate.annotations.Table(appliesTo="POOL_ADDRESS", optional=true),
+//	@org.hibernate.annotations.Table(appliesTo="POOL_ADDRESS_2", optional=true, inverse = true)
+})
+public class SwimmingPool extends Pool {
+
+    @Embedded
+    private PoolAddress address;
+
+//	@Embedded
+//	@AttributeOverride(name = "address", column = @Column(table = "POOL_ADDRESS_2"))
+//	private PoolAddress secondaryAddress;
+
+    public PoolAddress getAddress() {
+        return address;
+    }
+
+    public void setAddress(PoolAddress address) {
+        this.address = address;
+    }
+
+//	public PoolAddress getSecondaryAddress() {
+//		return secondaryAddress;
+//	}
+//
+//	public void setSecondaryAddress(PoolAddress secondaryAddress) {
+//		this.secondaryAddress = secondaryAddress;
+//	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/UnionSubclassAndSecondaryTable.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/inheritance/union/UnionSubclassAndSecondaryTable.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.inheritance.union;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Emmanuel Bernard
+ */
+public class UnionSubclassAndSecondaryTable extends BaseCoreFunctionalTestCase {
+	@Test
+	public void testSecondaryTableAndJoined() throws Exception {
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		SwimmingPool sp = new SwimmingPool();
+		s.persist( sp );
+		s.flush();
+		s.clear();
+
+		long rowCount = getTableRowCount( s, "POOL_ADDRESS" );
+		assertEquals(
+				"The address table is marked as optional. For null values no database row should be created",
+				0,
+				rowCount
+		);
+
+//
+//		rowCount = getTableRowCount( s, "POOL_ADDRESS_2" );
+//		assertEquals(
+//				"The address table is marked as inverse. No database row should be created",
+//				0,
+//				rowCount
+//		);
+
+
+		SwimmingPool sp2 = (SwimmingPool) s.get( SwimmingPool.class, sp.getId() );
+		assertNull( sp.getAddress() );
+
+		PoolAddress address = new PoolAddress();
+		address.setAddress( "Park Avenue" );
+		sp2.setAddress( address );
+//		sp2.setSecondaryAddress( address );
+
+		s.flush();
+		s.clear();
+
+		sp2 = (SwimmingPool) s.get( SwimmingPool.class, sp.getId() );
+
+		rowCount = getTableRowCount( s, "POOL_ADDRESS" );
+		assertEquals(
+				"Now we should have a row in the pool address table ",
+				1,
+				rowCount
+		);
+
+//		rowCount = getTableRowCount( s, "POOL_ADDRESS_2" );
+//		assertEquals(
+//				"The address table is marked as inverse. No database row should be created",
+//				0,
+//				rowCount
+//		);
+
+		assertNotNull( sp2.getAddress() );
+//		assertNull( sp2.getSecondaryAddress() );
+		assertEquals( sp2.getAddress().getAddress(), "Park Avenue" );
+
+		tx.rollback();
+		s.close();
+	}
+
+	private long getTableRowCount(Session s, String tableName) {
+		// the type returned for count(*) in a native query depends on the dialect
+		// Oracle returns Types.NUMERIC, which is mapped to BigDecimal;
+		// H2 returns Types.BIGINT, which is mapped to BigInteger;
+		Object retVal = s.createSQLQuery( "select count(*) from " + tableName).uniqueResult();
+		assertTrue( Number.class.isInstance( retVal ) );
+		return ( ( Number ) retVal ).longValue();
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Pool.class, SwimmingPool.class };
+	}
+}


### PR DESCRIPTION
Initial draft for supporting `SecondaryTables` on the `UnionSubclassPersister`. I have had to change quite a lot of the persister, as the assumption of a single table throughout the class turned out to be plain wrong. I could reuse quite some parts from the `SingleTableClassPersister` and have decided to reuse most of the code (similarly to what is done in the `JoinedTableClassPersister`) and not abstract the code to another layer.

I'd like to point out that this PR is an initial draft and I mostly seek some early feedback. There are still a couple of things that probably should be addressed, such as whether the secondary tables (or any other join tables, if these exist?) should be added to the query spaces.

Jira ticket: https://hibernate.atlassian.net/browse/HHH-12676