### PR TITLE
Added private empty constructor to Country in Testcase 

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PrivateConstructorEnhancerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PrivateConstructorEnhancerTest.java
@@ -173,6 +173,8 @@ public class PrivateConstructorEnhancerTest extends BaseNonConfigCoreFunctionalT
 		@Basic(fetch = FetchType.LAZY)
 		private String name;
 
+		private Country() {}
+
 		private Country(String name) {
 			this.name = name;
 		}


### PR DESCRIPTION
Testing error message in case of lazily instantiating a class with private constructor. See https://discourse.hibernate.org/t/bytecode-enhancement-failed-nosuchmethodexception-when-lazy-fetching-a-member/1358/10.