### PR TITLE
HHH-12666 Don't wrap PersistenceException inside PersistenceException

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
@@ -483,8 +483,8 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 			});
 			fail("Should throw NonUniqueDiscoveredSqlAliasException!");
 		}
-		catch (PersistenceException expected) {
-			assertEquals( NonUniqueDiscoveredSqlAliasException.class, expected.getCause().getClass() );
+		catch (NonUniqueDiscoveredSqlAliasException e) {
+			// expected
 		}
 	}
 
@@ -506,9 +506,6 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 		}
 		catch (NonUniqueDiscoveredSqlAliasException e) {
 			// expected
-		}
-		catch (PersistenceException e) {
-			assertTyping( NonUniqueDiscoveredSqlAliasException.class, e.getCause() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/ExceptionConverterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ExceptionConverterImpl.java
@@ -145,6 +145,11 @@ public class ExceptionConverterImpl implements ExceptionConverter {
 			}
 			return new IllegalStateException( e ); //Spec 3.2.3 Synchronization rules
 		}
+		else if ( cause instanceof PersistenceException ) {
+			final PersistenceException converted = (PersistenceException) cause;
+			handlePersistenceException( converted );
+			return converted;
+		}
 		else {
 			final PersistenceException converted = new PersistenceException( cause );
 			handlePersistenceException( converted );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/connection/TestConnectionPool.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/connection/TestConnectionPool.java
@@ -62,13 +62,8 @@ public class TestConnectionPool
 
 						entityManager.createQuery( criteriaQuery ).getResultList();
 					}
-					catch ( PersistenceException e ) {
-						if ( e.getCause() instanceof SQLGrammarException ) {
-							//expected, the schema was not created
-						}
-						else {
-							throw e;
-						}
+					catch ( SQLGrammarException e ) {
+						// Expected
 					}
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/nulliteral/CriteriaLiteralsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/nulliteral/CriteriaLiteralsTest.java
@@ -82,11 +82,8 @@ public class CriteriaLiteralsTest extends BaseEntityManagerFunctionalTestCase {
 			} );
 			fail( "Should have thrown exception!" );
 		}
