### PR TITLE
HHH-12542 - Add necessary privileged action blocks for SM on WildFly

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
@@ -12,6 +12,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Properties;
 
 import org.hibernate.boot.cfgxml.spi.LoadedConfig;
@@ -48,27 +50,32 @@ public class ConfigLoader {
 	}
 
 	public LoadedConfig loadConfigXmlResource(String cfgXmlResourceName) {
-		final InputStream stream = bootstrapServiceRegistry.getService( ClassLoaderService.class ).locateResourceStream( cfgXmlResourceName );
-		if ( stream == null ) {
-			throw new ConfigurationException( "Could not locate cfg.xml resource [" + cfgXmlResourceName + "]" );
-		}
+		final JaxbCfgHibernateConfiguration jaxbCfg = AccessController.doPrivileged( new PrivilegedAction<JaxbCfgHibernateConfiguration>() {
+			@Override
+			public JaxbCfgHibernateConfiguration run() {
+				final InputStream stream = bootstrapServiceRegistry.getService( ClassLoaderService.class ).locateResourceStream( cfgXmlResourceName );
+				if ( stream == null ) {
+					throw new ConfigurationException( "Could not locate cfg.xml resource [" + cfgXmlResourceName + "]" );
+				}
 
-		try {
-			final JaxbCfgHibernateConfiguration jaxbCfg = jaxbProcessorHolder.getValue().unmarshal(
-					stream,
-					new Origin( SourceType.RESOURCE, cfgXmlResourceName )
-			);
+				try {
+					return jaxbProcessorHolder.getValue().unmarshal(
+							stream,
+							new Origin( SourceType.RESOURCE, cfgXmlResourceName )
+					);
+				}
+				finally {
+					try {
+						stream.close();
+					}
+					catch ( IOException e ) {
+						log.debug( "Unable to close cfg.xml resource stream", e );
+					}
+				}
+			}
+		} );
 
-			return LoadedConfig.consume( jaxbCfg );
-		}
-		finally {
-			try {
-				stream.close();
-			}
-			catch (IOException e) {
-				log.debug( "Unable to close cfg.xml resource stream", e );
-			}
-		}
+		return LoadedConfig.consume( jaxbCfg );
 	}
 
 	public LoadedConfig loadConfigXmlFile(File cfgXmlFile) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
@@ -50,7 +50,7 @@ public class ConfigLoader {
 	}
 
 	public LoadedConfig loadConfigXmlResource(String cfgXmlResourceName) {
-		final JaxbCfgHibernateConfiguration jaxbCfg = AccessController.doPrivileged( new PrivilegedAction<JaxbCfgHibernateConfiguration>() {
+		final PrivilegedAction<JaxbCfgHibernateConfiguration> action = new PrivilegedAction<JaxbCfgHibernateConfiguration>() {
 			@Override
 			public JaxbCfgHibernateConfiguration run() {
 				final InputStream stream = bootstrapServiceRegistry.getService( ClassLoaderService.class ).locateResourceStream( cfgXmlResourceName );
@@ -73,9 +73,11 @@ public class ConfigLoader {
 					}
 				}
 			}
-		} );
+		};
 
-		return LoadedConfig.consume( jaxbCfg );
+		return LoadedConfig.consume(
+				System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run()
+		);
 	}
 
 	public LoadedConfig loadConfigXmlFile(File cfgXmlFile) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
