### PR TITLE
Remove final form EntityAction subclasses

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -31,7 +31,7 @@ import org.hibernate.metamodel.model.domain.spi.EntityTypeDescriptor;
  *
  * @see EntityIdentityInsertAction
  */
-public final class EntityInsertAction extends AbstractEntityInsertAction {
+public class EntityInsertAction extends AbstractEntityInsertAction {
 	private Object version;
 	private Object cacheEntry;
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -33,7 +33,7 @@ import org.hibernate.type.internal.TypeHelper;
 /**
  * The action for performing entity updates.
  */
-public final class EntityUpdateAction extends EntityAction {
+public class EntityUpdateAction extends EntityAction {
 	private final Object[] state;
 	private final Object[] previousState;
 	private final Object previousVersion;


### PR DESCRIPTION
They are declared as final making it impossible to extends them and create custom actions.
The ActionQueue only accept them as actions, making it impossible to add custom actions to the queue.

Probably there are others to update.