### PR TITLE
HHH-12935 : Constraint and AuxiliaryDatabaseObject export identifiers are not qualified by schema or catalog

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/NamedAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/NamedAuxiliaryDatabaseObject.java
@@ -8,6 +8,8 @@ package org.hibernate.boot.model.relational;
 
 import java.util.Set;
 
+import org.hibernate.boot.model.naming.Identifier;
+
 /**
  * Mainly this is used to support legacy sequence exporting.
  *
@@ -42,6 +44,10 @@ public class NamedAuxiliaryDatabaseObject
 
 	@Override
 	public String getExportIdentifier() {
-		return name;
+		return new QualifiedNameImpl(
+				Identifier.toIdentifier( getCatalogName() ),
+				Identifier.toIdentifier( getSchemaName() ),
+				Identifier.toIdentifier( name )
+		).render();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
@@ -93,6 +93,14 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 		return copy;
 	}
 
+	protected String getCatalogName() {
+		return catalogName;
+	}
+
+	protected String getSchemaName() {
+		return schemaName;
+	}
+
 	private String injectCatalogAndSchema(String ddlString) {
 		String rtn = StringHelper.replace( ddlString, CATALOG_NAME_PLACEHOLDER, catalogName == null ? "" : catalogName );
 		rtn = StringHelper.replace( rtn, SCHEMA_NAME_PLACEHOLDER, schemaName == null ? "" : schemaName );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -33,7 +33,7 @@ public class ForeignKey extends Constraint {
 	@Override
 	public String getExportIdentifier() {
 		// NOt sure name is always set.  Might need some implicit naming
-		return StringHelper.qualify( getTable().getName(), "FK-" + getName() );
+		return StringHelper.qualify( getTable().getExportIdentifier(), "FK-" + getName() );
 	}
 
 	public void disableCreation() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
@@ -238,6 +238,6 @@ public class Index implements RelationalModel, Exportable, Serializable {
 
 	@Override
 	public String getExportIdentifier() {
-		return StringHelper.qualify( getTable().getName(), "IDX-" + getName() );
+		return StringHelper.qualify( getTable().getExportIdentifier(), "IDX-" + getName() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
@@ -89,6 +89,6 @@ public class PrimaryKey extends Constraint {
 
 	@Override
 	public String getExportIdentifier() {
-		return StringHelper.qualify( getTable().getName(), "PK-" + getName() );
+		return StringHelper.qualify( getTable().getExportIdentifier(), "PK-" + getName() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
@@ -72,6 +72,6 @@ public class UniqueKey extends Constraint {
 
 	@Override
 	public String getExportIdentifier() {
-		return StringHelper.qualify( getTable().getName(), "UK-" + getName() );
+		return StringHelper.qualify( getTable().getExportIdentifier(), "UK-" + getName() );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/ExportIdentifierTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/ExportIdentifierTest.java
@@ -1,0 +1,175 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.schemaupdate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.Exportable;
+import org.hibernate.boot.model.relational.NamedAuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SimpleAuxiliaryDatabaseObject;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Index;
+import org.hibernate.mapping.PrimaryKey;
+import org.hibernate.mapping.Table;
+import org.hibernate.mapping.UniqueKey;
+
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExportIdentifierTest {
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12935" )
+	public void testUniqueExportableIdentifier() {
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder().build();
+		final MetadataBuildingOptions options = new MetadataBuilderImpl.MetadataBuildingOptionsImpl( ssr );
+		final Database database = new Database( options );
+
+		database.locateNamespace( null, null );
+		database.locateNamespace( Identifier.toIdentifier( "catalog1" ), null );
+		database.locateNamespace( Identifier.toIdentifier( "catalog2" ), null );
+		database.locateNamespace( null, Identifier.toIdentifier( "schema1" ) );
+		database.locateNamespace( null, Identifier.toIdentifier( "schema2" ) );
+		database.locateNamespace(
+				Identifier.toIdentifier( "catalog_both_1" ),
+				Identifier.toIdentifier( "schema_both_1" )
+		);
+		database.locateNamespace(
+				Identifier.toIdentifier( "catalog_both_2" ),
+				Identifier.toIdentifier( "schema_both_2" )
+		);
+
+		final List<String> exportIdentifierList = new ArrayList<>();
+		final Set<String> exportIdentifierSet = new HashSet<>();
+
+		try {
+			addTables( "aTable" , database.getNamespaces(), exportIdentifierList, exportIdentifierSet );
+			addSimpleAuxiliaryDatabaseObject( database.getNamespaces(), exportIdentifierList, exportIdentifierSet );
+			addNamedAuxiliaryDatabaseObjects(
+					"aNamedAuxiliaryDatabaseObject", database.getNamespaces(), exportIdentifierList, exportIdentifierSet
+			);
+			addSequences( "aSequence", database.getNamespaces(), exportIdentifierList, exportIdentifierSet );
+
+			assertEquals( exportIdentifierList.size(), exportIdentifierSet.size() );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+	private void addTables(
+			String name,
+			Iterable<Namespace> namespaces,
+			List<String> exportIdentifierList,
+			Set<String> exportIdentifierSet) {
+		for ( Namespace namespace : namespaces ) {
+
+			final Table table = new Table( namespace, Identifier.toIdentifier( name ), false );
+			addExportIdentifier( table, exportIdentifierList, exportIdentifierSet );
+
+			final ForeignKey foreignKey = new ForeignKey();
+			foreignKey.setName( name );
+			foreignKey.setTable( table );
+			addExportIdentifier( foreignKey, exportIdentifierList, exportIdentifierSet );
+
+			final Index index = new Index();
+			index.setName( name );
+			index.setTable( table );
+			addExportIdentifier( index, exportIdentifierList, exportIdentifierSet );
+
+			final PrimaryKey primaryKey = new PrimaryKey( table );
+			primaryKey.setName( name );
+			addExportIdentifier( primaryKey, exportIdentifierList, exportIdentifierSet );
+
+			final UniqueKey uniqueKey = new UniqueKey();
+			uniqueKey.setName( name );
+			uniqueKey.setTable( table );
+			addExportIdentifier( uniqueKey, exportIdentifierList, exportIdentifierSet );
+		}
+	}
+
+	private void addSequences(
+			String name,
+			Iterable<Namespace> namespaces,
+			List<String> exportIdentifierList,
+			Set<String> exportIdentifierSet) {
+
+		for ( Namespace namespace : namespaces ) {
+			addExportIdentifier(
+					new Sequence(
+							namespace.getName().getCatalog(),
+							namespace.getName().getSchema(),
+							Identifier.toIdentifier( name )
+					),
+					exportIdentifierList,
+					exportIdentifierSet
+			);
+		}
+	}
+
+	private void addSimpleAuxiliaryDatabaseObject(
+			Iterable<Namespace> namespaces,
+			List<String> exportIdentifierList,
+			Set<String> exportIdentifierSet) {
+		for ( Namespace namespace : namespaces ) {
+			addExportIdentifier(
+					new SimpleAuxiliaryDatabaseObject(
+							namespace,
+							"create",
+							"drop",
+							Collections.<String>emptySet()
+					),
+					exportIdentifierList,
+					exportIdentifierSet
+			);
+		}
+	}
+
+	private void addNamedAuxiliaryDatabaseObjects(
+			String name,
+			Iterable<Namespace> namespaces,
+			List<String> exportIdentifierList,
+			Set<String> exportIdentifierSet) {
+		for ( Namespace namespace : namespaces ) {
+			addExportIdentifier(
+					new NamedAuxiliaryDatabaseObject(
+							name,
+							namespace,
+							"create",
+							"drop",
+							Collections.<String>emptySet()
+					),
+					exportIdentifierList,
+					exportIdentifierSet
+			);
+		}
+	}
+
+	private void addExportIdentifier(
+			Exportable exportable,
+			List<String> exportIdentifierList,
+			Set<String> exportIdentifierSet) {
+		exportIdentifierList.add( exportable.getExportIdentifier() );
+		exportIdentifierSet.add( exportable.getExportIdentifier() );
+		assertEquals( exportIdentifierList.size(), exportIdentifierSet.size() );
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/various/ExportIdentifierTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/various/ExportIdentifierTest.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.various;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.boot.internal.MetadataBuilderImpl;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.QualifiedNameImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.id.enhanced.SequenceStructure;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExportIdentifierTest {
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12935" )
+	public void testUniqueExportableIdentifier() {
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder().build();
+		final MetadataBuildingOptions options = new MetadataBuilderImpl.MetadataBuildingOptionsImpl( ssr );
+		final Database database = new Database( options );
+
+		database.locateNamespace( null, null );
+		database.locateNamespace( Identifier.toIdentifier( "catalog1" ), null );
+		database.locateNamespace( Identifier.toIdentifier( "catalog2" ), null );
+		database.locateNamespace( null, Identifier.toIdentifier( "schema1" ) );
+		database.locateNamespace( null, Identifier.toIdentifier( "schema2" ) );
+		database.locateNamespace( Identifier.toIdentifier( "catalog_both_1" ), Identifier.toIdentifier( "schema_both_1" ) );
+		database.locateNamespace( Identifier.toIdentifier( "catalog_both_2" ), Identifier.toIdentifier( "schema_both_2" ) );
+
+		try {
+			final Set<String> exportIdentifierSet = new HashSet<>();
+			int namespaceSize = 0;
+			for ( Namespace namespace : database.getNamespaces() ) {
+				final SequenceStructure sequenceStructure = new SequenceStructure(
+						ssr.getService( JdbcEnvironment.class ),
+						new QualifiedNameImpl(
+								namespace.getName(),
+								Identifier.toIdentifier( "aSequence" )
+						),
+						1,
+						1,
+						Integer.class
+				);
+				sequenceStructure.registerExportables( database );
+				exportIdentifierSet.add( namespace.getSequences().iterator().next().getExportIdentifier() );
+				namespaceSize++;
+			}
+			assertEquals( 7, namespaceSize );
+			assertEquals( 7, exportIdentifierSet.size() );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12935