### PR TITLE
Hhh 10891

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractCompositionAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractCompositionAttribute.java
@@ -92,7 +92,6 @@ public abstract class AbstractCompositionAttribute
 							// we build the association-key here because of the "goofiness" with 'currentColumnPosition'
 							final AssociationKey associationKey;
 							final AssociationType aType = (AssociationType) type;
-							final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
 
 							if ( aType.isAnyType() ) {
 								associationKey = new AssociationKey(
@@ -111,6 +110,8 @@ public abstract class AbstractCompositionAttribute
 								);
 							}
 							else if ( aType.getForeignKeyDirection() == ForeignKeyDirection.FROM_PARENT ) {
+                                final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
+
 								final String lhsTableName;
 								final String[] lhsColumnNames;
 
@@ -133,7 +134,8 @@ public abstract class AbstractCompositionAttribute
 								associationKey = new AssociationKey( lhsTableName, lhsColumnNames );
 							}
 							else {
-								associationKey = new AssociationKey(
+                                final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
+                                associationKey = new AssociationKey(
 										joinable.getTableName(),
 										getRHSColumnNames( aType, sessionFactory() )
 								);

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractCompositionAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractCompositionAttribute.java
@@ -110,7 +110,7 @@ public abstract class AbstractCompositionAttribute
 								);
 							}
 							else if ( aType.getForeignKeyDirection() == ForeignKeyDirection.FROM_PARENT ) {
-                                final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
+								final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
 
 								final String lhsTableName;
 								final String[] lhsColumnNames;
@@ -134,8 +134,8 @@ public abstract class AbstractCompositionAttribute
 								associationKey = new AssociationKey( lhsTableName, lhsColumnNames );
 							}
 							else {
-                                final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
-                                associationKey = new AssociationKey(
+								final Joinable joinable = aType.getAssociatedJoinable( sessionFactory() );
+								associationKey = new AssociationKey(
 										joinable.getTableName(),
 										getRHSColumnNames( aType, sessionFactory() )
 								);


### PR DESCRIPTION
We were using a very old version of hibernate & moving to the latest version broke the code as described in the bug.

The (if) code block that handles Any type in the iterator's next method has no data dependency on the joinable variable. By removing this unnecessary dependency, we stopped getting the error "any types do not have a unique referenced persister error" during hibernate load.

The simple code refactoring fix made all of our existing code to work as was working earlier (and we use Any extensively). Please note that we use polymorphic attributes only for persistence & not for retrieval. We use JDBC for retrieval (because of some application specific customization).

Therefore, I am unsure of the completeness of the fix (the retrieval of polymorphic attributes in components annotated with Embeddable is not tested).