### PR TITLE
HHH-13128 Add missing jaxb-runtime dependency to metamodel generator

### DIFF
--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -17,8 +17,10 @@ ext {
 }
 
 dependencies {
-    compile( libraries.jaxb_api )
 
+    // JAXB
+    compile( libraries.jaxb_api )
+    compile( libraries.jaxb_runtime )
     xjc( libraries.jaxb_runtime )
     xjc( libraries.jaxb_xjc )
     xjc( libraries.jaxb2_basics )


### PR DESCRIPTION
It's necessary for JDK 11 and we missed it when we added the
jaxb-runtime dependency to hibernate-core.

 * https://hibernate.atlassian.net/browse/HHH-13128
