### PR TITLE
HHH-12649 Auto-register entity and collection caches based on the Hibernate @Cache annotation (XML mapping) settings

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
@@ -563,9 +563,9 @@ Only by specifying the second property `hibernate.javax.cache.uri` will you be a
 ==== JCache missing cache strategy
 
 By default, the JCache region factory
-will throw an exception when asked to retrieve a cache that is not pre-configured and pre-started in the underlying cache manager.
+will log a warning when asked to create a cache that is not explicitly configured and pre-started in the underlying cache manager.
 Thus if you configure an entity type or a collection as cached, but do not configure the corresponding cache explicitly,
-Hibernate ORM will fail to start.
+one warning will be logged for each cache that was not configured explicitly.
 
 You may change this behavior by setting the `hibernate.javax.cache.missing_cache_strategy` property
 to one of the following values:
@@ -574,8 +574,8 @@ to one of the following values:
 [cols=",",options="header",]
 |======================================
 | Value        | Description
-|`fail`        | **Default value**. Fail with an exception on missing caches.
-|`create-warn` | Create a new cache when a cache is not found (see `create` below),
+|`fail`        | Fail with an exception on missing caches.
+|`create-warn` | **Default value**. Create a new cache when a cache is not found (see `create` below),
 and also log a warning about the missing cache.
 |`create`      | Create a new cache when a cache is not found, without logging any warning about the missing cache.
 |======================================

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/MissingCacheStrategy.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/MissingCacheStrategy.java
@@ -52,7 +52,7 @@ public enum MissingCacheStrategy {
 
 		if ( StringHelper.isEmpty( externalRepresentation ) ) {
 			// Use the default
-			return MissingCacheStrategy.FAIL;
+			return MissingCacheStrategy.CREATE_WARN;
 		}
 
 		for ( MissingCacheStrategy strategy : values() ) {

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/MissingCacheStrategyTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/MissingCacheStrategyTest.java
@@ -45,26 +45,22 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 
 	@Test
 	public void testMissingCacheStrategyDefault() {
-		doTestMissingCacheStrategyFail(
+		doTestMissingCacheStrategyCreateWarn(
 				ignored -> { } // default settings
 		);
 	}
 
 	@Test
 	public void testMissingCacheStrategyFail() {
-		doTestMissingCacheStrategyFail(
-				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
-		);
-	}
-
-	private void doTestMissingCacheStrategyFail(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
 		// first, lets make sure that the region names we think are non-existent really do not exist
 		for ( String regionName : TestHelper.allDomainRegionNames ) {
 			assertThat( TestHelper.getCache( regionName ), nullValue() );
 		}
 
 		// and now let's try to build the standard testing SessionFactory, without pre-defining caches
-		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "fail" )
+		) ) {
 			fail();
 		}
 		catch (ServiceException expected) {
@@ -98,6 +94,12 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 
 	@Test
 	public void testMissingCacheStrategyCreateWarn() {
+		doTestMissingCacheStrategyCreateWarn(
+				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
+		);
+	}
+
+	private void doTestMissingCacheStrategyCreateWarn(Consumer<StandardServiceRegistryBuilder> additionalSettings) {
 		Map<String, Triggerable> triggerables = new HashMap<>();
 
 		// first, lets make sure that the region names we think are non-existent really do not exist
@@ -111,9 +113,7 @@ public class MissingCacheStrategyTest extends BaseUnitTestCase {
 			);
 		}
 
-		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory(
-				builder -> builder.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, "create-warn" )
-		) ) {
+		try ( SessionFactoryImplementor ignored = TestHelper.buildStandardSessionFactory( additionalSettings ) ) {
 			for ( String regionName : TestHelper.allDomainRegionNames ) {
 				// The caches should have been created automatically
 				assertThat(


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12649

Follows up on #2369. Changes the default behavior for the JCache region factory on missing caches, to be consistent with the Ehcache region factory, following our discussion on the mailing list.