### PR TITLE
fix non-standard functions in select clause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -10,7 +10,6 @@ import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.produce.function.spi.PairedFunctionTemplate;
 import org.hibernate.type.spi.StandardSpiBasicTypes;
 
-import static org.hibernate.query.sqm.produce.function.StandardArgumentsValidators.min;
 import static org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers.useArgType;
 
 /**
@@ -499,13 +498,13 @@ public class CommonFunctionFactory {
 
 	public static void coalesce(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder("coalesce")
-				.setArgumentsValidator( min(1) )
+				.setMinArgumentCount( 1 )
 				.register();
 	}
 
 	public static void coalesce_value(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder("value")
-				.setArgumentsValidator( min(1) )
+				.setMinArgumentCount( 1 )
 				.register();
 		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "coalesce", "value" );
 	}
@@ -625,6 +624,7 @@ public class CommonFunctionFactory {
 
 	public static void extract(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().patternTemplateBuilder("extract", "extract(?1 from ?2)")
+//				.setInvariantType( StandardSpiBasicTypes.INTEGER )
 				.setExactArgumentCount(2)
 				.setReturnTypeResolver( useArgType(1) )
 				.register();
@@ -632,7 +632,8 @@ public class CommonFunctionFactory {
 
 	public static void extract_datepart(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder( "datepart" )
-				.setInvariantType( StandardSpiBasicTypes.INTEGER )
+//				.setInvariantType( StandardSpiBasicTypes.INTEGER )
+				.setReturnTypeResolver( useArgType(1) )
 				.setExactArgumentCount( 2 )
 				.register();
 		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "extract", "datepart ");
@@ -671,10 +672,10 @@ public class CommonFunctionFactory {
 
 	public static void leastGreatest(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder( "least" )
-				.setArgumentsValidator( min(1) )
+				.setMinArgumentCount( 1 )
 				.register();
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder( "greatest" )
-				.setArgumentsValidator( min(1) )
+				.setMinArgumentCount( 1 )
 				.register();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/NvlCoalesceEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/NvlCoalesceEmulation.java
@@ -17,6 +17,7 @@ import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunctio
 import org.hibernate.query.sqm.produce.function.spi.AbstractSqmFunctionTemplate;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.util.Arrays.asList;
 
@@ -42,7 +43,8 @@ public class NvlCoalesceEmulation
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 
 		SqmFunctionTemplate nvl = queryEngine.getSqmFunctionRegistry().namedTemplateBuilder("nvl").setExactArgumentCount(2).template();
 
@@ -52,7 +54,12 @@ public class NvlCoalesceEmulation
 
 		while (pos>0) {
 			SqmExpression<?> next = (SqmExpression<?>) arguments.get( --pos );
-			result = nvl.makeSqmFunctionExpression( asList( next, result ), type, queryEngine );
+			result = nvl.makeSqmFunctionExpression(
+					asList( next, result ),
+					type,
+					queryEngine,
+					typeConfiguration
+			);
 		}
 
 		//noinspection unchecked

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/TransactSQLTrimEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/TransactSQLTrimEmulation.java
@@ -18,6 +18,7 @@ import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.sql.TrimSpec;
 import org.hibernate.type.spi.StandardSpiBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.util.Arrays.asList;
 
@@ -82,7 +83,8 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 	public <T> SelfRenderingSqmFunction<T>  makeSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		final TrimSpec specification = ( (SqmTrimSpecification) arguments.get( 0 ) ).getSpecification();
 		//noinspection unchecked
 		final SqmLiteral<Character> trimCharacterExpr = (SqmLiteral<Character>) arguments.get( 1 );
@@ -93,13 +95,13 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 
 		switch ( specification ) {
 			case LEADING: {
-				return trimLeading( trimCharacterExpr, sourceExpr, queryEngine );
+				return trimLeading( trimCharacterExpr, sourceExpr, queryEngine, typeConfiguration );
 			}
 			case TRAILING: {
-				return trimTrailing( trimCharacterExpr, sourceExpr, queryEngine );
+				return trimTrailing( trimCharacterExpr, sourceExpr, queryEngine, typeConfiguration );
 			}
 			default: {
-				return trimBoth( trimCharacterExpr, sourceExpr, queryEngine );
+				return trimBoth( trimCharacterExpr, sourceExpr, queryEngine, typeConfiguration );
 			}
 		}
 	}
@@ -107,23 +109,25 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 	private SelfRenderingSqmFunction trimLeading(
 			SqmLiteral<Character> trimChar,
 			SqmExpression source,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		if ( trimChar.getLiteralValue() == ' ' ) {
-			return trimLeadingSpaces( source, queryEngine );
+			return trimLeadingSpaces( source, queryEngine, typeConfiguration );
 		}
 		else {
-			return trimLeadingNonSpaces( trimChar, source, queryEngine );
+			return trimLeadingNonSpaces( trimChar, source, queryEngine, typeConfiguration );
 		}
 	}
 
-	private SelfRenderingSqmFunction trimLeadingSpaces(SqmExpression source, QueryEngine queryEngine) {
-		return ltrim( source, queryEngine );
+	private SelfRenderingSqmFunction trimLeadingSpaces(SqmExpression source, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
+		return ltrim( source, queryEngine, typeConfiguration );
 	}
 
 	private SelfRenderingSqmFunction trimLeadingNonSpaces(
 			SqmLiteral<Character> trimChar,
 			SqmExpression source,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		final SqmLiteral<Character> space = charExpr( ' ', queryEngine );
 		final SqmLiteral<String> placeholder = placeholder( queryEngine );
 
@@ -140,44 +144,51 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 												source,
 												space,
 												placeholder,
-												queryEngine
+												queryEngine,
+												typeConfiguration
 										),
 										space,
 										placeholder,
-										queryEngine
+										queryEngine,
+										typeConfiguration
 								),
-								queryEngine
+								queryEngine,
+								typeConfiguration
 						),
 						space,
 						trimChar,
-						queryEngine
+						queryEngine,
+						typeConfiguration
 				),
 				placeholder,
 				space,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 
 	private SelfRenderingSqmFunction trimTrailing(
 			SqmLiteral<Character> trimChar,
 			SqmExpression source,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		if ( trimChar.getLiteralValue() == ' ' ) {
-			return trimTrailingSpaces( source, queryEngine );
+			return trimTrailingSpaces( source, queryEngine, typeConfiguration );
 		}
 		else {
-			return trimTrailingNonSpaces( trimChar, source, queryEngine );
+			return trimTrailingNonSpaces( trimChar, source, queryEngine, typeConfiguration );
 		}
 	}
 
-	private SelfRenderingSqmFunction trimTrailingSpaces(SqmExpression sourceExpr, QueryEngine queryEngine) {
-		return rtrim( sourceExpr, queryEngine );
+	private SelfRenderingSqmFunction trimTrailingSpaces(SqmExpression sourceExpr, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
+		return rtrim( sourceExpr, queryEngine, typeConfiguration );
 	}
 
 	private SelfRenderingSqmFunction trimTrailingNonSpaces(
 			SqmLiteral<Character> trimChar,
 			SqmExpression source,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		final SqmLiteral<Character> space = charExpr( ' ', queryEngine );
 		final SqmLiteral<String> placeholder = placeholder( queryEngine );
 
@@ -194,42 +205,48 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 												source,
 												space,
 												placeholder,
-												queryEngine
+												queryEngine,
+												typeConfiguration
 										),
 										space,
 										placeholder,
-										queryEngine
+										queryEngine,
+										typeConfiguration
 								),
-								queryEngine
+								queryEngine,
+								typeConfiguration
 						),
 						space,
 						trimChar,
-						queryEngine
+						queryEngine,
+						typeConfiguration
 				),
 				placeholder,
 				space,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 
 	private SelfRenderingSqmFunction trimBoth(
 			SqmLiteral<Character> trimCharacterExpr,
 			SqmExpression sourceExpr,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		// BOTH
 		if ( trimCharacterExpr.getLiteralValue() == ' ' ) {
-			return trimBothSpaces( sourceExpr, queryEngine );
+			return trimBothSpaces( sourceExpr, queryEngine, typeConfiguration );
 		}
 		else {
-			return trimBothNonSpaces( trimCharacterExpr, sourceExpr, queryEngine );
+			return trimBothNonSpaces( trimCharacterExpr, sourceExpr, queryEngine, typeConfiguration );
 		}
 	}
 
-	private SelfRenderingSqmFunction trimBothSpaces(SqmExpression sourceExpr, QueryEngine queryEngine) {
-		return ltrim( rtrim( sourceExpr, queryEngine ), queryEngine );
+	private SelfRenderingSqmFunction trimBothSpaces(SqmExpression sourceExpr, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
+		return ltrim( rtrim( sourceExpr, queryEngine, typeConfiguration ), queryEngine, typeConfiguration );
 	}
 
-	private SelfRenderingSqmFunction trimBothNonSpaces(SqmLiteral<Character> trimChar, SqmExpression source, QueryEngine queryEngine) {
+	private SelfRenderingSqmFunction trimBothNonSpaces(SqmLiteral<Character> trimChar, SqmExpression source, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
 		final SqmLiteral<Character> space = charExpr( ' ', queryEngine );
 		final SqmLiteral<String> placeholder = placeholder( queryEngine );
 
@@ -248,23 +265,29 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 														source,
 														space,
 														placeholder,
-														queryEngine
+														queryEngine,
+														typeConfiguration
 												),
 												space,
 												placeholder,
-												queryEngine
+												queryEngine,
+												typeConfiguration
 										),
-										queryEngine
+										queryEngine,
+										typeConfiguration
 								),
-								queryEngine
+								queryEngine,
+								typeConfiguration
 						),
 						space,
 						trimChar,
-						queryEngine
+						queryEngine,
+						typeConfiguration
 				),
 				placeholder,
 				space,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 
@@ -272,32 +295,36 @@ public class TransactSQLTrimEmulation implements SqmFunctionTemplate {
 			SqmExpression source,
 			SqmExpression searchPattern,
 			SqmExpression replacement,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		return function(
 				replaceFunctionName,
 				queryEngine,
+				typeConfiguration,
 				source,
 				searchPattern,
 				replacement
 		);
 	}
 
-	private SelfRenderingSqmFunction rtrim(SqmExpression source, QueryEngine queryEngine) {
-		return function( rtrimFunctionName, queryEngine, source );
+	private SelfRenderingSqmFunction rtrim(SqmExpression source, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
+		return function( rtrimFunctionName, queryEngine, typeConfiguration, source );
 	}
 
-	private SelfRenderingSqmFunction ltrim(SqmExpression source, QueryEngine queryEngine) {
-		return function( ltrimFunctionName, queryEngine, source );
+	private SelfRenderingSqmFunction ltrim(SqmExpression source, QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
+		return function( ltrimFunctionName, queryEngine, typeConfiguration, source );
 	}
 
 	private static SelfRenderingSqmFunction function(
 			String name,
 			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration,
 			SqmExpression... arguments) {
 		return queryEngine.getSqmFunctionRegistry().findFunctionTemplate(name).makeSqmFunctionExpression(
 				asList( arguments ),
 				StandardSpiBasicTypes.STRING,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -147,7 +147,6 @@ import org.hibernate.sql.TrimSpec;
 import org.hibernate.sql.ast.produce.metamodel.spi.BasicValuedExpressableType;
 import org.hibernate.sql.ast.produce.metamodel.spi.EntityValuedExpressableType;
 import org.hibernate.sql.ast.produce.metamodel.spi.ExpressableType;
-import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.java.spi.BasicJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 import org.jboss.logging.Logger;
@@ -1336,7 +1335,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 						(SqmExpression) ctx.expression( 1 ).accept( this )
 				),
 				resolveExpressableTypeBasic( String.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1412,7 +1412,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("mod").makeSqmFunctionExpression(
 				asList( dividend, divisor ),
 				(AllowableFunctionReturnType) dividend.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1476,7 +1477,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("current_date")
 				.makeSqmFunctionExpression(
 						resolveExpressableTypeBasic( Date.class ),
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1485,7 +1487,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("current_time")
 				.makeSqmFunctionExpression(
 						resolveExpressableTypeBasic( Time.class ),
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1494,7 +1497,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
 						resolveExpressableTypeBasic( Timestamp.class ),
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1503,7 +1507,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
 						resolveExpressableTypeBasic( Instant.class ),
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1524,7 +1529,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				.makeSqmFunctionExpression(
 						arguments,
 						(AllowableFunctionReturnType<?>) type,
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1545,7 +1551,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				.makeSqmFunctionExpression(
 						arguments,
 						(AllowableFunctionReturnType<?>) type,
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1566,7 +1573,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				.makeSqmFunctionExpression(
 						arguments,
 						(AllowableFunctionReturnType<?>) type,
-						creationContext.getQueryEngine()
+						creationContext.getQueryEngine(),
+						creationContext.getDomainModel().getTypeConfiguration()
 				);
 	}
 
@@ -1578,7 +1586,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("nullif").makeSqmFunctionExpression(
 				asList( arg1, arg2 ),
 				(AllowableFunctionReturnType) arg1.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1669,7 +1678,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	private SqmLiteral<String> stringLiteral(String text) {
 		return new SqmLiteral<>(
 				text,
-				creationContext.getDomainModel().getTypeConfiguration().resolveStandardBasicType( StandardBasicTypes.STRING ),
+				resolveExpressableTypeBasic( String.class ),
 				creationContext.getNodeBuilder()
 		);
 	}
@@ -1840,7 +1849,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return functionTemplate.makeSqmFunctionExpression(
 				functionArguments,
 				null,
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1864,7 +1874,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return functionTemplate.makeSqmFunctionExpression(
 				functionArguments,
 				null,
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1904,7 +1915,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("ceiling").makeSqmFunctionExpression(
 				arg,
 				resolveExpressableTypeBasic( Long.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1915,7 +1927,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("floor").makeSqmFunctionExpression(
 				arg,
 				resolveExpressableTypeBasic( Long.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1930,7 +1943,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("abs").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1941,7 +1955,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("sign").makeSqmFunctionExpression(
 				arg,
 				resolveExpressableTypeBasic( Integer.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1953,7 +1968,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("mod").makeSqmFunctionExpression(
 				asList( dividend, divisor ),
 				(AllowableFunctionReturnType) dividend.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1965,7 +1981,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("power").makeSqmFunctionExpression(
 				asList( base, power ),
 				(AllowableFunctionReturnType) base.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1976,7 +1993,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate( ctx.trigFunctionName().getText() ).makeSqmFunctionExpression(
 				arg,
 				resolveExpressableTypeBasic( Double.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1987,7 +2005,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("sqrt").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -1999,7 +2018,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("round").makeSqmFunctionExpression(
 				asList(arg, precision),
 				(AllowableFunctionReturnType) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2011,7 +2031,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("atan2").makeSqmFunctionExpression(
 				asList(sin, cos),
 				(AllowableFunctionReturnType) sin.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2022,7 +2043,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("ln").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 
 	}
@@ -2034,7 +2056,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("exp").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2112,7 +2135,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("extract").makeSqmFunctionExpression(
 				asList( extractFieldExpression, expressionToExtract ),
 				extractFieldExpression.getType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2131,7 +2155,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("cast").makeSqmFunctionExpression(
 				asList( expressionToCast, castTargetExpression ),
 				castTargetExpression.getType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2166,7 +2191,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("upper").makeSqmFunctionExpression(
 				expression,
 				(BasicValuedExpressableType) expression.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2178,7 +2204,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("lower").makeSqmFunctionExpression(
 				expression,
 				(BasicValuedExpressableType) expression.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2193,7 +2220,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("concat").makeSqmFunctionExpression(
 				arguments,
 				resolveExpressableTypeBasic( String.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2205,7 +2233,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("character_length").makeSqmFunctionExpression(
 				arg,
 				resolveExpressableTypeBasic( Integer.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2218,7 +2247,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("locate").makeSqmFunctionExpression(
 				asList( pattern, string ),
 				resolveExpressableTypeBasic( Integer.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2236,7 +2266,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 						? asList( pattern, string )
 						: asList( pattern, string, start ),
 				resolveExpressableTypeBasic( Integer.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2250,7 +2281,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("replace").makeSqmFunctionExpression(
 				asList( string, pattern, replacement ),
 				resolveExpressableTypeBasic( String.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2261,7 +2293,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("cast").makeSqmFunctionExpression(
 				asList( arg, new SqmCastTarget<>( type, creationContext.getNodeBuilder() ) ),
 				type,
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2272,7 +2305,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("max").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType<?>) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2283,7 +2317,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("min").makeSqmFunctionExpression(
 				arg,
 				(AllowableFunctionReturnType<?>) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2296,7 +2331,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("sum").makeSqmFunctionExpression(
 				argument,
 				(AllowableFunctionReturnType<?>) arg.getExpressableType(),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2309,7 +2345,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("avg").makeSqmFunctionExpression(
 				argument,
 				resolveExpressableTypeBasic( Double.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2324,7 +2361,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("count").makeSqmFunctionExpression(
 				argument,
 				resolveExpressableTypeBasic( Long.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 
@@ -2339,7 +2377,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		return getFunctionTemplate("substring").makeSqmFunctionExpression(
 				length==null ? asList( source, start ) : asList( source, start, length ),
 				resolveExpressableTypeBasic( String.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 
 	}
@@ -2355,7 +2394,8 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 						source
 				),
 				resolveExpressableTypeBasic( String.class ),
-				creationContext.getQueryEngine()
+				creationContext.getQueryEngine(),
+				creationContext.getDomainModel().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmCriteriaNodeBuilder.java
@@ -178,7 +178,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("cast").makeSqmFunctionExpression(
 				asList( (SqmTypedNode) expression, new SqmCastTarget<>( type, this ) ),
 				type,
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -384,7 +385,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("avg").makeSqmFunctionExpression(
 				(SqmTypedNode) argument,
 				StandardSpiBasicTypes.DOUBLE,
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -394,7 +396,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("sum").makeSqmFunctionExpression(
 				(SqmTypedNode) argument,
 				(AllowableFunctionReturnType<N>) ((SqmExpression<N>) argument).getExpressableType(),
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -414,7 +417,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("max").makeSqmFunctionExpression(
 				(SqmTypedNode) argument,
 				(AllowableFunctionReturnType<N>) ((SqmExpression<N>) argument).getExpressableType(),
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -424,7 +428,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("min").makeSqmFunctionExpression(
 				(SqmTypedNode) argument,
 				(AllowableFunctionReturnType<N>) ((SqmExpression<N>) argument).getExpressableType(),
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -443,7 +448,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("count").makeSqmFunctionExpression(
 				(SqmTypedNode) argument,
 				StandardSpiBasicTypes.LONG,
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -452,7 +458,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("count").makeSqmFunctionExpression(
 				new SqmDistinct<>( (SqmExpression<?>) argument, getQueryEngine().getCriteriaBuilder() ),
 				StandardSpiBasicTypes.LONG,
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -471,7 +478,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("abs").makeSqmFunctionExpression(
 				(SqmTypedNode) x,
 				(AllowableFunctionReturnType<N>) ((SqmExpression<N>) x).getExpressableType(),
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -613,7 +621,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						((SqmExpression) x).getExpressableType(),
 						StandardSpiBasicTypes.DOUBLE
 				),
-				queryEngine
+				queryEngine,
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -736,7 +745,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						ySqmExpression.getExpressableType(),
 						StandardSpiBasicTypes.STRING
 				),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -752,7 +762,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						ySqmExpression.getExpressableType(),
 						StandardSpiBasicTypes.STRING
 				),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -768,7 +779,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						ySqmExpression.getExpressableType(),
 						StandardSpiBasicTypes.STRING
 				),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -784,7 +796,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						ySqmExpression.getExpressableType(),
 						StandardSpiBasicTypes.STRING
 				),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -808,7 +821,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate( "substring" ).makeSqmFunctionExpression(
 				len==null ? asList( source, from ) : asList( source, from, len ),
 				resultType,
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -863,7 +877,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 			return getFunctionTemplate( "trim" ).makeSqmFunctionExpression(
 					arguments,
 					(BasicValuedExpressableType) QueryHelper.highestPrecedenceType2( source.getExpressableType(), StandardSpiBasicTypes.STRING ),
-					getQueryEngine()
+					getQueryEngine(),
+					domainModel.getTypeConfiguration()
 			);
 	}
 
@@ -924,7 +939,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate( "lower" ).makeSqmFunctionExpression(
 				(SqmExpression) x,
 				type,
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -940,7 +956,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate( "upper" ).makeSqmFunctionExpression(
 				(SqmExpression) x,
 				type,
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -954,7 +971,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 						((SqmExpression) argument).getExpressableType(),
 						StandardSpiBasicTypes.INTEGER
 				),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -994,7 +1012,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("locate").makeSqmFunctionExpression(
 				arguments,
 				type,
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 
 	}
@@ -1032,7 +1051,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("current_date")
 				.makeSqmFunctionExpression(
 						(AllowableFunctionReturnType) StandardSpiBasicTypes.DATE,
-						queryEngine
+						queryEngine,
+						domainModel.getTypeConfiguration()
 				);
 	}
 
@@ -1042,7 +1062,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
 						(AllowableFunctionReturnType) StandardSpiBasicTypes.TIMESTAMP,
-						queryEngine
+						queryEngine,
+						domainModel.getTypeConfiguration()
 				);
 	}
 
@@ -1052,7 +1073,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("current_time")
 				.makeSqmFunctionExpression(
 						(AllowableFunctionReturnType) StandardSpiBasicTypes.TIME,
-						queryEngine
+						queryEngine,
+						domainModel.getTypeConfiguration()
 				);
 	}
 
@@ -1061,7 +1083,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
 						StandardSpiBasicTypes.INSTANT,
-						queryEngine
+						queryEngine,
+						domainModel.getTypeConfiguration()
 				);
 	}
 
@@ -1076,7 +1099,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return functionTemplate.makeSqmFunctionExpression(
 				(List) expressionList( args ),
 				getTypeConfiguration().standardExpressableTypeForJavaType( type ),
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 	}
 
@@ -1200,7 +1224,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder {
 		return getFunctionTemplate("nullif").makeSqmFunctionExpression(
 				asList( first, second ),
 				type,
-				getQueryEngine()
+				getQueryEngine(),
+				domainModel.getTypeConfiguration()
 		);
 
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionReturnTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionReturnTypeResolver.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Pluggable strategy for resolving a function return type for a specific call.
@@ -29,9 +30,11 @@ public interface FunctionReturnTypeResolver {
 	 * @param impliedType the context-impled type
 	 * @param arguments the arguments "passed" to this call.
 	 *
+	 * @param typeConfiguration
 	 * @return The resolved type.
 	 */
 	AllowableFunctionReturnType<?> resolveFunctionReturnType(
 			AllowableFunctionReturnType<?> impliedType,
-			List<SqmTypedNode<?>> arguments);
+			List<SqmTypedNode<?>> arguments,
+			TypeConfiguration typeConfiguration);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/JdbcFunctionEscapeWrapperTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/JdbcFunctionEscapeWrapperTemplate.java
@@ -14,6 +14,7 @@ import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunctio
 import org.hibernate.query.sqm.produce.function.spi.AbstractSqmFunctionTemplate;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.function.SqmJdbcFunctionEscapeWrapper;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Acts as a wrapper to another SqmFunctionTemplate - upon rendering uses the
