### PR TITLE
HHH-12696 (master) - Allow map attribute key and value subgraphs to both be added to entity / sub graphs.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -7,6 +7,7 @@
 package org.hibernate.graph.spi;
 
 import javax.persistence.AttributeNode;
+import javax.persistence.Subgraph;
 import javax.persistence.metamodel.Attribute;
 
 /**
@@ -15,4 +16,9 @@ import javax.persistence.metamodel.Attribute;
 public interface AttributeNodeImplementor<T> extends AttributeNode<T> {
 	public Attribute<?,T> getAttribute();
 	public AttributeNodeImplementor<T> makeImmutableCopy();
+	
+	public <X extends T> Subgraph<X> getSubgraph(boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getSubgraph(Class<X> type, boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getKeySubgraph(boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getKeySubgraph(Class<X> type, boolean createIfNotPresent);
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/graph/internal/AbstractGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/graph/internal/AbstractGraphNode.java
@@ -97,8 +97,64 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 		}
 	}
 
+	/**
+	 * @see #getAttribute(Attribute, boolean)
+	 */
 	public AttributeNodeImpl addAttribute(String attributeName) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		return addAttributeNode( buildAttributeNode( attributeName ) );
+	}
+
+	/**
+	 * Returns an attribute by name (existing or new one if requested).
+	 * 
+	 * @param attributeName Name of the attribute being sought.
+	 * 
+	 * @param createIfNotPresent If {@code true} and the attribute has not been previously added,
+	 * a new one will be created.
+	 * 
+	 * @return An existing or newly created attribute (if {@code createIfNotPresent} is {@code true})
+	 * or {@code null} if {@code createIfNotPresent==false} and the specified attribute has not been
+	 * previously added.
+	 */
+	public AttributeNodeImplementor<?> getAttribute(String attributeName, boolean createIfNotPresent) {
+
+		if ( attributeNodeMap == null ) {
+			if ( !createIfNotPresent ) {
+				return null;
+			}
+			initializeAttributeNodeMap();
+		}
+		AttributeNodeImplementor<?> attrNode = attributeNodeMap.get( attributeName );
+		if ( ( attrNode == null ) && createIfNotPresent ) {
+			attrNode = addAttributeNode( buildAttributeNode( attributeName ) );
+		}
+		return attrNode;
+	}
+	
+	protected <T> AttributeNodeImplementor<T> getAttribute(Attribute<?,T> attributeToAdd, boolean createIfNotPresent) {
+		if ( attributeNodeMap == null ) {
+			if ( !createIfNotPresent ) {
+				return null;
+			}
+			initializeAttributeNodeMap();
+		}
+		@SuppressWarnings("unchecked")
+		AttributeNodeImplementor<T> attrNode = (AttributeNodeImplementor<T>) attributeNodeMap.get( attributeToAdd.getName() );
+		if ( attrNode == null ) {
+			if ( createIfNotPresent ) {
+				attrNode = addAttributeNode( buildAttributeNode( attributeToAdd.getName() ) );
+			}
+		}
+		else {
+			// Validate it is the same attribute
+			if ( attrNode.getAttribute().equals( attributeToAdd ) ) {
+				throw new IllegalStateException( "Different attribute by the same name is present already." );
+			}
+		}
+		return attrNode;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -112,15 +168,24 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 	protected <X> AttributeNodeImpl<X> buildAttributeNode(Attribute<T, X> attribute) {
 		return new AttributeNodeImpl<>( sessionFactory, getManagedType(), attribute );
 	}
-
+	
+	private final void initializeAttributeNodeMap() {
+		if ( attributeNodeMap == null ) {
+			attributeNodeMap = new HashMap<>();
+		}
+	}
+	
 	@SuppressWarnings("WeakerAccess")
 	protected AttributeNodeImpl addAttributeNode(AttributeNodeImpl attributeNode) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		if ( ! mutable ) {
 			throw new IllegalStateException( "Entity/sub graph is not mutable" );
 		}
 
 		if ( attributeNodeMap == null ) {
-			attributeNodeMap = new HashMap<>();
+			initializeAttributeNodeMap();
 		}
 		else {
 			final AttributeNode old = attributeNodeMap.get( attributeNode.getRegistrationName() );
@@ -146,49 +211,59 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 		}
 	}
 
