### PR TITLE
[HHH-12842] Fix lazy loading for OneToOne associations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
@@ -70,6 +70,7 @@ public class OneToOne extends ToOne {
 					referencedPropertyName,
 					isLazy(),
 					isUnwrapProxy(),
+					isNullable(),
 					entityName,
 					propertyName
 			);
@@ -82,6 +83,7 @@ public class OneToOne extends ToOne {
 					referencedPropertyName,
 					isLazy(),
 					isUnwrapProxy(),
+					isNullable(),
 					entityName,
 					propertyName
 			);

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -29,10 +29,11 @@ public class OneToOneType extends EntityType {
 	private final ForeignKeyDirection foreignKeyType;
 	private final String propertyName;
 	private final String entityName;
+	private final boolean isNullable;
 
 	/**
-	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String)}
-	 *  instead.
+	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, boolean, String, String)}
+	 * instead.
 	 */
 	@Deprecated
 	public OneToOneType(
@@ -47,6 +48,11 @@ public class OneToOneType extends EntityType {
 		this( scope, referencedEntityName, foreignKeyType, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName );
 	}
 
+	/**
+	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, boolean, String, String)}
+	 * instead.
+	 */
+	@Deprecated
 	public OneToOneType(
 			TypeFactory.TypeScope scope,
 			String referencedEntityName,
@@ -57,10 +63,25 @@ public class OneToOneType extends EntityType {
 			boolean unwrapProxy,
 			String entityName,
 			String propertyName) {
+		this( scope, referencedEntityName, foreignKeyType, referenceToPrimaryKey, uniqueKeyPropertyName, lazy, unwrapProxy, foreignKeyType==ForeignKeyDirection.TO_PARENT, entityName, propertyName );
+	}
+
+	public OneToOneType(
+			TypeFactory.TypeScope scope,
+			String referencedEntityName,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			boolean nullable,
+			String entityName,
+			String propertyName) {
 		super( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, !lazy, unwrapProxy );
 		this.foreignKeyType = foreignKeyType;
 		this.propertyName = propertyName;
 		this.entityName = entityName;
+		this.isNullable = nullable;
 	}
 
 	public OneToOneType(OneToOneType original, String superTypeEntityName) {
@@ -68,6 +89,7 @@ public class OneToOneType extends EntityType {
 		this.foreignKeyType = original.foreignKeyType;
 		this.propertyName = original.propertyName;
 		this.entityName = original.entityName;
+		this.isNullable = original.isNullable;
 	}
 
 	@Override
@@ -156,7 +178,7 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	protected boolean isNullable() {
-		return foreignKeyType==ForeignKeyDirection.TO_PARENT;
+		return isNullable;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/SpecialOneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SpecialOneToOneType.java
@@ -27,7 +27,8 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 public class SpecialOneToOneType extends OneToOneType {
 	
 	/**
-	 * @deprecated Use {@link #SpecialOneToOneType(org.hibernate.type.TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String)} instead.
+	 * @deprecated Use {@link SpecialOneToOneType#SpecialOneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, boolean, String, String)}
+	 * instead.
 	 */
 	@Deprecated
 	public SpecialOneToOneType(
@@ -41,7 +42,12 @@ public class SpecialOneToOneType extends OneToOneType {
 			String propertyName) {
 		this( scope, referencedEntityName, foreignKeyType, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName );
 	}
-	
+
+	/**
+	 * @deprecated Use {@link SpecialOneToOneType#SpecialOneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, boolean, String, String)}
+	 * instead.
+	 */
+	@Deprecated
 	public SpecialOneToOneType(
 			TypeFactory.TypeScope scope,
 			String referencedEntityName,
@@ -52,7 +58,7 @@ public class SpecialOneToOneType extends OneToOneType {
 			boolean unwrapProxy,
 			String entityName,
 			String propertyName) {
-		super(
+		this(
 				scope,
 				referencedEntityName, 
 				foreignKeyType,
@@ -60,9 +66,35 @@ public class SpecialOneToOneType extends OneToOneType {
 				uniqueKeyPropertyName, 
 				lazy,
 				unwrapProxy,
+				foreignKeyType==ForeignKeyDirection.TO_PARENT,
 				entityName, 
 				propertyName
 			);
+	}
+
+	public SpecialOneToOneType(
+			TypeFactory.TypeScope scope,
+			String referencedEntityName,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			boolean nullable,
+			String entityName,
+			String propertyName) {
+		super(
+				scope,
+				referencedEntityName,
+				foreignKeyType,
+				referenceToPrimaryKey,
+				uniqueKeyPropertyName,
+				lazy,
+				unwrapProxy,
+				nullable,
+				entityName,
+				propertyName
+		);
 	}
 
 	public SpecialOneToOneType(SpecialOneToOneType original, String superTypeEntityName) {

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -207,11 +207,12 @@ public final class TypeFactory implements Serializable {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
+			boolean nullable,
 			String entityName,
 			String propertyName) {
 		return new OneToOneType(
 				typeScope, persistentClass, foreignKeyType, referenceToPrimaryKey,
-				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName
+				uniqueKeyPropertyName, lazy, unwrapProxy, nullable, entityName, propertyName
 		);
 	}
 
@@ -222,11 +223,12 @@ public final class TypeFactory implements Serializable {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
+			boolean nullable,
 			String entityName,
 			String propertyName) {
 		return new SpecialOneToOneType(
 				typeScope, persistentClass, foreignKeyType, referenceToPrimaryKey,
-				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName
+				uniqueKeyPropertyName, lazy, unwrapProxy, nullable, entityName, propertyName
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/lazy/LazyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/lazy/LazyToOneTest.java
@@ -1,0 +1,166 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.lazy;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Table;
+import java.util.Date;
+
+import static org.hibernate.Hibernate.isInitialized;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertFalse;
+
+@TestForIssue(jiraKey = "HHH-12842")
+public class LazyToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Post.class, PostDetails.class };
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		doInHibernate( this::sessionFactory, s -> {
+			Post post = new Post();
+			post.setDetails( new PostDetails() );
+			post.getDetails().setCreatedBy( "ME" );
+			post.getDetails().setCreatedOn( new Date() );
+			post.setTitle( "title" );
+			s.persist( post );
+		} );
+	}
+
+	@Test
+	public void testOneToOneLazyLoading() {
+		doInHibernate( this::sessionFactory, s -> {
+			PostDetails post = (PostDetails) s.createQuery( "select a from PostDetails a" ).getResultList().get( 0 );
+			assertFalse( isInitialized( post.post ) );
+		} );
+	}
+
+	@Entity(name = "PostDetails")
+	@Table(name = "post_details")
+	public static class PostDetails {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Column(name = "created_on")
+		private Date createdOn;
+
+		@Column(name = "created_by")
+		private String createdBy;
+
+		@MapsId
+		@OneToOne(fetch = FetchType.LAZY, mappedBy = "details", optional = false)
+		private Post post;
+
+		public PostDetails() {
+		}
+
+		public PostDetails(String createdBy) {
+			createdOn = new Date();
+			this.createdBy = createdBy;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Date getCreatedOn() {
+			return createdOn;
+		}
+
+		public void setCreatedOn(Date createdOn) {
+			this.createdOn = createdOn;
+		}
+
+		public String getCreatedBy() {
+			return createdBy;
+		}
+
+		public void setCreatedBy(String createdBy) {
+			this.createdBy = createdBy;
+		}
+
+		public Post getPost() {
+			return post;
+		}
+
+		public void setPost(Post post) {
+			this.post = post;
+		}
+
+	}
+
+	@Entity(name = "Post")
+	@Table(name = "post")
+	public static class Post {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String title;
+
+		@PrimaryKeyJoinColumn
+		@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private PostDetails details;
+
+
+		public void setDetails(PostDetails details) {
+			if ( details == null ) {
+				if ( this.details != null ) {
+					this.details.setPost( null );
+				}
+			}
+			else {
+				details.setPost( this );
+			}
+			this.details = details;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public PostDetails getDetails() {
+			return details;
+		}
+	}
+
+}


### PR DESCRIPTION
Suggested fix for: https://hibernate.atlassian.net/browse/HHH-12842

Todo: 
* ~Still waiting on full pass test results~
* The exact same approach should probably be applied to ManyToOne relations (currently using the `@NotFound(Ignore)` setting instead). I have a feeling that the solution should be more universal (perhaps a combination of the two).
