### PR TITLE
HHH-13266 LocalDateTime values are wrong around 1900 (caused by JDK-8061577)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaDescriptor.java
@@ -61,7 +61,13 @@ public class InstantJavaDescriptor extends AbstractTypeDescriptor<Instant> {
 		}
 
 		if ( java.sql.Timestamp.class.isAssignableFrom( type ) ) {
-			return (X) Timestamp.from( instant );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use Timestamp.from(), but this won't always work.
+			 * Timestamp.from() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return (X) Timestamp.valueOf( instant.atZone( ZoneId.systemDefault() ).toLocalDateTime() );
 		}
 
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
@@ -95,7 +101,13 @@ public class InstantJavaDescriptor extends AbstractTypeDescriptor<Instant> {
 
 		if ( Timestamp.class.isInstance( value ) ) {
 			final Timestamp ts = (Timestamp) value;
-			return ts.toInstant();
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use ts.toInstant(), but this won't always work.
+			 * ts.toInstant() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return ts.toLocalDateTime().atZone( ZoneId.systemDefault() ).toInstant();
 		}
 
 		if ( Long.class.isInstance( value ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaDescriptor.java
@@ -63,6 +63,13 @@ public class LocalDateJavaDescriptor extends AbstractTypeDescriptor<LocalDate> {
 		final LocalDateTime localDateTime = value.atStartOfDay();
 
 		if ( Timestamp.class.isAssignableFrom( type ) ) {
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * We could have done Timestamp.from( localDateTime.atZone( ZoneId.systemDefault() ).toInstant() ),
+			 * but on top of being more complex than the line below, it won't always work.
+			 * Timestamp.from() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
 			return (X) Timestamp.valueOf( localDateTime );
 		}
 
@@ -97,7 +104,14 @@ public class LocalDateJavaDescriptor extends AbstractTypeDescriptor<LocalDate> {
 
 		if ( Timestamp.class.isInstance( value ) ) {
 			final Timestamp ts = (Timestamp) value;
-			return LocalDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() ).toLocalDate();
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * We used to do LocalDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() ).toLocalDate(),
+			 * but on top of being more complex than the line below, it won't always work.
+			 * ts.toInstant() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return ts.toLocalDateTime().toLocalDate();
 		}
 
 		if ( Long.class.isInstance( value ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaDescriptor.java
@@ -55,8 +55,14 @@ public class LocalDateTimeJavaDescriptor extends AbstractTypeDescriptor<LocalDat
 		}
 
 		if ( java.sql.Timestamp.class.isAssignableFrom( type ) ) {
-			Instant instant = value.atZone( ZoneId.systemDefault() ).toInstant();
-			return (X) java.sql.Timestamp.from( instant );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * We used to do Timestamp.from( value.atZone( ZoneId.systemDefault() ).toInstant() ),
+			 * but on top of being more complex than the line below, it won't always work.
+			 * Timestamp.from() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return (X) Timestamp.valueOf( value );
 		}
 
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
@@ -98,7 +104,14 @@ public class LocalDateTimeJavaDescriptor extends AbstractTypeDescriptor<LocalDat
 
 		if ( Timestamp.class.isInstance( value ) ) {
 			final Timestamp ts = (Timestamp) value;
-			return LocalDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * We used to do LocalDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() ),
+			 * but on top of being more complex than the line below, it won't always work.
+			 * ts.toInstant() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return ts.toLocalDateTime();
 		}
 
 		if ( Long.class.isInstance( value ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaDescriptor.java
@@ -59,7 +59,13 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 		}
 
 		if ( Timestamp.class.isAssignableFrom( type ) ) {
-			return (X) Timestamp.from( offsetDateTime.toInstant() );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use Timestamp.from( offsetDateTime.toInstant() ), but this won't always work.
+			 * Timestamp.from() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return (X) Timestamp.valueOf( offsetDateTime.atZoneSameInstant( ZoneId.systemDefault() ).toLocalDateTime() );
 		}
 
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
@@ -93,7 +99,13 @@ public class OffsetDateTimeJavaDescriptor extends AbstractTypeDescriptor<OffsetD
 
 		if ( Timestamp.class.isInstance( value ) ) {
 			final Timestamp ts = (Timestamp) value;
-			return OffsetDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use OffsetDateTime.ofInstant( ts.toInstant(), ... ), but this won't always work.
+			 * ts.toInstant() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return ts.toLocalDateTime().atZone( ZoneId.systemDefault() ).toOffsetDateTime();
 		}
 
 		if ( Date.class.isInstance( value ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaDescriptor.java
@@ -59,7 +59,13 @@ public class ZonedDateTimeJavaDescriptor extends AbstractTypeDescriptor<ZonedDat
 		}
 
 		if ( Timestamp.class.isAssignableFrom( type ) ) {
-			return (X) Timestamp.from( zonedDateTime.toInstant() );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use Timestamp.from( zonedDateTime.toInstant() ), but this won't always work.
+			 * Timestamp.from() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return (X) Timestamp.valueOf( zonedDateTime.withZoneSameInstant( ZoneId.systemDefault() ).toLocalDateTime() );
 		}
 
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
@@ -93,7 +99,13 @@ public class ZonedDateTimeJavaDescriptor extends AbstractTypeDescriptor<ZonedDat
 
 		if ( java.sql.Timestamp.class.isInstance( value ) ) {
 			final Timestamp ts = (Timestamp) value;
-			return ZonedDateTime.ofInstant( ts.toInstant(), ZoneId.systemDefault() );
+			/*
+			 * Workaround for HHH-13266 (JDK-8061577).
+			 * Ideally we'd want to use ZonedDateTime.ofInstant( ts.toInstant(), ... ), but this won't always work.
+			 * ts.toInstant() assumes the number of milliseconds since the epoch
+			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 */
+			return ts.toLocalDateTime().atZone( ZoneId.systemDefault() );
 		}
 
 		if ( java.util.Date.class.isInstance( value ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
@@ -1,0 +1,222 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.type;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for storage of Instant properties.
+ *
+ * @param <T> The time type being tested.
+ * @param <E> The entity type used in tests.
+ */
+@RunWith(CustomParameterized.class)
+abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalTestCase {
+
+	private static Dialect determineDialect() {
+		try {
+			return Dialect.getDialect();
+		}
+		catch (Exception e) {
+			return new Dialect() {
+			};
+		}
+	}
+
+	protected static final String ENTITY_NAME = "theentity";
+	protected static final String ID_COLUMN_NAME = "theid";
+	protected static final String PROPERTY_COLUMN_NAME = "thevalue";
+
+	protected static final ZoneId ZONE_UTC_MINUS_8 = ZoneId.of( "UTC-8" );
+	protected static final ZoneId ZONE_PARIS = ZoneId.of( "Europe/Paris" );
+	protected static final ZoneId ZONE_GMT = ZoneId.of( "GMT" );
+	protected static final ZoneId ZONE_OSLO = ZoneId.of( "Europe/Oslo" );
+	protected static final ZoneId ZONE_AMSTERDAM = ZoneId.of( "Europe/Amsterdam" );
+
+	private final EnvironmentParameters env;
+
+	public AbstractJavaTimeTypeTest(EnvironmentParameters env) {
+		this.env = env;
+	}
+
+	@Override
+	protected final Class<?>[] getAnnotatedClasses() {
+		return new Class[] { getEntityType() };
+	}
+
+	protected abstract Class<E> getEntityType();
+
+	protected abstract E createEntity(int id);
+
+	protected abstract T getExpectedPropertyValue();
+
+	protected abstract T getActualPropertyValue(E entity);
+
+	protected abstract Object getExpectedJdbcValue();
+
+	protected abstract Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException;
+
+	@Before
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM " + ENTITY_NAME ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( () -> {
+			inTransaction( session -> {
+				session.persist( createEntity( 1 ) );
+			} );
+			inTransaction( session -> {
+				T read = getActualPropertyValue( session.find( getEntityType(), 1 ) );
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedPropertyValue(), read
+				);
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( () -> {
+			inTransaction( session -> {
+				session.persist( createEntity( 1 ) );
+			} );
+			inTransaction( session -> {
+				session.doWork( connection -> {
+					final PreparedStatement statement = connection.prepareStatement(
+							"SELECT " + PROPERTY_COLUMN_NAME + " FROM " + ENTITY_NAME + " WHERE " + ID_COLUMN_NAME + " = ?"
+					);
+					statement.setInt( 1, 1 );
+					statement.execute();
+					final ResultSet resultSet = statement.getResultSet();
+					resultSet.next();
+					Object nativeRead = getActualJdbcValue( resultSet, 1 );
+					assertEquals(
+							"Values written by Hibernate ORM should match the original value (same day, hour, ...)",
+							getExpectedJdbcValue(),
+							nativeRead
+					);
+				} );
+			} );
+		} );
+	}
+
+	protected final void withDefaultTimeZone(Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( env.defaultJvmTimeZone ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
+		try {
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
+		}
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
+			}
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
+		}
+		finally {
+			TimeZone.setDefault( timeZoneBefore );
+		}
+	}
+
+	protected static abstract class AbstractParametersBuilder<S extends AbstractParametersBuilder<S>> {
+
+		private final Dialect dialect;
+
+		private final List<Object[]> result = new ArrayList<>();
+
+		protected AbstractParametersBuilder() {
+			dialect = determineDialect();
+		}
+
+		protected final boolean isNanosecondPrecisionSupported() {
+			// PostgreSQL apparently doesn't support nanosecond precision correctly
+			return !( dialect instanceof PostgreSQL81Dialect );
+		}
+
+		protected final S add(ZoneId defaultJvmTimeZone, Object ... subClassParameters) {
+			List<Object> parameters = new ArrayList<>();
+			parameters.add( new EnvironmentParameters( defaultJvmTimeZone ) );
+			Collections.addAll( parameters, subClassParameters );
+			result.add( parameters.toArray() );
+			return thisAsS();
+		}
+
+		private S thisAsS() {
+			return (S) this;
+		}
+
+		public List<Object[]> build() {
+			return result;
+		}
+
+	}
+
+	protected final static class EnvironmentParameters {
+
+		/*
+		 * The default timezone affects conversions done using java.util,
+		 * which is why we take it into account even with timezone-independent types such as Instant.
+		 */
+		private final ZoneId defaultJvmTimeZone;
+
+		private EnvironmentParameters(ZoneId defaultJvmTimeZone) {
+			this.defaultJvmTimeZone = defaultJvmTimeZone;
+		}
+
+		@Override
+		public String toString() {
+			return String.format( "[JVM TZ: %s]", defaultJvmTimeZone );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.type;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -85,12 +86,12 @@ public class InstantTest extends AbstractJavaTimeTypeTest<Instant, InstantTest.E
 	}
 
 	@Override
-	protected EntityWithInstant createEntity(int id) {
-		return new EntityWithInstant( id, getExpectedPropertyValue() );
+	protected EntityWithInstant createEntityForHibernateWrite(int id) {
+		return new EntityWithInstant( id, getExpectedPropertyValueAfterHibernateRead() );
 	}
 
 	@Override
-	protected Instant getExpectedPropertyValue() {
+	protected Instant getExpectedPropertyValueAfterHibernateRead() {
 		return OffsetDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneOffset.UTC ).toInstant();
 	}
 
@@ -100,8 +101,13 @@ public class InstantTest extends AbstractJavaTimeTypeTest<Instant, InstantTest.E
 	}
 
 	@Override
-	protected Object getExpectedJdbcValue() {
-		LocalDateTime dateTimeInDefaultTimeZone = getExpectedPropertyValue().atZone( ZoneId.systemDefault() )
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
+		statement.setTimestamp( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+	}
+
+	@Override
+	protected Timestamp getExpectedJdbcValueAfterHibernateWrite() {
+		LocalDateTime dateTimeInDefaultTimeZone = getExpectedPropertyValueAfterHibernateRead().atZone( ZoneId.systemDefault() )
 				.toLocalDateTime();
 		return new Timestamp(
 				dateTimeInDefaultTimeZone.getYear() - 1900, dateTimeInDefaultTimeZone.getMonthValue() - 1,

--- a/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
@@ -6,91 +6,57 @@
  */
 package org.hibernate.test.type;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.junit4.CustomParameterized;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for storage of Instant properties.
  */
-@RunWith(CustomParameterized.class)
-public class InstantTest extends BaseCoreFunctionalTestCase {
+public class InstantTest extends AbstractJavaTimeTypeTest<Instant, InstantTest.EntityWithInstant> {
 
-	private static Dialect DIALECT;
-	private static Dialect determineDialect() {
-		try {
-			return Dialect.getDialect();
-		}
-		catch (Exception e) {
-			return new Dialect() {
-			};
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int year, int month, int day,
+				int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add( defaultTimeZone, year, month, day, hour, minute, second, nanosecond );
 		}
 	}
 
-	/*
-	 * The default timezone affects conversions done using java.util,
-	 * which is why we take it into account even when testing Instant.
-	 */
-	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6}Z [JVM TZ: {7}]")
+	@Parameterized.Parameters(name = "{1}-{2}-{3}T{4}:{5}:{6}.{7}Z {0}")
 	public static List<Object[]> data() {
-		DIALECT = determineDialect();
-		return Arrays.asList(
+		return new ParametersBuilder()
 				// Not affected by HHH-13266 (JDK-8061577)
-				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 500, ZoneId.of( "Europe/Paris" ) ),
-				data( 1970, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 2, 0, 9, 21, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1900, 1, 2, 0, 19, 32, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 500, ZONE_PARIS )
+				.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_PARIS )
+				.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
 				// Affected by HHH-13266 (JDK-8061577)
-				data( 1892, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1899, 12, 31, 23, 59, 59, 999_999_999, ZoneId.of( "Europe/Paris" ) ),
-				data( 1899, 12, 31, 23, 59, 59, 999_999_999, ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1600, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) )
-		);
-	}
-
-	private static Object[] data(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
-		if ( DIALECT instanceof PostgreSQL81Dialect ) {
-			// PostgreSQL apparently doesn't support nanosecond precision correctly
-			nanosecond = 0;
-		}
-		return new Object[] { year, month, day, hour, minute, second, nanosecond, defaultTimeZone };
+				.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_PARIS )
+				.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_AMSTERDAM )
+				.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.build();
 	}
 
 	private final int year;
@@ -100,10 +66,10 @@ public class InstantTest extends BaseCoreFunctionalTestCase {
 	private final int minute;
 	private final int second;
 	private final int nanosecond;
-	private final ZoneId defaultTimeZone;
 
-	public InstantTest(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+	public InstantTest(EnvironmentParameters env, int year, int month, int day,
+			int hour, int minute, int second, int nanosecond) {
+		super( env );
 		this.year = year;
 		this.month = month;
 		this.day = day;
@@ -111,15 +77,31 @@ public class InstantTest extends BaseCoreFunctionalTestCase {
 		this.minute = minute;
 		this.second = second;
 		this.nanosecond = nanosecond;
-		this.defaultTimeZone = defaultTimeZone;
 	}
 
-	private Instant getExpectedInstant() {
+	@Override
+	protected Class<EntityWithInstant> getEntityType() {
+		return EntityWithInstant.class;
+	}
+
+	@Override
+	protected EntityWithInstant createEntity(int id) {
+		return new EntityWithInstant( id, getExpectedPropertyValue() );
+	}
+
+	@Override
+	protected Instant getExpectedPropertyValue() {
 		return OffsetDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneOffset.UTC ).toInstant();
 	}
 
-	private Timestamp getExpectedTimestamp() {
-		LocalDateTime dateTimeInDefaultTimeZone = getExpectedInstant().atZone( ZoneId.systemDefault() )
+	@Override
+	protected Instant getActualPropertyValue(EntityWithInstant entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected Object getExpectedJdbcValue() {
+		LocalDateTime dateTimeInDefaultTimeZone = getExpectedPropertyValue().atZone( ZoneId.systemDefault() )
 				.toLocalDateTime();
 		return new Timestamp(
 				dateTimeInDefaultTimeZone.getYear() - 1900, dateTimeInDefaultTimeZone.getMonthValue() - 1,
@@ -131,104 +113,18 @@ public class InstantTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { EntityWithInstant.class };
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getTimestamp( columnIndex );
 	}
 
-	@Before
-	public void cleanup() {
-		inTransaction( session -> {
-			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithInstant( 1, getExpectedInstant() ) );
-			} );
-			inTransaction( session -> {
-				Instant read = session.find( EntityWithInstant.class, 1 ).value;
-				assertEquals(
-						"Writing then reading a value should return the original value",
-						getExpectedInstant(), read
-				);
-			} );
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenNativeRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithInstant( 1, getExpectedInstant() ) );
-			} );
-			inTransaction( session -> {
-				session.doWork( connection -> {
-					final PreparedStatement statement = connection.prepareStatement(
-							"SELECT thevalue FROM theentity WHERE theid = ?"
-					);
-					statement.setInt( 1, 1 );
-					statement.execute();
-					final ResultSet resultSet = statement.getResultSet();
-					resultSet.next();
-					Timestamp nativeRead = resultSet.getTimestamp( 1 );
-					assertEquals(
-							"Raw values written in database should match the original value (same day, hour, ...)",
-							getExpectedTimestamp(),
-							nativeRead
-					);
-				} );
-			} );
-		} );
-	}
-
-	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
-		TimeZone timeZoneBefore = TimeZone.getDefault();
-		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
-		/*
-		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
-		 * cache data dependent on the default timezone in thread local variables,
-		 * and we want this data to be reinitialized with the new default time zone.
-		 */
-		try {
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			Future<?> future = executor.submit( runnable );
-			executor.shutdown();
-			future.get();
-		}
-		catch (InterruptedException e) {
-			throw new IllegalStateException( "Interrupted while testing", e );
-		}
-		catch (ExecutionException e) {
-			Throwable cause = e.getCause();
-			if ( cause instanceof RuntimeException ) {
-				throw (RuntimeException) cause;
-			}
-			else if ( cause instanceof Error ) {
-				throw (Error) cause;
-			}
-			else {
-				throw new IllegalStateException( "Unexpected exception while testing", cause );
-			}
-		}
-		finally {
-			TimeZone.setDefault( timeZoneBefore );
-		}
-	}
-
-	@Entity
-	@Table(name = "theentity")
-	private static final class EntityWithInstant {
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithInstant {
 		@Id
-		@Column(name = "theid")
+		@Column(name = ID_COLUMN_NAME)
 		private Integer id;
 
 		@Basic
-		@Column(name = "thevalue")
+		@Column(name = PROPERTY_COLUMN_NAME)
 		private Instant value;
 
 		protected EntityWithInstant() {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
@@ -1,0 +1,242 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.type;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for storage of Instant properties.
+ */
+@RunWith(CustomParameterized.class)
+public class InstantTest extends BaseCoreFunctionalTestCase {
+
+	private static Dialect DIALECT;
+	private static Dialect determineDialect() {
+		try {
+			return Dialect.getDialect();
+		}
+		catch (Exception e) {
+			return new Dialect() {
+			};
+		}
+	}
+
+	/*
+	 * The default timezone affects conversions done using java.util,
+	 * which is why we take it into account even when testing Instant.
+	 */
+	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6}Z [JVM TZ: {7}]")
+	public static List<Object[]> data() {
+		DIALECT = determineDialect();
+		return Arrays.asList(
+				// Not affected by HHH-13266 (JDK-8061577)
+				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 500, ZoneId.of( "Europe/Paris" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 2, 0, 9, 21, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1900, 1, 2, 0, 19, 32, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				// Affected by HHH-13266 (JDK-8061577)
+				data( 1892, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1899, 12, 31, 23, 59, 59, 999_999_999, ZoneId.of( "Europe/Paris" ) ),
+				data( 1899, 12, 31, 23, 59, 59, 999_999_999, ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) )
+		);
+	}
+
+	private static Object[] data(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+		if ( DIALECT instanceof PostgreSQL81Dialect ) {
+			// PostgreSQL apparently doesn't support nanosecond precision correctly
+			nanosecond = 0;
+		}
+		return new Object[] { year, month, day, hour, minute, second, nanosecond, defaultTimeZone };
+	}
+
+	private final int year;
+	private final int month;
+	private final int day;
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+	private final ZoneId defaultTimeZone;
+
+	public InstantTest(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	private Instant getExpectedInstant() {
+		return OffsetDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneOffset.UTC ).toInstant();
+	}
+
+	private Timestamp getExpectedTimestamp() {
+		LocalDateTime dateTimeInDefaultTimeZone = getExpectedInstant().atZone( ZoneId.systemDefault() )
+				.toLocalDateTime();
+		return new Timestamp(
+				dateTimeInDefaultTimeZone.getYear() - 1900, dateTimeInDefaultTimeZone.getMonthValue() - 1,
+				dateTimeInDefaultTimeZone.getDayOfMonth(),
+				dateTimeInDefaultTimeZone.getHour(), dateTimeInDefaultTimeZone.getMinute(),
+				dateTimeInDefaultTimeZone.getSecond(),
+				dateTimeInDefaultTimeZone.getNano()
+		);
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityWithInstant.class };
+	}
+
+	@Before
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithInstant( 1, getExpectedInstant() ) );
+			} );
+			inTransaction( session -> {
+				Instant read = session.find( EntityWithInstant.class, 1 ).value;
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedInstant(), read
+				);
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithInstant( 1, getExpectedInstant() ) );
+			} );
+			inTransaction( session -> {
+				session.doWork( connection -> {
+					final PreparedStatement statement = connection.prepareStatement(
+							"SELECT thevalue FROM theentity WHERE theid = ?"
+					);
+					statement.setInt( 1, 1 );
+					statement.execute();
+					final ResultSet resultSet = statement.getResultSet();
+					resultSet.next();
+					Timestamp nativeRead = resultSet.getTimestamp( 1 );
+					assertEquals(
+							"Raw values written in database should match the original value (same day, hour, ...)",
+							getExpectedTimestamp(),
+							nativeRead
+					);
+				} );
+			} );
+		} );
+	}
+
+	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
+		try {
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
+		}
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
+			}
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
+		}
+		finally {
+			TimeZone.setDefault( timeZoneBefore );
+		}
+	}
+
+	@Entity
+	@Table(name = "theentity")
+	private static final class EntityWithInstant {
+		@Id
+		@Column(name = "theid")
+		private Integer id;
+
+		@Basic
+		@Column(name = "thevalue")
+		private Instant value;
+
+		protected EntityWithInstant() {
+		}
+
+		private EntityWithInstant(int id, Instant value) {
+			this.id = id;
+			this.value = value;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.test.type;
 
 import java.sql.Date;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -68,12 +69,12 @@ public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDate
 	}
 
 	@Override
-	protected EntityWithLocalDate createEntity(int id) {
-		return new EntityWithLocalDate( id, getExpectedPropertyValue() );
+	protected EntityWithLocalDate createEntityForHibernateWrite(int id) {
+		return new EntityWithLocalDate( id, getExpectedPropertyValueAfterHibernateRead() );
 	}
 
 	@Override
-	protected LocalDate getExpectedPropertyValue() {
+	protected LocalDate getExpectedPropertyValueAfterHibernateRead() {
 		return LocalDate.of( year, month, day );
 	}
 
@@ -83,7 +84,12 @@ public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDate
 	}
 
 	@Override
-	protected Object getExpectedJdbcValue() {
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
+		statement.setDate( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+	}
+
+	@Override
+	protected Date getExpectedJdbcValueAfterHibernateWrite() {
 		return new Date( year - 1900, month - 1, day );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -1,103 +1,200 @@
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */
 package org.hibernate.test.type;
 
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.Session;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
-
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 /**
- * @author Andrea Boriero
+ * Tests for storage of LocalDate properties.
  */
+@RunWith(CustomParameterized.class)
 @TestForIssue(jiraKey = "HHH-10371")
-public class LocalDateTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LocalDateTest extends BaseCoreFunctionalTestCase {
 
-	private static final LocalDate expectedLocalDate = LocalDate.of( 1, 1, 1 );
+	/*
+	 * The default timezone affects conversions done using java.util,
+	 * which is why we take it into account even when testing LocalDateTime.
+	 */
+	@Parameterized.Parameters(name = "{0}-{1}-{2} [JVM TZ: {3}]")
+	public static List<Object[]> data() {
+		return Arrays.asList(
+				// Not affected by HHH-13266 (JDK-8061577)
+				data( 2017, 11, 6, ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, ZoneId.of( "Europe/Paris" ) ),
+				data( 1970, 1, 1, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 2, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 2, ZoneId.of( "Europe/Amsterdam" ) ),
+				// Could have been affected by HHH-13266 (JDK-8061577), but was not
+				data( 1892, 1, 1, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, ZoneId.of( "Europe/Amsterdam" ) )
+		);
+	}
+
+	private static Object[] data(int year, int month, int day, ZoneId defaultTimeZone) {
+		return new Object[] { year, month, day, defaultTimeZone };
+	}
+
+	private final int year;
+	private final int month;
+	private final int day;
+	private final ZoneId defaultTimeZone;
+
+	public LocalDateTest(int year, int month, int day, ZoneId defaultTimeZone) {
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	private LocalDate getExpectedLocalDate() {
+		return LocalDate.of( year, month, day );
+	}
+
+	private Date getExpectedSqlDate() {
+		return new Date( year - 1900, month - 1, day );
+	}
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {LocalDateEvent.class};
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityWithLocalDate.class };
 	}
 
 	@Before
-	public void setUp() {
-		final Session s = openSession();
-		s.getTransaction().begin();
-		try {
-			s.save( new LocalDateEvent( 1L, expectedLocalDate ) );
-			s.getTransaction().commit();
-		}
-		catch (Exception e) {
-			if ( s.getTransaction() != null && s.getTransaction().getStatus() == TransactionStatus.ACTIVE ) {
-				s.getTransaction().rollback();
-			}
-			fail( e.getMessage() );
-		}
-		finally {
-			s.close();
-		}
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
+		} );
 	}
 
 	@Test
-	public void testLocalDate() {
-		final Session s = openSession();
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithLocalDate( 1, getExpectedLocalDate() ) );
+			} );
+			inTransaction( session -> {
+				LocalDate read = session.find( EntityWithLocalDate.class, 1 ).value;
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedLocalDate(), read
+				);
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithLocalDate( 1, getExpectedLocalDate() ) );
+			} );
+			inTransaction( session -> {
+				session.doWork( connection -> {
+					final PreparedStatement statement = connection.prepareStatement(
+							"SELECT thevalue FROM theentity WHERE theid = ?"
+					);
+					statement.setInt( 1, 1 );
+					statement.execute();
+					final ResultSet resultSet = statement.getResultSet();
+					resultSet.next();
+					Date nativeRead = resultSet.getDate( 1 );
+					assertEquals(
+							"Raw values written in database should match the original value (same day, hour, ...)",
+							getExpectedSqlDate(),
+							nativeRead
+					);
+				} );
+			} );
+		} );
+	}
+
+	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
 		try {
-			final LocalDateEvent localDateEvent = s.get( LocalDateEvent.class, 1L );
-			assertThat( localDateEvent.getStartDate(), is( expectedLocalDate ) );
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
+		}
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
+			}
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
 		}
 		finally {
-			s.close();
+			TimeZone.setDefault( timeZoneBefore );
 		}
 	}
 
