### PR TITLE
HHH-12696 - Allow map attribute key and value subgraphs to both be added to entity / sub graphs.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -24,6 +24,7 @@
 package org.hibernate.graph.spi;
 
 import javax.persistence.AttributeNode;
+import javax.persistence.Subgraph;
 import javax.persistence.metamodel.Attribute;
 
 /**
@@ -32,4 +33,9 @@ import javax.persistence.metamodel.Attribute;
 public interface AttributeNodeImplementor<T> extends AttributeNode<T> {
 	public Attribute<?,T> getAttribute();
 	public AttributeNodeImplementor<T> makeImmutableCopy();
+	
+	public <X extends T> Subgraph<X> getSubgraph(boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getSubgraph(Class<X> type, boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getKeySubgraph(boolean createIfNotPresent);
+	public <X extends T> Subgraph<X> getKeySubgraph(Class<X> type, boolean createIfNotPresent);
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
@@ -322,6 +322,26 @@ public abstract class AbstractEntityGraphVisitationStrategy
 		public String toString() {
 			return "Mocked NON-EXIST attribute node";
 		}
+
+		@Override
+		public Subgraph getSubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public Subgraph getSubgraph(Class type, boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public Subgraph getKeySubgraph(boolean createIfNotPresent) {
+			return null;
+		}
+
+		@Override
+		public Subgraph getKeySubgraph(Class type, boolean createIfNotPresent) {
+			return null;
+		}
 	};
 	private static final GraphNodeImplementor NON_EXIST_SUBGRAPH_NODE = new GraphNodeImplementor() {
 		@Override

--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/graph/internal/AbstractGraphNode.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/graph/internal/AbstractGraphNode.java
@@ -110,9 +110,66 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 		}
 	}
 
+	/**
+	 * @see #getAttribute(Attribute, boolean)
+	 */
 	public AttributeNodeImpl addAttribute(String attributeName) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		return addAttributeNode( buildAttributeNode( attributeName ) );
 	}
+
+	/**
+	 * Returns an attribute by name (existing or new one if requested).
+	 * 
+	 * @param attributeName Name of the attribute being sought.
+	 * 
+	 * @param createIfNotPresent If {@code true} and the attribute has not been previously added,
+	 * a new one will be created.
+	 * 
+	 * @return An existing or newly created attribute (if {@code createIfNotPresent} is {@code true})
+	 * or {@code null} if {@code createIfNotPresent==false} and the specified attribute has not been
+	 * previously added.
+	 */
+	public AttributeNodeImplementor<?> getAttribute(String attributeName, boolean createIfNotPresent) {
+
+		if ( attributeNodeMap == null ) {
+			if ( !createIfNotPresent ) {
+				return null;
+			}
+			initializeAttributeNodeMap();
+		}
+		AttributeNodeImplementor<?> attrNode = attributeNodeMap.get( attributeName );
+		if ( ( attrNode == null ) && createIfNotPresent ) {
+			attrNode = addAttributeNode( buildAttributeNode( attributeName ) );
+		}
+		return attrNode;
+	}
+	
+	protected <T> AttributeNodeImplementor<T> getAttribute(Attribute<?,T> attributeToAdd, boolean createIfNotPresent) {
+		if ( attributeNodeMap == null ) {
+			if ( !createIfNotPresent ) {
+				return null;
+			}
+			initializeAttributeNodeMap();
+		}
+		@SuppressWarnings("unchecked")
+		AttributeNodeImplementor<T> attrNode = (AttributeNodeImplementor<T>) attributeNodeMap.get( attributeToAdd.getName() );
+		if ( attrNode == null ) {
+			if ( createIfNotPresent ) {
+				attrNode = addAttributeNode( buildAttributeNode( attributeToAdd.getName() ) );
+			}
+		}
+		else {
+			// Validate it is the same attribute
+			if ( attrNode.getAttribute().equals( attributeToAdd ) ) {
+				throw new IllegalStateException( "Different attribute by the same name is present already." );
+			}
+		}
+		return attrNode;
+	}
+
 
 	@SuppressWarnings("unchecked")
 	private AttributeNodeImpl<?> buildAttributeNode(String attributeName) {
@@ -124,14 +181,23 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 	protected <X> AttributeNodeImpl<X> buildAttributeNode(Attribute<T, X> attribute) {
 		return new AttributeNodeImpl<X>( entityManagerFactory, attribute );
 	}
+	
+	private final void initializeAttributeNodeMap() {
+		if ( attributeNodeMap == null ) {
+			attributeNodeMap = new HashMap<String, AttributeNodeImplementor<?>>();
+		}
+	}
 
 	protected AttributeNodeImpl addAttributeNode(AttributeNodeImpl attributeNode) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		if ( ! mutable ) {
 			throw new IllegalStateException( "Entity/sub graph is not mutable" );
 		}
 
 		if ( attributeNodeMap == null ) {
-			attributeNodeMap = new HashMap<String, AttributeNodeImplementor<?>>();
+			initializeAttributeNodeMap();
 		}
 		else {
 			final AttributeNode old = attributeNodeMap.get( attributeNode.getRegistrationName() );
@@ -156,49 +222,57 @@ public abstract class AbstractGraphNode<T> implements GraphNodeImplementor, Hibe
 		}
 	}
 
