### PR TITLE
 HHH-12842 - Fix lazy loading of ID OneToOne relations that are non-optional / constrained

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToOne.java
@@ -71,7 +71,8 @@ public class OneToOne extends ToOne {
 					isLazy(),
 					isUnwrapProxy(),
 					entityName,
-					propertyName
+					propertyName,
+					constrained
 			);
 		}
 		else {
@@ -83,7 +84,8 @@ public class OneToOne extends ToOne {
 					isLazy(),
 					isUnwrapProxy(),
 					entityName,
-					propertyName
+					propertyName,
+					constrained
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -386,7 +386,7 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 			}
 		}
 
-		if ( (! etype.isNullable() || etype.isReferenceToPrimaryKey() ) && idPropName != null ) {
+		if ( (! etype.isNullable() ) && idPropName != null ) {
 			String idpath2 = extendPath( path, idPropName );
 			addPropertyPath( idpath2, idtype, columns, columnReaders, columnReaderTemplates, null, factory );
 			initPropertyPaths( idpath2, idtype, columns, columnReaders, columnReaderTemplates, null, factory );

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -29,9 +29,10 @@ public class OneToOneType extends EntityType {
 	private final ForeignKeyDirection foreignKeyType;
 	private final String propertyName;
 	private final String entityName;
+	private final boolean constrained;
 
 	/**
-	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String)}
+	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
 	 *  instead.
 	 */
 	@Deprecated
@@ -47,6 +48,11 @@ public class OneToOneType extends EntityType {
 		this( scope, referencedEntityName, foreignKeyType, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName );
 	}
 
+	/**
+	 * @deprecated Use {@link #OneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
+	 *  instead.
+	 */
+	@Deprecated
 	public OneToOneType(
 			TypeFactory.TypeScope scope,
 			String referencedEntityName,
@@ -57,10 +63,25 @@ public class OneToOneType extends EntityType {
 			boolean unwrapProxy,
 			String entityName,
 			String propertyName) {
+		this( scope, referencedEntityName, foreignKeyType, referenceToPrimaryKey, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName, foreignKeyType != ForeignKeyDirection.TO_PARENT );
+	}
+
+	public OneToOneType(
+			TypeFactory.TypeScope scope,
+			String referencedEntityName,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			String entityName,
+			String propertyName,
+			boolean constrained) {
 		super( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, !lazy, unwrapProxy );
 		this.foreignKeyType = foreignKeyType;
 		this.propertyName = propertyName;
 		this.entityName = entityName;
+		this.constrained = constrained;
 	}
 
 	public OneToOneType(OneToOneType original, String superTypeEntityName) {
@@ -68,6 +89,7 @@ public class OneToOneType extends EntityType {
 		this.foreignKeyType = original.foreignKeyType;
 		this.propertyName = original.propertyName;
 		this.entityName = original.entityName;
+		this.constrained = original.constrained;
 	}
 
 	@Override
@@ -156,7 +178,7 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	public boolean isNullable() {
-		return foreignKeyType==ForeignKeyDirection.TO_PARENT;
+		return !constrained;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/SpecialOneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SpecialOneToOneType.java
@@ -25,9 +25,10 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  * @author Gavin King
  */
 public class SpecialOneToOneType extends OneToOneType {
-	
+
 	/**
-	 * @deprecated Use {@link #SpecialOneToOneType(org.hibernate.type.TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String)} instead.
+	 * @deprecated Use {@link SpecialOneToOneType#SpecialOneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
+	 *  instead.
 	 */
 	@Deprecated
 	public SpecialOneToOneType(
@@ -41,7 +42,36 @@ public class SpecialOneToOneType extends OneToOneType {
 			String propertyName) {
 		this( scope, referencedEntityName, foreignKeyType, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName );
 	}
-	
+
+	/**
+	 * @deprecated Use {@link SpecialOneToOneType#SpecialOneToOneType(TypeFactory.TypeScope, String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
+	 *  instead.
+	 */
+	@Deprecated
+	public SpecialOneToOneType(
+			TypeFactory.TypeScope scope,
+			String referencedEntityName,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			String entityName,
+			String propertyName) {
+		this (
+				scope,
+				referencedEntityName,
+				foreignKeyType,
+				referenceToPrimaryKey,
+				uniqueKeyPropertyName,
+				lazy,
+				unwrapProxy,
+				entityName,
+				propertyName,
+				foreignKeyType != ForeignKeyDirection.TO_PARENT
+		);
+	}
+
 	public SpecialOneToOneType(
 			TypeFactory.TypeScope scope,
 			String referencedEntityName,
@@ -51,7 +81,8 @@ public class SpecialOneToOneType extends OneToOneType {
 			boolean lazy,
 			boolean unwrapProxy,
 			String entityName,
-			String propertyName) {
+			String propertyName,
+			boolean constrained) {
 		super(
 				scope,
 				referencedEntityName, 
@@ -61,7 +92,8 @@ public class SpecialOneToOneType extends OneToOneType {
 				lazy,
 				unwrapProxy,
 				entityName, 
-				propertyName
+				propertyName,
+				constrained
 			);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -200,6 +200,11 @@ public final class TypeFactory implements Serializable {
 
 	// one-to-one type builders ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+	/**
+	 * @deprecated Use {@link TypeFactory#oneToOne(String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
+	 *  instead.
+	 */
+	@Deprecated
 	public EntityType oneToOne(
 			String persistentClass,
 			ForeignKeyDirection foreignKeyType,
@@ -209,9 +214,39 @@ public final class TypeFactory implements Serializable {
 			boolean unwrapProxy,
 			String entityName,
 			String propertyName) {
+		return oneToOne( persistentClass, foreignKeyType, referenceToPrimaryKey, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName, foreignKeyType != ForeignKeyDirection.TO_PARENT );
+	}
+
+	/**
+	 * @deprecated Use {@link TypeFactory#specialOneToOne(String, ForeignKeyDirection, boolean, String, boolean, boolean, String, String, boolean)}
+	 *  instead.
+	 */
+	@Deprecated
+	public EntityType specialOneToOne(
+			String persistentClass,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			String entityName,
+			String propertyName) {
+		return specialOneToOne( persistentClass, foreignKeyType, referenceToPrimaryKey, uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName, foreignKeyType != ForeignKeyDirection.TO_PARENT );
+	}
+
+	public EntityType oneToOne(
+			String persistentClass,
+			ForeignKeyDirection foreignKeyType,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			boolean lazy,
+			boolean unwrapProxy,
+			String entityName,
+			String propertyName,
+			boolean constrained) {
 		return new OneToOneType(
 				typeScope, persistentClass, foreignKeyType, referenceToPrimaryKey,
-				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName
+				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName, constrained
 		);
 	}
 
@@ -223,10 +258,12 @@ public final class TypeFactory implements Serializable {
 			boolean lazy,
 			boolean unwrapProxy,
 			String entityName,
-			String propertyName) {
+			String propertyName,
+			boolean constrained) {
 		return new SpecialOneToOneType(
 				typeScope, persistentClass, foreignKeyType, referenceToPrimaryKey,
-				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName
+				uniqueKeyPropertyName, lazy, unwrapProxy, entityName, propertyName,
+				constrained
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/lazy/LazyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/lazy/LazyToOneTest.java
@@ -1,0 +1,164 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.onetoone.lazy;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.Table;
+import java.util.Date;
+
+import static org.hibernate.Hibernate.isInitialized;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertFalse;
+
+@TestForIssue(jiraKey = "HHH-12842")
+public class LazyToOneTest extends BaseCoreFunctionalTestCase {
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { Post.class, PostDetails.class};
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        doInHibernate( this::sessionFactory, s -> {
+            Post post = new Post();
+            post.setDetails(new PostDetails());
+            post.getDetails().setCreatedBy("ME");
+            post.getDetails().setCreatedOn(new Date());
+            post.setTitle("title");
+            s.persist(post);
+        } );
+    }
+
+    @Test
+    public void testOneToOneLazyLoading() {
+        doInHibernate( this::sessionFactory, s -> {
+            PostDetails post = (PostDetails) s.createQuery("select a from PostDetails a").getResultList().get(0);
+            assertFalse(isInitialized(post.post));
+        } );
+    }
+
+    @Entity(name = "PostDetails")
+    @Table(name = "post_details")
+    public static class PostDetails {
+
+        @Id
+        private Long id;
+
+        @Column(name = "created_on")
+        private Date createdOn;
+
+        @Column(name = "created_by")
+        private String createdBy;
+
+        @MapsId
+        @OneToOne(fetch = FetchType.LAZY, mappedBy = "details", optional = false)
+        private Post post;
+
+        public PostDetails() {}
+
+        public PostDetails(String createdBy) {
+            createdOn = new Date();
+            this.createdBy = createdBy;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Date getCreatedOn() {
+            return createdOn;
+        }
+
+        public void setCreatedOn(Date createdOn) {
+            this.createdOn = createdOn;
+        }
+
+        public String getCreatedBy() {
+            return createdBy;
+        }
+
+        public void setCreatedBy(String createdBy) {
+            this.createdBy = createdBy;
+        }
+
+        public Post getPost() {
+            return post;
+        }
+
+        public void setPost(Post post) {
+            this.post = post;
+        }
+
+    }
+
+    @Entity(name = "Post")
+    @Table(name = "post")
+    public static class Post {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String title;
+
+        @PrimaryKeyJoinColumn
+        @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+        private PostDetails details;
+
+
+        public void setDetails(PostDetails details) {
+            if (details == null) {
+                if (this.details != null) {
+                    this.details.setPost(null);
+                }
+            }
+            else {
+                details.setPost(this);
+            }
+            this.details = details;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public PostDetails getDetails() {
+            return details;
+        }
+    }
+
+}


### PR DESCRIPTION
Fix lazy loading of inverse OneToOne relations that are non-optional / constrained, by passing the OneToOne constrained value to determine nullability of type as it was prior to Hibernate 5.2.13.

Fixes [HHH-12842](https://hibernate.atlassian.net/browse/HHH-12842) and the test case that I had already provided in PR #2474 .

Partially applies PR #2226 that @vladmihalcea provided for [HHH-12436](https://hibernate.atlassian.net/browse/HHH-12436), but leaves out the changes related to the determination of the ForeignKeyDirection of the OneToOne association (the fix for HHH-12436), which caused some issues that @gbadner is still addressing.