### PR TITLE
HHH-13016 HHH-13199 Fix literal enums in the select clause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/CaseLiteralExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/CaseLiteralExpression.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query.criteria.internal.expression;
+
+import org.hibernate.query.criteria.internal.CriteriaBuilderImpl;
+import org.hibernate.query.criteria.internal.compile.RenderingContext;
+import org.hibernate.query.criteria.internal.expression.function.CastFunction;
+
+/**
+ * @author Andrea Boriero
+ */
+public class CaseLiteralExpression<T> extends LiteralExpression<T> {
+
+	public CaseLiteralExpression(CriteriaBuilderImpl criteriaBuilder, Class<T> type, T literal) {
+		super( criteriaBuilder, type, literal );
+	}
+
+	@Override
+	public String render(RenderingContext renderingContext) {
+		// There's no need to cast a boolean value and it actually breaks on
+		// MySQL and MariaDB because they don't support casting to bit.
+		// Skip the cast for a boolean literal.
+		if ( getJavaType() == Boolean.class && Boolean.class.isInstance( getLiteral() ) ) {
+			return super.render( renderingContext );
+		}
+
+		// wrapping the result in a cast to determine the node type during the antlr hql parsing phase
+		return CastFunction.CAST_NAME + '(' +
+				super.render( renderingContext ) +
+				" as " +
+				renderingContext.getCastType( getJavaType() ) +
+				')';
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SearchedCaseExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SearchedCaseExpression.java
@@ -9,7 +9,7 @@ package org.hibernate.query.criteria.internal.expression;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
+
 import javax.persistence.criteria.CriteriaBuilder.Case;
 import javax.persistence.criteria.Expression;
 
@@ -69,7 +69,7 @@ public class SearchedCaseExpression<R>
 		final Class<R> type = result != null
 				? (Class<R>) result.getClass()
 				: getJavaType();
-		return new LiteralExpression<R>( criteriaBuilder(), type, result );
+		return new CaseLiteralExpression<R>( criteriaBuilder(), type, result );
 	}
 
 	public Case<R> when(Expression<Boolean> condition, Expression<? extends R> result) {

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SimpleCaseExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SimpleCaseExpression.java
@@ -76,7 +76,7 @@ public class SimpleCaseExpression<C,R>
 		final Class<R> type = result != null
 				? (Class<R>) result.getClass()
 				: getJavaType();
-		return new LiteralExpression<R>( criteriaBuilder(), type, result );
+		return new CaseLiteralExpression<R>( criteriaBuilder(), type, result );
 	}
 
 	public SimpleCase<C, R> when(C condition, Expression<? extends R> result) {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/simplecase/BasicSimpleCaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/simplecase/BasicSimpleCaseTest.java
@@ -39,6 +39,26 @@ public class BasicSimpleCaseTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-13016")
+	public void testCaseEnumResult() {
+		EntityManager em = getOrCreateEntityManager();
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+
+		CriteriaQuery<Tuple> query = builder.createTupleQuery();
+		Root<Customer> root = query.from( Customer.class );
+
+		Path<String> emailPath = root.get( "email" );
+		CriteriaBuilder.Case<EmailType> selectCase = builder.selectCase();
+		selectCase.when( builder.greaterThan( builder.length( emailPath ), 13 ), EmailType.LONG );
+		selectCase.when( builder.greaterThan( builder.length( emailPath ), 12 ), EmailType.NORMAL );
+		Expression<EmailType> emailType = selectCase.otherwise( EmailType.UNKNOWN );
+
+		query.multiselect( emailPath, emailType );
+
+		em.createQuery( query ).getResultList();
+	}
+	
+	@Test
 	@TestForIssue(jiraKey = "HHH-9343")
 	public void testCaseStringResult() {
 		EntityManager em = getOrCreateEntityManager();
@@ -186,5 +206,9 @@ public class BasicSimpleCaseTest extends BaseEntityManagerFunctionalTestCase {
 		public void setEmail(String email) {
 			this.email = email;
 		}
+	}
+
+	public enum EmailType {
+		LONG, NORMAL, UNKNOWN
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/simplecase/BasicSimpleCaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/simplecase/BasicSimpleCaseTest.java
@@ -6,24 +6,30 @@
  */
 package org.hibernate.jpa.test.criteria.simplecase;
 
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Tuple;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaBuilder.SimpleCase;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
-import org.junit.Test;
-
 import org.hibernate.testing.TestForIssue;
-
-import static javax.persistence.criteria.CriteriaBuilder.SimpleCase;
+import org.junit.Test;
 
 /**
  * Mote that these are simply performing syntax checking (can the criteria query
@@ -35,29 +41,9 @@ public class BasicSimpleCaseTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {Customer.class};
+		return new Class[] {Customer.class, TestEntity.class};
 	}
 
-	@Test
-	@TestForIssue(jiraKey = "HHH-13016")
-	public void testCaseEnumResult() {
-		EntityManager em = getOrCreateEntityManager();
-		CriteriaBuilder builder = em.getCriteriaBuilder();
-
-		CriteriaQuery<Tuple> query = builder.createTupleQuery();
-		Root<Customer> root = query.from( Customer.class );
-
-		Path<String> emailPath = root.get( "email" );
-		CriteriaBuilder.Case<EmailType> selectCase = builder.selectCase();
-		selectCase.when( builder.greaterThan( builder.length( emailPath ), 13 ), EmailType.LONG );
-		selectCase.when( builder.greaterThan( builder.length( emailPath ), 12 ), EmailType.NORMAL );
-		Expression<EmailType> emailType = selectCase.otherwise( EmailType.UNKNOWN );
-
-		query.multiselect( emailPath, emailType );
-
-		em.createQuery( query ).getResultList();
-	}
-	
 	@Test
 	@TestForIssue(jiraKey = "HHH-9343")
 	public void testCaseStringResult() {
@@ -184,6 +170,86 @@ public class BasicSimpleCaseTest extends BaseEntityManagerFunctionalTestCase {
 
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-13016")
+	public void testCaseEnumResult() {
+		EntityManager em = getOrCreateEntityManager();
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+
+		CriteriaQuery<Tuple> query = builder.createTupleQuery();
+		Root<Customer> root = query.from( Customer.class );
+
+		Path<String> emailPath = root.get( "email" );
+		CriteriaBuilder.Case<EmailType> selectCase = builder.selectCase();
+		selectCase.when( builder.greaterThan( builder.length( emailPath ), 13 ), EmailType.LONG );
+		selectCase.when( builder.greaterThan( builder.length( emailPath ), 12 ), EmailType.NORMAL );
+		Expression<EmailType> emailType = selectCase.otherwise( EmailType.UNKNOWN );
+
+		query.multiselect( emailPath, emailType );
+
+		em.createQuery( query ).getResultList();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13199")
+	public void testCaseEnumInSum() throws Exception {
+		doInJPA( this::entityManagerFactory, em -> {
+			// create entities
+			TestEntity e1 = new TestEntity();
+			e1.setEnumField( TestEnum.VAL_1 );
+			e1.setValue( 20L );
+			em.persist( e1 );
+
+			TestEntity e2 = new TestEntity();
+			e2.setEnumField( TestEnum.VAL_2 );
+			e2.setValue( 10L );
+			em.persist( e2 );
+		} );
+
+		doInJPA( this::entityManagerFactory, em -> {
+			// Works in previous version (e.g. Hibernate 5.3.7.Final)
+			// Fails in Hibernate 5.4.0.Final
+			CriteriaBuilder cb = em.getCriteriaBuilder();
+			CriteriaQuery<Tuple> query = cb.createTupleQuery();
+			Root<TestEntity> r = query.from( TestEntity.class );
+
+			CriteriaBuilder.Case<Long> case1 = cb.selectCase();
+			case1.when( cb.equal( r.<TestEnum> get( "enumField" ), cb.literal( TestEnum.VAL_1 ) ),
+					r.<Long> get( "value" ) );
+			case1.otherwise( cb.nullLiteral( Long.class ) );
+
+			CriteriaBuilder.Case<Long> case2 = cb.selectCase();
+			case2.when( cb.equal( r.<TestEnum> get( "enumField" ), cb.literal( TestEnum.VAL_2 ) ),
+					r.<Long> get( "value" ) );
+			case2.otherwise( cb.nullLiteral( Long.class ) );
+
+			/*
+			 * Generates something like on 5.3.7 "SELECT enumfield AS enumField, SUM(CASE WHEN enumfield ='1' THEN value
+			 * ELSE NULL END) AS VAL_1, SUM(CASE WHEN enumfield ='2' THEN value ELSE NULL END) AS VAL_1 FROM testentity
+			 * GROUP BY enumfield"
+			 */
+			query
+					.select( cb.tuple( r.<TestEnum> get( "enumField" ).alias( "enumField" ),
+							cb.sum( case1 ).alias( "VAL_1" ),
+							cb.sum( case2 ).alias( "VAL_2" ) ) )
+					.groupBy( r.<TestEnum> get( "enumField" ) );
+
+			List<Tuple> list = em.createQuery( query ).getResultList();
+			assertEquals( 2, list.size() );
+			for ( Tuple tuple : list ) {
+				TestEnum enumVal = tuple.get( "enumField", TestEnum.class );
+				if ( enumVal == TestEnum.VAL_1 ) {
+					assertEquals( 20L, tuple.get( "VAL_1", Long.class ).longValue() );
+					assertNull( tuple.get( "VAL_2", Long.class ) );
+				}
+				else if ( enumVal == TestEnum.VAL_2 ) {
+					assertNull( tuple.get( "VAL_1", Long.class ) );
+					assertEquals( 10L, tuple.get( "VAL_2", Long.class ).longValue() );
+				}
+			}
+		} );
+	}
+
 	@Entity(name = "Customer")
 	@Table(name = "customer")
 	public static class Customer {
@@ -210,5 +276,73 @@ public class BasicSimpleCaseTest extends BaseEntityManagerFunctionalTestCase {
 
 	public enum EmailType {
 		LONG, NORMAL, UNKNOWN
+	}
+
+	@Entity
+	public static class TestEntity {
+		@Id
+		@GeneratedValue
+		private long id;
+
+		@Convert(converter = TestEnumConverter.class)
+		private TestEnum enumField;
+
+		private Long value;
+
+		public long getId() {
+			return id;
+		}
+
+		public TestEnum getEnumField() {
+			return enumField;
+		}
+
+		public void setEnumField(TestEnum enumField) {
+			this.enumField = enumField;
+		}
+
+		public Long getValue() {
+			return value;
+		}
+
+		public void setValue(Long value) {
+			this.value = value;
+		}
+	}
+
+	public static enum TestEnum {
+		VAL_1("1"),
+		VAL_2("2");
+
+		private final String value;
+
+		private TestEnum(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public static TestEnum fromValue(String value) {
+			if (value.equals(VAL_1.value)) {
+				return VAL_1;
+			} else if (value.equals(VAL_2.value)) {
+				return VAL_2;
+			}
+			return null;
+		}
+	}
+
+	public static class TestEnumConverter implements AttributeConverter<TestEnum, String> {
+		@Override
+		public String convertToDatabaseColumn(TestEnum attribute) {
+			return attribute == null ? null : attribute.getValue();
+		}
+
+		@Override
+		public TestEnum convertToEntityAttribute(String dbData) {
+			return dbData == null ? null : TestEnum.fromValue(dbData);
+		}
 	}
 }


### PR DESCRIPTION
I agree it is not pretty but I think it's the best we can do for now to fix these 2 regressions:
 * https://hibernate.atlassian.net/browse/HHH-13199 (regression introduced in 5.4 by fixing a totally valid thing (https://hibernate.atlassian.net/browse/HHH-13001): it's just the bug was hidden before)
 * https://hibernate.atlassian.net/browse/HHH-13016 (regression introduced in 5.2 hidden by the regression introduced in 5.4)

Background: in the select clause literals are supposed to be included as is and not use binding parameters as, apparently, some drivers didn't support parameters in the select clause back in the time (no idea if it's still true, couldn't find any precise info about that).

Rendering enum literals has always been buggy and the only reason it worked is that the `renderProjection()` usage (which is used in the select case) was not propagated correctly when using `case when` or functions so enums worked in this contact by using binding parameters.

I haven't found a proper way to render an enum literal (at least not an easy one) so I decided to bring back the old behavior by forcing it. I also added a few safe guards to avoid NPE. It's definitely not pretty so if you have a better idea, it's welcome...

HHH-13016 had another issue, `CaseLiteralExpression` was removed as part of #1361 and we need it for the particular case of having `case when` expressions at the root of the select (i.e. when we cannot deduce the type automatically). I introduced it back.

@dreab8 do you confirm it was removed in #1361 because you thought it was not useful anymore?