### PR TITLE
Fix Javadocs comments for Query.getHibernateMaxResults() method

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/Query.java
@@ -135,7 +135,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * @see #setMaxResults(int) (int)
 	 * @see #setHibernateMaxResults(int) (int)
 	 *
-	 * @deprecated {@link #setMaxResults(int)} should be used instead.
+	 * @deprecated {@link #getMaxResults(int)} should be used instead.
 	 */
 	@Deprecated
 	default Integer getHibernateMaxResults() {


### PR DESCRIPTION
The generated Javadocs for Query.getHibernateMaxResults [1] suggests a setter method to replace a getter method. 

[1] http://docs.jboss.org/hibernate/orm/5.3/javadocs/org/hibernate/Query.html#getHibernateMaxResults--