-	@Entity(name = "LocalDateEvent")
-	@Table(name = "LOCAL_DATE_EVENT")
-	public static class LocalDateEvent {
-		private Long id;
-		private LocalDate startDate;
-
-		public LocalDateEvent() {
-		}
-
-		public LocalDateEvent(Long id, LocalDate startDate) {
-			this.id = id;
-			this.startDate = startDate;
-		}
-
+	@Entity
+	@Table(name = "theentity")
+	private static final class EntityWithLocalDate {
 		@Id
-		public Long getId() {
-			return id;
+		@Column(name = "theid")
+		private Integer id;
+
+		@Basic
+		@Column(name = "thevalue")
+		private LocalDate value;
+
+		protected EntityWithLocalDate() {
 		}
 
-		public void setId(Long id) {
+		private EntityWithLocalDate(int id, LocalDate value) {
 			this.id = id;
-		}
-
-		@Column(name = "START_DATE")
-		public LocalDate getStartDate() {
-			return startDate;
-		}
-
-		public void setStartDate(LocalDate startDate) {
-			this.startDate = startDate;
+			this.value = value;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -7,186 +7,99 @@
 package org.hibernate.test.type;
 
 import java.sql.Date;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.junit4.CustomParameterized;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for storage of LocalDate properties.
  */
-@RunWith(CustomParameterized.class)
 @TestForIssue(jiraKey = "HHH-10371")
-public class LocalDateTest extends BaseCoreFunctionalTestCase {
+public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDateTest.EntityWithLocalDate> {
 
-	/*
-	 * The default timezone affects conversions done using java.util,
-	 * which is why we take it into account even when testing LocalDateTime.
-	 */
-	@Parameterized.Parameters(name = "{0}-{1}-{2} [JVM TZ: {3}]")
-	public static List<Object[]> data() {
-		return Arrays.asList(
-				// Not affected by HHH-13266 (JDK-8061577)
-				data( 2017, 11, 6, ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, ZoneId.of( "Europe/Paris" ) ),
-				data( 1970, 1, 1, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 2, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 2, ZoneId.of( "Europe/Amsterdam" ) ),
-				// Could have been affected by HHH-13266 (JDK-8061577), but was not
-				data( 1892, 1, 1, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 1, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1600, 1, 1, ZoneId.of( "Europe/Amsterdam" ) )
-		);
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int year, int month, int day, ZoneId defaultTimeZone) {
+			return add( defaultTimeZone, year, month, day );
+		}
 	}
 
-	private static Object[] data(int year, int month, int day, ZoneId defaultTimeZone) {
-		return new Object[] { year, month, day, defaultTimeZone };
+	@Parameterized.Parameters(name = "{1}-{2}-{3} {0}")
+	public static List<Object[]> data() {
+		return new ParametersBuilder()
+				// Not affected by HHH-13266 (JDK-8061577)
+				.add( 2017, 11, 6, ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, ZONE_PARIS )
+				.add( 1970, 1, 1, ZONE_GMT )
+				.add( 1900, 1, 1, ZONE_GMT )
+				.add( 1900, 1, 1, ZONE_OSLO )
+				.add( 1900, 1, 2, ZONE_PARIS )
+				.add( 1900, 1, 2, ZONE_AMSTERDAM )
+				// Could have been affected by HHH-13266 (JDK-8061577), but was not
+				.add( 1892, 1, 1, ZONE_OSLO )
+				.add( 1900, 1, 1, ZONE_PARIS )
+				.add( 1900, 1, 1, ZONE_AMSTERDAM )
+				.add( 1600, 1, 1, ZONE_AMSTERDAM )
+				.build();
 	}
 
 	private final int year;
 	private final int month;
 	private final int day;
-	private final ZoneId defaultTimeZone;
 
-	public LocalDateTest(int year, int month, int day, ZoneId defaultTimeZone) {
+	public LocalDateTest(EnvironmentParameters env, int year, int month, int day) {
+		super( env );
 		this.year = year;
 		this.month = month;
 		this.day = day;
-		this.defaultTimeZone = defaultTimeZone;
 	}
 
-	private LocalDate getExpectedLocalDate() {
+	@Override
+	protected Class<EntityWithLocalDate> getEntityType() {
+		return EntityWithLocalDate.class;
+	}
+
+	@Override
+	protected EntityWithLocalDate createEntity(int id) {
+		return new EntityWithLocalDate( id, getExpectedPropertyValue() );
+	}
+
+	@Override
+	protected LocalDate getExpectedPropertyValue() {
 		return LocalDate.of( year, month, day );
 	}
 
-	private Date getExpectedSqlDate() {
+	@Override
+	protected LocalDate getActualPropertyValue(EntityWithLocalDate entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected Object getExpectedJdbcValue() {
 		return new Date( year - 1900, month - 1, day );
 	}
 
 	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { EntityWithLocalDate.class };
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getDate( columnIndex );
 	}
 
-	@Before
-	public void cleanup() {
-		inTransaction( session -> {
-			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithLocalDate( 1, getExpectedLocalDate() ) );
-			} );
-			inTransaction( session -> {
-				LocalDate read = session.find( EntityWithLocalDate.class, 1 ).value;
-				assertEquals(
-						"Writing then reading a value should return the original value",
-						getExpectedLocalDate(), read
-				);
-			} );
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenNativeRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithLocalDate( 1, getExpectedLocalDate() ) );
-			} );
-			inTransaction( session -> {
-				session.doWork( connection -> {
-					final PreparedStatement statement = connection.prepareStatement(
-							"SELECT thevalue FROM theentity WHERE theid = ?"
-					);
-					statement.setInt( 1, 1 );
-					statement.execute();
-					final ResultSet resultSet = statement.getResultSet();
-					resultSet.next();
-					Date nativeRead = resultSet.getDate( 1 );
-					assertEquals(
-							"Raw values written in database should match the original value (same day, hour, ...)",
-							getExpectedSqlDate(),
-							nativeRead
-					);
-				} );
-			} );
-		} );
-	}
-
-	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
-		TimeZone timeZoneBefore = TimeZone.getDefault();
-		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
-		/*
-		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
-		 * cache data dependent on the default timezone in thread local variables,
-		 * and we want this data to be reinitialized with the new default time zone.
-		 */
-		try {
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			Future<?> future = executor.submit( runnable );
-			executor.shutdown();
-			future.get();
-		}
-		catch (InterruptedException e) {
-			throw new IllegalStateException( "Interrupted while testing", e );
-		}
-		catch (ExecutionException e) {
-			Throwable cause = e.getCause();
-			if ( cause instanceof RuntimeException ) {
-				throw (RuntimeException) cause;
-			}
-			else if ( cause instanceof Error ) {
-				throw (Error) cause;
-			}
-			else {
-				throw new IllegalStateException( "Unexpected exception while testing", cause );
-			}
-		}
-		finally {
-			TimeZone.setDefault( timeZoneBefore );
-		}
-	}
-
-	@Entity
-	@Table(name = "theentity")
-	private static final class EntityWithLocalDate {
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithLocalDate {
 		@Id
-		@Column(name = "theid")
+		@Column(name = ID_COLUMN_NAME)
 		private Integer id;
 
 		@Basic
-		@Column(name = "thevalue")
+		@Column(name = PROPERTY_COLUMN_NAME)
 		private LocalDate value;
 
 		protected EntityWithLocalDate() {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
@@ -6,86 +6,52 @@
  */
 package org.hibernate.test.type;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.junit4.CustomParameterized;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for storage of LocalDateTime properties.
  */
-@RunWith(CustomParameterized.class)
-public class LocalDateTimeTest extends BaseCoreFunctionalTestCase {
+public class LocalDateTimeTest extends AbstractJavaTimeTypeTest<LocalDateTime, LocalDateTimeTest.EntityWithLocalDateTime> {
 
-	private static Dialect DIALECT;
-	private static Dialect determineDialect() {
-		try {
-			return Dialect.getDialect();
-		}
-		catch (Exception e) {
-			return new Dialect() {
-			};
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int year, int month, int day,
+				int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add( defaultTimeZone, year, month, day, hour, minute, second, nanosecond );
 		}
 	}
 
-	/*
-	 * The default timezone affects conversions done using java.util,
-	 * which is why we take it into account even when testing LocalDateTime.
-	 */
-	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6} [JVM TZ: {7}]")
+	@Parameterized.Parameters(name = "{1}-{2}-{3}T{4}:{5}:{6}.{7} {0}")
 	public static List<Object[]> data() {
-		DIALECT = determineDialect();
-		return Arrays.asList(
+		return new ParametersBuilder()
 				// Not affected by HHH-13266 (JDK-8061577)
-				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 500, ZoneId.of( "Europe/Paris" ) ),
-				data( 1970, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 2, 0, 9, 21, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 2, 0, 19, 32, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 500, ZONE_PARIS )
+				.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+				.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
 				// Affected by HHH-13266 (JDK-8061577)
-				data( 1892, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 1, 0, 9, 20, 0, ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 31, 0, ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1600, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) )
-		);
-	}
-
-	private static Object[] data(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
-		if ( DIALECT instanceof PostgreSQL81Dialect ) {
-			// PostgreSQL apparently doesn't support nanosecond precision correctly
-			nanosecond = 0;
-		}
-		return new Object[] { year, month, day, hour, minute, second, nanosecond, defaultTimeZone };
+				.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.add( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
+				.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.build();
 	}
 
 	private final int year;
@@ -95,10 +61,10 @@ public class LocalDateTimeTest extends BaseCoreFunctionalTestCase {
 	private final int minute;
 	private final int second;
 	private final int nanosecond;
-	private final ZoneId defaultTimeZone;
 
-	public LocalDateTimeTest(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+	public LocalDateTimeTest(EnvironmentParameters env, int year, int month, int day,
+			int hour, int minute, int second, int nanosecond) {
+		super( env );
 		this.year = year;
 		this.month = month;
 		this.day = day;
@@ -106,14 +72,30 @@ public class LocalDateTimeTest extends BaseCoreFunctionalTestCase {
 		this.minute = minute;
 		this.second = second;
 		this.nanosecond = nanosecond;
-		this.defaultTimeZone = defaultTimeZone;
 	}
 
-	private LocalDateTime getExpectedLocalDateTime() {
+	@Override
+	protected Class<EntityWithLocalDateTime> getEntityType() {
+		return EntityWithLocalDateTime.class;
+	}
+
+	@Override
+	protected EntityWithLocalDateTime createEntity(int id) {
+		return new EntityWithLocalDateTime( id, getExpectedPropertyValue() );
+	}
+
+	@Override
+	protected LocalDateTime getExpectedPropertyValue() {
 		return LocalDateTime.of( year, month, day, hour, minute, second, nanosecond );
 	}
 
-	private Timestamp getExpectedTimestamp() {
+	@Override
+	protected LocalDateTime getActualPropertyValue(EntityWithLocalDateTime entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected Object getExpectedJdbcValue() {
 		return new Timestamp(
 				year - 1900, month - 1, day,
 				hour, minute, second, nanosecond
@@ -121,104 +103,18 @@ public class LocalDateTimeTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { EntityWithLocalDateTime.class };
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getTimestamp( columnIndex );
 	}
 
-	@Before
-	public void cleanup() {
-		inTransaction( session -> {
-			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithLocalDateTime( 1, getExpectedLocalDateTime() ) );
-			} );
-			inTransaction( session -> {
-				LocalDateTime read = session.find( EntityWithLocalDateTime.class, 1 ).value;
-				assertEquals(
-						"Writing then reading a value should return the original value",
-						getExpectedLocalDateTime(), read
-				);
-			} );
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenNativeRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithLocalDateTime( 1, getExpectedLocalDateTime() ) );
-			} );
-			inTransaction( session -> {
-				session.doWork( connection -> {
-					final PreparedStatement statement = connection.prepareStatement(
-							"SELECT thevalue FROM theentity WHERE theid = ?"
-					);
-					statement.setInt( 1, 1 );
-					statement.execute();
-					final ResultSet resultSet = statement.getResultSet();
-					resultSet.next();
-					Timestamp nativeRead = resultSet.getTimestamp( 1 );
-					assertEquals(
-							"Raw values written in database should match the original value (same day, hour, ...)",
-							getExpectedTimestamp(),
-							nativeRead
-					);
-				} );
-			} );
-		} );
-	}
-
-	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
-		TimeZone timeZoneBefore = TimeZone.getDefault();
-		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
-		/*
-		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
-		 * cache data dependent on the default timezone in thread local variables,
-		 * and we want this data to be reinitialized with the new default time zone.
-		 */
-		try {
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			Future<?> future = executor.submit( runnable );
-			executor.shutdown();
-			future.get();
-		}
-		catch (InterruptedException e) {
-			throw new IllegalStateException( "Interrupted while testing", e );
-		}
-		catch (ExecutionException e) {
-			Throwable cause = e.getCause();
-			if ( cause instanceof RuntimeException ) {
-				throw (RuntimeException) cause;
-			}
-			else if ( cause instanceof Error ) {
-				throw (Error) cause;
-			}
-			else {
-				throw new IllegalStateException( "Unexpected exception while testing", cause );
-			}
-		}
-		finally {
-			TimeZone.setDefault( timeZoneBefore );
-		}
-	}
-
-	@Entity
-	@Table(name = "theentity")
-	private static final class EntityWithLocalDateTime {
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithLocalDateTime {
 		@Id
-		@Column(name = "theid")
+		@Column(name = ID_COLUMN_NAME)
 		private Integer id;
 
 		@Basic
-		@Column(name = "thevalue")
+		@Column(name = PROPERTY_COLUMN_NAME)
 		private LocalDateTime value;
 
 		protected EntityWithLocalDateTime() {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
@@ -1,0 +1,224 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.type;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for storage of LocalDateTime properties.
+ */
+@RunWith(CustomParameterized.class)
+public class LocalDateTimeTest extends BaseCoreFunctionalTestCase {
+
+	private static Dialect DIALECT;
+	private static Dialect determineDialect() {
+		try {
+			return Dialect.getDialect();
+		}
+		catch (Exception e) {
+			return new Dialect() {
+			};
+		}
+	}
+
+	/*
+	 * The default timezone affects conversions done using java.util,
+	 * which is why we take it into account even when testing LocalDateTime.
+	 */
+	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6} [JVM TZ: {7}]")
+	public static List<Object[]> data() {
+		DIALECT = determineDialect();
+		return Arrays.asList(
+				// Not affected by HHH-13266 (JDK-8061577)
+				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 500, ZoneId.of( "Europe/Paris" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 2, 0, 9, 21, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 2, 0, 19, 32, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				// Affected by HHH-13266 (JDK-8061577)
+				data( 1892, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 9, 20, 0, ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, 0, 0, 0, 0, ZoneId.of( "Europe/Amsterdam" ) )
+		);
+	}
+
+	private static Object[] data(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+		if ( DIALECT instanceof PostgreSQL81Dialect ) {
+			// PostgreSQL apparently doesn't support nanosecond precision correctly
+			nanosecond = 0;
+		}
+		return new Object[] { year, month, day, hour, minute, second, nanosecond, defaultTimeZone };
+	}
+
+	private final int year;
+	private final int month;
+	private final int day;
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+	private final ZoneId defaultTimeZone;
+
+	public LocalDateTimeTest(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	private LocalDateTime getExpectedLocalDateTime() {
+		return LocalDateTime.of( year, month, day, hour, minute, second, nanosecond );
+	}
+
+	private Timestamp getExpectedTimestamp() {
+		return new Timestamp(
+				year - 1900, month - 1, day,
+				hour, minute, second, nanosecond
+		);
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityWithLocalDateTime.class };
+	}
+
+	@Before
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithLocalDateTime( 1, getExpectedLocalDateTime() ) );
+			} );
+			inTransaction( session -> {
+				LocalDateTime read = session.find( EntityWithLocalDateTime.class, 1 ).value;
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedLocalDateTime(), read
+				);
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithLocalDateTime( 1, getExpectedLocalDateTime() ) );
+			} );
+			inTransaction( session -> {
+				Timestamp nativeRead = (Timestamp) session.createNativeQuery(
+						"SELECT thevalue FROM theentity WHERE theid = :id"
+				)
+						.setParameter( "id", 1 )
+						.uniqueResult();
+				assertEquals(
+						"Raw values written in database should match the original value (same day, hour, ...)",
+						getExpectedTimestamp(), nativeRead
+				);
+			} );
+		} );
+	}
+
+	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
+		try {
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
+		}
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
+			}
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
+		}
+		finally {
+			TimeZone.setDefault( timeZoneBefore );
+		}
+	}
+
+	@Entity
+	@Table(name = "theentity")
+	private static final class EntityWithLocalDateTime {
+		@Id
+		@Column(name = "theid")
+		private Integer id;
+
+		@Basic
+		@Column(name = "thevalue")
+		private LocalDateTime value;
+
+		protected EntityWithLocalDateTime() {
+		}
+
+		private EntityWithLocalDateTime(int id, LocalDateTime value) {
+			this.id = id;
+			this.value = value;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.type;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -80,12 +81,12 @@ public class LocalDateTimeTest extends AbstractJavaTimeTypeTest<LocalDateTime, L
 	}
 
 	@Override
-	protected EntityWithLocalDateTime createEntity(int id) {
-		return new EntityWithLocalDateTime( id, getExpectedPropertyValue() );
+	protected EntityWithLocalDateTime createEntityForHibernateWrite(int id) {
+		return new EntityWithLocalDateTime( id, getExpectedPropertyValueAfterHibernateRead() );
 	}
 
 	@Override
-	protected LocalDateTime getExpectedPropertyValue() {
+	protected LocalDateTime getExpectedPropertyValueAfterHibernateRead() {
 		return LocalDateTime.of( year, month, day, hour, minute, second, nanosecond );
 	}
 
@@ -95,7 +96,12 @@ public class LocalDateTimeTest extends AbstractJavaTimeTypeTest<LocalDateTime, L
 	}
 
 	@Override
-	protected Object getExpectedJdbcValue() {
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
+		statement.setTimestamp( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+	}
+
+	@Override
+	protected Timestamp getExpectedJdbcValueAfterHibernateWrite() {
 		return new Timestamp(
 				year - 1900, month - 1, day,
 				hour, minute, second, nanosecond

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
@@ -1,0 +1,186 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.type;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests for storage of LocalTime properties.
+ */
+public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTimeTest.EntityWithLocalTime> {
+
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add( defaultTimeZone, hour, minute, second, nanosecond, 1970, 1, 1 );
+		}
+
+		public ParametersBuilder addPersistedWithoutHibernate(int yearWhenPersistedWithoutHibernate,
+				int monthWhenPersistedWithoutHibernate, int dayWhenPersistedWithoutHibernate,
+				int hour, int minute, int second, int nanosecond, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add(
+					defaultTimeZone, hour, minute, second, nanosecond,
+					yearWhenPersistedWithoutHibernate,
+					monthWhenPersistedWithoutHibernate, dayWhenPersistedWithoutHibernate
+			);
+		}
+	}
+
+	@Parameterized.Parameters(name = "{1}:{2}:{3}.{4} (JDBC write date: {5}-{6}-{7}) {0}")
+	public static List<Object[]> data() {
+		return new ParametersBuilder()
+				.alsoTestRemappingsWithH2( TimeAsTimestampRemappingH2Dialect.class )
+				// None of these values was affected by HHH-13266 (JDK-8061577)
+				.add( 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
+				.add( 19, 19, 1, 0, ZONE_PARIS )
+				.add( 19, 19, 1, 500, ZONE_PARIS )
+				.add( 0, 0, 0, 0, ZONE_GMT )
+				.add( 0, 0, 0, 0, ZONE_OSLO )
+				.add( 0, 9, 20, 0, ZONE_PARIS )
+				.add( 0, 19, 31, 0, ZONE_AMSTERDAM )
+				.add( 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.addPersistedWithoutHibernate( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+				.addPersistedWithoutHibernate( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
+				.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
+				.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.build();
+	}
+
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+
+	private final int yearWhenPersistedWithoutHibernate;
+	private final int monthWhenPersistedWithoutHibernate;
+	private final int dayWhenPersistedWithoutHibernate;
+
+	public LocalTimeTest(EnvironmentParameters env, int hour, int minute, int second, int nanosecond,
+			int yearWhenPersistedWithoutHibernate, int monthWhenPersistedWithoutHibernate, int dayWhenPersistedWithoutHibernate) {
+		super( env );
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.yearWhenPersistedWithoutHibernate = yearWhenPersistedWithoutHibernate;
+		this.monthWhenPersistedWithoutHibernate = monthWhenPersistedWithoutHibernate;
+		this.dayWhenPersistedWithoutHibernate = dayWhenPersistedWithoutHibernate;
+	}
+
+	@Override
+	protected Class<EntityWithLocalTime> getEntityType() {
+		return EntityWithLocalTime.class;
+	}
+
+	@Override
+	protected EntityWithLocalTime createEntityForHibernateWrite(int id) {
+		return new EntityWithLocalTime( id, getOriginalPropertyValue() );
+	}
+
+	protected LocalTime getOriginalPropertyValue() {
+		return LocalTime.of( hour, minute, second, nanosecond );
+	}
+
+	@Override
+	protected LocalTime getExpectedPropertyValueAfterHibernateRead() {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			return getOriginalPropertyValue();
+		}
+		else {
+			// When storing time as java.sql.Time, we only get second precision (not nanosecond)
+			return getOriginalPropertyValue().withNano( 0 );
+		}
+	}
+
+	@Override
+	protected LocalTime getActualPropertyValue(EntityWithLocalTime entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex)
+			throws SQLException {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			statement.setTimestamp(
+					parameterIndex,
+					new Timestamp(
+							yearWhenPersistedWithoutHibernate - 1900,
+							monthWhenPersistedWithoutHibernate - 1,
+							dayWhenPersistedWithoutHibernate,
+							hour, minute, second, nanosecond
+					)
+			);
+		}
+		else {
+			statement.setTime( parameterIndex, new Time( hour, minute, second ) );
+		}
+	}
+
+	@Override
+	protected Object getExpectedJdbcValueAfterHibernateWrite() {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			return new Timestamp( 1970 - 1900, 0, 1, hour, minute, second, nanosecond );
+		}
+		else {
+			return new Time( hour, minute, second );
+		}
+	}
+
+	@Override
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getTimestamp( columnIndex );
+	}
+
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithLocalTime {
+		@Id
+		@Column(name = ID_COLUMN_NAME)
+		private Integer id;
+
+		@Basic
+		@Column(name = PROPERTY_COLUMN_NAME)
+		private LocalTime value;
+
+		protected EntityWithLocalTime() {
+		}
+
+		private EntityWithLocalTime(int id, LocalTime value) {
+			this.id = id;
+			this.value = value;
+		}
+	}
+
+	public static class TimeAsTimestampRemappingH2Dialect extends AbstractRemappingH2Dialect {
+		public TimeAsTimestampRemappingH2Dialect() {
+			super( Types.TIME, TimestampTypeDescriptor.INSTANCE );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
@@ -6,160 +6,294 @@
  */
 package org.hibernate.test.type;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.OffsetDateTimeType;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Andrea Boriero
  */
+@RunWith(CustomParameterized.class)
 @TestForIssue(jiraKey = "HHH-10372")
 public class OffsetDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
 
+	private static Dialect DIALECT;
+	private static Dialect determineDialect() {
+		try {
+			return Dialect.getDialect();
+		}
+		catch (Exception e) {
+			return new Dialect() {
+			};
+		}
+	}
+
+	/*
+	 * The default timezone affects conversions done using java.util,
+	 * which is why we take it into account even when testing OffsetDateTime.
+	 */
+	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6}[{7}] [JVM TZ: {8}]")
+	public static List<Object[]> data() {
+		DIALECT = determineDialect();
+		return Arrays.asList(
+				// Not affected by HHH-13266
+				data( 2017, 11, 6, 19, 19, 1, 0, "+10:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+07:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+01:30", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+01:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+00:30", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-02:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-06:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-08:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+10:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+07:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+01:30", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 500, "+01:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+01:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "+00:30", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-02:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-06:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "-08:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "+01:00", ZoneId.of( "GMT" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "+00:00", ZoneId.of( "GMT" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "-01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "+01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "-01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 9, 21, 0, "+00:09:21", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
+				// Affected by HHH-13266
+				data( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZoneId.of( "Europe/Amsterdam" ) )
+		);
+	}
+
+	private static Object[] data(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, String offset, ZoneId defaultTimeZone) {
+		if ( DIALECT instanceof PostgreSQL81Dialect ) {
+			// PostgreSQL apparently doesn't support nanosecond precision correctly
+			nanosecond = 0;
+		}
+		return new Object[] { year, month, day, hour, minute, second, nanosecond, offset, defaultTimeZone };
+	}
+
+	private final int year;
+	private final int month;
+	private final int day;
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+	private final String offset;
+	private final ZoneId defaultTimeZone;
+
+	public OffsetDateTimeTest(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, String offset, ZoneId defaultTimeZone) {
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.offset = offset;
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	private OffsetDateTime getOriginalOffsetDateTime() {
+		return OffsetDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneOffset.of( offset ) );
+	}
+
+	private OffsetDateTime getExpectedOffsetDateTime() {
+		return getOriginalOffsetDateTime().atZoneSameInstant( ZoneId.systemDefault() ).toOffsetDateTime();
+	}
+
+	private Timestamp getExpectedTimestamp() {
+		LocalDateTime dateTimeInDefaultTimeZone = getOriginalOffsetDateTime().atZoneSameInstant( ZoneId.systemDefault() )
+				.toLocalDateTime();
+		return new Timestamp(
+				dateTimeInDefaultTimeZone.getYear() - 1900, dateTimeInDefaultTimeZone.getMonthValue() - 1,
+				dateTimeInDefaultTimeZone.getDayOfMonth(),
+				dateTimeInDefaultTimeZone.getHour(), dateTimeInDefaultTimeZone.getMinute(),
+				dateTimeInDefaultTimeZone.getSecond(),
+				dateTimeInDefaultTimeZone.getNano()
+		);
+	}
+
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {OffsetDateTimeEvent.class};
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityWithOffsetDateTime.class };
+	}
+
+	@Before
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
+		} );
 	}
 
 	@Test
-	public void testOffsetDateTimeWithHoursZoneOffset() {
-		final OffsetDateTime expectedStartDate = OffsetDateTime.of(
-				2015,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.ofHours( 5 )
-		);
-
-		saveOffsetDateTimeEventWithStartDate( expectedStartDate );
-
-		checkSavedOffsetDateTimeIsEqual( expectedStartDate );
-		compareSavedOffsetDateTimeWith( expectedStartDate );
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithOffsetDateTime( 1, getOriginalOffsetDateTime() ) );
+			} );
+			inTransaction( session -> {
+				OffsetDateTime read = session.find( org.hibernate.test.type.OffsetDateTimeTest.EntityWithOffsetDateTime.class, 1 ).value;
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedOffsetDateTime(), read
+				);
+				assertTrue(
+						getExpectedOffsetDateTime().isEqual( read )
+				);
+				assertEquals(
+						0,
+						OffsetDateTimeType.INSTANCE.getComparator().compare( getExpectedOffsetDateTime(), read )
+				);
+			} );
+		} );
 	}
 
 	@Test
