### PR TITLE
HHH-12964 Upgrade to dom4j 2.1.1

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -52,7 +52,7 @@ ext {
             woodstox:           "org.codehaus.woodstox:woodstox-core-asl:4.3.0",
 
             // Dom4J
-            dom4j:          'dom4j:dom4j:1.6.1@jar',
+            dom4j:          'org.dom4j:dom4j:2.1.1@jar',
 
             // Javassist
             javassist:      "org.javassist:javassist:${javassistVersion}",


### PR DESCRIPTION
Upgrade dom4j to version 2.1.1.

Unfortunately there is no upgrade bundle for osgi.

HHH-12964