### PR TITLE
HHH-13443: Build failing to parse *.properties file attributes containing trailing space

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/Action.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/Action.java
@@ -150,7 +150,7 @@ public enum Action {
 			return hbm2ddlSetting( (Action) value );
 		}
 
-		final String name = value.toString();
+		final String name = value.toString().trim();
 		if ( StringHelper.isEmpty( name ) || NONE.externalJpaName.equals( name ) ) {
 			// default is NONE
 			return NONE;
@@ -178,7 +178,7 @@ public enum Action {
 			}
 		}
 
-		throw new IllegalArgumentException( "Unrecognized legacy `hibernate.hbm2ddl.auto` value : " + value );
+		throw new IllegalArgumentException( "Unrecognized legacy `hibernate.hbm2ddl.auto` value : `" + value + "`");
 	}
 
 	private static Action hbm2ddlSetting(Action action) {


### PR DESCRIPTION
My accidently putting "spring.jpa.hibernate.ddl-auto=update "(*note one trailing space!) in my application-dev.properties failing build, giving me: "Unrecognized legacy `hibernate.hbm2ddl.auto` value : update" whereas real message should be: "Unrecognized legacy `hibernate.hbm2ddl.auto` value : `update `" which may give us a clue we have malformed attributes/properties or we can have a trim before exception conclude