### PR TITLE
HHH-13415 Restore build compatibility with JDK11.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: java
 
-jdk:
-  - oraclejdk8
-install:
+jobs:
+  include:
+    - stage: Oracle JDK 8
+      jdk: oraclejdk8
+    - stage: AdoptOpenJDK 11.0.3
+      install:
+        - curl -L -o install-jdk.sh https://github.com/sormuras/bach/raw/master/install-jdk.sh
+        - source ./install-jdk.sh --target ./openjdk11 --url https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz
+
+before_script:
+  - java -version
   - ./gradlew assemble
 script:
   - travis_wait 45 ./gradlew check

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -128,17 +128,15 @@ task aggregateJavadocs(type: Javadoc) {
 				'http://docs.jboss.org/cdi/api/2.0/',
 				'https://javaee.github.io/javaee-spec/javadocs/'
 		]
-
-		//Workaround to get the JVM version while ignoring the Gradle Enums for versions,
-		//as they never support upcoming JVM versions (doesn't have a isJava12Compatible() yet )
+		
 		if ( JavaVersion.current().isJava11Compatible() ) {
-			//The need to set `--source 8` applies to all JVMs after 11, and also to 11
+			//The need to set `--source 1.8` applies to all JVMs after 11, and also to 11
 			// but after excluding the first two builds; see also specific comments on
 			// https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762
 			// For now, let's be compatible with JDK 11.0.3+. We can improve on it if people
 			// complain they cannot build with JDK 11.0.0, 11.0.1 and 11.0.2.
 			System.out.println("Forcing Javadoc in Java 8 compatible mode");
-			options.addStringOption('source', '8')
+			options.source = project.baselineJavaVersion
 		}
 
 		if ( JavaVersion.current().isJava8Compatible() ) {

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -98,16 +98,15 @@ javadoc {
 				'http://docs.jboss.org/cdi/api/2.0/',
 				'https://javaee.github.io/javaee-spec/javadocs/'
 		]
-		//Workaround to get the JVM version while ignoring the Gradle Enums for versions,
-		//as they never support upcoming JVM versions (doesn't have a isJava12Compatible() yet )
+		
 		if ( JavaVersion.current().isJava11Compatible() ) {
-			//The need to set `--source 8` applies to all JVMs after 11, and also to 11
+			//The need to set `--source 1.8` applies to all JVMs after 11, and also to 11
 			// but after excluding the first two builds; see also specific comments on
 			// https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762
 			// For now, let's be compatible with JDK 11.0.3+. We can improve on it if people
 			// complain they cannot build with JDK 11.0.0, 11.0.1 and 11.0.2.
 			System.out.println("Forcing Javadoc in Java 8 compatible mode");
-			options.addStringOption('source', '8')
+			options.source = project.baselineJavaVersion
 		}
 
 		if ( JavaVersion.current().isJava8Compatible() ) {

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -17,10 +17,28 @@ ext {
 	paxExamVersion = '4.12.0'
 }
 
+/*
+ * With the current karaf/pax-exam versions and with JDK11.0.3,
+ * we get errors like "java.lang.IllegalStateException: Unknown protocol: jrt".
+ *
+ * This is suspiciously similar to the problems we had on Hibernate Search,
+ * and we gave up the idea of fixing those after a few hours.
+ *
+ * Copy-pasting the explanation from Search (not sure it applies here, but it's likely):
+ * > Upgrading to Karaf 4.2.5 fixes that, but then we get errors about "/karaf.log" not being accessible.
+ * > Upgrading once again to Pax-exam 4.13.1 fixes that, but then startup looks stuck at some point,
+ * > without any particular error even if we raise all the different log levels to "trace".
+ * > Upgrading pax-url to 2.6.1 to be in line with the versions in the Karaf pom doesn't change anything.
+ * > Strangely, with these upgrades, everything still works fine with JDK8,
+ * > but we get in trouble with JDK11.0.0 and above.
+ * > A bit ironic since the problems we were trying to solve initially only affected JDK11.0.3,
+ * > not JDK11.0.0.
+ */
 if ( JavaVersion.current().isJava11Compatible() ) {
 	logger.warn( '[WARN] Skipping all tests for hibernate-osgi due to Karaf/Pax-Exam issues with latest JDK 11' )
 	test.enabled = false
 }
+
 
 sourceSets {
 	test {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-13415

Necessary to work on [HHH-13409](https://hibernate.atlassian.net//browse/HHH-13409) in particular.