### PR TITLE
HHH-9861 Fix wrong mapping of ColumnType FLOAT for H2 database

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -118,7 +118,8 @@ public class H2Dialect extends Dialect {
 		registerColumnType( Types.DECIMAL, "decimal($p,$s)" );
 		registerColumnType( Types.NUMERIC, "decimal($p,$s)" );
 		registerColumnType( Types.DOUBLE, "double" );
-		registerColumnType( Types.FLOAT, "float" );
+		// H2 does not have a float type. Instead, it's mapping floats as alias to double
+		registerColumnType( Types.FLOAT, "double" );
 		registerColumnType( Types.INTEGER, "integer" );
 		registerColumnType( Types.LONGVARBINARY, "longvarbinary" );
 		// H2 does define "longvarchar", but it is a simple alias to "varchar"

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/FormulaWithColumnTypesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/FormulaWithColumnTypesTest.java
@@ -163,7 +163,7 @@ public class FormulaWithColumnTypesTest extends BaseCoreFunctionalTestCase {
 			this.displayCode = displayCode;
 		}
 
-		@Formula("CAST(DISPLAY_CODE AS FLOAT)")
+		@Formula("CAST(DISPLAY_CODE AS DOUBLE)")
 		public Integer getDisplayCodeAsFloat() {
 			return displayCodeAsFloat;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
@@ -400,6 +400,7 @@ public class HQLTest extends QueryTranslatorTestCase {
 		}
 		if ( getDialect() instanceof H2Dialect ) {
 			// H2 does not have a float type. Instead, H2 aliases float to double
+			assertTranslation( "from Animal where abs(cast(1 as double) - cast(:param as double)) = 1.0" );
 			return;
 		}
 		assertTranslation("from Animal where abs(cast(1 as float) - cast(:param as float)) = 1.0");

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
@@ -398,6 +398,10 @@ public class HQLTest extends QueryTranslatorTestCase {
 			// parser does not; so the outputs do not match here...
 			return;
 		}
+		if ( getDialect() instanceof H2Dialect ) {
+			// H2 does not have a float type. Instead, H2 aliases float to double
+			return;
+		}
 		assertTranslation("from Animal where abs(cast(1 as float) - cast(:param as float)) = 1.0");
 	}
 


### PR DESCRIPTION
H2 has no float datatype. Instead, float is an alias for double. This leads to an error when hibernate is trying to validate the schema (found: double, expected: float).

Source for H2 datatypes:
http://www.h2database.com/html/datatypes.html