### PR TITLE
HHH-13092 Upgrade Hibernate Commons Annotations to 5.1.0.Final

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -14,8 +14,8 @@ ext {
     bytemanVersion = '4.0.3' //Compatible with JDK10
     jnpVersion = '5.0.6.CR1'
 
+    hibernateCommonsVersion = '5.1.0.Final'
     hibernateValidatorVersion = '6.0.13.Final'
-    hibernateCommonsVersion = '5.0.5.Final'
     validationApiVersion = '2.0.1.Final'
     elVersion = '3.0.1-b09'
 


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HHH-13092

CI will fail as the artifact is not on Central yet but this way I won't forget about it.