### PR TITLE
HHH-11771 - @Id annotation ignored with @MappedSuperclass inheritance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1510,6 +1510,18 @@ public final class AnnotationBinder {
 		// and if so, skip it..
 		for ( PropertyData propertyData : inFlightPropertyDataList ) {
 			if ( propertyData.getPropertyName().equals( property.getName() ) ) {
+				Id incomingIdProperty = property.getAnnotation( Id.class );
+				Id existingIdProperty = propertyData.getProperty().getAnnotation( Id.class );
+				if ( incomingIdProperty != null && existingIdProperty == null ) {
+					throw new MappingException(
+							String.format(
+									"You cannot override the [%s] non-identifier property from the [%s] base class or @MappedSuperclass and make it an identifier in the [%s] subclass!",
+									propertyData.getProperty().getName(),
+									propertyData.getProperty().getDeclaringClass().getName(),
+									property.getDeclaringClass().getName()
+							)
+					);
+				}
 				// EARLY EXIT!!!
 				return 0;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassBasicPropertyIdAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassBasicPropertyIdAttributeOverrideTest.java
@@ -1,0 +1,60 @@
+package org.hibernate.test.annotations.override.mappedsuperclass;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Stanislav Gubanov
+ */
+@TestForIssue(jiraKey = "HHH-11771")
+public class MappedSuperClassBasicPropertyIdAttributeOverrideTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Test
+	public void test() {
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				BaseMappedSuperClass.class,
+				ExtendBase.class
+		};
+	}
+
+	@MappedSuperclass
+	@Access(AccessType.FIELD)
+	public static class BaseMappedSuperClass {
+
+		@Id
+		Long uid;
+
+		public Long getUid() {
+			return uid;
+		}
+
+		public void setUid(Long uid) {
+			this.uid = uid;
+		}
+	}
+
+	@Entity
+	public static class ExtendBase extends BaseMappedSuperClass {
+
+		@Access(AccessType.PROPERTY)
+		@Override
+		@AttributeOverride(name = "uid", column = @Column(name = "id_extend_table", insertable = false, updatable = false))
+		public Long getUid() {
+			return super.getUid();
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassIdPropertyBasicAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassIdPropertyBasicAttributeOverrideTest.java
@@ -1,0 +1,44 @@
+package org.hibernate.test.annotations.override.mappedsuperclass;
+
+import org.hibernate.MappingException;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Stanislav Gubanov
+ */
+@TestForIssue(jiraKey = "HHH-11771")
+public class MappedSuperClassIdPropertyBasicAttributeOverrideTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				MappedSuperClassWithUuidAsBasic.class,
+				SubclassWithUuidAsId.class
+		};
+	}
+
+	@Override
+	protected void buildResources() {
+		try {
+			super.buildResources();
+			fail( "Should throw exception!" );
+		}
+		catch (MappingException expected) {
+			assertEquals(
+					"You cannot override the [uid] non-identifier property from the [org.hibernate.test.annotations.override.mappedsuperclass.MappedSuperClassWithUuidAsBasic] base class or @MappedSuperclass and make it an identifier in the [org.hibernate.test.annotations.override.mappedsuperclass.SubclassWithUuidAsId] subclass!",
+					expected.getMessage()
+			);
+		}
+	}
+
+	@Test
+	public void test() {
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassWithUuidAsBasic.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/MappedSuperClassWithUuidAsBasic.java
@@ -1,0 +1,23 @@
+package org.hibernate.test.annotations.override.mappedsuperclass;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * @author Vlad Mihalcea
+ */
+@MappedSuperclass
+@Access(AccessType.FIELD)
+public class MappedSuperClassWithUuidAsBasic {
+
+	Long uid;
+
+	public Long getUid() {
+		return uid;
+	}
+
+	public void setUid(Long uid) {
+		this.uid = uid;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/SubclassWithUuidAsId.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/mappedsuperclass/SubclassWithUuidAsId.java
@@ -1,0 +1,23 @@
+package org.hibernate.test.annotations.override.mappedsuperclass;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * @author Vlad Mihalcea
+ */
+@Entity
+@AttributeOverride(name = "uid", column = @Column(name = "id_extend_table", insertable = false, updatable = false))
+public class SubclassWithUuidAsId extends MappedSuperClassWithUuidAsBasic {
+
+	@Id
+	@Access(AccessType.PROPERTY)
+	@Override
+	public Long getUid() {
+		return super.getUid();
+	}
+}


### PR DESCRIPTION
Based on [this PR](https://github.com/hibernate/hibernate-orm/pull/2513), I think we should just throw an exception since the standard does not say we should override a basic property from a base class and promote it as an `@Id`.