### PR TITLE
HHH-13332 Update c3p0 to 0.9.5.3

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -133,7 +133,7 @@ ext {
             // EL required by Hibernate Validator at test runtime
             expression_language: "org.glassfish:javax.el:${elVersion}",
 
-            c3p0:            "com.mchange:c3p0:0.9.5.2",
+            c3p0:            "com.mchange:c3p0:0.9.5.3",
             ehcache:         "net.sf.ehcache:ehcache:2.10.6",
             ehcache3:        "org.ehcache:ehcache:3.6.1",
             jcache:          "javax.cache:cache-api:1.0.0",


### PR DESCRIPTION
Update c3p0 dependency to addresses the XXE vulnerability (CVE-2018-20433)