### PR TITLE
Port HHH-13309 to 6.0 - Extended bean managers implementing the new interface are not correctly detected 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/spi/jpa/ExtendedBeanManager.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/spi/jpa/ExtendedBeanManager.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.jpa.event.spi.jpa;
 
+import javax.enterprise.inject.spi.BeanManager;
+
 /**
  * @deprecated Use {@link org.hibernate.resource.beans.container.spi.ExtendedBeanManager} instead
  */
@@ -15,7 +17,22 @@ public interface ExtendedBeanManager extends org.hibernate.resource.beans.contai
 
 	@Override
 	default void registerLifecycleListener(org.hibernate.resource.beans.container.spi.ExtendedBeanManager.LifecycleListener lifecycleListener) {
-		registerLifecycleListener( (LifecycleListener) lifecycleListener );
+		/*
+		 * Casting the argument to our own LifecycleListener interface won't work here,
+		 * since we would be down-casting and the argument may not implement the correct interface.
+		 * Just use an adaptor.
+		 */
+		registerLifecycleListener( new LifecycleListener() {
+			@Override
+			public void beanManagerInitialized(BeanManager beanManager) {
+				lifecycleListener.beanManagerInitialized( beanManager );
+			}
+
+			@Override
+			public void beforeBeanManagerDestroyed(BeanManager beanManager) {
+				lifecycleListener.beforeBeanManagerDestroyed( beanManager );
+			}
+		} );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
@@ -35,7 +35,7 @@ public class CdiBeanContainerBuilder {
 	private static final String CONTAINER_FQN_DELAYED = "org.hibernate.resource.beans.container.internal.CdiBeanContainerDelayedAccessImpl";
 	private static final String CONTAINER_FQN_EXTENDED = "org.hibernate.resource.beans.container.internal.CdiBeanContainerExtendedAccessImpl";
 
-	private static final String BEAN_MANAGER_EXTENSION_FQN = "org.hibernate.jpa.event.spi.jpa.ExtendedBeanManager";
+	private static final String BEAN_MANAGER_EXTENSION_FQN = "org.hibernate.resource.beans.container.spi.ExtendedBeanManager";
 
 	@SuppressWarnings("unchecked")
 	public static BeanContainer fromBeanManagerReference(

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
@@ -8,11 +8,11 @@ package org.hibernate.resource.beans.container.internal;
 
 import javax.enterprise.inject.spi.BeanManager;
 
-import org.hibernate.jpa.event.spi.jpa.ExtendedBeanManager;
 import org.hibernate.resource.beans.container.spi.AbstractCdiBeanContainer;
 import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
 import org.hibernate.resource.beans.container.spi.ContainedBean;
 import org.hibernate.resource.beans.container.spi.ContainedBeanImplementor;
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 
 import org.jboss.logging.Logger;

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingExtendedBeanManager.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingExtendedBeanManager.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.testsupport;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+public interface TestingExtendedBeanManager {
+
+	void notifyListenerReady(BeanManager beanManager);
+
+	void notifyListenerShuttingDown(BeanManager beanManager);
+
+	static TestingExtendedBeanManager create() {
+		return new TestingExtendedBeanManagerImpl();
+	}
+
+	static TestingExtendedBeanManager createLegacy() {
+		return new TestingLegacyExtendedBeanManagerImpl();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingExtendedBeanManagerImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingExtendedBeanManagerImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.testsupport;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+class TestingExtendedBeanManagerImpl
+		implements TestingExtendedBeanManager, ExtendedBeanManager {
+
+	private ExtendedBeanManager.LifecycleListener lifecycleListener;
+
+	@Override
+	public void registerLifecycleListener(ExtendedBeanManager.LifecycleListener lifecycleListener) {
+		if ( this.lifecycleListener != null ) {
+			throw new RuntimeException( "LifecycleListener already registered" );
+		}
+		this.lifecycleListener = lifecycleListener;
+	}
+
+	@Override
+	public void notifyListenerReady(BeanManager beanManager) {
+		lifecycleListener.beanManagerInitialized( beanManager );
+	}
+
+	@Override
+	public void notifyListenerShuttingDown(BeanManager beanManager) {
+		lifecycleListener.beforeBeanManagerDestroyed( beanManager );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingLegacyExtendedBeanManagerImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/testsupport/TestingLegacyExtendedBeanManagerImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.testsupport;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.hibernate.jpa.event.spi.jpa.ExtendedBeanManager;
+
+class TestingLegacyExtendedBeanManagerImpl
+		implements TestingExtendedBeanManager, org.hibernate.jpa.event.spi.jpa.ExtendedBeanManager {
+
+	private ExtendedBeanManager.LifecycleListener lifecycleListener;
+
+	@Override
+	public void registerLifecycleListener(ExtendedBeanManager.LifecycleListener lifecycleListener) {
+		if ( this.lifecycleListener != null ) {
+			throw new RuntimeException( "LifecycleListener already registered" );
+		}
+		this.lifecycleListener = lifecycleListener;
+	}
+
+	@Override
+	public void notifyListenerReady(BeanManager beanManager) {
+		lifecycleListener.beanManagerInitialized( beanManager );
+	}
+
+	@Override
+	public void notifyListenerShuttingDown(BeanManager beanManager) {
+		lifecycleListener.beforeBeanManagerDestroyed( beanManager );
+	}
+}

--- a/hibernate-core/src/test2/java/org/hibernate/test/cdi/events/extended/InvalidExtendedCdiSupportTest.java
+++ b/hibernate-core/src/test2/java/org/hibernate/test/cdi/events/extended/InvalidExtendedCdiSupportTest.java
@@ -19,6 +19,7 @@ import org.hibernate.tool.schema.Action;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.hibernate.test.cdi.events.Monitor;
 import org.hibernate.test.cdi.events.TheEntity;
+import org.hibernate.test.cdi.testsupport.TestingExtendedBeanManager;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil2.inTransaction;
@@ -34,16 +35,27 @@ import static org.junit.Assert.fail;
  */
 public class InvalidExtendedCdiSupportTest extends BaseUnitTestCase {
 	@Test
-	public void testIt() {
-		Monitor.reset();
+	public void test() {
+		doTest( TestingExtendedBeanManager.create() );
+	}
 
-		final ExtendedBeanManagerImpl standIn = new ExtendedBeanManagerImpl();
+	/**
+	 * NOTE : we use the deprecated one here to make sure this continues to work.
+	 * Scott still uses this in WildFly and we need it to continue to work there
+	 */
+	@Test
+	public void testLegacy() {
+		doTest( TestingExtendedBeanManager.createLegacy() );
+	}
+
+	private void doTest(TestingExtendedBeanManager beanManager) {
+		Monitor.reset();
 
 		BootstrapServiceRegistry bsr = new BootstrapServiceRegistryBuilder().build();
 
 		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder( bsr )
 				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
-				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, standIn )
+				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, beanManager )
 				.build();
 
 
@@ -91,12 +103,6 @@ public class InvalidExtendedCdiSupportTest extends BaseUnitTestCase {
 		}
 		finally {
 			sessionFactory.close();
-		}
-	}
-
-	public static class ExtendedBeanManagerImpl implements ExtendedBeanManager {
-		@Override
-		public void registerLifecycleListener(LifecycleListener lifecycleListener) {
 		}
 	}
 }

--- a/hibernate-core/src/test2/java/org/hibernate/test/cdi/general/mixed/ExtendedMixedAccessTest.java
+++ b/hibernate-core/src/test2/java/org/hibernate/test/cdi/general/mixed/ExtendedMixedAccessTest.java
@@ -19,6 +19,7 @@ import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.tool.schema.Action;
 
+import org.hibernate.test.cdi.testsupport.TestingExtendedBeanManager;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -32,8 +33,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ExtendedMixedAccessTest implements BeanContainer.LifecycleOptions {
 	@Test
 	public void testExtendedMixedAccess() {
-		final Helper.TestingExtendedBeanManager extendedBeanManager = Helper.createExtendedBeanManager();
+		doTest( TestingExtendedBeanManager.create() );
+	}
 
+	/**
+	 * NOTE : we use the deprecated one here to make sure this continues to work.
+	 * Scott still uses this in WildFly and we need it to continue to work there
+	 */
+	@Test
+	public void testLegacyExtendedMixedAccess() {
+		doTest( TestingExtendedBeanManager.createLegacy() );
+	}
+
+	private void doTest(TestingExtendedBeanManager extendedBeanManager) {
 		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
 				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
 				.applySetting( AvailableSettings.CDI_BEAN_MANAGER, extendedBeanManager )

--- a/hibernate-core/src/test2/java/org/hibernate/test/cdi/general/mixed/Helper.java
+++ b/hibernate-core/src/test2/java/org/hibernate/test/cdi/general/mixed/Helper.java
@@ -22,37 +22,4 @@ public class Helper {
 				.addBeanClasses( HostedBean.class, InjectedHostedBean.class );
 		return cdiInitializer.initialize();
 	}
-
-	/**
-	 * NOTE : we use the deprecated one here to make sure this continues to work.
-	 * Scott still uses this in WildFly and we need it to continue to work there
-	 */
-	public static TestingExtendedBeanManager createExtendedBeanManager() {
-		return new TestingExtendedBeanManager() {
-			private ExtendedBeanManager.LifecycleListener lifecycleListener;
-
-			@Override
-			public void registerLifecycleListener(LifecycleListener lifecycleListener) {
-				if ( this.lifecycleListener != null ) {
-					throw new RuntimeException( "LifecycleListener already registered" );
-				}
-				this.lifecycleListener = lifecycleListener;
-			}
-
-			@Override
-			public void notifyListenerReady(BeanManager beanManager) {
-				lifecycleListener.beanManagerInitialized( beanManager );
-			}
-
-			@Override
-			public void notifyListenerShuttingDown(BeanManager beanManager) {
-				lifecycleListener.beforeBeanManagerDestroyed( beanManager );
-			}
-		};
-	}
-
-	public interface TestingExtendedBeanManager extends ExtendedBeanManager {
-		void notifyListenerReady(BeanManager beanManager);
-		void notifyListenerShuttingDown(BeanManager beanManager);
-	}
 }


### PR DESCRIPTION
Port of #2809 to branch wip/6.0.

Ticket: https://hibernate.atlassian.net/browse/HHH-13309

Waiting for CI; I didn't run tests locally. But there wasn't any conflict.