### PR TITLE
HHH-13172 Only throw exception if incorrect inheritance type is being…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -565,7 +565,7 @@ public final class AnnotationBinder {
 				inheritanceState
 		);
 
-		if(superEntity != null && (
+		if(inheritanceState.getType() != InheritanceType.TABLE_PER_CLASS && superEntity != null && (
 				clazzToProcess.getAnnotation( AttributeOverride.class ) != null ||
 				clazzToProcess.getAnnotation( AttributeOverrides.class ) != null ) ) {
 			throw new AnnotationException(

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/inheritance/EntityInheritanceWithTablePerClassAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/inheritance/EntityInheritanceWithTablePerClassAttributeOverrideTest.java
@@ -12,34 +12,29 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
-import javax.persistence.MappedSuperclass;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * @author Vlad Mihalcea
+ * @author Petar Tahchiev
  */
 @TestForIssue( jiraKey = "HHH-12609, HHH-12654,HHH-13172" )
-public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFunctionalTestCase {
+public class EntityInheritanceWithTablePerClassAttributeOverrideTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
 	public Class[] getAnnotatedClasses() {
 		return new Class[]{
-			CategoryEntity.class,
-			TaxonEntity.class,
-			AbstractEntity.class
+				CategoryEntity.class,
+				TaxonEntity.class,
+				AbstractEntity.class
 		};
 	}
 
@@ -47,10 +42,10 @@ public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFun
 	public void buildEntityManagerFactory() {
 		try {
 			super.buildEntityManagerFactory();
-			fail("Should throw AnnotationException");
 		}
 		catch (AnnotationException e) {
-			assertTrue( e.getMessage().startsWith( "An entity annotated with @Inheritance cannot use @AttributeOverride or @AttributeOverrides" ) );
+			e.printStackTrace();
+			fail("Should not throw AnnotationException - TABLE_PER_CLASS should allow overriding attributes");
 		}
 	}
 
@@ -58,8 +53,8 @@ public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFun
 	public void test() {
 	}
 
-	@Entity(name = "AbstractEntity")
-	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@Entity(name = "AbstractEntity1")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 	public static class AbstractEntity {
 
 		@Id
@@ -86,15 +81,15 @@ public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFun
 
 	}
 
-	@Entity(name = "Category")
+	@Entity(name = "Category1")
 	public static class CategoryEntity extends AbstractEntity {
 
 	}
 
-	@Entity(name = "Taxon")
+	@Entity(name = "Taxon1")
 	@Table(
-		name = "taxon",
-		uniqueConstraints = @UniqueConstraint(name = "category_code", columnNames = { "catalog_version_id", "code" })
+			name = "taxon",
+			uniqueConstraints = @UniqueConstraint(name = "category_code", columnNames = { "catalog_version_id", "code" })
 	)
 	@AttributeOverride(name = "code", column = @Column(name = "code", nullable = false, unique = false))
 	public static class TaxonEntity extends CategoryEntity {


### PR DESCRIPTION
… used.

As Vlad Mihalcea mentioned in a comment here: https://hibernate.atlassian.net/projects/HHH/issues/HHH-12609
using @Inheritance and @AttributeOverride makes sense only if TABLE_PER_CLASS inheritance strategy is being used.

Issue is now: https://hibernate.atlassian.net/browse/HHH-13172