### PR TITLE
HHH-12555 : Fix merging of lazy loaded blobs/clobs/nclobs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -345,17 +345,10 @@ public abstract class AbstractStandardBasicType<T>
 	}
 
 	@Override
+	@SuppressWarnings({ "unchecked" })
 	public final Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner, Map copyCache) {
 		if ( original == null && target == null ) {
 			return null;
-		}
-
-		if ( original == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-			return target;
-		}
-
-		if ( target == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-			return getReplacement( (T) original, null, session );
 		}
 
 		return getReplacement( (T) original, (T) target, session );

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -71,11 +71,7 @@ public abstract class AbstractStandardBasicType<T>
 	}
 
 	protected T getReplacement(T original, T target, SharedSessionContractImplementor session) {
-		if ( original == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-			return target;
-		}
-		else if ( !isMutable() ||
-					( target != LazyPropertyInitializer.UNFETCHED_PROPERTY && isEqual( original, target ) ) ) {
+		if ( !isMutable() || ( target != null && isEqual( original, target ) ) ) {
 			return original;
 		}
 		else {
@@ -349,8 +345,19 @@ public abstract class AbstractStandardBasicType<T>
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked" })
 	public final Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner, Map copyCache) {
+		if ( original == null && target == null ) {
+			return null;
+		}
+
+		if ( original == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+			return target;
+		}
+
+		if ( target == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+			return getReplacement( (T) original, null, session );
+		}
+
 		return getReplacement( (T) original, (T) target, session );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/BlobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BlobType.java
@@ -7,12 +7,8 @@
 package org.hibernate.type;
 
 import java.sql.Blob;
-import java.sql.SQLException;
 
-import org.hibernate.engine.jdbc.LobCreator;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.type.descriptor.java.BlobTypeDescriptor;
 
 /**
@@ -40,23 +36,7 @@ public class BlobType extends AbstractSingleColumnStandardBasicType<Blob> {
 
 	@Override
 	protected Blob getReplacement(Blob original, Blob target, SharedSessionContractImplementor session) {
-		if ( target == null ) {
-			return copyOriginalBlob( (Blob) original, session );
-		}
-
 		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeBlob( original, target, session );
 	}
 
-	private Blob copyOriginalBlob(Blob original, SharedSessionContractImplementor session) {
-		try {
-			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator(
-					session );
-			return original == null
-					? lobCreator.createBlob( ArrayHelper.EMPTY_BYTE_ARRAY )
-					: lobCreator.createBlob( original.getBinaryStream(), original.length() );
-		}
-		catch (SQLException e) {
-			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge BLOB data" );
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/BlobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BlobType.java
@@ -7,8 +7,12 @@
 package org.hibernate.type;
 
 import java.sql.Blob;
+import java.sql.SQLException;
 
+import org.hibernate.engine.jdbc.LobCreator;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.type.descriptor.java.BlobTypeDescriptor;
 
 /**
@@ -36,7 +40,23 @@ public class BlobType extends AbstractSingleColumnStandardBasicType<Blob> {
 
 	@Override
 	protected Blob getReplacement(Blob original, Blob target, SharedSessionContractImplementor session) {
+		if ( target == null ) {
+			return copyOriginalBlob( (Blob) original, session );
+		}
+
 		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeBlob( original, target, session );
 	}
 
+	private Blob copyOriginalBlob(Blob original, SharedSessionContractImplementor session) {
+		try {
+			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator(
+					session );
+			return original == null
+					? lobCreator.createBlob( ArrayHelper.EMPTY_BYTE_ARRAY )
+					: lobCreator.createBlob( original.getBinaryStream(), original.length() );
+		}
+		catch (SQLException e) {
+			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge BLOB data" );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/ClobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ClobType.java
@@ -7,7 +7,10 @@
 package org.hibernate.type;
 
 import java.sql.Clob;
+import java.sql.SQLException;
 
+import org.hibernate.engine.jdbc.LobCreator;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.ClobTypeDescriptor;
 
@@ -36,7 +39,21 @@ public class ClobType extends AbstractSingleColumnStandardBasicType<Clob> {
 
 	@Override
 	protected Clob getReplacement(Clob original, Clob target, SharedSessionContractImplementor session) {
-		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeClob( original, target, session );
+		if ( target == null ) {
+			return copyOriginalClob( (Clob) original, session );
+		}
+		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeClob( (Clob) original, (Clob) target, session );
 	}
 
+	private Clob copyOriginalClob(Clob original, SharedSessionContractImplementor session) {
+		try {
+			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator( session );
+			return original == null
+					? lobCreator.createClob( "" )
+					: lobCreator.createClob( original.getCharacterStream(), original.length() );
+		}
+		catch (SQLException e) {
+			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge CLOB data" );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/ClobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ClobType.java
@@ -7,10 +7,7 @@
 package org.hibernate.type;
 
 import java.sql.Clob;
-import java.sql.SQLException;
 
-import org.hibernate.engine.jdbc.LobCreator;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.ClobTypeDescriptor;
 
@@ -39,21 +36,6 @@ public class ClobType extends AbstractSingleColumnStandardBasicType<Clob> {
 
 	@Override
 	protected Clob getReplacement(Clob original, Clob target, SharedSessionContractImplementor session) {
-		if ( target == null ) {
-			return copyOriginalClob( (Clob) original, session );
-		}
 		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeClob( (Clob) original, (Clob) target, session );
-	}
-
-	private Clob copyOriginalClob(Clob original, SharedSessionContractImplementor session) {
-		try {
-			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator( session );
-			return original == null
-					? lobCreator.createClob( "" )
-					: lobCreator.createClob( original.getCharacterStream(), original.length() );
-		}
-		catch (SQLException e) {
-			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge CLOB data" );
-		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/NClobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/NClobType.java
@@ -7,12 +7,15 @@
 package org.hibernate.type;
 
 import java.sql.NClob;
+import java.sql.SQLException;
 
+import org.hibernate.engine.jdbc.LobCreator;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.NClobTypeDescriptor;
 
 /**
- * A type that maps between {@link java.sql.Types#CLOB CLOB} and {@link java.sql.Clob}
+ * A type that maps between {@link java.sql.Types#NCLOB NCLOB} and {@link java.sql.NClob}
  *
  * @author Gavin King
  * @author Steve Ebersole
@@ -36,7 +39,21 @@ public class NClobType extends AbstractSingleColumnStandardBasicType<NClob> {
 
 	@Override
 	protected NClob getReplacement(NClob original, NClob target, SharedSessionContractImplementor session) {
+		if ( target == null ) {
+			return copyOriginalNClob( original, session );
+		}
 		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeNClob( original, target, session );
 	}
 
+	private NClob copyOriginalNClob(NClob original, SharedSessionContractImplementor session) {
+		try {
+			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator( session );
+			return original == null
+					? lobCreator.createNClob( "" )
+					: lobCreator.createNClob( original.getCharacterStream(), original.length() );
+		}
+		catch (SQLException e) {
+			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge NCLOB data" );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/NClobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/NClobType.java
@@ -7,10 +7,7 @@
 package org.hibernate.type;
 
 import java.sql.NClob;
-import java.sql.SQLException;
 
-import org.hibernate.engine.jdbc.LobCreator;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.NClobTypeDescriptor;
 
@@ -39,21 +36,6 @@ public class NClobType extends AbstractSingleColumnStandardBasicType<NClob> {
 
 	@Override
 	protected NClob getReplacement(NClob original, NClob target, SharedSessionContractImplementor session) {
-		if ( target == null ) {
-			return copyOriginalNClob( original, session );
-		}
 		return session.getJdbcServices().getJdbcEnvironment().getDialect().getLobMergeStrategy().mergeNClob( original, target, session );
-	}
-
-	private NClob copyOriginalNClob(NClob original, SharedSessionContractImplementor session) {
-		try {
-			final LobCreator lobCreator = session.getFactory().getServiceRegistry().getService( JdbcServices.class ).getLobCreator( session );
-			return original == null
-					? lobCreator.createNClob( "" )
-					: lobCreator.createNClob( original.getCharacterStream(), original.length() );
-		}
-		catch (SQLException e) {
-			throw session.getJdbcServices().getSqlExceptionHelper().convert( e, "unable to merge NCLOB data" );
-		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -159,6 +159,9 @@ public class TypeHelper {
 			if ( original[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY || original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				copied[i] = target[i];
 			}
+			else if ( target[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+				copied[i] = types[i].replace( original[i], null, session, owner, copyCache );
+			}
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache );
 			}
@@ -192,6 +195,9 @@ public class TypeHelper {
 			if ( original[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
 					|| original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				copied[i] = target[i];
+			}
+			else if ( target[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+				copied[i] = types[i].replace( original[i], null, session, owner, copyCache, foreignKeyDirection );
 			}
 			else {
 				copied[i] = types[i].replace( original[i], target[i], session, owner, copyCache, foreignKeyDirection );

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LobUnfetchedPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LobUnfetchedPropertyTest.java
@@ -1,0 +1,165 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.type;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.NClob;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TestForIssue(jiraKey = "HHH-12555")
+@RequiresDialectFeature(DialectChecks.SupportsExpectedLobUsagePattern.class)
+@RunWith(BytecodeEnhancerRunner.class)
+public class LobUnfetchedPropertyTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ FileBlob.class, FileClob.class, FileNClob.class };
+	}
+
+	@Test
+	public void testBlob() {
+		doInHibernate( this::sessionFactory, s -> {
+			FileBlob file = new FileBlob();
+			file.setBlob( s.getLobHelper().createBlob( "TEST CASE".getBytes() ) );
+			s.save( file );
+			s.clear();
+			s.merge( file );
+		} );
+	}
+
+	@Test
+	public void testClob() {
+		doInHibernate( this::sessionFactory, s -> {
+			FileClob file = new FileClob();
+			file.setClob( s.getLobHelper().createClob( "TEST CASE" ) );
+			s.save( file );
+			s.clear();
+			s.merge( file );
+		} );
+	}
+
+	@Test
+	public void testNClob() {
+		doInHibernate( this::sessionFactory, s -> {
+			FileNClob file = new FileNClob();
+			file.setNClob( s.getLobHelper().createNClob( "TEST CASE" ) );
+			s.save( file );
+			s.clear();
+			s.merge( file );
+		} );
+	}
+
+	@Entity(name = "FileBlob")
+	@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
+	public static class FileBlob {
+
+		private int id;
+
+		private Blob blob;
+
+		@Id
+		@GeneratedValue
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		@Column(name = "filedata", length = 1024 * 1024)
+		@Lob
+		@Basic(fetch = FetchType.LAZY)
+		public Blob getBlob() {
+			return blob;
+		}
+
+		public void setBlob(Blob blob) {
+			this.blob = blob;
+		}
+	}
+
+	@Entity(name = "FileClob")
+	@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
+	public static class FileClob {
+
+		private int id;
+
+		private Clob clob;
+
+		@Id
+		@GeneratedValue
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		@Column(name = "filedata", length = 1024 * 1024)
+		@Lob
+		@Basic(fetch = FetchType.LAZY)
+		public Clob getClob() {
+			return clob;
+		}
+
+		public void setClob(Clob clob) {
+			this.clob = clob;
+		}
+	}
+
+	@Entity(name = "FileNClob")
+	@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, include = "non-lazy")
+	public static class FileNClob {
+
+		private int id;
+
+		private NClob nClob;
+
+		@Id
+		@GeneratedValue
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		@Column(name = "filedata", length = 1024 * 1024)
+		@Lob
+		@Basic(fetch = FetchType.LAZY)
+		public NClob getNClob() {
+			return nClob;
+		}
+
+		public void setNClob(NClob nClob) {
+			this.nClob = nClob;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/TypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/TypeTest.java
@@ -6,6 +6,23 @@
  */
 package org.hibernate.test.type;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Currency;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
+
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.internal.util.SerializationHelper;
@@ -42,25 +59,10 @@ import org.hibernate.type.TimeType;
 import org.hibernate.type.TimeZoneType;
 import org.hibernate.type.TimestampType;
 import org.hibernate.type.TrueFalseType;
+import org.hibernate.type.Type;
+import org.hibernate.type.TypeHelper;
 import org.hibernate.type.YesNoType;
 import org.junit.Test;
-
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Calendar;
-import java.util.Currency;
-import java.util.GregorianCalendar;
-import java.util.Locale;
-import java.util.SimpleTimeZone;
-import java.util.TimeZone;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -344,8 +346,11 @@ public class TypeTest extends BaseUnitTestCase {
 		assertTrue( original == type.replace( original, copy, null, null, null ) );
 
 		// following tests assert that types work with properties not yet loaded in bytecode enhanced entities
-		assertSame( copy, type.replace( LazyPropertyInitializer.UNFETCHED_PROPERTY, copy, null, null, null ) );
-		assertNotEquals( LazyPropertyInitializer.UNFETCHED_PROPERTY, type.replace( original, LazyPropertyInitializer.UNFETCHED_PROPERTY, null, null, null ) );
+		Type[] types = new Type[]{ type };
+		assertSame( copy, TypeHelper.replace( new Object[]{ LazyPropertyInitializer.UNFETCHED_PROPERTY },
+				new Object[]{ copy }, types, null, null, null )[0] );
+		assertNotEquals( LazyPropertyInitializer.UNFETCHED_PROPERTY, TypeHelper.replace( new Object[]{ original },
+				new Object[]{ LazyPropertyInitializer.UNFETCHED_PROPERTY }, types, null, null, null )[0] );
 
 		assertTrue( type.isSame( original, copy ) );
 		assertTrue( type.isEqual( original, copy ) );


### PR DESCRIPTION
Supersedes https://github.com/hibernate/hibernate-orm/pull/2390.

I removed code in LobMergeStrategy implementations that copied original Lob when target is null. Instead `#getReplacement` delegates to the `LobMergeStrategy`.

I also added some code to the tests to check that the Lobs were persisted properly.

I found a bug with enhancement involving a property that starts with a lowercase letter followed by an uppercase letter, like `FileNClob#nclob`. I've renamed the property to `clob`. I'll create a jira for the enhancement bug on Monday.