### PR TITLE
HHH-12816 Enable the experimental features of ByteBuddy when building with JDK 11

### DIFF
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -231,6 +231,12 @@ processTestResources {
 	}
 }
 
+// Enable the experimental features of ByteBuddy with JDK 11
+test {
+	if ( JavaVersion.current().isJava11Compatible() ) {
+		systemProperty 'net.bytebuddy.experimental', true
+	}
+}
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
With this PR, our tests pass with ByteBuddy and JDK 11.

Except for the hibernate-orm-modules tests which are commented due to a Gradle issue.