### PR TITLE
HHH-13043 + HHH-13116 Upgrade to JAXB 2.3

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -36,6 +36,11 @@ ext {
 
     jodaTimeVersion = '2.3'
 
+    jaxbApiVersion = '2.3.1'
+    // We can't upgrade JAXB in Karaf (yet), but fortunately everything works fine with the version built in Karaf
+    jaxbApiVersionOsgiRange = "[2.2,3)"
+    jaxbRuntimeVersion = '2.3.1'
+
     libraries = [
             // Ant
             ant:            'org.apache.ant:ant:1.8.2',
@@ -75,14 +80,13 @@ ext {
             logging_processor:  'org.jboss.logging:jboss-logging-processor:2.1.0.Final',
 
             // jaxb task
-            // Strangely, jaxb-runtime 2.2.11 depends on jaxb-api 2.2.12-b140109.1041
-            jaxb_api: 'javax.xml.bind:jaxb-api:2.2.12-b140109.1041',
-            jaxb_runtime: 'org.glassfish.jaxb:jaxb-runtime:2.2.11',
-            jaxb_xjc: 'org.glassfish.jaxb:jaxb-xjc:2.2.11',
+            jaxb_api: "javax.xml.bind:jaxb-api:${jaxbApiVersion}",
+            jaxb_runtime: "org.glassfish.jaxb:jaxb-runtime:${jaxbRuntimeVersion}",
+            jaxb_xjc: "org.glassfish.jaxb:jaxb-xjc:${jaxbRuntimeVersion}",
             // Note that jaxb2_basics is a set of tools on *top* of JAXB.
             // See https://github.com/highsource/jaxb2-basics
-            jaxb2_basics: 'org.jvnet.jaxb2_commons:jaxb2-basics:0.11.0',
-            jaxb2_basics_ant: 'org.jvnet.jaxb2_commons:jaxb2-basics-ant:0.11.0',
+            jaxb2_basics: 'org.jvnet.jaxb2_commons:jaxb2-basics:0.12.0',
+            jaxb2_basics_ant: 'org.jvnet.jaxb2_commons:jaxb2-basics-ant:0.12.0',
 
             geolatte:       "org.geolatte:geolatte-geom:${geolatteVersion}",
 

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -126,7 +126,9 @@ jar {
             'javax.enterprise.inject.spi;resolution:=optional',
             'javax.inject;resolution:=optional',
             'net.bytebuddy.*;resolution:=optional',
-            'javax.xml.bind.*'
+            // We must specify the version explicitly to allow Karaf
+            // to use an older version of JAXB (the only one we can use in Karaf)
+            "javax.xml.bind.*;version=\"${project.jaxbApiVersionOsgiRange}\""
 
 //        // TODO: Uncomment once EntityManagerFactoryBuilderImpl no longer
 //        // uses ClassLoaderServiceImpl.


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-13043
https://hibernate.atlassian.net//browse/HHH-13116

I gave up on doing the upgrade for OSGi; it's just too early for that. We don't really have any code that is specific to JAXB 2.3, so tests work fine in karaf, which uses JAXB 2.2 in the classpath. I guess that's good enough for now?

The most important thing is that Maven users will finally be able to use ORM in a JDK11 environment, i.e. [HHH-13116](https://hibernate.atlassian.net/browse/HHH-13116) will be fixed.

### How to reproduce HHH-13116 and check that it's fixed

Due to the need to use Maven to reproduce [HHH-13116](https://hibernate.atlassian.net/browse/HHH-13116), I didn't even try to add a reproducer in ORM itself. If you want to check that it is indeed fixed:

* Clone this PR, go to the corresponding directory
* Publish 5.4.0-SNAPSHOT locally:
  ```
  ./gradlew clean publishToMavenLocal -x test
  ```
* Clone the [reproducer from the Hibernate Search repo](https://github.com/yrodiere/hibernate-search/tree/HHH-13116-reproducer) (it's just a branch with all the necessary commits to upgrade to ORM 5.4 and make Search compatible with JDK11):
  ```
  cd $(mktemp -d)
  git clone --depth 50 --no-single-branch https://github.com/yrodiere/hibernate-search.git
  cd hibernate-search
  git checkout --track origin/HHH-13116-reproducer
* Build the reproducer:
  ```
  mvn clean install -DskipTests -pl :hibernate-search-orm -am
  ```
* Define the path to your JDK11 home:
  ```
  export my_java_home=/path/to/jdk11
  ```
* Execute the test, showing something doesn't work (this will use ORM 5.4.0.CR1):
  ```
  JAVA_HOME=$my_java_home PATH=$my_java_home/bin:$PATH  mvn clean install -pl :hibernate-search-orm -Dtest='SearchAndEnversIntegrationTest'
  ```
* Upgrade to ORM 5.4.0-SNAPSHOT to benefit from the JAXB upgrade:
  ```
  git checkout --track origin/HHH-13116-reproducer-fixed
  ```
* Launch the test that used to fail:
  ```
  JAVA_HOME=$my_java_home PATH=$my_java_home/bin:$PATH  mvn clean install -pl :hibernate-search-orm -Dtest='SearchAndEnversIntegrationTest'
  ```