### PR TITLE
HHH-13090 Depend on Ehcache interface instead of depending on one of the implem…

### DIFF
--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/EhcacheRegionFactory.java
@@ -11,7 +11,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
-import net.sf.ehcache.Cache;
+import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.Configuration;
 import net.sf.ehcache.config.ConfigurationFactory;
@@ -131,7 +131,7 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 		return regionName;
 	}
 
-	protected Cache getOrCreateCache(String unqualifiedRegionName, SessionFactoryImplementor sessionFactory) {
+	protected Ehcache getOrCreateCache(String unqualifiedRegionName, SessionFactoryImplementor sessionFactory) {
 		verifyStarted();
 		assert !RegionNameQualifier.INSTANCE.isQualified( unqualifiedRegionName, sessionFactory.getSessionFactoryOptions() );
 
@@ -140,14 +140,14 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 				sessionFactory.getSessionFactoryOptions()
 		);
 
-		final Cache cache = cacheManager.getCache( qualifiedRegionName );
+		final Ehcache cache = cacheManager.getEhcache( qualifiedRegionName );
 		if ( cache == null ) {
 			return createCache( qualifiedRegionName );
 		}
 		return cache;
 	}
 
-	protected Cache createCache(String regionName) {
+	protected Ehcache createCache(String regionName) {
 		switch ( missingCacheStrategy ) {
 			case CREATE_WARN:
 				SecondLevelCacheLogger.INSTANCE.missingCacheCreated(
@@ -155,10 +155,10 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 						ConfigSettings.MISSING_CACHE_STRATEGY, MissingCacheStrategy.CREATE.getExternalRepresentation()
 				);
 				cacheManager.addCache( regionName );
-				return cacheManager.getCache( regionName );
+                return cacheManager.getEhcache( regionName );
 			case CREATE:
 				cacheManager.addCache( regionName );
-				return cacheManager.getCache( regionName );
+                return cacheManager.getEhcache( regionName );
 			case FAIL:
 				throw new CacheException( "On-the-fly creation of Ehcache Cache objects is not supported [" + regionName + "]" );
 			default:
@@ -171,7 +171,7 @@ public class EhcacheRegionFactory extends RegionFactoryTemplate {
 				unqualifiedRegionName,
 				sessionFactory.getSessionFactoryOptions()
 		);
-		return cacheManager.getCache( qualifiedRegionName ) != null;
+        return cacheManager.getEhcache( qualifiedRegionName ) != null;
 	}
 
 

--- a/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/StorageAccessImpl.java
+++ b/hibernate-ehcache/src/main/java/org/hibernate/cache/ehcache/internal/StorageAccessImpl.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.cache.ehcache.internal;
 
-import net.sf.ehcache.Cache;
+import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.constructs.nonstop.NonStopCacheException;
 import net.sf.ehcache.hibernate.nonstop.HibernateNonstopCacheExceptionHandler;
@@ -25,14 +25,14 @@ import org.jboss.logging.Logger;
 public class StorageAccessImpl implements DomainDataStorageAccess  {
 	private static final Logger LOG = Logger.getLogger( StorageAccessImpl.class );
 
-	private final Cache cache;
+	private final Ehcache cache;
 
 	@SuppressWarnings("WeakerAccess")
-	public StorageAccessImpl(Cache cache) {
+	public StorageAccessImpl(Ehcache cache) {
 		this.cache = cache;
 	}
 
-	public Cache getCache() {
+	public Ehcache getCache() {
 		return cache;
 	}
 


### PR DESCRIPTION
Depend on Ehcache interface instead of depending on one of the implementation (for example BlockingCache is not working in current version)
Current ehcache2 integration uses one of the implementation of Ehcache named net.sf.ehcache.Cache

But I am using BlockingCache from net.sf.ehcache.constructs.blocking package, 
that extends EhcacheDecoratorAdapter and is an implementation of Ehcache, 
but doen't extend net.sf.ehcache.Cache 

I think it's better appoach depending on interfaces, not implementations