### PR TITLE
HHH-13184 org.hibernate.dialect.Database does not return latest oracle dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
@@ -381,7 +381,7 @@ public enum Database {
 					case 8:
 						return new Oracle8iDialect();
 					default:
-						latestDialectInstance( this );
+						return latestDialectInstance( this );
 
 				}
 			}


### PR DESCRIPTION
Default should return latestDialectInstance.

https://hibernate.atlassian.net/browse/HHH-13184