### PR TITLE
HHH-13303: fix some LGTM alerts

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/CacheableFileXmlSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/CacheableFileXmlSource.java
@@ -117,9 +117,9 @@ public class CacheableFileXmlSource extends XmlSource {
 	}
 
 	private static void writeSerFile(Serializable binding, File xmlFile, File serFile) {
-		try {
+		try (FileOutputStream fos = new FileOutputStream( serFile )){
 			log.debugf( "Writing cache file for: %s to: %s", xmlFile.getAbsolutePath(), serFile.getAbsolutePath() );
-			SerializationHelper.serialize( binding, new FileOutputStream( serFile ) );
+			SerializationHelper.serialize( binding, fos );
 			boolean success = serFile.setLastModified( System.currentTimeMillis() );
 			if ( !success ) {
 				log.warn( "Could not update cacheable hbm.xml bin file timestamp" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1036,7 +1036,7 @@ public abstract class AbstractHANADialect extends Dialect {
 				createSequenceString += " minvalue " + initialValue;
 			}
 		}
-		else if ( incrementSize < 0 ) {
+		else {
 			if ( initialValue > -1 ) {
 				// default maxvalue for a descending sequence is -1
 				createSequenceString += " maxvalue " + initialValue;

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
@@ -279,7 +279,7 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 		if ( columns != null ) {
 			for ( int i = 0; i < columns.length; i++ ) {
 				buf.append( columns[i] );
-				if ( i < columns.length ) {
+				if ( i < columns.length - 1 ) {
 					buf.append( " " );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/TupleBuilderTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/TupleBuilderTransformer.java
@@ -149,7 +149,7 @@ public class TupleBuilderTransformer extends BasicTransformerAdapter {
 			if ( i < 0 ) {
 				throw new IllegalArgumentException( "requested tuple index must be greater than zero" );
 			}
-			if ( i > tuple.length ) {
+			if ( i >= tuple.length ) {
 				throw new IllegalArgumentException( "requested tuple index exceeds actual tuple size" );
 			}
 			return tuple[i];

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3573,7 +3573,7 @@ public abstract class AbstractEntityPersister
 //					}
 //					// no dirty fields and no dirty collections so no update needed ???
 //				}
-				if ( fieldsPreUpdateNeeded.length != 0 && dirtyFields != null ) {
+				if ( dirtyFields != null ) {
 					dirtyFields = ArrayHelper.join( dirtyFields, ArrayHelper.trim( fieldsPreUpdateNeeded, count ) );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -1094,7 +1094,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		if ( index >= subclassNamesBySubclassTable.length ) {
 			throw new IllegalArgumentException(
-					"Given subclass table number is outside expected range [" + subclassNamesBySubclassTable.length
+					"Given subclass table number is outside expected range [" + (subclassNamesBySubclassTable.length -1)
 							+ "] as defined by subclassTableNameClosure/subclassClosure"
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -1092,7 +1092,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	private String[] getSubclassNameClosureBySubclassTable(int subclassTableNumber) {
 		final int index = subclassTableNumber - getTableSpan();
 
-		if ( index > subclassNamesBySubclassTable.length ) {
+		if ( index >= subclassNamesBySubclassTable.length ) {
 			throw new IllegalArgumentException(
 					"Given subclass table number is outside expected range [" + subclassNamesBySubclassTable.length
 							+ "] as defined by subclassTableNameClosure/subclassClosure"

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -245,7 +245,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 				for ( Table table : namespace.getTables() ) {
 					if ( schemaFilter.includeTable( table ) ) {
 						final TableInformation tableInformation = nameSpaceTablesInformation.getTableInformation( table );
-						if ( tableInformation == null || ( tableInformation != null && tableInformation.isPhysicalTable() ) ) {
+						if ( tableInformation == null || tableInformation.isPhysicalTable() ) {
 							applyForeignKeys( table, tableInformation, dialect, metadata, formatter, options, targets );
 						}
 					}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
@@ -70,7 +70,7 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 					if ( tableInformation == null ) {
 						createTable( table, dialect, metadata, formatter, options, targets );
 					}
-					else if ( tableInformation != null && tableInformation.isPhysicalTable() ) {
+					else if ( tableInformation.isPhysicalTable() ) {
 						tablesInformation.addTableInformation( tableInformation );
 						migrateTable( table, tableInformation, dialect, metadata, formatter, options, targets );
 					}
@@ -80,7 +80,7 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 			for ( Table table : namespace.getTables() ) {
 				if ( schemaFilter.includeTable( table ) && table.isPhysicalTable() ) {
 					final TableInformation tableInformation = tablesInformation.getTableInformation( table );
-					if ( tableInformation == null || ( tableInformation != null && tableInformation.isPhysicalTable() ) ) {
+					if ( tableInformation == null || tableInformation.isPhysicalTable() ) {
 						applyIndexes( table, tableInformation, dialect, metadata, formatter, options, targets );
 						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options, targets );
 					}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
@@ -70,7 +70,7 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 					if ( tableInformation == null ) {
 						createTable( table, dialect, metadata, formatter, options, targets );
 					}
-					else if ( tableInformation != null && tableInformation.isPhysicalTable() ) {
+					else if ( tableInformation.isPhysicalTable() ) {
 						tablesInformation.addTableInformation( tableInformation );
 						migrateTable( table, tableInformation, dialect, metadata, formatter, options, targets );
 					}
@@ -80,7 +80,7 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 			for ( Table table : namespace.getTables() ) {
 				if ( schemaFilter.includeTable( table ) && table.isPhysicalTable() ) {
 					final TableInformation tableInformation = tablesInformation.getTableInformation( table );
-					if ( tableInformation == null || ( tableInformation != null && tableInformation.isPhysicalTable() ) ) {
+					if ( tableInformation == null || tableInformation.isPhysicalTable() ) {
 						applyIndexes( table, tableInformation, dialect, metadata, formatter, options, targets );
 						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options, targets );
 					}


### PR DESCRIPTION
Fix some of the alerts raised by LGTM.

- `Array index out of bounds` in `TupleBuilderTransformer` and `JoinedSubclassEntityPersister`
- `Potential output resource leak` in `CacheableFileXmlSource`
- `Useless comparison test` in `AbstractEntityPersister`, `FromElement`, `AbstractHANADialect`
- `Useless null check` in `AbstractSchemaMigrator`, `GroupedSchemaMigratorImpl` (2 instances), `IndividuallySchemaMigratorImpl` (2 instances)