### PR TITLE
HHH-13084 : Querying entity with non-ID property named 'id' fails if entity has an IdClass composite key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
@@ -25,6 +25,7 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.loader.PropertyPath;
 import org.hibernate.param.ParameterSpecification;
 import org.hibernate.persister.collection.CollectionPropertyMapping;
 import org.hibernate.persister.collection.CollectionPropertyNames;
@@ -33,6 +34,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.Joinable;
 import org.hibernate.persister.entity.PropertyMapping;
 import org.hibernate.persister.entity.Queryable;
+import org.hibernate.tuple.IdentifierProperty;
 import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
 
@@ -685,7 +687,27 @@ class FromElementType {
 	public String getIdentifierPropertyName() {
 		if ( getEntityPersister() != null && getEntityPersister().getEntityMetamodel() != null
 				&& getEntityPersister().getEntityMetamodel().hasNonIdentifierPropertyNamedId() ) {
-			return getEntityPersister().getIdentifierPropertyName();
+			if ( getEntityPersister().hasIdentifierProperty() ) {
+				return getEntityPersister().getIdentifierPropertyName();
+			}
+			else {
+				final IdentifierProperty identifierProperty =
+						getEntityPersister().getEntityMetamodel().getIdentifierProperty();
+				if ( identifierProperty.hasIdentifierMapper() && !identifierProperty.isEmbedded() ) {
+					return PropertyPath.IDENTIFIER_MAPPER_PROPERTY;
+				}
+				else {
+					throw new UnsupportedOperationException(
+							String.format(
+									"[%s] has a composite key and a non-ID property named 'id'; " +
+											"Hibernate only supports this use case when " +
+											"the composite ID is mapped using a primary key class.",
+									getEntityPersister().getEntityName()
+							)
+
+					);
+				}
+			}
 		}
 		else {
 			return EntityPersister.ENTITY_ID;

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInEmbeddedIdTest.java
@@ -52,6 +52,8 @@ public class PropertyNamedIdInEmbeddedIdTest extends BaseCoreFunctionalTestCase 
 						.size()
 		);
 
+		assertEquals( 3L, s.createQuery( "select count( p ) from Person p" ).uniqueResult() );
+
 		s.createQuery( "delete from Person" ).executeUpdate();
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInEmbeddedIdTest.java
@@ -1,0 +1,132 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdInEmbeddedIdTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13084")
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0 ) );
+		s.persist( new Person( "John Doe", 1 ) );
+		s.persist( new Person( "Jane Doe", 0 ) );
+		s.flush();
+
+		assertEquals(
+				1, s.createQuery( "from Person p where p.id = :id", Person.class )
+						.setParameter( "id", new PersonId( "John Doe", 0 ) )
+						.list()
+						.size()
+		);
+
+		assertEquals(
+				2, s.createQuery( "from Person p where p.id.id = :id", Person.class )
+						.setParameter( "id", 0 )
+						.list()
+						.size()
+		);
+
+		s.createQuery( "delete from Person" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Entity(name = "Person")
+	public static class Person implements Serializable {
+		@EmbeddedId
+		private PersonId personId;
+
+		public Person(String name, int id) {
+			this();
+			personId = new PersonId( name, id );
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		public PersonId getPersonId() {
+			return personId;
+		}
+	}
+
+	@Embeddable
+	public static class PersonId implements Serializable {
+		private String name;
+		private Integer id;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int id) {
+			setName( name );
+			setId( id );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( id != personId.id ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + id;
+			return result;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInIdClassTest.java
@@ -40,6 +40,8 @@ public class PropertyNamedIdInIdClassTest extends BaseCoreFunctionalTestCase {
 
 		assertEquals( 2, s.createQuery( "from Person p where p.id = 0", Person.class ).list().size() );
 
+		assertEquals( 3L, s.createQuery( "select count( p ) from Person p" ).uniqueResult() );
+
 		s.createQuery( "delete from Person" ).executeUpdate();
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInIdClassTest.java
@@ -1,0 +1,135 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdInIdClassTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13084")
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0 ) );
+		s.persist( new Person( "John Doe", 1 ) );
+		s.persist( new Person( "Jane Doe", 0 ) );
+		s.flush();
+
+		assertEquals( 2, s.createQuery( "from Person p where p.id = 0", Person.class ).list().size() );
+
+		s.createQuery( "delete from Person" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Entity(name = "Person")
+	@IdClass(PersonId.class)
+	public static class Person implements Serializable {
+		@Id
+		private String name;
+
+		@Id
+		private Integer id;
+
+		public Person(String name, Integer id) {
+			this();
+			setName( name );
+			setId( id );
+		}
+		public String getName() {
+			return name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		protected void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	public static class PersonId implements Serializable {
+		private String name;
+		private Integer id;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int id) {
+			setName( name );
+			setId( id );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( id != personId.id ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + id;
+			return result;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInNonJpaCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInNonJpaCompositeIdTest.java
@@ -39,6 +39,8 @@ public class PropertyNamedIdInNonJpaCompositeIdTest extends BaseCoreFunctionalTe
 
 		assertEquals( 2, s.createQuery( "from Person p where p.id = 0", Person.class ).list().size() );
 
+		assertEquals( 3L, s.createQuery( "select count( p ) from Person p" ).uniqueResult() );
+
 		s.createQuery( "delete from Person" ).executeUpdate();
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInNonJpaCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdInNonJpaCompositeIdTest.java
@@ -1,0 +1,133 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdInNonJpaCompositeIdTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13084")
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0 ) );
+		s.persist( new Person( "John Doe", 1 ) );
+		s.persist( new Person( "Jane Doe", 0 ) );
+		s.flush();
+
+		assertEquals( 2, s.createQuery( "from Person p where p.id = 0", Person.class ).list().size() );
+
+		s.createQuery( "delete from Person" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Entity(name = "Person")
+	public static class Person implements Serializable {
+		@Id
+		private String name;
+
+		@Id
+		private Integer id;
+
+		public Person(String name, Integer id) {
+			this();
+			setName( name );
+			setId( id );
+		}
+		public String getName() {
+			return name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		protected void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	public static class PersonId implements Serializable {
+		private String name;
+		private Integer id;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int id) {
+			setName( name );
+			setId( id );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( id != personId.id ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + id;
+			return result;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfEmbeddedIdTest.java
@@ -46,6 +46,8 @@ public class PropertyNamedIdOutOfEmbeddedIdTest extends BaseCoreFunctionalTestCa
 						.size()
 		);
 
+		assertEquals( 3L, s.createQuery( "select count( p ) from Person p" ).uniqueResult() );
+
 		s.createQuery( "delete from Person" ).executeUpdate();
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfEmbeddedIdTest.java
@@ -1,0 +1,134 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdOutOfEmbeddedIdTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13084")
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0, 6 ) );
+		s.persist( new Person( "John Doe", 1, 6 ) );
+		s.persist( new Person( "Jane Doe", 0 ) );
+		s.flush();
+
+		assertEquals(
+				2, s.createQuery( "from Person p where p.id = :id", Person.class )
+						.setParameter( "id", 6 )
+						.list()
+						.size()
+		);
+
+		s.createQuery( "delete from Person" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Entity(name = "Person")
+	public static class Person implements Serializable {
+		@EmbeddedId
+		private PersonId personId;
+
+		private Integer id;
+
+		public Person(String name, int index) {
+			this();
+			personId = new PersonId( name, index );
+		}
+
+		public Person(String name, int index, Integer id) {
+			this( name, index );
+			this.id = id;
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		public PersonId getPersonId() {
+			return personId;
+		}
+	}
+
+	@Embeddable
+	public static class PersonId implements Serializable {
+		private String name;
+		@Column(name = "ind")
+		private int index;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int index) {
+			setName( name );
+			setIndex( index );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setIndex(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( index != personId.index ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + index;
+			return result;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfIdClassTest.java
@@ -41,6 +41,7 @@ public class PropertyNamedIdOutOfIdClassTest extends BaseCoreFunctionalTestCase 
 
 		assertEquals( 1, s.createQuery( "from Person p where p.id is null", Person.class ).list().size() );
 		assertEquals( 2, s.createQuery( "from Person p where p.id is not null", Person.class ).list().size() );
+		assertEquals( 3L, s.createQuery( "select count( p ) from Person p" ).uniqueResult() );
 
 		s.createQuery( "delete from Person" ).executeUpdate();
 		s.getTransaction().commit();

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfIdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfIdClassTest.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdOutOfIdClassTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13084")
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0 ) );
+		s.persist( new Person( "John Doe", 1, 1 ) );
+		s.persist( new Person( "John Doe", 2, 2 ) );
+		s.flush();
+
+		assertEquals( 1, s.createQuery( "from Person p where p.id is null", Person.class ).list().size() );
+		assertEquals( 2, s.createQuery( "from Person p where p.id is not null", Person.class ).list().size() );
+
+		s.createQuery( "delete from Person" ).executeUpdate();
+		s.getTransaction().commit();
+		s.close();
+	}
+
+	@Entity(name = "Person")
+	@IdClass(PersonId.class)
+	public static class Person implements Serializable {
+		@Id
+		private String name;
+
+		@Id
+		@Column( name = "ind")
+		private int index;
+
+		private Integer id;
+
+		public Person(String name, int index) {
+			this();
+			setName( name );
+			setIndex( index );
+		}
+
+
+		public Person(String name, int index, int id) {
+			this( name, index );
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		protected void setIndex(int index) {
+			this.index = index;
+		}
+
+		protected void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	public static class PersonId implements Serializable {
+		private String name;
+		private int index;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int index) {
+			setName( name );
+			setIndex( index );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setIndex(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( index != personId.index ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + index;
+			return result;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfNonJpaCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/PropertyNamedIdOutOfNonJpaCompositeIdTest.java
@@ -1,0 +1,157 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idprops;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Gail Badner
+ */
+public class PropertyNamedIdOutOfNonJpaCompositeIdTest extends BaseCoreFunctionalTestCase {
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	public void testHql() {
+		Session s = openSession();
+		s.beginTransaction();
+		s.persist( new Person( "John Doe", 0 ) );
+		s.persist( new Person( "John Doe", 1, 1 ) );
+		s.persist( new Person( "John Doe", 2, 2 ) );
+		s.flush();
+
+		try {
+			s.createQuery( "from Person p where p.id is null", Person.class ).list();
+			fail( "should have thrown UnsupportedOperationException" );
+		}
+		catch (UnsupportedOperationException ex) {
+			//expected
+		}
+		finally {
+			s.getTransaction().rollback();
+			s.close();
+		}
+	}
+
+	@Entity(name = "Person")
+	public static class Person implements Serializable {
+		@Id
+		private String name;
+
+		@Id
+		@Column( name = "ind")
+		private int index;
+
+		private Integer id;
+
+		public Person(String name, int index) {
+			this();
+			setName( name );
+			setIndex( index );
+		}
+
+
+		public Person(String name, int index, int id) {
+			this( name, index );
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		protected Person() {
+			// this form used by Hibernate
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		protected void setIndex(int index) {
+			this.index = index;
+		}
+
+		protected void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	public static class PersonId implements Serializable {
+		private String name;
+		private int index;
+
+		public PersonId() {
+		}
+
+		public PersonId(String name, int index) {
+			setName( name );
+			setIndex( index );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setIndex(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			PersonId personId = (PersonId) o;
+
+			if ( index != personId.index ) {
+				return false;
+			}
+			return name.equals( personId.name );
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + index;
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13084

This fix specifically does not fix the case where an entity has a non-ID property named "id" and a composite ID that does not have a primary key class. The user doc says that composite keys without a primary key class is deprecated, so I assume it's OK to not cover that case.