### PR TITLE
HHH-12763 - Log which JtaPlatform implementation is used at startup on info level

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
@@ -49,7 +49,29 @@ public class JtaPlatformInitiator implements StandardServiceInitiator<JtaPlatfor
 			platform = getFallbackProvider( configurationValues, registry );
 		}
 
+		LOG.info( String.format( "Returning platform [%s]", getPlatformDescription( platform ) ) );
 		return platform;
+	}
+
+	/**
+	 * Retrieves the {@link JtaPlatform} information and transform it to a String description
+	 * 
+	 * @param platform The Platform to be analized
+	 * @return A platform description
+	 */
+	private String getPlatformDescription(JtaPlatform platform) {
+		if ( platform != null ) {
+			StringBuilder descBuilder = new StringBuilder( "JtaPlatform : " );
+			descBuilder.append( " canRegisterSynchronization: " ).append( platform.canRegisterSynchronization() )
+					.append( ", UserTransaction: " )
+					.append( platform.retrieveUserTransaction() != null ? platform.retrieveUserTransaction().getClass().getName() : "null" )
+					.append( ", TransactionManager: " )
+					.append( platform.retrieveTransactionManager() != null ? platform.retrieveTransactionManager().getClass().getName() : "null" );
+
+			return descBuilder.toString();
+		}
+		else
+			return null;
 	}
 
 	@SuppressWarnings({"WeakerAccess", "unused"})


### PR DESCRIPTION
As suggested in the ticket, I added a `LOG.info()` just before return statement.
To make it a little bit smarter, The String is built in a private helper method. The retrieved information is just basic based in the main `JtaPlatform` interface contract.