### PR TITLE
[HHH-13410] Revert Miscellaneous Fixes

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
@@ -20,16 +20,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.MariaDB10Dialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
 import org.hibernate.testing.TestForIssue;
@@ -219,6 +214,10 @@ abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalTestCase
 		finally {
 			TimeZone.setDefault( timeZoneBefore );
 		}
+	}
+
+	protected final ZoneId getDefaultJvmTimeZone() {
+		return env.defaultJvmTimeZone;
 	}
 
 	protected final Class<? extends AbstractRemappingH2Dialect> getRemappingDialectClass() {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -18,6 +18,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -30,6 +31,7 @@ import org.hibernate.type.descriptor.sql.BigIntTypeDescriptor;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
 import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.SkipLog;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -183,9 +185,31 @@ public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetT
 
 	@Override
 	@Test
+	public void nativeWriteThenRead() {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) &&
+				!ZONE_GMT.equals( getDefaultJvmTimeZone() ) ) {
+			SkipLog.reportSkip( "OffsetTimeType remapped as timestamp only works reliably with GMT default JVM for nativeWriteThenRead; see HHH-13357" );
+			return;
+		}
+		super.nativeWriteThenRead();
+	}
+
+	@Override
+	@Test
 	@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA seems to return a java.sql.Timestamp instead of a java.sql.Time")
 	public void writeThenNativeRead() {
 		super.writeThenNativeRead();
+	}
+
+	@Override
+	@Test
+	public void writeThenRead() {
+		if ( TimeAsTimestampRemappingH2Dialect.class.equals( getRemappingDialectClass() ) &&
+				!ZONE_GMT.equals( getDefaultJvmTimeZone() ) ) {
+			SkipLog.reportSkip( "OffsetTimeType remapped as timestamp only works reliably with GMT default JVM for writeThenRead; see HHH-13357" );
+			return;
+		}
+		super.writeThenRead();
 	}
 
 	@Entity(name = ENTITY_NAME)


### PR DESCRIPTION
Several fixes were made in https://github.com/hibernate/hibernate-orm/pull/2726:

1. https://hibernate.atlassian.net/browse/HHH-13068 fix
2. (Probably) Considering components of Composite Identifiers during sorting
3. Others which are unreferenced in the PR

Since this PR has created issue https://hibernate.atlassian.net/projects/HHH/issues/HHH-13410 , I have attempted to isolate fixes made to https://hibernate.atlassian.net/browse/HHH-13068 and reverted other fixes in the PR so that regressions can be better tracked. This PR fixes linked issue HHH-13410