### PR TITLE
HHH-13266 Oracle, Mariadb and HANA test fixes

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
@@ -26,6 +26,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
@@ -255,8 +256,8 @@ abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalTestCase
 		}
 
 		protected final boolean isNanosecondPrecisionSupported() {
-			// PostgreSQL apparently doesn't support nanosecond precision correctly
-			return !( dialect instanceof PostgreSQL81Dialect );
+			// Most databases apparently don't support nanosecond precision correctly
+			return dialect instanceof H2Dialect;
 		}
 
 		protected final S add(ZoneId defaultJvmTimeZone, Object ... subClassParameters) {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -26,6 +27,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.MariaDB10Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
@@ -244,6 +246,19 @@ abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalTestCase
 		protected AbstractParametersBuilder() {
 			dialect = determineDialect();
 			remappingDialectClasses.add( null ); // Always test without remapping
+		}
+
+		public S skippedForDialects(List<Class<?>> dialectClasses, Consumer<S> skippedIfDialectMatchesClasses) {
+			boolean skip = false;
+			for ( Class<?> dialectClass : dialectClasses ) {
+				if ( dialectClass.isInstance( dialect ) ) {
+					skip = true;
+				}
+			}
+			if ( !skip ) {
+				skippedIfDialectMatchesClasses.accept( thisAsS() );
+			}
+			return thisAsS();
 		}
 
 		@SafeVarargs

--- a/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/InstantTest.java
@@ -15,11 +15,15 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 
 import org.junit.runners.Parameterized;
 
@@ -45,18 +49,23 @@ public class InstantTest extends AbstractJavaTimeTypeTest<Instant, InstantTest.E
 				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
 				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 500, ZONE_PARIS )
