### PR TITLE
HHH-12792 : Document binary incompatibility of persisters

### DIFF
--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -171,6 +171,11 @@ making the `org.hibernate.jpa.event.spi.JpaIntegrator` no longer needed.
 Existing applications migrating to 5.3 with classes extending `org.hibernate.jpa.event.spi.JpaIntegrator` have to change these classes to implement the `org.hibernate.integrator.spi.Integrator` interface.
 ====
 
+=== Persister changes
+
+Due to changes to SPIs for persisters (in `org.hibernate.persister` package), custom persisters will need
+to be updated to follow the new SPIs.
+
 === 5.1 -> 5.3 exception handling changes
 
 In 5.3 (as well as 5.2), exception handling for a `SessionFactory` built via Hibernate's native


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12792

SPIs for persisters changed going from 5.2 to 5.3; tuplizer SPIs stayed the same.

Update for 5.3 migration guide.