-	public void testOffsetDateTimeWithUTCZoneOffset() {
-		final OffsetDateTime expectedStartDate = OffsetDateTime.of(
-				1,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.UTC
-		);
-
-		saveOffsetDateTimeEventWithStartDate( expectedStartDate );
-
-		checkSavedOffsetDateTimeIsEqual( expectedStartDate );
-		compareSavedOffsetDateTimeWith( expectedStartDate );
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithOffsetDateTime( 1, getOriginalOffsetDateTime() ) );
+			} );
+			inTransaction( session -> {
+				session.doWork( connection -> {
+					final PreparedStatement statement = connection.prepareStatement(
+							"SELECT thevalue FROM theentity WHERE theid = ?"
+					);
+					statement.setInt( 1, 1 );
+					statement.execute();
+					final ResultSet resultSet = statement.getResultSet();
+					resultSet.next();
+					Timestamp nativeRead = resultSet.getTimestamp( 1 );
+					assertEquals(
+							"Raw values written in database should match the original value (same instant)",
+							getExpectedTimestamp(),
+							nativeRead
+					);
+				} );
+			} );
+		} );
 	}
 
 	@Test
 	public void testRetrievingEntityByOffsetDateTime() {
-
-		final OffsetDateTime startDate = OffsetDateTime.of(
-				1,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.ofHours( 3 )
-		);
-
-		saveOffsetDateTimeEventWithStartDate( startDate );
-
-		final Session s = openSession();
-		try {
-			Query query = s.createQuery( "from OffsetDateTimeEvent o where o.startDate = :date" );
-			query.setParameter( "date", startDate, OffsetDateTimeType.INSTANCE );
-			List<OffsetDateTimeEvent> list = query.list();
-			assertThat( list.size(), is( 1 ) );
-		}
-		finally {
-			s.close();
-		}
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithOffsetDateTime( 1, getOriginalOffsetDateTime() ) );
+			} );
+			Consumer<OffsetDateTime> checkOneMatch = expected -> inSession( s -> {
+				Query query = s.createQuery( "from EntityWithOffsetDateTime o where o.value = :date" );
+				query.setParameter( "date", expected, OffsetDateTimeType.INSTANCE );
+				List<EntityWithOffsetDateTime> list = query.list();
+				assertThat( list.size(), is( 1 ) );
+			} );
+			checkOneMatch.accept( getOriginalOffsetDateTime() );
+			checkOneMatch.accept( getExpectedOffsetDateTime() );
+			checkOneMatch.accept( getExpectedOffsetDateTime().withOffsetSameInstant( ZoneOffset.UTC ) );
+		} );
 	}
 
