### PR TITLE
HHH-12848 Restore the original Oracle LimitHandler

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
@@ -10,8 +10,6 @@ import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.Oracle12cIdentityColumnSupport;
-import org.hibernate.dialect.pagination.LimitHandler;
-import org.hibernate.dialect.pagination.SQL2008StandardLimitHandler;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.service.ServiceRegistry;
@@ -53,11 +51,6 @@ public class Oracle12cDialect extends Oracle10gDialect {
 	protected void registerDefaultProperties() {
 		super.registerDefaultProperties();
 		getDefaultProperties().setProperty( Environment.USE_GET_GENERATED_KEYS, "true" );
-	}
-
-	@Override
-	public LimitHandler getLimitHandler() {
-		return SQL2008StandardLimitHandler.INSTANCE;
 	}
 
 	@Override


### PR DESCRIPTION
Oracle does not support using the SQL 2008 standard limit handler with
FOR UPDATE clauses. Thus we need to get back to the old limit handler.

https://hibernate.atlassian.net/browse/HHH-12848