### PR TITLE
HHH-12492 Jpa DELETE Query generated has missing table alias and thus incorrect semantics 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
@@ -341,12 +341,10 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 
 		final String propertyName = getIdentifierPropertyName();
 
-		if ( getWalker().getStatementType() == HqlSqlTokenTypes.SELECT ) {
-			return getPropertyMapping( propertyName ).toColumns( table, propertyName );
-		}
-		else {
-			return getPropertyMapping( propertyName ).toColumns( propertyName );
-		}
+		return toColumns(
+				table, propertyName,
+				getWalker().getStatementType() == HqlSqlTokenTypes.SELECT
+		);
 	}
 
 	public void setCollectionJoin(boolean collectionJoin) {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
@@ -197,6 +197,15 @@ public class IdentNode extends FromReferenceNode implements SelectExpression {
 
 		String[] columnExpressions = element.getIdentityColumns();
 
+		// TODO Remove this? See HHH-12492
+		// This is legacy code that shouldn't be necessary, because getIdentityColumns is supposed to add the alias
+		if ( ! isFromElementUpdateOrDeleteRoot( element ) ) {
+			if ( StringHelper.isNotEmpty( element.getTableAlias() ) ) {
+				// apparently we also need to check that they are not already qualified.  Ugh!
+				columnExpressions = StringHelper.qualifyIfNot( element.getTableAlias(), columnExpressions );
+			}
+		}
+
 		final Dialect dialect = getWalker().getSessionFactoryHelper().getFactory().getDialect();
 		final boolean isInCount = getWalker().isInCount();
 		final boolean isInDistinctCount = isInCount && getWalker().isInCountDistinct();

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/IdentNode.java
@@ -197,14 +197,6 @@ public class IdentNode extends FromReferenceNode implements SelectExpression {
 
 		String[] columnExpressions = element.getIdentityColumns();
 
-		// determine whether to apply qualification (table alias) to the column(s)...
-		if ( ! isFromElementUpdateOrDeleteRoot( element ) ) {
-			if ( StringHelper.isNotEmpty( element.getTableAlias() ) ) {
-				// apparently we also need to check that they are not already qualified.  Ugh!
-				columnExpressions = StringHelper.qualifyIfNot( element.getTableAlias(), columnExpressions );
-			}
-		}
-
 		final Dialect dialect = getWalker().getSessionFactoryHelper().getFactory().getDialect();
 		final boolean isInCount = getWalker().isInCount();
 		final boolean isInDistinctCount = isInCount && getWalker().isInCountDistinct();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/DeleteQuerySubqueryReferencingTargetPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/DeleteQuerySubqueryReferencingTargetPropertyTest.java
@@ -1,0 +1,83 @@
+package org.hibernate.test.hql;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+@TestForIssue(jiraKey = "HHH-12492")
+public class DeleteQuerySubqueryReferencingTargetPropertyTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Master.class, Detail.class };
+	}
+
+	@Test
+	@FailureExpected(jiraKey = "HHH-12492")
+	public void testSubQueryReferencingTargetProperty() {
+		// prepare
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Master m1 = new Master();
+			entityManager.persist( m1 );
+			Detail d11 = new Detail( m1 );
+			entityManager.persist( d11 );
+			Detail d12 = new Detail( m1 );
+			entityManager.persist( d12 );
+
+			Master m2 = new Master();
+			entityManager.persist( m2 );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			// depending on the generated ids above this delete removes all masters or nothing
+			// removal of all masters results in foreign key constraint violation
+			// removal of nothing is incorrect since 2nd master does not have any details
+
+			// DO NOT CHANGE this query: it used to trigger a very specific bug caused
+			// by the alias not being added to the generated query
+			String d = "delete from Master m where not exists (select d from Detail d where d.master=m)";
+			Query del = entityManager.createQuery( d );
+			del.executeUpdate();
+
+			// so check for exactly one master after deletion
+			CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+			CriteriaQuery<Master> query = builder.createQuery( Master.class );
+			query.select( query.from( Master.class ) );
+			Assert.assertEquals( 1, entityManager.createQuery( query ).getResultList().size() );
+		} );
+	}
+
+	@Entity(name = "Master")
+	public static class Master {
+		@Id
+		@GeneratedValue
+		private Integer id;
+	}
+
+	@Entity(name = "Detail")
+	public static class Detail {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@ManyToOne(optional = false)
+		private Master master;
+
+		public Detail(Master master) {
+			this.master = master;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/DeleteQuerySubqueryReferencingTargetPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/DeleteQuerySubqueryReferencingTargetPropertyTest.java
@@ -10,7 +10,6 @@ import javax.persistence.criteria.CriteriaQuery;
 
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,7 +25,6 @@ public class DeleteQuerySubqueryReferencingTargetPropertyTest extends BaseEntity
 	}
 
 	@Test
-	@FailureExpected(jiraKey = "HHH-12492")
 	public void testSubQueryReferencingTargetProperty() {
 		// prepare
 		doInJPA( this::entityManagerFactory, entityManager -> {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-12492

Given the very sensitive section of the code I had to change, maybe we should wait for 5.4 before merging this. That being said, my first attempt was definitely buggy and at least 3 previously existing tests failed as a result, which is reassuring.