### PR TITLE
HHH-12905 Bind value [null] was not of specified type in StoredProced…

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/procedure/StoredProcedureParameterTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/procedure/StoredProcedureParameterTypeTest.java
@@ -29,7 +29,7 @@ import javax.persistence.ParameterMode;
 import javax.sql.rowset.serial.SerialBlob;
 import javax.sql.rowset.serial.SerialClob;
 
-import org.hibernate.dialect.H2Dialect;
+import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.type.BigDecimalType;
 import org.hibernate.type.BigIntegerType;
 import org.hibernate.type.BinaryType;
@@ -61,7 +61,6 @@ import org.hibernate.type.UUIDBinaryType;
 import org.hibernate.type.UrlType;
 import org.hibernate.type.YesNoType;
 
-import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
@@ -71,7 +70,6 @@ import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 /**
  * @author Vlad Mihalcea
  */
-@TestForIssue( jiraKey = "HHH-12661" )
 public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	private static final String TEST_STRING = "test_string";
@@ -79,6 +77,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	private static final byte[] TEST_BYTE_ARRAY = TEST_STRING.getBytes();
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testNumericBooleanTypeInParameter() {
 		doInHibernate( this::sessionFactory, session -> {
 			session.createStoredProcedureQuery( "test" )
@@ -89,6 +88,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testYesNoTypeInParameter() {
 		doInHibernate( this::sessionFactory, session -> {
 			session.createStoredProcedureQuery( "test" )
@@ -99,6 +99,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testStringTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -108,6 +109,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testMaterializedClobTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -117,6 +119,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTextTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -126,6 +129,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testCharacterTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -135,6 +139,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTrueFalseTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -144,6 +149,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testBooleanTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -153,6 +159,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testByteTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -162,6 +169,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testShortTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -171,6 +179,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testIntegerTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -180,6 +189,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testLongTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -198,6 +208,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testDoubleTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -207,6 +218,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testBigIntegerTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -216,6 +228,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testBigDecimalTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -225,6 +238,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTimestampTypeDateInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -234,6 +248,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTimestampTypeTimestampInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -243,6 +258,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTimeTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -252,6 +268,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testDateTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -261,6 +278,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testCalendarTypeCalendarInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -270,6 +288,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testCurrencyTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -279,6 +298,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testLocaleTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -288,6 +308,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testTimeZoneTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -297,6 +318,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testUrlTypeInParameter() throws MalformedURLException {
 		final URL url = new URL( "http://example.com");
 		inTransaction(
@@ -307,6 +329,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testClassTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -316,6 +339,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testBlobTypeInParameter() throws SQLException {
 		final Blob blob = new SerialBlob( TEST_BYTE_ARRAY);
 		inTransaction(
@@ -326,6 +350,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testClobTypeInParameter() throws SQLException {
 		final Clob clob = new SerialClob( TEST_CHAR_ARRAY);
 		inTransaction(
@@ -336,6 +361,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testBinaryTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -345,6 +371,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testCharArrayTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -354,6 +381,7 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-12661" )
 	public void testUUIDBinaryTypeInParameter() {
 		inTransaction(
 				session -> session.createStoredProcedureQuery("test")
@@ -361,4 +389,16 @@ public class StoredProcedureParameterTypeTest extends BaseNonConfigCoreFunctiona
 						.setParameter( 1, UUID.randomUUID())
 		);
 	}
+
+    @Test
+	@TestForIssue( jiraKey = "HHH-12905" )
+    public void testStringTypeInParameterIsNull() {
+        inTransaction(
+                session -> {
+						ProcedureCall procedureCall = session.createStoredProcedureCall("test");
+						procedureCall.registerParameter(1, StringType.class, ParameterMode.IN).enablePassingNulls(true);
+						procedureCall.setParameter(1, null);
+				}
+        );
+    }
 }


### PR DESCRIPTION
I have set the enablePassingNulls to 'true', but it has thrown an Exception.
```
Bind value [null] was not of specified type [class org.hibernate.type.StringType
java.lang.IllegalArgumentException: Bind value [null] was not of specified type [class org.hibernate.type.StringType
	at org.hibernate.procedure.internal.ParameterBindImpl.internalSetValue(ParameterBindImpl.java:83)
	at org.hibernate.procedure.internal.ParameterBindImpl.setBindValue(ParameterBindImpl.java:64)
	at org.hibernate.procedure.internal.ProcedureCallImpl.setParameter(ProcedureCallImpl.java:824)
	at org.hibernate.procedure.internal.ProcedureCallImpl.setParameter(ProcedureCallImpl.java:70)
	at org.hibernate.test.procedure.StoredProcedureParameterTypeTest.lambda$testStringTypeInParameterIsNull$31(StoredProcedureParameterTypeTest.java:370)
	at org.hibernate.testing.transaction.TransactionUtil2.inTransaction(TransactionUtil2.java:57)
	at org.hibernate.testing.transaction.TransactionUtil2.lambda$inTransaction$0(TransactionUtil2.java:44)
	at org.hibernate.testing.transaction.TransactionUtil2.inSession(TransactionUtil2.java:29)
	at org.hibernate.testing.transaction.TransactionUtil2.inTransaction(TransactionUtil2.java:41)
	at org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase.inTransaction(BaseNonConfigCoreFunctionalTestCase.java:560)
	at org.hibernate.test.procedure.StoredProcedureParameterTypeTest.testStringTypeInParameterIsNull(StoredProcedureParameterTypeTest.java:366)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.hibernate.testing.junit4.ExtendedFrameworkMethod.invokeExplosively(ExtendedFrameworkMethod.java:45)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:745)
```