### PR TITLE
HHH-13210 Don't log about running a script of type ScriptSourceInputN…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -463,7 +463,6 @@ public class SchemaCreatorImpl implements SchemaCreator {
 
 		if ( importScriptSetting != null ) {
 			final ScriptSourceInput importScriptInput = interpretScriptSourceSetting( importScriptSetting, classLoaderService, charsetName );
-			log.executingImportScript( importScriptInput.toString() );
 			importScriptInput.prepare();
 			try {
 				for ( String command : importScriptInput.read( commandExtractor ) ) {
@@ -490,7 +489,6 @@ public class SchemaCreatorImpl implements SchemaCreator {
 			final ScriptSourceInput importScriptInput = interpretLegacyImportScriptSetting( resourceName, classLoaderService, charsetName );
 			importScriptInput.prepare();
 			try {
-				log.executingImportScript( importScriptInput.toString() );
 				for ( String command : importScriptInput.read( commandExtractor ) ) {
 					applySqlString( command, formatter, options, targets );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/AbstractScriptSourceInput.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/AbstractScriptSourceInput.java
@@ -11,7 +11,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractor;
+import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.spi.ScriptSourceInput;
 
 /**
@@ -20,12 +23,17 @@ import org.hibernate.tool.schema.spi.ScriptSourceInput;
  * @author Steve Ebersole
  */
 public abstract class AbstractScriptSourceInput implements ScriptSourceInput {
+
+	private static final CoreMessageLogger log = CoreLogging.messageLogger( SchemaCreatorImpl.class );
+
 	protected abstract Reader reader();
 
 	@Override
 	public void prepare() {
-		// by default there is nothing to do
+		log.executingImportScript( getScriptDescription() );
 	}
+
+	protected abstract String getScriptDescription();
 
 	@Override
 	public List<String> read(ImportSqlCommandExtractor commandExtractor) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromFile.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromFile.java
@@ -56,6 +56,11 @@ public class ScriptSourceInputFromFile extends AbstractScriptSourceInput impleme
 		this.reader = toReader( file, charsetName );
 	}
 
+	@Override
+	protected String getScriptDescription() {
+		return file.getAbsolutePath();
+	}
+
 	@SuppressWarnings("ResultOfMethodCallIgnored")
 	private static Reader toReader(File file, String charsetName) {
 		if ( ! file.exists() ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromReader.java
@@ -33,6 +33,11 @@ public class ScriptSourceInputFromReader extends AbstractScriptSourceInput imple
 	}
 
 	@Override
+	protected String getScriptDescription() {
+		return "[injected ScriptSourceInputFromReader script]";
+	}
+
+	@Override
 	public String toString() {
 		return "ScriptSourceInputFromReader()";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromUrl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputFromUrl.java
@@ -66,6 +66,11 @@ public class ScriptSourceInputFromUrl extends AbstractScriptSourceInput implemen
 	}
 
 	@Override
+	protected String getScriptDescription() {
+		return url.toExternalForm();
+	}
+
+	@Override
 	public void release() {
 		try {
 			reader().close();

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ScriptSourceInput.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ScriptSourceInput.java
@@ -17,8 +17,9 @@ import org.hibernate.tool.hbm2ddl.ImportSqlCommandExtractor;
  * @author Steve Ebersole
  */
 public interface ScriptSourceInput {
+
 	/**
-	 * Prepare source for use.
+	 * Prepare source for use, and log that this script is about to be imported.
 	 */
 	void prepare();
 


### PR DESCRIPTION
…onExistentImpl

This make the output look nice and precise in all cases:

### JVM jar resource:
   `HHH000476: Executing import script 'jar:file:/home/sanne/sources/rest-http-crud/shamrock/target/rest-http-crud-shamrock-1.0.0.Alpha1-SNAPSHOT-runner.jar!/import.sql'`

### GraalVM resource:
   `HHH000476: Executing import script 'resource:import.sql'`

### No resource 
no log.

### Files
rendered as absolute path.