### PR TITLE
HHH-12603 - Contributing using Eclipse Documentation out of Date

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,4 +103,4 @@ It is important that this topic branch on your fork:
 	PR will be closed, if not already, and the changes will be lost.
 
 # Notes
-<sup>(1)</sup> Currently, there are some issues with the Gradle `eclipse` plugin due to some upgrades made by the gradle development team. If you get some error message running `./gradlew clean eclipse --refresh-dependencies` command, you can try either with `./gradlew clean --refresh-dependencies` or with the IDE tools to import gradle projects, being this last one the suggested approach
+<sup>(1)</sup> Gradle `eclipse` plugin is no longer supported, so the recommended way to import the project in your IDE is with the proper IDE tools/plugins. Don't try to run `./gradlew clean eclipse --refresh-dependencies` from the command line as you'll get an error because `eclipse` no longer exists

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ the linked page, this also includes:
     * Clone your fork
 * See the wiki pages for setting up your IDE, whether you use 
 [IntelliJ IDEA](https://community.jboss.org/wiki/ContributingToHibernateUsingIntelliJ)
-or [Eclipse](https://community.jboss.org/wiki/ContributingToHibernateUsingEclipse).
+or [Eclipse](https://community.jboss.org/wiki/ContributingToHibernateUsingEclipse)<sup>(1)</sup>.
 
 
 ## Create the working (topic) branch
@@ -101,3 +101,6 @@ It is important that this topic branch on your fork:
 	a branch rather than specific commits.
 * remain until the PR is closed.  Once the underlying branch is deleted the corresponding
 	PR will be closed, if not already, and the changes will be lost.
+
+# Notes
+<sup>(1)</sup> Currently, there are some issues with the Gradle `eclipse` plugin due to some upgrades made by the gradle development team. If you get some error message running `./gradlew clean eclipse --refresh-dependencies` command, you can try either with `./gradlew clean --refresh-dependencies` or with the IDE tools to import gradle projects, being this last one the suggested approach

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ allprojects {
 		}
 		
 	apply plugin: 'idea'
-	apply plugin: 'eclipse'
 	}
 
 	// minimize changes, at least for now (gradle uses 'build' by default)..

--- a/build.gradle
+++ b/build.gradle
@@ -112,10 +112,10 @@ buildScan {
 
 
 
-//allprojects {
-//	apply plugin: 'idea'
-//	apply plugin: 'eclipse'
-//}
+allprojects {
+	apply plugin: 'idea'
+	apply plugin: 'eclipse'
+}
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ allprojects {
 			name "jboss-snapshots"
 			url "http://snapshots.jboss.org/maven2/"
 		}
+		
+	apply plugin: 'idea'
+	apply plugin: 'eclipse'
 	}
 
 	// minimize changes, at least for now (gradle uses 'build' by default)..
@@ -108,14 +111,6 @@ buildScan {
 //        name = "hibernate-orm"
 //    }
 //}
-
-
-
-
-allprojects {
-	apply plugin: 'idea'
-	apply plugin: 'eclipse'
-}
 
 
 


### PR DESCRIPTION
This is a continuation of [this PR](https://github.com/hibernate/hibernate-orm/pull/2313) with clean commits and according to the contributing guidelines.

The changes presented firstly are the same as before closing the previous PR. Some changes based on the suggestions stated there will be uploaded ASAP.