### PR TITLE
HHH-13331 : Query Cache should not be allowed for queris having Non Cacheable Query Spaces

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/UpdateTimestampsCache.java
@@ -13,7 +13,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
-
+import org.hibernate.loader.Loader;
 import org.jboss.logging.Logger;
 
 /**
@@ -68,7 +68,9 @@ public class UpdateTimestampsCache {
 			if ( DEBUG_ENABLED ) {
 				LOG.debugf( "Pre-invalidating space [%s], timestamp: %s", space, ts );
 			}
-
+			if (!Loader.validateSpace(space)) {
+				continue;
+			}
 			try {
 				session.getEventListenerManager().cachePutStart();
 
@@ -103,6 +105,9 @@ public class UpdateTimestampsCache {
 		for (Serializable space : spaces) {
 			if ( DEBUG_ENABLED ) {
 				LOG.debugf( "Invalidating space [%s], timestamp: %s", space, ts );
+			}
+			if (!Loader.validateSpace(space)) {
+				continue;
 			}
 
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -20,10 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-
-import javax.persistence.Cacheable;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
@@ -34,7 +31,6 @@ import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.WrongClassException;
-import org.hibernate.annotations.Cache;
 import org.hibernate.cache.spi.FilterKey;
 import org.hibernate.cache.spi.QueryCache;
 import org.hibernate.cache.spi.QueryKey;
@@ -108,8 +104,7 @@ public abstract class Loader {
 	protected static final boolean DEBUG_ENABLED = LOG.isDebugEnabled();
 	
 	private static Boolean metadataInitialized = false;
-	private static final Set<Serializable> cacheableSpacesSet = java.util.Collections
-			.newSetFromMap(new ConcurrentHashMap<>());
+	private static final Set<Serializable> cacheableSpacesSet = new HashSet<>();
 
 	private final SessionFactoryImplementor factory;
 	private volatile ColumnNameCache columnNameCache;


### PR DESCRIPTION
### HHH-13331 : Query Cache should not be allowed for queris having Non Cacheable Query Spaces

**Analysis:**
- When query is cacheable i.e. 'org.hibernate.cacheable=true', and is having query spaces which are non cacheable, then this may lead to the well known 'N+1' issue.
- I.e. the cached query result containing the 'N' ids, will further result in N queries of 'findById' to the database.

**Expectation:**
- Query Cache should not be allowed for queries having Non Cacheable Query Spaces. Either throw an exception while loading the query, or rather ignore the query cache in this case.
- With this, even high number of puts to 'UpdateTimestampCache' can be avoided. Which are originating from all the high number of transactional DMLs being executed to a query space which is non-cacheable.

**Resolution : org.hibernate.loader.Loader.list() Mehod**
- Maintained a set of all the cacheable 'query space (String)' - called it **'cacheableSpacesSet'** etc
- Within the method 'Loader.list()', additional check of validating the current query's spaces from the initially maintained 'cacheableSpacesSet'
- With the above additional validation, even though the system is configured as 'hibernate.cache.use_query_cache=true', and corresponding query is set as cacheable (i.e. 'org.hibernate.cacheable=true'), still the 'cacheable boolean' within the list() method will be set as false for query having query spaces which are not cacheable.


**Performance:**
- This newly added additional validation uses **'HashSet.contains()'** method internally. Which is having time complexity of **O(1)**
- On a simple laptop, for individual call with one query space, it took an additional **24us to 40us** for the complete additional logic.
- On a server, this time is expected to reduce significantly.