-	private void checkSavedOffsetDateTimeIsEqual(OffsetDateTime startdate) {
-		final Session s = openSession();
+	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
 		try {
-			final OffsetDateTimeEvent offsetDateEvent = s.get( OffsetDateTimeEvent.class, 1L );
-			assertThat( offsetDateEvent.startDate.isEqual( startdate ), is( true ) );
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
 		}
-		finally {
-			s.close();
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
 		}
-	}
-
-	private void compareSavedOffsetDateTimeWith(OffsetDateTime startdate) {
-		final Session s = openSession();
-		try {
-			final OffsetDateTimeEvent offsetDateEvent = s.get( OffsetDateTimeEvent.class, 1L );
-			assertThat(
-					OffsetDateTimeType.INSTANCE.getComparator().compare( offsetDateEvent.startDate, startdate ),
-					is( 0 )
-			);
-		}
-		finally {
-			s.close();
-		}
-	}
-
-	private void saveOffsetDateTimeEventWithStartDate(OffsetDateTime startdate) {
-		final OffsetDateTimeEvent event = new OffsetDateTimeEvent();
-		event.id = 1L;
-		event.startDate = startdate;
-
-		final Session s = openSession();
-		s.getTransaction().begin();
-		try {
-			s.save( event );
-			s.getTransaction().commit();
-		}
-		catch (Exception e) {
-			if ( s.getTransaction() != null && s.getTransaction().getStatus() == TransactionStatus.ACTIVE ) {
-				s.getTransaction().rollback();
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
 			}
-			fail( e.getMessage() );
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
 		}
 		finally {
-			s.close();
+			TimeZone.setDefault( timeZoneBefore );
 		}
 	}
 
