### PR TITLE
HHH-10661 - serialize method in StatefulPersistenceContext has duplicate code.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/SerializableKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/SerializableKey.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.internal;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+/**
+ * Provides custom serialization for entities and collection keys
+ *
+ * @author Alvaro Esteban Pedraza - aepedraza3117@gmail.com
+ */
+public interface SerializableKey {
+
+	/**
+	 * Custom serialization routine used during serialization of a Session/PersistenceContext for increased performance.
+	 *
+	 * @param oos The stream to which we should write the serial data.
+	 * 
+	 * @throws IOException Thrown by Java I/O
+	 */
+	void serialize(ObjectOutputStream oos) throws IOException;
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1436,25 +1436,24 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 * @throws IOException serialization errors.
 	 */
 	public void serialize(ObjectOutputStream oos) throws IOException {
-		final boolean tracing = LOG.isTraceEnabled();
-		if ( tracing ) {
+		if ( TRACE_ENABLED ) {
 			LOG.trace( "Serializing persistence-context" );
 		}
 
 		oos.writeBoolean( defaultReadOnly );
 		oos.writeBoolean( hasNonReadOnlyEntities );
 
-		writeKeyMapToStream( entitiesByKey, oos, tracing, "entitiesByKey" );
-		writeKeyMapToStream( entitiesByUniqueKey, oos, tracing, "entitiesByUniqueKey" );
-		writeKeyMapToStream( proxiesByKey, oos, tracing, "proxiesByKey" );
-		writeKeyMapToStream( entitySnapshotsByKey, oos, tracing, "entitySnapshotsByKey" );
+		writeKeyMapToStream( entitiesByKey, oos, "entitiesByKey" );
+		writeKeyMapToStream( entitiesByUniqueKey, oos, "entitiesByUniqueKey" );
+		writeKeyMapToStream( proxiesByKey, oos, "proxiesByKey" );
+		writeKeyMapToStream( entitySnapshotsByKey, oos, "entitySnapshotsByKey" );
 
 		entityEntryContext.serialize( oos );
 
-		writeKeyMapToStream( collectionsByKey, oos, tracing, "collectionsByKey" );
+		writeKeyMapToStream( collectionsByKey, oos, "collectionsByKey" );
 
 		oos.writeInt( collectionEntries.size() );
-		if ( tracing ) {
+		if ( TRACE_ENABLED ) {
 			LOG.trace( "Starting serialization of [" + collectionEntries.size() + "] collectionEntries entries" );
 		}
 		for ( Map.Entry<PersistentCollection,CollectionEntry> entry : collectionEntries.entrySet() ) {
@@ -1463,7 +1462,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( arrayHolders.size() );
-		if ( tracing ) {
+		if ( TRACE_ENABLED ) {
 			LOG.trace( "Starting serialization of [" + arrayHolders.size() + "] arrayHolders entries" );
 		}
 		for ( Map.Entry<Object,PersistentCollection> entry : arrayHolders.entrySet() ) {
@@ -1472,7 +1471,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		oos.writeInt( nullifiableEntityKeys.size() );
-		if ( tracing ) {
+		if ( TRACE_ENABLED ) {
 			LOG.trace( "Starting serialization of [" + nullifiableEntityKeys.size() + "] nullifiableEntityKey entries" );
 		}
 		for ( EntityKey entry : nullifiableEntityKeys ) {
@@ -1490,11 +1489,10 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 *
 	 * @throws IOException Thrown by Java I/O
 	 */
-	// TODO improve parameters: is tracing and keysName needed?
-	private void writeKeyMapToStream(Map<? extends SerializableKey, ? extends Object> keyMap, ObjectOutputStream oos, boolean tracing, String keysName)
+	private void writeKeyMapToStream(Map<? extends SerializableKey, ? extends Object> keyMap, ObjectOutputStream oos, String keysName)
 			throws IOException {
 		oos.writeInt( keyMap.size() );
-		if ( tracing ) {
+		if ( TRACE_ENABLED ) {
 			LOG.trace( "Starting serialization of [" + keyMap.size() + "] " + keysName + " entries" );
 		}
 		for ( Entry<? extends SerializableKey, ? extends Object> entry : keyMap.entrySet() ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionKey.java
@@ -12,6 +12,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 import org.hibernate.EntityMode;
+import org.hibernate.engine.internal.SerializableKey;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.type.Type;
@@ -21,7 +22,7 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  */
-public final class CollectionKey implements Serializable {
+public final class CollectionKey implements Serializable, SerializableKey {
 	private final String role;
 	private final Serializable key;
 	private final Type keyType;
@@ -99,15 +100,7 @@ public final class CollectionKey implements Serializable {
 		return hashCode;
 	}
 
-
-	/**
-	 * Custom serialization routine used during serialization of a
-	 * Session/PersistenceContext for increased performance.
-	 *
-	 * @param oos The stream to which we should write the serial data.
-	 *
-	 * @throws java.io.IOException
-	 */
+	@Override
 	public void serialize(ObjectOutputStream oos) throws IOException {
 		oos.writeObject( role );
 		oos.writeObject( key );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.engine.internal.SerializableKey;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
 
@@ -29,7 +30,7 @@ import org.hibernate.pretty.MessageHelper;
  * @author Gavin King
  * @author Sanne Grinovero
  */
-public final class EntityKey implements Serializable {
+public final class EntityKey implements Serializable, SerializableKey {
 
 	private final Serializable identifier;
 	private final int hashCode;
@@ -113,15 +114,9 @@ public final class EntityKey implements Serializable {
 				MessageHelper.infoString( this.persister, identifier, persister.getFactory() );
 	}
 
-	/**
-	 * Custom serialization routine used during serialization of a
-	 * Session/PersistenceContext for increased performance.
-	 *
-	 * @param oos The stream to which we should write the serial data.
-	 *
-	 * @throws IOException Thrown by Java I/O
-	 */
-	public void serialize(ObjectOutputStream oos) throws IOException {
+
+	@Override
+	public void serialize(final ObjectOutputStream oos) throws IOException {
 		oos.writeObject( identifier );
 		oos.writeObject( persister.getEntityName() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityUniqueKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityUniqueKey.java
@@ -100,7 +100,7 @@ public class EntityUniqueKey implements Serializable, SerializableKey {
 			throw new IllegalStateException(
 					"Cannot serialize an EntityUniqueKey which represents a non " +
 							"serializable property value [" + entityName + "." + uniqueKeyName + "]"
-					);
+			);
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityUniqueKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityUniqueKey.java
@@ -12,6 +12,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 import org.hibernate.EntityMode;
+import org.hibernate.engine.internal.SerializableKey;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.type.Type;
 
@@ -25,7 +26,7 @@ import org.hibernate.type.Type;
  * @author Gavin King
  * @see EntityKey
  */
-public class EntityUniqueKey implements Serializable {
+public class EntityUniqueKey implements Serializable, SerializableKey {
 	private final String uniqueKeyName;
 	private final String entityName;
 	private final Object key;
@@ -99,18 +100,11 @@ public class EntityUniqueKey implements Serializable {
 			throw new IllegalStateException(
 					"Cannot serialize an EntityUniqueKey which represents a non " +
 							"serializable property value [" + entityName + "." + uniqueKeyName + "]"
-			);
+					);
 		}
 	}
 
-	/**
-	 * Custom serialization routine used during serialization of a
-	 * Session/PersistenceContext for increased performance.
-	 *
-	 * @param oos The stream to which we should write the serial data.
-	 *
-	 * @throws IOException
-	 */
+	@Override
 	public void serialize(ObjectOutputStream oos) throws IOException {
 		checkAbilityToSerialize();
 		oos.writeObject( uniqueKeyName );


### PR DESCRIPTION
I added a new Interface with a `serialize()` method in order to be able to add a private helper method in `StatefulPersistenceContext`. This `writeKeyMapToStream()` method is doing the same duplicated routine, so no business logic was changed.
Writing this I found `private static boolean TRACE_ENABLED = LOG.isTraceEnabled()`, which is the same as `boolean tracing` used in `StatefulPersistenceContext.serialize()` so I'll be improving that also ASAP.
**Just a little warning:** `StatefulPersistenceContext` doesn't have a test class and I don't know yet how to test the whole project, so any help with this kind of checks is appreciated, please contact me.