### PR TITLE
[HHH-13319]setParameter doesn't work in native Query if Query is already executed with different parameter value for collection type when new collection length is less than the previous	

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -547,6 +547,9 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 
 		for ( Map.Entry<QueryParameter, QueryParameterListBinding> entry : parameterListBindingMap.entrySet() ) {
 			final NamedParameterDescriptor sourceParam = (NamedParameterDescriptor) entry.getKey();
+			//HHH-13319
+			parameterBindingMap.entrySet()
+                    		.removeIf(e->e.getKey().getName().startsWith(( sourceParam.isJpaPositionalParameter() ? 'x' : "" ) + sourceParam.getName()+"_"));
 			final Collection bindValues = entry.getValue().getBindValues();
 
 			int bindValueCount = bindValues.size();

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh13319/NativeQueryParameterUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh13319/NativeQueryParameterUpdateTest.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query.hhh13319;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Query;
+
+import java.util.Arrays;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+/**
+ * @author Rabin Banerjee
+ */
+public class NativeQueryParameterUpdateTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] {
+			Person.class
+		};
+	}
+
+	@Test
+	public void testhhh13319() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Query query = entityManager.createNativeQuery(
+				"SELECT * from person where id in (:ids)");
+			query.setParameter("ids",Arrays.asList(1,2,5,10));
+			query.getResultList();
+			
+			//Now query with another set of ids having more length than last
+			query.setParameter("ids",Arrays.asList(15,278,58,110,98,53,29,25));
+			query.getResultList();
+
+			//Now query with another set of ids having less length than last
+			query.setParameter("ids",Arrays.asList(91,26));
+			query.getResultList();
+		} );
+	}
+
+	@Entity
+	@Table(name = "person")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh13319/NativeQueryParameterUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh13319/NativeQueryParameterUpdateTest.java
@@ -74,15 +74,15 @@ public class NativeQueryParameterUpdateTest extends BaseEntityManagerFunctionalT
 			doTest(query,inp);
 
 			//Again query with 2 element
-			query.setParameter("ids",Arrays.asList(16,17));
+			inp = Arrays.asList(16,17);
 			doTest(query,inp);
 
 			//Again query with more element
-                        query.setParameter("ids",Arrays.asList(13,14,19,20));
+			inp = Arrays.asList(13,14,8,12);
                         doTest(query,inp);
 
 			//Again query with less element
-                        query.setParameter("ids",Arrays.asList(12,17));
+			inp = Arrays.asList(12,17,15);
                         doTest(query,inp);
 
 			//Again query with element which doesn not exist


### PR DESCRIPTION
When re using a native query with a Collection type param , its not removing the already expanded parameter from parameterBindingMap in expandListValuedParameters. For example first time the Collection had 3 values so it expanded to ids_0 , ids_1, ids_2 . Then next run it has two values so its just updating ids_0 , ids_1 not removing ids_2 from parameterBindingMap which is causing Caused by: org.hibernate.QueryException: Named parameter does not appear in Query: ids_2