### PR TITLE
allow IF b THEN x ELSE y END as alternative to CASE in HQL

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlLexer.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlLexer.g4
@@ -157,6 +157,7 @@ GREATEST			: [gG] [rR] [eE] [aA] [tT] [eE] [sS] [tT];
 GROUP				: [gG] [rR] [oO] [uU] [pP];
 HAVING				: [hH] [aA] [vV] [iI] [nN] [gG];
 HOUR				: [hH] [oO] [uU] [rR];
+IF					: [iI] [fF];
 IFNULL				: [iI] [fF] [nN] [uU] [lL] [lL];
 IN					: [iI] [nN];
 INDEX				: [iI] [nN] [dD] [eE] [xX];

--- a/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
@@ -411,6 +411,7 @@ entityTypeReference
 caseStatement
 	: simpleCaseStatement
 	| searchedCaseStatement
+	| ifStatement
 	;
 
 simpleCaseStatement
@@ -432,6 +433,10 @@ searchedCaseStatement
 searchedCaseWhen
 	: WHEN predicate THEN expression
 	;
+
+ifStatement
+    : IF predicate THEN expression ELSE expression END
+    ;
 
 greatestFunction
 	: GREATEST LEFT_PAREN expression (COMMA expression)+ RIGHT_PAREN

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -1455,7 +1455,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 	@Override
 	public SqmCaseSearched visitSearchedCaseStatement(HqlParser.SearchedCaseStatementContext ctx) {
-		final SqmCaseSearched<?> caseExpression = new SqmCaseSearched<>( creationContext.getNodeBuilder());
+		final SqmCaseSearched<?> caseExpression = new SqmCaseSearched<>( creationContext.getNodeBuilder() );
 
 		for ( HqlParser.SearchedCaseWhenContext whenFragment : ctx.searchedCaseWhen() ) {
 			caseExpression.when(
@@ -1469,6 +1469,20 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		}
 
 		return caseExpression;
+	}
+
+	@Override
+	public Object visitIfStatement(HqlParser.IfStatementContext ctx) {
+		final SqmCaseSearched<?> ifExpression = new SqmCaseSearched<>( creationContext.getNodeBuilder() );
+
+		ifExpression.when(
+				(SqmPredicate) ctx.predicate().accept(this),
+				(SqmExpression) ctx.expression(0).accept( this )
+		);
+
+		ifExpression.otherwise( (SqmExpression) ctx.expression(1).accept( this ) );
+
+		return ifExpression;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -328,4 +328,24 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
         );
     }
 
+    @Test
+    public void testIfThen() {
+        inTransaction(
+                session -> {
+                    session.createQuery("select if e.theInt > 0 then 'pos' else 'neg' end from EntityOfBasics e")
+                            .list();
+                }
+        );
+    }
+
+    @Test
+    public void testCaseWhen() {
+        inTransaction(
+                session -> {
+                    session.createQuery("select case when e.theInt > 0 then 'pos' else 'neg' end from EntityOfBasics e")
+                            .list();
+                }
+        );
+    }
+
 }


### PR DESCRIPTION
Currently you can write `case when b then x else y end`, but I find that pretty verbose for something quite common.

This patch lets you write it as `if b then x else y end`.

It's a very minor thing, but I definitely find it nicer to look at. 