### PR TITLE
HHH-12968 - Flush is not flushing inserts for inherited tables before a select within a transaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
@@ -32,4 +32,9 @@ public abstract class AbstractPostInsertGenerator
 	public String determineBulkInsertionIdentifierGenerationSelectFragment(Dialect dialect) {
 		return null;
 	}
+
+	@Override
+	public boolean supportsJdbcBatchInserts() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
@@ -7,7 +7,6 @@
 package org.hibernate.id;
 
 import java.io.Serializable;
-
 import javax.persistence.GeneratedValue;
 
 import org.hibernate.HibernateException;
@@ -60,4 +59,13 @@ public interface IdentifierGenerator {
 	 * @throws HibernateException Indicates trouble generating the identifier
 	 */
 	Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException;
+
+	/**
+	 * Check if JDBC batch inserts are supported.
+	 *
+	 * @return JDBC batch inserts are supported.
+	 */
+	default boolean supportsJdbcBatchInserts() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -77,7 +77,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.ValueInclusion;
 import org.hibernate.id.IdentifierGenerator;
-import org.hibernate.id.IdentityGenerator;
 import org.hibernate.id.PostInsertIdentifierGenerator;
 import org.hibernate.id.PostInsertIdentityPersister;
 import org.hibernate.id.insert.Binder;
@@ -3128,7 +3127,9 @@ public abstract class AbstractEntityPersister
 		// TODO : shouldn't inserts be Expectations.NONE?
 		final Expectation expectation = Expectations.appropriateExpectation( insertResultCheckStyles[j] );
 		final int jdbcBatchSizeToUse = session.getConfiguredJdbcBatchSize();
-		final boolean useBatch = expectation.canBeBatched() && jdbcBatchSizeToUse > 1 && !( getIdentifierGenerator() instanceof IdentityGenerator );
+		final boolean useBatch = expectation.canBeBatched() &&
+						jdbcBatchSizeToUse > 1 &&
+						getIdentifierGenerator().supportsJdbcBatchInserts();
 
 		if ( useBatch && inserBatchKey == null ) {
 			inserBatchKey = new BasicBatchKey(


### PR DESCRIPTION
Extract IdentityGenerator batch support validation logic