+	/**
+	 * @see #getAttribute(Attribute, boolean)
+	 */
 	@SuppressWarnings("unchecked")
 	protected AttributeNodeImpl addAttribute(Attribute attribute) {
+		// This method does not allow both map keys and values to be configured.
+		// See HHH-12696 for details.
+		// Not modifying it for compatibility.
 		return addAttributeNode( buildAttributeNode( attribute ) );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(Attribute<T, X> attribute) {
-		return addAttribute( attribute ).makeSubgraph();
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getSubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<? extends X> addSubgraph(Attribute<T, X> attribute, Class<? extends X> type) {
-		return addAttribute( attribute ).makeSubgraph( type );
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getSubgraph( type, true );
 	}
 
 	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(String attributeName) {
-		return addAttribute( attributeName ).makeSubgraph();
+		return (SubgraphImpl<X>) getAttribute( attributeName, true ).getSubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addSubgraph(String attributeName, Class<X> type) {
-		return addAttribute( attributeName ).makeSubgraph( type );
+		@SuppressWarnings("unchecked")
+		final AttributeNodeImplementor<X> attrNode = (AttributeNodeImplementor<X>) getAttribute( attributeName, true );
+		@SuppressWarnings("unchecked")
+		final SubgraphImpl<X> subgraph = (SubgraphImpl<X>) attrNode.getSubgraph( type, true );
+		return subgraph;
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(Attribute<T, X> attribute) {
-		return addAttribute( attribute ).makeKeySubgraph();
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getKeySubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<? extends X> addKeySubgraph(Attribute<T, X> attribute, Class<? extends X> type) {
-		return addAttribute( attribute ).makeKeySubgraph( type );
+		return (SubgraphImpl<X>) getAttribute( attribute, true ).getKeySubgraph( type, true );
 	}
 
 	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(String attributeName) {
-		return addAttribute( attributeName ).makeKeySubgraph();
+		return (SubgraphImpl<X>) getAttribute( attributeName, true ).getKeySubgraph( true );
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> SubgraphImpl<X> addKeySubgraph(String attributeName, Class<X> type) {
-		return addAttribute( attributeName ).makeKeySubgraph( type );
+		@SuppressWarnings("unchecked")
+		final AttributeNodeImplementor<X> attrNode = (AttributeNodeImplementor<X>) getAttribute( attributeName, true );
+		@SuppressWarnings("unchecked")
+		final SubgraphImpl<X> subgraph = (SubgraphImpl<X>) attrNode.getKeySubgraph( type, true );
+		return subgraph;
 	}
 	
 	@Override

--- a/hibernate-entitymanager/src/main/java/org/hibernate/jpa/internal/metamodel/AbstractAttribute.java
+++ b/hibernate-entitymanager/src/main/java/org/hibernate/jpa/internal/metamodel/AbstractAttribute.java
@@ -129,4 +129,57 @@ public abstract class AbstractAttribute<X, Y>
 		// should only ever be a field or the getter-method...
 		oos.writeObject( Method.class.isInstance( getJavaMember() ) ? "method" : "field" );
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( declaringType == null ) ? 0 : declaringType.hashCode() );
+		result = prime * result + ( ( javaType == null ) ? 0 : javaType.hashCode() );
+		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+		result = prime * result + ( ( persistentAttributeType == null ) ? 0 : persistentAttributeType.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		AbstractAttribute other = (AbstractAttribute) obj;
+		if ( declaringType == null ) {
+			if ( other.declaringType != null ) {
+				return false;
+			}
+		}
+		else if ( !declaringType.equals( other.declaringType ) ) {
+			return false;
+		}
+		if ( javaType == null ) {
+			if ( other.javaType != null ) {
+				return false;
+			}
+		}
+		else if ( !javaType.equals( other.javaType ) ) {
+			return false;
+		}
+		if ( name == null ) {
+			if ( other.name != null ) {
+				return false;
+			}
+		}
+		else if ( !name.equals( other.name ) ) {
+			return false;
+		}
+		if ( persistentAttributeType != other.persistentAttributeType ) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/graphs/EntityGraphTest.java
+++ b/hibernate-entitymanager/src/test/java/org/hibernate/jpa/test/graphs/EntityGraphTest.java
@@ -31,6 +31,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 
+import javax.persistence.AttributeNode;
+import javax.persistence.CascadeType;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
@@ -46,6 +49,11 @@ import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Christian Bauer
  * @author Brett Meyer
@@ -55,7 +63,8 @@ public class EntityGraphTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Foo.class, Bar.class, Baz.class,
-				Company.class, Employee.class, Manager.class, Location.class };
+				Company.class, Employee.class, Manager.class, Location.class,
+				EntityWithMap.class };
 	}
 
 	@Test
@@ -262,6 +271,52 @@ public class EntityGraphTest extends BaseEntityManagerFunctionalTestCase {
         em.getTransaction().commit();
         em.close();
     }
+    
+    @Test
+    @TestForIssue(jiraKey = "HHH-12696")
+    public void createKeyThenValueMapSubgraphs() {
+
+        EntityManager em = getOrCreateEntityManager();
+        
+        EntityGraph<EntityWithMap> graph = em.createEntityGraph(EntityWithMap.class);
+        Subgraph<EntityWithMap> keySubgraph = graph.addKeySubgraph("map");
+        assertNotNull( keySubgraph );
+        Subgraph<EntityWithMap> valueSubgraph = graph.addSubgraph("map");
+        assertNotNull( valueSubgraph );
+        
+        validateMapKeyAndValueSubgraphs( graph );
+        
+        em.close();
+    }
+    
+    @Test
+    @TestForIssue(jiraKey = "HHH-12696")
+    public void createValueThenKeyMapSubgraphs() {
+
+        EntityManager em = getOrCreateEntityManager();
+        
+        EntityGraph<EntityWithMap> graph = em.createEntityGraph(EntityWithMap.class);
+        Subgraph<EntityWithMap> valueSubgraph = graph.addSubgraph("map");
+        assertNotNull( valueSubgraph );
+        Subgraph<EntityWithMap> keySubgraph = graph.addKeySubgraph("map");
+        assertNotNull( keySubgraph );
+        
+        validateMapKeyAndValueSubgraphs( graph );
+        
+        em.close();
+    }
+
+	private void validateMapKeyAndValueSubgraphs(EntityGraph<EntityWithMap> graph) {
+		int count = 0;
+        for (AttributeNode<?>node: graph.getAttributeNodes()) {
+            if ("map".equals(node.getAttributeName())) {
+                count++;
+                assertTrue("Missing the value subgraph", !node.getSubgraphs().isEmpty());
+                assertTrue("Missing the key subgraph", !node.getKeySubgraphs().isEmpty());
+            }
+        }
+        assertEquals( "Incorrect number of attributes found", 1, count );
+	}
 
     @Entity
     public static class Foo {
@@ -299,5 +354,17 @@ public class EntityGraphTest extends BaseEntityManagerFunctionalTestCase {
         public Set<Foo> foos = new HashSet<Foo>();
 
 	}
+
+	@Entity
+	public static class EntityWithMap {
+
+		@Id
+		@GeneratedValue
+		public Integer id;
+
+		@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+		@ElementCollection( targetClass = EntityWithMap.class)
+		public Map<EntityWithMap, EntityWithMap> map;
+  }
 
 }


### PR DESCRIPTION
Backport of:
[pull request 2354 for master](https://github.com/hibernate/hibernate-orm/pull/2354). Description from there:

We hit HHH-12696 and decided that I can contribute the fix back. This is my first contribution back to Hibernate but, I hope, I covered everything:

I made minimal changes and kept the old behaviour still available to the maximum extent possible, as far as I am aware.
Added more JavaDoc than there was before.
Created unit tests. Confirmed that they fail before and succeed after the change. (No preexisting tests fail before or after.)
This is in the same area as HHH-10378, which is of interest to me too and could fix it as well.