### PR TITLE
HHH-13104 - Oracle 12c / SAP Hana insert fails when entity contains only an identity-based column.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1648,4 +1648,9 @@ public abstract class AbstractHANADialect extends Dialect {
 	public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
 		return false;
 	}
+
+	@Override
+	public String getNoColumnsInsertString() {
+		throw new MappingException( "SAP HANA requires at least one value in insert value-list clause." );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/Oracle12cIdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/Oracle12cIdentityColumnSupport.java
@@ -33,4 +33,9 @@ public class Oracle12cIdentityColumnSupport extends IdentityColumnSupportImpl {
 			PostInsertIdentityPersister persister, Dialect dialect) {
 		return new Oracle12cGetGeneratedKeysDelegate( persister, dialect );
 	}
+
+	@Override
+	public String getIdentityInsertString() {
+		return "default";
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.hibernate.MappingException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.LiteralType;
 
@@ -95,7 +96,18 @@ public class Insert {
 		buf.append("insert into ")
 			.append(tableName);
 		if ( columns.size()==0 ) {
-			buf.append(' ').append( dialect.getNoColumnsInsertString() );
+			try {
+				buf.append( ' ' ).append( dialect.getNoColumnsInsertString() );
+			}
+			catch ( MappingException e ) {
+				throw new MappingException(
+						String.format(
+								"Unable to build insert statement for table [%s]: %s",
+								tableName,
+								e.getMessage()
+						)
+				);
+			}
 		}
 		else {
 			buf.append(" (");

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/IdentityInsertSoleColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/identity/IdentityInsertSoleColumnTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.identity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.junit.Test;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.TestForIssue;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * The purpose of this test is to insure that when an entity that contains a single column
+ * which also happens to be an identity-generated identifier, the generated insert SQL is
+ * correct for the dialect.
+ *
+ * We found through research that SAP Hana doesn't support an empty values-list clause, the
+ * omission of the values-list clause, or any default value in the values-list clause for
+ * the identifier column; therefore we'll skip this test for that platform.
+ *
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-13104")
+@RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
+@SkipForDialect(value=AbstractHANADialect.class, comment="SAP HANA requires at least value in insert value-list clause.")
+public class IdentityInsertSoleColumnTest extends BaseEntityManagerFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Animal.class };
+	}
+
+	@Test
+	public void testEntityInsertWithSingleIdentityAttributeColumn() {
+		// insert the entity
+		final Integer entityId = doInJPA( this::entityManagerFactory, entityManager -> {
+			final Animal animal = new Animal();
+			entityManager.persist( animal );
+			return animal.getId();
+		} );
+
+		// make sure the identifier was generated
+		assertNotNull( entityId );
+
+		// verify the entity can be fetched
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final Animal animal = entityManager.find( Animal.class, entityId );
+			assertNotNull( animal );
+		} );
+	}
+
+	@Entity(name = "Animal")
+	public static class Animal {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Integer id;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13104

I stumbled onto this problem when fixing a test for HHH-13053 where the entity contained a single column that was an identity-based column.  While Oracle 12c seems to have a solution, it seems SAP Hana does not based on my research (unless I overlooked something).  Therefore SAP Hana throws a `MappingException` if we determine a mapping falls into this scenario rather than only happening during the insert at runtime.