### PR TITLE
HHH-14393 Respect precision and scale for type DOUBLE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -96,7 +96,7 @@ public class MySQLDialect extends Dialect {
 		registerColumnType( Types.INTEGER, "integer" );
 		registerColumnType( Types.CHAR, "char(1)" );
 		registerColumnType( Types.FLOAT, "float" );
-		registerColumnType( Types.DOUBLE, "double precision" );
+		registerColumnType( Types.DOUBLE, "double precision($p,$s)" );
 		registerColumnType( Types.BOOLEAN, "bit" ); // HHH-6935
 		registerColumnType( Types.DATE, "date" );
 		registerColumnType( Types.TIME, "time" );


### PR DESCRIPTION
```
	@Column(precision = 8, scale = 6)
	private Double latitude;
```
hibernate should create column latitude with double(8,6), but only double.