### PR TITLE
HHH-13442 - CollectionType#getCollection() method improvements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/LoadContexts.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/LoadContexts.java
@@ -159,20 +159,20 @@ public class LoadContexts {
 	}
 
 	/**
-	 * Attempt to locate the loading collection given the owner's key.  The lookup here
+	 * Attempt to locate the loading collection given the CollectionKey obtained from the owner's key.  The lookup here
 	 * occurs against all result-set contexts...
 	 *
 	 * @param persister The collection persister
-	 * @param ownerKey The owner key
+	 * @param key The collection key
 	 * @return The loading collection, or null if not found.
 	 */
-	public PersistentCollection locateLoadingCollection(CollectionPersister persister, Serializable ownerKey) {
-		final LoadingCollectionEntry lce = locateLoadingCollectionEntry( new CollectionKey( persister, ownerKey ) );
+	public PersistentCollection locateLoadingCollection(CollectionPersister persister, CollectionKey key) {
+		final LoadingCollectionEntry lce = locateLoadingCollectionEntry( key ) ;
 		if ( lce != null ) {
 			if ( LOG.isTraceEnabled() ) {
 				LOG.tracef(
 						"Returning loading collection: %s",
-						MessageHelper.collectionInfoString( persister, ownerKey, getSession().getFactory() )
+						MessageHelper.collectionInfoString( persister, key.getKey(), getSession().getFactory() )
 				);
 			}
 			return lce.getCollection();

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -771,12 +771,13 @@ public abstract class CollectionType extends AbstractType implements Association
 		final CollectionPersister persister = getPersister( session );
 		final PersistenceContext persistenceContext = session.getPersistenceContext();
 
+		final CollectionKey collectionKey = new CollectionKey( persister, key );
 		// check if collection is currently being loaded
-		PersistentCollection collection = persistenceContext.getLoadContexts().locateLoadingCollection( persister, key );
+		PersistentCollection collection = persistenceContext.getLoadContexts()
+				.locateLoadingCollection( persister, collectionKey );
 
 		if ( collection == null ) {
 
-			final CollectionKey collectionKey = new CollectionKey( persister, key );
 			// check if it is already completely loaded, but unowned
 			collection = persistenceContext.useUnownedCollection( collectionKey );
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13442

inside the `CollectionType#getCollection()` the `CollectionKey` is created twice, the first time inside the `LoadContext#locateLoadingCollection`. 