### PR TITLE
Fix tests on SAP HANA

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyElementCollectionBasicNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyElementCollectionBasicNonUniqueIdWhereTest.java
@@ -47,9 +47,9 @@ public class LazyElementCollectionBasicNonUniqueIdWhereTest extends BaseCoreFunc
 		Session session = openSession();
 		session.beginTransaction();
 		{
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE COLLECTION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE MATERIAL_RATINGS" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MAIN_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("COLLECTION_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MATERIAL_RATINGS") ).executeUpdate();
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest.java
@@ -52,9 +52,9 @@ public class LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest extends 
 		Session session = openSession();
 		session.beginTransaction();
 		{
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE COLLECTION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE MATERIAL_RATINGS" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MAIN_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("COLLECTION_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MATERIAL_RATINGS") ).executeUpdate();
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyElementCollectionBasicNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyElementCollectionBasicNonUniqueIdWhereTest.java
@@ -38,9 +38,9 @@ public class LazyElementCollectionBasicNonUniqueIdWhereTest extends BaseCoreFunc
 		Session session = openSession();
 		session.beginTransaction();
 		{
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE COLLECTION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE MATERIAL_RATINGS" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "COLLECTION_TABLE" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" ) ).executeUpdate();
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest.java
@@ -38,9 +38,9 @@ public class LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest extends 
 		Session session = openSession();
 		session.beginTransaction();
 		{
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE COLLECTION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "DROP TABLE MATERIAL_RATINGS" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MAIN_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("COLLECTION_TABLE") ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString("MATERIAL_RATINGS") ).executeUpdate();
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +


### PR DESCRIPTION
The following tests fail because of a DROP TABLE statement without CASCADE
- org.hibernate.test.where.annotations.LazyElementCollectionBasicNonUniqueIdWhereTest
- org.hibernate.test.where.annotations.LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest
- org.hibernate.test.where.hbm.LazyElementCollectionBasicNonUniqueIdWhereTest
- org.hibernate.test.where.hbm.LazyElementCollectionWithLazyManyToOneNonUniqueIdWhereTest