### PR TITLE
Remove superflous logging

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/ExceptionMapperStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ExceptionMapperStandardImpl.java
@@ -36,7 +36,6 @@ public class ExceptionMapperStandardImpl implements ExceptionMapper {
 			String message,
 			RuntimeException failure,
 			SessionImplementor session) {
-		log.unableToPerformManagedFlush( failure.getMessage() );
 		return failure;
 	}
 }


### PR DESCRIPTION
This log is spamming our system in a scenario where we catch the exception as it is expected behaviour. The logging should not be performed by a mapper but by the code handling the exception. Suggest possibly to set it at debug or info level if needed for diagnostics.