### PR TITLE
HHH-13172 Log a warning instead of throwing an exception when @AttributeOverride is used in conjunction with entity inheritance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -568,10 +568,7 @@ public final class AnnotationBinder {
 		if(superEntity != null && (
 				clazzToProcess.getAnnotation( AttributeOverride.class ) != null ||
 				clazzToProcess.getAnnotation( AttributeOverrides.class ) != null ) ) {
-			throw new AnnotationException(
-					"An entity annotated with @Inheritance cannot use @AttributeOverride or @AttributeOverrides: " +
-							clazzToProcess.getName()
-			);
+			LOG.unsupportedAttributeOverrideWithEntityInheritance( clazzToProcess.getName() );
 		}
 
 		PersistentClass persistentClass = makePersistentClass( inheritanceState, superEntity, context );
@@ -3043,7 +3040,7 @@ public final class AnnotationBinder {
 				column.setUpdatable( false );
 			}
 		}
-		
+
 		final JoinColumn joinColumn = property.getAnnotation( JoinColumn.class );
 		final JoinColumns joinColumns = property.getAnnotation( JoinColumns.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1848,4 +1848,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = DEBUG)
 	@Message(value = "Detaching an uninitialized collection with queued operations from a session due to rollback: %s", id = 498)
 	void queuedOperationWhenDetachFromSessionOnRollback(String collectionInfoString);
+
+	@LogMessage(level = WARN)
+	@Message(value = "Using @AttributeOverride or @AttributeOverrides in conjunction with entity inheritance is not supported: %s. The overriding definitions are ignored.", id = 499)
+	void unsupportedAttributeOverrideWithEntityInheritance(String entityName);
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/override/inheritance/EntityInheritanceAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/override/inheritance/EntityInheritanceAttributeOverrideTest.java
@@ -6,36 +6,39 @@
  */
 package org.hibernate.test.annotations.override.inheritance;
 
+import static org.junit.Assert.assertTrue;
+
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
-import javax.persistence.MappedSuperclass;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
-import org.hibernate.AnnotationException;
+import org.hibernate.cfg.AnnotationBinder;
+import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.jboss.logging.Logger;
+import org.junit.Rule;
 import org.junit.Test;
-
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Vlad Mihalcea
  */
-@TestForIssue( jiraKey = "HHH-12609, HHH-12654" )
+@TestForIssue( jiraKey = "HHH-12609, HHH-12654, HHH-13172" )
 public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFunctionalTestCase {
 
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
+			Logger.getMessageLogger( CoreMessageLogger.class, AnnotationBinder.class.getName() ) );
+
 	@Override
-	public Class[] getAnnotatedClasses() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class[]{
 			CategoryEntity.class,
 			TaxonEntity.class,
@@ -45,13 +48,11 @@ public class EntityInheritanceAttributeOverrideTest extends BaseEntityManagerFun
 
 	@Override
 	public void buildEntityManagerFactory() {
-		try {
-			super.buildEntityManagerFactory();
-			fail("Should throw AnnotationException");
-		}
-		catch (AnnotationException e) {
-			assertTrue( e.getMessage().startsWith( "An entity annotated with @Inheritance cannot use @AttributeOverride or @AttributeOverrides" ) );
-		}
+		Triggerable warningLogged = logInspection.watchForLogMessages( "HHH000499:" );
+
+		super.buildEntityManagerFactory();
+
+		assertTrue("A warning should have been logged for this unsupported configuration", warningLogged.wasTriggered());
 	}
 
 	@Test


### PR DESCRIPTION
This is a follow-up of https://github.com/hibernate/hibernate-orm/pull/2706 .

I'm not sure exactly about what is supported or not so the condition might need some tweaking. Gail, do you know more about that?

My understanding is that it's atm only supported for `@MappedSuperclass`.

In any case, let's not throw an exception as it seems to break some applications.