### PR TITLE
Update GroupedSchemaMigratorImpl.java

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
@@ -62,11 +62,12 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 					namespace,
 					targets
 			);
-			final NameSpaceTablesInformation tables = existingDatabase.getTablesInformation( namespace );
+
 			for ( Table table : namespace.getTables() ) {
 				if ( schemaFilter.includeTable( table ) && table.isPhysicalTable() ) {
 					checkExportIdentifier( table, exportIdentifiers );
-					final TableInformation tableInformation = tables.getTableInformation( table );
+					final TableInformation tableInformation = existingDatabase.getTableInformation(namespace.getName(),
+													table.getNameIdentifier());
 					if ( tableInformation == null ) {
 						createTable( table, dialect, metadata, formatter, options, targets );
 					}


### PR DESCRIPTION
Performance problem:There are tens of thousands of tables in the system, only a small number of tables are generated through hibernate. When the number of tables is large, calling existingDatabase.getTablesInformation()  method takes a lot of time.