### PR TITLE
Add test for cascade entities removal in context

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
@@ -35,23 +35,16 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
   @Test
   public void testCascadeContextCleanup() {
 
+    // create test data: Table1 -> Column -> Relation -> Table2
+    createTablesData();
+
     final EntityManager entityManager = getOrCreateEntityManager();
 
-    // create test data: Table1 -> Column -> Relation -> Table2
-    createTablesData( entityManager );
-
-    // remove table 1
-    // expected to remove Table, Column and Relation
-    // and it does remove them from DB, but they stay in Persistence Context
     entityManager.getTransaction().begin();
     final TableEntity table = entityManager.find( TableEntity.class, "1" );
     assertEquals(1, table.getColumns().size());
     entityManager.remove( table );
-    entityManager.getTransaction().commit();
 
-    // remove table 2
-    // throws org.hibernate.TransientPropertyValueException
-    entityManager.getTransaction().begin();
     final TableEntity table2 = entityManager.find( TableEntity.class, "2" );
     entityManager.remove( table2 );
     entityManager.getTransaction().commit();
@@ -59,8 +52,9 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     entityManager.close();
   }
 
-  private void createTablesData( EntityManager entityManager ) {
+  private void createTablesData() {
 
+    final EntityManager entityManager = getOrCreateEntityManager();
     entityManager.getTransaction().begin();
 
     final TableEntity parentTable = new TableEntity();
@@ -85,6 +79,7 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     entityManager.persist( relation );
 
     entityManager.getTransaction().commit();
+    entityManager.close();
   }
 
   @Entity

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
@@ -1,0 +1,211 @@
+package org.hibernate.jpa.test.cascade;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.junit.Test;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCase {
+
+  @Override
+  protected Class<?>[] getAnnotatedClasses() {
+    return new Class<?>[] {
+            TableEntity.class,
+            ColumnEntity.class,
+            RelationEntity.class
+    };
+  }
+
+  @Test
+  public void testCascadeContextCleanup() {
+
+    final EntityManager entityManager = getOrCreateEntityManager();
+
+    // create test data: Table1 -> Column -> Relation -> Table2
+    createTablesData( entityManager );
+
+    // remove table 1
+    // expected to remove Table, Column and Relation
+    // and it does remove them from DB, but they stay in Persistence Context
+    entityManager.getTransaction().begin();
+    final TableEntity table = entityManager.find( TableEntity.class, "1" );
+    entityManager.remove( table );
+    entityManager.getTransaction().commit();
+
+    // remove table 2
+    // throws org.hibernate.TransientPropertyValueException
+    entityManager.getTransaction().begin();
+    final TableEntity table2 = entityManager.find( TableEntity.class, "2" );
+    entityManager.remove( table2 );
+    entityManager.getTransaction().commit();
+
+    entityManager.close();
+  }
+
+  private void createTablesData( EntityManager entityManager ) {
+
+    entityManager.getTransaction().begin();
+
+    final TableEntity parentTable = new TableEntity();
+    parentTable.setId( "1" );
+    entityManager.persist( parentTable );
+
+    final TableEntity childTable = new TableEntity();
+    childTable.setId( "2" );
+    entityManager.persist( childTable );
+
+    final ColumnEntity column = new ColumnEntity();
+    column.setId( "1" );
+    column.setTable( parentTable );
+    entityManager.persist( column );
+
+    final RelationEntity relation = new RelationEntity();
+    relation.setForeignTable( parentTable );
+    relation.setColumn( column );
+    entityManager.persist( relation );
+
+    entityManager.getTransaction().commit();
+  }
+
+  @Entity
+  public static class TableEntity {
+
+    private String id;
+    private Collection<ColumnEntity> columns = new ArrayList<>();
+    private Collection<RelationEntity> relationsToThisTable = new ArrayList<>();
+
+    @Id
+    public String getId() {
+      return id;
+    }
+
+    public void setId( String id ) {
+      this.id = id;
+    }
+
+    @OneToMany( mappedBy = "table", cascade = CascadeType.ALL, orphanRemoval = true )
+    @OnDelete( action = OnDeleteAction.CASCADE )
+    public Collection<ColumnEntity> getColumns() {
+      return columns;
+    }
+
+    public void setColumns( Collection<ColumnEntity> columns ) {
+      this.columns = columns;
+    }
+
+    @OneToMany( mappedBy = "foreignTable", cascade = CascadeType.ALL, orphanRemoval = true )
+    @OnDelete( action = OnDeleteAction.CASCADE )
+    public Collection<RelationEntity> getRelationsToThisTable() {
+      return relationsToThisTable;
+    }
+
+    public void setRelationsToThisTable( Collection<RelationEntity> relationsToThisTable ) {
+      this.relationsToThisTable = relationsToThisTable;
+    }
+  }
+
+  @Entity
+  public static class ColumnEntity {
+
+    private String id;
+    private String tableId;
+
+    private TableEntity table;
+
+    @Id
+    public String getId()
+    {
+      return id;
+    }
+
+    public void setId( String id ) {
+      this.id = id;
+    }
+
+    @Column( name = "tableId", insertable = false, updatable = false )
+    public String getTableId() {
+      return tableId;
+    }
+
+    private void setTableId( String tableId ) {
+      this.tableId = tableId;
+    }
+
+    @ManyToOne( fetch = FetchType.LAZY )
+    @JoinColumn( name = "tableId" )
+    public TableEntity getTable() {
+      return table;
+    }
+
+    public void setTable( TableEntity table ) {
+      this.setTableId( table.getId() );
+      this.table = table;
+    }
+  }
+
+  @Entity
+  public static class RelationEntity {
+
+    private String foreignTableId;
+    private String columnId;
+
+    private TableEntity foreignTable;
+    private ColumnEntity column;
+
+    @Id
+    public String getColumnId() {
+      return columnId;
+    }
+
+    private void setColumnId( String columnId ) {
+      this.columnId = columnId;
+    }
+
+    @Column( name = "foreignTableId", nullable = false, insertable = false, updatable = false )
+    public String getForeignTableId() {
+      return foreignTableId;
+    }
+
+    private void setForeignTableId( String foreignTableId ) {
+      this.foreignTableId = foreignTableId;
+    }
+
+    @ManyToOne
+    @JoinColumn( name = "foreignTableId", referencedColumnName = "id", nullable = false )
+    public TableEntity getForeignTable() {
+      return foreignTable;
+    }
+
+    public void setForeignTable( TableEntity foreignTable ) {
+      this.setForeignTableId( foreignTable.getId() );
+      this.foreignTable = foreignTable;
+    }
+
+    @OneToOne( fetch = FetchType.LAZY )
+    @MapsId
+    @JoinColumn( name = "columnId" )
+    @OnDelete( action = OnDeleteAction.CASCADE )
+    public ColumnEntity getColumn() {
+      return column;
+    }
+
+    public void setColumn( ColumnEntity column ) {
+      this.setColumnId( column.getId() );
+      this.column = column;
+    }
+  }
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
@@ -78,8 +78,8 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     entityManager.persist( column );
 
     final RelationEntity relation = new RelationEntity();
-    relation.setForeignTable( parentTable );
-    parentTable.getRelationsToThisTable().add( relation );
+    relation.setForeignTable( childTable );
+    childTable.getRelationsToThisTable().add( relation );
     relation.setColumn( column );
     column.setRelationEntity( relation );
     entityManager.persist( relation );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/cascade/CascadeContextCleanupTest.java
@@ -104,7 +104,7 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     }
 
     @OneToMany( mappedBy = "table", cascade = CascadeType.ALL, orphanRemoval = true )
-    //@OnDelete( action = OnDeleteAction.CASCADE )
+    @OnDelete( action = OnDeleteAction.CASCADE )
     public Collection<ColumnEntity> getColumns() {
       return columns;
     }
@@ -114,7 +114,7 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     }
 
     @OneToMany( mappedBy = "foreignTable", cascade = CascadeType.ALL, orphanRemoval = true )
