### PR TITLE
HHH-11833 - Fixed/created a workaround for the issue.

### DIFF
--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL56SpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL56SpatialDialect.java
@@ -77,6 +77,18 @@ public class MySQL56SpatialDialect extends MySQL55Dialect implements SpatialDial
 	}
 
 	/**
+	 * This method calls {@link #registerColumnType(int, String)} on the {@link #dialectDelegate}.
+	 * This is necessary because the delegated design makes calling {@link #registerColumnType(int, String)} on this
+	 * class directly ineffective.
+	 *
+	 * @param code The {@link java.sql.Types} typecode
+	 * @param name The database type name
+	 */
+	protected void registerColumnTypeDelegated(int code, String name) {
+		dialectDelegate.registerColumnTypeDelegated(code, name);
+	}
+
+	/**
 	 * Allows the Dialect to contribute additional types
 	 *
 	 * @param typeContributions Callback to contribute the types

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQLSpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQLSpatialDialect.java
@@ -133,4 +133,14 @@ public class MySQLSpatialDialect extends MySQLDialect implements SpatialDialect 
 		}
 	}
 
+	/**
+	 * This method is here to allow for access to the {@link #registerColumnType(int, String)} method to be accessed
+	 * through delegation by upstream classes.
+	 *
+	 * @param code The {@link java.sql.Types} typecode
+	 * @param name The database type name
+	 */
+	void registerColumnTypeDelegated(int code, String name) {
+		registerColumnType(code, name);
+	}
 }


### PR DESCRIPTION
Unfortunately, it appears that the combination of delegation and class
extension used in the design of the MySQL spatial dialects make it
necessary to create a new method, registerColumnTypeDelegated(), that
should be called by extending classes to work around the issue. Calls
directly to registerColumnType() will be lost because they don't
modify the delegate.