### PR TITLE
Remove SessionFactoryImplementor field from Collectionkey

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionKey.java
@@ -25,16 +25,10 @@ public final class CollectionKey implements Serializable {
 	private final String role;
 	private final Serializable key;
 	private final Type keyType;
-	private final SessionFactoryImplementor factory;
 	private final int hashCode;
 
 	public CollectionKey(CollectionPersister persister, Serializable key) {
-		this(
-				persister.getRole(),
-				key,
-				persister.getKeyType(),
-				persister.getFactory()
-		);
+		this( persister.getRole(), key, persister.getKeyType() );
 	}
 
 	/**
@@ -43,18 +37,16 @@ public final class CollectionKey implements Serializable {
 	 */
 	@Deprecated
 	public CollectionKey(CollectionPersister persister, Serializable key, EntityMode em) {
-		this( persister.getRole(), key, persister.getKeyType(), persister.getFactory() );
+		this( persister.getRole(), key, persister.getKeyType() );
 	}
 
 	private CollectionKey(
 			String role,
 			Serializable key,
-			Type keyType,
-			SessionFactoryImplementor factory) {
+			Type keyType) {
 		this.role = role;
 		this.key = key;
 		this.keyType = keyType;
-		this.factory = factory;
 		//cache the hash-code
 		this.hashCode = generateHashCode();
 	}
@@ -62,7 +54,7 @@ public final class CollectionKey implements Serializable {
 	private int generateHashCode() {
 		int result = 17;
 		result = 37 * result + role.hashCode();
-		result = 37 * result + keyType.getHashCode( key, factory );
+		result = 37 * result + keyType.getHashCode( key );
 		return result;
 	}
 
@@ -77,7 +69,7 @@ public final class CollectionKey implements Serializable {
 	@Override
 	public String toString() {
 		return "CollectionKey"
-				+ MessageHelper.collectionInfoString( factory.getCollectionPersister( role ), key, factory );
+				+ MessageHelper.collectionInfoString( role, key );
 	}
 
 	@Override
@@ -91,7 +83,7 @@ public final class CollectionKey implements Serializable {
 
 		final CollectionKey that = (CollectionKey) other;
 		return that.role.equals( role )
-				&& keyType.isEqual( that.key, key, factory );
+				&& keyType.isEqual( that.key, key );
 	}
 
 	@Override
@@ -132,8 +124,7 @@ public final class CollectionKey implements Serializable {
 		return new CollectionKey(
 				(String) ois.readObject(),
 				(Serializable) ois.readObject(),
-				(Type) ois.readObject(),
-				(session == null ? null : session.getFactory())
+				(Type) ois.readObject()
 		);
 	}
 }


### PR DESCRIPTION
@sebersole @gbadner , based on @Sanne perf tests  seems that this change can improve performances, but I'm not sure it can't cause problems.
it seems to me that for `o.h.type.Type#getHashCode()` and `o.h.type.Type#isEqual` the `SessionFactoryImplementor` is useful only for an `EntityType` and that a `CollectionKey#keyType` cannot be an `EntityType`, but I may be wrong.

If you all think that it is fine I will open a Jira.