### PR TITLE
HHH-12531 JCache existing cache not detected.

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
@@ -557,6 +557,36 @@ In order to control which provider to use and specify configuration for the `Cac
 
 Only by specifying the second property `hibernate.javax.cache.uri` will you be able to have a `CacheManager` per `SessionFactory`.
 
+[[caching-provider-jcache-missing-cache-strategy]]
+==== JCache missing cache strategy
+
+By default, the JCache region factory
+will throw an exception when asked to retrieve a cache that is not pre-configured and pre-started in the underlying cache manager.
+Thus if you configure an entity type or a collection as cached, but do not configure the corresponding cache explicitly,
+Hibernate ORM will fail to start.
+
+You may change this behavior by setting the `hibernate.javax.cache.missing_cache_strategy` property
+to one of the following values:
+
+.Missing cache strategies
+[cols=",",options="header",]
+|======================================
+| Value        | Description
+|`fail`        | **Default value**. Fail with an exception on missing caches.
+|`create-warn` | Create a new cache when a cache is not found (see `create` below),
+and also log a warning about the missing cache.
+|`create`      | Create a new cache when a cache is not found, without logging any warning about the missing cache.
+|======================================
+
+[WARNING]
+====
+Note that caches created this way may be very badly configured (unlimited size and no eviction in particular)
+unless the cache provider was explicitly configured to use a specific configuration for default caches.
+
+Ehcache in particular allows to set such default configuration using cache templates,
+see http://www.ehcache.org/documentation/3.0/107.html#supplement-jsr-107-configurations
+====
+
 [[caching-provider-ehcache]]
 === Ehcache
 
@@ -613,6 +643,33 @@ shared among multiple `SessionFactory` instances in the same JVM.
 [NOTE]
 ====
 http://www.ehcache.org/documentation/2.8/integrations/hibernate#optional[Ehcache documentation] recommends using multiple non-singleton `CacheManager(s)` when there are multiple Hibernate `SessionFactory` instances running in the same JVM.
+====
+
+[[caching-provider-ehcache-missing-cache-strategy]]
+==== Ehcache missing cache strategy
+
+By default, the Ehcache region factory
+will log a warning when asked to create a cache that is not explicitly configured and pre-started in the underlying cache manager.
+Thus if you configure an entity type or a collection as cached, but do not configure the corresponding cache explicitly,
+one warning will be logged for each cache that was not configured explicitly.
+
+You may change this behavior by setting the `hibernate.cache.ehcache.missing_cache_strategy` property
+to one of the following values:
+
+.Missing cache strategies
+[cols=",",options="header",]
+|======================================
+| Value        | Description
+|`fail`        | Fail with an exception on missing caches.
+|`create-warn` | **Default value**. Create a new cache when a cache is not found (see `create` below),
+and also log a warning about the missing cache.
+|`create`      | Create a new cache when a cache is not found, without logging any warning about the missing cache.
+|======================================
+
+[WARNING]
+====
+Note that caches created this way may be very badly configured (large size in particular)
+unless an appropriate `<defaultCache>` entry is added to the Ehcache configuration.
 ====
 
 [[caching-provider-infinispan]]

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/identifier/CacheableNaturalIdTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/identifier/CacheableNaturalIdTest.java
@@ -31,8 +31,8 @@ public class CacheableNaturalIdTest extends BaseEntityManagerFunctionalTestCase 
 
 	@Override
 	public void buildEntityManagerFactory() {
-		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.cache.spi.TimestampsRegion", new MutableConfiguration<>() );
-		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.cache.spi.QueryResultsRegion", new MutableConfiguration<>() );
+		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.cache.spi.UpdateTimestampsCache", new MutableConfiguration<>() );
+		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.cache.internal.StandardQueryCache", new MutableConfiguration<>() );
 		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.userguide.mapping.identifier.CacheableNaturalIdTest$Book##NaturalId", new MutableConfiguration<>() );
 //		JCacheHelper.locateStandardCacheManager().createCache( "", new MutableConfiguration<>() );
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
@@ -52,6 +52,10 @@ import org.hibernate.type.descriptor.java.StringTypeDescriptor;
 public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildingContext {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( EnabledCaching.class );
 
+	// These are legacy names that users have to include in their caching configuration, do not change them
+	public static final String QUERY_RESULT_REGION_UNQUALIFIED_NAME = "org.hibernate.cache.internal.StandardQueryCache";
+	public static final String TIMESTAMPS_REGION_UNQUALIFIED_NAME = "org.hibernate.cache.spi.UpdateTimestampsCache";
+
 	private final SessionFactoryImplementor sessionFactory;
 	private final RegionFactory regionFactory;
 
@@ -78,7 +82,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 
 		if ( getSessionFactory().getSessionFactoryOptions().isQueryCacheEnabled() ) {
 			final TimestampsRegion timestampsRegion = regionFactory.buildTimestampsRegion(
-					TimestampsRegion.class.getName(),
+					TIMESTAMPS_REGION_UNQUALIFIED_NAME,
 					sessionFactory
 			);
 			timestampsCache = sessionFactory.getSessionFactoryOptions()
@@ -87,7 +91,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 			legacySecondLevelCacheNames.add( timestampsRegion.getName() );
 
 			final QueryResultsRegion queryResultsRegion = regionFactory.buildQueryResultsRegion(
-					QueryResultsRegion.class.getName(),
+					QUERY_RESULT_REGION_UNQUALIFIED_NAME,
 					sessionFactory
 			);
 			regionsByName.put( queryResultsRegion.getName(), queryResultsRegion );

--- a/hibernate-ehcache/hibernate-ehcache.gradle
+++ b/hibernate-ehcache/hibernate-ehcache.gradle
@@ -12,4 +12,6 @@ description = "Integration for using Ehcache 2.x as a Hibernate second-level-cac
 dependencies {
     compile project( ':hibernate-core' )
     compile( libraries.ehcache )
+
+    testCompile project( ':hibernate-testing' )
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/ConfigSettings.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/ConfigSettings.java
@@ -20,6 +20,16 @@ public interface ConfigSettings {
 	String CACHE_MANAGER = PROP_PREFIX + "cache_manager";
 
 	/**
+	 * Define the behavior of the region factory when a cache is missing,
+	 * i.e. when the cache was not created by the cache manager as it started.
+	 *
+	 * See {@link MissingCacheStrategy} for the various possible values.
+	 *
+	 * Default value is {@link MissingCacheStrategy#FAIL}.
+	 */
+	String MISSING_CACHE_STRATEGY = PROP_PREFIX + "missing_cache_strategy";
+
+	/**
 	 * This is the legacy property name.  No need to change it to fit under {@link #PROP_PREFIX}
 	 */
 	String EHCACHE_CONFIGURATION_RESOURCE_NAME = "net.sf.ehcache.configurationResourceName";

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/ConfigSettings.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/ConfigSettings.java
@@ -15,7 +15,7 @@ public interface ConfigSettings {
 	String PROP_PREFIX = "hibernate.cache.ehcache.";
 
 	/**
-	 * Allows providing `hibernate-jcache` with a custom JCache {@link CacheManager}.
+	 * Allows providing `hibernate-ehcache` with a custom Ehcache {@link CacheManager}.
 	 */
 	String CACHE_MANAGER = PROP_PREFIX + "cache_manager";
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/MissingCacheStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/MissingCacheStrategy.java
@@ -45,7 +45,8 @@ public enum MissingCacheStrategy {
 
 		if ( StringHelper.isEmpty( externalRepresentation ) ) {
 			// Use the default
-			return MissingCacheStrategy.FAIL;
+			// Default is CREATE_WARN for backward compatibility reasons; we should switch to FAIL at some point.
+			return MissingCacheStrategy.CREATE_WARN;
 		}
 
 		for ( MissingCacheStrategy strategy : values() ) {

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/MissingCacheStrategy.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/MissingCacheStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache;
+
+import org.hibernate.internal.util.StringHelper;
+
+public enum MissingCacheStrategy {
+
+	/**
+	 * Fail with an exception on missing caches.
+	 */
+	FAIL("fail"),
+
+	/**
+	 * Create a new cache when a cache is not found (see {@link #CREATE})
+	 * and also log a warning about the missing cache.
+	 */
+	CREATE_WARN("create-warn"),
+
+	/**
+	 * Create a new cache when a cache is not found,
+	 * without logging any warning about the missing cache.
+	 *
+	 * Note that caches created this way may be very badly configured (large size in particular)
+	 * unless an appropriate `&lt;defaultCache&gt;` entry is added to the Ehcache configuration.
+	 */
+	CREATE("create");
+
+	private final String externalRepresentation;
+
+	MissingCacheStrategy(String externalRepresentation) {
+		this.externalRepresentation = externalRepresentation;
+	}
+
+	public static MissingCacheStrategy interpretSetting(Object value) {
+		if ( value instanceof MissingCacheStrategy ) {
+			return (MissingCacheStrategy) value;
+		}
+
+		final String externalRepresentation = value == null ? null : value.toString();
+
+		if ( StringHelper.isEmpty( externalRepresentation ) ) {
+			// Use the default
+			return MissingCacheStrategy.FAIL;
+		}
+
+		for ( MissingCacheStrategy strategy : values() ) {
+			if ( strategy.externalRepresentation.equals( externalRepresentation ) ) {
+				return strategy;
+			}
+		}
+
+		throw new IllegalArgumentException( "Unrecognized missing cache strategy value : " + value );
+	}
+}

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhCacheMessageLogger.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhCacheMessageLogger.java
@@ -7,6 +7,8 @@
 package org.hibernate.cache.ehcache.internal;
 
 
+import org.hibernate.cache.ehcache.ConfigSettings;
+import org.hibernate.cache.ehcache.MissingCacheStrategy;
 import org.hibernate.internal.CoreMessageLogger;
 
 import org.jboss.logging.Logger;
@@ -19,12 +21,12 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * The jboss-logging {@link MessageLogger} for the hibernate-ehcache module.  It reserves message ids ranging from
- * 20099 to 20099 (allow 20100 for our DeprecationLogger) inclusively.
+ * 20001 to 20099 (allow 20100 for our DeprecationLogger) inclusively.
  * <p/>
  * New messages must be added after the last message defined to ensure message codes are unique.
  */
 @MessageLogger(projectCode = "HHH")
-@ValidIdRange( min = 20001, max = 20099)
+@ValidIdRange(min = 20001, max = 20099)
 public interface EhCacheMessageLogger extends CoreMessageLogger {
 	EhCacheMessageLogger INSTANCE = Logger.getMessageLogger(
 			EhCacheMessageLogger.class,
@@ -110,5 +112,16 @@ public interface EhCacheMessageLogger extends CoreMessageLogger {
 			id = 20008
 	)
 	void softLockedCacheExpired(String regionName, Object key, String lock);
+
+	@LogMessage(level = WARN)
+	@Message(
+			value = "Missing cache[%s] was created on-the-fly." +
+					" The created cache will use the <defaultCache> configuration: " +
+					" make sure to configure it." +
+					" You can disable this warning by setting '" + ConfigSettings.MISSING_CACHE_STRATEGY +
+					"' to 'create'.",
+			id = 20009
+	)
+	void missingCacheCreated(String regionName);
 
 }

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
@@ -103,7 +103,7 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 	}
 
 	protected Cache createCache(String regionName) {
-		throw new CacheException( "On-the-fly creation of JCache Cache objects is not supported [" + regionName + "]" );
+		throw new CacheException( "On-the-fly creation of Ehcache Cache objects is not supported [" + regionName + "]" );
 	}
 
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
@@ -21,6 +21,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.cache.cfg.spi.DomainDataRegionBuildingContext;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.ehcache.ConfigSettings;
+import org.hibernate.cache.ehcache.MissingCacheStrategy;
 import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
@@ -39,11 +40,12 @@ import static org.hibernate.cache.ehcache.internal.HibernateEhcacheUtils.setCach
  * @author Alex Snaps
  */
 public class EhcacheRegionFactory extends RegionFactoryTemplate {
-	private static final Logger LOG = Logger.getLogger( EhcacheRegionFactory.class );
+	private static final EhCacheMessageLogger LOG = EhCacheMessageLogger.INSTANCE;
 
 	private final CacheKeysFactory cacheKeysFactory;
 
 	private volatile CacheManager cacheManager;
+	private volatile MissingCacheStrategy missingCacheStrategy;
 
 	public EhcacheRegionFactory() {
 		this( DefaultCacheKeysFactory.INSTANCE );
@@ -103,9 +105,20 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 	}
 
 	protected Cache createCache(String regionName) {
-		throw new CacheException( "On-the-fly creation of Ehcache Cache objects is not supported [" + regionName + "]" );
+		switch ( missingCacheStrategy ) {
+			case CREATE_WARN:
+				LOG.missingCacheCreated( regionName );
+				cacheManager.addCache( regionName );
+				return cacheManager.getCache( regionName );
+			case CREATE:
+				cacheManager.addCache( regionName );
+				return cacheManager.getCache( regionName );
+			case FAIL:
+				throw new CacheException( "On-the-fly creation of Ehcache Cache objects is not supported [" + regionName + "]" );
+			default:
+				throw new IllegalStateException( "Unsupported missing cache strategy: " + missingCacheStrategy );
+		}
 	}
-
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -122,6 +135,9 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 			if ( this.cacheManager == null ) {
 				throw new CacheException( "Could not start Ehcache CacheManager" );
 			}
+			this.missingCacheStrategy = MissingCacheStrategy.interpretSetting(
+					configValues.get( ConfigSettings.MISSING_CACHE_STRATEGY )
+			);
 		}
 	}
 

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/MissingCacheStrategyTest.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/MissingCacheStrategyTest.java
@@ -1,0 +1,127 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.ehcache.ConfigSettings;
+import org.hibernate.cache.ehcache.internal.EhCacheMessageLogger;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.spi.ServiceException;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.hamcrest.CoreMatchers;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MissingCacheStrategyTest extends BaseUnitTestCase {
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule( EhCacheMessageLogger.INSTANCE );
+
+	@Test
+	public void testMissingCacheStrategyDefault() {
+		doTestMissingCacheStrategyFail(
+				ignored -> { } // default settings
+		);
+	}
+
+	@Test
+	public void testMissingCacheStrategyFail() {
+		doTestMissingCacheStrategyFail(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
+		);
+	}
+
+	private void doTestMissingCacheStrategyFail(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
+		/*
+		 * The cache manager is created per session factory, and we don't use any specific ehcache configuration,
+		 * so we know the caches don't exist before we start the session factory.
+		 */
+
+		// let's try to build the standard testing SessionFactory, without pre-defining caches
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
+			fail();
+		}
+		catch (ServiceException expected) {
+			assertTyping( CacheException.class, expected.getCause() );
+			assertThat( expected.getMessage(), CoreMatchers.equalTo( "Unable to create requested service [" + org.hibernate.cache.spi.CacheImplementor.class.getName() + "]" ) );
+			assertThat( expected.getCause().getMessage(), CoreMatchers.startsWith( "On-the-fly creation of Ehcache Cache objects is not supported" ) );
+		}
+		catch (CacheException expected) {
+			assertThat( expected.getMessage(), CoreMatchers.equalTo( "On-the-fly creation of Ehcache Cache objects is not supported" ) );
+		}
+	}
+
+	@Test
+	public void testMissingCacheStrategyCreate() {
+		/*
+		 * The cache manager is created per session factory, and we don't use any specific ehcache configuration,
+		 * so we know the caches don't exist before we start the session factory.
+		 */
+
+		// and now let's try to build the standard testing SessionFactory, without pre-defining caches
+		try ( SessionFactoryImplementor sessionFactory = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create" )
+		) ) {
+			// The caches should have been created automatically
+			for ( String regionName : TestHelper.allRegionNames ) {
+				assertThat( "Cache '" + regionName + "' should have been created",
+						TestHelper.getCache( sessionFactory, regionName ), notNullValue() );
+			}
+		}
+	}
+
+	@Test
+	public void testMissingCacheStrategyCreateWarn() {
+		/*
+		 * The cache manager is created per session factory, and we don't use any specific ehcache configuration,
+		 * so we know the caches don't exist before we start the session factory.
+		 */
+
+		Map<String, Triggerable> triggerables = new HashMap<>();
+		for ( String regionName : TestHelper.allRegionNames ) {
+			triggerables.put(
+					regionName,
+					logInspection.watchForLogMessages(
+							"HHH020009: Missing cache[" + TestHelper.prefix( regionName ) + "] was created on-the-fly"
+					)
+			);
+		}
+
+		try ( SessionFactoryImplementor sessionFactory = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
+		) ) {
+			for ( String regionName : TestHelper.allRegionNames ) {
+				// The caches should have been created automatically
+				assertThat(
+						"Cache '" + regionName + "' should have been created",
+						TestHelper.getCache( sessionFactory, regionName ), notNullValue()
+				);
+				// Logs should have been triggered
+				assertTrue(
+						"Cache '" + regionName + "' should have triggered a warning",
+						triggerables.get( regionName ).wasTriggered()
+				);
+			}
+		}
+	}
+
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/MissingCacheStrategyTest.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/MissingCacheStrategyTest.java
@@ -38,26 +38,22 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 
 	@Test
 	public void testMissingCacheStrategyDefault() {
-		doTestMissingCacheStrategyFail(
+		doTestMissingCacheStrategyCreateWarn(
 				ignored -> { } // default settings
 		);
 	}
 
 	@Test
 	public void testMissingCacheStrategyFail() {
-		doTestMissingCacheStrategyFail(
-				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
-		);
-	}
-
-	private void doTestMissingCacheStrategyFail(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
 		/*
 		 * The cache manager is created per session factory, and we don't use any specific ehcache configuration,
 		 * so we know the caches don't exist before we start the session factory.
 		 */
 
 		// let's try to build the standard testing SessionFactory, without pre-defining caches
-		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
+		) ) {
 			fail();
 		}
 		catch (ServiceException expected) {
@@ -91,6 +87,12 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 
 	@Test
 	public void testMissingCacheStrategyCreateWarn() {
+		doTestMissingCacheStrategyCreateWarn(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
+		);
+	}
+
+	private void doTestMissingCacheStrategyCreateWarn(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
 		/*
 		 * The cache manager is created per session factory, and we don't use any specific ehcache configuration,
 		 * so we know the caches don't exist before we start the session factory.
@@ -106,9 +108,7 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 			);
 		}
 
-		try ( SessionFactoryImplementor sessionFactory = TestHelper.buildStandardSessionFactory(
-				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
-		) ) {
+		try ( SessionFactoryImplementor sessionFactory = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
 			for ( String regionName : TestHelper.allRegionNames ) {
 				// The caches should have been created automatically
 				assertThat(

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/TestHelper.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/TestHelper.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.ehcache.internal.EhcacheRegionFactory;
+import org.hibernate.cache.ehcache.test.domain.Event;
+import org.hibernate.cache.ehcache.test.domain.Item;
+import org.hibernate.cache.ehcache.test.domain.VersionedItem;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.support.RegionNameQualifier;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.tool.schema.Action;
+
+/**
+ * @author Steve Ebersole
+ */
+public class TestHelper {
+	public static String[] entityRegionNames = new String[] {
+			Item.class.getName(),
+			VersionedItem.class.getName(),
+			Event.class.getName()
+	};
+	public static String[] collectionRegionNames = new String[] {
+			Event.class.getName() + ".participants"
+	};
+
+	public static String[] allRegionNames =
+			Stream.concat( Arrays.stream( entityRegionNames ), Arrays.stream( collectionRegionNames ) )
+					.toArray( String[]::new );
+
+	public static SessionFactoryImplementor buildStandardSessionFactory() {
+		return buildStandardSessionFactory( ignored -> { } );
+
+	}
+
+	public static SessionFactoryImplementor buildStandardSessionFactory(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
+		final StandardServiceRegistryBuilder ssrb = getStandardServiceRegistryBuilder();
+
+		additionalSettings.accept( ssrb );
+
+		final StandardServiceRegistry ssr = ssrb.build();
+
+		return (SessionFactoryImplementor) new MetadataSources( ssr ).buildMetadata().buildSessionFactory();
+	}
+
+	public static StandardServiceRegistryBuilder getStandardServiceRegistryBuilder() {
+		final StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder()
+				.configure( "hibernate-config/hibernate.cfg.xml" )
+				.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" )
+				.applySetting( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.CREATE )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+
+		if ( H2Dialect.class.equals( Dialect.getDialect().getClass() ) ) {
+			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc;MVCC=true" );
+		}
+		return ssrb;
+	}
+
+	public static String prefix(String regionName) {
+		return RegionNameQualifier.INSTANCE.qualify( "hibernate.test", regionName );
+	}
+
+	public static Cache getCache(SessionFactoryImplementor sessionFactoryImplementor, String regionName) {
+		final RegionFactory regionFactory = sessionFactoryImplementor.getCache().getRegionFactory();
+		final EhcacheRegionFactory ehcacheRegionFactory = (EhcacheRegionFactory) regionFactory;
+		final CacheManager cacheManager = ehcacheRegionFactory.getCacheManager();
+		regionName = prefix( regionName );
+		return cacheManager.getCache( regionName );
+	}
+
+	private TestHelper() {
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Account.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Account.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.cache.ehcache.test.domain;
+
+public class Account {
+
+	private Long id;
+	private Person person;
+
+	public Account() {
+		//
+	}
+
+	public Person getPerson() {
+		return person;
+	}
+
+	public void setPerson(Person person) {
+		this.person = person;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String toString() {
+		return super.toString();
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Event.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Event.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Event {
+	private Long id;
+
+	private String title;
+	private Date date;
+	private Set participants = new HashSet();
+	private Person organizer;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setOrganizer(Person organizer) {
+		this.organizer = organizer;
+	}
+
+	public Person getOrganizer() {
+		return organizer;
+	}
+
+	public Set getParticipants() {
+		return participants;
+	}
+
+	public void setParticipants(Set participants) {
+		this.participants = participants;
+	}
+
+	public void addParticipant(Person person) {
+		participants.add(person);
+		person.getEvents().add(this);
+	}
+
+	public void removeParticipant(Person person) {
+		participants.remove(person);
+		person.getEvents().remove(this);
+	}
+
+	public String toString() {
+		return getTitle() + ": " + getDate();
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/EventManager.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/EventManager.java
@@ -1,0 +1,240 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
+public class EventManager {
+
+	private final SessionFactory sessionFactory;
+
+	public EventManager(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	public List listEmailsOfEvent(Long eventId) {
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		List emailList = new ArrayList();
+		Event event = (Event)session.load(Event.class, eventId);
+		for (Iterator it = event.getParticipants().iterator(); it.hasNext(); ) {
+			Person person = (Person)it.next();
+			emailList.addAll(person.getEmailAddresses());
+		}
+
+		session.getTransaction().commit();
+		return emailList;
+	}
+
+	public Long createAndStoreEvent(String title, Person organizer, Date theDate) {
+
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		Event theEvent = new Event();
+		theEvent.setTitle(title);
+		theEvent.setDate(theDate);
+		theEvent.setOrganizer(organizer);
+
+		Long eventId = (Long)session.save(theEvent);
+
+		session.getTransaction().commit();
+		return eventId;
+	}
+
+	public Long createAndStorePerson(String firstName, String lastName) {
+
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		Person person = new Person();
+		person.setFirstname(firstName);
+		person.setLastname(lastName);
+
+		Long personId = (Long)session.save(person);
+
+		session.getTransaction().commit();
+		return personId;
+	}
+
+	public Long createAndStorePerson(Person person) {
+
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		Long personId = (Long)session.save(person);
+
+		session.getTransaction().commit();
+		return personId;
+	}
+
+	public List listEvents() {
+
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		List result = session.createQuery("from Event").setCacheable(true).list();
+
+		session.getTransaction().commit();
+
+		return result;
+	}
+
+	/**
+	 * Call setEntity() on a cacheable query - see FORGE-265
+	 */
+	public List listEventsOfOrganizer(Person organizer) {
+
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		Query query = session.createQuery("from Event ev where ev.organizer = :organizer");
+
+		query.setCacheable(true);
+		query.setEntity("organizer", organizer);
+		List result = query.list();
+
+		session.getTransaction().commit();
+
+		return result;
+	}
+
+	/**
+	 * Use a Criteria query - see FORGE-247
+	 */
+	public List listEventsWithCriteria() {
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		List result = session.createCriteria(Event.class)
+			.setCacheable(true)
+			.list();
+
+		session.getTransaction().commit();
+
+		return result;
+	}
+
+	public void addPersonToEvent(Long personId, Long eventId) {
+
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Person aPerson = (Person)session.load(Person.class, personId);
+		Event anEvent = (Event)session.load(Event.class, eventId);
+
+		aPerson.getEvents().add(anEvent);
+
+		session.getTransaction().commit();
+	}
+
+	public Long addPersonToAccount(Long personId, Account account) {
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Person aPerson = (Person)session.load(Person.class, personId);
+		account.setPerson(aPerson);
+
+		Long accountId = (Long)session.save(account);
+
+		session.getTransaction().commit();
+		return accountId;
+	}
+
+	public Account getAccount(Long accountId) {
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Account account = (Account)session.load(Account.class, accountId);
+
+		session.getTransaction().commit();
+		return account;
+	}
+
+	public void addEmailToPerson(Long personId, String emailAddress) {
+
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Person aPerson = (Person)session.load(Person.class, personId);
+
+		// The getEmailAddresses() might trigger a lazy load of the collection
+		aPerson.getEmailAddresses().add(emailAddress);
+
+		session.getTransaction().commit();
+	}
+
+	public void addPhoneNumberToPerson(Long personId, PhoneNumber pN) {
+
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Person aPerson = (Person)session.load(Person.class, personId);
+		pN.setPersonId(personId.longValue());
+		aPerson.getPhoneNumbers().add(pN);
+
+		session.getTransaction().commit();
+	}
+
+	public void addTalismanToPerson(Long personId, String talisman) {
+
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		Person aPerson = (Person)session.load(Person.class, personId);
+		aPerson.addTalisman(talisman);
+
+		session.getTransaction().commit();
+	}
+
+	public Long createHolidayCalendar() {
+
+		Session session = sessionFactory.getCurrentSession();
+		session.beginTransaction();
+
+		// delete all existing calendars
+		List calendars = session.createQuery("from HolidayCalendar").setCacheable(true).list();
+		for (ListIterator li = calendars.listIterator(); li.hasNext(); ) {
+			session.delete(li.next());
+		}
+
+		HolidayCalendar calendar = new HolidayCalendar();
+		calendar.init();
+
+		Long calendarId = (Long)session.save(calendar);
+
+		session.getTransaction().commit();
+		return calendarId;
+	}
+
+	public HolidayCalendar getHolidayCalendar() {
+		Session session = sessionFactory.getCurrentSession();
+
+		session.beginTransaction();
+
+		List calendars = session.createQuery("from HolidayCalendar").setCacheable(true).list();
+
+		session.getTransaction().commit();
+
+		return calendars.isEmpty() ? null : (HolidayCalendar)calendars.get(0);
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/HolidayCalendar.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/HolidayCalendar.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HolidayCalendar {
+
+
+	private Long id;
+	// Date -> String
+	private Map holidays = new HashMap();
+
+	public HolidayCalendar init() {
+		DateFormat df = new SimpleDateFormat("yyyy.MM.dd");
+		try {
+			holidays.clear();
+			holidays.put(df.parse("2009.01.01"), "New Year's Day");
+			holidays.put(df.parse("2009.02.14"), "Valentine's Day");
+			holidays.put(df.parse("2009.11.11"), "Armistice Day");
+		} catch (ParseException e) {
+			throw new RuntimeException(e);
+		}
+		return this;
+	}
+
+	public Map getHolidays() {
+		return holidays;
+	}
+
+	protected void setHolidays(Map holidays) {
+		this.holidays = holidays;
+	}
+
+	public void addHoliday(Date d, String name) {
+		holidays.put(d, name);
+	}
+
+	public String getHoliday(Date d) {
+		return (String)holidays.get(d);
+	}
+
+	public boolean isHoliday(Date d) {
+		return holidays.containsKey(d);
+	}
+
+	protected Long getId() {
+		return id;
+	}
+
+	protected void setId(Long id) {
+		this.id = id;
+	}
+}
+

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Item.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Item.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+public class Item {
+	private Long id;
+	private String name;
+	private String description;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Person.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/Person.java
@@ -1,0 +1,111 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.cache.ehcache.test.domain;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Person {
+
+	private Long id;
+	private int age;
+	private String firstname;
+	private String lastname;
+	private List events = new ArrayList(); // list semantics, e.g., indexed
+	private Set emailAddresses = new HashSet();
+	private Set phoneNumbers = new HashSet();
+	private List talismans = new ArrayList(); // a Bag of good-luck charms.
+
+	public Person() {
+		//
+	}
+
+	public List getEvents() {
+		return events;
+	}
+
+	protected void setEvents(List events) {
+		this.events = events;
+	}
+
+	public void addToEvent(Event event) {
+		this.getEvents().add(event);
+		event.getParticipants().add(this);
+	}
+
+	public void removeFromEvent(Event event) {
+		this.getEvents().remove(event);
+		event.getParticipants().remove(this);
+	}
+
+	public int getAge() {
+		return age;
+	}
+
+	public void setAge(int age) {
+		this.age = age;
+	}
+
+	public String getFirstname() {
+		return firstname;
+	}
+
+	public void setFirstname(String firstname) {
+		this.firstname = firstname;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	public void setLastname(String lastname) {
+		this.lastname = lastname;
+	}
+
+	public Set getEmailAddresses() {
+		return emailAddresses;
+	}
+
+	public void setEmailAddresses(Set emailAddresses) {
+		this.emailAddresses = emailAddresses;
+	}
+
+	public Set getPhoneNumbers() {
+		return phoneNumbers;
+	}
+
+	public void setPhoneNumbers(Set phoneNumbers) {
+		this.phoneNumbers = phoneNumbers;
+	}
+
+	public void addTalisman(String name) {
+		talismans.add(name);
+	}
+
+	public List getTalismans() {
+		return talismans;
+	}
+
+	public void setTalismans(List talismans) {
+		this.talismans = talismans;
+	}
+
+	public String toString() {
+		return getFirstname() + " " + getLastname();
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/PhoneNumber.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/PhoneNumber.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.cache.ehcache.test.domain;
+
+import java.io.Serializable;
+
+/**
+ * PhoneNumber
+ */
+public class PhoneNumber implements Serializable {
+	private long personId = 0;
+	private String numberType = "home";
+	private long phone = 0;
+
+	public long getPersonId() {
+		return personId;
+	}
+
+	public void setPersonId(long personId) {
+		this.personId = personId;
+	}
+
+	public String getNumberType() {
+		return numberType;
+	}
+
+	public void setNumberType(String numberType) {
+		this.numberType = numberType;
+	}
+
+	public long getPhone() {
+		return phone;
+	}
+
+	public void setPhone(long phone) {
+		this.phone = phone;
+	}
+
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result
+						 + ((numberType == null) ? 0 : numberType.hashCode());
+		result = prime * result + (int)(personId ^ (personId >>> 32));
+		result = prime * result + (int)(phone ^ (phone >>> 32));
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		final PhoneNumber other = (PhoneNumber)obj;
+		if (numberType == null) {
+			if (other.numberType != null)
+				return false;
+		} else if (!numberType.equals(other.numberType))
+			return false;
+		if (personId != other.personId)
+			return false;
+		if (phone != other.phone)
+			return false;
+		return true;
+	}
+
+	public String toString() {
+		return numberType + ":" + phone;
+	}
+
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/UuidItem.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/UuidItem.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+public class UuidItem {
+	private String id;
+	private String name;
+	private String description;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/VersionedItem.java
+++ b/hibernate-ehcache/src/test/java/org/hibernate/cache/ehcache/test/domain/VersionedItem.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.ehcache.test.domain;
+
+public class VersionedItem extends Item {
+	private Long version;
+
+	public Long getVersion() {
+		return version;
+	}
+
+	public void setVersion(Long version) {
+		this.version = version;
+	}
+}

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/Account.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/Account.hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class name="org.hibernate.cache.ehcache.test.domain.Account" table="ACCOUNT" lazy="false">
+        <id name="id" column="ACCOUNT_ID">
+            <generator class="native"/>
+        </id>
+
+        <many-to-one name="person" class="org.hibernate.cache.ehcache.test.domain.Person" cascade="save-update,lock"
+                     column="person_id"
+                     unique="true"
+                     not-null="true"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/Event.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/Event.hbm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class name="org.hibernate.cache.ehcache.test.domain.Event" table="EVENTS">
+        <cache usage="read-write"/>
+        <id name="id" column="EVENT_ID">
+            <generator class="native"/>
+        </id>
+        <property name="date" type="timestamp" column="EVENT_DATE"/>
+        <property name="title"/>
+        <many-to-one name="organizer" column="EVENT_ORGANIZER" class="org.hibernate.cache.ehcache.test.domain.Person"/>
+
+        <set name="participants" table="PERSON_EVENT" lazy="false"
+             inverse="true" cascade="lock">
+            <cache usage="read-write"/>
+            <key column="EVENT_ID"/>
+            <many-to-many column="PERSON_ID"
+                          class="org.hibernate.cache.ehcache.test.domain.Person"/>
+        </set>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/HolidayCalendar.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/HolidayCalendar.hbm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class name="org.hibernate.cache.ehcache.test.domain.HolidayCalendar" table="CALENDAR" lazy="false">
+        <id name="id" column="CALENDAR_ID">
+            <generator class="native"/>
+        </id>
+
+        <map name="holidays" table="CALENDAR_HOLIDAYS" lazy="false">
+            <key column="CALENDAR_ID"/>
+            <map-key column="hol_date" type="date"/>
+            <element column="hol_name" type="string"/>
+        </map>
+
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/Item.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/Item.hbm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.cache.ehcache.test.domain">
+
+
+    <class name="Item" table="Items">
+        <cache usage="read-write"/>
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name" not-null="true"/>
+        <property name="description" not-null="true"/>
+    </class>
+
+    <class name="VersionedItem" table="VersionedItems">
+        <cache usage="read-write"/>
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <version name="version" type="long"/>
+        <property name="name" not-null="true"/>
+        <property name="description" not-null="true"/>
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/Person.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/Person.hbm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class name="org.hibernate.cache.ehcache.test.domain.Person" table="PERSON" lazy="true">
+        <id name="id" column="PERSON_ID">
+            <generator class="native"/>
+        </id>
+        <property name="age"/>
+        <property name="firstname"/>
+        <property name="lastname"/>
+
+        <list name="events" table="PERSON_EVENT" lazy="true">
+            <key column="PERSON_ID"/>
+            <list-index column="EVENT_ORDER"/>
+            <many-to-many column="EVENT_ID" class="org.hibernate.cache.ehcache.test.domain.Event"/>
+        </list>
+
+        <bag name="talismans" table="PERSON_TALISMAN" lazy="true">
+            <key column="PERSON_ID"/>
+            <element type="string" column="TALISMAN_NAME"/>
+        </bag>
+
+        <set name="emailAddresses" table="PERSON_EMAIL_ADDR" lazy="true">
+            <key column="PERSON_ID"/>
+            <element type="string" column="EMAIL_ADDR"/>
+        </set>
+
+        <set name="phoneNumbers" cascade="all" lazy="true">
+            <key column="PERSON_ID"/>
+            <one-to-many class="org.hibernate.cache.ehcache.test.domain.PhoneNumber"/>
+        </set>
+
+
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/domain/PhoneNumber.hbm.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/domain/PhoneNumber.hbm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class name="org.hibernate.cache.ehcache.test.domain.PhoneNumber" table="PHONE_NUMBERS">
+        <composite-id>
+            <key-property column="PERSON_ID" name="personId" type="java.lang.Long"/>
+            <key-property column="NUMBER_TYPE" name="numberType" type="java.lang.String"/>
+        </composite-id>
+
+        <property name="phone" type="java.lang.Long">
+            <column name="PHONE" precision="22" scale="0"/>
+        </property>
+
+    </class>
+
+</hibernate-mapping>

--- a/hibernate-ehcache/src/test/resources/hibernate-config/hibernate.cfg.xml
+++ b/hibernate-ehcache/src/test/resources/hibernate-config/hibernate.cfg.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+
+    <session-factory>
+
+        <!-- Enable Hibernate's automatic session context management -->
+        <property name="current_session_context_class">thread</property>
+
+        <property name="cache.use_query_cache">true</property>
+        <property name="cache.use_second_level_cache">true</property>
+        <property name="cache.use_structured_entries">true</property>
+        <property name="cache.region.factory_class">ehcache</property>
+        <!-- Echo all executed SQL to stdout -->
+        <property name="show_sql">true</property>
+
+        <mapping resource="hibernate-config/domain/Event.hbm.xml"/>
+        <mapping resource="hibernate-config/domain/Person.hbm.xml"/>
+        <mapping resource="hibernate-config/domain/PhoneNumber.hbm.xml"/>
+        <mapping resource="hibernate-config/domain/Account.hbm.xml"/>
+        <mapping resource="hibernate-config/domain/HolidayCalendar.hbm.xml"/>
+
+        <mapping resource="hibernate-config/domain/Item.hbm.xml"/>
+
+    </session-factory>
+
+</hibernate-configuration>

--- a/hibernate-ehcache/src/test/resources/hibernate.properties
+++ b/hibernate-ehcache/src/test/resources/hibernate.properties
@@ -1,0 +1,17 @@
+#
+# Hibernate, Relational Persistence for Idiomatic Java
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+hibernate.dialect @db.dialect@
+hibernate.connection.driver_class @jdbc.driver@
+hibernate.connection.url @jdbc.url@
+hibernate.connection.username @jdbc.user@
+hibernate.connection.password @jdbc.pass@
+
+hibernate.connection.pool_size 5
+
+hibernate.cache.region_prefix hibernate.test
+
+hibernate.service.allow_crawling=false

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/ConfigSettings.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/ConfigSettings.java
@@ -28,6 +28,16 @@ public interface ConfigSettings {
 	String PROVIDER = PROP_PREFIX + "provider";
 
 	/**
+	 * Define the behavior of the region factory when a cache is missing,
+	 * i.e. when the cache was not created by the cache manager as it started.
+	 *
+	 * See {@link MissingCacheStrategy} for the various possible values.
+	 *
+	 * Default value is {@link MissingCacheStrategy#FAIL}.
+	 */
+	String MISSING_CACHE_STRATEGY = PROP_PREFIX + "missing_cache_strategy";
+
+	/**
 	 * Designates the URI for a specific JCache {@link CacheManager} JCacheRegionFactory
 	 * should ask the {@link javax.cache.spi.CachingProvider} for
 	 *

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/MissingCacheStrategy.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/MissingCacheStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.jcache;
+
+import org.hibernate.internal.util.StringHelper;
+
+public enum MissingCacheStrategy {
+
+	/**
+	 * Fail with an exception on missing caches.
+	 */
+	FAIL("fail"),
+
+	/**
+	 * Create a new cache when a cache is not found (see {@link #CREATE}),
+	 * and also log a warning about the missing cache.
+	 */
+	CREATE_WARN("create-warn"),
+
+	/**
+	 * Create a new cache when a cache is not found,
+	 * without logging any warning about the missing cache.
+	 *
+	 * Note that caches created this way may be very badly configured (unlimited size and no eviction in particular)
+	 * unless the cache provider was explicitly configured to use an appropriate configuration for default caches.
+	 *
+	 * Ehcache in particular allows to set such default configuration using cache templates,
+	 * see http://www.ehcache.org/documentation/3.0/107.html#supplement-jsr-107-configurations
+	 */
+	CREATE("create");
+
+	private final String externalRepresentation;
+
+	MissingCacheStrategy(String externalRepresentation) {
+		this.externalRepresentation = externalRepresentation;
+	}
+
+	public static MissingCacheStrategy interpretSetting(Object value) {
+		if ( value instanceof MissingCacheStrategy ) {
+			return (MissingCacheStrategy) value;
+		}
+
+		final String externalRepresentation = value == null ? null : value.toString();
+
+		if ( StringHelper.isEmpty( externalRepresentation ) ) {
+			// Use the default
+			return MissingCacheStrategy.FAIL;
+		}
+
+		for ( MissingCacheStrategy strategy : values() ) {
+			if ( strategy.externalRepresentation.equals( externalRepresentation ) ) {
+				return strategy;
+			}
+		}
+
+		throw new IllegalArgumentException( "Unrecognized missing cache strategy value : " + value );
+	}
+}

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/JCacheMessageLogger.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/JCacheMessageLogger.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.cache.jcache.internal;
+
+
+import org.hibernate.cache.jcache.ConfigSettings;
+import org.hibernate.internal.CoreMessageLogger;
+
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+
+import static org.jboss.logging.Logger.Level.WARN;
+
+/**
+ * The jboss-logging {@link MessageLogger} for the hibernate-jcache module.  It reserves message ids ranging from
+ * 25099 to 25099 inclusively.
+ * <p/>
+ * New messages must be added after the last message defined to ensure message codes are unique.
+ */
+@MessageLogger(projectCode = "HHH")
+@ValidIdRange(min = 25001, max = 25099)
+public interface JCacheMessageLogger extends CoreMessageLogger {
+	JCacheMessageLogger INSTANCE = Logger.getMessageLogger(
+			JCacheMessageLogger.class,
+			"org.hibernate.orm.javax.cache"
+	);
+
+	@LogMessage(level = WARN)
+	@Message(
+			value = "Missing cache[%s] was created on-the-fly." +
+					" The created cache will use a provider-specific default configuration:" +
+					" make sure you defined one." +
+					" You can disable this warning by setting '" + ConfigSettings.MISSING_CACHE_STRATEGY +
+					"' to 'create'.",
+			id = 25001
+	)
+	void missingCacheCreated(String regionName);
+
+}

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/BaseFunctionalTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/BaseFunctionalTest.java
@@ -21,7 +21,8 @@ public abstract class BaseFunctionalTest extends BaseUnitTestCase {
 	@Before
 	public void createSessionFactory() {
 		assert sessionFactory == null || sessionFactory.isClosed();
-		sessionFactory = TestHelper.buildStandardSessionFactory( true );
+		TestHelper.preBuildCaches();
+		sessionFactory = TestHelper.buildStandardSessionFactory();
 	}
 
 	@After

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/MissingCacheStrategyTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/MissingCacheStrategyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jcache.test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.jcache.ConfigSettings;
+import org.hibernate.cache.jcache.internal.JCacheMessageLogger;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.spi.ServiceException;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.hamcrest.CoreMatchers;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests around {@link org.hibernate.cache.jcache.MissingCacheStrategy}
+ *
+ * @author Steve Ebersole
+ * @author Yoann Rodiere
+ */
+public class MissingCacheStrategyTest extends BaseUnitTestCase {
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule( JCacheMessageLogger.INSTANCE );
+
+	@Test
+	public void testMissingCacheStrategyDefault() {
+		doTestMissingCacheStrategyFail(
+				ignored -> { } // default settings
+		);
+	}
+
+	@Test
+	public void testMissingCacheStrategyFail() {
+		doTestMissingCacheStrategyFail(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
+		);
+	}
+
+	private void doTestMissingCacheStrategyFail(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
+		// first, lets make sure that the region names we think are non-existent really do not exist
+		for ( String regionName : TestHelper.allRegionNames ) {
+			assertThat( TestHelper.getCache( regionName ), nullValue() );
+		}
+
+		// and now let's try to build the standard testing SessionFactory, without pre-defining caches
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
+			fail();
+		}
+		catch (ServiceException expected) {
+			assertTyping( CacheException.class, expected.getCause() );
+			assertThat( expected.getMessage(), CoreMatchers.equalTo( "Unable to create requested service [" + org.hibernate.cache.spi.CacheImplementor.class.getName() + "]" ) );
+			assertThat( expected.getCause().getMessage(), CoreMatchers.startsWith( "On-the-fly creation of JCache Cache objects is not supported" ) );
+		}
+		catch (CacheException expected) {
+			assertThat( expected.getMessage(), CoreMatchers.equalTo( "On-the-fly creation of JCache Cache objects is not supported" ) );
+		}
+	}
+
+	@Test
+	public void testMissingCacheStrategyCreate() {
+		// first, lets make sure that the region names we think are non-existent really do not exist
+		for ( String regionName : TestHelper.allRegionNames ) {
+			assertThat( TestHelper.getCache( regionName ), nullValue() );
+		}
+
+		// and now let's try to build the standard testing SessionFactory, without pre-defining caches
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create" )
+		) ) {
+			// The caches should have been created automatically
+			for ( String regionName : TestHelper.allRegionNames ) {
+				assertThat( "Cache '" + regionName + "' should have been created",
+						TestHelper.getCache( regionName ), notNullValue() );
+			}
+		}
+	}
+
+	@Test
+	public void testMissingCacheStrategyCreateWarn() {
+		Map<String, Triggerable> triggerables = new HashMap<>();
+
+		// first, lets make sure that the region names we think are non-existent really do not exist
+		for ( String regionName : TestHelper.allRegionNames ) {
+			assertThat( TestHelper.getCache( regionName ), nullValue() );
+			triggerables.put(
+					regionName,
+					logInspection.watchForLogMessages(
+							"HHH025001: Missing cache[" + TestHelper.prefix( regionName ) + "] was created on-the-fly"
+					)
+			);
+		}
+
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
+		) ) {
+			for ( String regionName : TestHelper.allRegionNames ) {
+				// The caches should have been created automatically
+				assertThat(
+						"Cache '" + regionName + "' should have been created",
+						TestHelper.getCache( regionName ), notNullValue()
+				);
+				// Logs should have been triggered
+				assertTrue(
+						"Cache '" + regionName + "' should have triggered a warning",
+						triggerables.get( regionName ).wasTriggered()
+				);
+			}
+		}
+	}
+
+}

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/TestHelper.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/TestHelper.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -20,12 +19,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.internal.EnabledCaching;
 import org.hibernate.cache.jcache.JCacheHelper;
-import org.hibernate.cache.spi.QueryResultsRegion;
-import org.hibernate.cache.spi.TimestampsRegion;
 import org.hibernate.cache.spi.support.RegionNameQualifier;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -70,8 +67,8 @@ public class TestHelper {
 			createCache( cacheManager, regionName, prefixCaches );
 		}
 
-		createCache( cacheManager, TimestampsRegion.class.getName(), prefixCaches );
-		createCache( cacheManager, QueryResultsRegion.class.getName(), prefixCaches );
+		createCache( cacheManager, EnabledCaching.TIMESTAMPS_REGION_UNQUALIFIED_NAME, prefixCaches );
+		createCache( cacheManager, EnabledCaching.QUERY_RESULT_REGION_UNQUALIFIED_NAME, prefixCaches );
 	}
 
 	public static SessionFactoryImplementor buildStandardSessionFactory() {
@@ -187,8 +184,8 @@ public class TestHelper {
 		}
 
 		if ( queryRegions ) {
-			createCache( cacheManager, TimestampsRegion.class.getName(), prefixRegions );
-			createCache( cacheManager, QueryResultsRegion.class.getName(), prefixRegions );
+			createCache( cacheManager, EnabledCaching.TIMESTAMPS_REGION_UNQUALIFIED_NAME, prefixRegions );
+			createCache( cacheManager, EnabledCaching.QUERY_RESULT_REGION_UNQUALIFIED_NAME, prefixRegions );
 		}
 	}
 

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/TestHelper.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/TestHelper.java
@@ -6,10 +6,12 @@
  */
 package org.hibernate.jcache.test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.configuration.MutableConfiguration;
@@ -49,27 +51,38 @@ public class TestHelper {
 			org.hibernate.jcache.test.domain.Event.class.getName() + ".participants"
 	};
 
-	public static SessionFactoryImplementor buildStandardSessionFactory(boolean preBuildCaches) {
-		return buildStandardSessionFactory( preBuildCaches, true );
+	public static String[] allRegionNames =
+			Stream.concat( Arrays.stream( entityRegionNames ), Arrays.stream( collectionRegionNames ) )
+					.toArray( String[]::new );
+
+	public static void preBuildCaches() {
+		preBuildCaches( true );
 	}
 
-	public static SessionFactoryImplementor buildStandardSessionFactory(boolean preBuildCaches, boolean prefixCaches) {
-		if ( preBuildCaches ) {
-			final CacheManager cacheManager = locateStandardCacheManager();
+	public static void preBuildCaches(boolean prefixCaches) {
+		final CacheManager cacheManager = locateStandardCacheManager();
 
-			for ( String regionName : entityRegionNames ) {
-				createCache( cacheManager, regionName, prefixCaches );
-			}
-
-			for ( String regionName : collectionRegionNames ) {
-				createCache( cacheManager, regionName, prefixCaches );
-			}
-
-			createCache( cacheManager, TimestampsRegion.class.getName(), prefixCaches );
-			createCache( cacheManager, QueryResultsRegion.class.getName(), prefixCaches );
+		for ( String regionName : entityRegionNames ) {
+			createCache( cacheManager, regionName, prefixCaches );
 		}
 
+		for ( String regionName : collectionRegionNames ) {
+			createCache( cacheManager, regionName, prefixCaches );
+		}
+
+		createCache( cacheManager, TimestampsRegion.class.getName(), prefixCaches );
+		createCache( cacheManager, QueryResultsRegion.class.getName(), prefixCaches );
+	}
+
+	public static SessionFactoryImplementor buildStandardSessionFactory() {
+		return buildStandardSessionFactory( ignored -> { } );
+
+	}
+
+	public static SessionFactoryImplementor buildStandardSessionFactory(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
 		final StandardServiceRegistryBuilder ssrb = getStandardServiceRegistryBuilder();
+
+		additionalSettings.accept( ssrb );
 
 		final StandardServiceRegistry ssr = ssrb.build();
 
@@ -95,7 +108,7 @@ public class TestHelper {
 
 	public static void createCache(CacheManager cacheManager, String name, boolean usePrefix) {
 		if ( usePrefix ) {
-			name = RegionNameQualifier.INSTANCE.qualify( "hibernate.test", name );
+			name = prefix( name );
 		}
 
 		if ( cacheManager.getCache( name ) != null ) {
@@ -107,6 +120,16 @@ public class TestHelper {
 
 	public static void createCache(String name) {
 		createCache( locateStandardCacheManager(), name );
+	}
+
+	public static String prefix(String regionName) {
+		return RegionNameQualifier.INSTANCE.qualify( "hibernate.test", regionName );
+	}
+
+	public static Cache<?, ?> getCache(String regionName) {
+		final CacheManager cacheManager = JCacheHelper.locateStandardCacheManager();
+		regionName = prefix( regionName );
+		return cacheManager.getCache( regionName );
 	}
 
 	public static void visitAllRegions(Consumer<Cache> action) {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12531

Based on #2369, which should be merged first.

This simply reverts the name of the caches to their pre-5.3 value.