### PR TITLE
HHH-3138 - make constructor of DynamicMapEntityTuplizer public

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/DynamicMapEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/DynamicMapEntityTuplizer.java
@@ -34,7 +34,7 @@ import org.hibernate.tuple.Instantiator;
 public class DynamicMapEntityTuplizer extends AbstractEntityTuplizer {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( DynamicMapEntityTuplizer.class );
 
-	DynamicMapEntityTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
+	protected DynamicMapEntityTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
 		super( entityMetamodel, mappedEntity );
 	}
 


### PR DESCRIPTION
As requested in the ticket, I just changed the constructor's visibility from default (package) to public.

I commented in the ticket if this change is even desirable but got no answers. Maybe this is the proper site for discussion.