### PR TITLE
add additional target types for cast() function

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
@@ -611,14 +611,7 @@ castFunction
 	;
 
 castTarget
-	// todo (6.0) : should allow either
-	// 		- named cast (IDENTIFIER)
-	//			- JavaTypeDescriptorRegistry (imported) key
-	//			- java.sql.Types field NAME (alias for its value as a coded cast)
-	//			- "pass through"
-	//		- coded cast (INTEGER_LITERAL)
-	//			- SqlTypeDescriptorRegistry key
-	: identifier
+	: identifier (LEFT_PAREN INTEGER_LITERAL (COMMA INTEGER_LITERAL)? RIGHT_PAREN)?
 	;
 
 concatFunction

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -271,6 +271,11 @@ public abstract class AbstractHANADialect extends Dialect {
 		getDefaultProperties().setProperty( AvailableSettings.USE_GET_GENERATED_KEYS, "false" );
 	}
 
+	@Override
+	public int getDefaultDecimalPrecision() {
+		//the maximum on HANA
+		return 34;
+	}
 
 	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -40,7 +40,7 @@ abstract class AbstractTransactSQLDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "smallint" );
 		registerColumnType( Types.INTEGER, "int" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CUBRIDDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CUBRIDDialect.java
@@ -35,7 +35,7 @@ public class CUBRIDDialect extends Dialect {
 		registerColumnType( Types.BIT, "bit(8)" );
 		registerColumnType( Types.BLOB, "bit varying(65535)" );
 		registerColumnType( Types.BOOLEAN, "bit(8)" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.CLOB, "string" );
 		registerColumnType( Types.DATE, "date" );
 		registerColumnType( Types.DECIMAL, "decimal" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -248,6 +248,12 @@ public class Cache71Dialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//the largest *meaningful* value
+		return 19;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -215,7 +215,7 @@ public class Cache71Dialect extends Dialect {
 		registerColumnType( Types.BINARY, "varbinary($1)" );
 		registerColumnType( Types.BIGINT, "BigInt" );
 		registerColumnType( Types.BIT, "bit" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.DATE, "date" );
 		registerColumnType( Types.DECIMAL, "decimal" );
 		registerColumnType( Types.DOUBLE, "double" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -133,6 +133,12 @@ public class DB2Dialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//this is the maximum allowed in DB2
+		return 31;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -96,7 +96,7 @@ public class DB2Dialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "smallint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -98,6 +98,7 @@ import org.hibernate.sql.ANSIJoinFragment;
 import org.hibernate.sql.CaseFragment;
 import org.hibernate.sql.ForUpdateFragment;
 import org.hibernate.sql.JoinFragment;
+import org.hibernate.sql.SqlExpressableType;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
@@ -115,11 +116,7 @@ import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.spi.ClobSqlDescriptor;
 import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptor;
-import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptorRegistry;
 import org.hibernate.type.spi.StandardSpiBasicTypes;
-
-import static org.hibernate.query.sqm.produce.function.StandardArgumentsValidators.min;
-import static org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers.useArgType;
 
 /**
  * Represents a dialect of SQL implemented by a particular RDBMS.  Subclasses implement Hibernate compatibility
@@ -522,13 +519,33 @@ public abstract class Dialect implements ConversionContext {
 
 	/**
 	 * Get the name of the database type appropriate for casting operations
-	 * (via the CAST() SQL function) for the given {@link java.sql.Types} typecode.
+	 * (via the CAST() SQL function) for the given {@link SqlExpressableType}
+	 * SQL type.
 	 *
-	 * @param code The {@link java.sql.Types} typecode
 	 * @return The database type name
 	 */
-	public String getCastTypeName(int code) {
-		return getTypeName( code, Size.Builder.DEFAULT_LENGTH, Size.Builder.DEFAULT_PRECISION, Size.Builder.DEFAULT_SCALE );
+	public String getCastTypeName(SqlExpressableType type, Long length, Integer precision, Integer scale) {
+		Size size;
+		if ( length == null && precision == null ) {
+			//use defaults
+			size = getDefaultSizeStrategy().resolveDefaultSize(
+					type.getSqlTypeDescriptor(),
+					type.getJavaTypeDescriptor()
+			);
+		}
+		else {
+			//use the given length/precision/scale
+			if ( precision != null && scale == null ) {
+				//needed for cast(x as BigInteger(p))
+				scale = type.getJavaTypeDescriptor().getDefaultSqlScale();
+			}
+			size = new Size.Builder().setLength( length )
+					.setPrecision( precision )
+					.setScale( scale )
+					.cast();
+		}
+
+		return getTypeName( type.getSqlTypeDescriptor().getJdbcTypeCode(), size );
 	}
 
 	/**
@@ -3241,17 +3258,21 @@ public abstract class Dialect implements ConversionContext {
 					|| jdbcTypeCode == Types.LONGVARCHAR
 					|| jdbcTypeCode == Types.NCHAR
 					|| jdbcTypeCode == Types.NVARCHAR
-					|| jdbcTypeCode == Types.LONGNVARCHAR ) {
-				builder.setLength( Size.Builder.DEFAULT_LENGTH );
+					|| jdbcTypeCode == Types.LONGNVARCHAR
+					|| jdbcTypeCode == Types.BINARY ) {
+				builder.setLength( javaType.getDefaultSqlLength() );
 				return builder.build();
 			}
-			else if ( jdbcTypeCode == Types.FLOAT ) {
-				builder.setPrecision( Size.Builder.DEFAULT_PRECISION );
+			else if ( jdbcTypeCode == Types.FLOAT
+					|| jdbcTypeCode == Types.DOUBLE
+					|| jdbcTypeCode == Types.REAL ) {
+				builder.setPrecision( javaType.getDefaultSqlPrecision() );
 				return builder.build();
 			}
-			else if ( jdbcTypeCode == Types.NUMERIC ) {
-				builder.setPrecision( Size.Builder.DEFAULT_PRECISION );
-				builder.setScale( Size.Builder.DEFAULT_SCALE );
+			else if ( jdbcTypeCode == Types.NUMERIC
+					|| jdbcTypeCode == Types.DECIMAL ) {
+				builder.setPrecision( javaType.getDefaultSqlPrecision() );
+				builder.setScale( javaType.getDefaultSqlScale() );
 				return builder.build();
 			}
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3187,7 +3187,22 @@ public abstract class Dialect implements ConversionContext {
 		this.defaultSizeStrategy = defaultSizeStrategy;
 	}
 
-	public static class DefaultSizeStrategyImpl implements DefaultSizeStrategy {
+	/**
+	 * This is the default precision for a generated
+	 * column mapped to a BigInteger or BigDecimal.
+	 *
+	 * Usually returns the maximum precision of the
+	 * database, except when there is no such maximum
+	 * precision, or the maximum precision is very high.
+	 */
+	public int getDefaultDecimalPrecision() {
+		//this is the maximum for Oracle, SQL Server,
+		//Sybase, and Teradata, so it makes a reasonable
+		//default (uses 17 bytes on SQL Server and MySQL)
+		return 38;
+	}
+
+	public class DefaultSizeStrategyImpl implements DefaultSizeStrategy {
 		@Override
 		public Size resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor javaType) {
 			final Size.Builder builder = new Size.Builder();
@@ -3202,18 +3217,18 @@ public abstract class Dialect implements ConversionContext {
 					|| jdbcTypeCode == Types.NVARCHAR
 					|| jdbcTypeCode == Types.LONGNVARCHAR
 					|| jdbcTypeCode == Types.BINARY ) {
-				builder.setLength( javaType.getDefaultSqlLength() );
+				builder.setLength( javaType.getDefaultSqlLength(Dialect.this) );
 				return builder.build();
 			}
 			else if ( jdbcTypeCode == Types.FLOAT
 					|| jdbcTypeCode == Types.DOUBLE
 					|| jdbcTypeCode == Types.REAL ) {
-				builder.setPrecision( javaType.getDefaultSqlPrecision() );
+				builder.setPrecision( javaType.getDefaultSqlPrecision(Dialect.this) );
 				return builder.build();
 			}
 			else if ( jdbcTypeCode == Types.NUMERIC
 					|| jdbcTypeCode == Types.DECIMAL ) {
-				builder.setPrecision( javaType.getDefaultSqlPrecision() );
+				builder.setPrecision( javaType.getDefaultSqlPrecision(Dialect.this) );
 				builder.setScale( javaType.getDefaultSqlScale() );
 				return builder.build();
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -549,64 +549,6 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Return an expression casting the value to the specified type
-	 *
-	 * @param value The value to cast
-	 * @param jdbcTypeCode The JDBC type code to cast to
-	 * @param length The type length
-	 * @param precision The type precision
-	 * @param scale The type scale
-	 *
-	 * @return The cast expression
-	 */
-	public String cast(String value, int jdbcTypeCode, int length, int precision, int scale) {
-		return cast( value, jdbcTypeCode, (long) length, precision, scale );
-	}
-
-	public String cast(String value, int jdbcTypeCode, long length, int precision, int scale) {
-		if ( jdbcTypeCode == Types.CHAR ) {
-			return "cast(" + value + " as char(" + length + "))";
-		}
-		else {
-			return "cast(" + value + "as " + getTypeName( jdbcTypeCode, length, precision, scale ) + ")";
-		}
-	}
-
-	/**
-	 * Return an expression casting the value to the specified type.  Simply calls
-	 * {@link #cast(String, int, int, int, int)} passing {@link Size.Builder#DEFAULT_PRECISION} and
-	 * {@link Size.Builder#DEFAULT_SCALE} as the precision/scale.
-	 *
-	 * @param value The value to cast
-	 * @param jdbcTypeCode The JDBC type code to cast to
-	 * @param length The type length
-	 *
-	 * @return The cast expression
-	 */
-	public String cast(String value, int jdbcTypeCode, int length) {
-		return cast( value, jdbcTypeCode, (long) length );
-	}
-
-	public String cast(String value, int jdbcTypeCode, long length) {
-		return cast( value, jdbcTypeCode, length, Size.Builder.DEFAULT_PRECISION, Size.Builder.DEFAULT_SCALE );
-	}
-
-	/**
-	 * Return an expression casting the value to the specified type.  Simply calls
-	 * {@link #cast(String, int, int, int, int)} passing {@link Size.Builder#DEFAULT_LENGTH} as the length
-	 *
-	 * @param value The value to cast
-	 * @param jdbcTypeCode The JDBC type code to cast to
-	 * @param precision The type precision
-	 * @param scale The type scale
-	 *
-	 * @return The cast expression
-	 */
-	public String cast(String value, int jdbcTypeCode, int precision, int scale) {
-		return cast( value, jdbcTypeCode, Size.Builder.DEFAULT_LENGTH, precision, scale );
-	}
-
-	/**
 	 * Subclasses register a type name for the given type code and maximum
 	 * column length. <tt>$l</tt> in the type name with be replaced by the
 	 * column length (if appropriate).

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FrontBaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FrontBaseDialect.java
@@ -48,7 +48,7 @@ public class FrontBaseDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "tinyint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -77,6 +77,12 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//the maximum
+		return 32;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -101,6 +101,12 @@ public class IngresDialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//the maximum
+		return 39;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
@@ -51,7 +51,7 @@ public class InterbaseDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "smallint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/JDataStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/JDataStoreDialect.java
@@ -29,7 +29,7 @@ public class JDataStoreDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "tinyint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MckoiDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MckoiDialect.java
@@ -42,7 +42,7 @@ public class MckoiDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "tinyint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
@@ -63,6 +63,12 @@ public class MimerSQLDialect extends Dialect {
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, "50" );
 	}
 
+//	@Override
+//	public int getDefaultDecimalPrecision() {
+//		//the maximum, but I guess it's too high
+//		return 45;
+//	}
+
 	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -37,9 +37,6 @@ import org.hibernate.query.sqm.mutation.spi.idtable.LocalTempTableExporter;
 import org.hibernate.query.sqm.mutation.spi.idtable.LocalTemporaryTableStrategy;
 import org.hibernate.sql.SqlExpressableType;
 import org.hibernate.tool.schema.spi.Exporter;
-import org.hibernate.type.descriptor.sql.spi.BinarySqlDescriptor;
-import org.hibernate.type.descriptor.sql.spi.NumericSqlDescriptor;
-import org.hibernate.type.descriptor.sql.spi.StandardSqlExpressableTypeImpl;
 import org.hibernate.type.spi.StandardSpiBasicTypes;
 
 /**
@@ -180,6 +177,12 @@ public class MySQLDialect extends Dialect {
 		// from_unixtime(), timestamp() are functions that return TIMESTAMP that do not support a
 		// fractional seconds precision argument (so there's no need to override them here):
 	}
+
+//	@Override
+//	public int getDefaultDecimalPrecision() {
+//		//this is the maximum, but I guess it's too high
+//		return 65;
+//	}
 
 	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
@@ -392,7 +395,7 @@ public class MySQLDialect extends Dialect {
 				//the default scale is 0 (no decimal places)
 				return String.format(
 						"decimal(%d, %d)",
-						precision == null ? type.getJavaTypeDescriptor().getDefaultSqlPrecision() : precision,
+						precision == null ? type.getJavaTypeDescriptor().getDefaultSqlPrecision(this) : precision,
 						scale == null ? type.getJavaTypeDescriptor().getDefaultSqlScale() : scale
 				);
 			case Types.VARBINARY:
@@ -402,7 +405,7 @@ public class MySQLDialect extends Dialect {
 				//inconsistent with other Dialects which need a length
 				return String.format(
 						"binary(%d)",
-						length == null ? type.getJavaTypeDescriptor().getDefaultSqlLength() : length
+						length == null ? type.getJavaTypeDescriptor().getDefaultSqlLength(this) : length
 				);
 			case Types.VARCHAR:
 			case Types.LONGVARCHAR:
@@ -411,7 +414,7 @@ public class MySQLDialect extends Dialect {
 				//inconsistent with other Dialects which need a length
 				return String.format(
 						"char(%d)",
-						length == null ? type.getJavaTypeDescriptor().getDefaultSqlLength() : length
+						length == null ? type.getJavaTypeDescriptor().getDefaultSqlLength(this) : length
 				);
 			default:
 				return super.getCastTypeName( type, length, precision, scale );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -94,7 +94,7 @@ public class MySQLDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "tinyint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );
 		registerColumnType( Types.BOOLEAN, "bit" ); // HHH-6935

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -169,7 +169,7 @@ public class Oracle8iDialect extends Dialect {
 	}
 
 	protected void registerCharacterTypeMappings() {
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, 4000, "varchar2($l)" );
 		registerColumnType( Types.VARCHAR, "long" );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -40,7 +40,7 @@ public class OracleDialect extends Oracle9Dialect {
 		// Oracle8 and previous define only a "DATE" type which
 		//      is used to represent all aspects of date/time
 		registerColumnType( Types.TIMESTAMP, "date" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, 4000, "varchar2($l)" );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PointbaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PointbaseDialect.java
@@ -37,7 +37,7 @@ public class PointbaseDialect extends org.hibernate.dialect.Dialect {
 		//no pointbase TINYINT
 		registerColumnType( Types.TINYINT, "smallint" );
 		registerColumnType( Types.INTEGER, "integer" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -84,7 +84,7 @@ public class PostgreSQL81Dialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "int2" );
 		registerColumnType( Types.TINYINT, "int2" );
 		registerColumnType( Types.INTEGER, "int4" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float4" );
 		registerColumnType( Types.DOUBLE, "float8" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
@@ -158,6 +158,12 @@ public class RDMSOS2200Dialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//the (really low) maximum
+		return 21;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SAPDBDialect.java
@@ -44,7 +44,7 @@ public class SAPDBDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "smallint" );
 		registerColumnType( Types.TINYINT, "fixed(3,0)" );
 		registerColumnType( Types.INTEGER, "int" );
-		registerColumnType( Types.CHAR, "char(1)" );
+		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.DOUBLE, "double precision" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -29,6 +29,7 @@ import org.hibernate.metamodel.model.relational.spi.Sequence;
 import org.hibernate.metamodel.model.relational.spi.UniqueKey;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.mutation.spi.idtable.IdTable;
+import org.hibernate.sql.SqlExpressableType;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.spi.StandardSpiBasicTypes;
 
@@ -497,11 +498,6 @@ public class SpannerDialect extends Dialect {
 		return true;
 	}
 
-	@Override
-	public boolean supportsCaseInsensitiveLike() {
-		return false;
-	}
-
 	/* DDL-related functions */
 
 	@Override
@@ -781,13 +777,11 @@ public class SpannerDialect extends Dialect {
 	/* Type conversion and casting */
 
 	@Override
-	public String getCastTypeName(int code) {
-		switch ( code ) {
-			case Types.VARCHAR:
-				return "STRING";
-			default:
-				return super.getCastTypeName( code );
-		}
+	public String getCastTypeName(SqlExpressableType type, Long length, Integer precision, Integer scale) {
+		String result = super.getCastTypeName( type, length, precision, scale );
+		//Spanner doesn't let you specify a length in cast() types
+		int paren = result.indexOf('(');
+		return paren>0 ? result.substring(0, paren) : result;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
@@ -43,7 +43,7 @@ public class TeradataDialect extends Dialect {
 		registerColumnType( Types.VARBINARY, "VARBYTE($l)" );
 		registerColumnType( Types.BINARY, "BYTEINT" );
 		registerColumnType( Types.LONGVARCHAR, "LONG VARCHAR" );
-		registerColumnType( Types.CHAR, "CHAR(1)" );
+		registerColumnType( Types.CHAR, "CHAR($l)" );
 		registerColumnType( Types.DECIMAL, "DECIMAL" );
 		registerColumnType( Types.INTEGER, "INTEGER" );
 		registerColumnType( Types.SMALLINT, "SMALLINT" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
@@ -83,6 +83,12 @@ public class TimesTenDialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultDecimalPrecision() {
+		//the maximum
+		return 40;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
@@ -64,7 +64,7 @@ public class TimesTenDialect extends Dialect {
 		registerColumnType( Types.SMALLINT, "SMALLINT" );
 		registerColumnType( Types.TINYINT, "TINYINT" );
 		registerColumnType( Types.INTEGER, "INTEGER" );
-		registerColumnType( Types.CHAR, "CHAR(1)" );
+		registerColumnType( Types.CHAR, "CHAR($l)" );
 		registerColumnType( Types.VARCHAR, "VARCHAR($l)" );
 		registerColumnType( Types.FLOAT, "FLOAT" );
 		registerColumnType( Types.DOUBLE, "DOUBLE" );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/Size.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/relational/spi/Size.java
@@ -163,5 +163,12 @@ public class Size implements Serializable {
 
 			return new Size( precision, scale, length, lobMultiplier );
 		}
+
+		public Size cast() {
+			// disable the above checks because in Dialect.getCastTypeName()
+			// we don't know whether what we have is a length or a precision
+			// (the cast target syntax is ambiguous)
+			return new Size( precision, scale, length, lobMultiplier );
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.hibernate.NullPrecedence;
 import org.antlr.v4.runtime.Token;
 import org.hibernate.SortOrder;
@@ -760,7 +761,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				}
 			}
 
-			return new SqmLiteral<>( position, resolveExpressableTypeBasic( Integer.class ), creationContext.getNodeBuilder() );
+			return new SqmLiteral<>( position, basicType( Integer.class ), creationContext.getNodeBuilder() );
 		}
 
 		if ( ctx.identifier() != null ) {
@@ -1337,7 +1338,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 						(SqmExpression) ctx.expression( 0 ).accept( this ),
 						(SqmExpression) ctx.expression( 1 ).accept( this )
 				),
-				resolveExpressableTypeBasic( String.class ),
+				basicType( String.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -1477,7 +1478,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmExpression visitCurrentDateFunction(HqlParser.CurrentDateFunctionContext ctx) {
 		return getFunctionTemplate("current_date")
 				.makeSqmFunctionExpression(
-						resolveExpressableTypeBasic( Date.class ),
+						basicType( Date.class ),
 						creationContext.getQueryEngine()
 				);
 	}
@@ -1486,7 +1487,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmExpression visitCurrentTimeFunction(HqlParser.CurrentTimeFunctionContext ctx) {
 		return getFunctionTemplate("current_time")
 				.makeSqmFunctionExpression(
-						resolveExpressableTypeBasic( Time.class ),
+						basicType( Time.class ),
 						creationContext.getQueryEngine()
 				);
 	}
@@ -1495,7 +1496,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmExpression visitCurrentTimestampFunction(HqlParser.CurrentTimestampFunctionContext ctx) {
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
-						resolveExpressableTypeBasic( Timestamp.class ),
+						basicType( Timestamp.class ),
 						creationContext.getQueryEngine()
 				);
 	}
@@ -1504,7 +1505,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmExpression visitCurrentInstantFunction(HqlParser.CurrentInstantFunctionContext ctx) {
 		return getFunctionTemplate("current_timestamp")
 				.makeSqmFunctionExpression(
-						resolveExpressableTypeBasic( Instant.class ),
+						basicType( Instant.class ),
 						creationContext.getQueryEngine()
 				);
 	}
@@ -1652,7 +1653,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	}
 
 	private SqmLiteral<Boolean> booleanLiteral(boolean value) {
-		final BasicValuedExpressableType expressionType = resolveExpressableTypeBasic( Boolean.class );
+		final BasicValuedExpressableType expressionType = basicType( Boolean.class );
 		return new SqmLiteral<>( value, expressionType, creationContext.getQueryEngine().getCriteriaBuilder() );
 	}
 
@@ -1663,7 +1664,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		}
 		return new SqmLiteral<>(
 				text.charAt( 0 ),
-				resolveExpressableTypeBasic( Character.class ),
+				basicType( Character.class ),
 				creationContext.getNodeBuilder()
 		);
 	}
@@ -1682,7 +1683,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			final Integer value = Integer.valueOf( text );
 			return new SqmLiteral<>(
 					value,
-					resolveExpressableTypeBasic( Integer.class ),
+					basicType( Integer.class ),
 					creationContext.getQueryEngine().getCriteriaBuilder()
 			);
 		}
@@ -1704,7 +1705,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			final Long value = Long.valueOf( text );
 			return new SqmLiteral<>(
 					value,
-					resolveExpressableTypeBasic( Long.class ),
+					basicType( Long.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -1725,7 +1726,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			}
 			return new SqmLiteral<>(
 					new BigInteger( text ),
-					resolveExpressableTypeBasic( BigInteger.class  ),
+					basicType( BigInteger.class  ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -1742,7 +1743,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		try {
 			return new SqmLiteral<>(
 					Float.valueOf( text ),
-					resolveExpressableTypeBasic( Float.class ),
+					basicType( Float.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -1759,7 +1760,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		try {
 			return new SqmLiteral<>(
 					Double.valueOf( text ),
-					resolveExpressableTypeBasic( Double.class ),
+					basicType( Double.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -1780,7 +1781,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			}
 			return new SqmLiteral<>(
 					new BigDecimal( text ),
-					resolveExpressableTypeBasic( BigDecimal.class ),
+					basicType( BigDecimal.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -1792,7 +1793,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		}
 	}
 
-	private <J> BasicValuedExpressableType<J> resolveExpressableTypeBasic(Class<J> javaType) {
+	private <J> BasicValuedExpressableType<J> basicType(Class<J> javaType) {
 		return creationContext.getDomainModel().getTypeConfiguration().standardExpressableTypeForJavaType( javaType );
 	}
 
@@ -1905,7 +1906,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("ceiling").makeSqmFunctionExpression(
 				arg,
-				resolveExpressableTypeBasic( Long.class ),
+				basicType( Long.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -1916,7 +1917,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("floor").makeSqmFunctionExpression(
 				arg,
-				resolveExpressableTypeBasic( Long.class ),
+				basicType( Long.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -1942,7 +1943,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("sign").makeSqmFunctionExpression(
 				arg,
-				resolveExpressableTypeBasic( Integer.class ),
+				basicType( Integer.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -1977,7 +1978,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate( ctx.trigFunctionName().getText() ).makeSqmFunctionExpression(
 				arg,
-				resolveExpressableTypeBasic( Double.class ),
+				basicType( Double.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2044,28 +2045,28 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public Object visitDatetimeField(HqlParser.DatetimeFieldContext ctx) {
 		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
 		if (ctx.DAY()!=null) {
-			return new SqmExtractUnit<>("day", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("day", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.MONTH()!=null) {
-			return new SqmExtractUnit<>("month", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("month", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.YEAR()!=null) {
-			return new SqmExtractUnit<>("year", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("year", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.HOUR()!=null) {
-			return new SqmExtractUnit<>("hour", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("hour", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.MINUTE()!=null) {
-			return new SqmExtractUnit<>("minute", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("minute", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.SECOND()!=null) {
-			return new SqmExtractUnit<>("second", resolveExpressableTypeBasic( Float.class ), nodeBuilder);
+			return new SqmExtractUnit<>("second", basicType( Float.class ), nodeBuilder);
 		}
 		if (ctx.WEEK()!=null) {
-			return new SqmExtractUnit<>("week", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("week", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.QUARTER()!=null) {
-			return new SqmExtractUnit<>("quarter", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("quarter", basicType( Integer.class ), nodeBuilder);
 		}
 		return super.visitDatetimeField(ctx);
 	}
@@ -2075,11 +2076,11 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
 		if (ctx.MICROSECOND()!=null) {
 			//TODO: need to go back to the dialect, it's called "microseconds" on some
-			return new SqmExtractUnit<>("microsecond", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("microsecond", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.MILLISECOND()!=null) {
 			//TODO: need to go back to the dialect, it's called "milliseconds" on some
-			return new SqmExtractUnit<>("millisecond", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("millisecond", basicType( Integer.class ), nodeBuilder);
 		}
 		return super.visitSecondsField(ctx);
 	}
@@ -2088,10 +2089,10 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public Object visitTimeZoneField(HqlParser.TimeZoneFieldContext ctx) {
 		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
 		if (ctx.TIMEZONE_HOUR()!=null) {
-			return new SqmExtractUnit<>("timezone_hour", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("timezone_hour", basicType( Integer.class ), nodeBuilder);
 		}
 		if (ctx.TIMEZONE_MINUTE()!=null) {
-			return new SqmExtractUnit<>("timezone_minute", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+			return new SqmExtractUnit<>("timezone_minute", basicType( Integer.class ), nodeBuilder);
 		}
 		return super.visitTimeZoneField(ctx);
 	}
@@ -2122,13 +2123,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmExpression visitCastFunction(HqlParser.CastFunctionContext ctx) {
 
 		final SqmExpression<?> expressionToCast = (SqmExpression) ctx.expression().accept( this );
-		final SqmCastTarget<?> castTargetExpression = interpretCastTarget( ctx.castTarget() );
-
-		//getSessionFactory().getTypeConfiguration().resolveCastTargetType( ctx.dataType().IDENTIFIER().getText() )
-
-//		if ( !AllowableFunctionReturnType.class.isInstance( castTargetExpression ) ) {
-//			throw new SqmProductionException( "Found cast target expression [%s] which is not allowed as a function return" );
-//		}
+		final SqmCastTarget<?> castTargetExpression = (SqmCastTarget) ctx.castTarget().accept( this );
 
 		return getFunctionTemplate("cast").makeSqmFunctionExpression(
 				asList( expressionToCast, castTargetExpression ),
@@ -2137,29 +2132,27 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		);
 	}
 
-	private SqmCastTarget<?> interpretCastTarget(HqlParser.CastTargetContext castTargetContext) {
-		// todo (6.0) : what are the allowable forms of specifying cast-target?
-		// 		the exactness of this is being discussed on the dev ml.  Most
-		//		likely we will accept either:
-		//			1) a String, which might represent:
-		//				a) a Java type name
-		//				b) a java.sql.Types field name (e.g. VARCHAR...)
-		//				c) (not huge fan of this...) a "pass-thru" value
-		//			2) an int signifying the SqlTypeDescriptor (JDBC type code)
+	@Override
+	public SqmCastTarget<?> visitCastTarget(HqlParser.CastTargetContext castTargetContext) {
+		String targetName = castTargetContext.identifier().getText();
 
-		String text = castTargetContext.identifier().getText();
-		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
-		switch (text.toLowerCase()) {
-			case "string": return new SqmCastTarget<>( resolveExpressableTypeBasic( String.class ), nodeBuilder );
-			case "integer": return new SqmCastTarget<>( resolveExpressableTypeBasic( Integer.class ), nodeBuilder );
-			case "long": return new SqmCastTarget<>( resolveExpressableTypeBasic( Long.class ), nodeBuilder );
-			case "float": return new SqmCastTarget<>( resolveExpressableTypeBasic( Float.class ), nodeBuilder );
-			case "double": return new SqmCastTarget<>( resolveExpressableTypeBasic( Double.class ), nodeBuilder );
-			case "time": return new SqmCastTarget<>( resolveExpressableTypeBasic( Time.class ), nodeBuilder );
-			case "date": return new SqmCastTarget<>( resolveExpressableTypeBasic( Date.class ), nodeBuilder );
-			case "timestamp": return new SqmCastTarget<>( resolveExpressableTypeBasic( Timestamp.class ), nodeBuilder );
-			default: throw new SqmProductionException("unrecognized cast target type: " + text);
+		List<TerminalNode> args = castTargetContext.INTEGER_LITERAL();
+		Long length = args.size() == 1 ? Long.valueOf( args.get(0).getText() ) : null;
+		Integer precision = args.size()>0 ? Integer.valueOf( args.get(0).getText() ) : null;
+		Integer scale = args.size()>1 ? Integer.valueOf( args.get(1).getText() ) : null;
+
+		BasicValuedExpressableType<?> targetType = creationContext.getDomainModel().getTypeConfiguration().resolveCastTargetType(targetName);
+		if ( !AllowableFunctionReturnType.class.isInstance( targetType ) ) {
+			throw new SqmProductionException( "Found cast target expression [%s] which is not allowed as a function return" );
 		}
+
+		return new SqmCastTarget<>(
+				(AllowableFunctionReturnType<?>) targetType,
+				//TODO: is there some way to interpret as length vs precision/scale here at this point?
+				length,
+				precision, scale,
+				creationContext.getNodeBuilder()
+		);
 	}
 
 	@Override
@@ -2194,7 +2187,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("concat").makeSqmFunctionExpression(
 				arguments,
-				resolveExpressableTypeBasic( String.class ),
+				basicType( String.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2206,7 +2199,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("character_length").makeSqmFunctionExpression(
 				arg,
-				resolveExpressableTypeBasic( Integer.class ),
+				basicType( Integer.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2219,7 +2212,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("locate").makeSqmFunctionExpression(
 				asList( pattern, string ),
-				resolveExpressableTypeBasic( Integer.class ),
+				basicType( Integer.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2237,7 +2230,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				start == null
 						? asList( pattern, string )
 						: asList( pattern, string, start ),
-				resolveExpressableTypeBasic( Integer.class ),
+				basicType( Integer.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2251,7 +2244,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("replace").makeSqmFunctionExpression(
 				asList( string, pattern, replacement ),
-				resolveExpressableTypeBasic( String.class ),
+				basicType( String.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2259,7 +2252,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	@Override
 	public Object visitStrFunction(HqlParser.StrFunctionContext ctx) {
 		final SqmExpression<?> arg = (SqmExpression) ctx.expression().accept( this );
-		BasicValuedExpressableType<String> type = resolveExpressableTypeBasic( String.class );
+		BasicValuedExpressableType<String> type = basicType( String.class );
 		return getFunctionTemplate("cast").makeSqmFunctionExpression(
 				asList( arg, new SqmCastTarget<>( type, creationContext.getNodeBuilder() ) ),
 				type,
@@ -2310,7 +2303,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("avg").makeSqmFunctionExpression(
 				argument,
-				resolveExpressableTypeBasic( Double.class ),
+				basicType( Double.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2325,7 +2318,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("count").makeSqmFunctionExpression(
 				argument,
-				resolveExpressableTypeBasic( Long.class ),
+				basicType( Long.class ),
 				creationContext.getQueryEngine()
 		);
 	}
@@ -2340,7 +2333,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("substring").makeSqmFunctionExpression(
 				length==null ? asList( source, start ) : asList( source, start, length ),
-				resolveExpressableTypeBasic( String.class ),
+				basicType( String.class ),
 				creationContext.getQueryEngine()
 		);
 
@@ -2352,16 +2345,17 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionTemplate("trim").makeSqmFunctionExpression(
 				asList(
-						interpretTrimSpecification( ctx.trimSpecification() ),
-						visitTrimCharacter( ctx.trimCharacter() ),
+						(SqmTrimSpecification) ctx.trimSpecification().accept( this ),
+						(SqmLiteral<Character>) ctx.trimCharacter().accept( this ),
 						source
 				),
-				resolveExpressableTypeBasic( String.class ),
+				basicType( String.class ),
 				creationContext.getQueryEngine()
 		);
 	}
 
-	private SqmTrimSpecification interpretTrimSpecification(HqlParser.TrimSpecificationContext ctx) {
+	@Override
+	public SqmTrimSpecification visitTrimSpecification(HqlParser.TrimSpecificationContext ctx) {
 		TrimSpec spec = TrimSpec.BOTH;	// JPA says the default is BOTH
 
 		if ( ctx.LEADING() != null ) {
@@ -2385,7 +2379,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			}
 			return new SqmLiteral<>(
 					trimCharText.charAt( 0 ),
-					resolveExpressableTypeBasic( Character.class ),
+					basicType( Character.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -2397,7 +2391,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 			}
 			return new SqmLiteral<>(
 					trimCharText.charAt( 0 ),
-					resolveExpressableTypeBasic( Character.class ),
+					basicType( Character.class ),
 					creationContext.getNodeBuilder()
 			);
 		}
@@ -2405,7 +2399,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		// JPA says space is the default
 		return new SqmLiteral<>(
 				' ',
-				resolveExpressableTypeBasic( Character.class ),
+				basicType( Character.class ),
 				creationContext.getNodeBuilder()
 		);
 	}
@@ -2414,7 +2408,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	public SqmCollectionSize visitCollectionSizeFunction(HqlParser.CollectionSizeFunctionContext ctx) {
 		return new SqmCollectionSize(
 				consumeDomainPath( ctx.path() ),
-				resolveExpressableTypeBasic( Integer.class ),
+				basicType( Integer.class ),
 				creationContext.getNodeBuilder()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -2141,13 +2141,10 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		Integer precision = args.size()>0 ? Integer.valueOf( args.get(0).getText() ) : null;
 		Integer scale = args.size()>1 ? Integer.valueOf( args.get(1).getText() ) : null;
 
-		BasicValuedExpressableType<?> targetType = creationContext.getDomainModel().getTypeConfiguration().resolveCastTargetType(targetName);
-		if ( !AllowableFunctionReturnType.class.isInstance( targetType ) ) {
-			throw new SqmProductionException( "Found cast target expression [%s] which is not allowed as a function return" );
-		}
-
 		return new SqmCastTarget<>(
-				(AllowableFunctionReturnType<?>) targetType,
+				(AllowableFunctionReturnType<?>)
+						creationContext.getDomainModel().getTypeConfiguration()
+								.resolveCastTargetType( targetName ),
 				//TODO: is there some way to interpret as length vs precision/scale here at this point?
 				length,
 				precision, scale,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/consume/spi/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/consume/spi/BaseSqmToSqlAstConverter.java
@@ -722,7 +722,10 @@ public abstract class BaseSqmToSqlAstConverter
 		shallownessStack.push( Shallowness.FUNCTION );
 		try {
 			return new CastTarget(
-					target.getType().getSqlExpressableType()
+					target.getType().getSqlExpressableType(),
+					target.getLength(),
+					target.getPrecision(),
+					target.getScale()
 			);
 		}
 		finally {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -115,7 +115,7 @@ public class StandardFunctionReturnTypeResolvers {
 					String.format(
 							Locale.ROOT,
 							"Function argument [%s] at specified position [%d] in call arguments was not typed as an allowable function return type",
-							specifiedArgument,
+							specifiedArgType,
 							position
 					)
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/function/SqmCastTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/function/SqmCastTarget.java
@@ -13,17 +13,60 @@ import org.hibernate.query.sqm.tree.AbstractSqmNode;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.SqmVisitableNode;
 import org.hibernate.sql.ast.produce.metamodel.spi.ExpressableType;
-import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
 
 /**
  * @author Gavin King
  */
 public class SqmCastTarget<T> extends AbstractSqmNode implements SqmTypedNode<T>, SqmVisitableNode {
 	private AllowableFunctionReturnType<T> type;
+	private Long length;
+	private Integer precision;
+	private Integer scale;
 
-	public SqmCastTarget(AllowableFunctionReturnType<T> type, NodeBuilder nodeBuilder) {
+	public Long getLength() {
+		return length;
+	}
+
+	public Integer getPrecision() {
+		return precision;
+	}
+
+	public Integer getScale() {
+		return scale;
+	}
+
+	public SqmCastTarget(
+			AllowableFunctionReturnType<T> type,
+			NodeBuilder nodeBuilder) {
+		this( type, null, nodeBuilder );
+	}
+
+	public SqmCastTarget(
+			AllowableFunctionReturnType<T> type,
+			Long length,
+			NodeBuilder nodeBuilder) {
+		this( type, length, null, null, nodeBuilder );
+	}
+
+	public SqmCastTarget(
+			AllowableFunctionReturnType<T> type,
+			Integer precision,
+			Integer scale,
+			NodeBuilder nodeBuilder) {
+		this( type, null, precision, scale, nodeBuilder );
+	}
+
+	public SqmCastTarget(
+			AllowableFunctionReturnType<T> type,
+			Long length,
+			Integer precision,
+			Integer scale,
+			NodeBuilder nodeBuilder) {
 		super( nodeBuilder );
 		this.type = type;
+		this.length = length;
+		this.precision = precision;
+		this.scale = scale;
 	}
 
 	public AllowableFunctionReturnType<T> getType() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/SelectValues.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SelectValues.java
@@ -60,22 +60,6 @@ public class SelectValues {
 		return this;
 	}
 
-	public SelectValues addParameter(int jdbcTypeCode, int length) {
-		final String selectExpression = dialect.requiresCastingOfParametersInSelectClause()
-				? dialect.cast( "?", jdbcTypeCode, length )
-				: "?";
-		selectValueList.add( new SelectValue( null, selectExpression, null ) );
-		return this;
-	}
-
-	public SelectValues addParameter(int jdbcTypeCode, int precision, int scale) {
-		final String selectExpression = dialect.requiresCastingOfParametersInSelectClause()
-				? dialect.cast( "?", jdbcTypeCode, precision, scale )
-				: "?";
-		selectValueList.add( new SelectValue( null, selectExpression, null ) );
-		return this;
-	}
-
 	public String render() {
 		final StringBuilder buf = new StringBuilder( selectValueList.size() * 10 );
 		final HashSet<String> uniqueAliases = new HashSet<String>();

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/consume/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/consume/spi/AbstractSqlAstWalker.java
@@ -421,11 +421,15 @@ public abstract class AbstractSqlAstWalker
 
 	@Override
 	public void visitCastTarget(CastTarget target) {
-		int typecode = target.getExpressableType().getSqlTypeDescriptor().getJdbcTypeCode();
-		String type = sessionFactory.getJdbcServices().getDialect().getCastTypeName( typecode );
-		appendSql( type );
+		appendSql(
+				sessionFactory.getJdbcServices().getDialect().getCastTypeName(
+						target.getExpressableType(),
+						target.getLength(),
+						target.getPrecision(),
+						target.getScale()
+				)
+		);
 	}
-
 
 	@Override
 	public void visitSqlSelectionExpression(SqlSelectionExpression expression) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CastTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CastTarget.java
@@ -16,9 +16,27 @@ import org.hibernate.sql.ast.tree.SqlAstNode;
  */
 public class CastTarget implements SqlExpressable, SqlAstNode {
 	private SqlExpressableType type;
+	private Long length;
+	private Integer precision;
+	private Integer scale;
 
-	public CastTarget(SqlExpressableType type) {
+	public CastTarget(SqlExpressableType type, Long length, Integer precision, Integer scale) {
 		this.type = type;
+		this.length = length;
+		this.precision = precision;
+		this.scale = scale;
+	}
+
+	public Long getLength() {
+		return length;
+	}
+
+	public Integer getPrecision() {
+		return precision;
+	}
+
+	public Integer getScale() {
+		return scale;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigDecimalJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigDecimalJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.spi.SqlTypeDescriptorIndicators;
@@ -93,13 +94,13 @@ public class BigDecimalJavaDescriptor extends AbstractNumericJavaDescriptor<BigD
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision() + 2;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect) + 2;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
-		return 38;
+	public int getDefaultSqlPrecision(Dialect dialect) {
+		return dialect.getDefaultDecimalPrecision();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigDecimalJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigDecimalJavaDescriptor.java
@@ -91,4 +91,15 @@ public class BigDecimalJavaDescriptor extends AbstractNumericJavaDescriptor<BigD
 		}
 		throw unknownWrap( value.getClass() );
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision() + 2;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 38;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigIntegerJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigIntegerJavaDescriptor.java
@@ -29,7 +29,7 @@ public class BigIntegerJavaDescriptor extends AbstractNumericJavaDescriptor<BigI
 
 	@Override
 	public SqlTypeDescriptor getJdbcRecommendedSqlType(SqlTypeDescriptorIndicators context) {
-		return context.getTypeConfiguration().getSqlTypeDescriptorRegistry().getDescriptor( Types.BIGINT );
+		return context.getTypeConfiguration().getSqlTypeDescriptorRegistry().getDescriptor( Types.NUMERIC );
 	}
 
 	@Override
@@ -93,4 +93,20 @@ public class BigIntegerJavaDescriptor extends AbstractNumericJavaDescriptor<BigI
 		}
 		throw unknownWrap( value.getClass() );
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 38;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigIntegerJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BigIntegerJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.spi.SqlTypeDescriptorIndicators;
@@ -95,13 +96,13 @@ public class BigIntegerJavaDescriptor extends AbstractNumericJavaDescriptor<BigI
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+1;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
-		return 38;
+	public int getDefaultSqlPrecision(Dialect dialect) {
+		return dialect.getDefaultDecimalPrecision();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BooleanJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BooleanJavaDescriptor.java
@@ -138,4 +138,19 @@ public class BooleanJavaDescriptor extends AbstractBasicJavaDescriptor<Boolean> 
 //		return charValue == 't' || charValue == 'T' || charValue == 'y' || charValue == 'Y';
 		return charValue == 'T';
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return 1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 1;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BooleanJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/BooleanJavaDescriptor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.descriptor.java.internal;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractBasicJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -140,12 +141,12 @@ public class BooleanJavaDescriptor extends AbstractBasicJavaDescriptor<Boolean> 
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
+	public long getDefaultSqlLength(Dialect dialect) {
 		return 1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 1;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteArrayJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteArrayJavaDescriptor.java
@@ -44,7 +44,7 @@ public class ByteArrayJavaDescriptor extends AbstractBasicJavaDescriptor<Byte[]>
 			jdbcCode = Types.BLOB;
 		}
 		else {
-			jdbcCode = Types.LONGVARBINARY;
+			jdbcCode = Types.VARBINARY;
 		}
 
 		return context.getTypeConfiguration().getSqlTypeDescriptorRegistry().getDescriptor( jdbcCode );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteJavaDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java.internal;
 
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -107,12 +108,12 @@ public class ByteJavaDescriptor extends AbstractNumericJavaDescriptor<Byte> impl
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
+	public long getDefaultSqlLength(Dialect dialect) {
 		return 1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 3;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ByteJavaDescriptor.java
@@ -105,4 +105,20 @@ public class ByteJavaDescriptor extends AbstractNumericJavaDescriptor<Byte> impl
 	public VersionSupport<Byte> getVersionSupport() {
 		return ByteVersionSupport.INSTANCE ;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return 1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 3;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/CharacterJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/CharacterJavaDescriptor.java
@@ -91,5 +91,18 @@ public class CharacterJavaDescriptor extends AbstractBasicJavaDescriptor<Charact
 		throw new UnsupportedOperationException( "char has no non-null default" );
 	}
 
+	@Override
+	public long getDefaultSqlLength() {
+		return 1;
+	}
 
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 3;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/CharacterJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/CharacterJavaDescriptor.java
@@ -9,6 +9,7 @@ package org.hibernate.type.descriptor.java.internal;
 import java.sql.Types;
 
 import org.hibernate.HibernateException;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractBasicJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -92,12 +93,12 @@ public class CharacterJavaDescriptor extends AbstractBasicJavaDescriptor<Charact
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
+	public long getDefaultSqlLength(Dialect dialect) {
 		return 1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 3;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/DoubleJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/DoubleJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -109,12 +110,12 @@ public class DoubleJavaDescriptor extends AbstractNumericJavaDescriptor<Double> 
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+2+6;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+2+6;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 17;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/DoubleJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/DoubleJavaDescriptor.java
@@ -107,4 +107,14 @@ public class DoubleJavaDescriptor extends AbstractNumericJavaDescriptor<Double> 
 	public Double getDefaultValue() {
 		return ZERO;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+2+6;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 17;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/FloatJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/FloatJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -107,12 +108,12 @@ public class FloatJavaDescriptor extends AbstractNumericJavaDescriptor<Float> im
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+2+5;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+2+5;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 8;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/FloatJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/FloatJavaDescriptor.java
@@ -105,4 +105,14 @@ public class FloatJavaDescriptor extends AbstractNumericJavaDescriptor<Float> im
 	public Float getDefaultValue() {
 		return ZERO;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+2+5;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 8;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/IntegerJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/IntegerJavaDescriptor.java
@@ -114,4 +114,20 @@ public class IntegerJavaDescriptor extends AbstractNumericJavaDescriptor<Integer
 	public VersionSupport<Integer> getVersionSupport() {
 		return IntegerVersionSupport.INSTANCE;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 10;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/IntegerJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/IntegerJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -116,12 +117,12 @@ public class IntegerJavaDescriptor extends AbstractNumericJavaDescriptor<Integer
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+1;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 10;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/JavaTypeDescriptorBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/JavaTypeDescriptorBaseline.java
@@ -69,6 +69,7 @@ public class JavaTypeDescriptorBaseline {
 		target.addBaselineDescriptor( DurationJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( InstantJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( LocalDateJavaDescriptor.INSTANCE );
+		target.addBaselineDescriptor( LocalTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( LocalDateTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( OffsetDateTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( OffsetTimeJavaDescriptor.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/LongJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/LongJavaDescriptor.java
@@ -114,4 +114,20 @@ public class LongJavaDescriptor extends AbstractNumericJavaDescriptor<Long> impl
 	public VersionSupport<Long> getVersionSupport() {
 		return LongVersionSupport.INSTANCE;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 19;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/LongJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/LongJavaDescriptor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -116,12 +117,12 @@ public class LongJavaDescriptor extends AbstractNumericJavaDescriptor<Long> impl
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+1;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 19;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ShortJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ShortJavaDescriptor.java
@@ -104,4 +104,19 @@ public class ShortJavaDescriptor extends AbstractNumericJavaDescriptor<Short> im
 	public VersionSupport<Short> getVersionSupport() {
 		return ShortVersionSupport.INSTANCE;
 	}
+
+	@Override
+	public long getDefaultSqlLength() {
+		return getDefaultSqlPrecision()+1;
+	}
+
+	@Override
+	public int getDefaultSqlPrecision() {
+		return 5;
+	}
+
+	@Override
+	public int getDefaultSqlScale() {
+		return 0;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ShortJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/internal/ShortJavaDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java.internal;
 
 import java.sql.Types;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.java.spi.AbstractNumericJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -106,12 +107,12 @@ public class ShortJavaDescriptor extends AbstractNumericJavaDescriptor<Short> im
 	}
 
 	@Override
-	public long getDefaultSqlLength() {
-		return getDefaultSqlPrecision()+1;
+	public long getDefaultSqlLength(Dialect dialect) {
+		return getDefaultSqlPrecision(dialect)+1;
 	}
 
 	@Override
-	public int getDefaultSqlPrecision() {
+	public int getDefaultSqlPrecision(Dialect dialect) {
 		return 5;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/AbstractJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/AbstractJavaDescriptor.java
@@ -9,6 +9,8 @@ package org.hibernate.type.descriptor.java.spi;
 import java.util.Comparator;
 import java.util.Objects;
 
+import org.hibernate.dialect.Dialect;
+import org.hibernate.metamodel.model.relational.spi.Size;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
 
 import org.jboss.logging.Logger;
@@ -78,4 +80,7 @@ public abstract class AbstractJavaDescriptor<T> implements JavaTypeDescriptor<T>
 	public boolean areEqual(T one, T another) {
 		return Objects.equals( one, another );
 	}
+
+
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptor.java
@@ -7,6 +7,7 @@
 package org.hibernate.type.descriptor.java.spi;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.model.relational.spi.Size;
 import org.hibernate.type.descriptor.spi.SqlTypeDescriptorIndicators;
 import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptor;
 
@@ -33,6 +34,18 @@ public interface JavaTypeDescriptor<T> extends org.hibernate.type.descriptor.jav
 	 * todo (6.0) : ? - rename `#getImplicitSqlTypeDescriptor` ?
 	 */
 	SqlTypeDescriptor getJdbcRecommendedSqlType(SqlTypeDescriptorIndicators context);
+
+	default long getDefaultSqlLength() {
+		return Size.Builder.DEFAULT_LENGTH;
+	}
+
+	default int getDefaultSqlPrecision() {
+		return Size.Builder.DEFAULT_PRECISION;
+	}
+
+	default int getDefaultSqlScale() {
+		return Size.Builder.DEFAULT_SCALE;
+	}
 
 	/**
 	 * Unwrap an instance of our handled Java type into the requested type.

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.descriptor.java.spi;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.relational.spi.Size;
 import org.hibernate.type.descriptor.spi.SqlTypeDescriptorIndicators;
@@ -35,11 +36,11 @@ public interface JavaTypeDescriptor<T> extends org.hibernate.type.descriptor.jav
 	 */
 	SqlTypeDescriptor getJdbcRecommendedSqlType(SqlTypeDescriptorIndicators context);
 
-	default long getDefaultSqlLength() {
+	default long getDefaultSqlLength(Dialect dialect) {
 		return Size.Builder.DEFAULT_LENGTH;
 	}
 
-	default int getDefaultSqlPrecision() {
+	default int getDefaultSqlPrecision(Dialect dialect) {
 		return Size.Builder.DEFAULT_PRECISION;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorRegistry.java
@@ -56,7 +56,7 @@ public class JavaTypeDescriptorRegistry implements Serializable, JavaTypeDescrip
 		if ( descriptor.getJavaType() == null ) {
 			throw new IllegalStateException( "Illegal to add BasicJavaTypeDescriptor with null Java type" );
 		}
-		addBaselineDescriptor( (Class) descriptor.getJavaType(), descriptor );
+		addBaselineDescriptor( descriptor.getJavaType(), descriptor );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -14,6 +14,9 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -589,6 +592,9 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			case "time": return standardExpressableTypeForJavaType( Time.class );
 			case "date": return standardExpressableTypeForJavaType( Date.class );
 			case "timestamp": return standardExpressableTypeForJavaType( Timestamp.class );
+			case "localtime": return standardExpressableTypeForJavaType( LocalTime.class );
+			case "localdate": return standardExpressableTypeForJavaType( LocalDate.class );
+			case "localdatetime": return standardExpressableTypeForJavaType( LocalDateTime.class );
 			case "biginteger": return standardExpressableTypeForJavaType( BigInteger.class );
 			case "bigdecimal": return standardExpressableTypeForJavaType( BigDecimal.class );
 			case "binary":

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -580,6 +580,7 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	public BasicValuedExpressableType<?> resolveCastTargetType(String name) {
 		switch ( name.toLowerCase() ) {
 			case "string": return standardExpressableTypeForJavaType( String.class );
+			case "character": return standardExpressableTypeForJavaType( Character.class );
 			case "byte": return standardExpressableTypeForJavaType( Byte.class );
 			case "integer": return standardExpressableTypeForJavaType( Integer.class );
 			case "long": return standardExpressableTypeForJavaType( Long.class );
@@ -594,6 +595,9 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 				//TODO: why does this not work:
 //				standardExpressableTypeForJavaType( byte[].class );
 				return resolveStandardBasicType( StandardSpiBasicTypes.BINARY );
+			//this one is very fragile ... works well for BIT or BOOLEAN columns only
+			//works OK, I suppose, for integer columns, but not at all for char columns
+			case "boolean": return standardExpressableTypeForJavaType( Boolean.class );
 			default: throw new HibernateException( "unrecognized cast target type: " + name );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -10,6 +10,9 @@ import java.io.InvalidObjectException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,7 +26,6 @@ import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.cfgxml.spi.CfgXmlAccessService;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataBuildingContext;
-import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.id.uuid.LocalObjectUuidHelper;
 import org.hibernate.internal.CoreMessageLogger;
@@ -562,14 +564,39 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 
 	}
 
-	public BasicType resolveCastTargetType(String name) {
-		throw new NotYetImplementedException(  );
+	/**
+	 * Understands the following target type names for the cast() function:
+	 *
+	 * - String
+	 * - Byte, Integer, Long
+	 * - Float, Double
+	 * - Time, Date, Timestamp
+	 * - BigInteger
+	 * - BigDecimal
+	 * - Binary
+	 *
+	 * (The type names are not case-sensitive.)
+	 */
+	public BasicValuedExpressableType<?> resolveCastTargetType(String name) {
+		switch ( name.toLowerCase() ) {
+			case "string": return standardExpressableTypeForJavaType( String.class );
+			case "byte": return standardExpressableTypeForJavaType( Byte.class );
+			case "integer": return standardExpressableTypeForJavaType( Integer.class );
+			case "long": return standardExpressableTypeForJavaType( Long.class );
+			case "float": return standardExpressableTypeForJavaType( Float.class );
+			case "double": return standardExpressableTypeForJavaType( Double.class );
+			case "time": return standardExpressableTypeForJavaType( Time.class );
+			case "date": return standardExpressableTypeForJavaType( Date.class );
+			case "timestamp": return standardExpressableTypeForJavaType( Timestamp.class );
+			case "biginteger": return standardExpressableTypeForJavaType( BigInteger.class );
+			case "bigdecimal": return standardExpressableTypeForJavaType( BigDecimal.class );
+			case "binary":
+				//TODO: why does this not work:
+//				standardExpressableTypeForJavaType( byte[].class );
+				return resolveStandardBasicType( StandardSpiBasicTypes.BINARY );
+			default: throw new HibernateException( "unrecognized cast target type: " + name );
+		}
 	}
-
-
-
-
-
 
 	/**
 	 * Encapsulation of lifecycle concerns for a TypeConfiguration, mainly in

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -205,6 +205,8 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                             .list();
                     session.createQuery("select cast(e.id as String), cast(e.theInt as String), cast(e.theDouble as String) from EntityOfBasics e")
                             .list();
+                    session.createQuery("select cast(e.id as Float), cast(e.theInt as Double), cast(e.theDouble as Long) from EntityOfBasics e")
+                            .list();
                     session.createQuery("select cast(e.id as BigInteger(10)), cast(e.theDouble as BigDecimal(10,5)) from EntityOfBasics e")
                             .list();
                     session.createQuery("select cast(e.theString as String(15)), cast(e.theDouble as String(8)) from EntityOfBasics e")
@@ -225,6 +227,10 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                     session.createQuery("select cast('3811234234.12312' as Double) from EntityOfBasics")
                             .getResultList();
                     session.createQuery("select cast('1234234' as Integer) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast(1 as Boolean), cast(0 as Boolean) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('ABCDEF' as Character) from EntityOfBasics")
                             .getResultList();
                 }
         );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -217,21 +217,28 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                             .list();
 
                     session.createQuery("select cast('1002342345234523.452435245245243' as BigDecimal) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('1002342345234523.452435245245243' as BigDecimal(30, 10)) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('1234234523452345243524524524' as BigInteger) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('1234234523452345243524524524' as BigInteger(30)) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('3811234234.12312' as Double) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('1234234' as Integer) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast(1 as Boolean), cast(0 as Boolean) from EntityOfBasics")
-                            .getResultList();
+                            .list();
                     session.createQuery("select cast('ABCDEF' as Character) from EntityOfBasics")
-                            .getResultList();
+                            .list();
+
+                    session.createQuery("select cast('12:13:14' as LocalTime) from EntityOfBasics")
+                            .list();
+                    session.createQuery("select cast('1911-10-09' as LocalDate) from EntityOfBasics")
+                            .list();
+                    session.createQuery("select cast('1911-10-09 12:13:14.123' as LocalDateTime) from EntityOfBasics")
+                            .list();
                 }
         );
     }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -233,6 +233,13 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                     session.createQuery("select cast('ABCDEF' as Character) from EntityOfBasics")
                             .list();
 
+                    session.createQuery("select cast('12:13:14' as Time) from EntityOfBasics")
+                            .list();
+                    session.createQuery("select cast('1911-10-09' as Date) from EntityOfBasics")
+                            .list();
+                    session.createQuery("select cast('1911-10-09 12:13:14.123' as Timestamp) from EntityOfBasics")
+                            .list();
+
                     session.createQuery("select cast('12:13:14' as LocalTime) from EntityOfBasics")
                             .list();
                     session.createQuery("select cast('1911-10-09' as LocalDate) from EntityOfBasics")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -201,10 +201,31 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
     public void testCastFunction() {
         inTransaction(
                 session -> {
-                    session.createQuery("select cast(e.theDate as string), cast(e.theTime as string), cast(e.theTimestamp as string) from EntityOfBasics e")
+                    session.createQuery("select cast(e.theDate as String), cast(e.theTime as String), cast(e.theTimestamp as String) from EntityOfBasics e")
                             .list();
-                    session.createQuery("select cast(e.id as string), cast(e.theInt as string), cast(e.theDouble as string) from EntityOfBasics e")
+                    session.createQuery("select cast(e.id as String), cast(e.theInt as String), cast(e.theDouble as String) from EntityOfBasics e")
                             .list();
+                    session.createQuery("select cast(e.id as BigInteger(10)), cast(e.theDouble as BigDecimal(10,5)) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select cast(e.theString as String(15)), cast(e.theDouble as String(8)) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select cast(e.theString as Binary) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select cast(e.theString as Binary(10)) from EntityOfBasics e")
+                            .list();
+
+                    session.createQuery("select cast('1002342345234523.452435245245243' as BigDecimal) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('1002342345234523.452435245245243' as BigDecimal(30, 10)) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('1234234523452345243524524524' as BigInteger) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('1234234523452345243524524524' as BigInteger(30)) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('3811234234.12312' as Double) from EntityOfBasics")
+                            .getResultList();
+                    session.createQuery("select cast('1234234' as Integer) from EntityOfBasics")
+                            .getResultList();
                 }
         );
     }


### PR DESCRIPTION
With this patch, the following additional `cast()` target types are now supported

- `Binary`
- `Character`
- `BigDecimal` and `BigInteger`
- `Boolean` (with caveats)
- `LocalTime`
- `LocalDate`
- `LocalDateTime`

Also, length or precision/scale may be specified for target types.

- `cast(number as String(10))`
- `cast(text as Binary(100)`
- `cast(amount as BigInteger(20))`
- `cast(measurement as BigDecimal(10, 5))`

Of course, the length, precision, or scale might be ignored, depending on the database type defined by the `Dialect`. (In particular, the are *always* ignored on Spanner, which doesn't support length, precision, or scale in `cast()`.)

Also, when any `DECIMAL` type occurs without an explicitly-defined precision, a database-specific default is used. This makes `cast`ing and DDL generation more portable across databases when you're using `BigInteger`s or `BigDecimal`s.