@@ -7,6 +7,9 @@
 package org.hibernate.boot.jaxb.internal;
 
 import java.io.InputStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -98,8 +101,13 @@ public abstract class AbstractBinder implements Binder {
 
 	private Binding doBind(XMLEventReader eventReader, Origin origin) {
 		try {
-			final StartElement rootElementStartEvent = seekRootElementStartEvent( eventReader, origin );
-			return doBind( eventReader, rootElementStartEvent, origin );
+			return AccessController.doPrivileged( new PrivilegedAction<Binding>() {
+				@Override
+				public Binding run() {
+					final StartElement rootElementStartEvent = seekRootElementStartEvent( eventReader, origin );
+					return doBind( eventReader, rootElementStartEvent, origin );
+				}
+			} );
 		}
 		finally {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
@@ -101,13 +101,15 @@ public abstract class AbstractBinder implements Binder {
 
 	private Binding doBind(XMLEventReader eventReader, Origin origin) {
 		try {
-			return AccessController.doPrivileged( new PrivilegedAction<Binding>() {
+			final PrivilegedAction<Binding> action = new PrivilegedAction<Binding>() {
 				@Override
 				public Binding run() {
 					final StartElement rootElementStartEvent = seekRootElementStartEvent( eventReader, origin );
 					return doBind( eventReader, rootElementStartEvent, origin );
 				}
-			} );
+			};
+
+			return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 		}
 		finally {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 import org.hibernate.HibernateException;
 import org.hibernate.cfg.Environment;
@@ -113,27 +115,32 @@ public final class ConfigHelper {
 	}
 
 	public static InputStream getResourceAsStream(String resource) {
-		String stripped = resource.startsWith( "/" )
-				? resource.substring( 1 )
-				: resource;
+		return AccessController.doPrivileged( new PrivilegedAction<InputStream>() {
+			@Override
+			public InputStream run() {
+				String stripped = resource.startsWith( "/" )
+						? resource.substring( 1 )
+						: resource;
 
-		InputStream stream = null;
-		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-		if ( classLoader != null ) {
-			stream = classLoader.getResourceAsStream( stripped );
-		}
-		if ( stream == null ) {
-			stream = Environment.class.getResourceAsStream( resource );
-		}
-		if ( stream == null ) {
-			stream = Environment.class.getClassLoader().getResourceAsStream( stripped );
-		}
-		if ( stream == null ) {
-			throw new HibernateException( resource + " not found" );
-		}
-		return stream;
+				InputStream stream = null;
+				ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+				if ( classLoader != null ) {
+					stream = classLoader.getResourceAsStream( stripped );
+				}
+				if ( stream == null ) {
+					stream = Environment.class.getResourceAsStream( resource );
+				}
+				if ( stream == null ) {
+					stream = Environment.class.getClassLoader().getResourceAsStream( stripped );
+				}
+				if ( stream == null ) {
+					throw new HibernateException( resource + " not found" );
+				}
+				return stream;
+
+			}
+		} );
 	}
-
 
 	public static InputStream getUserResourceAsStream(String resource) {
 		boolean hasLeadingSlash = resource.startsWith( "/" );

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
@@ -115,7 +115,7 @@ public final class ConfigHelper {
 	}
 
 	public static InputStream getResourceAsStream(String resource) {
-		return AccessController.doPrivileged( new PrivilegedAction<InputStream>() {
+		final PrivilegedAction<InputStream> action = new PrivilegedAction<InputStream>() {
 			@Override
 			public InputStream run() {
 				String stripped = resource.startsWith( "/" )
@@ -137,9 +137,9 @@ public final class ConfigHelper {
 					throw new HibernateException( resource + " not found" );
 				}
 				return stream;
-
 			}
-		} );
+		};
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 
 	public static InputStream getUserResourceAsStream(String resource) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -716,17 +716,6 @@ public final class ReflectHelper {
 	 * as an abstract - but again, that is such an edge case...
 	 */
 	public static Method findGetterMethodForFieldAccess(Field field, String propertyName) {
-//		final PrivilegedAction<Method[]> action = new PrivilegedAction<Method[]>() {
-//			@Override
-//			public Method[] run() {
-//				return field.getDeclaringClass().getDeclaredMethods();
-//			}
-//		};
-//
-//		final Method[] methods = System.getSecurityManager() != null
-//				? AccessController.doPrivileged( action )
-//				: action.run();
-
 		for ( Method method : getDeclaredMethods( field.getDeclaringClass() ) ) {
 			// if the method has parameters, skip it
 			if ( method.getParameterCount() != 0 ) {

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;
@@ -72,7 +74,14 @@ public class CallbackBuilderLegacyImpl implements CallbackBuilder {
 					}
 					continue;
 				}
-				final Callback[] callbacks = resolveEntityCallbacks( entityXClass, callbackType, reflectionManager );
+
+				final Callback[] callbacks = AccessController.doPrivileged( new PrivilegedAction<Callback[]>() {
+					@Override
+					public Callback[] run() {
+						return resolveEntityCallbacks( entityXClass, callbackType, reflectionManager );
+					}
+				} );
+
 				callbackRegistrar.registerCallbacks( entityClass, callbacks );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
@@ -75,13 +75,7 @@ public class CallbackBuilderLegacyImpl implements CallbackBuilder {
 					continue;
 				}
 
-				final Callback[] callbacks = AccessController.doPrivileged( new PrivilegedAction<Callback[]>() {
-					@Override
-					public Callback[] run() {
-						return resolveEntityCallbacks( entityXClass, callbackType, reflectionManager );
-					}
-				} );
-
+				final Callback[] callbacks = resolveEntityCallbacks( entityXClass, callbackType, reflectionManager );
 				callbackRegistrar.registerCallbacks( entityClass, callbacks );
 			}
 		}
@@ -128,7 +122,7 @@ public class CallbackBuilderLegacyImpl implements CallbackBuilder {
 		final boolean debugEnabled = log.isDebugEnabled();
 		do {
 			Callback callback = null;
-			List<XMethod> methods = currentClazz.getDeclaredMethods();
+			List<XMethod> methods = getDeclaredMethods( currentClazz );
 			for ( final XMethod xMethod : methods ) {
 				if ( xMethod.isAnnotationPresent( callbackType.getCallbackAnnotation() ) ) {
 					Method method = reflectionManager.toMethod( xMethod );
@@ -199,7 +193,7 @@ public class CallbackBuilderLegacyImpl implements CallbackBuilder {
 			if ( listener != null ) {
 				XClass xListener = reflectionManager.toXClass( listener );
 				callbacksMethodNames = new ArrayList<>();
-				List<XMethod> methods = xListener.getDeclaredMethods();
+				List<XMethod> methods = getDeclaredMethods( xListener );
 				for ( final XMethod xMethod : methods ) {
 					if ( xMethod.isAnnotationPresent( callbackType.getCallbackAnnotation() ) ) {
 						final Method method = reflectionManager.toMethod( xMethod );
@@ -346,5 +340,15 @@ public class CallbackBuilderLegacyImpl implements CallbackBuilder {
 				}
 			}
 		}
+	}
+
+	private static List<XMethod> getDeclaredMethods(XClass clazz) {
+		final PrivilegedAction<List<XMethod>> action = new PrivilegedAction<List<XMethod>>() {
+			@Override
+			public List<XMethod> run() {
+				return clazz.getDeclaredMethods();
+			}
+		};
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -372,7 +372,7 @@ class MetadataContext {
 		}
 		final String metamodelClassName = managedTypeClass.getName() + '_';
 
-		AccessController.doPrivileged( new PrivilegedAction<Object>() {
+		final PrivilegedAction<Object> action = new PrivilegedAction<Object>() {
 			@Override
 			public Object run() {
 				try {
@@ -385,7 +385,13 @@ class MetadataContext {
 				}
 				return null;
 			}
-		} );
+		};
+		if ( System.getSecurityManager() != null ) {
+			AccessController.doPrivileged( action );
+		}
+		else {
+			action.run();
+		}
 
 		// todo : this does not account for @MappeSuperclass, mainly because this is not being tracked in our
 		// internal metamodel as populated from the annotatios properly

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -159,29 +159,51 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 				null :
 				ReflectHelper.getMethod( proxyInterface, idSetterMethod );
 
-		return AccessController.doPrivileged( new PrivilegedAction<ProxyFactory>() {
-			@Override
-			public ProxyFactory run() {
-				ProxyFactory pf = buildProxyFactoryInternal( persistentClass, idGetter, idSetter );
-				try {
-					pf.postInstantiate(
-							getEntityName(),
-							mappedClass,
-							proxyInterfaces,
-							proxyGetIdentifierMethod,
-							proxySetIdentifierMethod,
-							persistentClass.hasEmbeddedIdentifier() ?
-									(CompositeType) persistentClass.getIdentifier().getType() :
-									null
-					);
-				}
-				catch (HibernateException he) {
-					LOG.unableToCreateProxyFactory( getEntityName(), he );
-					pf = null;
-				}
-				return pf;
+		if ( System.getSecurityManager() == null ) {
+			ProxyFactory pf = buildProxyFactoryInternal( persistentClass, idGetter, idSetter );
+			try {
+				pf.postInstantiate(
+						getEntityName(),
+						mappedClass,
+						proxyInterfaces,
+						proxyGetIdentifierMethod,
+						proxySetIdentifierMethod,
+						persistentClass.hasEmbeddedIdentifier() ?
+								(CompositeType) persistentClass.getIdentifier().getType() :
+								null
+				);
 			}
-		} );
+			catch (HibernateException he) {
+				LOG.unableToCreateProxyFactory( getEntityName(), he );
+				pf = null;
+			}
+			return pf;
+		}
+		else {
+			return AccessController.doPrivileged( new PrivilegedAction<ProxyFactory>() {
+				@Override
+				public ProxyFactory run() {
+					ProxyFactory pf = buildProxyFactoryInternal( persistentClass, idGetter, idSetter );
+					try {
+						pf.postInstantiate(
+								getEntityName(),
+								mappedClass,
+								proxyInterfaces,
+								proxyGetIdentifierMethod,
+								proxySetIdentifierMethod,
+								persistentClass.hasEmbeddedIdentifier() ?
+										(CompositeType) persistentClass.getIdentifier().getType() :
+										null
+						);
+					}
+					catch ( HibernateException he ) {
+						LOG.unableToCreateProxyFactory( getEntityName(), he );
+						pf = null;
+					}
+					return pf;
+				}
+			} );
+		}
 	}
 
 	protected ProxyFactory buildProxyFactoryInternal(

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.envers.boot.internal;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Properties;
 
@@ -151,17 +153,22 @@ public class EnversServiceImpl implements EnversService, Configurable, Stoppable
 				revInfoCfgResult.getRevisionInfoTimestampData(),
 				serviceRegistry
 		);
-		this.entitiesConfigurations = new EntitiesConfigurator().configure(
-				metadata,
-				serviceRegistry,
-				reflectionManager,
-				mappingCollector,
-				globalConfiguration,
-				auditEntitiesConfiguration,
-				auditStrategy,
-				revInfoCfgResult.getRevisionInfoXmlMapping(),
-				revInfoCfgResult.getRevisionInfoRelationMapping()
-		);
+		this.entitiesConfigurations = AccessController.doPrivileged( new PrivilegedAction<EntitiesConfigurations>() {
+			@Override
+			public EntitiesConfigurations run() {
+				return new EntitiesConfigurator().configure(
+						metadata,
+						serviceRegistry,
+						reflectionManager,
+						mappingCollector,
+						globalConfiguration,
+						auditEntitiesConfiguration,
+						auditStrategy,
+						revInfoCfgResult.getRevisionInfoXmlMapping(),
+						revInfoCfgResult.getRevisionInfoRelationMapping()
+				);
+			}
+		} );
 	}
 
 	private static AuditStrategy initializeAuditStrategy(

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.envers.boot.internal;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Properties;
 
@@ -153,22 +151,17 @@ public class EnversServiceImpl implements EnversService, Configurable, Stoppable
 				revInfoCfgResult.getRevisionInfoTimestampData(),
 				serviceRegistry
 		);
-		this.entitiesConfigurations = AccessController.doPrivileged( new PrivilegedAction<EntitiesConfigurations>() {
-			@Override
-			public EntitiesConfigurations run() {
-				return new EntitiesConfigurator().configure(
-						metadata,
-						serviceRegistry,
-						reflectionManager,
-						mappingCollector,
-						globalConfiguration,
-						auditEntitiesConfiguration,
-						auditStrategy,
-						revInfoCfgResult.getRevisionInfoXmlMapping(),
-						revInfoCfgResult.getRevisionInfoRelationMapping()
-				);
-			}
-		} );
+		this.entitiesConfigurations = new EntitiesConfigurator().configure(
+				metadata,
+				serviceRegistry,
+				reflectionManager,
+				mappingCollector,
+				globalConfiguration,
+				auditEntitiesConfiguration,
+				auditStrategy,
+				revInfoCfgResult.getRevisionInfoXmlMapping(),
+				revInfoCfgResult.getRevisionInfoRelationMapping()
+		);
 	}
 
 	private static AuditStrategy initializeAuditStrategy(

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/AuditedPropertiesReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/AuditedPropertiesReader.java
@@ -7,6 +7,8 @@
 package org.hibernate.envers.configuration.internal.metadata.reader;
 
 import java.lang.annotation.Annotation;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -47,6 +49,7 @@ import org.hibernate.loader.PropertyPath;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Value;
+
 import org.jboss.logging.Logger;
 
 import static org.hibernate.envers.internal.tools.Tools.newHashMap;
@@ -354,24 +357,45 @@ public class AuditedPropertiesReader {
 
 		//look in the class
 		addFromProperties(
-				clazz.getDeclaredProperties( "field" ),
+				getPropertiesFromClassByType( clazz, AccessType.FIELD ),
 				it -> "field",
 				fieldAccessedPersistentProperties,
 				allClassAudited
 		);
+
 		addFromProperties(
-				clazz.getDeclaredProperties( "property" ),
+				getPropertiesFromClassByType( clazz, AccessType.PROPERTY ),
 				propertyAccessedPersistentProperties::get,
 				propertyAccessedPersistentProperties.keySet(),
 				allClassAudited
 		);
 
 		if ( allClassAudited != null || !auditedPropertiesHolder.isEmpty() ) {
-			final XClass superclazz = clazz.getSuperclass();
+			final PrivilegedAction<XClass> action = new PrivilegedAction<XClass>() {
+				@Override
+				public XClass run() {
+					return clazz.getSuperclass();
+				}
+			};
+
+			final XClass superclazz = System.getSecurityManager() != null
+					? AccessController.doPrivileged( action )
+					: action.run();
+
 			if ( !clazz.isInterface() && !"java.lang.Object".equals( superclazz.getName() ) ) {
 				addPropertiesFromClass( superclazz );
 			}
 		}
+	}
+
+	private Iterable<XProperty> getPropertiesFromClassByType(XClass clazz, AccessType accessType) {
+		final PrivilegedAction<Iterable<XProperty>> action = new PrivilegedAction<Iterable<XProperty>>() {
+			@Override
+			public Iterable<XProperty> run() {
+				return clazz.getDeclaredProperties( accessType.getType() );
+			}
+		};
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 
 	private void addFromProperties(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12542

@gsmet @raphw - Would you guys be able to check my changes to the ByteBuddy implementation to see if that makes sense for the signed jar issue that you guys worked on as a part of [HHH-12618][1]?  We need to make sure that the proxy we create uses the ORM protection domain and not the target class so that when reflective methods are invoked, the proper access controls are allowed.

@gbadner You may want to compare this with your PR #2280 if you need it backported to 5.1.

[1]: https://hibernate.atlassian.net/browse/HHH-12618.