### PR TITLE
HHH-12920 Fix a debug message causing an exception at debug level

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractCachedDomainDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractCachedDomainDataAccess.java
@@ -38,9 +38,8 @@ public abstract class AbstractCachedDomainDataAccess implements CachedDomainData
 		return storageAccess;
 	}
 
-	@SuppressWarnings({"unchecked", "WeakerAccess"})
 	protected void clearCache() {
-		log.debugf( "Clearing cache data map [region=`%s`]" );
+		log.debugf( "Clearing cache data map [region=`%s`]", region.getName() );
 		getStorageAccess().evictData();
 	}
 


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HHH-12920

@gbadner even, if it could be considered minor, I think we should backport that one to 5.3 as it could cause exceptions when someone is trying to debug an issue with the cache. WDYT?