### PR TITLE
HHH-13189 org.hibernate.Query#setParameter(String, Object) is slow

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
@@ -36,8 +36,8 @@ import org.hibernate.type.Type;
 public class ParameterMetadataImpl implements ParameterMetadata {
 	private final Map<Integer,OrdinalParameterDescriptor> ordinalDescriptorMap;
 	private final Map<String,NamedParameterDescriptor> namedDescriptorMap;
-	private final Set<OrdinalParameterDescriptor> ordinalDescriptorValueCache;
-	private final Set<NamedParameterDescriptor> namedDescriptorValueCache;
+	private final Collection<QueryParameter> ordinalDescriptorValueCache;
+	private final Collection<QueryParameter> namedDescriptorValueCache;
 
 	public ParameterMetadataImpl(
 			Map<Integer,OrdinalParameterDescriptor> ordinalDescriptorMap,
@@ -47,13 +47,13 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 				: Collections.unmodifiableMap( ordinalDescriptorMap );
 		this.ordinalDescriptorValueCache = this.ordinalDescriptorMap.isEmpty()
 				? Collections.emptySet()
-				: Collections.unmodifiableSet(new HashSet<>(this.ordinalDescriptorMap.values()));
+				: Collections.unmodifiableCollection( this.ordinalDescriptorMap.values() );
 		this.namedDescriptorMap = namedDescriptorMap == null
 				? Collections.emptyMap()
 				: Collections.unmodifiableMap( namedDescriptorMap );
 		this.namedDescriptorValueCache = this.namedDescriptorMap.isEmpty()
 				? Collections.emptySet()
-				: Collections.unmodifiableSet(new HashSet<>(this.namedDescriptorMap.values()));
+				: Collections.unmodifiableCollection( this.namedDescriptorMap.values() );
 
 
 		if (ordinalDescriptorMap != null &&  ! ordinalDescriptorMap.isEmpty() ) {
@@ -87,14 +87,13 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 
 	@Override
 	public Collection<QueryParameter> getPositionalParameters() {
-		return Collections.unmodifiableCollection( ordinalDescriptorMap.values() );
+		return ordinalDescriptorValueCache;
 	}
 
 	@Override
 	public Collection<QueryParameter> getNamedParameters() {
-		return Collections.unmodifiableCollection( namedDescriptorMap.values() );
+		return namedDescriptorValueCache;
 	}
-
 
 	@Override
 	public int getParameterCount() {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
@@ -36,6 +36,8 @@ import org.hibernate.type.Type;
 public class ParameterMetadataImpl implements ParameterMetadata {
 	private final Map<Integer,OrdinalParameterDescriptor> ordinalDescriptorMap;
 	private final Map<String,NamedParameterDescriptor> namedDescriptorMap;
+	private final Set<OrdinalParameterDescriptor> ordinalDescriptorValueCache;
+	private final Set<NamedParameterDescriptor> namedDescriptorValueCache;
 
 	public ParameterMetadataImpl(
 			Map<Integer,OrdinalParameterDescriptor> ordinalDescriptorMap,
@@ -43,9 +45,16 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 		this.ordinalDescriptorMap = ordinalDescriptorMap == null
 				? Collections.emptyMap()
 				: Collections.unmodifiableMap( ordinalDescriptorMap );
+		this.ordinalDescriptorValueCache = ordinalDescriptorMap == null
+				? Collections.emptySet()
+				: Collections.unmodifiableSet(new HashSet<>(this.ordinalDescriptorMap.values()));
 		this.namedDescriptorMap = namedDescriptorMap == null
 				? Collections.emptyMap()
 				: Collections.unmodifiableMap( namedDescriptorMap );
+		this.namedDescriptorValueCache = namedDescriptorMap == null
+				? Collections.emptySet()
+				: Collections.unmodifiableSet(new HashSet<>(this.namedDescriptorMap.values()));
+
 
 		if (ordinalDescriptorMap != null &&  ! ordinalDescriptorMap.isEmpty() ) {
 			final List<Integer> sortedPositions = new ArrayList<>( ordinalDescriptorMap.keySet() );
@@ -95,8 +104,8 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 	@Override
 	@SuppressWarnings("SuspiciousMethodCalls")
 	public boolean containsReference(QueryParameter parameter) {
-		return ordinalDescriptorMap.containsValue( parameter )
-				|| namedDescriptorMap.containsValue( parameter );
+		return ordinalDescriptorValueCache.contains( parameter )
+				|| namedDescriptorValueCache.contains( parameter );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ParameterMetadataImpl.java
@@ -45,13 +45,13 @@ public class ParameterMetadataImpl implements ParameterMetadata {
 		this.ordinalDescriptorMap = ordinalDescriptorMap == null
 				? Collections.emptyMap()
 				: Collections.unmodifiableMap( ordinalDescriptorMap );
-		this.ordinalDescriptorValueCache = ordinalDescriptorMap == null
+		this.ordinalDescriptorValueCache = this.ordinalDescriptorMap.isEmpty()
 				? Collections.emptySet()
 				: Collections.unmodifiableSet(new HashSet<>(this.ordinalDescriptorMap.values()));
 		this.namedDescriptorMap = namedDescriptorMap == null
 				? Collections.emptyMap()
 				: Collections.unmodifiableMap( namedDescriptorMap );
-		this.namedDescriptorValueCache = namedDescriptorMap == null
+		this.namedDescriptorValueCache = this.namedDescriptorMap.isEmpty()
 				? Collections.emptySet()
 				: Collections.unmodifiableSet(new HashSet<>(this.namedDescriptorMap.values()));
 


### PR DESCRIPTION
With 50000 params, the time to create the params is 30s on my instance.
After proposed change, the time goes back to ~1s as it used to in 4.3.x release.

https://hibernate.atlassian.net/browse/HHH-13189