### PR TITLE
Fix Constructor Not Found with Lombok's @Value + JPA Projections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -315,7 +315,7 @@ public final class ReflectHelper {
 	 * @throws PropertyNotFoundException Indicates we could not locate an appropriate constructor (todo : again with PropertyNotFoundException???)
 	 */
 	public static Constructor getConstructor(Class clazz, Type[] types) throws PropertyNotFoundException {
-		final Constructor[] candidates = clazz.getConstructors();
+		final Constructor[] candidates = clazz.getDeclaredConstructors();
 		Constructor constructor = null;
 		int numberOfMatchingConstructors = 0;
 		for ( final Constructor candidate : candidates ) {


### PR DESCRIPTION
**Fix Constructor Not Found with Lombok's @Value when used with projections and Spring Data JPA**
Couldn't find bug-reporting, so suggesting this fix for the problem. 
Right now created all args constructor manually to avoid this issue.