### PR TITLE
HHH-13239: fix lock timeout on HANA

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -1453,7 +1454,7 @@ public abstract class AbstractHANADialect extends Dialect {
 	@Override
 	public String getWriteLockString(int timeout) {
 		if ( timeout > 0 ) {
-			return getForUpdateString() + " wait " + timeout;
+			return getForUpdateString() + " wait " + getLockWaitTimeoutInSeconds( timeout );
 		}
 		else if ( timeout == 0 ) {
 			return getForUpdateNowaitString();
@@ -1466,7 +1467,7 @@ public abstract class AbstractHANADialect extends Dialect {
 	@Override
 	public String getWriteLockString(String aliases, int timeout) {
 		if ( timeout > 0 ) {
-			return getForUpdateString( aliases ) + " wait " + timeout;
+			return getForUpdateString( aliases ) + " wait " + getLockWaitTimeoutInSeconds( timeout );
 		}
 		else if ( timeout == 0 ) {
 			return getForUpdateNowaitString( aliases );
@@ -1474,6 +1475,16 @@ public abstract class AbstractHANADialect extends Dialect {
 		else {
 			return getForUpdateString( aliases );
 		}
+	}
+
+	private long getLockWaitTimeoutInSeconds(int timeoutInMilliseconds) {
+		Duration duration = Duration.ofMillis( timeoutInMilliseconds );
+		long timeoutInSeconds = duration.getSeconds();
+		if ( duration.getNano() != 0 ) {
+			LOG.info( "Changing the query timeout from " + timeoutInMilliseconds + " ms to " + timeoutInSeconds
+					+ " s, because HANA requires the timeout in seconds" );
+		}
+		return timeoutInSeconds;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/dialect/HANADialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/HANADialectTestCase.java
@@ -1,0 +1,48 @@
+package org.hibernate.dialect;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+public class HANADialectTestCase extends BaseUnitTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13239")
+	public void testLockWaitTimeout() {
+		HANAColumnStoreDialect dialect = new HANAColumnStoreDialect();
+
+		String sql = "select dummy from sys.dummy";
+
+		LockOptions lockOptions = new LockOptions( LockMode.PESSIMISTIC_WRITE );
+		lockOptions.setTimeOut( 2000 );
+
+		Map<String, String[]> keyColumns = new HashMap<>();
+
+		String sqlWithLock = dialect.applyLocksToSql( sql, lockOptions, new HashMap<>() );
+		assertEquals( sql + " for update wait 2", sqlWithLock );
+
+		lockOptions.setTimeOut( 0 );
+		sqlWithLock = dialect.applyLocksToSql( sql, lockOptions, new HashMap<>() );
+		assertEquals( sql + " for update nowait", sqlWithLock );
+
+		lockOptions.setTimeOut( 500 );
+		sqlWithLock = dialect.applyLocksToSql( sql, lockOptions, new HashMap<>() );
+		assertEquals( sql + " for update wait 0", sqlWithLock );
+
+		lockOptions.setTimeOut( 1500 );
+		sqlWithLock = dialect.applyLocksToSql( sql, lockOptions, new HashMap<>() );
+		assertEquals( sql + " for update wait 1", sqlWithLock );
+
+		lockOptions.setAliasSpecificLockMode( "dummy", LockMode.PESSIMISTIC_READ );
+		keyColumns.put( "dummy", new String[]{ "dummy" } );
+		sqlWithLock = dialect.applyLocksToSql( sql, lockOptions, keyColumns );
+		assertEquals( sql + " for update of dummy.dummy wait 1", sqlWithLock );
+	}
+}


### PR DESCRIPTION
- Convert the lock wait timeout to seconds by dividing the timeout by 1000, i.e.
  ignoring all fractions of a second