### PR TITLE
Assorted JDK 11 adjustments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,14 @@ task release {
 	description = "The task performed when we are performing a release build.  Relies on " +
 			"the fact that subprojects will appropriately define a release task " +
 			"themselves if they have any release-related activities to perform"
+
+	// Force to release with JDK 8. Releasing with JDK 11 is not supported yet:
+	// - the hibernate-orm-modules tests do not run due to an issue with the ASM version currently used by Gradle
+	doFirst {
+		if ( !JavaVersion.current().isJava8() ) {
+			throw new IllegalStateException( "Please use JDK 8 to perform the release." )
+		}
+	}
 }
 
 task publish {

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task ciBuild {
 
 
 wrapper {
-	gradleVersion = '4.8'
+	gradleVersion = '4.8.1'
 	distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -124,7 +124,7 @@ task aggregateJavadocs(type: Javadoc) {
 
 		links = [
 				'https://docs.oracle.com/javase/8/docs/api/',
-				'https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/',
+				'http://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/',
 				'http://docs.jboss.org/cdi/api/2.0/',
 				'https://javaee.github.io/javaee-spec/javadocs/'
 		]

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -120,8 +120,8 @@ ext {
             informix:        'com.ibm.informix:jdbc:4.10.7.20160517',
             jboss_jta:       "org.jboss.jbossts:jbossjta:4.16.4.Final",
             xapool:          "com.experlog:xapool:1.5.0",
-            mockito:         'org.mockito:mockito-core:2.19.0',
-            mockito_inline:  'org.mockito:mockito-inline:2.19.0',
+            mockito:         'org.mockito:mockito-core:2.19.1',
+            mockito_inline:  'org.mockito:mockito-inline:2.19.1',
 
             validator:       "org.hibernate.validator:hibernate-validator:${hibernateValidatorVersion}",
             // EL required by Hibernate Validator at test runtime

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -23,7 +23,7 @@ ext {
     weldVersion = '3.0.0.Final'
 
     javassistVersion = '3.23.1-GA'
-    byteBuddyVersion = '1.8.12' // Now with JDK10 compatibility and preliminary support for JDK11
+    byteBuddyVersion = '1.8.13' // Now with JDK10 compatibility and preliminary support for JDK11
 
     geolatteVersion = '1.3.0'
 

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -87,9 +87,6 @@ javadoc {
 	final int currentYear = new GregorianCalendar().get( Calendar.YEAR )
 
 	configure( options ) {
-		docletpath = configurations.asciidoclet.files.asType(List)
-		doclet = 'org.asciidoctor.Asciidoclet'
-
 		windowTitle = "$project.name JavaDocs"
 		docTitle = "$project.name JavaDocs ($project.version)"
 		bottom = "Copyright &copy; 2001-$currentYear <a href=\"http://redhat.com\">Red Hat, Inc.</a>  All Rights Reserved."

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -91,7 +91,7 @@ public final class ByteBuddyState {
 		return buddy;
 	}
 
-	public static ClassLoadingStrategy<?> resolveClassLoadingStrategy(Class<?> originalClass) {
+	public static ClassLoadingStrategy<ClassLoader> resolveClassLoadingStrategy(Class<?> originalClass) {
 		if ( ClassInjector.UsingLookup.isAvailable() ) {
 			// This is only enabled for JDK 9+
 

--- a/hibernate-core/src/test/java/org/hibernate/boot/spi/metadatabuildercontributor/SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/spi/metadatabuildercontributor/SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest.java
@@ -35,7 +35,8 @@ public class SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest
 			fail("Should throw exception!");
 		}
 		catch (ClassCastException e) {
-			assertTrue( e.getMessage().contains( "cannot be cast to org.hibernate.boot.spi.MetadataBuilderContributor" ) );
+			assertTrue( e.getMessage().contains( "cannot be cast to" ) );
+			assertTrue( e.getMessage().contains( "org.hibernate.boot.spi.MetadataBuilderContributor" ) );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
@@ -6,8 +6,12 @@
  */
 package org.hibernate.cfg.annotations;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.hibernate.MappingException;
 import org.hibernate.annotations.common.reflection.XClass;
@@ -17,16 +21,10 @@ import org.hibernate.cfg.PropertyHolder;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
-
 import org.mockito.Mockito;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test for HHH-10106
@@ -39,20 +37,18 @@ public class CollectionBinderTest extends BaseUnitTestCase {
 	@TestForIssue(jiraKey = "HHH-10106")
 	public void testAssociatedClassException() throws SQLException {
 		final Collection collection = mock(Collection.class);
-		final Map persistentClasses = mock(Map.class);
 		final XClass collectionType = mock(XClass.class);
 		final MetadataBuildingContext buildingContext = mock(MetadataBuildingContext.class);
 		final InFlightMetadataCollector inFly = mock(InFlightMetadataCollector.class);
 		final PersistentClass persistentClass = mock(PersistentClass.class);
 		final Table table = mock(Table.class);
-		
+
 		when(buildingContext.getMetadataCollector()).thenReturn(inFly);
-		when(persistentClasses.get(null)).thenReturn(null);
 		when(collection.getOwner()).thenReturn(persistentClass);
 		when(collectionType.getName()).thenReturn("List");
 		when(persistentClass.getTable()).thenReturn(table);
 		when(table.getName()).thenReturn("Hibernate");
-		
+
 		CollectionBinder collectionBinder = new CollectionBinder(false) {
 			@Override
 			protected Collection createCollection(PersistentClass persistentClass) {
@@ -69,7 +65,7 @@ public class CollectionBinderTest extends BaseUnitTestCase {
 
 		String expectMessage = "Association [abc] for entity [CollectionBinderTest] references unmapped class [List]";
 		try {
-			collectionBinder.bindOneToManySecondPass(collection, persistentClasses, null, collectionType, false, false, buildingContext, null);
+			collectionBinder.bindOneToManySecondPass(collection, new HashMap(), null, collectionType, false, false, buildingContext, null);
 		} catch (MappingException e) {
 			assertEquals(expectMessage, e.getMessage());
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/bytebuddysubclass/MyEntityInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/bytebuddysubclass/MyEntityInstantiator.java
@@ -8,11 +8,11 @@ package org.hibernate.test.annotations.tuplizer.bytebuddysubclass;
 
 import java.io.Serializable;
 
+import org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.tuple.Instantiator;
 
 import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.matcher.ElementMatchers;
 
@@ -42,7 +42,8 @@ public class MyEntityInstantiator implements Instantiator {
 				.method( ElementMatchers.named( "toString" ) )
 				.intercept( FixedValue.value( "transformed" ) )
 				.make()
-				.load( entityClass.getClassLoader(), ClassLoadingStrategy.Default.INJECTION )
+				// we use our internal helper to get a class loading strategy suitable for the JDK used
+				.load( entityClass.getClassLoader(), ByteBuddyState.resolveClassLoadingStrategy( entityClass ) )
 				.getLoaded();
 
 		try {

--- a/hibernate-orm-modules/hibernate-orm-modules.gradle
+++ b/hibernate-orm-modules/hibernate-orm-modules.gradle
@@ -39,6 +39,11 @@ ext {
 	fpackStagingDir = file( "target/featurepack" ) //Target build directory for the Feature Pack
 }
 
+if ( JavaVersion.current().isJava11Compatible() ) {
+	logger.warn( '[WARN] Skipping all tests for hibernate-orm-modules due to Gradle issues with JDK 11' )
+	test.enabled = false
+}
+
 description = "Feature Pack of Hibernate ORM modules for WildFly ${project.wildFlyMajorVersion}"
 
 configurations {


### PR DESCRIPTION
With this PR, the build passes with `-Dhibernate.bytecode.provider=javassist`.

* https://hibernate.atlassian.net/browse/HHH-12800
* https://hibernate.atlassian.net/browse/HHH-12801
* https://hibernate.atlassian.net/browse/HHH-12803
* https://hibernate.atlassian.net/browse/HHH-12804
* https://hibernate.atlassian.net/browse/HHH-12805
* https://hibernate.atlassian.net/browse/HHH-12807
* https://hibernate.atlassian.net/browse/HHH-12808
* https://hibernate.atlassian.net/browse/HHH-12809
* https://hibernate.atlassian.net/browse/HHH-12813

**Important, the last commit still has to be confirmed (mail sent on the hibernate-dev mailing list).**