### PR TITLE
HHH-13068: Fix for FK violation if "order_inserts = true" 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -1234,7 +1234,8 @@ public class ActionQueue {
 					List<AbstractEntityInsertAction> batch = actionBatches.get( rootIdentifier );
 					insertions.addAll( batch );
 				}
-			}else {
+			}
+			else {
 				LOG.warn( "Cycle detected in entity relationship in the batch containing " + latestBatches.size() + 
 								" statements, cannot be topologcal sorted" );
 			}
@@ -1321,7 +1322,8 @@ public class ActionQueue {
 				for ( BatchIdentifier adj : node.getChildren() ) {
 					if ( !visisted.contains( adj ) && isCycleUtil( adj, visisted, recursionStack ) ) {
 						return true;
-					} else if ( recursionStack.contains( adj ) ) {
+					} 
+					else if ( recursionStack.contains( adj ) ) {
 						return true;
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.hibernate.AssertionFailure;


### PR DESCRIPTION
Following are the changes proposed against [HHH-13068](https://hibernate.atlassian.net/browse/HHH-13068) :
1. Added set of children inside BatchIdentifier to detect cycle in the entity relationship.
2. Added methods to check if cycle exists in the generated dependency graph.
3. Since the time complexity of current sorting mechanism is n*n and is not certain about the order at the end which let the FK violation to be occurred even there are chances of cycle, hence changed the sorting mechanism to sorting the batch by **topological sort** if there is no cycle in dependency graph.
4. Test cases are attached in the ticket [HHH-13068](https://hibernate.atlassian.net/browse/HHH-13068).   