-	@Entity(name = "OffsetDateTimeEvent")
-	@Table(name = "OFFSET_DATE_TIME_EVENT")
-	public static class OffsetDateTimeEvent {
-
+	@Entity(name = "EntityWithOffsetDateTime")
+	@Table(name = "theentity")
+	private static final class EntityWithOffsetDateTime {
 		@Id
-		private Long id;
+		@Column(name = "theid")
+		private Integer id;
 
-		@Column(name = "START_DATE")
-		private OffsetDateTime startDate;
+		@Basic
+		@Column(name = "thevalue")
+		private OffsetDateTime value;
+
+		protected EntityWithOffsetDateTime() {
+		}
+
+		private EntityWithOffsetDateTime(int id, OffsetDateTime value) {
+			this.id = id;
+			this.value = value;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.type;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -114,7 +115,7 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTest<OffsetDateTime,
 	}
 
 	@Override
-	protected EntityWithOffsetDateTime createEntity(int id) {
+	protected EntityWithOffsetDateTime createEntityForHibernateWrite(int id) {
 		return new EntityWithOffsetDateTime( id, getOriginalOffsetDateTime() );
 	}
 
@@ -123,7 +124,7 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTest<OffsetDateTime,
 	}
 
 	@Override
-	protected OffsetDateTime getExpectedPropertyValue() {
+	protected OffsetDateTime getExpectedPropertyValueAfterHibernateRead() {
 		return getOriginalOffsetDateTime().atZoneSameInstant( ZoneId.systemDefault() ).toOffsetDateTime();
 	}
 
@@ -133,7 +134,12 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTest<OffsetDateTime,
 	}
 
 	@Override
-	protected Object getExpectedJdbcValue() {
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
+		statement.setTimestamp( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+	}
+
+	@Override
+	protected Timestamp getExpectedJdbcValueAfterHibernateWrite() {
 		LocalDateTime dateTimeInDefaultTimeZone = getOriginalOffsetDateTime().atZoneSameInstant( ZoneId.systemDefault() )
 				.toLocalDateTime();
 		return new Timestamp(
@@ -163,8 +169,8 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTest<OffsetDateTime,
 				assertThat( list.size(), is( 1 ) );
 			} );
 			checkOneMatch.accept( getOriginalOffsetDateTime() );
-			checkOneMatch.accept( getExpectedPropertyValue() );
-			checkOneMatch.accept( getExpectedPropertyValue().withOffsetSameInstant( ZoneOffset.UTC ) );
+			checkOneMatch.accept( getExpectedPropertyValueAfterHibernateRead() );
+			checkOneMatch.accept( getExpectedPropertyValueAfterHibernateRead().withOffsetSameInstant( ZoneOffset.UTC ) );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -1,0 +1,203 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.type;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.type.descriptor.sql.BigIntTypeDescriptor;
+import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests for storage of LocalTime properties.
+ */
+public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetTimeTest.EntityWithOffsetTime> {
+
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int hour, int minute, int second, int nanosecond, String offset, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add( defaultTimeZone, hour, minute, second, nanosecond, offset, 1970, 1, 1 );
+		}
+
+		public ParametersBuilder addPersistedWithoutHibernate(int yearWhenPersistedWithoutHibernate,
+				int monthWhenPersistedWithoutHibernate, int dayWhenPersistedWithoutHibernate,
+				int hour, int minute, int second, int nanosecond, String offset, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add(
+					defaultTimeZone, hour, minute, second, nanosecond, offset,
+					yearWhenPersistedWithoutHibernate,
+					monthWhenPersistedWithoutHibernate, dayWhenPersistedWithoutHibernate
+			);
+		}
+	}
+
+	@Parameterized.Parameters(name = "{1}:{2}:{3}.{4}[{5}] (JDBC write date: {6}-{7}-{8}) {0}")
+	public static List<Object[]> data() {
+		return new ParametersBuilder()
+				.alsoTestRemappingsWithH2( TimeAsTimestampRemappingH2Dialect.class )
+				// None of these values was affected by HHH-13266 (JDK-8061577)
+				.add( 19, 19, 1, 0, "+10:00", ZONE_UTC_MINUS_8 )
+				.add( 19, 19, 1, 0, "+01:30", ZONE_UTC_MINUS_8 )
+				.add( 19, 19, 1, 0, "-06:00", ZONE_UTC_MINUS_8 )
+				.add( 19, 19, 1, 0, "+10:00", ZONE_PARIS )
+				.add( 19, 19, 1, 0, "+01:30", ZONE_PARIS )
+				.add( 19, 19, 1, 500, "+01:00", ZONE_PARIS )
+				.add( 19, 19, 1, 0, "-08:00", ZONE_PARIS )
+				.add( 0, 0, 0, 0, "+01:00", ZONE_GMT )
+				.add( 0, 0, 0, 0, "+00:00", ZONE_GMT )
+				.add( 0, 0, 0, 0, "-01:00", ZONE_GMT )
+				.add( 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+				.add( 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
+				.add( 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
+				.add( 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.add( 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
+				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.build();
+	}
+
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+	private final String offset;
+
+	private final int yearWhenPersistedWithoutHibernate;
+	private final int monthWhenPersistedWithoutHibernate;
+	private final int dayWhenPersistedWithoutHibernate;
+
+	public OffsetTimeTest(EnvironmentParameters env, int hour, int minute, int second, int nanosecond, String offset,
+			int yearWhenPersistedWithoutHibernate, int monthWhenPersistedWithoutHibernate, int dayWhenPersistedWithoutHibernate) {
+		super( env );
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.offset = offset;
+		this.yearWhenPersistedWithoutHibernate = yearWhenPersistedWithoutHibernate;
+		this.monthWhenPersistedWithoutHibernate = monthWhenPersistedWithoutHibernate;
+		this.dayWhenPersistedWithoutHibernate = dayWhenPersistedWithoutHibernate;
+	}
+
+	@Override
+	protected Class<EntityWithOffsetTime> getEntityType() {
+		return EntityWithOffsetTime.class;
+	}
+
+	@Override
+	protected EntityWithOffsetTime createEntityForHibernateWrite(int id) {
+		return new EntityWithOffsetTime( id, getOriginalPropertyValue() );
+	}
+
+	protected OffsetTime getOriginalPropertyValue() {
+		return OffsetTime.of( hour, minute, second, nanosecond, ZoneOffset.of( offset ) );
+	}
+
+	@Override
+	protected OffsetTime getExpectedPropertyValueAfterHibernateRead() {
+		// For some reason, the offset is not stored, so the restored values use the offset from the default JVM timezone.
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			return getOriginalPropertyValue().withOffsetSameLocal( OffsetDateTime.now().getOffset() );
+		}
+		else {
+			// When storing time as java.sql.Time, we only get second precision (not nanosecond)
+			return getOriginalPropertyValue().withNano( 0 ).withOffsetSameLocal( OffsetDateTime.now().getOffset() );
+		}
+	}
+
+	@Override
+	protected OffsetTime getActualPropertyValue(EntityWithOffsetTime entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex)
+			throws SQLException {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			statement.setTimestamp(
+					parameterIndex,
+					new Timestamp(
+							yearWhenPersistedWithoutHibernate - 1900,
+							monthWhenPersistedWithoutHibernate - 1,
+							dayWhenPersistedWithoutHibernate,
+							hour, minute, second, nanosecond
+					)
+			);
+		}
+		else {
+			statement.setTime( parameterIndex, new Time( hour, minute, second ) );
+		}
+	}
+
+	@Override
+	protected Object getExpectedJdbcValueAfterHibernateWrite() {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) ) {
+			return new Timestamp( 1970 - 1900, 0, 1, hour, minute, second, nanosecond );
+		}
+		else {
+			return new Time( hour, minute, second );
+		}
+	}
+
+	@Override
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getTimestamp( columnIndex );
+	}
+
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithOffsetTime {
+		@Id
+		@Column(name = ID_COLUMN_NAME)
+		private Integer id;
+
+		@Basic
+		@Column(name = PROPERTY_COLUMN_NAME)
+		private OffsetTime value;
+
+		protected EntityWithOffsetTime() {
+		}
+
+		private EntityWithOffsetTime(int id, OffsetTime value) {
+			this.id = id;
+			this.value = value;
+		}
+	}
+
+	public static class TimeAsTimestampRemappingH2Dialect extends AbstractRemappingH2Dialect {
+		public TimeAsTimestampRemappingH2Dialect() {
+			super( Types.TIME, TimestampTypeDescriptor.INSTANCE );
+		}
+	}
+
+	public static class TimeAsBigIntRemappingH2Dialect extends AbstractRemappingH2Dialect {
+		public TimeAsBigIntRemappingH2Dialect() {
+			super( Types.TIME, BigIntTypeDescriptor.INSTANCE );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.type;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -126,7 +127,7 @@ public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, Z
 	}
 
 	@Override
-	protected EntityWithZonedDateTime createEntity(int id) {
+	protected EntityWithZonedDateTime createEntityForHibernateWrite(int id) {
 		return new EntityWithZonedDateTime(
 				id,
 				getOriginalZonedDateTime()
@@ -138,7 +139,7 @@ public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, Z
 	}
 
 	@Override
-	protected ZonedDateTime getExpectedPropertyValue() {
+	protected ZonedDateTime getExpectedPropertyValueAfterHibernateRead() {
 		return getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() );
 	}
 
@@ -148,7 +149,12 @@ public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, Z
 	}
 
 	@Override
-	protected Object getExpectedJdbcValue() {
+	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
+		statement.setTimestamp( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+	}
+
+	@Override
+	protected Timestamp getExpectedJdbcValueAfterHibernateWrite() {
 		LocalDateTime dateTimeInDefaultTimeZone = getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() )
 				.toLocalDateTime();
 		return new Timestamp(
@@ -178,8 +184,8 @@ public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, Z
 				assertThat( list.size(), is( 1 ) );
 			} );
 			checkOneMatch.accept( getOriginalZonedDateTime() );
-			checkOneMatch.accept( getExpectedPropertyValue() );
-			checkOneMatch.accept( getExpectedPropertyValue().withZoneSameInstant( ZoneOffset.UTC ) );
+			checkOneMatch.accept( getExpectedPropertyValueAfterHibernateRead() );
+			checkOneMatch.accept( getExpectedPropertyValueAfterHibernateRead().withZoneSameInstant( ZoneOffset.UTC ) );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
@@ -6,127 +6,96 @@
  */
 package org.hibernate.test.type;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.Arrays;
+import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.TimeZone;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
 import org.hibernate.Query;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.ZonedDateTimeType;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.testing.junit4.CustomParameterized;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Andrea Boriero
  */
-@RunWith(CustomParameterized.class)
 @TestForIssue(jiraKey = "HHH-10372")
-public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
+public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, ZonedDateTimeTest.EntityWithZonedDateTime> {
 
-	private static Dialect DIALECT;
-	private static Dialect determineDialect() {
-		try {
-			return Dialect.getDialect();
-		}
-		catch (Exception e) {
-			return new Dialect() {
-			};
+	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {
+		public ParametersBuilder add(int year, int month, int day,
+				int hour, int minute, int second, int nanosecond, String zone, ZoneId defaultTimeZone) {
+			if ( !isNanosecondPrecisionSupported() ) {
+				nanosecond = 0;
+			}
+			return add( defaultTimeZone, year, month, day, hour, minute, second, nanosecond, zone );
 		}
 	}
 
-	/*
-	 * The default timezone affects conversions done using java.util,
-	 * which is why we take it into account even when testing ZonedDateTime.
-	 */
-	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6}[{7}] [JVM TZ: {8}]")
+	@Parameterized.Parameters(name = "{1}-{2}-{3}T{4}:{5}:{6}.{7}[{8}] {0}")
 	public static List<Object[]> data() {
-		DIALECT = determineDialect();
-		return Arrays.asList(
+		return new ParametersBuilder()
 				// Not affected by HHH-13266
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZoneId.of( "UTC-8" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 500, "GMT+01:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZoneId.of( "Europe/Paris" ) ),
-				data( 1970, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZoneId.of( "GMT" ) ),
-				data( 1970, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "GMT" ) ),
-				data( 1970, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZoneId.of( "GMT" ) ),
-				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 1, 0, 9, 21, 0, "GMT+00:09:21", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 9, 21, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 31, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) ),
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZONE_UTC_MINUS_8 )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 500, "GMT+01:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZONE_PARIS )
+				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZONE_PARIS )
+				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
+				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
+				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
+				.add( 1900, 1, 1, 0, 9, 21, 0, "GMT+00:09:21", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 9, 21, 0, "Europe/Paris", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Paris", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+				.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
 				// Affected by HHH-13266
-				data( 1892, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "Europe/Oslo" ) ),
-				data( 1892, 1, 1, 0, 0, 0, 0, "Europe/Oslo", ZoneId.of( "Europe/Oslo" ) ),
-				data( 1900, 1, 1, 0, 9, 20, 0, "GMT+00:09:21", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 9, 20, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZoneId.of( "Europe/Paris" ) ),
-				data( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1900, 1, 1, 0, 19, 31, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1600, 1, 1, 0, 0, 0, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
-				data( 1600, 1, 1, 0, 0, 0, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) )
-		);
-	}
-
-	private static Object[] data(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, String zone, ZoneId defaultTimeZone) {
-		if ( DIALECT instanceof PostgreSQL81Dialect ) {
-			// PostgreSQL apparently doesn't support nanosecond precision correctly
-			nanosecond = 0;
-		}
-		return new Object[] { year, month, day, hour, minute, second, nanosecond, zone, defaultTimeZone };
+				.add( 1892, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
+				.add( 1892, 1, 1, 0, 0, 0, 0, "Europe/Oslo", ZONE_OSLO )
+				.add( 1900, 1, 1, 0, 9, 20, 0, "GMT+00:09:21", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 9, 20, 0, "Europe/Paris", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_PARIS )
+				.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+				.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+				.add( 1600, 1, 1, 0, 0, 0, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+				.add( 1600, 1, 1, 0, 0, 0, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+				.build();
 	}
 
 	private final int year;
@@ -137,10 +106,10 @@ public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
 	private final int second;
 	private final int nanosecond;
 	private final String zone;
-	private final ZoneId defaultTimeZone;
 
-	public ZonedDateTimeTest(int year, int month, int day,
-			int hour, int minute, int second, int nanosecond, String zone, ZoneId defaultTimeZone) {
+	public ZonedDateTimeTest(EnvironmentParameters env, int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, String zone) {
+		super( env );
 		this.year = year;
 		this.month = month;
 		this.day = day;
@@ -149,18 +118,37 @@ public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
 		this.second = second;
 		this.nanosecond = nanosecond;
 		this.zone = zone;
-		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	@Override
+	protected Class<EntityWithZonedDateTime> getEntityType() {
+		return EntityWithZonedDateTime.class;
+	}
+
+	@Override
+	protected EntityWithZonedDateTime createEntity(int id) {
+		return new EntityWithZonedDateTime(
+				id,
+				getOriginalZonedDateTime()
+		);
 	}
 
 	private ZonedDateTime getOriginalZonedDateTime() {
 		return ZonedDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneId.of( zone ) );
 	}
 
-	private ZonedDateTime getExpectedZonedDateTime() {
+	@Override
+	protected ZonedDateTime getExpectedPropertyValue() {
 		return getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() );
 	}
 
-	private Timestamp getExpectedTimestamp() {
+	@Override
+	protected ZonedDateTime getActualPropertyValue(EntityWithZonedDateTime entity) {
+		return entity.value;
+	}
+
+	@Override
+	protected Object getExpectedJdbcValue() {
 		LocalDateTime dateTimeInDefaultTimeZone = getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() )
 				.toLocalDateTime();
 		return new Timestamp(
@@ -173,129 +161,36 @@ public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { EntityWithZonedDateTime.class };
-	}
-
-	@Before
-	public void cleanup() {
-		inTransaction( session -> {
-			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
-			} );
-			inTransaction( session -> {
-				ZonedDateTime read = session.find( ZonedDateTimeTest.EntityWithZonedDateTime.class, 1 ).value;
-				assertEquals(
-						"Writing then reading a value should return the original value",
-						getExpectedZonedDateTime(), read
-				);
-				assertTrue(
-						getExpectedZonedDateTime().isEqual( read )
-				);
-				assertEquals(
-						0,
-						ZonedDateTimeType.INSTANCE.getComparator().compare( getExpectedZonedDateTime(), read )
-				);
-			} );
-		} );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-13266")
-	public void writeThenNativeRead() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
-			inTransaction( session -> {
-				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
-			} );
-			inTransaction( session -> {
-				session.doWork( connection -> {
-					final PreparedStatement statement = connection.prepareStatement(
-							"SELECT thevalue FROM theentity WHERE theid = ?"
-					);
-					statement.setInt( 1, 1 );
-					statement.execute();
-					final ResultSet resultSet = statement.getResultSet();
-					resultSet.next();
-					Timestamp nativeRead = resultSet.getTimestamp( 1 );
-					assertEquals(
-							"Raw values written in database should match the original value (same instant)",
-							getExpectedTimestamp(),
-							nativeRead
-					);
-				} );
-			} );
-		} );
+	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
+		return resultSet.getTimestamp( columnIndex );
 	}
 
 	@Test
 	public void testRetrievingEntityByZonedDateTime() {
-		withDefaultTimeZone( defaultTimeZone, () -> {
+		withDefaultTimeZone( () -> {
 			inTransaction( session -> {
 				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
 			} );
 			Consumer<ZonedDateTime> checkOneMatch = expected -> inSession( s -> {
-				Query query = s.createQuery( "from EntityWithZonedDateTime o where o.value = :date" );
+				Query query = s.createQuery( "from " + ENTITY_NAME + " o where o.value = :date" );
 				query.setParameter( "date", expected, ZonedDateTimeType.INSTANCE );
 				List<EntityWithZonedDateTime> list = query.list();
 				assertThat( list.size(), is( 1 ) );
 			} );
 			checkOneMatch.accept( getOriginalZonedDateTime() );
-			checkOneMatch.accept( getExpectedZonedDateTime() );
-			checkOneMatch.accept( getExpectedZonedDateTime().withZoneSameInstant( ZoneOffset.UTC ) );
+			checkOneMatch.accept( getExpectedPropertyValue() );
+			checkOneMatch.accept( getExpectedPropertyValue().withZoneSameInstant( ZoneOffset.UTC ) );
 		} );
 	}
 
-	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
-		TimeZone timeZoneBefore = TimeZone.getDefault();
-		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
-		/*
-		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
-		 * cache data dependent on the default timezone in thread local variables,
-		 * and we want this data to be reinitialized with the new default time zone.
-		 */
-		try {
-			ExecutorService executor = Executors.newSingleThreadExecutor();
-			Future<?> future = executor.submit( runnable );
-			executor.shutdown();
-			future.get();
-		}
-		catch (InterruptedException e) {
-			throw new IllegalStateException( "Interrupted while testing", e );
-		}
-		catch (ExecutionException e) {
-			Throwable cause = e.getCause();
-			if ( cause instanceof RuntimeException ) {
-				throw (RuntimeException) cause;
-			}
-			else if ( cause instanceof Error ) {
-				throw (Error) cause;
-			}
-			else {
-				throw new IllegalStateException( "Unexpected exception while testing", cause );
-			}
-		}
-		finally {
-			TimeZone.setDefault( timeZoneBefore );
-		}
-	}
-
-	@Entity(name = "EntityWithZonedDateTime")
-	@Table(name = "theentity")
-	private static final class EntityWithZonedDateTime {
+	@Entity(name = ENTITY_NAME)
+	static final class EntityWithZonedDateTime {
 		@Id
-		@Column(name = "theid")
+		@Column(name = ID_COLUMN_NAME)
 		private Integer id;
 
 		@Basic
-		@Column(name = "thevalue")
+		@Column(name = PROPERTY_COLUMN_NAME)
 		private ZonedDateTime value;
 
 		protected EntityWithZonedDateTime() {
@@ -305,10 +200,5 @@ public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
 			this.id = id;
 			this.value = value;
 		}
-	}
-
-	@Override
-	protected boolean isCleanupTestDataRequired() {
-		return true;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
@@ -6,157 +6,305 @@
  */
 package org.hibernate.test.type;
 
-import java.time.ZoneOffset;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.ZonedDateTimeType;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Andrea Boriero
  */
+@RunWith(CustomParameterized.class)
+@TestForIssue(jiraKey = "HHH-10372")
 public class ZonedDateTimeTest extends BaseNonConfigCoreFunctionalTestCase {
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {ZonedDateTimeEvent.class};
-	}
 
-	@Test
-	public void testZoneDateTimeWithHoursZoneOffset() {
-		final ZonedDateTime expectedStartDate = ZonedDateTime.of(
-				2015,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.ofHours( 5 )
-		);
-
-		saveZoneDateTimeEventWithStartDate( expectedStartDate );
-
-		checkSavedZonedDateTimeIsEqual( expectedStartDate );
-		compareSavedZonedDateTimeWith( expectedStartDate );
-	}
-
-	@Test
-	public void testZoneDateTimeWithUTCZoneOffset() {
-		final ZonedDateTime expectedStartDate = ZonedDateTime.of(
-				1,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.UTC
-		);
-
-		saveZoneDateTimeEventWithStartDate( expectedStartDate );
-
-		checkSavedZonedDateTimeIsEqual( expectedStartDate );
-		compareSavedZonedDateTimeWith( expectedStartDate );
-	}
-
-	@Test
-	public void testRetrievingEntityByZoneDateTime() {
-
-		final ZonedDateTime startDate = ZonedDateTime.of(
-				1,
-				1,
-				1,
-				0,
-				0,
-				0,
-				0,
-				ZoneOffset.ofHours( 3 )
-		);
-
-		saveZoneDateTimeEventWithStartDate( startDate );
-
-		final Session s = openSession();
+	private static Dialect DIALECT;
+	private static Dialect determineDialect() {
 		try {
-			Query query = s.createQuery( "from ZonedDateTimeEvent o where o.startDate = :date" );
-			query.setParameter( "date", startDate, ZonedDateTimeType.INSTANCE );
-			List<ZonedDateTimeEvent> list = query.list();
-			assertThat( list.size(), is( 1 ) );
-		}
-		finally {
-			s.close();
-		}
-	}
-
-	private void checkSavedZonedDateTimeIsEqual(ZonedDateTime startdate) {
-		final Session s = openSession();
-		try {
-			final ZonedDateTimeEvent zonedDateTimeEvent = s.get( ZonedDateTimeEvent.class, 1L );
-			assertThat( zonedDateTimeEvent.startDate.isEqual( startdate ), is( true ) );
-		}
-		finally {
-			s.close();
-		}
-	}
-
-	private void compareSavedZonedDateTimeWith(ZonedDateTime startdate) {
-		final Session s = openSession();
-		try {
-			final ZonedDateTimeEvent zonedDateTimeEvent = s.get( ZonedDateTimeEvent.class, 1L );
-			assertThat(
-					ZonedDateTimeType.INSTANCE.getComparator().compare( zonedDateTimeEvent.startDate, startdate ),
-					is( 0 )
-			);
-		}
-		finally {
-			s.close();
-		}
-	}
-
-	private void saveZoneDateTimeEventWithStartDate(ZonedDateTime startdate) {
-		final ZonedDateTimeEvent event = new ZonedDateTimeEvent();
-		event.id = 1L;
-		event.startDate = startdate;
-
-		final Session s = openSession();
-		s.getTransaction().begin();
-		try {
-			s.save( event );
-			s.getTransaction().commit();
+			return Dialect.getDialect();
 		}
 		catch (Exception e) {
-			if ( s.getTransaction() != null && s.getTransaction().getStatus() == TransactionStatus.ACTIVE ) {
-				s.getTransaction().rollback();
-			}
-			fail( e.getMessage() );
-		}
-		finally {
-			s.close();
+			return new Dialect() {
+			};
 		}
 	}
 
-	@Entity(name = "ZonedDateTimeEvent")
-	@Table(name = "ZONE_DATE_TIME_EVENT")
-	public static class ZonedDateTimeEvent {
+	/*
+	 * The default timezone affects conversions done using java.util,
+	 * which is why we take it into account even when testing ZonedDateTime.
+	 */
+	@Parameterized.Parameters(name = "{0}-{1}-{2}T{3}:{4}:{5}.{6}[{7}] [JVM TZ: {8}]")
+	public static List<Object[]> data() {
+		DIALECT = determineDialect();
+		return Arrays.asList(
+				// Not affected by HHH-13266
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZoneId.of( "UTC-8" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+10:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+07:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:30", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+01:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 500, "GMT+01:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "Europe/London", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT+00:30", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZoneId.of( "Europe/Paris" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZoneId.of( "GMT" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "GMT" ) ),
+				data( 1970, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZoneId.of( "GMT" ) ),
+				data( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 9, 21, 0, "GMT+00:09:21", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 9, 21, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) ),
+				// Affected by HHH-13266
+				data( 1892, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZoneId.of( "Europe/Oslo" ) ),
+				data( 1892, 1, 1, 0, 0, 0, 0, "Europe/Oslo", ZoneId.of( "Europe/Oslo" ) ),
+				data( 1900, 1, 1, 0, 9, 20, 0, "GMT+00:09:21", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 9, 20, 0, "Europe/Paris", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZoneId.of( "Europe/Paris" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1900, 1, 1, 0, 19, 31, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, 0, 0, 0, 0, "GMT+00:19:32", ZoneId.of( "Europe/Amsterdam" ) ),
+				data( 1600, 1, 1, 0, 0, 0, 0, "Europe/Amsterdam", ZoneId.of( "Europe/Amsterdam" ) )
+		);
+	}
 
+	private static Object[] data(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, String zone, ZoneId defaultTimeZone) {
+		if ( DIALECT instanceof PostgreSQL81Dialect ) {
+			// PostgreSQL apparently doesn't support nanosecond precision correctly
+			nanosecond = 0;
+		}
+		return new Object[] { year, month, day, hour, minute, second, nanosecond, zone, defaultTimeZone };
+	}
+
+	private final int year;
+	private final int month;
+	private final int day;
+	private final int hour;
+	private final int minute;
+	private final int second;
+	private final int nanosecond;
+	private final String zone;
+	private final ZoneId defaultTimeZone;
+
+	public ZonedDateTimeTest(int year, int month, int day,
+			int hour, int minute, int second, int nanosecond, String zone, ZoneId defaultTimeZone) {
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.hour = hour;
+		this.minute = minute;
+		this.second = second;
+		this.nanosecond = nanosecond;
+		this.zone = zone;
+		this.defaultTimeZone = defaultTimeZone;
+	}
+
+	private ZonedDateTime getOriginalZonedDateTime() {
+		return ZonedDateTime.of( year, month, day, hour, minute, second, nanosecond, ZoneId.of( zone ) );
+	}
+
+	private ZonedDateTime getExpectedZonedDateTime() {
+		return getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() );
+	}
+
+	private Timestamp getExpectedTimestamp() {
+		LocalDateTime dateTimeInDefaultTimeZone = getOriginalZonedDateTime().withZoneSameInstant( ZoneId.systemDefault() )
+				.toLocalDateTime();
+		return new Timestamp(
+				dateTimeInDefaultTimeZone.getYear() - 1900, dateTimeInDefaultTimeZone.getMonthValue() - 1,
+				dateTimeInDefaultTimeZone.getDayOfMonth(),
+				dateTimeInDefaultTimeZone.getHour(), dateTimeInDefaultTimeZone.getMinute(),
+				dateTimeInDefaultTimeZone.getSecond(),
+				dateTimeInDefaultTimeZone.getNano()
+		);
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityWithZonedDateTime.class };
+	}
+
+	@Before
+	public void cleanup() {
+		inTransaction( session -> {
+			session.createNativeQuery( "DELETE FROM theentity" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
+			} );
+			inTransaction( session -> {
+				ZonedDateTime read = session.find( ZonedDateTimeTest.EntityWithZonedDateTime.class, 1 ).value;
+				assertEquals(
+						"Writing then reading a value should return the original value",
+						getExpectedZonedDateTime(), read
+				);
+				assertTrue(
+						getExpectedZonedDateTime().isEqual( read )
+				);
+				assertEquals(
+						0,
+						ZonedDateTimeType.INSTANCE.getComparator().compare( getExpectedZonedDateTime(), read )
+				);
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13266")
+	public void writeThenNativeRead() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
+			} );
+			inTransaction( session -> {
+				session.doWork( connection -> {
+					final PreparedStatement statement = connection.prepareStatement(
+							"SELECT thevalue FROM theentity WHERE theid = ?"
+					);
+					statement.setInt( 1, 1 );
+					statement.execute();
+					final ResultSet resultSet = statement.getResultSet();
+					resultSet.next();
+					Timestamp nativeRead = resultSet.getTimestamp( 1 );
+					assertEquals(
+							"Raw values written in database should match the original value (same instant)",
+							getExpectedTimestamp(),
+							nativeRead
+					);
+				} );
+			} );
+		} );
+	}
+
+	@Test
+	public void testRetrievingEntityByZonedDateTime() {
+		withDefaultTimeZone( defaultTimeZone, () -> {
+			inTransaction( session -> {
+				session.persist( new EntityWithZonedDateTime( 1, getOriginalZonedDateTime() ) );
+			} );
+			Consumer<ZonedDateTime> checkOneMatch = expected -> inSession( s -> {
+				Query query = s.createQuery( "from EntityWithZonedDateTime o where o.value = :date" );
+				query.setParameter( "date", expected, ZonedDateTimeType.INSTANCE );
+				List<EntityWithZonedDateTime> list = query.list();
+				assertThat( list.size(), is( 1 ) );
+			} );
+			checkOneMatch.accept( getOriginalZonedDateTime() );
+			checkOneMatch.accept( getExpectedZonedDateTime() );
+			checkOneMatch.accept( getExpectedZonedDateTime().withZoneSameInstant( ZoneOffset.UTC ) );
+		} );
+	}
+
+	private static void withDefaultTimeZone(ZoneId zoneId, Runnable runnable) {
+		TimeZone timeZoneBefore = TimeZone.getDefault();
+		TimeZone.setDefault( TimeZone.getTimeZone( zoneId ) );
+		/*
+		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
+		 * cache data dependent on the default timezone in thread local variables,
+		 * and we want this data to be reinitialized with the new default time zone.
+		 */
+		try {
+			ExecutorService executor = Executors.newSingleThreadExecutor();
+			Future<?> future = executor.submit( runnable );
+			executor.shutdown();
+			future.get();
+		}
+		catch (InterruptedException e) {
+			throw new IllegalStateException( "Interrupted while testing", e );
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			if ( cause instanceof RuntimeException ) {
+				throw (RuntimeException) cause;
+			}
+			else if ( cause instanceof Error ) {
+				throw (Error) cause;
+			}
+			else {
+				throw new IllegalStateException( "Unexpected exception while testing", cause );
+			}
+		}
+		finally {
+			TimeZone.setDefault( timeZoneBefore );
+		}
+	}
+
+	@Entity(name = "EntityWithZonedDateTime")
+	@Table(name = "theentity")
+	private static final class EntityWithZonedDateTime {
 		@Id
-		private Long id;
+		@Column(name = "theid")
+		private Integer id;
 
-		@Column(name = "START_DATE")
-		private ZonedDateTime startDate;
+		@Basic
+		@Column(name = "thevalue")
+		private ZonedDateTime value;
+
+		protected EntityWithZonedDateTime() {
+		}
+
+		private EntityWithZonedDateTime(int id, ZonedDateTime value) {
+			this.id = id;
+			this.value = value;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-13266

Adding Gail because I think we should backport this to 5.3.

I added a comment to the ticket: https://hibernate.atlassian.net/browse/HHH-13266?focusedCommentId=104778&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-104778

In short, there's a bug in the java.util classes that leads to "drifts" when converting between year/month/day/hours/etc. to milliseconds since the epoch, and back. This only happens before a certain point in time around 1900 (different depending on the timezone).
Generally the bug is rather innocuous because we happen to run two conversions, and the two conversions fortunately drift in a way that compensate each other.
However, near 1900, there's a chance that the first conversion make the date drift after the breaking point, meaning the second conversion will not lead to a drift, and we'll end up storing the wrong, "drifted" value (and also giving this value back to the user when reading).

Anyway... The new strategy for converting LocalDateTime that was suggested will work, but there's still a bug internally in the JDK. I *think* we're relatively safe with the new approach, and we won't suffer from this bug anymore. From what I can see, the new strategy is also backward compatible with the old one: it will read back from the database exactly like the old strategy would have, and it will write the same values to the database, except for the bug we're fixing.
However, users previously affected by this bug already have stored incorrect values in the database, and there's nothing we can do about this. If they load an entity and write it back to the database, the incorrect value will still be incorrect.