### PR TITLE
HHH-13389: Fix JPA metamodel generation NPEs for any-to-many access="noop" properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/NoopMember.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/NoopMember.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.metamodel.model.domain.internal;
+
+import java.lang.reflect.Member;
+
+/**
+ * Represents a no-op domain model member, or a member which intentionally does not exist on the DTO and is ignored during persistence and hydration in order to prevent
+ * unnecessary work (generally for performance reasons).
+ *
+ * @author Mike Hill
+ * @see org.hibernate.property.access.internal.PropertyAccessStrategyNoopImpl
+ */
+public class NoopMember implements Member {
+
+	/**
+	 * Singleton access
+	 */
+	public static final NoopMember INSTANCE = new NoopMember();
+
+
+	@Override
+	public Class<?> getDeclaringClass() {
+		return null;
+	}
+
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+
+	@Override
+	public int getModifiers() {
+		return 0;
+	}
+
+
+	@Override
+	public boolean isSynthetic() {
+		return false;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyNoopImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyNoopImpl.java
@@ -12,17 +12,23 @@ import java.util.Map;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.model.domain.internal.NoopMember;
 import org.hibernate.property.access.spi.Getter;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.property.access.spi.Setter;
 
 /**
- * Yeah, right, so....  No idea...
+ * Describes a strategy for property access which is intentionally ignored (no-op). This is used to describe properties for DB fields which can be used in queries but which will
+ * not be represented at the POJO level.
+ * <p>
+ * Take, for example, a field used for ordering which is updated nightly by some SQL batch job. If this field is a no-op field, then it may be used for ordering in queries without
+ * needing to exist in the mapped DTO.
  *
  * @author Michael Bartmann
  * @author Gavin King
  * @author Steve Ebersole
+ * @author Mike Hill
  */
 public class PropertyAccessStrategyNoopImpl implements PropertyAccessStrategy {
 	/**
@@ -80,7 +86,7 @@ public class PropertyAccessStrategyNoopImpl implements PropertyAccessStrategy {
 
 		@Override
 		public Member getMember() {
-			return null;
+			return NoopMember.INSTANCE;
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/property/NoopPropertyAccessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/property/NoopPropertyAccessorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property;
+
+import org.hibernate.metamodel.model.domain.internal.NoopMember;
+import org.hibernate.property.access.internal.PropertyAccessStrategyNoopImpl;
+import org.hibernate.property.access.spi.PropertyAccess;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mike Hill
+ */
+public class NoopPropertyAccessorTest extends BaseUnitTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13389")
+	public void testAccessorProperties() {
+		PropertyAccessStrategyNoopImpl accessStrategy = PropertyAccessStrategyNoopImpl.INSTANCE;
+		final PropertyAccess access = accessStrategy.buildPropertyAccess( Object.class, "foo" );
+		assertNull( access.getGetter().getMethod() );
+		assertNull( access.getGetter().getMethodName() );
+		assertSame( Object.class, access.getGetter().getReturnType() );
+		assertTrue( access.getGetter().getMember() instanceof NoopMember );
+		assertNull( access.getSetter().getMethod() );
+		assertNull( access.getSetter().getMethodName() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Address.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Address.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.propertyref.noop;
+
+/**
+ * @author Mike Hill
+ */
+public class Address {
+	private Long id;
+	private String address;
+	private String zip;
+	private String country;
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getAddress() {
+		return this.address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+
+	public String getZip() {
+		return this.zip;
+	}
+
+	public void setZip(String zip) {
+		this.zip = zip;
+	}
+
+	public String getCountry() {
+		return this.country;
+	}
+
+	public void setCountry(String country) {
+		this.country = country;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Noop.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Noop.hbm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.hibernate.test.propertyref.noop">
+    <class name="Person" table="PROPREF_PERS">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="name" length="100"/>
+        <!-- One-to-one access="noop" property -->
+        <property name="personOrder" column="PERSON_ORDER" type="java.lang.Integer" access="noop" insert="false"
+                  update="false"/>
+        <!-- Any-to-many access="noop" property -->
+        <bag name="addresses" table="PROPREF_PERS_ADDRESS" access="noop" inverse="true">
+            <key column="PERSON_ID" />
+            <many-to-many column="ADDRESS_ID" class="Address" />
+        </bag>
+    </class>
+
+    <class name="Address" table="PROPREF_ADDRESS">
+        <id name="id">
+            <generator class="increment"/>
+        </id>
+        <property name="address" length="300"/>
+        <property name="zip" length="5"/>
+        <property name="country" length="25"/>
+        <!-- Any-to-many access="noop" property -->
+        <bag name="persons" table="PROPEF_PERS_ADDRESS" lazy="true" access="noop" inverse="true">
+            <key column="ADDRESS_ID" />
+            <many-to-many column="PERSON_ID" class="Person" />
+        </bag>
+    </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/NoopPropertiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/NoopPropertiesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.propertyref.noop;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Mike Hill
+ */
+public class NoopPropertiesTest extends BaseCoreFunctionalTestCase {
+
+	private static final Map<String, Integer> NAME_TO_ORDER_MAP = new HashMap<String, Integer>() {{
+		put( "Harry", 10 );
+		put( "Sally", 20 );
+		put( "Frank", 30 );
+		put( "Mary", 40 );
+		put( "Jill", 50 );
+		put( "Jane", 60 );
+	}};
+
+	@Override
+	public String[] getMappings() {
+		return new String[] { "propertyref/noop/Noop.hbm.xml" };
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13389")
+	public void testNoopAccessorSqlUpdate() {
+		Session s = openSession();
+		Transaction t = s.beginTransaction();
+		prepareData( s, false );
+		s.flush();
+		s.clear();
+		assertQueryResults( s );
+		s.createQuery( "delete Person" ).executeUpdate();
+		t.commit();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13389")
+	public void testNoopAccessorHqlUpdate() {
+		Session s = openSession();
+		Transaction t = s.beginTransaction();
+		prepareData( s, true );
+		s.flush();
+		s.clear();
+		assertQueryResults( s );
+		s.createQuery( "delete Person" ).executeUpdate();
+		t.commit();
+		s.close();
+	}
+
+	private void prepareData(Session s, boolean hql) {
+		NAME_TO_ORDER_MAP.forEach( (name, order) -> {
+			Person p = new Person();
+			p.setName( name );
+			s.persist( p );
+			s.flush();
+			if ( hql ) {
+				s.createQuery( "UPDATE Person SET personOrder = :personOrder WHERE name = :name" )
+						.setParameter( "personOrder", order )
+						.setParameter( "name", name )
+						.executeUpdate();
+			}
+			else {
+				s.createSQLQuery( "UPDATE PROPREF_PERS SET PERSON_ORDER = " + order + " WHERE NAME = '" + name + "';" )
+						.executeUpdate();
+			}
+		} );
+	}
+
+	private void assertQueryResults(Session s) {
+		{
+			List<Person> persons = s.createQuery( "FROM Person p ORDER BY personOrder DESC", Person.class ).list();
+			List<String> personNames = persons.stream().map( Person::getName ).collect( Collectors.toList() );
+			assertEquals( Arrays.asList( "Jane", "Jill", "Mary", "Frank", "Sally", "Harry" ), personNames );
+		}
+		{
+			List<Person> persons = s.createQuery(
+					"FROM Person p WHERE personOrder < :personOrder ORDER BY personOrder",
+					Person.class
+			).setParameter( "personOrder", 40 ).list();
+			List<String> personNames = persons.stream().map( Person::getName ).collect( Collectors.toList() );
+			assertEquals( Arrays.asList( "Harry", "Sally", "Frank" ), personNames );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/propertyref/noop/Person.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.propertyref.noop;
+
+/**
+ * @author Mike Hill
+ */
+public class Person {
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}


### PR DESCRIPTION
JPA metamodel generation fails with NPEs with `access="noop"` properties when these properties use collection associations (any-to-many). This PR replaces the `null` member used in these property accessors with a non-null placeholder (`NoopMember`).