### PR TITLE
Improved IN clause parameter padding …

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -537,9 +537,17 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 
 			if ( inClauseParameterPaddingEnabled ) {
 				int bindValuePaddingCount = MathHelper.ceilingPowerOfTwo( bindValueCount );
+				if ( inExprLimit > 0 ) {
+					bindValuePaddingCount = Math.min( inExprLimit, bindValuePaddingCount );
+				}
 
-				if ( bindValueCount < bindValuePaddingCount && (inExprLimit == 0 || bindValuePaddingCount < inExprLimit) ) {
-					bindValueMaxCount = bindValuePaddingCount;
+				if ( bindValueCount < bindValuePaddingCount ) {
+					if ( inExprLimit == 0 || bindValuePaddingCount < inExprLimit ) {
+						bindValueMaxCount = bindValuePaddingCount;
+					}
+					else {
+						bindValueMaxCount = inExprLimit;
+					}
 				}
 			}
 


### PR DESCRIPTION
… for dialects with InExpressionCountLimit

When the number of parameters of an IN expression is limited by the dialect, and this limit is not the power of two (e.g. Oracle 1000),
the current implementation does not optimize statements with parameters between the optimization limit and the upper limit of the dialect. (e.g. Oracle 513-1000)
Over time, it can lead to increased memory consumption.

This change closes this gap.
