### PR TITLE
HHH-12762 No longer needing to use port-offset in WildFly integration…

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -227,8 +227,6 @@ test.dependsOn ':hibernate-orm-modules:prepareWildFlyForTests'
 
 test {
     systemProperty 'file.encoding', 'utf-8'
-    //Set the port-offset to match the offset in arquillian.xml
-    systemProperty 'jboss.socket.binding.port-offset', '137'
     beforeTest { descriptor ->
         //println "Starting test: " + descriptor
     }

--- a/hibernate-core/src/test/resources/arquillian.xml
+++ b/hibernate-core/src/test/resources/arquillian.xml
@@ -26,12 +26,10 @@
                 <!-- For Remote debugging of Wildfly add the following line to the 'javaVmArguments' section below: -->
                 <!-- -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y-->
                 <!-- DO NOT add comments within the property section below as the Arquillian parser can't deal with it -->
-                <!-- The port offset is defined to avoid classhing with NVidia drivers on Windows -->
                 <property name="javaVmArguments">
                     -Dee8.preview.mode=true
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    -Djboss.socket.binding.port-offset=137
                 </property>
             </configuration>
         </container>

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -151,7 +151,3 @@ processTestResources {
 	)
 }
 
-test {
-	//Set the port-offset to match the offset in arquillian.xml
-	systemProperties['jboss.socket.binding.port-offset'] = 137
-}

--- a/hibernate-orm-modules/src/test/resources/arquillian.xml
+++ b/hibernate-orm-modules/src/test/resources/arquillian.xml
@@ -26,12 +26,10 @@
                 <!-- For Remote debugging of Wildfly add the following line to the 'javaVmArguments' section below: -->
                 <!-- -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y-->
                 <!-- DO NOT add comments within the property section below as the Arquillian parser can't deal with it -->
-                <!-- The port offset is defined to avoid classhing with NVidia drivers on Windows -->
                 <property name="javaVmArguments">
                     -Dee8.preview.mode=true
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    -Djboss.socket.binding.port-offset=137
                 </property>
             </configuration>
         </container>


### PR DESCRIPTION
… tests

Hi @vladmihalcea , this is a trivial one. Would you mind verifying it doesn't make the Arquillian tests troublesome for you?

 - https://hibernate.atlassian.net/browse/HHH-12762