### PR TITLE
Backport: Enable more database tests enabled on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,13 @@ allprojects {
 			name "jboss-snapshots"
 			url "http://snapshots.jboss.org/maven2/"
 		}
+		//Allow loading additional dependencis from a local path;
+		//useful to load JDBC drivers which can not be distributed in public.
+		if (System.env['ADDITIONAL_REPO'] != null) {
+			flatDir {
+				dirs "${System.env.ADDITIONAL_REPO}"
+			}
+		}
 	}
 	apply plugin: 'idea'
 

--- a/databases/mssqlserver/matrix.gradle
+++ b/databases/mssqlserver/matrix.gradle
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+jdbcDependency 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'

--- a/databases/mssqlserver/resources/hibernate.properties
+++ b/databases/mssqlserver/resources/hibernate.properties
@@ -1,0 +1,33 @@
+#
+# Hibernate, Relational Persistence for Idiomatic Java
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+
+#
+# Hibernate, Relational Persistence for Idiomatic Java
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+
+hibernate.dialect org.hibernate.dialect.SQLServer2012Dialect
+hibernate.connection.driver_class com.microsoft.sqlserver.jdbc.SQLServerDriver
+hibernate.connection.url jdbc:sqlserver://hibernate-testing-mssql-express.ccuzkqo3zqzq.us-east-1.rds.amazonaws.com
+hibernate.connection.username hibernate_orm_test
+hibernate.connection.password hibernate_orm_test
+
+hibernate.connection.pool_size 5
+
+hibernate.show_sql false
+hibernate.format_sql true
+
+hibernate.max_fetch_depth 5
+
+hibernate.cache.region_prefix hibernate.test
+hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
+
+javax.persistence.validation.mode=NONE
+hibernate.service.allow_crawling=false
+hibernate.session.events.log=true

--- a/databases/oracle/matrix.gradle
+++ b/databases/oracle/matrix.gradle
@@ -4,4 +4,6 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency 'com.oracle.ojdbc:ojdbc7:12.1.0.2.0'
+// Expected to match the jar name: drop a copy of ojdbc8.jar in a local directory,
+// then point the environment variable ADDITIONAL_REPO to that directory.
+jdbcDependency name : 'ojdbc8'

--- a/databases/oracle/resources/hibernate.properties
+++ b/databases/oracle/resources/hibernate.properties
@@ -7,8 +7,9 @@
 
 hibernate.dialect org.hibernate.dialect.Oracle12cDialect
 hibernate.connection.driver_class oracle.jdbc.driver.OracleDriver
-hibernate.connection.url jdbc:oracle:thin:@orm-testing.ccuzkqo3zqzq.us-east-1.rds.amazonaws.com:1521:ORCL
-hibernate.connection.username ormmasteruser
+hibernate.connection.url jdbc:oracle:thin:@hibernate-testing-oracle-se.ccuzkqo3zqzq.us-east-1.rds.amazonaws.com:1521:ORCL
+hibernate.connection.username hibernate_orm_test
+hibernate.connection.password hibernate_orm_test
 
 hibernate.connection.pool_size 5
 


### PR DESCRIPTION
These should be harmless, but would be interesting to apply on 5.3 so to compare results.

 - https://hibernate.atlassian.net/browse/HHH-12898
 - https://hibernate.atlassian.net/browse/HHH-12899
 - https://hibernate.atlassian.net/browse/HHH-12901
