### PR TITLE
HHH-13433 EntityManager.find() should only check for roll-back-only condition if there is an active JTA transaction, otherwise ORM should throw convert( e, lockOptions )

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -3511,7 +3511,7 @@ public final class SessionImpl
 			throw exceptionConverter.convert( new IllegalArgumentException( e.getMessage(), e ) );
 		}
 		catch ( JDBCException e ) {
-			if ( accessTransaction().getRollbackOnly() ) {
+			if ( accessTransaction().isActive() && accessTransaction().getRollbackOnly() ) {
 				// assume this is the similar to the WildFly / IronJacamar "feature" described under HHH-12472
 				return null;
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13433
This change complements the HHH-12472 change, in the following way.  If there isn't an active JTA transaction, we will not throw "IllegalStateException: JPA compliance dictates throwing IllegalStateException when #getRollbackOnly is called on non-active transaction", instead we will throw the exception returned from call to convert(e, lockOptions).