### PR TITLE
HHH-13007 No longer use net.bytebuddy.experimental=true when testing …

### DIFF
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -229,14 +229,6 @@ processTestResources {
 	}
 }
 
-// Enable the experimental features of ByteBuddy with JDK 11
-test {
-	if ( JavaVersion.current().isJava11Compatible() ) {
-		systemProperty 'net.bytebuddy.experimental', true
-	}
-}
-
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // IDE
 


### PR DESCRIPTION
…on JDK11

https://hibernate.atlassian.net/browse/HHH-13007