### PR TITLE
HHH-12696 - Allow map attribute key and value subgraphs to both be added to entity / sub graphs.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -9,10 +9,17 @@ package org.hibernate.graph.spi;
 import javax.persistence.AttributeNode;
 import javax.persistence.metamodel.Attribute;
 
+import org.hibernate.jpa.graph.internal.SubgraphImpl;
+
 /**
  * @author Strong Liu <stliu@hibernate.org>
  */
 public interface AttributeNodeImplementor<T> extends AttributeNode<T> {
 	public Attribute<?,T> getAttribute();
 	public AttributeNodeImplementor<T> makeImmutableCopy();
+	
+	public <X extends T> SubgraphImpl<X> getSubgraph(boolean createIfNotPresent);
+	public <X extends T> SubgraphImpl<X> getSubgraph(Class<X> type, boolean createIfNotPresent);
+	public <X extends T> SubgraphImpl<X> getKeySubgraph(boolean createIfNotPresent);
+	public <X extends T> SubgraphImpl<X> getKeySubgraph(Class<X> type, boolean createIfNotPresent);
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphNodeImplementor;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.jpa.graph.internal.SubgraphImpl;
 import org.hibernate.loader.plan.spi.EntityReturn;
 import org.hibernate.loader.plan.spi.LoadPlan;
 import org.hibernate.loader.plan.spi.Return;
@@ -301,6 +302,26 @@ public abstract class AbstractEntityGraphVisitationStrategy
 		@Override
 		public String toString() {
 			return "Mocked NON-EXIST attribute node";
+		}
+
+		@Override
+		public SubgraphImpl getSubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getSubgraph(Class type, boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getKeySubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getKeySubgraph(Class type, boolean createIfNotPresent) {
+			return null;
 		}
 	};
 	private static final GraphNodeImplementor NON_EXIST_SUBGRAPH_NODE = new GraphNodeImplementor() {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractAttribute.java
@@ -112,4 +112,57 @@ public abstract class AbstractAttribute<X, Y>
 		// should only ever be a field or the getter-method...
 		oos.writeObject( Method.class.isInstance( getJavaMember() ) ? "method" : "field" );
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( declaringType == null ) ? 0 : declaringType.hashCode() );
+		result = prime * result + ( ( javaType == null ) ? 0 : javaType.hashCode() );
+		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+		result = prime * result + ( ( persistentAttributeType == null ) ? 0 : persistentAttributeType.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		AbstractAttribute other = (AbstractAttribute) obj;
+		if ( declaringType == null ) {
+			if ( other.declaringType != null ) {
+				return false;
+			}
+		}
+		else if ( !declaringType.equals( other.declaringType ) ) {
+			return false;
+		}
+		if ( javaType == null ) {
+			if ( other.javaType != null ) {
+				return false;
+			}
+		}
+		else if ( !javaType.equals( other.javaType ) ) {
+			return false;
+		}
+		if ( name == null ) {
+			if ( other.name != null ) {
+				return false;
+			}
+		}
+		else if ( !name.equals( other.name ) ) {
+			return false;
+		}
+		if ( persistentAttributeType != other.persistentAttributeType ) {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
We hit [HHH-12696](https://hibernate.atlassian.net/browse/HHH-12696) and decided that I can contribute the fix back. This is my first contribution back to Hibernate but, I hope, I covered everything:

1. I made minimal changes and kept the old behaviour still available to the maximum extent possible, as far as I am aware.
2. Added more JavaDoc than there was before.
3. Created unit tests. Confirmed that they fail before and succeed after the change. (No preexisting tests fail before or after.)

This is in the same area as [HHH-10378](https://hibernate.atlassian.net/browse/HHH-10378), which is of interest to me too and could fix it as well.

