### PR TITLE
Force the use of Ubuntu Trusty in the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 
 jobs:


### PR DESCRIPTION
If we don't force it, Travis will pick a release at random,
either Trusty or Xenial at the moment.

Using Oracle JDK 8 on Xenial is not easy, for some reason.

See:

* https://travis-ci.community/t/oracle-jdk-11-and-10-are-pre-installed-not-the-openjdk-builds/785/15
* https://github.com/travis-ci/travis-ci/issues/10289