### PR TITLE
 add 'day of week' and 'day of year' as allowed parameters to extract()

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
@@ -795,6 +795,7 @@ extractFunction
 
 extractField
 	: datetimeField
+	| dayField
 	| timeZoneField
 	| secondsField
 	;
@@ -809,6 +810,12 @@ datetimeField
 	| MINUTE
 	| SECOND
 	;
+
+dayField
+	: DAY OF MONTH
+	| DAY OF WEEK
+	| DAY OF YEAR
+    ;
 
 secondsField
 	: MILLISECOND

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -566,4 +566,15 @@ public class DB2Dialect extends Dialect {
 	public boolean supportsPartitionBy() {
 		return true;
 	}
+
+	@Override
+	public String translateExtractField(String fieldName) {
+		switch ( fieldName ) {
+			case "dayofmonth": return "day";
+			case "dayofyear": return "doy";
+			case "dayofweek": return "dow";
+			default: return fieldName;
+		}
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3257,4 +3257,13 @@ public abstract class Dialect implements ConversionContext {
 			return null;
 		}
 	}
+
+	public String translateExtractField(String fieldName) {
+		switch ( fieldName ) {
+			case "dayofmonth": return "dd";
+			case "dayofyear": return "dy";
+			case "dayofweek": return "dw";
+			default: return fieldName;
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -650,4 +650,14 @@ public class HSQLDialect extends Dialect {
 	public String getCascadeConstraintsString() {
 		return " CASCADE ";
 	}
+
+	@Override
+	public String translateExtractField(String fieldName) {
+		switch ( fieldName ) {
+			case "dayofmonth": return "day_of_month";
+			case "dayofyear": return "day_of_year";
+			case "dayofweek": return "day_of_week";
+			default: return fieldName;
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -322,4 +322,15 @@ public class IngresDialect extends Dialect {
 	public boolean supportsTupleDistinctCounts() {
 		return false;
 	}
+
+	@Override
+	public String translateExtractField(String fieldName) {
+		switch ( fieldName ) {
+			case "dayofmonth": return "day";
+			case "dayofyear": return "doy";
+			case "dayofweek": return "dow";
+			default: return fieldName;
+		}
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -604,4 +604,13 @@ public class PostgreSQL81Dialect extends Dialect {
 		return false;
 	}
 
+	@Override
+	public String translateExtractField(String fieldName) {
+		switch ( fieldName ) {
+			case "dayofmonth": return "day";
+			case "dayofyear": return "doy";
+			case "dayofweek": return "dow";
+			default: return fieldName;
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -2069,6 +2069,21 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	}
 
 	@Override
+	public Object visitDayField(HqlParser.DayFieldContext ctx) {
+		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
+		if (ctx.WEEK()!=null) {
+			return new SqmExtractUnit<>("dayofweek", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+		}
+		if (ctx.MONTH()!=null) {
+			return new SqmExtractUnit<>("dayofmonth", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+		}
+		if (ctx.YEAR()!=null) {
+			return new SqmExtractUnit<>("dayofyear", resolveExpressableTypeBasic( Integer.class ), nodeBuilder);
+		}
+		return super.visitDayField(ctx);
+	}
+
+	@Override
 	public Object visitSecondsField(HqlParser.SecondsFieldContext ctx) {
 		NodeBuilder nodeBuilder = creationContext.getNodeBuilder();
 		if (ctx.MICROSECOND()!=null) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/consume/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/consume/spi/AbstractSqlAstWalker.java
@@ -400,7 +400,7 @@ public abstract class AbstractSqlAstWalker
 
 	@Override
 	public void visitExtractUnit(ExtractUnit unit) {
-		appendSql( unit.getName() );
+		appendSql( sessionFactory.getJdbcServices().getDialect().translateExtractField( unit.getName() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -232,6 +232,18 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                     session.createQuery("select extract(day from e.theDate) from EntityOfBasics e")
                             .list();
 
+                    session.createQuery("select extract(day of year from e.theDate) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select extract(day of month from e.theDate) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select extract(day of week from e.theDate) from EntityOfBasics e")
+                            .list();
+
+                    session.createQuery("select extract(week from e.theDate) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select extract(quarter from e.theDate) from EntityOfBasics e")
+                            .list();
+
                     session.createQuery("select extract(hour from e.theTime) from EntityOfBasics e")
                             .list();
                     session.createQuery("select extract(minute from e.theTime) from EntityOfBasics e")
@@ -251,6 +263,12 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
                             .list();
                     session.createQuery("select extract(second from e.theTimestamp) from EntityOfBasics e")
                             .list();
+
+                    session.createQuery("select extract(timezone_hour from e.theTime) from EntityOfBasics e")
+                            .list();
+                    session.createQuery("select extract(timezone_hour minute from e.theTime) from EntityOfBasics e")
+                            .list();
+
                 }
         );
     }


### PR DESCRIPTION
With this patch, the `extract()` function accepts `day of week` and `day of year`. Oh and `day of month` just for completeness (a synonym for `day`).

    select extract(day of year from person.dob) from Person person

It works on Ingres, SQL Server, Sybase, H2, HSQLDB, Postgres, DB2, and Cache.

It doesn't work on MySQL, Oracle, SAP, HANA, Informix, Unisys, McKoi, nor TimesTen.

So, exactly *half* of the platforms.

In principle `extract(day of year from ...)` could be made to work on some other platforms by date arithmetic. For example, in MySQL it could map to:

    timestampdiff(day, arg, makedate(extract(year from arg), 0))

But I'm not going to implement that RN. 