### PR TITLE
HHH-13217 - Don't throw exception if both @MappedSuperclass and @Inheritance are used

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1864,6 +1864,6 @@ public interface CoreMessageLogger extends BasicLogger {
 	void ignoreImmutablePropertyModification(String propertyName, String entityName);
 
 	@LogMessage(level = WARN)
-	@Message(value = "An entity cannot be annotated with both @Inheritance and @MappedSuperclass: %s.", id = 503)
+	@Message(value = "A class should not be annotated with both @Inheritance and @MappedSuperclass. @Inheritance will be ignored for: %s.", id = 503)
 	void unsupportedMappedSuperclassWithEntityInheritance(String entityName);
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/MappedSuperclassInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/MappedSuperclassInheritanceTest.java
@@ -31,6 +31,7 @@ import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -60,7 +61,7 @@ public class MappedSuperclassInheritanceTest extends BaseEntityManagerFunctional
 		super.buildEntityManagerFactory();
 
 		assertTrue( triggerable.wasTriggered() );
-		assertTrue( triggerable.triggerMessage().contains( "An entity cannot be annotated with both @Inheritance and @MappedSuperclass" ) );
+		assertTrue( triggerable.triggerMessage().contains( "A class should not be annotated with both @Inheritance and @MappedSuperclass. @Inheritance will be ignored for" ) );
 	}
 
 	@Test
@@ -72,6 +73,7 @@ public class MappedSuperclassInheritanceTest extends BaseEntityManagerFunctional
 			try {
 				//Check the @Inheritance annotation was ignored
 				entityManager.createQuery("from Employee").getResultList();
+				fail();
 			} catch (Exception expected) {
 				QuerySyntaxException rootException = (QuerySyntaxException) ExceptionUtil.rootCause(expected);
 				assertEquals("Employee is not mapped", rootException.getMessage());


### PR DESCRIPTION
Make sure the @Inheritance annotation is ignored when used along with @MappedSuperclass