### PR TITLE
[HHH_12825] CriteriaHQLAlignmentTest.testCountReturnValues fails on d…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/hql/CriteriaHQLAlignmentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/CriteriaHQLAlignmentTest.java
@@ -280,6 +280,15 @@ public class CriteriaHQLAlignmentTest extends QueryTranslatorTestCase {
 				throw ex;
 			}
 		}
+		catch (PersistenceException e) {
+			SQLGrammarException cause = assertTyping( SQLGrammarException.class, e.getCause() );
+			if ( ! getDialect().supportsTupleCounts() ) {
+				// expected
+			}
+			else {
+				throw e;
+			}
+		}
 		finally {
 			t.rollback();
 			s.close();


### PR DESCRIPTION
…atabases that don't support tuple distinct counts because it expects wrong exception

https://hibernate.atlassian.net/browse/HHH-12825

Could you please backport fix also to 5.3 branch? 

The fix is a bit different from #2436 only because it uses the same approach from the same test (line 350)