### PR TITLE
HHH-11209 : Change log message to DEBUG when due to rollback

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -38,6 +38,7 @@ import org.hibernate.internal.util.collections.IdentitySet;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.IntegerType;
 import org.hibernate.type.LongType;
@@ -625,7 +626,20 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		if ( currentSession == this.session ) {
 			if ( !isTempSession ) {
 				if ( hasQueuedOperations() ) {
-					LOG.queuedOperationWhenDetachFromSession( MessageHelper.collectionInfoString( getRole(), getKey() ) );
+					final String collectionInfoString = MessageHelper.collectionInfoString( getRole(), getKey() );
+					final TransactionStatus transactionStatus =
+							session.getTransactionCoordinator().getTransactionDriverControl().getStatus();
+					if ( transactionStatus.isOneOf(
+							TransactionStatus.ROLLED_BACK,
+							TransactionStatus.MARKED_ROLLBACK,
+							TransactionStatus.FAILED_COMMIT,
+							TransactionStatus.FAILED_ROLLBACK,
+							TransactionStatus.ROLLING_BACK
+					) )
+						LOG.queuedOperationWhenDetachFromSessionOnRollback( collectionInfoString );
+					else {
+						LOG.queuedOperationWhenDetachFromSession( collectionInfoString );
+					}
 				}
 				this.session = null;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1844,4 +1844,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = WARN)
 	@Message(value = "The increment size of the [%s] sequence is set to [%d] in the entity mapping while the associated database sequence increment size is [%d]. The database sequence increment size will take precedence to avoid identifier allocation conflicts.", id = 497)
 	void sequenceIncrementSizeMismatch(String sequenceName, int incrementSize, int databaseIncrementSize);
+
+	@LogMessage(level = DEBUG)
+	@Message(value = "Detaching an uninitialized collection with queued operations from a session due to rollback: %s", id = 498)
+	void queuedOperationWhenDetachFromSessionOnRollback(String collectionInfoString);
 }

--- a/hibernate-core/src/test/resources/log4j.properties
+++ b/hibernate-core/src/test/resources/log4j.properties
@@ -53,6 +53,7 @@ log4j.logger.org.hibernate.engine.internal.Cascade=trace
 
 log4j.logger.org.hibernate.testing.junit4.TestClassMetadata=info, unclosedSessionFactoryFile
 log4j.logger.org.hibernate.boot.model.process.internal.ScanningCoordinator=debug
+log4j.logger.org.hibernate.collection.internal.AbstractPersistentCollection=debug
 
 log4j.logger.org.hibernate.cache trace
 log4j.logger.org.hibernate.stat trace


### PR DESCRIPTION
Logging a warning when a collection with queued operations is detached due to rollback is too noisy. On rollback, the application should throw away data from the session because it is not consistent with persisted data, so there really isn't a need for this warning. Instead, it will be logged as a DEBUG message.

https://hibernate.atlassian.net/browse/HHH-11209