### PR TITLE
promote left() and right() functions to work on all platforms

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/query/hql/internal/HqlParser.g4
@@ -577,6 +577,8 @@ standardFunction
 	|	extractFunction
 	|	concatFunction
 	|	substringFunction
+	|	leftFunction
+	|	rightFunction
 	|   replaceFunction
 	|	trimFunction
 	|	upperFunction
@@ -623,6 +625,13 @@ castTarget
 
 concatFunction
 	: CONCAT LEFT_PAREN expression (COMMA expression)+ RIGHT_PAREN
+	;
+
+leftFunction
+	: LEFT LEFT_PAREN expression COMMA expression RIGHT_PAREN
+	;
+rightFunction
+	: RIGHT LEFT_PAREN expression COMMA expression RIGHT_PAREN
 	;
 
 substringFunction

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -293,7 +293,6 @@ public abstract class AbstractHANADialect extends Dialect {
 		CommonFunctionFactory.weekQuarter( queryEngine );
 		CommonFunctionFactory.daynameMonthname( queryEngine );
 		CommonFunctionFactory.lastDay( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.characterLength_length( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.chr_char( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -73,7 +73,6 @@ abstract class AbstractTransactSQLDialect extends Dialect {
 		CommonFunctionFactory.chr_char( queryEngine );
 		CommonFunctionFactory.trim1( queryEngine );
 		CommonFunctionFactory.repeat_replicate( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.characterLength_len( queryEngine );
 		CommonFunctionFactory.extract_datepart( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -268,7 +268,6 @@ public class Cache71Dialect extends Dialect {
 		CommonFunctionFactory.truncate( queryEngine );
 		CommonFunctionFactory.dayofweekmonthyear( queryEngine );
 		CommonFunctionFactory.repeat_replicate( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.extract_datepart( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.chr_char( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -164,7 +164,6 @@ public class DB2Dialect extends Dialect {
 		CommonFunctionFactory.toCharNumberDateTimestamp( queryEngine );
 		CommonFunctionFactory.dateTimeTimestamp( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.octetLength( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.char_chr( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -278,6 +278,7 @@ public abstract class Dialect implements ConversionContext {
 	 * And a number of additional "standard" functions:
 	 *
 	 * 	    * ifnull (two-argument synonym for coalesce)
+	 *      * left, right
 	 *      * replace
 	 *      * least, greatest
 	 *      * sign
@@ -321,6 +322,7 @@ public abstract class Dialect implements ConversionContext {
 		CommonFunctionFactory.characterLength(queryEngine);
 		CommonFunctionFactory.locate(queryEngine);
 		CommonFunctionFactory.substring(queryEngine);
+		CommonFunctionFactory.leftRight(queryEngine);
 		CommonFunctionFactory.replace(queryEngine);
 		CommonFunctionFactory.concat(queryEngine);
 		CommonFunctionFactory.lowerUpper(queryEngine);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -160,7 +160,6 @@ public class H2Dialect extends Dialect {
 		CommonFunctionFactory.dayOfWeekMonthYear( queryEngine );
 		CommonFunctionFactory.weekQuarter( queryEngine );
 		CommonFunctionFactory.daynameMonthname( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.localtimeLocaltimestamp( queryEngine );
 		CommonFunctionFactory.bitLength( queryEngine );
 		CommonFunctionFactory.octetLength( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -200,7 +200,6 @@ public class HSQLDialect extends Dialect {
 		CommonFunctionFactory.trim1( queryEngine );
 		CommonFunctionFactory.toCharNumberDateTimestamp( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.localtimeLocaltimestamp( queryEngine );
 		CommonFunctionFactory.bitLength( queryEngine );
 		CommonFunctionFactory.octetLength( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -98,7 +98,6 @@ public class InformixDialect extends Dialect {
 		CommonFunctionFactory.yearMonthDay( queryEngine );
 		CommonFunctionFactory.ceiling_ceil( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.char_chr( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -117,7 +117,6 @@ public class IngresDialect extends Dialect {
 		CommonFunctionFactory.trunc( queryEngine );
 		CommonFunctionFactory.truncate( queryEngine );
 		CommonFunctionFactory.initcap( queryEngine );
-		CommonFunctionFactory.substring_substr( queryEngine );
 		CommonFunctionFactory.yearMonthDay( queryEngine );
 		CommonFunctionFactory.hourMinuteSecond( queryEngine );
 		CommonFunctionFactory.dayofweekmonthyear( queryEngine );
@@ -125,7 +124,6 @@ public class IngresDialect extends Dialect {
 		CommonFunctionFactory.lastDay( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
 		CommonFunctionFactory.substring_substr( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.char_chr( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MckoiDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MckoiDialect.java
@@ -62,6 +62,7 @@ public class MckoiDialect extends Dialect {
 		super.initializeFunctionRegistry(queryEngine);
 
 		CommonFunctionFactory.characterLength_length( queryEngine );
+		CommonFunctionFactory.trim1( queryEngine );
 
 		queryEngine.getSqmFunctionRegistry().patternTemplateBuilder( "nullif", "if(?1=?2, null, ?1)" )
 				.setExactArgumentCount(2)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -206,7 +206,6 @@ public class MySQLDialect extends Dialect {
 		CommonFunctionFactory.variance( queryEngine );
 		CommonFunctionFactory.dateTimeTimestamp( queryEngine );
 		CommonFunctionFactory.rand( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.crc32( queryEngine );
 		CommonFunctionFactory.sha1sha2( queryEngine );
 		CommonFunctionFactory.sha( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -153,6 +153,7 @@ public class Oracle8iDialect extends Dialect {
 		CommonFunctionFactory.initcap( queryEngine );
 		CommonFunctionFactory.instr( queryEngine );
 		CommonFunctionFactory.substring_substr( queryEngine );
+		CommonFunctionFactory.leftRight_substr( queryEngine );
 		CommonFunctionFactory.translate( queryEngine );
 		CommonFunctionFactory.bitand( queryEngine );
 		CommonFunctionFactory.lastDay( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9Dialect.java
@@ -107,6 +107,7 @@ public class Oracle9Dialect extends Dialect {
 		CommonFunctionFactory.initcap( queryEngine );
 		CommonFunctionFactory.instr( queryEngine );
 		CommonFunctionFactory.substring_substr( queryEngine );
+		CommonFunctionFactory.leftRight_substr( queryEngine );
 		CommonFunctionFactory.translate( queryEngine );
 		CommonFunctionFactory.bitand( queryEngine );
 		CommonFunctionFactory.lastDay( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -126,7 +126,6 @@ public class PostgreSQL81Dialect extends Dialect {
 		CommonFunctionFactory.rand_random( queryEngine );
 		CommonFunctionFactory.toCharNumberDateTimestamp( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.localtimeLocaltimestamp( queryEngine );
 		CommonFunctionFactory.bitLength( queryEngine );
 		CommonFunctionFactory.octetLength( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
@@ -187,7 +187,6 @@ public class RDMSOS2200Dialect extends Dialect {
 		CommonFunctionFactory.lastDay( queryEngine );
 		CommonFunctionFactory.ceiling_ceil( queryEngine );
 		CommonFunctionFactory.concat_operator( queryEngine );
-		CommonFunctionFactory.leftRight( queryEngine );
 		CommonFunctionFactory.ascii( queryEngine );
 		CommonFunctionFactory.chr_char( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenDialect.java
@@ -93,6 +93,7 @@ public class TimesTenDialect extends Dialect {
 		CommonFunctionFactory.toCharNumberDateTimestamp( queryEngine );
 		CommonFunctionFactory.ceiling_ceil( queryEngine );
 		CommonFunctionFactory.substring_substr( queryEngine );
+		CommonFunctionFactory.leftRight_substr( queryEngine );
 		CommonFunctionFactory.char_chr( queryEngine );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -218,6 +218,17 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	public static void leftRight_substr(QueryEngine queryEngine) {
+		queryEngine.getSqmFunctionRegistry().patternTemplateBuilder( "left", "substr(?1,0,?2)" )
+				.setInvariantType( StandardSpiBasicTypes.STRING )
+				.setExactArgumentCount( 2 )
+				.register();
+		queryEngine.getSqmFunctionRegistry().patternTemplateBuilder( "right", "substr(?1,-?2)" )
+				.setInvariantType( StandardSpiBasicTypes.STRING )
+				.setExactArgumentCount( 2 )
+				.register();
+	}
+
 	public static void repeat_replicate(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder( "replicate" )
 				.setInvariantType( StandardSpiBasicTypes.STRING )

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -2341,7 +2341,30 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 				resolveExpressableTypeBasic( String.class ),
 				creationContext.getQueryEngine()
 		);
+	}
 
+	@Override
+	public SqmExpression visitLeftFunction(HqlParser.LeftFunctionContext ctx) {
+		final SqmExpression source = (SqmExpression) ctx.expression(0).accept( this );
+		final SqmExpression length = (SqmExpression) ctx.expression(1).accept( this );
+
+		return getFunctionTemplate("left").makeSqmFunctionExpression(
+				asList( source, length ),
+				resolveExpressableTypeBasic( String.class ),
+				creationContext.getQueryEngine()
+		);
+	}
+
+	@Override
+	public SqmExpression visitRightFunction(HqlParser.RightFunctionContext ctx) {
+		final SqmExpression source = (SqmExpression) ctx.expression(0).accept( this );
+		final SqmExpression length = (SqmExpression) ctx.expression(1).accept( this );
+
+		return getFunctionTemplate("right").makeSqmFunctionExpression(
+				asList( source, length ),
+				resolveExpressableTypeBasic( String.class ),
+				creationContext.getQueryEngine()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/execution/FunctionTests.java
@@ -152,6 +152,16 @@ public class FunctionTests extends SessionFactoryBasedFunctionalTest {
     }
 
     @Test
+    public void testLeftRightFunctions() {
+        inTransaction(
+                session -> {
+                    session.createQuery("select left(e.theString, e.theInt), right(e.theString, e.theInt) from EntityOfBasics e")
+                            .list();
+                }
+        );
+    }
+
+    @Test
     public void testPositionFunction() {
         inTransaction(
                 session -> {


### PR DESCRIPTION
The standard `substring()` function defined (in slightly different forms) by ANSI SQL and JPA is useful, but can be quite hard to use for some simple things, especially since the XQLs have no `let` expressions.

For many common tasks, `left()` and `right()` are easier to use, especially since you don't need to compute the length of the string to use `right()`.

Hence, almost every database supports `left()` and `right()`, except Oracle and TimesTen which let you simulate `right()` by passing a negative index to `substring()`.

This patch makes it possible to use `left()` and `right()` on all platforms (including Oracle and TimesTen). Well, all platforms except McKoi, but I don't think we care about McKoi.

