### PR TITLE
HHH-13380 - bytecode enhanced entities in OneToMany relationship with…

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/proxy/tuplizer/DynamicInstantiator.java
+++ b/documentation/src/test/java/org/hibernate/userguide/proxy/tuplizer/DynamicInstantiator.java
@@ -11,6 +11,7 @@ package org.hibernate.userguide.proxy.tuplizer;
 import java.io.Serializable;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.tuple.Instantiator;
 
 /**
@@ -32,12 +33,12 @@ public class DynamicInstantiator
         }
     }
 
-    public Object instantiate(Serializable id) {
+    public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
         return ProxyHelper.newProxy( targetClass, id );
     }
 
-    public Object instantiate() {
-        return instantiate( null );
+    public Object instantiate(SharedSessionContractImplementor session) {
+        return instantiate( null, session );
     }
 
     public boolean isInstance(Object object) {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.PersistentClass;
 
 public class DynamicMapInstantiator implements Instantiator {
@@ -36,11 +37,11 @@ public class DynamicMapInstantiator implements Instantiator {
 		}
 	}
 
-	public final Object instantiate(Serializable id) {
-		return instantiate();
+	public final Object instantiate(Serializable id, SharedSessionContractImplementor session) {
+		return instantiate(session);
 	}
 
-	public final Object instantiate() {
+	public final Object instantiate(SharedSessionContractImplementor session) {
 		Map map = generateMap();
 		if ( entityName!=null ) {
 			map.put( KEY, entityName );

--- a/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/Instantiator.java
@@ -5,6 +5,8 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.tuple;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
 import java.io.Serializable;
 
 /**
@@ -20,16 +22,17 @@ public interface Instantiator extends Serializable {
 	 * This form is never called for component instantiation, only entity instantiation.
 	 *
 	 * @param id The id of the entity to be instantiated.
+	 * @param session The Session
 	 * @return An appropriately instantiated entity.
 	 */
-	public Object instantiate(Serializable id);
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session);
 
 	/**
 	 * Perform the requested instantiation.
-	 *
+	 * @param session The Session
 	 * @return The instantiated data structure. 
 	 */
-	public Object instantiate();
+	public Object instantiate(SharedSessionContractImplementor session);
 
 	/**
 	 * Performs check to see if the given object is an instance of the entity

--- a/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/PojoInstantiator.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Constructor;
 import org.hibernate.InstantiationException;
 import org.hibernate.PropertyNotFoundException;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ReflectHelper;
@@ -74,7 +75,7 @@ public class PojoInstantiator implements Instantiator, Serializable {
 		constructor = ReflectHelper.getDefaultConstructor( mappedClass );
 	}
 
-	public Object instantiate() {
+	public Object instantiate(SharedSessionContractImplementor session) {
 		if ( isAbstract ) {
 			throw new InstantiationException( "Cannot instantiate abstract class or interface: ", mappedClass );
 		}
@@ -86,7 +87,7 @@ public class PojoInstantiator implements Instantiator, Serializable {
 		}
 		else {
 			try {
-				return applyInterception( constructor.newInstance( (Object[]) null ) );
+				return applyInterception( constructor.newInstance( (Object[]) null ), session );
 			}
 			catch ( Exception e ) {
 				throw new InstantiationException( "Could not instantiate entity: ", mappedClass, e );
@@ -94,15 +95,15 @@ public class PojoInstantiator implements Instantiator, Serializable {
 		}
 	}
 
-	protected Object applyInterception(Object entity) {
+	protected Object applyInterception(Object entity, SharedSessionContractImplementor session) {
 		return entity;
 	}
 
-	public Object instantiate(Serializable id) {
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
 		final boolean useEmbeddedIdentifierInstanceAsEntity = embeddedIdentifier &&
 				id != null &&
 				id.getClass().equals(mappedClass);
-		return useEmbeddedIdentifierInstanceAsEntity ? id : instantiate();
+		return useEmbeddedIdentifierInstanceAsEntity ? id : instantiate(session);
 	}
 
 	public boolean isInstance(Object object) {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/AbstractComponentTuplizer.java
@@ -81,7 +81,7 @@ public abstract class AbstractComponentTuplizer implements ComponentTuplizer {
 	* This method does not populate the component parent
 	*/
 	public Object instantiate() throws HibernateException {
-		return instantiator.instantiate();
+		return instantiator.instantiate(null);
 	}
 
 	public Object getParent(Object component) {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
@@ -14,6 +14,7 @@ import org.hibernate.bytecode.spi.BasicProxyFactory;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Property;
@@ -165,11 +166,11 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 			}
 		}
 