-		catch ( Exception expected ) {
-			assertEquals(
-					SQLGrammarException.class,
-					expected.getCause().getClass()
-			);
+		catch ( SQLGrammarException expected ) {
+			// Expected
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/exception/ExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/exception/ExceptionTest.java
@@ -111,8 +111,7 @@ public class ExceptionTest extends BaseEntityManagerFunctionalTestCase {
 			fail();
 		}
 		catch ( PersistenceException e ) {
-			Throwable t = e.getCause();
-			assertTrue( "Should be a constraint violation", t instanceof ConstraintViolationException );
+			assertTrue( "Should be a constraint violation", e instanceof ConstraintViolationException );
 			em.getTransaction().rollback();
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/TransactionJoiningTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/transaction/TransactionJoiningTest.java
@@ -208,7 +208,7 @@ public class TransactionJoiningTest extends BaseEntityManagerFunctionalTestCase 
 
 		TestingJtaPlatformImpl.INSTANCE.getTransactionManager().commit();
 	}
-	
+
 	/**
 	 * In certain JTA environments (JBossTM, etc.), a background thread (reaper)
 	 * can rollback a transaction if it times out.  These timeouts are rare and
@@ -243,7 +243,7 @@ public class TransactionJoiningTest extends BaseEntityManagerFunctionalTestCase 
 			em.persist( new Book( "The Book of Foo", 1 ) );
 		}
 		catch ( PersistenceException e ) {
-			caught = e.getCause().getClass().equals( HibernateException.class );
+			caught = e.getClass().equals( HibernateException.class );
 		}
 		assertTrue( caught );
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/embeddables/EmbeddableIntegratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/embeddables/EmbeddableIntegratorTest.java
@@ -57,7 +57,7 @@ public class EmbeddableIntegratorTest extends BaseUnitTestCase {
 				Investor inv = (Investor) sess.get( Investor.class, 1L );
 				assertEquals( new BigDecimal( "100" ), inv.getInvestments().get( 0 ).getAmount().getAmount() );
 			}catch (PersistenceException e){
-				assertTyping(JDBCException.class, e.getCause());
+				assertTyping(JDBCException.class, e);
 				sess.getTransaction().rollback();
 			}
 			sess.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/join/JoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/join/JoinTest.java
@@ -136,7 +136,7 @@ public class JoinTest extends BaseNonConfigCoreFunctionalTestCase {
 		tx.commit();
 		s.close();
 	}
-	
+
 	@Test
 	public void testReferenceColumnWithBacktics() throws Exception {
 		Session s=openSession();
@@ -150,7 +150,7 @@ public class JoinTest extends BaseNonConfigCoreFunctionalTestCase {
 		s.getTransaction().commit();
 		s.close();
 	}
-	
+
 	@Test
 	public void testUniqueConstaintOnSecondaryTable() throws Exception {
 		Cat cat = new Cat();
@@ -167,7 +167,7 @@ public class JoinTest extends BaseNonConfigCoreFunctionalTestCase {
 		}
 		catch (PersistenceException e) {
 			try {
-				assertTyping( ConstraintViolationException.class, e.getCause() );
+				assertTyping( ConstraintViolationException.class, e );
 				//success
 			}
 			finally {
@@ -189,7 +189,7 @@ public class JoinTest extends BaseNonConfigCoreFunctionalTestCase {
 		s.persist( cat );
 		s.flush();
 		s.clear();
-		
+
 		s.get( Cat.class, cat.getId() );
 		//Find a way to test it, I need to define the secondary table on a subclass
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OneToManyTest.java
@@ -179,7 +179,7 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 		}
 		catch (PersistenceException ce) {
 			try {
-				assertTyping( ConstraintViolationException.class, ce.getCause() );
+				assertTyping( ConstraintViolationException.class, ce );
 				//success
 
 			}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
@@ -42,8 +42,7 @@ public class OptionalOneToOneMappedByTest extends BaseCoreFunctionalTestCase {
 				fail( "should have failed with IdentifierGenerationException" );
 			} );
 		}
-		catch (PersistenceException ex) {
-			assertTyping( IdentifierGenerationException.class, ex.getCause() );
+		catch (IdentifierGenerationException ex) {
 			// expected
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
@@ -41,8 +41,7 @@ public class OptionalOneToOnePKJCTest extends BaseCoreFunctionalTestCase {
 			s.flush();
 			fail( "should have thrown IdentifierGenerationException.");
 		}
-		catch (PersistenceException ex) {
-			assertTyping(IdentifierGenerationException.class, ex.getCause());
+		catch (IdentifierGenerationException ex) {
 			// expected
 		}
 		finally {
@@ -65,8 +64,7 @@ public class OptionalOneToOnePKJCTest extends BaseCoreFunctionalTestCase {
 			s.flush();
 			fail( "should have thrown IdentifierGenerationException.");
 		}
-		catch (PersistenceException ex) {
-			assertTyping(IdentifierGenerationException.class, ex.getCause());
+		catch (IdentifierGenerationException ex) {
 			// expected
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/hhh9798/OneToOneJoinTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/hhh9798/OneToOneJoinTableTest.java
@@ -43,8 +43,8 @@ public class OneToOneJoinTableTest extends BaseCoreFunctionalTestCase {
 			tx.commit();
 
 			fail();
-		}catch (PersistenceException e){
-			assertTyping( ConstraintViolationException.class, e.getCause());
+		}
+		catch (ConstraintViolationException e) {
 			// expected
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/tableperclass/TablePerClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/tableperclass/TablePerClassTest.java
@@ -78,8 +78,7 @@ public class TablePerClassTest extends BaseCoreFunctionalTestCase {
 			s.flush();
 			fail( "Database Exception not handled" );
 		}
-		catch (PersistenceException e) {
-			assertTyping( JDBCException.class, e.getCause() );
+		catch (JDBCException e) {
 			//success
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
  * @author Brett Meyer
  */
 public class UniqueConstraintTest extends BaseCoreFunctionalTestCase {
-	
+
 	protected Class[] getAnnotatedClasses() {
         return new Class[]{
                 Room.class,
@@ -57,8 +57,7 @@ public class UniqueConstraintTest extends BaseCoreFunctionalTestCase {
             s.flush();
             fail( "Database constraint non-existant" );
         }
-        catch (PersistenceException e) {
-            assertTyping( JDBCException.class, e.getCause() );
+        catch (JDBCException e) {
             //success
         }
         finally {
@@ -66,5 +65,5 @@ public class UniqueConstraintTest extends BaseCoreFunctionalTestCase {
             s.close();
         }
     }
-    
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintThrowsConstraintViolationExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/uniqueconstraint/UniqueConstraintThrowsConstraintViolationExceptionTest.java
@@ -53,11 +53,8 @@ public class UniqueConstraintThrowsConstraintViolationExceptionTest extends Base
 			} );
 			fail( "Should throw" );
 		}
-		catch ( PersistenceException e ) {
-			assertEquals(
-					ConstraintViolationException.class,
-					e.getCause().getClass()
-			);
+		catch ( ConstraintViolationException e ) {
+			// expected
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/interceptor/InterceptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/interceptor/InterceptorTest.java
@@ -142,11 +142,11 @@ public class InterceptorTest extends BaseCoreFunctionalTestCase {
             fail( "Transaction should have timed out" );
         }
 		catch (PersistenceException e){
-			assertTyping(TransactionException.class, e.getCause());
+			assertTyping(TransactionException.class, e);
 			assertTrue(
 					"Transaction failed for the wrong reason.  Expecting transaction timeout, but found [" +
-							e.getCause().getMessage() + "]"					,
-					e.getCause().getMessage().contains( "transaction timeout expired" )
+							e.getMessage() + "]"					,
+					e.getMessage().contains( "transaction timeout expired" )
 			);
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/manytomanyassociationclass/surrogateid/generated/ManyToManyAssociationClassGeneratedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/manytomanyassociationclass/surrogateid/generated/ManyToManyAssociationClassGeneratedIdTest.java
@@ -55,7 +55,7 @@ public class ManyToManyAssociationClassGeneratedIdTest extends AbstractManyToMan
 		catch (PersistenceException e) {
 			s.getTransaction().rollback();
 			// expected
-			assertTyping( ConstraintViolationException.class, e.getCause() );
+			assertTyping( ConstraintViolationException.class, e );
 		}
 		finally {
 			s.close();
@@ -84,7 +84,7 @@ public class ManyToManyAssociationClassGeneratedIdTest extends AbstractManyToMan
 		catch (PersistenceException e) {
 			s.getTransaction().rollback();
 			// expected
-			assertTyping( ConstraintViolationException.class, e.getCause() );
+			assertTyping( ConstraintViolationException.class, e );
 		}
 		finally {
 			s.close();
@@ -113,7 +113,7 @@ public class ManyToManyAssociationClassGeneratedIdTest extends AbstractManyToMan
 		catch (PersistenceException e) {
 			s.getTransaction().rollback();
 			// expected
-			assertTyping( ConstraintViolationException.class, e.getCause() );
+			assertTyping( ConstraintViolationException.class, e );
 		}
 		finally {
 			s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/CreateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/CreateTest.java
@@ -134,7 +134,7 @@ public class CreateTest extends AbstractOperationTestCase {
 		}
 		catch (PersistenceException e){
 			//verify that an exception is thrown!
-			assertTyping(ConstraintViolationException.class, e.getCause());
+			assertTyping(ConstraintViolationException.class, e);
 		}
 		tx.rollback();
 		s.close();
@@ -151,7 +151,7 @@ public class CreateTest extends AbstractOperationTestCase {
 		}
 		catch (PersistenceException e){
 			//verify that an exception is thrown!
-			assertTyping(ConstraintViolationException.class, e.getCause());
+			assertTyping(ConstraintViolationException.class, e);
 		}
 		tx.rollback();
 		s.close();
@@ -175,7 +175,7 @@ public class CreateTest extends AbstractOperationTestCase {
 		}
 		catch (PersistenceException e){
 			//verify that an exception is thrown!
-			assertTyping(PersistentObjectException.class, e.getCause());
+			assertTyping(PersistentObjectException.class, e);
 		}
 		tx.rollback();
 		s.close();
@@ -191,7 +191,7 @@ public class CreateTest extends AbstractOperationTestCase {
 		}
 		catch (PersistenceException e){
 			//verify that an exception is thrown!
-			assertTyping(PersistentObjectException.class, e.getCause());
+			assertTyping(PersistentObjectException.class, e);
 		}
 		tx.rollback();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/autodiscovery/AutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/autodiscovery/AutoDiscoveryTest.java
@@ -80,9 +80,8 @@ public class AutoDiscoveryTest extends BaseCoreFunctionalTestCase {
 			}
 			session.getTransaction().commit();
 		}
-		catch (PersistenceException e) {
+		catch (NonUniqueDiscoveredSqlAliasException e) {
 			//expected
-			assertTyping( NonUniqueDiscoveredSqlAliasException.class, e.getCause() );
 		}
 		session.close();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/TransactionTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/TransactionTimeoutTest.java
@@ -73,9 +73,6 @@ public class TransactionTimeoutTest extends BaseCoreFunctionalTestCase {
 		catch (TransactionException e) {
 			// expected
 		}
-		catch (PersistenceException e) {
-			assertTyping( TransactionException.class, e.getCause() );
-		}
 		finally {
 			session.close();
 		}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HHH-12666

So it might break user code for 5.2 and early 5.3 but I think it's a bug and should be treated as such: we shouldn't wrap our nicely typed exceptions in a generic `PersistenceException` when our exception is already one.

If a user is using `getCause()`, it will be an issue.

I tried to use `initCause()` with the initial exception in it to try to mitigate the issue but I got a `Self-causation not permitted` exception.

We may have to warn the Spring people about this change.
