### PR TITLE
Fix and tests for HHH-12247

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceProvider.java
@@ -47,22 +47,14 @@ public class HibernatePersistenceProvider implements PersistenceProvider {
 	@Override
 	public EntityManagerFactory createEntityManagerFactory(String persistenceUnitName, Map properties) {
 		log.tracef( "Starting createEntityManagerFactory for persistenceUnitName %s", persistenceUnitName );
-
-		try {
-			final EntityManagerFactoryBuilder builder = getEntityManagerFactoryBuilderOrNull( persistenceUnitName, properties );
-			if ( builder == null ) {
-				log.trace( "Could not obtain matching EntityManagerFactoryBuilder, returning null" );
-				return null;
-			}
-			else {
-				return builder.build();
-			}
+		final EntityManagerFactoryBuilder builder = getEntityManagerFactoryBuilderOrNull( persistenceUnitName, properties );
+		if ( builder == null ) {
+			log.trace( "Could not obtain matching EntityManagerFactoryBuilder, returning null" );
+			return null;
 		}
-		catch (Exception e) {
-			log.debug( "Unable to create EntityManagerFactory", e );
+		else {
+			return builder.build();
 		}
-
-		return null;
 	}
 
 	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map properties) {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/boot/BootFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/boot/BootFailureTest.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.boot;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.internal.util.ConfigHelper;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.service.spi.ServiceException;
+
+import org.junit.Test;
+
+/**
+ * Test to verify that a dump configuration error results in an exception being
+ * thrown even when booting via the standard JPA boostrap API.
+ *
+ * @author Andrea Boriero
+ * @author Sanne Grinovero
+ */
+public class BootFailureTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Test(expected = ServiceException.class)
+	public void exceptionOnIllegalPUTest() {
+		bootstrapPersistenceUnit( "IntentionallyBroken" );
+	}
+
+	@Test(expected = ServiceException.class)
+	public void exceptionOnIllegalPUWithoutProviderTest() {
+		bootstrapPersistenceUnit( "IntentionallyBrokenWihoutExplicitProvider" );
+	}
+
+	private void bootstrapPersistenceUnit(final String puName) {
+		final Map<String, Object> properties = new HashMap<>();
+		properties.put( AvailableSettings.CLASSLOADERS, Arrays.asList( new TestClassLoader() ) );
+		EntityManagerFactory broken = Persistence.createEntityManagerFactory(
+				puName,
+				properties
+		);
+		if ( broken != null ) {
+			broken.close();
+		}
+	}
+
+	private static class TestClassLoader extends ClassLoader {
+		static final List<URL> urls = Arrays.asList( ConfigHelper.findAsResource( "org/hibernate/jpa/test/bootstrap/META-INF/persistence.xml" ) );
+
+		@Override
+		protected Enumeration<URL> findResources(String name) {
+			return name.equals( "META-INF/persistence.xml" ) ?
+					Collections.enumeration( urls ) :
+					Collections.emptyEnumeration();
+		}
+	}
+
+}
+

--- a/hibernate-core/src/test/resources/org/hibernate/jpa/test/bootstrap/META-INF/persistence.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/jpa/test/bootstrap/META-INF/persistence.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <!-- Used to test org.hibernate.jpa.test.boot.BootFailureTest :
+         intentionally needs to refer to some invalid configuration properties
+         so to fail bootstrap -->
+    <persistence-unit name="IntentionallyBroken" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <property name="hibernate.connection.driver_class" value="IntentionallyWrongClassName"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="IntentionallyBrokenWihoutExplicitProvider" transaction-type="RESOURCE_LOCAL">
+        <properties>
+            <property name="hibernate.connection.driver_class" value="IntentionallyWrongClassName"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
This makes sure that critical bootstrap errors are not just logged but propagated as runtime exceptions.

 - https://hibernate.atlassian.net/browse/HHH-12247

It's trivial, yet requires @sebersole 's approval as the semantics had quite some discussion (see JIRA).