-				.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_PARIS )
-				.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
-				.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
-				// Affected by HHH-13266 (JDK-8061577)
-				.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_PARIS )
-				.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_PARIS )
+								.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+								.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
+								// Affected by HHH-13266 (JDK-8061577)
+								.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_PARIS )
+								.add( 1899, 12, 31, 23, 59, 59, 999_999_999, ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -14,12 +14,15 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
 import org.hibernate.testing.TestForIssue;
@@ -44,16 +47,21 @@ public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDate
 				// Not affected by HHH-13266 (JDK-8061577)
 				.add( 2017, 11, 6, ZONE_UTC_MINUS_8 )
 				.add( 2017, 11, 6, ZONE_PARIS )
-				.add( 1970, 1, 1, ZONE_GMT )
-				.add( 1900, 1, 1, ZONE_GMT )
-				.add( 1900, 1, 1, ZONE_OSLO )
-				.add( 1900, 1, 2, ZONE_PARIS )
-				.add( 1900, 1, 2, ZONE_AMSTERDAM )
-				// Affected by HHH-13266 (JDK-8061577), but only when remapping dates as timestamps
-				.add( 1892, 1, 1, ZONE_OSLO )
-				.add( 1900, 1, 1, ZONE_PARIS )
-				.add( 1900, 1, 1, ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 1970, 1, 1, ZONE_GMT )
+								.add( 1900, 1, 1, ZONE_GMT )
+								.add( 1900, 1, 1, ZONE_OSLO )
+								.add( 1900, 1, 2, ZONE_PARIS )
+								.add( 1900, 1, 2, ZONE_AMSTERDAM )
+								// Affected by HHH-13266 (JDK-8061577), but only when remapping dates as timestamps
+								.add( 1892, 1, 1, ZONE_OSLO )
+								.add( 1900, 1, 1, ZONE_PARIS )
+								.add( 1900, 1, 1, ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -21,10 +21,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.runners.Parameterized;
 
@@ -32,6 +34,7 @@ import org.junit.runners.Parameterized;
  * Tests for storage of LocalDate properties.
  */
 @TestForIssue(jiraKey = "HHH-10371")
+@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA systematically returns the wrong date when the JVM default timezone is not UTC")
 public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDateTest.EntityWithLocalDate> {
 
 	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTimeTest.java
@@ -12,11 +12,15 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 
 import org.junit.runners.Parameterized;
 
@@ -42,16 +46,21 @@ public class LocalDateTimeTest extends AbstractJavaTimeTypeTest<LocalDateTime, L
 				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
 				.add( 2017, 11, 6, 19, 19, 1, 0, ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 500, ZONE_PARIS )
-				.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
-				.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
-				// Affected by HHH-13266 (JDK-8061577)
-				.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 1970, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.add( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+								.add( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
+								// Affected by HHH-13266 (JDK-8061577)
+								.add( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
@@ -21,10 +21,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
+import org.hibernate.testing.SkipForDialect;
+import org.junit.Test;
 import org.junit.runners.Parameterized;
 
 /**
@@ -165,6 +168,13 @@ public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTime
 	@Override
 	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
 		return resultSet.getTimestamp( columnIndex );
+	}
+
+	@Override
+	@Test
+	@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA seems to return a java.sql.Timestamp instead of a java.sql.Time")
+	public void writeThenNativeRead() {
+		super.writeThenNativeRead();
 	}
 
 	@Entity(name = ENTITY_NAME)

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
@@ -14,12 +14,15 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
 import org.junit.runners.Parameterized;
@@ -59,18 +62,23 @@ public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTime
 				.add( 19, 19, 1, 0, ZONE_UTC_MINUS_8 )
 				.add( 19, 19, 1, 0, ZONE_PARIS )
 				.add( 19, 19, 1, 500, ZONE_PARIS )
-				.add( 0, 0, 0, 0, ZONE_GMT )
-				.add( 0, 0, 0, 0, ZONE_OSLO )
 				.add( 0, 9, 20, 0, ZONE_PARIS )
 				.add( 0, 19, 31, 0, ZONE_AMSTERDAM )
-				.add( 0, 0, 0, 0, ZONE_AMSTERDAM )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.addPersistedWithoutHibernate( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
-				.addPersistedWithoutHibernate( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
-				.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
-				.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 0, 0, 0, 0, ZONE_GMT )
+								.add( 0, 0, 0, 0, ZONE_OSLO )
+								.add( 0, 0, 0, 0, ZONE_AMSTERDAM )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.addPersistedWithoutHibernate( 1900, 1, 2, 0, 9, 21, 0, ZONE_PARIS )
+								.addPersistedWithoutHibernate( 1900, 1, 2, 0, 19, 32, 0, ZONE_AMSTERDAM )
+								.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, ZONE_OSLO )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, ZONE_PARIS )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, ZONE_AMSTERDAM )
+								.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetDateTimeTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.persistence.Basic;
@@ -22,6 +23,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.Query;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.OffsetDateTimeType;
 
 import org.hibernate.testing.TestForIssue;
@@ -68,22 +71,27 @@ public class OffsetDateTimeTest extends AbstractJavaTimeTypeTest<OffsetDateTime,
 				.add( 2017, 11, 6, 19, 19, 1, 0, "-02:00", ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 0, "-06:00", ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 0, "-08:00", ZONE_PARIS )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_GMT )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_GMT )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 9, 21, 0, "+00:09:21", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZONE_AMSTERDAM )
-				// Affected by HHH-13266
-				.add( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 1970, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_GMT )
+								.add( 1970, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_GMT )
+								.add( 1970, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "+01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "-01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 9, 21, 0, "+00:09:21", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "+00:19:32", ZONE_AMSTERDAM )
+								// Affected by HHH-13266
+								.add( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -23,11 +23,14 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.BigIntTypeDescriptor;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
+import org.hibernate.testing.SkipForDialect;
+import org.junit.Test;
 import org.junit.runners.Parameterized;
 
 /**
@@ -176,6 +179,13 @@ public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetT
 	@Override
 	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
 		return resultSet.getTimestamp( columnIndex );
+	}
+
+	@Override
+	@Test
+	@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA seems to return a java.sql.Timestamp instead of a java.sql.Time")
+	public void writeThenNativeRead() {
+		super.writeThenNativeRead();
 	}
 
 	@Entity(name = ENTITY_NAME)

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -16,12 +16,15 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.BigIntTypeDescriptor;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
@@ -66,19 +69,24 @@ public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetT
 				.add( 19, 19, 1, 0, "+01:30", ZONE_PARIS )
 				.add( 19, 19, 1, 500, "+01:00", ZONE_PARIS )
 				.add( 19, 19, 1, 0, "-08:00", ZONE_PARIS )
-				.add( 0, 0, 0, 0, "+01:00", ZONE_GMT )
-				.add( 0, 0, 0, 0, "+00:00", ZONE_GMT )
-				.add( 0, 0, 0, 0, "-01:00", ZONE_GMT )
-				.add( 0, 0, 0, 0, "+00:00", ZONE_OSLO )
 				.add( 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
 				.add( 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
 				.add( 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
-				.add( 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
-				.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
-				.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
-				.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 0, 0, 0, 0, "+01:00", ZONE_GMT )
+								.add( 0, 0, 0, 0, "+00:00", ZONE_GMT )
+								.add( 0, 0, 0, 0, "-01:00", ZONE_GMT )
+								.add( 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+								.add( 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+								.addPersistedWithoutHibernate( 1892, 1, 1, 0, 0, 0, 0, "+00:00", ZONE_OSLO )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 9, 20, 0, "+00:09:21", ZONE_PARIS )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_PARIS )
+								.addPersistedWithoutHibernate( 1900, 1, 1, 0, 19, 31, 0, "+00:19:32", ZONE_AMSTERDAM )
+								.addPersistedWithoutHibernate( 1600, 1, 1, 0, 0, 0, 0, "+00:19:32", ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/ZonedDateTimeTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.persistence.Basic;
@@ -22,6 +23,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.Query;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.ZonedDateTimeType;
 
 import org.hibernate.testing.TestForIssue;
@@ -72,30 +75,35 @@ public class ZonedDateTimeTest extends AbstractJavaTimeTypeTest<ZonedDateTime, Z
 				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-02:00", ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-06:00", ZONE_PARIS )
 				.add( 2017, 11, 6, 19, 19, 1, 0, "GMT-08:00", ZONE_PARIS )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
-				.add( 1970, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
-				.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 9, 21, 0, "GMT+00:09:21", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 9, 21, 0, "Europe/Paris", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Paris", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
-				.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
-				// Affected by HHH-13266
-				.add( 1892, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
-				.add( 1892, 1, 1, 0, 0, 0, 0, "Europe/Oslo", ZONE_OSLO )
-				.add( 1900, 1, 1, 0, 9, 20, 0, "GMT+00:09:21", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 9, 20, 0, "Europe/Paris", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_PARIS )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
-				.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, 0, 0, 0, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
-				.add( 1600, 1, 1, 0, 0, 0, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+				.skippedForDialects(
+						// MySQL/Mariadb cannot store values equal to epoch exactly, or less, in a timestamp.
+						Arrays.asList( MySQLDialect.class, MariaDBDialect.class ),
+						b -> b
+								.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
+								.add( 1970, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+								.add( 1970, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "GMT-01:00", ZONE_GMT )
+								.add( 1900, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 9, 21, 0, "GMT+00:09:21", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 9, 21, 0, "Europe/Paris", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Paris", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+								.add( 1900, 1, 1, 0, 19, 32, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+								// Affected by HHH-13266
+								.add( 1892, 1, 1, 0, 0, 0, 0, "GMT+00:00", ZONE_OSLO )
+								.add( 1892, 1, 1, 0, 0, 0, 0, "Europe/Oslo", ZONE_OSLO )
+								.add( 1900, 1, 1, 0, 9, 20, 0, "GMT+00:09:21", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 9, 20, 0, "Europe/Paris", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_PARIS )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+								.add( 1900, 1, 1, 0, 19, 31, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, 0, 0, 0, 0, "GMT+00:19:32", ZONE_AMSTERDAM )
+								.add( 1600, 1, 1, 0, 0, 0, 0, "Europe/Amsterdam", ZONE_AMSTERDAM )
+				)
 				.build();
 	}
 


### PR DESCRIPTION
Follow-up on #2813 

Some tests failed for Oracle, Mariadb and HANA. This disable the tests, because the cause of the failures seems to be limitations of the databases.

I checked this works fine for MariaDB. I couldn't get Oracle Express or HANA to run on my machine, so this will have to be checked by the CI.