### PR TITLE
HHH-12695 Incompatibility in return value for org.hibernate.procedure.ParameterRegistration.getType() 5.1 vs 5.3

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
@@ -42,7 +42,7 @@ public abstract class AbstractParameterDescriptor implements QueryParameter {
 	}
 
 	@Override
-	public Type getType() {
+	public Type getHibernateType() {
 		return getExpectedType();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
@@ -6,12 +6,16 @@
  */
 package org.hibernate.engine.query.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.type.Type;
 
 /**
+ * NOTE: Consider this contract (and its sub-contracts) as incubating as we transition to 6.0 and SQM
+ *
  * @author Steve Ebersole
  */
+@Incubating
 public abstract class AbstractParameterDescriptor implements QueryParameter {
 	private final int[] sourceLocations;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NamedParameterDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NamedParameterDescriptor.java
@@ -30,6 +30,7 @@ public class NamedParameterDescriptor extends AbstractParameterDescriptor {
 		this.name = name;
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
@@ -25,6 +25,7 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 	 *
 	 * @return The name;
 	 */
+	@Override
 	String getName();
 
 	/**
@@ -33,6 +34,7 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 	 *
 	 * @return The name;
 	 */
+	@Override
 	Integer getPosition();
 
 	/**
@@ -41,6 +43,7 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 	 *
 	 * @return The parameter mode.
 	 */
+	@Override
 	ParameterMode getMode();
 
 	/**
@@ -59,6 +62,7 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 	 *
 	 * @param enabled {@code true} indicates that the NULL should be passed; {@code false} indicates it should not.
 	 */
+	@Override
 	void enablePassingNulls(boolean enabled);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
@@ -38,6 +38,17 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 	Integer getPosition();
 
 	/**
+	 * Return the Java type of the parameter.
+	 *
+	 * @return The Java type of the parameter.
+	 * @deprecated Call {@link #getParameterType()} instead.
+	 */
+	@Deprecated
+	default Class<T> getType() {
+		return getParameterType();
+	}
+
+	/**
 	 * Retrieves the parameter "mode" which describes how the parameter is defined in the actual database procedure
 	 * definition (is it an INPUT parameter?  An OUTPUT parameter? etc).
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/procedure/spi/ParameterRegistrationImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/spi/ParameterRegistrationImplementor.java
@@ -46,6 +46,7 @@ public interface ParameterRegistrationImplementor<T> extends ParameterRegistrati
 	 * that the parameter will simply be ignored, with the assumption that the corresponding argument
 	 * defined a default value.
 	 */
+	@Override
 	boolean isPassNullsEnabled();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/procedure/spi/ParameterRegistrationImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/spi/ParameterRegistrationImplementor.java
@@ -34,6 +34,7 @@ public interface ParameterRegistrationImplementor<T> extends ParameterRegistrati
 	 *
 	 * @return The Hibernate Type
 	 */
+	@Override
 	Type getHibernateType();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryParameter.java
@@ -21,7 +21,7 @@ public interface QueryParameter<T> extends javax.persistence.Parameter<T> {
 	 *
 	 * @return The Hibernate Type.
 	 */
-	Type getType();
+	Type getHibernateType();
 
 	int[] getSourceLocations();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/ParameterExpressionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/ParameterExpressionImpl.java
@@ -52,22 +52,27 @@ public class ParameterExpressionImpl<T>
 		this.position = null;
 	}
 
+	@Override
 	public String getName() {
 		return name;
 	}
 
+	@Override
 	public Integer getPosition() {
 		return position;
 	}
 
+	@Override
 	public Class<T> getParameterType() {
 		return getJavaType();
 	}
 
+	@Override
 	public void registerParameters(ParameterRegistry registry) {
 		registry.registerParameter( this );
 	}
 
+	@Override
 	public String render(RenderingContext renderingContext) {
 		final ExplicitParameterInfo parameterInfo = renderingContext.registerExplicitParameter( this );
 		return parameterInfo.render();

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -840,7 +840,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 	protected Type determineType(String namedParam, Class retType) {
 		Type type = getQueryParameterBindings().getBinding( namedParam ).getBindType();
 		if ( type == null ) {
-			type = getParameterMetadata().getQueryParameter( namedParam ).getType();
+			type = getParameterMetadata().getQueryParameter( namedParam ).getHibernateType();
 		}
 		if ( type == null ) {
 			type = getProducer().getFactory().resolveParameterBindType( retType );

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -119,7 +119,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 			);
 		}
 
-		final QueryParameterBinding binding = makeBinding( queryParameter.getType() );
+		final QueryParameterBinding binding = makeBinding( queryParameter.getHibernateType() );
 		parameterBindingMap.put( queryParameter, binding );
 
 		return binding;
@@ -145,7 +145,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 		return parameterListBindingMap.computeIfAbsent(
 				param,
 				p -> new QueryParameterListBindingImpl(
-						param.getType(),
+						param.getHibernateType(),
 						shouldValidateBindingValue()
 				)
 		);
@@ -606,7 +606,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 
 					syntheticParam = new NamedParameterDescriptor(
 							syntheticName,
-							sourceParam.getType(),
+							sourceParam.getHibernateType(),
 							sourceParam.getSourceLocations()
 					);
 				}
@@ -624,7 +624,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 						syntheticParam = new OrdinalParameterDescriptor(
 								syntheticPosition,
 								syntheticPosition - jdbcStyleOrdinalCountBase,
-								sourceParam.getType(),
+								sourceParam.getHibernateType(),
 								sourceParam.getSourceLocations()
 						);
 					}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterImpl.java
@@ -25,7 +25,7 @@ public abstract class QueryParameterImpl<T> implements QueryParameter<T> {
 	}
 
 	@Override
-	public Type getType() {
+	public Type getHibernateType() {
 		return expectedType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterNamedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterNamedImpl.java
@@ -39,6 +39,7 @@ public class QueryParameterNamedImpl<T> extends QueryParameterImpl<T> implements
 		return null;
 	}
 
+	@Override
 	public int[] getSourceLocations() {
 		return sourceLocations;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/procedure/ProcedureParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/procedure/ProcedureParameter.java
@@ -8,12 +8,16 @@ package org.hibernate.query.procedure;
 
 import javax.persistence.ParameterMode;
 
+import org.hibernate.Incubating;
 import org.hibernate.procedure.spi.ParameterRegistrationImplementor;
 import org.hibernate.query.QueryParameter;
 
 /**
+ * NOTE: Consider this contract (and its sub-contracts) as incubating as we transition to 6.0 and SQM
+ *
  * @author Steve Ebersole
  */
+@Incubating
 public interface ProcedureParameter<T> extends QueryParameter<T> {
 	/**
 	 * Retrieves the parameter "mode".  Only really pertinent in regards to procedure/function calls.

--- a/hibernate-core/src/main/java/org/hibernate/query/procedure/internal/ProcedureParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/procedure/internal/ProcedureParameterImpl.java
@@ -119,11 +119,6 @@ public class ProcedureParameterImpl<T>
 	}
 
 	@Override
-	public Type getHibernateType() {
-		return getType();
-	}
-
-	@Override
 	public void setHibernateType(Type expectedType) {
 		super.setHibernateType( expectedType );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/procedure/internal/ProcedureParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/procedure/internal/ProcedureParameterImpl.java
@@ -308,6 +308,7 @@ public class ProcedureParameterImpl<T>
 						&& ((ProcedureParameterNamedBinder) hibernateType).canDoSetting();
 	}
 
+	@Override
 	public int[] getSqlTypes() {
 		if ( mode == ParameterMode.REF_CURSOR ) {
 			// we could use the Types#REF_CURSOR added in Java 8, but that would require requiring Java 8...

--- a/hibernate-core/src/main/java/org/hibernate/query/procedure/spi/ProcedureParameterImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/procedure/spi/ProcedureParameterImplementor.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.query.procedure.spi;
 
+import org.hibernate.Incubating;
 import org.hibernate.procedure.spi.ParameterRegistrationImplementor;
 import org.hibernate.query.procedure.ProcedureParameter;
 
 /**
+ * NOTE: Consider this contract (and its sub-contracts) as incubating as we transition to 6.0 and SQM
+ *
  * @author Steve Ebersole
  */
+@Incubating
 public interface ProcedureParameterImplementor<T> extends ProcedureParameter<T>, ParameterRegistrationImplementor<T> {
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12695

Note: if we merge this, we'll have to update the migration guide. In particular, we should add the following section [there](https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.3#known-changes) (at the end of "Known changes")

```
=== Query parameters

Method `org.hibernate.type.Type getType()` in `org.hibernate.query.QueryParameter` was renamed to `getHibernateType`.

This was done in order to allow for the re-introduction of `Class<T> getType()` in a sub-interface, `org.hibernate.procedure.ParameterRegistration`. That second method had been removed in 5.2, breaking compatibility with 5.1.
```