### PR TITLE
HHH-13156 - Enhance the @AnyMetaDef annotation section with more details about the optimal placement

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
@@ -558,7 +558,7 @@ include::{sourcedir}/any/package-info.java[tags=associations-any-meta-def-exampl
 
 [NOTE]
 ====
-It is recommended to place the `@AnyMetaDef` mapping as a package metadata.
+It is recommended to place the `@AnyMetaDef` mapping as a package metadata if you can reuse it.
 ====
 
 To see the `@Any` annotation in action, consider the next examples.


### PR DESCRIPTION
In my project, there is only one place to use @Any. Therefore, it
makes no sense to put its @AnyMetaDef as a package metadata for me.
Before this patch, the documentation seems to recommend to place
@AnyMetaDef as a package metadata unconditionally.