### PR TITLE
Choose the right dialect for Sybase SQL Anywhere

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
@@ -511,7 +511,7 @@ public enum Database {
 				return latestDialectInstance( this );
 			}
 
-			if ( databaseName.startsWith( "Adaptive Server Anywhere" ) ) {
+			if ( databaseName.startsWith( "Adaptive Server Anywhere" ) || "SQL Anywhere".equals( databaseName ) ) {
 				return new SybaseAnywhereDialect();
 			}
 


### PR DESCRIPTION
On SQL Anywhere 17.0.0.1062 the product name is "SQL Anywhere" and not "Adaptive Server Anywhere". I suggest to include this string in the test to select the right dialect.