### PR TITLE
HHH-13364 Query.getSingleResult and getResultList() throw PessimisticLockException when pessimistic lock fails with timeout

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1535,7 +1535,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			throw new IllegalArgumentException( e );
 		}
 		catch (HibernateException he) {
-			throw getExceptionConverter().convert( he );
+			throw getExceptionConverter().convert( he, getLockOptions() );
 		}
 		finally {
 			afterQuery();
@@ -1581,7 +1581,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			return uniqueElement( list );
 		}
 		catch ( HibernateException e ) {
-			throw getExceptionConverter().convert( e );
+			throw getExceptionConverter().convert( e, getLockOptions() );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/Lock.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/Lock.java
@@ -10,12 +10,21 @@ package org.hibernate.jpa.test.lock;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.LockModeType;
+import javax.persistence.NamedQuery;
+import javax.persistence.QueryHint;
 import javax.persistence.Version;
 
 /**
  * @author Emmanuel Bernard
  */
 @Entity(name="Lock_")
+@NamedQuery(
+		name="AllLocks",
+		query="from Lock_",
+		lockMode = LockModeType.PESSIMISTIC_WRITE,
+		hints = { @QueryHint( name = "javax.persistence.lock.timeout", value = "0")}
+)
 public class Lock {
 	private Integer id;
 	private Integer version;

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -117,9 +117,103 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
 				}
 				catch (PersistenceException pe) {
+					log.info(
+							"EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
+									"This is likely a consequence of " + getDialect().getClass()
+									.getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
+									"See HHH-7251 for an example of one such situation.", pe
+					);
+					fail( "EntityManager should be throwing LockTimeoutException." );
+				}
+			} );
+		} );
+	}
+
+	@Test(timeout = 5 * 1000) //5 seconds
+	@TestForIssue( jiraKey = "HHH-13364" )
+	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
+			comment = "Test verifies proper exception throwing when a lock timeout is specified for Query#getSingleResult.",
+			jiraKey = "HHH-13364" )
+	public void testQuerySingleResultPessimisticWriteLockTimeoutException() {
+		Lock lock = new Lock();
+		lock.setName( "name" );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( lock );
+		} );
+
+		doInJPA( this::entityManagerFactory, _entityManager -> {
+
+			Lock lock2 = _entityManager.find( Lock.class, lock.getId(), LockModeType.PESSIMISTIC_WRITE );
+			assertEquals( "lock mode should be PESSIMISTIC_WRITE ", LockModeType.PESSIMISTIC_WRITE, _entityManager.getLockMode( lock2 ) );
+
+			doInJPA( this::entityManagerFactory, entityManager -> {
+				try {
+					TransactionUtil.setJdbcTimeout( entityManager.unwrap( Session.class ) );
+					entityManager.createQuery( "from Lock_ where id = " + lock.getId(), Lock.class )
+							.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+							.setHint( "javax.persistence.lock.timeout", 0 )
+							.getSingleResult();
+					fail( "Exception should be thrown" );
+				}
+				catch (LockTimeoutException lte) {
+					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
+					lte.getCause();
+				}
+				catch (PessimisticLockException pe) {
+					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
+				}
+				catch (PersistenceException pe) {
 					log.info("EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
 									 "This is likely a consequence of " + getDialect().getClass().getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
 									 "See HHH-7251 for an example of one such situation.", pe);
+					fail( "EntityManager should be throwing LockTimeoutException." );
+				}
+			} );
+		} );
+	}
+
+	@Test(timeout = 5 * 1000) //5 seconds
+	@TestForIssue( jiraKey = "HHH-13364" )
+	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
+			comment = "Test verifies proper exception throwing when a lock timeout is specified for Query#getResultList.",
+			jiraKey = "HHH-13364" )
+	public void testQueryResultListPessimisticWriteLockTimeoutException() {
+		Lock lock = new Lock();
+		lock.setName( "name" );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( lock );
+		} );
+
+		doInJPA( this::entityManagerFactory, _entityManager -> {
+
+			Lock lock2 = _entityManager.find( Lock.class, lock.getId(), LockModeType.PESSIMISTIC_WRITE );
+			assertEquals( "lock mode should be PESSIMISTIC_WRITE ", LockModeType.PESSIMISTIC_WRITE, _entityManager.getLockMode( lock2 ) );
+
+			doInJPA( this::entityManagerFactory, entityManager -> {
+				try {
+					TransactionUtil.setJdbcTimeout( entityManager.unwrap( Session.class ) );
+					entityManager.createQuery( "from Lock_ where id = " + lock.getId(), Lock.class )
+							.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+							.setHint( "javax.persistence.lock.timeout", 0 )
+							.getResultList();
+					fail( "Exception should be thrown" );
+				}
+				catch (LockTimeoutException lte) {
+					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
+					lte.getCause();
+				}
+				catch (PessimisticLockException pe) {
+					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
+				}
+				catch (PersistenceException pe) {
+					log.info(
+						"EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
+								"This is likely a consequence of " + getDialect().getClass()
+								.getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
+								"See HHH-7251 for an example of one such situation.", pe
+					);
 					fail( "EntityManager should be throwing LockTimeoutException." );
 				}
 			} );
@@ -132,9 +226,11 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 		Lock lock = new Lock();
 		lock.setName( "name" );
 
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			entityManager.persist( lock );
-		} );
+		doInJPA(
+				this::entityManagerFactory, entityManager -> {
+					entityManager.persist( lock );
+				}
+		);
 
 		doInJPA( this::entityManagerFactory, _entityManagaer -> {
 			Map<String, Object> properties = new HashMap<>();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -220,6 +220,50 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 		} );
 	}
 
+	@Test(timeout = 5 * 1000) //5 seconds
+	@TestForIssue( jiraKey = "HHH-13364" )
+	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
+			comment = "Test verifies proper exception throwing when a lock timeout is specified for NamedQuery#getResultList.",
+			jiraKey = "HHH-13364" )
+	public void testNamedQueryResultListPessimisticWriteLockTimeoutException() {
+		Lock lock = new Lock();
+		lock.setName( "name" );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( lock );
+		} );
+
+		doInJPA( this::entityManagerFactory, _entityManager -> {
+
+			Lock lock2 = _entityManager.find( Lock.class, lock.getId(), LockModeType.PESSIMISTIC_WRITE );
+			assertEquals( "lock mode should be PESSIMISTIC_WRITE ", LockModeType.PESSIMISTIC_WRITE, _entityManager.getLockMode( lock2 ) );
+
+			doInJPA( this::entityManagerFactory, entityManager -> {
+				try {
+					TransactionUtil.setJdbcTimeout( entityManager.unwrap( Session.class ) );
+					entityManager.createNamedQuery( "AllLocks", Lock.class ).getResultList();
+					fail( "Exception should be thrown" );
+				}
+				catch (LockTimeoutException lte) {
+					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
+					lte.getCause();
+				}
+				catch (PessimisticLockException pe) {
+					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
+				}
+				catch (PersistenceException pe) {
+					log.info(
+							"EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
+									"This is likely a consequence of " + getDialect().getClass()
+									.getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
+									"See HHH-7251 for an example of one such situation.", pe
+					);
+					fail( "EntityManager should be throwing LockTimeoutException." );
+				}
+			} );
+		} );
+	}
+
 	@Test
 	@RequiresDialectFeature( value = DialectChecks.SupportSkipLocked.class )
 	public void testUpdateWithPessimisticReadLockSkipLocked() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13364