-		public Object instantiate(Serializable id) {
+		public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
 			throw new AssertionFailure( "ProxiedInstantiator can only be used to instantiate component" );
 		}
 
-		public Object instantiate() {
+		public Object instantiate(SharedSessionContractImplementor session) {
 			return factory.getProxy();
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
@@ -670,7 +670,7 @@ public abstract class AbstractEntityTuplizer implements EntityTuplizer {
 
 	@Override
 	public final Object instantiate(Serializable id, SharedSessionContractImplementor session) {
-		Object result = getInstantiator().instantiate( id );
+		Object result = getInstantiator().instantiate( id, session );
 		if ( id != null ) {
 			setIdentifier( result, id, session );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityInstantiator.java
@@ -11,6 +11,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterc
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.tuple.PojoInstantiator;
@@ -39,7 +40,7 @@ public class PojoEntityInstantiator extends PojoInstantiator {
 	}
 
 	@Override
-	protected Object applyInterception(Object entity) {
+	protected Object applyInterception(Object entity, SharedSessionContractImplementor session) {
 		if ( !applyBytecodeInterception ) {
 			return entity;
 		}
@@ -49,7 +50,7 @@ public class PojoEntityInstantiator extends PojoInstantiator {
 				entityMetamodel.getBytecodeEnhancementMetadata()
 						.getLazyAttributesMetadata()
 						.getLazyAttributeNames(),
-				null
+				session
 		);
 		( (PersistentAttributeInterceptable) entity ).$$_hibernate_setInterceptor( interceptor );
 		return entity;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/DynamicInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/DynamicInstantiator.java
@@ -13,6 +13,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.tuple.Instantiator;
 
@@ -26,7 +27,7 @@ public class DynamicInstantiator implements Instantiator {
 		this.entityName = entityName;
 	}
 
-	public Object instantiate(Serializable id) {
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
 		if ( Cuisine.class.getName().equals( entityName ) ) {
 			return ProxyHelper.newCuisineProxy( id );
 		}
@@ -38,8 +39,8 @@ public class DynamicInstantiator implements Instantiator {
 		}
 	}
 
-	public Object instantiate() {
-		return instantiate( null );
+	public Object instantiate(SharedSessionContractImplementor session) {
+		return instantiate( null, session );
 	}
 
 	public boolean isInstance(Object object) {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/bytebuddysubclass/MyEntityInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/tuplizer/bytebuddysubclass/MyEntityInstantiator.java
@@ -8,6 +8,7 @@ package org.hibernate.test.annotations.tuplizer.bytebuddysubclass;
 
 import java.io.Serializable;
 
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.tuple.Instantiator;
 
@@ -28,12 +29,12 @@ public class MyEntityInstantiator implements Instantiator {
 	}
 
 	@Override
-	public Object instantiate(Serializable id) {
-		return instantiate();
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
+		return instantiate(session);
 	}
 
 	@Override
-	public Object instantiate() {
+	public Object instantiate(SharedSessionContractImplementor session) {
 		return createInstance( persistentClass.getMappedClass() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyOneToManyWithEqualsImplementationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyOneToManyWithEqualsImplementationTest.java
@@ -1,0 +1,122 @@
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+
+@TestForIssue(jiraKey = "HHH-13380")
+@RunWith( BytecodeEnhancerRunner.class )
+public class LazyOneToManyWithEqualsImplementationTest
+        extends BaseEntityManagerFunctionalTestCase {
+
+    private Long personId;
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { Person.class, Course.class };
+    }
+
+    @Before
+    public void setUp() {
+        doInJPA( this::entityManagerFactory, entityManager -> {
+            Person p = new Person();
+            entityManager.persist(p);
+            personId = p.getId();
+
+            Course c1 = new Course("First Course", p);
+            p.getCourses().add(c1);
+            entityManager.persist(c1);
+
+            Course c2 = new Course("Second Course", p);
+            p.getCourses().add(c2);
+            entityManager.persist(c2);
+        });
+    }
+
+
+    @Test
+    public void testRetrievalOfOneToMany() {
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Person p = entityManager.find(Person.class, personId);
+
+            Set<Course> courses = p.getCourses();
+            assertEquals(courses.size(), 2);
+        });
+    }
+
+    @Entity(name = "Person")
+    public static class Person {
+
+        @Id
+        @GeneratedValue()
+        private Long id;
+        public Long getId() {
+            return id;
+        }
+
+        @OneToMany(mappedBy="person", fetch = FetchType.LAZY)
+        private Set<Course> courses = new HashSet<>();
+        public Set<Course> getCourses() { return courses; }
+
+    }
+
+    @Entity(name = "Course")
+    public static class Course {
+
+        @Id
+        @GeneratedValue()
+        private Long id;
+        public Long getId() { return id; }
+
+        @Basic
+        private String title;
+        public String getTitle() { return title; }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @LazyToOne(LazyToOneOption.NO_PROXY)
+        private Person person;
+        public Person getPerson() { return person; }
+
+        protected Course() {}
+        public Course(String title, Person person) {
+            this.title = title;
+            this.person = person;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Course course = (Course) o;
+            return title.equals(course.title) &&
+                    person.equals(course.person);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(title, person);
+        }
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dynamicentity/tuplizer/MyEntityInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dynamicentity/tuplizer/MyEntityInstantiator.java
@@ -11,6 +11,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.tuple.Instantiator;
 
@@ -31,7 +32,7 @@ public class MyEntityInstantiator implements Instantiator {
 		this.entityName = entityName;
 	}
 
-	public Object instantiate(Serializable id) {
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
 		if ( Person.class.getName().equals( entityName ) ) {
 			return ProxyHelper.newPersonProxy( id );
 		}
@@ -49,8 +50,8 @@ public class MyEntityInstantiator implements Instantiator {
 		}
 	}
 
-	public Object instantiate() {
-		return instantiate( null );
+	public Object instantiate(SharedSessionContractImplementor session) {
+		return instantiate( null, session );
 	}
 
 	public boolean isInstance(Object object) {

--- a/hibernate-core/src/test/java/org/hibernate/test/dynamicentity/tuplizer2/MyEntityInstantiator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dynamicentity/tuplizer2/MyEntityInstantiator.java
@@ -9,6 +9,7 @@ package org.hibernate.test.dynamicentity.tuplizer2;
 import java.io.Serializable;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.test.dynamicentity.Address;
 import org.hibernate.test.dynamicentity.Company;
@@ -27,7 +28,7 @@ public class MyEntityInstantiator implements Instantiator {
 		this.entityName = entityName;
 	}
 
-	public Object instantiate(Serializable id) {
+	public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
 		if ( Person.class.getName().equals( entityName ) ) {
 			return ProxyHelper.newPersonProxy( id );
 		}
@@ -45,8 +46,8 @@ public class MyEntityInstantiator implements Instantiator {
 		}
 	}
 
-	public Object instantiate() {
-		return instantiate( null );
+	public Object instantiate(SharedSessionContractImplementor session) {
+		return instantiate( null, session );
 	}
 
 	public boolean isInstance(Object object) {


### PR DESCRIPTION
… custom equals() in child entity throws LazyInitializationException.

The core of the fix is in PojoEntityInstantiator so that it can set the session in the LazyAttributeLoadingInterceptor.  This allows the equals method in the child entity of the OneToMany to refer to the lazily loaded Parent entity and get it initialized.  Without this change, the lazy loading of the OneToMany throws a LazyInstantiationException because it had no reference to the session in order to load the parent entity.

