### PR TITLE
added st_makeenvelope

### DIFF
--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisFunctions.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisFunctions.java
@@ -46,6 +46,11 @@ class PostgisFunctions extends SpatialFunctionsRegistry {
 				)
 		);
 		put(
+				"makeenvelope", new StandardSQLFunction(
+						"st_makeenvelope"
+				)
+		);
+		put(
 				"astext", new StandardSQLFunction(
 						"st_astext",
 						StandardBasicTypes.STRING


### PR DESCRIPTION
st_makeenvelope is a commonly used function in postgis, so I think it should be supported. st_makeenvelope is necessary for example to make queries that only include items that are inside of the bounding box of a map that the users sees in his browser. 

https://postgis.net/docs/ST_MakeEnvelope.html