-    //@OnDelete( action = OnDeleteAction.CASCADE )
+    @OnDelete( action = OnDeleteAction.CASCADE )
     public Collection<RelationEntity> getRelationsToThisTable() {
       return relationsToThisTable;
     }
@@ -214,7 +214,7 @@ public class CascadeContextCleanupTest extends BaseEntityManagerFunctionalTestCa
     @OneToOne( fetch = FetchType.LAZY )
     @MapsId
     @JoinColumn( name = "columnId" )
-    //@OnDelete( action = OnDeleteAction.CASCADE )
+    @OnDelete( action = OnDeleteAction.CASCADE )
     public ColumnEntity getColumn() {
       return column;
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/hibernate/hibernate-orm/pull/2520. The patch from @vladmihalcea helped with that case, but then I found that the test data was being created not as expected. Fixed it with commit https://github.com/hibernate/hibernate-orm/commit/c441fa24627732b6a7cc5fe180e3ac3f4a5dd6d4. 

Also, had to uncomment the `@OnDelete` annotations, because otherwise the database constraint (which by default is `ON DELETE RESTRICT`) prevented removing the table by throwing an SQL exception about foreign key constraint failure.

P.S. I didn't really want to create a new MR for the same problem, but the original one did not pull the new commits. Please guide me if I'm missing how to merely update the previous MR.