### PR TITLE
HHH-13377 - remove lazy loaded attributes from initializedLazyFields for refresh of bytecode enhanced entities

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/LazyPropertyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/LazyPropertyInitializer.java
@@ -35,6 +35,7 @@ public interface LazyPropertyInitializer {
 	interface InterceptorImplementor {
 		Set<String> getInitializedLazyAttributeNames();
 		void attributeInitialized(String name);
+		void attributeUninitialized(String name);
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -331,6 +331,16 @@ public class LazyAttributeLoadingInterceptor
 	}
 
 	@Override
+	public void attributeUninitialized(String name) {
+		if ( initializedLazyFields != null ) {
+			initializedLazyFields.remove(name);
+			if ( initializedLazyFields.isEmpty() ) {
+				initializedLazyFields = null;
+			}
+		}
+	}
+
+	@Override
 	public Set<String> getInitializedLazyAttributeNames() {
 		return initializedLazyFields == null ? Collections.<String>emptySet() : initializedLazyFields;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -13,6 +13,7 @@ import org.hibernate.CacheMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.entry.CacheEntry;
 import org.hibernate.engine.profile.Fetch;
@@ -172,6 +173,11 @@ public final class TwoPhaseLoad {
 					// As mentioned above, hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY
 					// so do not assign the resolved, unitialized PersistentCollection back to hydratedState[i].
 					types[i].resolve( value, session, entity, overridingEager );
+				}
+				// HHH-13377
+				LazyAttributeLoadingInterceptor interceptor = persister.getInstrumentationMetadata().extractInterceptor(entity);
+				if (interceptor != null) {
+					interceptor.attributeUninitialized(propertyNames[i]);
 				}
 			}
 			else if ( value != PropertyAccessStrategyBackRefImpl.UNKNOWN ) {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/refresh/RefreshByteCodeInstrumentedEntityWithLazyPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/refresh/RefreshByteCodeInstrumentedEntityWithLazyPropertyTest.java
@@ -1,0 +1,222 @@
+package org.hibernate.jpa.test.refresh;
+
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+
+@TestForIssue(jiraKey = "HHH-13377")
+@RunWith( BytecodeEnhancerRunner.class )
+public class RefreshByteCodeInstrumentedEntityWithLazyPropertyTest
+        extends BaseEntityManagerFunctionalTestCase {
+
+    private Long personId;
+    private Long assistantProfessorPositionId;
+    private Long professorPositionId;
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { Person.class, Course.class, Position.class };
+    }
+
+    @Before
+    public void setUp() {
+        doInJPA( this::entityManagerFactory, entityManager -> {
+            Position professorPosition = new Position("Professor");
+            entityManager.persist(professorPosition);
+            professorPositionId = professorPosition.getId();
+
+            Position assistantProfessor = new Position("Assistant Professor");
+            entityManager.persist(assistantProfessor);
+            assistantProfessorPositionId = assistantProfessor.getId();
+
+            Person person = new Person("John", "Doe", assistantProfessor);
+            entityManager.persist(person);
+            personId = person.getId();
+        });
+    }
+
+    @Test
+    public void testRefreshOfLazyField() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Person p = entityManager.find(Person.class, personId);
+            assertEquals("Doe", p.getLastName());
+
+            entityManager.createQuery(
+            "update Person p " +
+                    "set p.lastName = 'Johnson' " +
+                    "where p.id = :id"
+                )
+                .setParameter("id", personId)
+                .executeUpdate();
+
+            entityManager.refresh(p);
+            assertEquals("stale lazy field found after refresh", "Johnson", p.getLastName());
+        });
+
+    }
+
+    @Test
+    public void testRefreshOfLazyFormula() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Person p = entityManager.find(Person.class, personId);
+            assertEquals("John Doe", p.getFullName());
+
+            p.setLastName("Johnson");
+            entityManager.flush();
+            entityManager.refresh(p);
+            assertEquals("stale lazy formula found after refresh", "John Johnson", p.getFullName());
+        });
+    }
+
+    @Test
+    public void testRefreshOfLazyOneToMany() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Person p = entityManager.find(Person.class, personId);
+            assertEquals(0, p.getCourses().size());
+
+            entityManager.createNativeQuery(
+        "insert into Course (id, title, person_id) values (?, ?, ?) "
+                )
+                .setParameter(1, 0)
+                .setParameter(2, "Book Title")
+                .setParameter(3, p.getId())
+                .executeUpdate();
+
+            entityManager.refresh(p);
+            assertEquals(1, p.getCourses().size());
+        });
+    }
+
+    @Test
+    public void testRefreshOfLazyManyToOne() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Person p = entityManager.find(Person.class, personId);
+            assertEquals(assistantProfessorPositionId, p.getPosition().getId());
+
+            entityManager.createNativeQuery(
+        "update Person " +
+                "set position_id = ? " +
+                "where id = ? "
+            )
+            .setParameter(1, professorPositionId)
+            .setParameter(2, p.getId())
+            .executeUpdate();
+
+            entityManager.refresh(p);
+            assertEquals(professorPositionId, p.getPosition().getId());
+        });
+    }
+
+    @Entity(name = "Person")
+    public static class Person {
+
+        @Id
+        @GeneratedValue()
+        private Long id;
+        public Long getId() {
+            return id;
+        }
+
+        @Basic
+        private String firstName;
+        public String getFirstName() {
+            return firstName;
+        }
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        @Basic(fetch = FetchType.LAZY)
+        private String lastName;
+        public String getLastName() {
+            return lastName;
+        }
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        @Basic(fetch = FetchType.LAZY)
+        @Formula("firstName || ' ' || lastName")
+        private String fullName;
+        public String getFullName() { return fullName; }
+
+        @OneToMany(mappedBy="person", fetch = FetchType.LAZY, cascade = CascadeType.REFRESH, orphanRemoval = true)
+        private Set<Course> courses = new HashSet<>();
+        public Set<Course> getCourses() { return courses; }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @LazyToOne(LazyToOneOption.NO_PROXY)
+        private Position position;
+        public Position getPosition() { return position; }
+
+        protected Person() {}
+        public Person(String firstName, String lastName, Position position) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.position = position;
+        }
+    }
+
+    @Entity(name = "Course")
+    public static class Course {
+
+        @Id
+        private Long id;
+        public Long getId() { return id; }
+
+        @Basic
+        private String title;
+        public String getTitle() { return title; }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        private Person person;
+        public Person getPerson() { return person; }
+
+        protected Course() {}
+        public Course(String title, Person person) {
+            this.title = title;
+            this.person = person;
+        }
+    }
+
+    @Entity(name = "Position")
+    public static class Position {
+
+        @Id
+        @GeneratedValue()
+        private Long id;
+        public Long getId() { return id; }
+
+        @Basic
+        private String description;
+        public String getDescription() { return description; }
+
+        protected Position() {}
+        public Position(String description) {
+            this.description = description;
+        }
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/basic/BasicEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/basic/BasicEnhancementTest.java
@@ -218,6 +218,10 @@ public class BasicEnhancementTest {
         @Override
         public void attributeInitialized(String name) {
         }
+
+        @Override
+        public void attributeUninitialized(String name) {
+        }
     }
 
     // --- //


### PR DESCRIPTION
Remove lazy loaded attributes from the initializedLazyFields set in the entity's bytecode interceptor so accessing these attributes will reload them after refresh of entity.

I'm not sure if TwoPhaseLoad is the proper place for this fix.  I first tried clearing the initializedLazyFields set in the LazyAttributeLoadingInterceptor in the afterInitialize method of PojoEntityTuplizer as this seemed or more likely place to do this.  However, this caused a handful of existing test cases to fail.

This change is necessary so that an entity with initialized lazy loaded attributes has these attributes marked as uninitialized after the entity is refreshed.