### PR TITLE
HHH-12720 + HHH-7686 Proxy serialization fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -13,6 +13,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LazyInitializationException;
 import org.hibernate.SessionException;
 import org.hibernate.TransientObjectException;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -232,10 +233,17 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 		}
 	}
 
+	/**
+	 * Initialize internal state based on the currently attached session,
+	 * in order to be ready to load data even after the proxy is detached from the session.
+	 *
+	 * This method only has any effect if
+	 * {@link SessionFactoryOptions#isInitializeLazyStateOutsideTransactionsEnabled()} is {@code true}.
+	 */
 	protected void prepareForPossibleLoadingOutsideTransaction() {
 		if ( session != null ) {
 			allowLoadOutsideTransaction = session.getFactory().getSessionFactoryOptions().isInitializeLazyStateOutsideTransactionsEnabled();
-
+			
 			if ( allowLoadOutsideTransaction && sessionFactoryUuid == null ) {
 				sessionFactoryUuid = session.getFactory().getUuid();
 			}
@@ -362,25 +370,57 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	}
 
 	/**
-	 * Set the read-only/modifiable setting that should be put in affect when it is
-	 * attached to a session.
-	 * <p/>
+	 * Get whether the proxy can load data even
+	 * if it's not attached to a session with an ongoing transaction.
+	 *
+	 * This method should only be called during serialization,
+	 * and only makes sense after a call to {@link #prepareForPossibleLoadingOutsideTransaction()}.
+	 *
+	 * @return {@code true} if out-of-transaction loads are allowed, {@code false} otherwise.
+	 */
+	protected boolean isAllowLoadOutsideTransaction() {
+		return allowLoadOutsideTransaction;
+	}
+
+	/**
+	 * Get the session factory UUID.
+	 *
+	 * This method should only be called during serialization,
+	 * and only makes sense after a call to {@link #prepareForPossibleLoadingOutsideTransaction()}.
+	 *
+	 * @return the session factory UUID.
+	 */
+	protected String getSessionFactoryUuid() {
+		return sessionFactoryUuid;
+	}
+
+	/**
+	 * Restore settings that are not passed to the constructor,
+	 * but are still preserved during serialization.
+	 * 
 	 * This method should only be called during deserialization, before associating
 	 * the proxy with a session.
 	 *
 	 * @param readOnlyBeforeAttachedToSession, the read-only/modifiable setting to use when
 	 * associated with a session; null indicates that the default should be used.
+	 * @param sessionFactoryUuid the session factory uuid, to be used if {@code allowLoadOutsideTransaction} is {@code true}.
+	 * @param allowLoadOutsideTransaction whether the proxy can load data even
+	 * if it's not attached to a session with an ongoing transaction.
 	 *
 	 * @throws IllegalStateException if isReadOnlySettingAvailable() == true
 	 */
 	/* package-private */
-	final void setReadOnlyBeforeAttachedToSession(Boolean readOnlyBeforeAttachedToSession) {
+	final void afterDeserialization(Boolean readOnlyBeforeAttachedToSession,
+			String sessionFactoryUuid, boolean allowLoadOutsideTransaction) {
 		if ( isReadOnlySettingAvailable() ) {
 			throw new IllegalStateException(
-					"Cannot call setReadOnlyBeforeAttachedToSession when isReadOnlySettingAvailable == true [" + entityName + "#" + id + "]"
+					"Cannot call afterDeserialization when isReadOnlySettingAvailable == true [" + entityName + "#" + id + "]"
 			);
 		}
 		this.readOnlyBeforeAttachedToSession = readOnlyBeforeAttachedToSession;
+
+		this.sessionFactoryUuid = sessionFactoryUuid;
+		this.allowLoadOutsideTransaction = allowLoadOutsideTransaction;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -45,8 +45,17 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	private boolean allowLoadOutsideTransaction;
 
 	/**
-	 * For serialization from the non-pojo initializers (HHH-3309)
+	 * @deprecated This constructor was initially intended for serialization only, and is not useful anymore.
+	 * In any case it should not be relied on by user code.
+	 * Subclasses should rather implement Serializable with an {@code Object writeReplace()} method returning
+	 * a subclass of {@link AbstractSerializableProxy},
+	 * which in turn implements Serializable and an {@code Object readResolve()} method
+	 * instantiating the {@link AbstractLazyInitializer} subclass
+	 * and calling {@link AbstractSerializableProxy#afterDeserialization(AbstractLazyInitializer)} on it.
+	 * See {@link org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor} and
+	 * {@link org.hibernate.proxy.pojo.bytebuddy.SerializableProxy} for examples.
 	 */
+	@Deprecated
 	protected AbstractLazyInitializer() {
 	}
 
@@ -240,7 +249,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	 * and the entity being proxied has been loaded and added to the persistence context
 	 * of that session since the proxy was created.
 	 */
-	protected final void initializeWithoutLoadIfPossible() {
+	public final void initializeWithoutLoadIfPossible() {
 		if ( !initialized && session != null && session.isOpen() ) {
 			final EntityKey key = session.generateEntityKey(
 					getIdentifier(),
@@ -380,7 +389,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	 *
 	 * @throws IllegalStateException if isReadOnlySettingAvailable() == true
 	 */
-	protected final Boolean isReadOnlyBeforeAttachedToSession() {
+	public final Boolean isReadOnlyBeforeAttachedToSession() {
 		if ( isReadOnlySettingAvailable() ) {
 			throw new IllegalStateException(
 					"Cannot call isReadOnlyBeforeAttachedToSession when isReadOnlySettingAvailable == true [" + entityName + "#" + id + "]"

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -234,6 +234,26 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	}
 
 	/**
+	 * Attempt to initialize the proxy without loading anything from the database.
+	 *
+	 * This will only have any effect if the proxy is still attached to a session,
+	 * and the entity being proxied has been loaded and added to the persistence context
+	 * of that session since the proxy was created.
+	 */
+	protected final void initializeWithoutLoadIfPossible() {
+		if ( !initialized && session != null && session.isOpen() ) {
+			final EntityKey key = session.generateEntityKey(
+					getIdentifier(),
+					session.getFactory().getMetamodel().entityPersister( getEntityName() )
+			);
+			final Object entity = session.getPersistenceContext().getEntity( key );
+			if ( entity != null ) {
+				setImplementation( entity );
+			}
+		}
+	}
+
+	/**
 	 * Initialize internal state based on the currently attached session,
 	 * in order to be ready to load data even after the proxy is detached from the session.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
@@ -21,8 +21,10 @@ public abstract class AbstractSerializableProxy implements Serializable {
 	private boolean allowLoadOutsideTransaction;
 
 	/**
-	 * For serialization
+	 * @deprecated This constructor was initially intended for serialization only, and is not useful anymore.
+	 * In any case it should not be relied on by user code.
 	 */
+	@Deprecated
 	protected AbstractSerializableProxy() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
@@ -9,7 +9,7 @@ package org.hibernate.proxy;
 import java.io.Serializable;
 
 /**
- * Convenience base class for SerializableProxy.
+ * Convenience base class for the serialized form of {@link AbstractLazyInitializer}.
  * 
  * @author Gail Badner
  */

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/MapLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/MapLazyInitializer.java
@@ -31,4 +31,20 @@ public class MapLazyInitializer extends AbstractLazyInitializer implements Seria
 		throw new UnsupportedOperationException("dynamic-map entity representation");
 	}
 
+	// Expose the following methods to MapProxy by overriding them (so that classes in this package see them)
+
+	@Override
+	protected void prepareForPossibleLoadingOutsideTransaction() {
+		super.prepareForPossibleLoadingOutsideTransaction();
+	}
+
+	@Override
+	protected boolean isAllowLoadOutsideTransaction() {
+		return super.isAllowLoadOutsideTransaction();
+	}
+
+	@Override
+	protected String getSessionFactoryUuid() {
+		return super.getSessionFactoryUuid();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
@@ -22,12 +22,10 @@ public class MapProxy implements HibernateProxy, Map, Serializable {
 
 	private MapLazyInitializer li;
 
+	private Object replacement;
+
 	MapProxy(MapLazyInitializer li) {
 		this.li = li;
-	}
-
-	public Object writeReplace() {
-		return this;
 	}
 
 	public LazyInitializer getHibernateLazyInitializer() {
@@ -80,6 +78,36 @@ public class MapProxy implements HibernateProxy, Map, Serializable {
 
 	public Object put(Object key, Object value) {
 		return li.getMap().put(key, value);
+	}
+
+	@Override
+	public Object writeReplace() {
+		/*
+		 * If the target has already been loaded somewhere, just not set on the proxy,
+		 * then use it to initialize the proxy so that we will serialize that instead of the proxy.
+		 */
+		li.initializeWithoutLoadIfPossible();
+
+		if ( li.isUninitialized() ) {
+			if ( replacement == null ) {
+				li.prepareForPossibleLoadingOutsideTransaction();
+				replacement = serializableProxy();
+			}
+			return replacement;
+		}
+		else {
+			return li.getImplementation();
+		}
+	}
+
+	private Object serializableProxy() {
+		return new SerializableMapProxy(
+				li.getEntityName(),
+				li.getIdentifier(),
+				( li.isReadOnlySettingAvailable() ? Boolean.valueOf( li.isReadOnly() ) : li.isReadOnlyBeforeAttachedToSession() ),
+				li.getSessionFactoryUuid(),
+				li.isAllowLoadOutsideTransaction()
+		);
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
@@ -28,54 +28,67 @@ public class MapProxy implements HibernateProxy, Map, Serializable {
 		this.li = li;
 	}
 
+	@Override
 	public LazyInitializer getHibernateLazyInitializer() {
 		return li;
 	}
 
+	@Override
 	public int size() {
 		return li.getMap().size();
 	}
 
+	@Override
 	public void clear() {
 		li.getMap().clear();
 	}
 
+	@Override
 	public boolean isEmpty() {
 		return li.getMap().isEmpty();
 	}
 
+	@Override
 	public boolean containsKey(Object key) {
 		return li.getMap().containsKey(key);
 	}
 
+	@Override
 	public boolean containsValue(Object value) {
 		return li.getMap().containsValue(value);
 	}
 
+	@Override
 	public Collection values() {
 		return li.getMap().values();
 	}
 
+	@Override
 	public void putAll(Map t) {
 		li.getMap().putAll(t);
 	}
 
+	@Override
 	public Set entrySet() {
 		return li.getMap().entrySet();
 	}
 
+	@Override
 	public Set keySet() {
 		return li.getMap().keySet();
 	}
 
+	@Override
 	public Object get(Object key) {
 		return li.getMap().get(key);
 	}
 
+	@Override
 	public Object remove(Object key) {
 		return li.getMap().remove(key);
 	}
 
+	@Override
 	public Object put(Object key, Object value) {
 		return li.getMap().put(key, value);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/SerializableMapProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/SerializableMapProxy.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.proxy.map;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+
+import org.hibernate.proxy.AbstractSerializableProxy;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor;
+import org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyFactory;
+import org.hibernate.type.CompositeType;
+
+public final class SerializableMapProxy extends AbstractSerializableProxy {
+
+	public SerializableMapProxy(
+			String entityName,
+			Serializable id,
+			Boolean readOnly,
+			String sessionFactoryUuid,
+			boolean allowLoadOutsideTransaction) {
+		super( entityName, id, readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
+	}
+
+	private Object readResolve() {
+		MapLazyInitializer initializer = new MapLazyInitializer( getEntityName(), getId(), null );
+		afterDeserialization( initializer );
+		return new MapProxy( initializer );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
@@ -105,6 +105,7 @@ public abstract class BasicLazyInitializer extends AbstractLazyInitializer {
 
 		if ( isUninitialized() ) {
 			if ( replacement == null ) {
+				prepareForPossibleLoadingOutsideTransaction();
 				replacement = serializableProxy();
 			}
 			return replacement;

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
@@ -9,7 +9,6 @@ package org.hibernate.proxy.pojo;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 
-import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.MarkerObject;
 import org.hibernate.proxy.AbstractLazyInitializer;
@@ -91,17 +90,11 @@ public abstract class BasicLazyInitializer extends AbstractLazyInitializer {
 	}
 
 	private Object getReplacement() {
-		final SharedSessionContractImplementor session = getSession();
-		if ( isUninitialized() && session != null && session.isOpen() ) {
-			final EntityKey key = session.generateEntityKey(
-					getIdentifier(),
-					session.getFactory().getMetamodel().entityPersister( getEntityName() )
-			);
-			final Object entity = session.getPersistenceContext().getEntity( key );
-			if ( entity != null ) {
-				setImplementation( entity );
-			}
-		}
+		/*
+		 * If the target has already been loaded somewhere, just not set on the proxy,
+		 * then use it to initialize the proxy so that we will serialize that instead of the proxy.
+		 */
+		initializeWithoutLoadIfPossible();
 
 		if ( isUninitialized() ) {
 			if ( replacement == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyInterceptor.java
@@ -17,13 +17,6 @@ import org.hibernate.proxy.ProxyConfiguration;
 import org.hibernate.proxy.pojo.BasicLazyInitializer;
 import org.hibernate.type.CompositeType;
 
-import net.bytebuddy.implementation.bind.annotation.AllArguments;
-import net.bytebuddy.implementation.bind.annotation.FieldValue;
-import net.bytebuddy.implementation.bind.annotation.Origin;
-import net.bytebuddy.implementation.bind.annotation.RuntimeType;
-import net.bytebuddy.implementation.bind.annotation.StubValue;
-import net.bytebuddy.implementation.bind.annotation.This;
-
 import static org.hibernate.internal.CoreLogging.messageLogger;
 
 public class ByteBuddyInterceptor extends BasicLazyInitializer implements ProxyConfiguration.Interceptor {
@@ -94,6 +87,8 @@ public class ByteBuddyInterceptor extends BasicLazyInitializer implements ProxyC
 				interfaces,
 				getIdentifier(),
 				( isReadOnlySettingAvailable() ? Boolean.valueOf( isReadOnly() ) : isReadOnlyBeforeAttachedToSession() ),
+				getSessionFactoryUuid(),
+				isAllowLoadOutsideTransaction(),
 				getIdentifierMethod,
 				setIdentifierMethod,
 				componentIdType

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
@@ -26,6 +26,10 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 
 	private final CompositeType componentIdType;
 
+	/**
+	 * @deprecated use {@link #SerializableProxy(String, Class, Class[], Serializable, Boolean, String, boolean, Method, Method, CompositeType)} instead.
+	 */
+	@Deprecated
 	public SerializableProxy(
 			String entityName,
 			Class persistentClass,
@@ -35,7 +39,24 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) {
-		super( entityName, id, readOnly );
+		this(
+				entityName, persistentClass, interfaces, id, readOnly, null, false,
+				getIdentifierMethod, setIdentifierMethod, componentIdType
+		);
+	}
+
+	public SerializableProxy(
+			String entityName,
+			Class persistentClass,
+			Class[] interfaces,
+			Serializable id,
+			Boolean readOnly,
+			String sessionFactoryUuid,
+			boolean allowLoadOutsideTransaction,
+			Method getIdentifierMethod,
+			Method setIdentifierMethod,
+			CompositeType componentIdType) {
+		super( entityName, id, readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
 		this.persistentClass = persistentClass;
 		this.interfaces = interfaces;
 		if ( getIdentifierMethod != null ) {
@@ -105,7 +126,7 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 
 	private Object readResolve() {
 		HibernateProxy proxy = ByteBuddyProxyFactory.deserializeProxy( this );
-		setReadOnlyBeforeAttachedToSession( (ByteBuddyInterceptor) proxy.getHibernateLazyInitializer() );
+		afterDeserialization( (ByteBuddyInterceptor) proxy.getHibernateLazyInitializer() );
 		return proxy;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistLazyInitializer.java
@@ -125,6 +125,8 @@ public class JavassistLazyInitializer extends BasicLazyInitializer implements Me
 				interfaces,
 				getIdentifier(),
 				( isReadOnlySettingAvailable() ? Boolean.valueOf( isReadOnly() ) : isReadOnlyBeforeAttachedToSession() ),
+				getSessionFactoryUuid(),
+				isAllowLoadOutsideTransaction(),
 				getIdentifierMethod,
 				setIdentifierMethod,
 				componentIdType

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/SerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/SerializableProxy.java
@@ -29,6 +29,10 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 
 	private final CompositeType componentIdType;
 
+	/**
+	 * @deprecated use {@link #SerializableProxy(String, Class, Class[], Serializable, Boolean, String, boolean, Method, Method, CompositeType)} instead.
+	 */
+	@Deprecated
 	public SerializableProxy(
 			String entityName,
 			Class persistentClass,
@@ -38,7 +42,24 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) {
-		super( entityName, id, readOnly );
+		this(
+				entityName, persistentClass, interfaces, id, readOnly, null, false,
+				getIdentifierMethod, setIdentifierMethod, componentIdType
+		);
+	}
+
+	public SerializableProxy(
+			String entityName,
+			Class persistentClass,
+			Class[] interfaces,
+			Serializable id,
+			Boolean readOnly,
+			String sessionFactoryUuid,
+			boolean allowLoadOutsideTransaction,
+			Method getIdentifierMethod,
+			Method setIdentifierMethod,
+			CompositeType componentIdType) {
+		super( entityName, id, readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
 		this.persistentClass = persistentClass;
 		this.interfaces = interfaces;
 		if ( getIdentifierMethod != null ) {
@@ -114,7 +135,7 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 	 */
 	private Object readResolve() {
 		HibernateProxy proxy = JavassistProxyFactory.deserializeProxy( this );
-		setReadOnlyBeforeAttachedToSession( ( JavassistLazyInitializer ) proxy.getHibernateLazyInitializer() );
+		afterDeserialization( ( JavassistLazyInitializer ) proxy.getHibernateLazyInitializer() );
 		return proxy;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/serialization/EntityProxySerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/serialization/EntityProxySerializationTest.java
@@ -1,0 +1,241 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.serialization;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.proxy.AbstractLazyInitializer;
+import org.hibernate.proxy.HibernateProxy;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Selaron
+ */
+public class EntityProxySerializationTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { SimpleEntity.class, ChildEntity.class };
+	}
+
+	@Override
+	protected void configure(final Configuration configuration) {
+		// enable LL without TX, which used to cause problems when serializing proxies (see HHH-12720)
+		configuration.setProperty( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, Boolean.TRUE.toString() );
+	}
+
+	/**
+	 * Prepare and persist a {@link SimpleEntity} with two {@link ChildEntity}.
+	 */
+	@Before
+	public void prepare() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+
+		try {
+			final Number count = (Number) s.createQuery("SELECT count(ID) FROM SimpleEntity").getSingleResult();
+			if (count.longValue() > 0L) {
+				// entity already added previously
+				return;
+			}
+
+			final SimpleEntity entity = new SimpleEntity();
+			entity.setId( 1L );
+			entity.setName( "TheParent" );
+
+			final ChildEntity c1 = new ChildEntity();
+			c1.setId( 1L );
+			c1.setParent( entity );
+
+			final ChildEntity c2 = new ChildEntity();
+			c2.setId( 2L );
+			c2.setParent( entity );
+
+			s.save( entity );
+			s.save( c1 );
+			s.save( c2 );
+		}
+		finally {
+			t.commit();
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that lazy loading without transaction nor open session is generally
+	 * working. The magic is done by {@link AbstractLazyInitializer} who opens a
+	 * temporary session.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testProxyInitializationWithoutTX() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final ChildEntity child = s.find( ChildEntity.class, 1L );
+
+			final SimpleEntity parent = child.getParent();
+
+			t.rollback();
+			session.close();
+
+			// assert we have an uninitialized proxy
+			assertTrue( parent instanceof HibernateProxy );
+			assertFalse( Hibernate.isInitialized( parent ) );
+
+			assertEquals( "TheParent", parent.getName() );
+
+			// assert we have an initialized proxy now
+			assertTrue( Hibernate.isInitialized( parent ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that lazy loading without transaction nor open session is generally
+	 * working. The magic is done by {@link AbstractLazyInitializer} who opens a
+	 * temporary session.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	@TestForIssue(jiraKey = "HHH-12720")
+	@FailureExpected(jiraKey = "HHH-12720")
+	public void testProxyInitializationWithoutTXAfterDeserialization() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final ChildEntity child = s.find( ChildEntity.class, 1L );
+
+			final SimpleEntity parent = child.getParent();
+
+			// destroy AbstractLazyInitializer internal state
+			final SimpleEntity deserializedParent = (SimpleEntity) SerializationHelper.clone( parent );
+
+			t.rollback();
+			session.close();
+
+			// assert we have an uninitialized proxy
+			assertTrue( deserializedParent instanceof HibernateProxy );
+			assertFalse( Hibernate.isInitialized( deserializedParent ) );
+
+			assertEquals( "TheParent", deserializedParent.getName() );
+
+			// assert we have an initialized proxy now
+			assertTrue( Hibernate.isInitialized( deserializedParent ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+	@Entity(name = "SimpleEntity")
+	static class SimpleEntity implements Serializable {
+
+		private Long id;
+
+		private String name;
+
+		Set<ChildEntity> children = new HashSet<>();
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(final Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+
+		@OneToMany(targetEntity = ChildEntity.class, mappedBy = "parent")
+		@LazyCollection(LazyCollectionOption.EXTRA)
+		@Fetch(FetchMode.SELECT)
+		public Set<ChildEntity> getChildren() {
+			return children;
+		}
+
+		public void setChildren(final Set<ChildEntity> children) {
+			this.children = children;
+		}
+
+	}
+
+	@Entity
+	static class ChildEntity {
+		private Long id;
+
+		private SimpleEntity parent;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(final Long id) {
+			this.id = id;
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn
+		@LazyToOne(LazyToOneOption.PROXY)
+		public SimpleEntity getParent() {
+			return parent;
+		}
+
+		public void setParent(final SimpleEntity parent) {
+			this.parent = parent;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/serialization/EntityProxySerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/serialization/EntityProxySerializationTest.java
@@ -31,7 +31,6 @@ import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.proxy.AbstractLazyInitializer;
 import org.hibernate.proxy.HibernateProxy;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Before;
@@ -139,7 +138,6 @@ public class EntityProxySerializationTest extends BaseCoreFunctionalTestCase {
 	@SuppressWarnings("unchecked")
 	@Test
 	@TestForIssue(jiraKey = "HHH-12720")
-	@FailureExpected(jiraKey = "HHH-12720")
 	public void testProxyInitializationWithoutTXAfterDeserialization() {
 		final Session s = openSession();
 

--- a/hibernate-core/src/test/java/org/hibernate/serialization/MapProxySerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/serialization/MapProxySerializationTest.java
@@ -1,0 +1,247 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.serialization;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.EntityMode;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.proxy.AbstractLazyInitializer;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.map.MapProxy;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Selaron
+ */
+public class MapProxySerializationTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected String[] getMappings() {
+		return new String[] { "serialization/DynamicMapMappings.hbm.xml" };
+	}
+
+	@Override
+	protected void configure(final Configuration configuration) {
+		// enable LL without TX, which used to cause problems when serializing proxies (see HHH-12720)
+		configuration.setProperty( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, Boolean.TRUE.toString() );
+
+		// dynamic-map by default.
+		configuration.setProperty( AvailableSettings.DEFAULT_ENTITY_MODE, EntityMode.MAP.getExternalName() );
+	}
+
+	@Before
+	public void prepare() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+
+		try {
+			final Number count = (Number) s.createQuery("SELECT count(ID) FROM SimpleEntity").getSingleResult();
+			if (count.longValue() > 0L) {
+				// entity already added previously
+				return;
+			}
+
+			final Map<String, Object> entity = new HashMap<>();
+			entity.put( "id", 1L );
+			entity.put( "name", "TheParent" );
+
+			final Map<String, Object> c1 = new HashMap<>();
+			c1.put( "id", 1L );
+			c1.put( "parent", entity );
+
+			s.save( "SimpleEntity", entity );
+			s.save( "ChildEntity", c1 );
+		}
+		finally {
+			t.commit();
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that serializing an initialized proxy will serialize the target instead.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	@TestForIssue(jiraKey = "HHH-7686")
+	@FailureExpected(jiraKey = "HHH-7686")
+	public void testInitializedProxySerializationIfTargetInPersistenceContext() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final Map<String, Object> child = (Map<String, Object>) s.load( "ChildEntity", 1L );
+
+			final Map<String, Object> parent = (Map<String, Object>) child.get( "parent" );
+
+			// assert we have an uninitialized proxy
+			assertTrue( parent instanceof MapProxy );
+			assertFalse( Hibernate.isInitialized( parent ) );
+
+			// Initialize the proxy
+			parent.get( "name" );
+			assertTrue( Hibernate.isInitialized( parent ) );
+
+			// serialize/deserialize the proxy
+			final Map<String, Object> deserializedParent =
+					(Map<String, Object>) SerializationHelper.clone( (Serializable) parent );
+
+			// assert the deserialized object is no longer a proxy, but the target of the proxy
+			assertFalse( deserializedParent instanceof HibernateProxy );
+			assertEquals( "TheParent", deserializedParent.get( "name" ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that serializing a proxy which is not initialized
+	 * but whose target has been (separately) added to the persistence context
+	 * will serialized the target instead.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	@TestForIssue(jiraKey = "HHH-7686")
+	@FailureExpected(jiraKey = "HHH-7686")
+	public void testUninitializedProxySerializationIfTargetInPersistenceContext() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final Map<String, Object> child = (Map<String, Object>) s.load( "ChildEntity", 1L );
+
+			final Map<String, Object> parent = (Map<String, Object>) child.get( "parent" );
+
+			// assert we have an uninitialized proxy
+			assertTrue( parent instanceof MapProxy );
+			assertFalse( Hibernate.isInitialized( parent ) );
+
+			// Load the target of the proxy without the proxy being made aware of it
+			s.detach( parent );
+			s.byId( "SimpleEntity" ).load( 1L );
+			s.update( parent );
+
+			// assert we still have an uninitialized proxy
+			assertFalse( Hibernate.isInitialized( parent ) );
+
+			// serialize/deserialize the proxy
+			final Map<String, Object> deserializedParent =
+					(Map<String, Object>) SerializationHelper.clone( (Serializable) parent );
+
+			// assert the deserialized object is no longer a proxy, but the target of the proxy
+			assertFalse( deserializedParent instanceof HibernateProxy );
+			assertEquals( "TheParent", deserializedParent.get( "name" ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that lazy loading without transaction nor open session is generally
+	 * working. The magic is done by {@link AbstractLazyInitializer} who opens a
+	 * temporary session.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testProxyInitializationWithoutTX() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final Map<String, Object> child = (Map<String, Object>) s.load( "ChildEntity", 1L );
+
+			final Map<String, Object> parent = (Map<String, Object>) child.get( "parent" );
+
+			t.rollback();
+			session.close();
+
+			// assert we have an uninitialized proxy
+			assertTrue( parent instanceof MapProxy );
+			assertFalse( Hibernate.isInitialized( parent ) );
+
+			assertEquals( "TheParent", parent.get( "name" ) );
+
+			// assert we have an initialized proxy now
+			assertTrue( Hibernate.isInitialized( parent ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+	/**
+	 * Tests that lazy loading without transaction nor open session is generally
+	 * working. The magic is done by {@link AbstractLazyInitializer} who opens a
+	 * temporary session.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	@TestForIssue(jiraKey = "HHH-7686")
+	@FailureExpected(jiraKey = "HHH-7686")
+	public void testProxyInitializationWithoutTXAfterDeserialization() {
+		final Session s = openSession();
+
+		final Transaction t = s.beginTransaction();
+		try {
+			final Map<String, Object> child = (Map<String, Object>) s.load( "ChildEntity", 1L );
+
+			final Map<String, Object> parent = (Map<String, Object>) child.get( "parent" );
+
+			// destroy AbstractLazyInitializer internal state
+			final Map<String, Object> deserializedParent =
+					(Map<String, Object>) SerializationHelper.clone( (Serializable) parent );
+
+			t.rollback();
+			session.close();
+
+			// assert we have an uninitialized proxy
+			assertTrue( deserializedParent instanceof MapProxy );
+			assertFalse( Hibernate.isInitialized( deserializedParent ) );
+
+			assertEquals( "TheParent", deserializedParent.get( "name" ) );
+
+			// assert we have an initialized proxy now
+			assertTrue( Hibernate.isInitialized( deserializedParent ) );
+		}
+		finally {
+			if ( t.isActive() ) {
+				t.rollback();
+			}
+			s.close();
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/serialization/MapProxySerializationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/serialization/MapProxySerializationTest.java
@@ -21,7 +21,6 @@ import org.hibernate.proxy.AbstractLazyInitializer;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.map.MapProxy;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Before;
@@ -86,7 +85,6 @@ public class MapProxySerializationTest extends BaseCoreFunctionalTestCase {
 	@SuppressWarnings("unchecked")
 	@Test
 	@TestForIssue(jiraKey = "HHH-7686")
-	@FailureExpected(jiraKey = "HHH-7686")
 	public void testInitializedProxySerializationIfTargetInPersistenceContext() {
 		final Session s = openSession();
 
@@ -128,7 +126,6 @@ public class MapProxySerializationTest extends BaseCoreFunctionalTestCase {
 	@SuppressWarnings("unchecked")
 	@Test
 	@TestForIssue(jiraKey = "HHH-7686")
-	@FailureExpected(jiraKey = "HHH-7686")
 	public void testUninitializedProxySerializationIfTargetInPersistenceContext() {
 		final Session s = openSession();
 
@@ -210,7 +207,6 @@ public class MapProxySerializationTest extends BaseCoreFunctionalTestCase {
 	@SuppressWarnings("unchecked")
 	@Test
 	@TestForIssue(jiraKey = "HHH-7686")
-	@FailureExpected(jiraKey = "HHH-7686")
 	public void testProxyInitializationWithoutTXAfterDeserialization() {
 		final Session s = openSession();
 

--- a/hibernate-core/src/test/resources/org/hibernate/test/serialization/DynamicMapMappings.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/serialization/DynamicMapMappings.hbm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+
+    <class entity-name="SimpleEntity">
+		<id name="id" column="ID" type="java.lang.Long" />
+		
+		<property name="name" type="string">
+            <column name="name" length="50" />
+        </property>
+
+        <set name="children" inverse="true" cascade="all" lazy="true">
+            <key column="PARENT" />
+            <one-to-many class="ChildEntity" />
+        </set>
+	</class>
+
+    <class entity-name="ChildEntity">
+        <id name="id" column="ID" type="java.lang.Long"/>
+
+        <many-to-one name="parent" class="SimpleEntity" cascade="none" lazy="proxy"/>
+    </class>
+
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12720
https://hibernate.atlassian.net//browse/HHH-7686

The two tickets are similar:

* In HHH-7686, uninitialized proxies for ["dynamic map" entities](http://docs.jboss.org/hibernate/orm/5.3/userguide/html_single/Hibernate_User_Guide.html#dynamic-model) (i.e. instances of `org.hibernate.proxy.map.MapProxy`) are serialized and deserialized without error, but the serialization probably hasn't been thought through and is very flawed (as it is, it ignores all fields from `AbstractLazyInitializer`). Thus any use of the deserialized proxy is bound to fail.
* In HHH-12720, uninitialized proxies for "traditional" entities (i.e. instances of subclasses of `org.hibernate.proxy.pojo.BasicLazyInitializer`) are serialized and deserialized properly (the core information is successfully serialized/deserialized), but some information is missing, resulting in the deserialized proxy being unable to load information from the database without being attached to a session (which the setting `hibernate.enable_lazy_load_no_trans true` should supposedly allow).

This PR:

* adds tests submitted by JIRA user [selaron](https://hibernate.atlassian.net/secure/ViewProfile.jspa?name=selaron) (and more)
* alters the serialized form of `BasicLazyInitializer` to add two previously missing fields in order to fix HHH-12720
* copies the serialization process from `BasicLazyInitializer` to `MapProxy` in order to fix HHH-7686

As far as I can tell, the resulting code should be able to deserialize proxies that were serialized before this patch, because I only added new fields and classes, and I made sure not to change the class hierarchies. It won't magically fix the issue in such "legacy" streams that are missing important information, though: only newly serialized streams of objects will benefit from the fix.