### PR TITLE
HHH-13175 - Add method to return null instead of throwing exception

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
@@ -139,7 +139,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	@Override
 	@SuppressWarnings("unchecked")
 	public <AJ> AttributeNodeImplementor<AJ> findAttributeNode(String attributeName) {
-		return findAttributeNode( (PersistentAttributeDescriptor) managedType.getAttribute( attributeName ) );
+		return findAttributeNode( (PersistentAttributeDescriptor) managedType.getAttributeIfExists( attributeName ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/ManagedDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/ManagedDomainType.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.metamodel.model.domain;
 
+import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.ManagedType;
 
 /**
  * @author Steve Ebersole
  */
 public interface ManagedDomainType<J> extends SimpleDomainType<J>, ManagedType<J> {
+	/**
+     *  Return the attribute of the managed
+     *  type that corresponds to the specified name if exists.
+     *  @param name  the name of the represented attribute
+     *  @return attribute if exists else null
+     */
+	Attribute<? super J, ?> getAttributeIfExists(String name); 
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractManagedType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractManagedType.java
@@ -107,16 +107,27 @@ public abstract class AbstractManagedType<J>
 	public Set<Attribute<J, ?>> getDeclaredAttributes() {
 		return new HashSet<>( declaredAttributes.values() );
 	}
-
-	@Override
-	@SuppressWarnings({ "unchecked" })
-	public PersistentAttributeDescriptor<? super J, ?> getAttribute(String name) {
+	
+	private PersistentAttributeDescriptor<? super J, ?> getAttribute(String name, boolean nullable) {
 		PersistentAttributeDescriptor<? super J, ?> attribute = declaredAttributes.get( name );
 		if ( attribute == null && getSuperType() != null ) {
 			attribute = getSuperType().getAttribute( name );
 		}
-		checkNotNull( "Attribute ", attribute, name );
+		
+		if(!nullable) {
+			checkNotNull( "Attribute ", attribute, name );
+		}
 		return attribute;
+	}
+
+	@Override
+	public PersistentAttributeDescriptor<? super J, ?> getAttribute(String name) {
+		return getAttribute(name, false);
+	}
+	
+	@Override
+	public PersistentAttributeDescriptor<? super J, ?> getAttributeIfExists(String name) {
+		return getAttribute(name, true);
 	}
 
 	@Override


### PR DESCRIPTION
IllegalArgumentException is thrown during two phase load's plan creation for member relation (i.e. ManyToMany).

While resolving relation, MetamodelGraphWalker visits each attribute of target entity type and checks whether fetchgraph or loadgraph has directed to eagerly fetch that attribute. If so, it modifies load plan.

Recent changes in 5.4.0 uses contracts specified by JPA 2.0 to walk down and manage types. getAttribute(name) contract specified by JPA's ManagedType throws IllegalArgumentException when asked attribute named as 'name' is not found.

But as per Hibernate's implementation, this contract is being used to check and modify load plan if attribute matches with specified EntityGraph.