### PR TITLE
HHH-12964 - Upgrade to dom4j 2.1.1 - 5.1

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -39,7 +39,7 @@ ext {
             woodstox:           "org.codehaus.woodstox:woodstox-core-asl:4.3.0",
 
             // Dom4J
-            dom4j:          'dom4j:dom4j:1.6.1@jar',
+            dom4j:          'org.dom4j:dom4j:2.1.1@jar',
 
             // Javassist
             javassist:      'org.javassist:javassist:3.20.0-GA',


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12964

(cherry picked from commit e66da8af0076c2fbca9c190e8e708441be5bfcd3)