### PR TITLE
HHH-12795 FlushMode Manual as annotation on a namedquery is not used

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -3776,12 +3776,7 @@ public final class SessionImpl
 		}
 
 		if ( namedQueryDefinition.getFlushMode() != null ) {
-			if ( namedQueryDefinition.getFlushMode() == FlushMode.COMMIT ) {
-				query.setFlushMode( FlushModeType.COMMIT );
-			}
-			else {
-				query.setFlushMode( FlushModeType.AUTO );
-			}
+			query.setHibernateFlushMode( namedQueryDefinition.getFlushMode() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -3732,51 +3732,12 @@ public final class SessionImpl
 	protected void initQueryFromNamedDefinition(Query query, NamedQueryDefinition namedQueryDefinition) {
 		super.initQueryFromNamedDefinition( query, namedQueryDefinition );
 
-		if ( namedQueryDefinition.isCacheable() ) {
-			query.setHint( QueryHints.HINT_CACHEABLE, true );
-			if ( namedQueryDefinition.getCacheRegion() != null ) {
-				query.setHint( QueryHints.HINT_CACHE_REGION, namedQueryDefinition.getCacheRegion() );
-			}
-		}
-
-		if ( namedQueryDefinition.getCacheMode() != null ) {
-			query.setHint( QueryHints.HINT_CACHE_MODE, namedQueryDefinition.getCacheMode() );
-		}
-
-		if ( namedQueryDefinition.isReadOnly() ) {
-			query.setHint( QueryHints.HINT_READONLY, true );
-		}
-
-		if ( namedQueryDefinition.getTimeout() != null ) {
-			query.setHint( QueryHints.SPEC_HINT_TIMEOUT, namedQueryDefinition.getTimeout() * 1000 );
-		}
-
-		if ( namedQueryDefinition.getFetchSize() != null ) {
-			query.setHint( QueryHints.HINT_FETCH_SIZE, namedQueryDefinition.getFetchSize() );
-		}
-
-		if ( namedQueryDefinition.getComment() != null ) {
-			query.setHint( QueryHints.HINT_COMMENT, namedQueryDefinition.getComment() );
-		}
-
-		if ( namedQueryDefinition.getFirstResult() != null ) {
-			query.setFirstResult( namedQueryDefinition.getFirstResult() );
-		}
-
-		if ( namedQueryDefinition.getMaxResults() != null ) {
-			query.setMaxResults( namedQueryDefinition.getMaxResults() );
-		}
-
 		if ( namedQueryDefinition.getLockOptions() != null ) {
 			if ( namedQueryDefinition.getLockOptions().getLockMode() != null ) {
 				query.setLockMode(
 						LockModeTypeHelper.getLockModeType( namedQueryDefinition.getLockOptions().getLockMode() )
 				);
 			}
-		}
-
-		if ( namedQueryDefinition.getFlushMode() != null ) {
-			query.setHibernateFlushMode( namedQueryDefinition.getFlushMode() );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/AddNamedQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/AddNamedQueryTest.java
@@ -121,7 +121,8 @@ public class AddNamedQueryTest extends BaseEntityManagerFunctionalTestCase {
 		//		NOTE: here we check "query options" via the Hibernate contract (allowing nullness checking); see below for access via the JPA contract
 		assertNull( hibernateQuery.getQueryOptions().getFirstRow() );
 		assertNull( hibernateQuery.getQueryOptions().getMaxRows() );
-		assertEquals( FlushMode.AUTO, hibernateQuery.getHibernateFlushMode() );
+		assertEquals( FlushMode.MANUAL, hibernateQuery.getHibernateFlushMode() );
+		assertEquals( FlushModeType.COMMIT, hibernateQuery.getFlushMode() );
 		assertEquals( CacheMode.IGNORE, hibernateQuery.getCacheMode() );
 		assertEquals( LockMode.PESSIMISTIC_WRITE, hibernateQuery.getLockOptions().getLockMode() );
 		// jpa timeout is in milliseconds, whereas Hibernate's is in seconds
@@ -137,7 +138,8 @@ public class AddNamedQueryTest extends BaseEntityManagerFunctionalTestCase {
 		//		NOTE: here we check "query options" via the JPA contract
 		assertEquals( 0, hibernateQuery.getFirstResult() );
 		assertEquals( Integer.MAX_VALUE, hibernateQuery.getMaxResults() );
-		assertEquals( FlushModeType.AUTO, hibernateQuery.getFlushMode() );
+		assertEquals( FlushMode.MANUAL, hibernateQuery.getHibernateFlushMode() );
+		assertEquals( FlushModeType.COMMIT, hibernateQuery.getFlushMode() );
 		assertEquals( CacheMode.IGNORE, hibernateQuery.getCacheMode() );
 		assertEquals( LockMode.PESSIMISTIC_WRITE, hibernateQuery.getLockOptions().getLockMode() );
 		assertEquals( (Integer) 10, hibernateQuery.getTimeout() );
@@ -150,7 +152,8 @@ public class AddNamedQueryTest extends BaseEntityManagerFunctionalTestCase {
 		// assert the state of the query config settings based on the initial named query
 		assertEquals( 0, hibernateQuery.getFirstResult() );
 		assertEquals( Integer.MAX_VALUE, hibernateQuery.getMaxResults() );
-		assertEquals( FlushModeType.AUTO, hibernateQuery.getFlushMode() );
+		assertEquals( FlushMode.MANUAL, hibernateQuery.getHibernateFlushMode() );
+		assertEquals( FlushModeType.COMMIT, hibernateQuery.getFlushMode() );
 		assertEquals( CacheMode.IGNORE, hibernateQuery.getCacheMode() );
 		assertEquals( LockMode.PESSIMISTIC_WRITE, hibernateQuery.getLockOptions().getLockMode() );
 		assertEquals( (Integer) 10, hibernateQuery.getTimeout() );
@@ -163,7 +166,8 @@ public class AddNamedQueryTest extends BaseEntityManagerFunctionalTestCase {
 		// assert the state of the query config settings based on the initial named query
 		assertEquals( 51, hibernateQuery.getFirstResult() );
 		assertEquals( Integer.MAX_VALUE, hibernateQuery.getMaxResults() );
-		assertEquals( FlushModeType.AUTO, hibernateQuery.getFlushMode() );
+		assertEquals( FlushMode.MANUAL, hibernateQuery.getHibernateFlushMode() );
+		assertEquals( FlushModeType.COMMIT, hibernateQuery.getFlushMode() );
 		assertEquals( CacheMode.IGNORE, hibernateQuery.getCacheMode() );
 		assertEquals( LockMode.PESSIMISTIC_WRITE, hibernateQuery.getLockOptions().getLockMode() );
 		assertEquals( (Integer) 10, hibernateQuery.getTimeout() );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NamedQueryFlushModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NamedQueryFlushModeTest.java
@@ -1,0 +1,257 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.query;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.FlushMode;
+import org.hibernate.annotations.FlushModeType;
+import org.hibernate.annotations.NamedNativeQuery;
+import org.hibernate.annotations.NamedQuery;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HHH-12795")
+public class NamedQueryFlushModeTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { TestEntity.class };
+	}
+
+	@Test
+	public void testNamedQueryWithFlushModeManual() {
+		String queryName = "NamedQueryFlushModeManual";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			Query<?> query = s.getNamedQuery( queryName );
+			Assert.assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+			// JPA flush mode is an approximation
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedQueryWithFlushModeCommit() {
+		String queryName = "NamedQueryFlushModeCommit";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			Query<?> query = s.getNamedQuery( queryName );
+			Assert.assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedQueryWithFlushModeAuto() {
+		String queryName = "NamedQueryFlushModeAuto";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			Query<?> query = s.getNamedQuery( queryName );
+			Assert.assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedQueryWithFlushModeAlways() {
+		String queryName = "NamedQueryFlushModeAlways";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			Query<?> query = s.getNamedQuery( queryName );
+			Assert.assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
+			// JPA flush mode is an approximation
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedQueryWithFlushModePersistenceContext() {
+		String queryName = "NamedQueryFlushModePersistenceContext";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			Query<?> query;
+
+			// A null Hibernate flush mode means we will use whatever mode is set on the session
+			// JPA doesn't allow null flush modes, so we expect some approximation of the flush mode to be returned
+
+			s.setHibernateFlushMode( FlushMode.MANUAL );
+			query = s.getNamedQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.COMMIT );
+			query = s.getNamedQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.AUTO );
+			query = s.getNamedQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.ALWAYS );
+			query = s.getNamedQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedNativeQueryWithFlushModeManual() {
+		String queryName = "NamedNativeQueryFlushModeManual";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			NativeQuery<?> query = s.getNamedNativeQuery( queryName );
+			Assert.assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedNativeQueryWithFlushModeCommit() {
+		String queryName = "NamedNativeQueryFlushModeCommit";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			NativeQuery<?> query = s.getNamedNativeQuery( queryName );
+			Assert.assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedNativeQueryWithFlushModeAuto() {
+		String queryName = "NamedNativeQueryFlushModeAuto";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			NativeQuery<?> query = s.getNamedNativeQuery( queryName );
+			Assert.assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedNativeQueryWithFlushModeAlways() {
+		String queryName = "NamedNativeQueryFlushModeAlways";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			NativeQuery<?> query = s.getNamedNativeQuery( queryName );
+			Assert.assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
+		} );
+	}
+
+	@Test
+	public void testNamedNativeQueryWithFlushModePersistenceContext() {
+		String queryName = "NamedNativeQueryFlushModePersistenceContext";
+		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+			NativeQuery<?> query;
+
+			// A null Hibernate flush mode means we will use whatever mode is set on the session
+			// JPA doesn't allow null flush modes, so we expect some approximation of the flush mode to be returned
+
+			s.setHibernateFlushMode( FlushMode.MANUAL );
+			query = s.getNamedNativeQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.COMMIT );
+			query = s.getNamedNativeQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.AUTO );
+			query = s.getNamedNativeQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+
+			s.setHibernateFlushMode( FlushMode.ALWAYS );
+			query = s.getNamedNativeQuery( queryName );
+			Assert.assertNull( query.getHibernateFlushMode() );
+			Assert.assertEquals( javax.persistence.FlushModeType.AUTO, query.getFlushMode() );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	@NamedQuery(
+			name = "NamedQueryFlushModeManual",
+			query = "select e from TestEntity e where e.text = :text",
+			flushMode = FlushModeType.MANUAL
+	)
+	@NamedQuery(
+			name = "NamedQueryFlushModeCommit",
+			query = "select e from TestEntity e where e.text = :text",
+			flushMode = FlushModeType.COMMIT
+	)
+	@NamedQuery(
+			name = "NamedQueryFlushModeAuto",
+			query = "select e from TestEntity e where e.text = :text",
+			flushMode = FlushModeType.AUTO
+	)
+	@NamedQuery(
+			name = "NamedQueryFlushModeAlways",
+			query = "select e from TestEntity e where e.text = :text",
+			flushMode = FlushModeType.ALWAYS
+	)
+	@NamedQuery(
+			name = "NamedQueryFlushModePersistenceContext",
+			query = "select e from TestEntity e where e.text = :text",
+			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+	)
+	@NamedNativeQuery(
+			name = "NamedNativeQueryFlushModeManual",
+			query = "select * from TestEntity e where e.text = :text",
+			resultClass = TestEntity.class,
+			flushMode = FlushModeType.MANUAL
+	)
+	@NamedNativeQuery(
+			name = "NamedNativeQueryFlushModeCommit",
+			query = "select * from TestEntity e where e.text = :text",
+			resultClass = TestEntity.class,
+			flushMode = FlushModeType.COMMIT
+	)
+	@NamedNativeQuery(
+			name = "NamedNativeQueryFlushModeAuto",
+			query = "select * from TestEntity e where e.text = :text",
+			resultClass = TestEntity.class,
+			flushMode = FlushModeType.AUTO
+	)
+	@NamedNativeQuery(
+			name = "NamedNativeQueryFlushModeAlways",
+			query = "select * from TestEntity e where e.text = :text",
+			resultClass = TestEntity.class,
+			flushMode = FlushModeType.ALWAYS
+	)
+	@NamedNativeQuery(
+			name = "NamedNativeQueryFlushModePersistenceContext",
+			query = "select * from TestEntity e where e.text = :text",
+			resultClass = TestEntity.class,
+			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+	)
+	public static class TestEntity {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String text;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12795

I ran the tests I added against 5.1, and they passed, so this definitely restores behavioral compatibility with 5.1.
It seems `AddNamedQueryTest` (which expects a different behavior from my own tests) was added during the development of 5.2 and has wrong expectations regarding the flush mode in newly instantiated named queries.

The last commit is not absolutely necessary, but may be a nice bonus if you think it's not too dangerous.