### PR TITLE
HHH-13104 - Oracle 12c / SAP Hana insert fails when entity contains only an identity-based column.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1649,8 +1649,7 @@ public abstract class AbstractHANADialect extends Dialect {
 		return false;
 	}
 
-	@Override
-	public String getNoColumnsInsertString() {
-		throw new MappingException( "SAP HANA requires at least one value in insert value-list clause." );
+	public boolean supportsNoColumnsInsert() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1763,6 +1763,15 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
+	 * Check if the INSERT statement is allowed to contain no column.
+	 *
+	 * @return if the Dialect supports no-column INSERT.
+	 */
+	public boolean supportsNoColumnsInsert() {
+		return true;
+	}
+
+	/**
 	 * The name of the SQL function that transforms a string to
 	 * lowercase
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
@@ -96,15 +96,15 @@ public class Insert {
 		buf.append("insert into ")
 			.append(tableName);
 		if ( columns.size()==0 ) {
-			try {
+			if ( dialect.supportsNoColumnsInsert() ) {
 				buf.append( ' ' ).append( dialect.getNoColumnsInsertString() );
 			}
-			catch ( MappingException e ) {
+			else {
 				throw new MappingException(
 						String.format(
-								"Unable to build insert statement for table [%s]: %s",
+								"The INSERT statement for table [%s] contains no column, and this is not supported by [%s]",
 								tableName,
-								e.getMessage()
+								dialect
 						)
 				);
 			}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadJpaComplianceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadJpaComplianceTest.java
@@ -17,6 +17,8 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
@@ -31,6 +33,7 @@ import static org.junit.Assert.fail;
  * @author Gavin King
  * @author Hardy Ferentschik
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class GetLoadJpaComplianceTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/GetLoadTest.java
@@ -16,7 +16,9 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
@@ -31,6 +33,7 @@ import static org.junit.Assert.fail;
  * @author Gavin King
  * @author Hardy Ferentschik
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class GetLoadTest extends BaseEntityManagerFunctionalTestCase {
 	@Test
 	@SkipForDialect(value = AbstractHANADialect.class, comment = " HANA doesn't support tables consisting of only a single auto-generated column")

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/PersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ops/PersistTest.java
@@ -19,6 +19,9 @@ import javax.persistence.RollbackException;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
@@ -31,6 +34,7 @@ import static org.junit.Assert.fail;
  * @author Gavin King
  * @author Hardy Ferentschik
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class PersistTest extends BaseEntityManagerFunctionalTestCase {
 	@Test
 	public void testCreateTree() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/MergeNotNullCollectionUsingIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/beanvalidation/MergeNotNullCollectionUsingIdentityTest.java
@@ -33,7 +33,10 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 /**
  * @author Ryan Emerson
  */
-@RequiresDialectFeature( value = DialectChecks.SupportsIdentityColumns.class, jiraKey = "HHH-9979")
+@RequiresDialectFeature( value = {
+		DialectChecks.SupportsIdentityColumns.class,
+		DialectChecks.SupportsNoColumnInsert.class
+}, jiraKey = "HHH-9979")
 @TestForIssue( jiraKey = "HHH-9979")
 public class MergeNotNullCollectionUsingIdentityTest extends BaseCoreFunctionalTestCase {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/bag/PersistentBagTest.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 import org.hibernate.Session;
 import org.hibernate.collection.internal.PersistentBag;
 import org.hibernate.dialect.AbstractHANADialect;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -24,6 +27,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Steve Ebersole
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class PersistentBagTest extends BaseCoreFunctionalTestCase {
 	@Override
 	public String[] getMappings() {

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/original/CollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/original/CollectionTest.java
@@ -13,6 +13,9 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.dialect.AbstractHANADialect;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
@@ -27,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Gavin King
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class CollectionTest extends BaseCoreFunctionalTestCase {
 	@Override
 	public String[] getMappings() {

--- a/hibernate-core/src/test/java/org/hibernate/test/event/collection/BrokenCollectionEventTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/event/collection/BrokenCollectionEventTest.java
@@ -18,7 +18,9 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.event.spi.AbstractCollectionEvent;
 import org.hibernate.test.event.collection.association.bidirectional.manytomany.ChildWithBidirectionalManyToMany;
 import org.hibernate.test.event.collection.association.unidirectional.ParentWithCollectionOfEntities;
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;
@@ -32,6 +34,7 @@ import static org.junit.Assert.assertSame;
  *
  * @author Gail Badner
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class BrokenCollectionEventTest extends BaseCoreFunctionalTestCase {
 	@Override
 	public String[] getMappings() {

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ClassicTranslatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ClassicTranslatorTest.java
@@ -14,6 +14,9 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.hql.internal.classic.ClassicQueryTranslatorFactory;
 
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+
 /**
  * Some simple test queries using the classic translator explicitly
  * to ensure that code is not broken in changes for the new translator.
@@ -22,6 +25,7 @@ import org.hibernate.hql.internal.classic.ClassicQueryTranslatorFactory;
  *
  * @author Steve Ebersole
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class ClassicTranslatorTest extends QueryTranslatorTestCase {
 	@Override
 	public void configure(Configuration cfg) {

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/EJBQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/EJBQLTest.java
@@ -22,6 +22,9 @@ import org.hibernate.hql.internal.ast.QueryTranslatorImpl;
 import org.hibernate.hql.internal.ast.util.ASTUtil;
 import org.hibernate.hql.spi.QueryTranslator;
 import org.hibernate.hql.spi.QueryTranslatorFactory;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static junit.framework.Assert.assertEquals;
@@ -30,6 +33,7 @@ import static junit.framework.Assert.assertTrue;
 /**
  * @author <a href="mailto:alex@jboss.org">Alexey Loubyansky</a>
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class EJBQLTest extends BaseCoreFunctionalTestCase {
 	@Override
 	public String[] getMappings() {

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
@@ -77,6 +77,7 @@ import static org.junit.Assert.fail;
  *
  * @author Gavin King
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class HQLTest extends QueryTranslatorTestCase {
 	@Override
 	public boolean createSchema() {

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
@@ -90,6 +90,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class FooBarTest extends LegacyTestCase {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FumTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FumTest.java
@@ -51,6 +51,9 @@ import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PointbaseDialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.dialect.TimesTenDialect;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.transform.Transformers;
 import org.hibernate.type.CalendarType;
@@ -60,6 +63,7 @@ import org.hibernate.type.StringType;
 import org.hibernate.type.Type;
 import org.junit.Test;
 
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class FumTest extends LegacyTestCase {
 	private static short fumKeyShort = 1;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -17,6 +17,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
@@ -51,7 +53,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class ParentChildTest extends LegacyTestCase {
 	@Override
 	public String[] getMappings() {

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/AbstractOperationTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/AbstractOperationTestCase.java
@@ -8,6 +8,9 @@ package org.hibernate.test.ops;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/CreateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/CreateTest.java
@@ -15,6 +15,9 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.exception.ConstraintViolationException;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
@@ -27,6 +30,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Gavin King
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class CreateTest extends AbstractOperationTestCase {
 	@Test
 	@SuppressWarnings( {"unchecked"})

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/DeleteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/DeleteTest.java
@@ -10,9 +10,13 @@ import org.junit.Test;
 
 import org.hibernate.Session;
 
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+
 /**
  * @author Steve Ebersole
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class DeleteTest extends AbstractOperationTestCase {
 	@Test
 	@SuppressWarnings( {"unchecked"})

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/HANANoColumnInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/HANANoColumnInsertTest.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.ops;
+
+import org.hibernate.MappingException;
+import org.hibernate.dialect.AbstractHANADialect;
+
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Vlad Mihalcea
+ */
+@RequiresDialect(value = { AbstractHANADialect.class })
+public class HANANoColumnInsertTest extends BaseCoreFunctionalTestCase {
+
+	public String[] getMappings() {
+		return new String[] {
+			"ops/Competition.hbm.xml"
+		};
+	}
+
+	@Override
+	protected void buildSessionFactory() {
+		try {
+			super.buildSessionFactory();
+
+			fail("Should have thrown MappingException!");
+		}
+		catch (MappingException e) {
+			assertEquals("The INSERT statement for table [Competition] contains no column, and this is not supported by [org.hibernate.dialect.HANAColumnStoreDialect]", e.getMessage());
+		}
+	}
+
+	@Test
+	public void test() throws Exception {
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/MergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/MergeTest.java
@@ -20,6 +20,9 @@ import org.hibernate.StaleObjectStateException;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Projections;
 import org.hibernate.dialect.AbstractHANADialect;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
@@ -33,6 +36,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Gavin King
  */
+@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
 public class MergeTest extends AbstractOperationTestCase {
 	@Test
 	public void testMergeStaleVersionFails() throws Exception {

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/OracleNoColumnInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/OracleNoColumnInsertTest.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.ops;
+
+import org.hibernate.dialect.Oracle9iDialect;
+
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * @author Vlad Mihalcea
+ */
+@RequiresDialect(value = { Oracle9iDialect.class })
+@TestForIssue( jiraKey = "HHH-13104" )
+public class OracleNoColumnInsertTest extends BaseCoreFunctionalTestCase {
+
+	public String[] getMappings() {
+		return new String[] {
+			"ops/Competition.hbm.xml"
+		};
+	}
+
+	@Test
+	public void test() throws Exception {
+		doInHibernate( this::sessionFactory, session -> {
+			Competition competition = new Competition();
+
+			session.persist( competition );
+		} );
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/test/ops/SimpleOpsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/ops/SimpleOpsTest.java
@@ -11,6 +11,8 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -260,6 +260,12 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class SupportsNoColumnInsert implements DialectCheck {
+		public boolean isMatch(Dialect dialect) {
+			return dialect.supportsNoColumnsInsert();
+		}
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13104