### PR TITLE
HHH-13271 Javadoc build failures on JDK 12

### DIFF
--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -98,6 +98,7 @@ javadoc {
 				'http://docs.jboss.org/cdi/api/2.0/',
 				'https://javaee.github.io/javaee-spec/javadocs/'
 		]
+		options.addStringOption('-source', '8')
 
 		if ( JavaVersion.current().isJava8Compatible() ) {
 			options.addStringOption( 'Xdoclint:none', '-quiet' )


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HHH-13271
