### PR TITLE
[HHH_12824] ASTParserLoadingTest.testComponentNullnessChecks fails wi…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -770,7 +770,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		assertEquals( 3, results.size() );
 		String query =
 				( getDialect() instanceof DB2Dialect || getDialect() instanceof HSQLDialect ) ?
-						"from Human where cast(? as string) is null" :
+						"from Human where cast(?1 as string) is null" :
 						"from Human where ?1 is null"
 				;
 		if ( getDialect() instanceof DerbyDialect ) {


### PR DESCRIPTION
…th DB2 because it uses legacy-style query parameter

https://hibernate.atlassian.net/browse/HHH-12824

Could you please backport fix also to 5.3? 