@@ -33,12 +34,14 @@ public class JdbcFunctionEscapeWrapperTemplate
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		return new SqmJdbcFunctionEscapeWrapper<>(
 				wrapped.makeSqmFunctionExpression(
 						arguments,
 						impliedResultType,
-						queryEngine
+						queryEngine,
+						typeConfiguration
 				),
 				queryEngine.getCriteriaBuilder()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/NamedFunctionTemplateBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/NamedFunctionTemplateBuilder.java
@@ -9,6 +9,7 @@ package org.hibernate.query.sqm.produce.function;
 import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 import org.hibernate.query.sqm.produce.function.spi.NamedSqmFunctionTemplate;
 
+import org.hibernate.type.StandardBasicTypes;
 import org.jboss.logging.Logger;
 
 /**
@@ -46,12 +47,16 @@ public class NamedFunctionTemplateBuilder {
 		return setArgumentsValidator( StandardArgumentsValidators.exactly( exactArgumentCount ) );
 	}
 
+	public NamedFunctionTemplateBuilder setMinArgumentCount(int min) {
+		return setArgumentsValidator( StandardArgumentsValidators.min( min ) );
+	}
+
 	public NamedFunctionTemplateBuilder setReturnTypeResolver(FunctionReturnTypeResolver returnTypeResolver) {
 		this.returnTypeResolver = returnTypeResolver;
 		return this;
 	}
 
-	public NamedFunctionTemplateBuilder setInvariantType(AllowableFunctionReturnType invariantType) {
+	public NamedFunctionTemplateBuilder setInvariantType(StandardBasicTypes.StandardBasicType<?> invariantType) {
 		setReturnTypeResolver( StandardFunctionReturnTypeResolvers.invariant( invariantType ) );
 		return this;
 	}
@@ -62,10 +67,7 @@ public class NamedFunctionTemplateBuilder {
 	}
 
 	public SqmFunctionTemplate register() {
-		return registry.register(
-				registrationKey,
-				template()
-		);
+		return registry.register( registrationKey, template() );
 	}
 
 	public SqmFunctionTemplate template() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/PatternFunctionTemplateBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/PatternFunctionTemplateBuilder.java
@@ -9,6 +9,7 @@ package org.hibernate.query.sqm.produce.function;
 import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 import org.hibernate.query.sqm.produce.function.internal.PatternRenderer;
 import org.hibernate.query.sqm.produce.function.spi.PatternBasedSqmFunctionTemplate;
+import org.hibernate.type.StandardBasicTypes;
 
 /**
  * @author Steve Ebersole
@@ -38,16 +39,12 @@ public class PatternFunctionTemplateBuilder {
 		return setArgumentsValidator( StandardArgumentsValidators.exactly( exactArgumentCount ) );
 	}
 
-	public PatternFunctionTemplateBuilder setArgumentCountBetween(int min, int max) {
-		return setArgumentsValidator( StandardArgumentsValidators.between( min, max ) );
-	}
-
 	public PatternFunctionTemplateBuilder setReturnTypeResolver(FunctionReturnTypeResolver returnTypeResolver) {
 		this.returnTypeResolver = returnTypeResolver;
 		return this;
 	}
 
-	public PatternFunctionTemplateBuilder setInvariantType(AllowableFunctionReturnType invariantType) {
+	public PatternFunctionTemplateBuilder setInvariantType(StandardBasicTypes.StandardBasicType<?> invariantType) {
 		setReturnTypeResolver( StandardFunctionReturnTypeResolvers.invariant( invariantType ) );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/SqmFunctionRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/SqmFunctionRegistry.java
@@ -11,6 +11,7 @@ import java.util.TreeMap;
 
 import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 
+import org.hibernate.type.StandardBasicTypes;
 import org.jboss.logging.Logger;
 
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
@@ -76,7 +77,7 @@ public class SqmFunctionRegistry {
 	 * Register a pattern-based template by name and invariant return type.  Shortcut for building the template
 	 * via {@link #patternTemplateBuilder} accepting its defaults.
 	 */
-	public SqmFunctionTemplate registerPattern(String name, String pattern, AllowableFunctionReturnType returnType) {
+	public SqmFunctionTemplate registerPattern(String name, String pattern, StandardBasicTypes.StandardBasicType<?> returnType) {
 		return patternTemplateBuilder( name, pattern )
 				.setInvariantType( returnType )
 				.register();
@@ -112,7 +113,7 @@ public class SqmFunctionRegistry {
 	 *
 	 * @param name The function name (and registration key)
 	 */
-	public SqmFunctionTemplate registerNamed(String name, AllowableFunctionReturnType returnType) {
+	public SqmFunctionTemplate registerNamed(String name, StandardBasicTypes.StandardBasicType<?> returnType) {
 		return namedTemplateBuilder( name ).setInvariantType( returnType ).register();
 	}
 
@@ -170,17 +171,17 @@ public class SqmFunctionRegistry {
 		return noArgsBuilder( registrationKey, name ).register();
 	}
 
-	public SqmFunctionTemplate registerNoArgs(String name, AllowableFunctionReturnType returnType) {
+	public SqmFunctionTemplate registerNoArgs(String name, StandardBasicTypes.StandardBasicType<?> returnType) {
 		return registerNoArgs( name, name, returnType );
 	}
 
-	public SqmFunctionTemplate registerNoArgs(String registrationKey, String name, AllowableFunctionReturnType returnType) {
+	public SqmFunctionTemplate registerNoArgs(String registrationKey, String name, StandardBasicTypes.StandardBasicType<?> returnType) {
 		return noArgsBuilder( registrationKey, name )
 				.setInvariantType( returnType )
 				.register();
 	}
 
-	public SqmFunctionTemplate registerVarArgs(String registrationKey, AllowableFunctionReturnType returnType, String begin, String sep, String end) {
+	public SqmFunctionTemplate registerVarArgs(String registrationKey, StandardBasicTypes.StandardBasicType<?> returnType, String begin, String sep, String end) {
 		return varArgsBuilder( registrationKey, begin, sep, end )
 				.setInvariantType( returnType )
 				.register();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/SqmFunctionTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/SqmFunctionTemplate.java
@@ -13,6 +13,7 @@ import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.sql.Template;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -25,6 +26,7 @@ import static java.util.Collections.singletonList;
  *
  * @author David Channon
  * @author Steve Ebersole
+ * @author Gavin King
  */
 public interface SqmFunctionTemplate {
 	/**
@@ -38,26 +40,37 @@ public interface SqmFunctionTemplate {
 	<T> SelfRenderingSqmFunction<T> makeSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine);
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration);
 
+	/**
+	 * Convenience for single argument
+	 */
 	default <T> SelfRenderingSqmFunction<T> makeSqmFunctionExpression(
 			SqmTypedNode<?> argument,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		return makeSqmFunctionExpression(
 				singletonList(argument),
 				impliedResultType,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 
+	/**
+	 * Convenience for no arguments
+	 */
 	default <T> SelfRenderingSqmFunction<T> makeSqmFunctionExpression(
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		return makeSqmFunctionExpression(
 				emptyList(),
 				impliedResultType,
-				queryEngine
+				queryEngine,
+				typeConfiguration
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/VarArgsFunctionTemplateBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/VarArgsFunctionTemplateBuilder.java
@@ -9,6 +9,7 @@ package org.hibernate.query.sqm.produce.function;
 import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 import org.hibernate.query.sqm.produce.function.spi.FunctionAsExpressionTemplate;
 
+import org.hibernate.type.StandardBasicTypes;
 import org.jboss.logging.Logger;
 
 /**
@@ -57,22 +58,23 @@ public class VarArgsFunctionTemplateBuilder {
 		return this;
 	}
 
-	public VarArgsFunctionTemplateBuilder setInvariantType(AllowableFunctionReturnType invariantType) {
+	public VarArgsFunctionTemplateBuilder setInvariantType(StandardBasicTypes.StandardBasicType<?> invariantType) {
 		setReturnTypeResolver( StandardFunctionReturnTypeResolvers.invariant( invariantType ) );
 		return this;
 	}
 
 	public SqmFunctionTemplate register() {
-		return registry.register(
-				registrationKey,
-				new FunctionAsExpressionTemplate(
-						begin,
-						sep,
-						end,
-						returnTypeResolver,
-						argumentsValidator,
-						registrationKey
-				)
+		return registry.register( registrationKey, template() );
+	}
+
+	public SqmFunctionTemplate template() {
+		return new FunctionAsExpressionTemplate(
+				begin,
+				sep,
+				end,
+				returnTypeResolver,
+				argumentsValidator,
+				registrationKey
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/SelfRenderingFunctionSqlAstExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/SelfRenderingFunctionSqlAstExpression.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.model.domain.spi.AllowableFunctionReturnType;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.SqmVisitableNode;
 import org.hibernate.sql.SqlExpressableType;
@@ -49,7 +50,8 @@ public class SelfRenderingFunctionSqlAstExpression<T>
 			SqmToSqlAstConverter walker) {
 		this.sqmExpression = sqmFunction;
 		this.sqlAstArguments = resolveSqlAstArguments( sqmFunction.getArguments(), walker );
-		this.type = sqmFunction.getExpressableType().getSqlExpressableType();
+		AllowableFunctionReturnType<T> type = sqmFunction.getExpressableType();
+		this.type = type==null ? null : type.getSqlExpressableType();
 	}
 
 	private static List<SqlAstNode> resolveSqlAstArguments(List<SqmTypedNode<?>> sqmArguments, SqmToSqlAstConverter walker) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/AbstractSelfRenderingFunctionTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/AbstractSelfRenderingFunctionTemplate.java
@@ -14,6 +14,7 @@ import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionReturnTypeResolver;
 import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * @author Steve Ebersole
@@ -33,7 +34,7 @@ public abstract class AbstractSelfRenderingFunctionTemplate extends AbstractSqmF
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> resolvedReturnType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine, TypeConfiguration typeConfiguration) {
 		//noinspection unchecked
 		return new SelfRenderingSqmFunction(
 				getRenderingFunctionSupport( arguments, resolvedReturnType, queryEngine ),

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/AbstractSqmFunctionTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/AbstractSqmFunctionTemplate.java
@@ -17,6 +17,7 @@ import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
 import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
 import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * @author Steve Ebersole
@@ -49,19 +50,26 @@ public abstract class AbstractSqmFunctionTemplate implements SqmFunctionTemplate
 	public final <T> SelfRenderingSqmFunction<T> makeSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		argumentsValidator.validate( arguments );
 
 		return generateSqmFunctionExpression(
 				arguments,
 				(AllowableFunctionReturnType<T>) //this cast is not truly correct
-						returnTypeResolver.resolveFunctionReturnType( impliedResultType, arguments ),
-				queryEngine
+						returnTypeResolver.resolveFunctionReturnType(
+								impliedResultType,
+								arguments,
+								typeConfiguration
+						),
+				queryEngine,
+				typeConfiguration
 		);
 	}
 
 	protected abstract <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine);
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/PairedFunctionTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/spi/PairedFunctionTemplate.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.produce.function.SqmFunctionTemplate;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
 import org.hibernate.query.sqm.produce.function.internal.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
 
@@ -34,8 +36,9 @@ public class PairedFunctionTemplate extends AbstractSqmFunctionTemplate {
 	public static void register(
 			QueryEngine queryEngine,
 			String name,
-			AllowableFunctionReturnType type,
-			String pattern2, String pattern3) {
+			StandardBasicTypes.StandardBasicType<?> type,
+			String pattern2,
+			String pattern3) {
 		queryEngine.getSqmFunctionRegistry().register(
 				name,
 				new PairedFunctionTemplate(
@@ -57,8 +60,9 @@ public class PairedFunctionTemplate extends AbstractSqmFunctionTemplate {
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
-			QueryEngine queryEngine) {
+			QueryEngine queryEngine,
+			TypeConfiguration typeConfiguration) {
 		return ( arguments.size()<3 ? binaryFunction : ternaryFunction )
-				.makeSqmFunctionExpression( arguments, impliedResultType, queryEngine );
+				.makeSqmFunctionExpression( arguments, impliedResultType, queryEngine, typeConfiguration);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExpression.java
@@ -88,7 +88,11 @@ public interface SqmExpression<T> extends SqmSelectableNode<T>, JpaExpression<T>
 
 	default <X> SqmExpression<X> castAs(AllowableFunctionReturnType<X> type) {
 		return nodeBuilder().getQueryEngine().getSqmFunctionRegistry().findFunctionTemplate( "cast" )
-				.makeSqmFunctionExpression( this, type, nodeBuilder().getQueryEngine() );
+				.makeSqmFunctionExpression(
+						this, type,
+						nodeBuilder().getQueryEngine(),
+						nodeBuilder().getDomainModel().getTypeConfiguration()
+				);
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/function/SqmCoalesce.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/function/SqmCoalesce.java
@@ -67,7 +67,8 @@ public class SqmCoalesce<T> extends AbstractSqmExpression<T> implements JpaCoale
 				coalesceFunction.makeSqmFunctionExpression(
 						new ArrayList<>(arguments),
 						(AllowableFunctionReturnType<?>) getExpressableType(),
-						nodeBuilder().getQueryEngine()
+						nodeBuilder().getQueryEngine(),
+						nodeBuilder().getDomainModel().getTypeConfiguration()
 				)
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -106,7 +106,8 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
     public void testAsciiChrFunctions() {
         inTransaction(
                 session -> {
-                    //NOTE: "function" syntax still not working in select clause
+                    session.createQuery("select function('ascii', 'x'), function('chr', 120) from EntityOfBasics w")
+                            .list();
                     session.createQuery("from EntityOfBasics e where function('ascii', 'x') > 0")
                             .list();
                     session.createQuery("from EntityOfBasics e where function('chr', 120) = 'z'")


### PR DESCRIPTION
Function templates are created by the `Dialect`s with refs to `StandardSpiBasicTypes` as return types, which need to be resolved before trying to use the produced function in a select.

This patch makes this JPA syntax work correctly:

    select function('ascii', 'x')