### PR TITLE
HHH-13462 Introduce a fastpath for SessionImpl#fireLoad to be used by…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -505,7 +505,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public boolean isConnected() {
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		return jdbcCoordinator.getLogicalConnection().isOpen();
 	}
 
@@ -629,7 +629,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public QueryImplementor getNamedQuery(String name) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		// look as HQL/JPQL first
@@ -722,7 +722,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public QueryImplementor createQuery(String queryString) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		try {
@@ -823,7 +823,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@SuppressWarnings("unchecked")
 	public <T> QueryImplementor<T> createQuery(String queryString, Class<T> resultClass) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		try {
@@ -896,7 +896,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	protected  <T> QueryImplementor<T> buildQueryFromName(String name, Class<T> resultType) {
 		checkOpen();
 		try {
-			checkTransactionSynchStatus();
+			pulseTransactionCoordinator();
 			delayedAfterCompletion();
 
 			// todo : apply stored setting at the JPA Query level too
@@ -1020,7 +1020,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public NativeQueryImplementor createNativeQuery(String sqlString, Class resultClass) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		try {
@@ -1045,7 +1045,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public NativeQueryImplementor createNativeQuery(String sqlString, String resultSetMapping) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		try {
@@ -1061,7 +1061,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public NativeQueryImplementor getNamedNativeQuery(String name) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		final NamedSQLQueryDefinition nativeQueryDefinition = factory.getNamedQueryRepository().getNamedSQLQueryDefinition( name );
@@ -1081,7 +1081,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			String queryString,
 			boolean isOrdinalParameterZeroBased) {
 		checkOpen();
-		checkTransactionSynchStatus();
+		pulseTransactionCoordinator();
 		delayedAfterCompletion();
 
 		try {


### PR DESCRIPTION
… internal loops

https://hibernate.atlassian.net/browse/HHH-13462

@gbadner @sebersole @dreab8  this patch introduces a copy of `void SessionImpl#fireLoad(LoadEvent event, LoadType loadType)`, which skips these 3 operations:

     checkOpenOrWaitingForAutoClose();
     checkTransactionSynchStatus();
     delayedAfterCompletion();

I called the new method `void fireLoadNoChecks(LoadEvent event, LoadType loadType)` , this should make it much more effective when invoked from hot loops.

I do believe it's safe to skip these "checks" from `internalLoad` and from `immediateLoad`. Could you have a thought on that please?

Also: if you know of any other method which could be a good candidate to invoke this method safely, please let me know. 
