### PR TITLE
HHH-13076 - Hibernate “Transaction already active” behaviour with custom transaction manager

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
@@ -72,7 +72,13 @@ public class TransactionImpl implements TransactionImplementor {
 
 		// per-JPA
 		if ( isActive() ) {
-			throw new IllegalStateException( "Transaction already active" );
+			if ( jpaCompliance.isJpaTransactionComplianceEnabled()
+					|| !transactionCoordinator.getTransactionCoordinatorBuilder().isJta() ) {
+				throw new IllegalStateException( "Transaction already active" );
+			}
+			else {
+				return;
+			}
 		}
 
 		LOG.debug( "begin" );

--- a/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jdbc/AlreadyStartedTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jdbc/AlreadyStartedTransactionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.resource.transaction.jdbc;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-13076")
+public class AlreadyStartedTransactionTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Test(expected = IllegalStateException.class)
+	public void anIllegalStateExceptionShouldBeThrownWhenBeginTxIsCalledWithAnAlreadyActiveTX() {
+		Transaction transaction = null;
+		try (Session session = openSession()) {
+			transaction = session.getTransaction();
+			transaction.begin();
+			// A call to begin() with an active Tx should cause an IllegalStateException
+			transaction.begin();
+		}
+		finally {
+			if ( transaction != null && transaction.isActive() ) {
+				transaction.rollback();
+			}
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jta/JpaComplianceAlreadyStartedTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jta/JpaComplianceAlreadyStartedTransactionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.resource.transaction.jta;
+
+import java.util.Map;
+import javax.transaction.Status;
+import javax.transaction.TransactionManager;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jta.TestingJtaBootstrap;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-13076")
+public class JpaComplianceAlreadyStartedTransactionTest extends BaseNonConfigCoreFunctionalTestCase {
+	private TransactionManager tm;
+
+	@Override
+	protected void addSettings(Map settings) {
+		super.addSettings( settings );
+		TestingJtaBootstrap.prepare( settings );
+		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );
+		settings.put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "true" );
+	}
+
+	@Before
+	public void setUp() {
+		tm = JtaPlatformStandardTestingImpl.INSTANCE.transactionManager();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void anIllegalStateExceptionShouldBeThrownWhenBeginTxIsCalledWithAnAlreadyActiveTX() throws Exception {
+		try (Session s = openSession()) {
+			tm.begin();
+			Transaction tx = null;
+			try {
+				// A call to begin() with an active Tx should cause an IllegalStateException
+				tx = s.beginTransaction();
+			}
+			catch (Exception e) {
+				if ( tx != null && tx.isActive() ) {
+					tx.rollback();
+				}
+				throw e;
+			}
+		}
+		catch (Exception e) {
+			if ( tm.getStatus() == Status.STATUS_ACTIVE ) {
+				tm.rollback();
+			}
+			throw e;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jta/NonJpaComplianceAlreadyStartedTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jta/NonJpaComplianceAlreadyStartedTransactionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.resource.transaction.jta;
+
+import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.transaction.Status;
+import javax.transaction.TransactionManager;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jta.TestingJtaBootstrap;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-13076")
+public class NonJpaComplianceAlreadyStartedTransactionTest extends BaseNonConfigCoreFunctionalTestCase {
+	private TransactionManager tm;
+
+	@Override
+	protected void addSettings(Map settings) {
+		super.addSettings( settings );
+		TestingJtaBootstrap.prepare( settings );
+		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { TestEntity.class };
+	}
+
+	@Before
+	public void setUp() {
+		tm = JtaPlatformStandardTestingImpl.INSTANCE.transactionManager();
+	}
+
+	@Test
+	public void noIllegalStateExceptionShouldBeThrownWhenBeginTxIsCalledWithAnAlreadyActiveTx() throws Exception {
+		tm.begin();
+		try (Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			try {
+				s.saveOrUpdate( new TestEntity( "ABC" ) );
+				tx.commit();
+			}
+			catch (Exception e) {
+				if ( tx.isActive() ) {
+					tx.rollback();
+				}
+				throw e;
+			}
+		}
+		try {
+			tm.commit();
+		}
+		catch (Exception e) {
+			if ( tm.getStatus() == Status.STATUS_ACTIVE ) {
+				tm.rollback();
+			}
+			throw e;
+		}
+	}
+
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String stringAttribute;
+
+		public TestEntity(String stringAttribute) {
+			this.stringAttribute = stringAttribute;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13076

The fix reintroduces the old behaviour for non JPA transaction compliance settings and JTA Transactions.