### PR TITLE
HHH-11147- Add a failing test

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/SetIdentifierOnAEnhancedProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/SetIdentifierOnAEnhancedProxyTest.java
@@ -1,0 +1,258 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.hamcrest.MatcherAssert;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-11147")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(lazyLoading = true)
+public class SetIdentifierOnAEnhancedProxyTest extends BaseNonConfigCoreFunctionalTestCase {
+
+
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
+		ssrb.applySetting( AvailableSettings.USE_SECOND_LEVEL_CACHE, "false" );
+		ssrb.applySetting( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
+		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
+	}
+
+	private static final int CHILDREN_SIZE = 10;
+	private Long lastChildID;
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Parent.class, Child.class, Person.class };
+	}
+
+	@Test
+	public void updateId() {
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		Long updatedId = new Long( CHILDREN_SIZE + 1 );
+
+		inTransaction(
+				session -> {
+					stats.clear();
+					Child loadedChild = session.load( Child.class, lastChildID );
+
+					final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) loadedChild;
+					final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
+					MatcherAssert.assertThat( interceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
+					final EnhancementAsProxyLazinessInterceptor proxyInterceptor = (EnhancementAsProxyLazinessInterceptor) interceptor;
+
+					loadedChild.setId( updatedId );
+
+					// ^ should have triggered "base fetch group" initialization which would mean a SQL select
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					// check that the `#setName` "persisted"
+					assertThat( loadedChild.getId(), is( updatedId ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+				}
+		);
+
+		inTransaction(
+				session -> {
+					Child loadedChild = session.load( Child.class, updatedId );
+					assertThat( loadedChild, is(notNullValue()) );
+				}
+		);
+
+	}
+
+	@Before
+	public void prepare() {
+		doInHibernate( this::sessionFactory, s -> {
+			Parent parent = new Parent();
+			for ( int i = 0; i < CHILDREN_SIZE; i++ ) {
+				Child child = new Child();
+				child.setId( new Long( i ) );
+				// Association management should kick in here
+				child.parent = parent;
+
+				Person relative = new Person();
+				relative.setName( "Luigi" );
+				child.addRelative( relative );
+
+				s.persist( relative );
+
+				s.persist( child );
+				lastChildID = child.id;
+			}
+			s.persist( parent );
+		} );
+	}
+
+	@After
+	public void tearDown() {
+		doInHibernate( this::sessionFactory, s -> {
+			s.createQuery( "delete from Child" ).executeUpdate();
+			s.createQuery( "delete from Parent" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "Parent")
+	@Table(name = "PARENT")
+	private static class Parent {
+
+		String name;
+
+		public Parent() {
+		}
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		Long id;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		List<Child> children;
+
+		void setChildren(List<Child> children) {
+			this.children = children;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	private static class Person {
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		Long id;
+
+		String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Child")
+	@Table(name = "CHILD")
+	private static class Child {
+
+		@Id
+		Long id;
+
+		@ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//		@LazyToOne(LazyToOneOption.NO_PROXY)
+				Parent parent;
+
+		@OneToMany
+		List<Person> relatives;
+
+		String name;
+
+		Child() {
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		Child(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+
+		public List<Person> getRelatives() {
+			return relatives;
+		}
+
+		public void setRelatives(List<Person> relatives) {
+			this.relatives = relatives;
+		}
+
+		public void addRelative(Person person) {
+			if ( this.relatives == null ) {
+				this.relatives = new ArrayList<>();
+			}
+			this.relatives.add( person );
+		}
+	}
+}


### PR DESCRIPTION
calling setId() of an enhanced proxy causes

```
java.lang.NullPointerException
	at org.hibernate.tuple.entity.AbstractEntityTuplizer.getPropertyValue(AbstractEntityTuplizer.java:593)
	at org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor.lambda$handleWrite$2(EnhancementAsProxyLazinessInterceptor.java:222)
	at org.hibernate.bytecode.enhance.spi.interceptor.EnhancementHelper.performWork(EnhancementHelper.java:130)
	at org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor.handleWrite(EnhancementAsProxyLazinessInterceptor.java:216)
	at org.hibernate.bytecode.enhance.spi.interceptor.AbstractInterceptor.writeObject(AbstractInterceptor.java:158)
	at org.hibernate.test.bytecode.enhancement.lazy.proxy.SetIdentifierOnAEnhancedProxyTest$Child.$$_hibernate_write_id(SetIdentifierOnAEnhancedProxyTest.java)
	at org.hibernate.test.bytecode.enhancement.lazy.proxy.SetIdentifierOnAEnhancedProxyTest$Child.setId(SetIdentifierOnAEnhancedProxyTest.java:250)
	at org.hibernate.test.bytecode.enhancement.lazy.proxy.SetIdentifierOnAEnhancedProxyTest.lambda$setIdTest$0(SetIdentifierOnAEnhancedProxyTest.java:96)

```