### PR TITLE
[PREVIEW, DO NOT MERGE] HHH-13022 Make OSGi integration work on JDK11

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -36,6 +36,10 @@ ext {
 
     jodaTimeVersion = '2.3'
 
+    jaxbVersion = '2.2.11'
+    // Strangely, jaxb-runtime 2.2.11 depends on jaxb-api 2.2.12-b140109.1041
+    jaxbApiVersion = '2.2.12-b140109.1041'
+
     libraries = [
             // Ant
             ant:            'org.apache.ant:ant:1.8.2',
@@ -75,10 +79,9 @@ ext {
             logging_processor:  'org.jboss.logging:jboss-logging-processor:2.1.0.Final',
 
             // jaxb task
-            // Strangely, jaxb-runtime 2.2.11 depends on jaxb-api 2.2.12-b140109.1041
-            jaxb_api: 'javax.xml.bind:jaxb-api:2.2.12-b140109.1041',
-            jaxb_runtime: 'org.glassfish.jaxb:jaxb-runtime:2.2.11',
-            jaxb_xjc: 'org.glassfish.jaxb:jaxb-xjc:2.2.11',
+            jaxb_api: "javax.xml.bind:jaxb-api:${jaxbApiVersion}",
+            jaxb_runtime: "org.glassfish.jaxb:jaxb-runtime:${jaxbVersion}",
+            jaxb_xjc: "org.glassfish.jaxb:jaxb-xjc:${jaxbVersion}",
             // Note that jaxb2_basics is a set of tools on *top* of JAXB.
             // See https://github.com/highsource/jaxb2-basics
             jaxb2_basics: 'org.jvnet.jaxb2_commons:jaxb2-basics:0.11.0',

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -19,13 +19,6 @@ ext {
 
 test.enabled = true
 
-if ( JavaVersion.current().isJava9Compatible() ) {
-	logger.warn( '[WARN] Skipping all tests for hibernate-osgi due to Karaf issues with JDK 9' )
-	// Hikari CP relies on Javassist which we know has issues with Java 9
-	test.enabled = false
-}
-
-
 sourceSets {
 	test {
 		// send javac output and resource copying to the same output directory for test

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -41,10 +41,6 @@ configurations {
 		description = 'Feature for easily adding Infinispan-based caching support to hibernate-orm'
 		transitive = false
 	}
-	jaxb {
-		description = 'Jaxb dependencies'
-		transitive = true
-	}
 }
 
 dependencies {
@@ -53,7 +49,7 @@ dependencies {
 		// this dependency wasn't there in the 5.2.x bundles so ignoring it for now
 		// we might reintroduce it at some point if users complain about it
 		exclude module: 'javax.activation-api'
-		// JAXB is included conditionally in the OSGi feature, see below
+		// JAXB is included in the Karaf distribution
 		exclude module: 'jaxb-api'
 		exclude module: 'jaxb-runtime'
 	}
@@ -81,9 +77,6 @@ dependencies {
 	karafDistro "org.apache.karaf:apache-karaf:${project.karafVersion}@tar.gz"
 
 	hibernateEnvers( project( ':hibernate-envers' ) )
-
-	jaxb(libraries.jaxb_api)
-	jaxb(libraries.jaxb_runtime)
 }
 
 jar {
@@ -124,34 +117,6 @@ karaf {
 	features {
 		xsdVersion  = '1.4.0'
 		feature {
-			name = 'hibernate-jaxb'
-			description = 'JAXB as required by Hibernate ORM'
-			includeProject = false
-			configurations 'jaxb'
-			/*
-			 * This is a hack to make the JAXB runtime available to Hibernate ORM through the application classpath.
-			 * We cannot rely on the JAXB runtime being provided by the JDK, because the JAXB runtime was removed in JDK11.
-			 * We cannot rely on the JAXB runtime being provided by Karaf, because Karaf only provides the JAXB API (strangely).
-			 * So we must add the bundle ourselves, and more importantly, make it visible to Hibernate ORM somehow.
-			 *
-			 * To make the bundle visible to Hibernate ORM, we declare the "META-INF.services" "package" as exported
-			 * by the bundle; this is enough to make the JAXB API find the service file pointing to the JAXBContext class.
-			 * This will work as long as the test bundle imports the "META-INF.services" "package", or just "*".
-			 *
-			 * There are probably better ways to do this, but all the solutions I found were worse or didn't work:
-			 * - using the mvn:com.sun.xml.bind/jaxb-osgi/${version.org.glassfish.jaxb} bundle would require us to
-			 * add a gazillion extra system packages to the Karaf configuration:
-			 * https://github.com/eclipse-ee4j/jaxb-ri/blob/afa88da958e1cfb953fb4c38f0b4a1cfec608162/jaxb-ri/bundles/osgi/tests/pom.xml#L85
-			 * - using the mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1 bundle from
-			 * Apache ServiceMix does not seem to work: the runtime is not found.
-			 */
-			bundle(libraries.jaxb_runtime) {
-				wrap = true
-				instruction 'Bundle-SymbolicName', 'org.hibernate.org.glassfish.jaxb.runtime'
-				instruction 'Export-Package', "com.sun.xml.bind.v2;version=\"${jaxbVersion}\",META-INF.services;version=\"${jaxbVersion}\""
-			}
-		}
-		feature {
 			name        = 'hibernate-orm'
 			description = 'Combines all Hibernate core dependencies and required modules into a single feature'
 			includeProject = true
@@ -161,10 +126,6 @@ karaf {
 			feature 'transaction-api'
 			// Most Hibernate modules declare OSGi metadata through blueprints, so we need this feature
 			feature 'aries-blueprint'
-
-			feature('hibernate-jaxb') {
-				version = project.version
-			}
 		}
 		// NOTE : would like to include spatial as well, but we need to wait for
 		//		it to not define dependency on postgresql driver

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -173,14 +173,18 @@ karaf {
 			description = 'Feature for easily adding Envers support to hibernate-orm'
 			includeProject = false
 			configurations 'hibernateEnvers'
-			feature 'hibernate-orm'
+			feature('hibernate-orm') {
+				version = project.version
+			}
 		}
 		feature {
 			name = 'hibernate-infinispan'
 			description = 'Feature for easily adding Infinispan-based caching support to hibernate-orm'
 			includeProject = false
 			configurations 'hibernateInfinispan'
-			feature 'hibernate-orm'
+			feature('hibernate-orm') {
+				version = project.version
+			}
 		}
 	}
 }

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -41,6 +41,10 @@ configurations {
 		description = 'Feature for easily adding Infinispan-based caching support to hibernate-orm'
 		transitive = false
 	}
+	jaxb {
+		description = 'Jaxb dependencies'
+		transitive = true
+	}
 }
 
 dependencies {
@@ -49,7 +53,7 @@ dependencies {
 		// this dependency wasn't there in the 5.2.x bundles so ignoring it for now
 		// we might reintroduce it at some point if users complain about it
 		exclude module: 'javax.activation-api'
-		// TODO HHH-13022 Find a way to include JAXB in the OSGi feature
+		// JAXB is included conditionally in the OSGi feature, see below
 		exclude module: 'jaxb-api'
 		exclude module: 'jaxb-runtime'
 	}
@@ -77,6 +81,9 @@ dependencies {
 	karafDistro "org.apache.karaf:apache-karaf:${project.karafVersion}@tar.gz"
 
 	hibernateEnvers( project( ':hibernate-envers' ) )
+
+	jaxb(libraries.jaxb_api)
+	jaxb(libraries.jaxb_runtime)
 }
 
 jar {
@@ -117,6 +124,34 @@ karaf {
 	features {
 		xsdVersion  = '1.4.0'
 		feature {
+			name = 'hibernate-jaxb'
+			description = 'JAXB as required by Hibernate ORM'
+			includeProject = false
+			configurations 'jaxb'
+			/*
+			 * This is a hack to make the JAXB runtime available to Hibernate ORM through the application classpath.
+			 * We cannot rely on the JAXB runtime being provided by the JDK, because the JAXB runtime was removed in JDK11.
+			 * We cannot rely on the JAXB runtime being provided by Karaf, because Karaf only provides the JAXB API (strangely).
+			 * So we must add the bundle ourselves, and more importantly, make it visible to Hibernate ORM somehow.
+			 *
+			 * To make the bundle visible to Hibernate ORM, we declare the "META-INF.services" "package" as exported
+			 * by the bundle; this is enough to make the JAXB API find the service file pointing to the JAXBContext class.
+			 * This will work as long as the test bundle imports the "META-INF.services" "package", or just "*".
+			 *
+			 * There are probably better ways to do this, but all the solutions I found were worse or didn't work:
+			 * - using the mvn:com.sun.xml.bind/jaxb-osgi/${version.org.glassfish.jaxb} bundle would require us to
+			 * add a gazillion extra system packages to the Karaf configuration:
+			 * https://github.com/eclipse-ee4j/jaxb-ri/blob/afa88da958e1cfb953fb4c38f0b4a1cfec608162/jaxb-ri/bundles/osgi/tests/pom.xml#L85
+			 * - using the mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1 bundle from
+			 * Apache ServiceMix does not seem to work: the runtime is not found.
+			 */
+			bundle(libraries.jaxb_runtime) {
+				wrap = true
+				instruction 'Bundle-SymbolicName', 'org.hibernate.org.glassfish.jaxb.runtime'
+				instruction 'Export-Package', "com.sun.xml.bind.v2;version=\"${jaxbVersion}\",META-INF.services;version=\"${jaxbVersion}\""
+			}
+		}
+		feature {
 			name        = 'hibernate-orm'
 			description = 'Combines all Hibernate core dependencies and required modules into a single feature'
 			includeProject = true
@@ -126,6 +161,10 @@ karaf {
 			feature 'transaction-api'
 			// Most Hibernate modules declare OSGi metadata through blueprints, so we need this feature
 			feature 'aries-blueprint'
+
+			feature('hibernate-jaxb') {
+				version = project.version
+			}
 		}
 		// NOTE : would like to include spatial as well, but we need to wait for
 		//		it to not define dependency on postgresql driver

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -13,7 +13,7 @@ description = 'Support for running Hibernate O/RM in OSGi environments'
 ext {
 	osgiCoreVersion = '6.0.0'
 	osgiCompediumVersion = '5.0.0'
-	karafVersion = '4.1.0'
+	karafVersion = '4.2.1'
 	paxExamVersion = '4.12.0'
 }
 
@@ -131,6 +131,8 @@ karaf {
 				prerequisite = true
 			}
 			feature 'transaction-api'
+			// Most Hibernate modules declare OSGi metadata through blueprints, so we need this feature
+			feature 'aries-blueprint'
 		}
 		// NOTE : would like to include spatial as well, but we need to wait for
 		//		it to not define dependency on postgresql driver

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -131,7 +131,7 @@ karaf {
 				prerequisite = true
 			}
 			feature 'transaction-api'
-	}
+		}
 		// NOTE : would like to include spatial as well, but we need to wait for
 		//		it to not define dependency on postgresql driver
 		feature {

--- a/hibernate-osgi/src/main/java/org/hibernate/osgi/OsgiPersistenceProviderService.java
+++ b/hibernate-osgi/src/main/java/org/hibernate/osgi/OsgiPersistenceProviderService.java
@@ -48,17 +48,7 @@ public class OsgiPersistenceProviderService implements ServiceFactory {
 		osgiClassLoader.addBundle( FrameworkUtil.getBundle( SessionFactory.class ) );
 		osgiClassLoader.addBundle( FrameworkUtil.getBundle( HibernateEntityManagerFactory.class ) );
 
-		// Some "boot time" code does still rely on TCCL.  "run time" code should all be using
-		// ClassLoaderService now.
-
-		final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader( osgiClassLoader );
-		try {
-			return new OsgiPersistenceProvider( osgiClassLoader, osgiJtaPlatform, osgiServiceUtil, requestingBundle );
-		}
-		finally {
-			Thread.currentThread().setContextClassLoader( originalTccl );
-		}
+		return new OsgiPersistenceProvider( osgiClassLoader, osgiJtaPlatform, osgiServiceUtil, requestingBundle );
 	}
 
 	@Override

--- a/hibernate-osgi/src/main/java/org/hibernate/osgi/OsgiSessionFactoryService.java
+++ b/hibernate-osgi/src/main/java/org/hibernate/osgi/OsgiSessionFactoryService.java
@@ -74,17 +74,7 @@ public class OsgiSessionFactoryService implements ServiceFactory {
 		// contained in the core jar.
 		osgiClassLoader.addBundle( FrameworkUtil.getBundle(SessionFactory.class) );
 
-		// Some "boot time" code does still rely on TCCL.  "run time" code should all be using
-		// ClassLoaderService now.
-
-		final ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
-		Thread.currentThread().setContextClassLoader( osgiClassLoader );
-		try {
-			return buildSessionFactory( requestingBundle, osgiClassLoader );
-		}
-		finally {
-			Thread.currentThread().setContextClassLoader( originalTccl );
-		}
+		return buildSessionFactory( requestingBundle, osgiClassLoader );
 	}
 
 	private Object buildSessionFactory(

--- a/hibernate-osgi/src/test/java/org/hibernate/osgi/test/OsgiIntegrationTest.java
+++ b/hibernate-osgi/src/test/java/org/hibernate/osgi/test/OsgiIntegrationTest.java
@@ -63,6 +63,7 @@ import static org.ops4j.pax.exam.CoreOptions.when;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.debugConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
@@ -115,6 +116,13 @@ public class OsgiIntegrationTest {
 				configureConsole().ignoreLocalConsole().ignoreRemoteShell(),
 				when( debug ).useOptions( keepRuntimeFolder() ),
 				logLevel( LogLevelOption.LogLevel.INFO ),
+				// also log to the console, so that the logs are writtten to the test output file
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.logging.cfg",
+						"log4j2.rootLogger.appenderRef.Console.filter.threshold.level",
+						"TRACE" // Means "whatever the root logger level is"
+				),
+
 				features( featureXmlUrl( paxExamEnvironment ), "hibernate-orm" ),
 				features( featureXmlUrl( paxExamEnvironment ), "hibernate-envers" ),
 				features( testingFeatureXmlUrl(), "hibernate-osgi-testing" )


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-13022

This is based on #2584, which should be merged first.

**PLEASE DO NOT MERGE**, I'm just opening this so we can discuss the current state of the code, and the remaining problems.

This is far from ideal, but it's the best I could do after several days spent investigating.

On the bright side, OSGi tests are now enabled regardless of the JDK version

On the dark side, making JAXB work in OSGi is really hell. It only works at the price of an ugly hack, and only when sticking to JAXB 2.2.11.

## JAXB and OSGi

The first issue is that, for some reason, when we execute Hibernate ORM in Karaf, the JAXB APIs are loaded from some `lib/` folder provided by Karaf. I don't know why exactly, but I suspect our `OsgiClassLoader` has something to do with this: as it is currently implemented, it looks up classes in the client's bundle context first, and only if not found there we look them up in the Hibernate ORM bundle context.

This is bad enough, but with the version currently included in Karaf, we can sort of make it work.

The second issue is that JAXB JARs do not work "out of the box". Just adding the runtime JAR as a bundle to our feature is not enough, the API classes will not detect it. Apparently it's because the JAXB JARs do not declare service implementations as OSGi requires (using blueprints, for example). Here are the solutions I could think of:

* Use `com.sun.xml.bind:jaxb-osgi`, which is an OSGi bundle by the JAXB maintainers. Looks ideal? No it's not:
  * This bundle includes jaxb-xfc, which requires a lot of dependencies, among which package 'com.sun.source.tree' which is part of the Java compiler APIs and is not available by default in Karaf (I couldn't find the appropriate OSGi bundle).
  * I'm not even sure this OSGi bundle will work correctly if we solve the problem above, because the source code for this Maven artifact doesn't look like it does anything special to declare service implementations (no blueprints in particular). Maybe it will, but given the strange stuff we do in our classloader, I wouldn't bet on it.
* Wrap the JAXB JARs ourselves, adding whatever OSGi configuration that is necessary.
  * Maybe we could [create a clean bundle with all the correct configuration](http://karaf.apache.org/manual/latest/#_statically_bundling_jars), but that would essentially mean re-building the `jaxb-osgi` artifact ourselves.
  * I was able to come up with a very simple wrapping. It's an ugly and probably fragile hack, but it works in Karaf with both JRE 8 and JRE 11. The hack consists in wrapping the JAXB runtime bundle, adding in particular an "Export-Package: META-INF.services" instruction to the manifest. Due to how resource loading works in Karaf, this ends up exposing the relevant `META-INF/services/XXX` file from the runtime bundle to the API classes, and the API classes end up instantiating the runtime as we would expect.

So once again, this is bad, but I was able to make it work, at least.

The third issue is that upgrading to JAXB 2.3 will probably be quite complex. I tried it, and faced the following challenges:

* JAXB 2.3.1 requires `javax.activation` 1.2.0, which declares an OSGi dependency to package `com.sun.activation.registries`, which is not available by default in Karaf (I couldn't find the appropriate OSGi bundle).
* JAXB 2.3.1 requires `stax-ex` 1.8, which declares an OSGi dependency to Java 9+, even though it should work just fine on Java 7 (it's built using JDK7)
* ... and that's only where I stopped, there may be more.