### PR TITLE
two fixes for boolean attribute handling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -129,7 +129,7 @@ public class HSQLDialect extends Dialect {
 
 		registerColumnType( Types.BIGINT, "bigint" );
 		registerColumnType( Types.BINARY, "binary($l)" );
-		registerColumnType( Types.BIT, "bit" );
+		registerColumnType( Types.BIT, "boolean" );
 		registerColumnType( Types.BOOLEAN, "boolean" );
 		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.DATE, "date" );
@@ -137,6 +137,7 @@ public class HSQLDialect extends Dialect {
 		registerColumnType( Types.DECIMAL, "decimal($p,$s)" );
 		registerColumnType( Types.DOUBLE, "double" );
 		registerColumnType( Types.FLOAT, "float" );
+		registerColumnType( Types.REAL, "real" );
 		registerColumnType( Types.INTEGER, "integer" );
 		registerColumnType( Types.LONGVARBINARY, "longvarbinary" );
 		registerColumnType( Types.LONGVARCHAR, "longvarchar" );
@@ -146,7 +147,6 @@ public class HSQLDialect extends Dialect {
 		registerColumnType( Types.TIMESTAMP, "timestamp" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
 		registerColumnType( Types.VARBINARY, "varbinary($l)" );
-		registerColumnType( Types.NCLOB, "clob" );
 
 		if ( hsqldbVersion < 200 ) {
 			registerColumnType( Types.NUMERIC, "numeric" );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/BitSqlDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/BitSqlDescriptor.java
@@ -19,6 +19,7 @@ import org.hibernate.sql.JdbcValueExtractor;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.type.descriptor.java.spi.BasicJavaDescriptor;
 import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptor;
+import org.hibernate.type.descriptor.sql.internal.JdbcLiteralFormatterBoolean;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -52,8 +53,7 @@ public class BitSqlDescriptor extends AbstractTemplateSqlTypeDescriptor {
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaTypeDescriptor<T> javaTypeDescriptor) {
-		// todo : how to handle this
-		return null;
+		return new JdbcLiteralFormatterBoolean(javaTypeDescriptor);
 	}
 
 	@Override


### PR DESCRIPTION
This patch makes two somewhat-related changes:

1. fixes rendering of boolean literals 'true' and 'false' to SQL
2. fixes type mapping for boolean attributes in HSQL

1: This is simply a fix for a bug in the new query parser

2: The HSQL documentation states explicitly that BIT is not the right way to
represent booleans in HSQL, and that BOOLEAN should be used instead.
And indeed, I was running in to problems arising from this incorrect
mapping.