### PR TITLE
HHH-13409 Hibernate ORM does not detect services provided by libraries in the module path

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -16,6 +16,7 @@ ext {
 			'hibernate-ehcache',
 			'hibernate-java8',
 			'hibernate-orm-modules',
+			'hibernate-integrationtest-java-modules',
 			'release'
 	]
 }

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -81,7 +81,6 @@ dependencies {
 	testRuntime( libraries.log4j )
 	testRuntime( libraries.javassist )
 	testRuntime( libraries.byteBuddy )
-	testRuntime( libraries.woodstox )
 
 	//Databases
 	testRuntime( libraries.h2 )

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -53,9 +53,6 @@ ext {
             jandex:         'org.jboss:jandex:2.0.5.Final',
             classmate:      'com.fasterxml:classmate:1.3.4',
 
-            // Woodstox
-            woodstox:           "org.codehaus.woodstox:woodstox-core-asl:4.3.0",
-
             // Dom4J
             dom4j:          'org.dom4j:dom4j:2.1.1@jar',
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedClassLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedClassLoader.java
@@ -22,7 +22,7 @@ public class AggregatedClassLoader extends ClassLoader {
 		tcclLookupPrecedence = precedence;
 	}
 
-	private Iterator<ClassLoader> newClassLoaderIterator() {
+	Iterator<ClassLoader> newClassLoaderIterator() {
 		final ClassLoader threadClassLoader = locateTCCL();
 		if ( tcclLookupPrecedence == TcclLookupPrecedence.NEVER || threadClassLoader == null ) {
 			return newTcclNeverIterator();

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
@@ -6,32 +6,77 @@
  */
 package org.hibernate.boot.registry.classloading.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 
 /**
  * A service loader bound to an {@link AggregatedClassLoader}.
+ * <p>
+ * When retrieving services from providers in the module path,
+ * the service loader internally uses a map from classloader to service catalog.
+ * Since the aggregated class loader is artificial and unknown from the service loader,
+ * it will never match any service from the module path.
+ * <p>
+ * To work around this problem,
+ * we instantiate one service loader per individual class loader and get services from these.
+ * This could result in duplicates, so we take specific care to avoid using the same service provider twice.
+ * See {@link #getAll()}.
+ * <p>
+ * Note that, in the worst case,
+ * the service retrieved from each individual class loader could load duplicate versions
+ * of classes already loaded from another class loader.
+ * For example in an aggregated class loader made up of individual class loader A, B, C:
+ * it is possible that class C1 was already loaded from A,
+ * but then we load service S1 from B, and this service will also need class C1 but won't find it in class loader B,
+ * so it will load its own version of that class.
+ * <p>
+ * We assume that this situation will never occur in practice because class loaders
+ * are structure in a hierarchy that prevents one class to be loaded twice.
+ *
  * @param <S> The type of the service contract.
  */
 final class AggregatedServiceLoader<S> {
 
-	private final ServiceLoader<S> delegate;
+	private final List<ServiceLoader<S>> delegates;
 
 	AggregatedServiceLoader(AggregatedClassLoader aggregatedClassLoader, Class<S> serviceContract) {
-		this.delegate = ServiceLoader.load( serviceContract, aggregatedClassLoader );
+		this.delegates = new ArrayList<>();
+		final Iterator<ClassLoader> clIterator = aggregatedClassLoader.newClassLoaderIterator();
+		while ( clIterator.hasNext() ) {
+			this.delegates.add(
+					ServiceLoader.load( serviceContract, clIterator.next() )
+			);
+		}
 	}
 
 	/**
 	 * @return All the loaded services.
 	 */
 	public Collection<S> getAll() {
-		final Set<S> services = new LinkedHashSet<>();
-		for ( S service : delegate ) {
-			services.add( service );
+		Set<String> alreadyEncountered = new HashSet<>();
+		Set<S> result = new LinkedHashSet<>();
+		for ( ServiceLoader<S> delegate : delegates ) {
+			for ( S service : delegate ) {
+				Class<?> type = service.getClass();
+				String typeName = type.getName();
+				/*
+				 * We may encounter the same service provider multiple times,
+				 * because the individual class loaders may give access to the same types
+				 * (at the very least a single class loader may be present twice in the aggregated class loader).
+				 * However, we only want to get the service from each provider once.
+				 */
+				if ( alreadyEncountered.add( typeName ) ) {
+					result.add( service );
+				}
+			}
 		}
-		return services;
+		return result;
 	}
 
 	/**
@@ -39,7 +84,8 @@ final class AggregatedServiceLoader<S> {
 	 */
 	public void close() {
 		// Clear service providers
-		delegate.reload();
+		for ( ServiceLoader<S> delegate : delegates ) {
+			delegate.reload();
+		}
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * A service loader bound to an {@link AggregatedClassLoader}.
+ * @param <S> The type of the service contract.
+ */
+final class AggregatedServiceLoader<S> {
+
+	private final ServiceLoader<S> delegate;
+
+	AggregatedServiceLoader(AggregatedClassLoader aggregatedClassLoader, Class<S> serviceContract) {
+		this.delegate = ServiceLoader.load( serviceContract, aggregatedClassLoader );
+	}
+
+	/**
+	 * @return All the loaded services.
+	 */
+	public Collection<S> getAll() {
+		final Set<S> services = new LinkedHashSet<>();
+		for ( S service : delegate ) {
+			services.add( service );
+		}
+		return services;
+	}
+
+	/**
+	 * Release all resources.
+	 */
+	public void close() {
+		// Clear service providers
+		delegate.reload();
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedServiceLoader.java
@@ -6,86 +6,236 @@
  */
 package org.hibernate.boot.registry.classloading.internal;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.hibernate.AssertionFailure;
 
 /**
  * A service loader bound to an {@link AggregatedClassLoader}.
- * <p>
- * When retrieving services from providers in the module path,
- * the service loader internally uses a map from classloader to service catalog.
- * Since the aggregated class loader is artificial and unknown from the service loader,
- * it will never match any service from the module path.
- * <p>
- * To work around this problem,
- * we instantiate one service loader per individual class loader and get services from these.
- * This could result in duplicates, so we take specific care to avoid using the same service provider twice.
- * See {@link #getAll()}.
- * <p>
- * Note that, in the worst case,
- * the service retrieved from each individual class loader could load duplicate versions
- * of classes already loaded from another class loader.
- * For example in an aggregated class loader made up of individual class loader A, B, C:
- * it is possible that class C1 was already loaded from A,
- * but then we load service S1 from B, and this service will also need class C1 but won't find it in class loader B,
- * so it will load its own version of that class.
- * <p>
- * We assume that this situation will never occur in practice because class loaders
- * are structure in a hierarchy that prevents one class to be loaded twice.
- *
  * @param <S> The type of the service contract.
  */
-final class AggregatedServiceLoader<S> {
+abstract class AggregatedServiceLoader<S> {
 
-	private final List<ServiceLoader<S>> delegates;
+	private static final Method SERVICE_LOADER_STREAM_METHOD;
+	private static final Method PROVIDER_TYPE_METHOD;
 
-	AggregatedServiceLoader(AggregatedClassLoader aggregatedClassLoader, Class<S> serviceContract) {
-		this.delegates = new ArrayList<>();
-		final Iterator<ClassLoader> clIterator = aggregatedClassLoader.newClassLoaderIterator();
-		while ( clIterator.hasNext() ) {
-			this.delegates.add(
-					ServiceLoader.load( serviceContract, clIterator.next() )
-			);
+	static {
+		Class<?> serviceLoaderClass = ServiceLoader.class;
+		Method serviceLoaderStreamMethod = null;
+		Method providerTypeMethod = null;
+		try {
+			/*
+			 * JDK 9 introduced the stream() method on ServiceLoader,
+			 * which we need in order to avoid duplicate service instantiation.
+			 * See ClassPathAndModulePathAggregatedServiceLoader.
+			 */
+			serviceLoaderStreamMethod = serviceLoaderClass.getMethod( "stream" );
+			Class<?> providerClass = Class.forName( serviceLoaderClass.getName() + "$Provider" );
+			providerTypeMethod = providerClass.getMethod( "type" );
+		}
+		catch (NoSuchMethodException | ClassNotFoundException e) {
+			/*
+			 * Probably Java 8.
+			 * Leave the method constants null,
+			 * we will automatically use a service loader implementation that doesn't rely on them.
+			 * See create(...).
+			 */
+		}
+
+		SERVICE_LOADER_STREAM_METHOD = serviceLoaderStreamMethod;
+		PROVIDER_TYPE_METHOD = providerTypeMethod;
+	}
+
+	static <S> AggregatedServiceLoader<S> create(AggregatedClassLoader aggregatedClassLoader,
+			Class<S> serviceContract) {
+		if ( SERVICE_LOADER_STREAM_METHOD != null ) {
+			// Java 9+
+			return new ClassPathAndModulePathAggregatedServiceLoader<>( aggregatedClassLoader, serviceContract );
+		}
+		else {
+			// Java 8
+			return new ClassPathOnlyAggregatedServiceLoader<>( aggregatedClassLoader, serviceContract );
 		}
 	}
 
 	/**
 	 * @return All the loaded services.
 	 */
-	public Collection<S> getAll() {
-		Set<String> alreadyEncountered = new HashSet<>();
-		Set<S> result = new LinkedHashSet<>();
-		for ( ServiceLoader<S> delegate : delegates ) {
-			for ( S service : delegate ) {
-				Class<?> type = service.getClass();
-				String typeName = type.getName();
-				/*
-				 * We may encounter the same service provider multiple times,
-				 * because the individual class loaders may give access to the same types
-				 * (at the very least a single class loader may be present twice in the aggregated class loader).
-				 * However, we only want to get the service from each provider once.
-				 */
-				if ( alreadyEncountered.add( typeName ) ) {
-					result.add( service );
-				}
-			}
-		}
-		return result;
-	}
+	public abstract Collection<S> getAll();
 
 	/**
 	 * Release all resources.
 	 */
-	public void close() {
-		// Clear service providers
-		for ( ServiceLoader<S> delegate : delegates ) {
+	public abstract void close();
+
+	/**
+	 * An {@link AggregatedServiceLoader} that will only detect services defined in the class path,
+	 * not in the module path,
+	 * because it passes the aggregated classloader directly to the service loader.
+	 * <p>
+	 * This implementation is best when running Hibernate ORM on Java 8.
+	 * On Java 9 and above, {@link ClassPathAndModulePathAggregatedServiceLoader} should be used.
+	 *
+	 * @param <S> The type of loaded services.
+	 */
+	private static class ClassPathOnlyAggregatedServiceLoader<S> extends AggregatedServiceLoader<S> {
+		private final ServiceLoader<S> delegate;
+
+		private ClassPathOnlyAggregatedServiceLoader(AggregatedClassLoader aggregatedClassLoader, Class<S> serviceContract) {
+			this.delegate = ServiceLoader.load( serviceContract, aggregatedClassLoader );
+		}
+
+		@Override
+		public Collection<S> getAll() {
+			final Set<S> services = new LinkedHashSet<>();
+			for ( S service : delegate ) {
+				services.add( service );
+			}
+			return services;
+		}
+
+		@Override
+		public void close() {
+			// Clear service providers
 			delegate.reload();
+		}
+	}
+
+	/**
+	 * An {@link AggregatedServiceLoader} that will detect services defined in the class path or in the module path.
+	 * <p>
+	 * This implementation only works when running Hibernate ORM on Java 9 and above.
+	 * On Java 8, {@link ClassPathOnlyAggregatedServiceLoader} must be used.
+	 * <p>
+	 * When retrieving services from providers in the module path,
+	 * the service loader internally uses a map from classloader to service catalog.
+	 * Since the aggregated class loader is artificial and unknown from the service loader,
+	 * it will never match any service from the module path.
+	 * <p>
+	 * To work around this problem,
+	 * we try to get services from a service loader bound to the aggregated class loader first,
+	 * then we try a service loader bound to each individual class loader.
+	 * <p>
+	 * This could result in duplicates, so we take specific care to avoid using the same service provider twice.
+	 * See {@link #getAll()}.
+	 * <p>
+	 * Note that, in the worst case,
+	 * the service retrieved from each individual class loader could load duplicate versions
+	 * of classes already loaded from another class loader.
+	 * For example in an aggregated class loader made up of individual class loader A, B, C:
+	 * it is possible that class C1 was already loaded from A,
+	 * but then we load service S1 from B, and this service will also need class C1 but won't find it in class loader B,
+	 * so it will load its own version of that class.
+	 * <p>
+	 * We assume that this situation will never occur in practice because class loaders
+	 * are structure in a hierarchy that prevents one class to be loaded twice.
+	 *
+	 * @param <S> The type of loaded services.
+	 */
+	private static class ClassPathAndModulePathAggregatedServiceLoader<S> extends AggregatedServiceLoader<S> {
+		private final List<ServiceLoader<S>> delegates;
+		private Collection<S> cache = null;
+
+		private ClassPathAndModulePathAggregatedServiceLoader(AggregatedClassLoader aggregatedClassLoader,
+				Class<S> serviceContract) {
+			this.delegates = new ArrayList<>();
+			// Always try the aggregated class loader first
+			this.delegates.add( ServiceLoader.load( serviceContract, aggregatedClassLoader ) );
+
+			// Then also try the individual class loaders,
+			// because only them can instantiate services provided by jars in the module path
+			final Iterator<ClassLoader> clIterator = aggregatedClassLoader.newClassLoaderIterator();
+			while ( clIterator.hasNext() ) {
+				this.delegates.add(
+						ServiceLoader.load( serviceContract, clIterator.next() )
+				);
+			}
+		}
+
+		@Override
+		public Collection<S> getAll() {
+			if ( cache == null ) {
+				/*
+				 * loadAll() uses ServiceLoader.Provider.get(), which doesn't cache the instance internally,
+				 * on contrary to ServiceLoader.iterator().
+				 * Looking at how https://hibernate.atlassian.net/browse/HHH-8363 was solved,
+				 * waiting for Hibernate ORM to shut down before clearing the service caches,
+				 * it seems caching of service instances is important, or at least used to be important.
+				 * Thus we cache service instances ourselves to avoid any kind of backward-incompatibility.
+				 * If one day we decide caching isn't important, this cache can be removed,
+				 * as well as the close() method,
+				 * and also the service loader map in ClassLoaderServiceImpl,
+				 * and we can simply call .reload() on the service loader after we load services
+				 * in ClassPathOnlyAggregatedServiceLoader.getAll().
+				 */
+				cache = Collections.unmodifiableCollection( loadAll() );
+			}
+			return cache;
+		}
+
+		@SuppressWarnings("unchecked")
+		private Collection<S> loadAll() {
+			Set<String> alreadyEncountered = new HashSet<>();
+			Set<S> result = new LinkedHashSet<>();
+			delegates.stream()
+					// Each loader's stream() method returns a stream of service providers: flatten these into a single stream
+					.flatMap( delegate -> {
+						try {
+							return (Stream<? extends Supplier<S>>) SERVICE_LOADER_STREAM_METHOD.invoke( delegate );
+						}
+						catch (RuntimeException | IllegalAccessException | InvocationTargetException e) {
+							throw new AssertionFailure( "Error calling ServiceLoader.stream()", e );
+						}
+					} )
+					// For each provider, check its type to be sure we don't use a provider twice, then get the service
+					.forEach( provider -> {
+						Class<?> type;
+						try {
+							type = (Class<?>) PROVIDER_TYPE_METHOD.invoke( provider );
+						}
+						catch (RuntimeException | IllegalAccessException | InvocationTargetException e) {
+							throw new AssertionFailure( "Error calling ServiceLoader.Provider.type()", e );
+						}
+						String typeName = type.getName();
+						/*
+						 * We may encounter the same service provider multiple times,
+						 * because the individual class loaders may give access to the same types
+						 * (at the very least a single class loader may be present twice in the aggregated class loader).
+						 * However, we only want to get the service from each provider once.
+						 *
+						 * ServiceLoader.stream() is useful in that regard,
+						 * since it allows us to check the type of the service provider
+						 * before the service is even instantiated.
+						 *
+						 * We could just instantiate every service and check their type afterwards,
+						 * but 1. it would lead to unnecessary instantiation which could have side effects,
+						 * in particular regarding class loading,
+						 * and 2. the type of the provider may not always be the type of the service,
+						 * and one provider may return different types of services
+						 * depending on conditions known only to itself.
+						 */
+						if ( alreadyEncountered.add( typeName ) ) {
+							result.add( provider.get() );
+						}
+					} );
+			return result;
+		}
+
+		@Override
+		public void close() {
+			cache = null;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/ClassLoaderServiceImpl.java
@@ -247,7 +247,7 @@ public class ClassLoaderServiceImpl implements ClassLoaderService {
 	public <S> Collection<S> loadJavaServices(Class<S> serviceContract) {
 		AggregatedServiceLoader<S> serviceLoader = (AggregatedServiceLoader<S>) serviceLoaders.get( serviceContract );
 		if ( serviceLoader == null ) {
-			serviceLoader = new AggregatedServiceLoader( getAggregatedClassLoader(), serviceContract );
+			serviceLoader = AggregatedServiceLoader.create( getAggregatedClassLoader(), serviceContract );
 			serviceLoaders.put( serviceContract, serviceLoader );
 		}
 		return serviceLoader.getAll();

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/spi/ClassLoaderService.java
@@ -31,7 +31,7 @@ public interface ClassLoaderService extends Service, Stoppable {
 	 *
 	 * @throws ClassLoadingException Indicates the class could not be found
 	 */
-	public <T> Class<T> classForName(String className);
+	<T> Class<T> classForName(String className);
 
 	/**
 	 * Locate a resource by name (classpath lookup).
@@ -40,7 +40,7 @@ public interface ClassLoaderService extends Service, Stoppable {
 	 *
 	 * @return The located URL; may return {@code null} to indicate the resource was not found
 	 */
-	public URL locateResource(String name);
+	URL locateResource(String name);
 
 	/**
 	 * Locate a resource by name (classpath lookup) and gets its stream.
@@ -49,7 +49,7 @@ public interface ClassLoaderService extends Service, Stoppable {
 	 *
 	 * @return The stream of the located resource; may return {@code null} to indicate the resource was not found
 	 */
-	public InputStream locateResourceStream(String name);
+	InputStream locateResourceStream(String name);
 
 	/**
 	 * Locate a series of resource by name (classpath lookup).
@@ -58,7 +58,7 @@ public interface ClassLoaderService extends Service, Stoppable {
 	 *
 	 * @return The list of URL matching; may return {@code null} to indicate the resource was not found
 	 */
-	public List<URL> locateResources(String name);
+	List<URL> locateResources(String name);
 
 	/**
 	 * Discovers and instantiates implementations of the named service contract.
@@ -71,7 +71,7 @@ public interface ClassLoaderService extends Service, Stoppable {
 	 *     
 	 * @return The ordered set of discovered services.
 	 */
-	public <S> Collection<S> loadJavaServices(Class<S> serviceContract);
+	<S> Collection<S> loadJavaServices(Class<S> serviceContract);
 
 	<T> T generateProxy(InvocationHandler handler, Class... interfaces);
 

--- a/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
+++ b/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+description = 'Integration tests for running Hibernate ORM in the Java module path'
+
+buildscript {
+	repositories {
+		maven {
+			url "https://plugins.gradle.org/m2/"
+		}
+	}
+	dependencies {
+		classpath "org.javamodularity:moduleplugin:1.5.0"
+	}
+}
+
+apply from: rootProject.file( 'gradle/java-module.gradle' )
+
+// No first-class, built-in support for Java modules in Gradle yet,
+// so we have to use https://github.com/java9-modularity/gradle-modules-plugin
+apply plugin: "org.javamodularity.moduleplugin"
+
+// Override -source and -target
+ext.baselineJavaVersion = 11
+sourceCompatibility = project.baselineJavaVersion
+targetCompatibility = project.baselineJavaVersion
+
+// Checkstyle fails for module-info
+checkstyleMain.exclude '**/module-info.java'
+
+dependencies {
+	compile( project( ':hibernate-core' ) )
+	compile( project( ':hibernate-envers' ) )
+	compile( libraries.jpa )
+}
+
+test {
+	useJUnit()
+}
+

--- a/hibernate-integrationtest-java-modules/src/main/java/module-info.java
+++ b/hibernate-integrationtest-java-modules/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+module org.hibernate.orm.integrationtest.java.module {
+	exports org.hibernate.orm.integrationtest.java.module.service;
+	opens org.hibernate.orm.integrationtest.java.module.entity to
+			org.hibernate.orm.core;
+
+	requires java.persistence;
+	/*
+	 * IDEA will not find the modules below because it apparently doesn't support automatic module names
+	 * for modules in the current project.
+	 * Everything should work fine when building from the command line, though.
+	 */
+	requires org.hibernate.orm.core;
+	requires org.hibernate.orm.envers;
+
+	/*
+	 * This is necessary in order to use SessionFactory,
+	 * which extends "javax.naming.Referenceable".
+	 * Without this, compilation as a Java module fails.
+	 */
+	requires java.naming;
+}

--- a/hibernate-integrationtest-java-modules/src/main/java/org/hibernate/orm/integrationtest/java/module/entity/Author.java
+++ b/hibernate-integrationtest-java-modules/src/main/java/org/hibernate/orm/integrationtest/java/module/entity/Author.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.integrationtest.java.module.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.envers.Audited;
+
+@Entity
+@Audited
+public class Author {
+
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@NaturalId
+	@Basic(optional = false)
+	private String name;
+
+	@Basic
+	private int favoriteNumber;
+
+	public Author() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public int getFavoriteNumber() {
+		return favoriteNumber;
+	}
+
+	public void setFavoriteNumber(int favoriteNumber) {
+		this.favoriteNumber = favoriteNumber;
+	}
+}

--- a/hibernate-integrationtest-java-modules/src/main/java/org/hibernate/orm/integrationtest/java/module/service/AuthorService.java
+++ b/hibernate-integrationtest-java-modules/src/main/java/org/hibernate/orm/integrationtest/java/module/service/AuthorService.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.integrationtest.java.module.service;
+
+import java.util.List;
+
+import javax.persistence.Persistence;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.orm.integrationtest.java.module.entity.Author;
+
+public class AuthorService implements AutoCloseable {
+
+	private final SessionFactory sessionFactory;
+
+	public AuthorService() {
+		sessionFactory = createSessionFactory();
+	}
+
+	private SessionFactory createSessionFactory() {
+		return Persistence.createEntityManagerFactory( "primaryPU" )
+				.unwrap( SessionFactory.class );
+	}
+
+	public void add(String name, Integer favoriteNumber) {
+		try ( Session session = sessionFactory.openSession() ) {
+			session.getTransaction().begin();
+			try {
+				Author entity = new Author();
+				entity.setName( name );
+				entity.setFavoriteNumber( favoriteNumber );
+				session.save( entity );
+				session.getTransaction().commit();
+			}
+			catch (Throwable e) {
+				try {
+					session.getTransaction().rollback();
+				}
+				catch (Throwable e2) {
+					e.addSuppressed( e2 );
+				}
+				throw e;
+			}
+		}
+	}
+
+	public void update(String name, Integer favoriteNumber) {
+		try ( Session session = sessionFactory.openSession() ) {
+			session.getTransaction().begin();
+			try {
+				Author entity = session.bySimpleNaturalId( Author.class ).getReference( name );
+				entity.setFavoriteNumber( favoriteNumber );
+				session.getTransaction().commit();
+			}
+			catch (Throwable e) {
+				try {
+					session.getTransaction().rollback();
+				}
+				catch (Throwable e2) {
+					e.addSuppressed( e2 );
+				}
+				throw e;
+			}
+		}
+	}
+
+	public Integer getFavoriteNumber(String name) {
+		try ( Session session = sessionFactory.openSession() ) {
+			session.getTransaction().begin();
+			try {
+				Author entity = session.bySimpleNaturalId( Author.class ).getReference( name );
+				Integer result = entity.getFavoriteNumber();
+				session.getTransaction().rollback();
+				return result;
+			}
+			catch (Throwable e) {
+				try {
+					session.getTransaction().rollback();
+				}
+				catch (Throwable e2) {
+					e.addSuppressed( e2 );
+				}
+				throw e;
+			}
+		}
+	}
+
+	public List<Number> getRevisions(String name) {
+		try ( Session session = sessionFactory.openSession() ) {
+			Author entity = session.bySimpleNaturalId( Author.class ).getReference( name );
+			AuditReader auditReader = AuditReaderFactory.get( session );
+			return auditReader.getRevisions( Author.class, entity.getId() );
+		}
+	}
+
+	@Override
+	public void close() {
+		sessionFactory.close();
+	}
+}

--- a/hibernate-integrationtest-java-modules/src/main/resources/META-INF/persistence.xml
+++ b/hibernate-integrationtest-java-modules/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+             version="1.0">
+    <persistence-unit name="primaryPU">
+        <class>org.hibernate.orm.integrationtest.java.module.entity.Author</class>
+        <properties>
+            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE"/>
+            <property name="hibernate.connection.username" value="sa"/>
+            <property name="hibernate.connection.password" value=""/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+
+            <property name="hibernate.show_sql" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/hibernate-integrationtest-java-modules/src/test/java/org/hibernate/orm/integrationtest/java/module/test/JavaModulePathIT.java
+++ b/hibernate-integrationtest-java-modules/src/test/java/org/hibernate/orm/integrationtest/java/module/test/JavaModulePathIT.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.integrationtest.java.module.test;
+
+
+import java.util.Arrays;
+
+import org.hibernate.Session;
+import org.hibernate.envers.boot.internal.EnversIntegrator;
+import org.hibernate.orm.integrationtest.java.module.service.AuthorService;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JavaModulePathIT {
+
+	/*
+	 * Test that the service successfully uses Hibernate ORM in the module path.
+	 * We don't really care about the features themselves,
+	 * but the easiest way to check this is to just use Hibernate ORM features and see if it works.
+	 */
+	@Test
+	public void core() {
+		checkIsInModulePath( Object.class );
+		checkIsInModulePath( AuthorService.class );
+		checkIsInModulePath( Session.class );
+
+		AuthorService service = new AuthorService();
+		service.add( "foo", 7 );
+		service.add( "bar", 42 );
+		service.add( "foo bar", 777 );
+
+		service.update( "foo", 8 );
+
+		assertEquals( (Integer) 8, service.getFavoriteNumber( "foo" ) );
+		assertEquals( (Integer) 42, service.getFavoriteNumber( "bar" ) );
+		assertEquals( (Integer) 777, service.getFavoriteNumber( "foo bar" ) );
+	}
+
+	/*
+	 * Test that the service successfully uses an extension of Hibernate ORM in the module path.
+	 * We don't really care about the features themselves,
+	 * but the easiest way to check this is to just use Envers features and see if it works.
+	 */
+	@Test
+	public void integrator() {
+		checkIsInModulePath( Object.class );
+		checkIsInModulePath( AuthorService.class );
+		checkIsInModulePath( Session.class );
+		checkIsInModulePath( EnversIntegrator.class );
+
+		AuthorService service = new AuthorService();
+		service.add( "foo", 7 );
+		service.add( "bar", 42 );
+		service.add( "foo bar", 777 );
+
+		service.update( "foo", 8 );
+
+		assertEquals( Arrays.asList( 1, 4 ), service.getRevisions( "foo" ) );
+		assertEquals( Arrays.asList( 2 ), service.getRevisions( "bar" ) );
+		assertEquals( Arrays.asList( 3 ), service.getRevisions( "foo bar" ) );
+	}
+
+	private void checkIsInModulePath(Class<?> clazz) {
+		Assert.assertTrue(
+				clazz + " should be part of a named module - there is a problem in test setup",
+				clazz.getModule().isNamed()
+		);
+	}
+}

--- a/hibernate-integrationtest-java-modules/src/test/resources/logging.properties
+++ b/hibernate-integrationtest-java-modules/src/test/resources/logging.properties
@@ -1,0 +1,23 @@
+#
+# Hibernate, Relational Persistence for Idiomatic Java
+#
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+#
+
+# Root logger option
+log4j.rootLogger=DEBUG, file
+ 
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=target/test.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) - %m%n
+log4j.appender.file.Threshold=DEBUG
+ 
+# Direct log messages to console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) - %m%n
+log4j.appender.console.Threshold=WARN

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,13 @@ include 'hibernate-jipijapa'
 
 include 'hibernate-orm-modules'
 
+if ( JavaVersion.current().isJava11Compatible() ) {
+    include 'hibernate-integrationtest-java-modules'
+}
+else {
+    logger.warn( '[WARN] Skipping Java module path integration tests because the JDK does not support it' )
+}
+
 include 'documentation'
 include 'release'
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HHH-13409

~Based on #2889 ([HHH-13415](https://hibernate.atlassian.net//browse/HHH-13415)) and #2887, which should be merged first.~ => Done

### The problem

When a user application runs as a module (with a module-info.java), with a dependency to Hibernate ORM, everything works well. *But* if the application needs to rely on an external component that integrates into ORM through Java services (using the ServiceLoader), this component will not be detected.

The reason is that the `ServiceLoader`, when loading services from Java modules, does not look for `META-INF/services/*` files directly anymore. Instead it looks for a service catalog in a map whose keys are classloaders.

Since we load services by passing the `AggregatedClassLoader` to the `ServiceLoader`, this aggregated class loader is used to look for a service catalog, and since this classloader is completely synthetic (we created it ourselves), there is no service catalog to be found, and the service loader will not find any service.

### The solution

I implemented two solutions:

1. one that is simple, but that may introduce regressions (I'm not sure).
2. one that is complex, but tries harder to preserve the previous behavior when it comes to services loaded from the classpath.

The first solution is implemented in commit `HHH-13409 Make AggregatedServiceLoader compatible with the module path (JDK9+)`. Basically instead of creating one service loader with the aggregated class loader, we create one service loader per individual class loader and aggregate the resulting loaded services, trying to remove duplicates, if any.

The second solution `HHH-13409 Rework AggregatedServiceLoader to minimize the risk of regression`, makes some changes:

1. It detects at bootstrap which JDK is running, and just uses the old behavior for JDK8
2. Even when creating one service loader per class loader, it creates a service loader for the aggregated class loader first. In practice it means services will retrieved as before, except those that can be found in individual class loaders and not in the aggregated class loader.
3. To be extra careful, we use the new `ServiceLoader.Provider` interface introduced in JDK9 to retrieve services: it allows to de-duplicate services *before* instantiating them, by checking metadata ahead of instantiation, instead of instantiating every service and then removing the duplicates. It might help to avoid some unwanted side-effects.

I think the second solution is better and probably the one we should go with when we drop support for JDK8 anyway, but maybe it's too defensive. I could use a second opinion :)