+	/**
+	 * @see #getAttribute(Attribute, boolean)
+	 */
 	@SuppressWarnings("unchecked")
 	protected AttributeNodeImpl addAttribute(Attribute attribute) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		return addAttributeNode( buildAttributeNode( attribute ) );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(Attribute<T, X> attribute) {
-		return addAttribute( attribute ).makeSubgraph();
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getSubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<? extends X> addSubgraph(Attribute<T, X> attribute, Class<? extends X> type) {
-		return addAttribute( attribute ).makeSubgraph( type );
+		@SuppressWarnings("unchecked")
+		SubgraphImpl<X> subgraph = (SubgraphImpl<X>) getAttribute( attribute, true ).getSubgraph( type, true );
+		return subgraph;
 	}
 
 	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(String attributeName) {
-		return addAttribute( attributeName ).makeSubgraph();
+		return (SubgraphImpl<X>) getAttribute( attributeName, true ).getSubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(String attributeName, Class<X> type) {
-		return addAttribute( attributeName ).makeSubgraph( type );
+		@SuppressWarnings("unchecked")
+		final AttributeNodeImplementor<X> attrNode = (AttributeNodeImplementor<X>) getAttribute( attributeName, true );
+		SubgraphImpl<X> subgraph = (SubgraphImpl<X>) attrNode.getSubgraph( type, true );
+		return subgraph;
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(Attribute<T, X> attribute) {
-		return addAttribute( attribute ).makeKeySubgraph();
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getKeySubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<? extends X> addKeySubgraph(Attribute<T, X> attribute, Class<? extends X> type) {
-		return addAttribute( attribute ).makeKeySubgraph( type );
+		@SuppressWarnings("unchecked")
+		SubgraphImpl<X> subgraph = (SubgraphImpl<X>) getAttribute( attribute, true ).getKeySubgraph( type, true );
+		return subgraph;
 	}
 
 	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(String attributeName) {
-		return addAttribute( attributeName ).makeKeySubgraph();
+		return (SubgraphImpl<X>) getAttribute( attributeName, true ).getKeySubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(String attributeName, Class<X> type) {
-		return addAttribute( attributeName ).makeKeySubgraph( type );
+		@SuppressWarnings("unchecked")
+		final AttributeNodeImplementor<X> attrNode = (AttributeNodeImplementor<X>) getAttribute( attributeName, true );
+		SubgraphImpl<X> subgraph = (SubgraphImpl<X>) attrNode.getKeySubgraph( type, true );
+		return subgraph;
 	}
 	
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphNodeImplementor;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.jpa.graph.internal.SubgraphImpl;
 import org.hibernate.loader.plan.spi.EntityReturn;
 import org.hibernate.loader.plan.spi.LoadPlan;
 import org.hibernate.loader.plan.spi.Return;
@@ -301,6 +302,26 @@ public abstract class AbstractEntityGraphVisitationStrategy
 		@Override
 		public String toString() {
 			return "Mocked NON-EXIST attribute node";
+		}
+
+		@Override
+		public SubgraphImpl getSubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getSubgraph(Class type, boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getKeySubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public SubgraphImpl getKeySubgraph(Class type, boolean createIfNotPresent) {
+			return null;
 		}
 	};
 	private static final GraphNodeImplementor NON_EXIST_SUBGRAPH_NODE = new GraphNodeImplementor() {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractAttribute.java
@@ -112,4 +112,57 @@ public abstract class AbstractAttribute<X, Y>
 		// should only ever be a field or the getter-method...
 		oos.writeObject( Method.class.isInstance( getJavaMember() ) ? "method" : "field" );
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( declaringType == null ) ? 0 : declaringType.hashCode() );
+		result = prime * result + ( ( javaType == null ) ? 0 : javaType.hashCode() );
+		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+		result = prime * result + ( ( persistentAttributeType == null ) ? 0 : persistentAttributeType.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		AbstractAttribute other = (AbstractAttribute) obj;
+		if ( declaringType == null ) {
+			if ( other.declaringType != null ) {
+				return false;
+			}
+		}
+		else if ( !declaringType.equals( other.declaringType ) ) {
+			return false;
+		}
+		if ( javaType == null ) {
+			if ( other.javaType != null ) {
+				return false;
+			}
+		}
+		else if ( !javaType.equals( other.javaType ) ) {
+			return false;
+		}
+		if ( name == null ) {
+			if ( other.name != null ) {
+				return false;
+			}
+		}
+		else if ( !name.equals( other.name ) ) {
+			return false;
+		}
+		if ( persistentAttributeType != other.persistentAttributeType ) {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
We hit [HHH-12696](https://hibernate.atlassian.net/browse/HHH-12696) and decided that I can contribute the fix back. This is my first contribution back to Hibernate but, I hope, I covered everything:

I made minimal changes and kept the old behaviour still available to the maximum extent possible, as far as I am aware.
Added more JavaDoc than there was before.
Created unit tests. Confirmed that they fail before and succeed after the change. (No preexisting tests fail before or after.)
This is in the same area as [HHH-10378,](https://hibernate.atlassian.net/browse/HHH-10378) which is of interest to me too and could fix it as well.

I also submitted the backport to 4.3 as a [pull request 2355](https://github.com/hibernate/hibernate-orm/pull/2355).