### PR TITLE
Do not log test progress by default, but provide a build option and enable it for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - java -version
   - ./gradlew assemble
 script:
-  - ./gradlew check
+  - ./gradlew check -Plog-test-progress=true
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -214,10 +214,13 @@ test {
 	}
 }
 
-// Log a statement for each test, so that Travis doesn't end up panicking because when there's no output for a long time
 test {
-	testLogging {
-		events "passed", "skipped", "failed"
+	if ( project.findProperty( 'log-test-progress' )?.toString()?.toBoolean() ) {
+		// Log a statement for each test.
+		// Used in the Travis build so that Travis doesn't end up panicking because there's no output for a long time.
+		testLogging {
+			events "passed", "skipped", "failed"
+		}
 	}
 }
 


### PR DESCRIPTION
So that the build isn't too verbose when running it locally.