### PR TITLE
HHH-13465 Allow inlined access to the PersistenceContext for internal…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -114,7 +114,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 		Serializable finalKey = key;
 		if ( key instanceof DelayedPostInsertIdentifier ) {
 			// need to look it up from the persistence-context
-			finalKey = session.getPersistenceContext().getEntry( collection.getOwner() ).getId();
+			finalKey = session.getPersistenceContextInternal().getEntry( collection.getOwner() ).getId();
 			if ( finalKey == key ) {
 				// we may be screwed here since the collection action is about to execute
 				// and we do not know the final owner key value

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
@@ -18,6 +18,7 @@ import org.hibernate.event.spi.PostCollectionRecreateEventListener;
 import org.hibernate.event.spi.PreCollectionRecreateEvent;
 import org.hibernate.event.spi.PreCollectionRecreateEventListener;
 import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * The action for recreating a collection
@@ -47,13 +48,15 @@ public final class CollectionRecreateAction extends CollectionAction {
 		final PersistentCollection collection = getCollection();
 		
 		preRecreate();
-		getPersister().recreate( collection, getKey(), getSession() );
-		getSession().getPersistenceContext().getCollectionEntry( collection ).afterAction( collection );
+		final SharedSessionContractImplementor session = getSession();
+		getPersister().recreate( collection, getKey(), session);
+		session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
 		evict();
 		postRecreate();
 
-		if ( getSession().getFactory().getStatistics().isStatisticsEnabled() ) {
-			getSession().getFactory().getStatistics().recreateCollection( getPersister().getRole() );
+		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+		if ( statistics.isStatisticsEnabled() ) {
+			statistics.recreateCollection( getPersister().getRole() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionUpdateAction.java
@@ -20,6 +20,7 @@ import org.hibernate.event.spi.PreCollectionUpdateEvent;
 import org.hibernate.event.spi.PreCollectionUpdateEventListener;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.pretty.MessageHelper;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * The action for updating a collection
@@ -88,12 +89,13 @@ public final class CollectionUpdateAction extends CollectionAction {
 			persister.insertRows( collection, id, session );
 		}
 
-		getSession().getPersistenceContext().getCollectionEntry( collection ).afterAction( collection );
+		session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
 		evict();
 		postUpdate();
 
-		if ( getSession().getFactory().getStatistics().isStatisticsEnabled() ) {
-			getSession().getFactory().getStatistics().updateCollection( getPersister().getRole() );
+		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+		if ( statistics.isStatisticsEnabled() ) {
+			statistics.updateCollection( getPersister().getRole() );
 		}
 	}
 	

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -101,7 +101,7 @@ public abstract class EntityAction
 	 */
 	public final Serializable getId() {
 		if ( id instanceof DelayedPostInsertIdentifier ) {
-			final EntityEntry entry = session.getPersistenceContext().getEntry( instance );
+			final EntityEntry entry = session.getPersistenceContextInternal().getEntry( instance );
 			final Serializable eeId = entry == null ? null : entry.getId();
 			return eeId instanceof DelayedPostInsertIdentifier ? null : eeId;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -24,6 +24,7 @@ import org.hibernate.event.spi.PostDeleteEventListener;
 import org.hibernate.event.spi.PreDeleteEvent;
 import org.hibernate.event.spi.PreDeleteEventListener;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * The action for performing an entity deletion.
@@ -61,7 +62,7 @@ public class EntityDeleteAction extends EntityAction {
 		this.state = state;
 
 		// before remove we need to remove the local (transactional) natural id cross-reference
-		naturalIdValues = session.getPersistenceContext().getNaturalIdHelper().removeLocalNaturalIdCrossReference(
+		naturalIdValues = session.getPersistenceContextInternal().getNaturalIdHelper().removeLocalNaturalIdCrossReference(
 				getPersister(),
 				getId(),
 				state
@@ -103,7 +104,7 @@ public class EntityDeleteAction extends EntityAction {
 		// After actually deleting a row, record the fact that the instance no longer 
 		// exists on the database (needed for identity-column key generation), and
 		// remove it from the session cache
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityEntry entry = persistenceContext.removeEntry( instance );
 		if ( entry == null ) {
 			throw new AssertionFailure( "possible nonthreadsafe access to session" );
@@ -121,8 +122,9 @@ public class EntityDeleteAction extends EntityAction {
 
 		postDelete();
 
-		if ( getSession().getFactory().getStatistics().isStatisticsEnabled() && !veto ) {
-			getSession().getFactory().getStatistics().deleteEntity( getPersister().getEntityName() );
+		final StatisticsImplementor statistics = getSession().getFactory().getStatistics();
+		if ( statistics.isStatisticsEnabled() && !veto ) {
+			statistics.deleteEntity( getPersister().getEntityName() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -11,8 +11,10 @@ import java.io.Serializable;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostCommitInsertEventListener;
 import org.hibernate.event.spi.PostInsertEvent;
@@ -20,6 +22,7 @@ import org.hibernate.event.spi.PostInsertEventListener;
 import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * The action for performing entity insertions when entity is using IDENTITY column identifier generation
@@ -85,9 +88,10 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 			//need to do that here rather than in the save event listener to let
 			//the post insert events to have a id-filled entity when IDENTITY is used (EJB3)
 			persister.setIdentifier( instance, generatedId, session );
-			session.getPersistenceContext().registerInsertedKey( getPersister(), generatedId );
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+			persistenceContext.registerInsertedKey( getPersister(), generatedId );
 			entityKey = session.generateEntityKey( generatedId, persister );
-			session.getPersistenceContext().checkUniqueness( entityKey, getInstance() );
+			persistenceContext.checkUniqueness( entityKey, getInstance() );
 		}
 
 
@@ -101,8 +105,9 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 
 		postInsert();
 
-		if ( session.getFactory().getStatistics().isStatisticsEnabled() && !isVeto() ) {
-			session.getFactory().getStatistics().insertEntity( getPersister().getEntityName() );
+		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+		if ( statistics.isStatisticsEnabled() && !isVeto() ) {
+			statistics.insertEntity( getPersister().getEntityName() );
 		}
 
 		markExecuted();
@@ -137,8 +142,9 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 	}
 
 	private void postInsert() {
+		final EventSource eventSource = eventSource();
 		if ( isDelayed ) {
-			getSession().getPersistenceContext().replaceDelayedEntityIdentityInsertKeys( delayedEntityKey, generatedId );
+			eventSource.getPersistenceContextInternal().replaceDelayedEntityIdentityInsertKeys( delayedEntityKey, generatedId );
 		}
 
 		final EventListenerGroup<PostInsertEventListener> listenerGroup = listenerGroup( EventType.POST_INSERT );
@@ -150,7 +156,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 				generatedId,
 				getState(),
 				getPersister(),
-				eventSource()
+				eventSource
 		);
 		for ( PostInsertEventListener listener : listenerGroup.listeners() ) {
 			listener.onPostInsert( event );

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -28,6 +28,7 @@ import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.internal.StatsHelper;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * The action for performing an entity insertion, for entities not defined to use IDENTITY generation.
@@ -88,7 +89,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		if ( !veto ) {
 			
 			persister.insert( id, getState(), instance, session );
-			PersistenceContext persistenceContext = session.getPersistenceContext();
+			PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			final EntityEntry entry = persistenceContext.getEntry( instance );
 			if ( entry == null ) {
 				throw new AssertionFailure( "possible non-threadsafe access to session" );
@@ -109,6 +110,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 
 		final SessionFactoryImplementor factory = session.getFactory();
 
+		final StatisticsImplementor statistics = factory.getStatistics();
 		if ( isCachePutEnabled( persister, session ) ) {
 			final CacheEntry ce = persister.buildCacheEntry(
 					instance,
@@ -122,8 +124,8 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 
 			final boolean put = cacheInsert( persister, ck );
 
-			if ( put && factory.getStatistics().isStatisticsEnabled() ) {
-				factory.getStatistics().entityCachePut(
+			if ( put && statistics.isStatisticsEnabled() ) {
+				statistics.entityCachePut(
 						StatsHelper.INSTANCE.getRootEntityRole( persister ),
 						cache.getRegion().getName()
 				);
@@ -134,8 +136,8 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 
 		postInsert();
 
-		if ( factory.getStatistics().isStatisticsEnabled() && !veto ) {
-			factory.getStatistics().insertEntity( getPersister().getEntityName() );
+		if ( statistics.isStatisticsEnabled() && !veto ) {
+			statistics.insertEntity( getPersister().getEntityName() );
 		}
 
 		markExecuted();

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/QueuedOperationCollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/QueuedOperationCollectionAction.java
@@ -54,7 +54,7 @@ public final class QueuedOperationCollectionAction extends CollectionAction {
 		// The other CollectionAction types call CollectionEntry#afterAction, which
 		// clears the dirty flag. We don't want to call CollectionEntry#afterAction unless
 		// there is no other CollectionAction that will be executed on the same collection.
-		final CollectionEntry ce = getSession().getPersistenceContext().getCollectionEntry( getCollection() );
+		final CollectionEntry ce = getSession().getPersistenceContextInternal().getCollectionEntry( getCollection() );
 		if ( !ce.isDoremove() && !ce.isDoupdate() && !ce.isDorecreate() ) {
 			ce.afterAction( getCollection() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
@@ -181,7 +181,7 @@ public class UnresolvedEntityInsertActions {
 	 */
 	@SuppressWarnings({ "unchecked" })
 	public Set<AbstractEntityInsertAction> resolveDependentActions(Object managedEntity, SessionImplementor session) {
-		final EntityEntry entityEntry = session.getPersistenceContext().getEntry( managedEntity );
+		final EntityEntry entityEntry = session.getPersistenceContextInternal().getEntry( managedEntity );
 		if ( entityEntry.getStatus() != Status.MANAGED && entityEntry.getStatus() != Status.READ_ONLY ) {
 			throw new IllegalArgumentException( "EntityEntry did not have status MANAGED or READ_ONLY: " + entityEntry );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
@@ -183,7 +183,7 @@ public class EnhancementAsProxyLazinessInterceptor extends AbstractLazyLoadInter
 
 		if ( isTemporarySession ) {
 			// Add an entry for this entity in the PC of the temp Session
-			session.getPersistenceContext().addEntity(
+			session.getPersistenceContextInternal().addEntity(
 					target,
 					Status.READ_ONLY,
 					// loaded state

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementHelper.java
@@ -210,7 +210,7 @@ public class EnhancementHelper {
 		final SessionFactoryImplementor sf = (SessionFactoryImplementor)
 				SessionFactoryRegistry.INSTANCE.getSessionFactory( interceptor.getSessionFactoryUuid() );
 		final SharedSessionContractImplementor session = (SharedSessionContractImplementor) sf.openSession();
-		session.getPersistenceContext().setDefaultReadOnly( true );
+		session.getPersistenceContextInternal().setDefaultReadOnly( true );
 		session.setHibernateFlushMode( FlushMode.MANUAL );
 		return session;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -87,7 +87,7 @@ public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor
 						final Object[] loadedState = null;
 						//		2) does a row exist in the db for this entity?
 						final boolean existsInDb = true;
-						session.getPersistenceContext().addEntity(
+						session.getPersistenceContextInternal().addEntity(
 								target,
 								Status.READ_ONLY,
 								loadedState,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
@@ -48,7 +48,7 @@ public class OptimisticForceIncrementLockingStrategy implements LockingStrategy 
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}
-		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		// Register the EntityIncrementVersionProcess action to run just prior to transaction commit.
 		( (EventSource) session ).getActionQueue().registerProcess( new EntityIncrementVersionProcess( object, entry ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
@@ -49,7 +49,7 @@ public class OptimisticLockingStrategy implements LockingStrategy {
 		if ( !lockable.isVersioned() ) {
 			throw new OptimisticLockException( object, "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}
-		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		// Register the EntityVerifyVersionProcess action to run just prior to transaction commit.
 		( (EventSource) session ).getActionQueue().registerProcess( new EntityVerifyVersionProcess( object, entry ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
@@ -47,7 +47,7 @@ public class PessimisticForceIncrementLockingStrategy implements LockingStrategy
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}
-		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		final EntityPersister persister = entry.getPersister();
 		final Object nextVersion = persister.forceVersionIncrement( entry.getId(), entry.getVersion(), session );
 		entry.forceLocked( object, nextVersion );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -309,7 +309,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 			return !isExistsInDatabase();
 		}
 		else {
-			return session.getPersistenceContext().getNullifiableEntityKeys().contains( getEntityKey() );
+			return session.getPersistenceContextInternal().getNullifiableEntityKeys().contains( getEntityKey() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/BatchFetchQueueHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/BatchFetchQueueHelper.java
@@ -79,7 +79,7 @@ public class BatchFetchQueueHelper {
 			EntityPersister persister,
 			SharedSessionContractImplementor session) {
 		final EntityKey entityKey = session.generateEntityKey( id, persister );
-		final BatchFetchQueue batchFetchQueue = session.getPersistenceContext().getBatchFetchQueue();
+		final BatchFetchQueue batchFetchQueue = session.getPersistenceContextInternal().getBatchFetchQueue();
 		batchFetchQueue.removeBatchLoadableEntityKey( entityKey );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
@@ -18,6 +18,7 @@ import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CollectionEntry;
 import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.internal.CoreLogging;
@@ -83,6 +84,7 @@ public final class Cascade {
 			if ( traceEnabled ) {
 				LOG.tracev( "Processing cascade {0} for: {1}", action, persister.getEntityName() );
 			}
+			final PersistenceContext persistenceContext = eventSource.getPersistenceContextInternal();
 
 			final Type[] types = persister.getPropertyTypes();
 			final String[] propertyNames = persister.getPropertyNames();
@@ -105,7 +107,7 @@ public final class Cascade {
 						// If parent is a detached entity being merged,
 						// then parent will not be in the PersistencContext
 						// (so lazy attributes must not be initialized).
-						if ( eventSource.getPersistenceContext().getEntry( parent ) == null ) {
+						if ( persistenceContext.getEntry( parent ) == null ) {
 							// parent was not in the PersistenceContext
 							continue;
 						}
@@ -271,7 +273,8 @@ public final class Cascade {
 			if ( style.hasOrphanDelete() && action.deleteOrphans() ) {
 				// value is orphaned if loaded state for this property shows not null
 				// because it is currently null.
-				final EntityEntry entry = eventSource.getPersistenceContext().getEntry( parent );
+				final PersistenceContext persistenceContext = eventSource.getPersistenceContextInternal();
+				final EntityEntry entry = persistenceContext.getEntry( parent );
 				if ( entry != null && entry.getStatus() != Status.SAVING ) {
 					Object loadedValue;
 					if ( componentPathStackDepth == 0 ) {
@@ -299,15 +302,13 @@ public final class Cascade {
 					// orphaned if the association was nulled (child == null) or receives a new value while the
 					// entity is managed (without first nulling and manually flushing).
 					if ( child == null || ( loadedValue != null && child != loadedValue ) ) {
-						EntityEntry valueEntry = eventSource
-								.getPersistenceContext().getEntry(
-										loadedValue );
+						EntityEntry valueEntry = persistenceContext.getEntry( loadedValue );
 
 						if ( valueEntry == null && loadedValue instanceof HibernateProxy ) {
 							// un-proxy and re-associate for cascade operation
 							// useful for @OneToOne defined as FetchType.LAZY
-							loadedValue = eventSource.getPersistenceContext().unproxyAndReassociate( loadedValue );
-							valueEntry = eventSource.getPersistenceContext().getEntry( loadedValue );
+							loadedValue = persistenceContext.unproxyAndReassociate( loadedValue );
+							valueEntry = persistenceContext.getEntry( loadedValue );
 
 							// HHH-11965
 							// Should the unwrapped proxy value be equal via reference to the entity's property value
@@ -485,12 +486,13 @@ public final class Cascade {
 				: null;
 		if ( style.reallyDoCascade( action ) ) {
 			//not really necessary, but good for consistency...
-			eventSource.getPersistenceContext().addChildParent( child, parent );
+			final PersistenceContext persistenceContext = eventSource.getPersistenceContextInternal();
+			persistenceContext.addChildParent( child, parent );
 			try {
 				action.cascade( eventSource, child, entityName, anything, isCascadeDeleteEnabled );
 			}
 			finally {
-				eventSource.getPersistenceContext().removeChildParent( child );
+				persistenceContext.removeChildParent( child );
 			}
 		}
 	}
@@ -570,7 +572,7 @@ public final class Cascade {
 		//TODO: suck this logic into the collection!
 		final Collection orphans;
 		if ( pc.wasInitialized() ) {
-			final CollectionEntry ce = eventSource.getPersistenceContext().getCollectionEntry( pc );
+			final CollectionEntry ce = eventSource.getPersistenceContextInternal().getCollectionEntry( pc );
 			orphans = ce==null
 					? java.util.Collections.EMPTY_LIST
 					: ce.getOrphans( entityName, pc );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
@@ -53,7 +53,7 @@ public final class Collections {
 	}
 
 	private static void processDereferencedCollection(PersistentCollection coll, SessionImplementor session) {
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final CollectionEntry entry = persistenceContext.getCollectionEntry( coll );
 		final CollectionPersister loadedPersister = entry.getLoadedPersister();
 
@@ -111,7 +111,7 @@ public final class Collections {
 
 	private static void processNeverReferencedCollection(PersistentCollection coll, SessionImplementor session)
 			throws HibernateException {
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final CollectionEntry entry = persistenceContext.getCollectionEntry( coll );
 
 		if ( LOG.isDebugEnabled() ) {
@@ -147,7 +147,8 @@ public final class Collections {
 			Object entity,
 			SessionImplementor session) {
 		collection.setOwner( entity );
-		final CollectionEntry ce = session.getPersistenceContext().getCollectionEntry( collection );
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		final CollectionEntry ce = persistenceContext.getCollectionEntry( collection );
 
 		if ( ce == null ) {
 			// refer to comment in StatefulPersistenceContext.addCollection()

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/ForeignKeys.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/ForeignKeys.java
@@ -160,7 +160,7 @@ public final class ForeignKeys {
 			if ( isDelete &&
 					value == LazyPropertyInitializer.UNFETCHED_PROPERTY &&
 					type.isEntityType() &&
-					!session.getPersistenceContext().getNullifiableEntityKeys().isEmpty() ) {
+					!session.getPersistenceContextInternal().getNullifiableEntityKeys().isEmpty() ) {
 				// IMPLEMENTATION NOTE: If cascade-remove was mapped for the attribute,
 				// then value should have been initialized previously, when the remove operation was
 				// cascaded to the property (because CascadingAction.DELETE.performOnLazyProperty()
@@ -225,7 +225,7 @@ public final class ForeignKeys {
 			// id is not "unsaved" (that is, we rely on foreign keys to keep
 			// database integrity)
 
-			final EntityEntry entityEntry = session.getPersistenceContext().getEntry( object );
+			final EntityEntry entityEntry = session.getPersistenceContextInternal().getEntry( object );
 			if ( entityEntry == null ) {
 				return isTransient( entityName, object, null, session );
 			}
@@ -254,7 +254,7 @@ public final class ForeignKeys {
 			return true;
 		}
 
-		if ( session.getPersistenceContext().isEntryFor( entity ) ) {
+		if ( session.getPersistenceContextInternal().isEntryFor( entity ) ) {
 			return true;
 		}
 
@@ -303,7 +303,7 @@ public final class ForeignKeys {
 		}
 
 		// hit the database, after checking the session cache for a snapshot
-		final Object[] snapshot = session.getPersistenceContext().getDatabaseSnapshot(
+		final Object[] snapshot = session.getPersistenceContextInternal().getDatabaseSnapshot(
 				persister.getIdentifier( entity, session ),
 				persister
 		);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1407,7 +1407,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			setEntityReadOnly( object, readOnly );
 			// PersistenceContext.proxyFor( entity ) returns entity if there is no proxy for that entity
 			// so need to check the return value to be sure it is really a proxy
-			final Object maybeProxy = getSession().getPersistenceContext().proxyFor( object );
+			final Object maybeProxy = getSession().getPersistenceContextInternal().proxyFor( object );
 			if ( maybeProxy instanceof HibernateProxy ) {
 				setProxyReadOnly( (HibernateProxy) maybeProxy, readOnly );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/loading/internal/CollectionLoadContext.java
@@ -23,6 +23,7 @@ import org.hibernate.cache.spi.entry.CollectionCacheEntry;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionEntry;
 import org.hibernate.engine.spi.CollectionKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
@@ -163,6 +164,7 @@ public class CollectionLoadContext {
 		// the #endRead processing.
 		List<LoadingCollectionEntry> matches = null;
 		final Iterator itr = localLoadingCollectionKeys.iterator();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		while ( itr.hasNext() ) {
 			final CollectionKey collectionKey = (CollectionKey) itr.next();
 			final LoadingCollectionEntry lce = loadContexts.locateLoadingCollectionEntry( collectionKey );
@@ -175,7 +177,7 @@ public class CollectionLoadContext {
 				}
 				matches.add( lce );
 				if ( lce.getCollection().getOwner() == null ) {
-					session.getPersistenceContext().addUnownedCollection(
+					persistenceContext.addUnownedCollection(
 							new CollectionKey(
 									persister,
 									lce.getKey()
@@ -310,7 +312,8 @@ public class CollectionLoadContext {
 	 * @param persister The persister
 	 */
 	private void addCollectionToCache(LoadingCollectionEntry lce, CollectionPersister persister) {
-		final SharedSessionContractImplementor session = getLoadContext().getPersistenceContext().getSession();
+		final PersistenceContext persistenceContext = getLoadContext().getPersistenceContext();
+		final SharedSessionContractImplementor session = persistenceContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 
 		if ( LOG.isDebugEnabled() ) {
@@ -331,7 +334,7 @@ public class CollectionLoadContext {
 
 		final Object version;
 		if ( persister.isVersioned() ) {
-			Object collectionOwner = getLoadContext().getPersistenceContext().getCollectionOwner( lce.getKey(), persister );
+			Object collectionOwner = persistenceContext.getCollectionOwner( lce.getKey(), persister );
 			if ( collectionOwner == null ) {
 				// generally speaking this would be caused by the collection key being defined by a property-ref, thus
 				// the collection key and the owner key would not match up.  In this case, try to use the key of the
@@ -342,7 +345,7 @@ public class CollectionLoadContext {
 					final Object linkedOwner = lce.getCollection().getOwner();
 					if ( linkedOwner != null ) {
 						final Serializable ownerKey = persister.getOwnerEntityPersister().getIdentifier( linkedOwner, session );
-						collectionOwner = getLoadContext().getPersistenceContext().getCollectionOwner( ownerKey, persister );
+						collectionOwner = persistenceContext.getCollectionOwner( ownerKey, persister );
 					}
 				}
 				if ( collectionOwner == null ) {
@@ -353,7 +356,7 @@ public class CollectionLoadContext {
 					);
 				}
 			}
-			version = getLoadContext().getPersistenceContext().getEntry( collectionOwner ).getVersion();
+			version = persistenceContext.getEntry( collectionOwner ).getVersion();
 		}
 		else {
 			version = null;
@@ -372,7 +375,7 @@ public class CollectionLoadContext {
 		if ( persister.getElementType().isAssociationType() ) {
 			for ( Serializable id : entry.getState() ) {
 				EntityPersister entityPersister = ( (QueryableCollection) persister ).getElementPersister();
-				if ( session.getPersistenceContext().wasInsertedDuringTransaction( entityPersister, id ) ) {
+				if ( persistenceContext.wasInsertedDuringTransaction( entityPersister, id ) ) {
 					isPutFromLoad = false;
 					break;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
@@ -393,7 +393,7 @@ public class CascadingActions {
 		}
 
 		private boolean isInManagedState(Object child, EventSource session) {
-			EntityEntry entry = session.getPersistenceContext().getEntry( child );
+			EntityEntry entry = session.getPersistenceContextInternal().getEntry( child );
 			return entry != null &&
 					(
 							entry.getStatus() == Status.MANAGED ||

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
@@ -204,7 +204,7 @@ public final class CollectionEntry implements Serializable {
 		collection.setSnapshot(loadedKey, role, snapshot);
 		if ( loadedPersister.getBatchSize() > 1 ) {
 			( (AbstractPersistentCollection) collection ).getSession()
-					.getPersistenceContext()
+					.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.removeBatchLoadableCollection( this );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
@@ -470,7 +470,7 @@ public final class QueryParameters {
 	public boolean isReadOnly(SharedSessionContractImplementor session) {
 		return isReadOnlyInitialized
 				? isReadOnly()
-				: session.getPersistenceContext().isDefaultReadOnly();
+				: session.getPersistenceContextInternal().isDefaultReadOnly();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -467,6 +467,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public PersistenceContext getPersistenceContextInternal() {
+		return delegate.getPersistenceContextInternal();
+	}
+
+	@Override
 	public SessionEventListenerManager getEventListenerManager() {
 		return delegate.getEventListenerManager();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -91,7 +91,13 @@ public interface SharedSessionContractImplementor
 	SessionEventListenerManager getEventListenerManager();
 
 	/**
-	 * Get the persistence context for this session
+	 * Get the persistence context for this session.
+	 * See also {@link #getPersistenceContextInternal()} for
+	 * an alternative.
+	 *
+	 * This method is not extremely fast: if you need to access
+	 * the PersistenceContext multiple times, prefer keeping
+	 * a reference to it over invoking this method multiple times.
 	 */
 	PersistenceContext getPersistenceContext();
 
@@ -504,4 +510,19 @@ public interface SharedSessionContractImplementor
 			Class<T> resultClass,
 			Selection selection,
 			HibernateEntityManagerImplementor.QueryOptions queryOptions);
+
+	/**
+	 * This is similar to {@link #getPersistenceContext()}, with
+	 * two main differences:
+	 * a) this version performs better as
+	 * it allows for inlining and probably better prediction
+	 * b) see SessionImpl{@link #getPersistenceContext()} : it
+	 * does some checks on the current state of the Session.
+	 *
+	 * Choose wisely: performance is important, correctness comes first.
+	 *
+	 * @return the PersistenceContext associated to this session.
+	 */
+	PersistenceContext getPersistenceContextInternal();
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -19,6 +19,7 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.internal.Collections;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
@@ -77,7 +78,7 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 
 		EventSource session = event.getSession();
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		session.getInterceptor().preFlush( new LazyIterator( persistenceContext.getEntitiesByKey() ) );
 
 		prepareEntityFlushes( session, persistenceContext );
@@ -111,7 +112,7 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 			return;
 		}
 		final EventSource session = event.getSession();
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		LOG.debugf(
 				"Flushed: %s insertions, %s updates, %s deletions to %s objects",
 				session.getActionQueue().numberOfInsertions(),
@@ -154,12 +155,13 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 
 	private void cascadeOnFlush(EventSource session, EntityPersister persister, Object object, Object anything)
 	throws HibernateException {
-		session.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			Cascade.cascade( getCascadingAction(), CascadePoint.BEFORE_FLUSH, session, persister, object, anything );
 		}
 		finally {
-			session.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 		}
 	}
 
@@ -347,17 +349,20 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 		//		during-flush callbacks more leniency in regards to initializing proxies and
 		//		lazy collections during their processing.
 		// For more information, see HHH-2763
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
 		try {
-			session.getJdbcCoordinator().flushBeginning();
-			session.getPersistenceContext().setFlushing( true );
+			jdbcCoordinator.flushBeginning();
+			persistenceContext.setFlushing( true );
 			// we need to lock the collection caches before executing entity inserts/updates in order to
 			// account for bi-directional associations
-			session.getActionQueue().prepareActions();
-			session.getActionQueue().executeActions();
+			final ActionQueue actionQueue = session.getActionQueue();
+			actionQueue.prepareActions();
+			actionQueue.executeActions();
 		}
 		finally {
-			session.getPersistenceContext().setFlushing( false );
-			session.getJdbcCoordinator().flushEnding();
+			persistenceContext.setFlushing( false );
+			jdbcCoordinator.flushEnding();
 		}
 	}
 
@@ -375,7 +380,7 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 
 		LOG.trace( "Post flush" );
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		persistenceContext.getCollectionsByKey().clear();
 		
 		// the database has changed now, so the subselect results need to be invalidated
@@ -406,6 +411,6 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 	}
 
 	protected void postPostFlush(SessionImplementor session) {
-		session.getInterceptor().postFlush( new LazyIterator( session.getPersistenceContext().getEntitiesByKey() ) );
+		session.getInterceptor().postFlush( new LazyIterator( session.getPersistenceContextInternal().getEntitiesByKey() ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractReassociateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractReassociateEventListener.java
@@ -12,6 +12,7 @@ import org.hibernate.LockMode;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.spi.AbstractEvent;
 import org.hibernate.event.spi.EventSource;
@@ -54,7 +55,8 @@ public abstract class AbstractReassociateEventListener implements Serializable {
 		final EventSource source = event.getSession();
 		final EntityKey key = source.generateEntityKey( id, persister );
 
-		source.getPersistenceContext().checkUniqueness( key, object );
+		final PersistenceContext persistenceContext = source.getPersistenceContext();
+		persistenceContext.checkUniqueness( key, object );
 
 		//get a snapshot
 		Object[] values = persister.getPropertyValues( object );
@@ -67,7 +69,7 @@ public abstract class AbstractReassociateEventListener implements Serializable {
 		);
 		Object version = Versioning.getVersion( values, persister );
 
-		EntityEntry newEntry = source.getPersistenceContext().addEntity(
+		EntityEntry newEntry = persistenceContext.addEntity(
 				object,
 				( persister.isMutable() ? Status.MANAGED : Status.READ_ONLY ),
 				values,

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
@@ -8,6 +8,7 @@ package org.hibernate.event.internal;
 
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.event.spi.AutoFlushEvent;
 import org.hibernate.event.spi.AutoFlushEventListener;
 import org.hibernate.event.spi.EventSource;
@@ -78,9 +79,10 @@ public class DefaultAutoFlushEventListener extends AbstractFlushingEventListener
 	}
 
 	private boolean flushMightBeNeeded(final EventSource source) {
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		return !source.getHibernateFlushMode().lessThan( FlushMode.AUTO )
 				&& source.getDontFlushFromFind() == 0
-				&& ( source.getPersistenceContext().getNumberOfManagedEntities() > 0 ||
-						source.getPersistenceContext().getCollectionEntries().size() > 0 );
+				&& ( persistenceContext.getNumberOfManagedEntities() > 0 ||
+						persistenceContext.getCollectionEntries().size() > 0 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -84,7 +84,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 
 		final EventSource source = event.getSession();
 
-		final PersistenceContext persistenceContext = source.getPersistenceContext();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		Object entity = persistenceContext.unproxyAndReassociate( event.getObject() );
 
 		EntityEntry entityEntry = persistenceContext.getEntry( entity );
@@ -255,7 +255,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			);
 		}
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final Type[] propTypes = persister.getPropertyTypes();
 		final Object version = entityEntry.getVersion();
 
@@ -359,7 +359,8 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 
 		CacheMode cacheMode = session.getCacheMode();
 		session.setCacheMode( CacheMode.GET );
-		session.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			// cascade-delete to collections BEFORE the collection owner is deleted
 			Cascade.cascade(
@@ -372,7 +373,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			);
 		}
 		finally {
-			session.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 			session.setCacheMode( cacheMode );
 		}
 	}
@@ -385,7 +386,8 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 
 		CacheMode cacheMode = session.getCacheMode();
 		session.setCacheMode( CacheMode.GET );
-		session.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			// cascade-delete to many-to-one AFTER the parent was deleted
 			Cascade.cascade(
@@ -398,7 +400,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			);
 		}
 		finally {
-			session.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 			session.setCacheMode( cacheMode );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
@@ -50,7 +50,7 @@ public class DefaultEvictEventListener implements EvictEventListener {
 		}
 
 		final EventSource source = event.getSession();
-		final PersistenceContext persistenceContext = source.getPersistenceContext();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 
 		if ( object instanceof HibernateProxy ) {
 			final LazyInitializer li = ( (HibernateProxy) object ).getHibernateLazyInitializer();
@@ -108,8 +108,9 @@ public class DefaultEvictEventListener implements EvictEventListener {
 			LOG.tracev( "Evicting {0}", MessageHelper.infoString( persister ) );
 		}
 
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		if ( persister.hasNaturalIdentifier() ) {
-			session.getPersistenceContext().getNaturalIdHelper().handleEviction(
+			persistenceContext.getNaturalIdHelper().handleEviction(
 					object,
 					persister,
 					key.getIdentifier()
@@ -127,8 +128,8 @@ public class DefaultEvictEventListener implements EvictEventListener {
 		// This is now handled by removeEntity()
 		//session.getPersistenceContext().removeDatabaseSnapshot(key);
 		
-		session.getPersistenceContext().removeEntity( key );
-		session.getPersistenceContext().removeEntry( object );
+		persistenceContext.removeEntity( key );
+		persistenceContext.removeEntry( object );
 
 		Cascade.cascade( CascadingActions.EVICT, CascadePoint.AFTER_EVICT, session, persister, object );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEventListener.java
@@ -11,6 +11,7 @@ import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.FlushEvent;
 import org.hibernate.event.spi.FlushEventListener;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
  * Defines the default flush event listeners used by hibernate for 
@@ -27,7 +28,7 @@ public class DefaultFlushEventListener extends AbstractFlushingEventListener imp
 	 */
 	public void onFlush(FlushEvent event) throws HibernateException {
 		final EventSource source = event.getSession();
-		final PersistenceContext persistenceContext = source.getPersistenceContext();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 
 		if ( persistenceContext.getNumberOfManagedEntities() > 0 ||
 				persistenceContext.getCollectionEntries().size() > 0 ) {
@@ -48,8 +49,9 @@ public class DefaultFlushEventListener extends AbstractFlushingEventListener imp
 
 			postPostFlush( source );
 
-			if ( source.getFactory().getStatistics().isStatisticsEnabled() ) {
-				source.getFactory().getStatistics().flush();
+			final StatisticsImplementor statistics = source.getFactory().getStatistics();
+			if ( statistics.isStatisticsEnabled() ) {
+				statistics.flush();
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -21,6 +21,7 @@ import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SelfDirtinessTracker;
@@ -141,14 +142,15 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 
 				// Check the persistence context for an entry relating to this
 				// entity to be merged...
-				EntityEntry entry = source.getPersistenceContext().getEntry( entity );
+				final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+				EntityEntry entry = persistenceContext.getEntry( entity );
 				if ( entry == null ) {
 					EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );
 					Serializable id = persister.getIdentifier( entity, source );
 					if ( id != null ) {
 						final EntityKey key = source.generateEntityKey( id, persister );
-						final Object managedEntity = source.getPersistenceContext().getEntity( key );
-						entry = source.getPersistenceContext().getEntry( managedEntity );
+						final Object managedEntity = persistenceContext.getEntity( key );
+						entry = persistenceContext.getEntry( managedEntity );
 						if ( entry != null ) {
 							// we have specialized case of a detached entity from the
 							// perspective of the merge operation.  Specifically, we
@@ -356,7 +358,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			EntityPersister persister,
 			EventSource source) {
 		if ( incoming instanceof HibernateProxy ) {
-			return source.getPersistenceContext().unproxy( managed );
+			return source.getPersistenceContextInternal().unproxy( managed );
 		}
 
 		if ( incoming instanceof PersistentAttributeInterceptable
@@ -424,13 +426,14 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 	}
 
 	private boolean existsInDatabase(Object entity, EventSource source, EntityPersister persister) {
-		EntityEntry entry = source.getPersistenceContext().getEntry( entity );
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		EntityEntry entry = persistenceContext.getEntry( entity );
 		if ( entry == null ) {
 			Serializable id = persister.getIdentifier( entity, source );
 			if ( id != null ) {
 				final EntityKey key = source.generateEntityKey( id, persister );
-				final Object managedEntity = source.getPersistenceContext().getEntity( key );
-				entry = source.getPersistenceContext().getEntry( managedEntity );
+				final Object managedEntity = persistenceContext.getEntity( key );
+				entry = persistenceContext.getEntry( managedEntity );
 			}
 		}
 
@@ -508,7 +511,8 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			final Object entity,
 			final Map copyCache
 	) {
-		source.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			Cascade.cascade(
 					getCascadeAction(),
@@ -520,7 +524,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			);
 		}
 		finally {
-			source.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
@@ -98,7 +98,7 @@ public class DefaultPersistEventListener
 			event.setEntityName( entityName );
 		}
 
-		final EntityEntry entityEntry = source.getPersistenceContext().getEntry( entity );
+		final EntityEntry entityEntry = source.getPersistenceContextInternal().getEntry( entity );
 		EntityState entityState = getEntityState( entity, entityName, entityEntry, source );
 		if ( entityState == EntityState.DETACHED ) {
 			// JPA 2, in its version of a "foreign generated", allows the id attribute value
@@ -160,7 +160,7 @@ public class DefaultPersistEventListener
 
 		//TODO: check that entry.getIdentifier().equals(requestedId)
 
-		final Object entity = source.getPersistenceContext().unproxy( event.getObject() );
+		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );
 		final EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );
 
 		if ( createCache.put( entity, entity ) == null ) {
@@ -186,7 +186,7 @@ public class DefaultPersistEventListener
 		LOG.trace( "Saving transient instance" );
 
 		final EventSource source = event.getSession();
-		final Object entity = source.getPersistenceContext().unproxy( event.getObject() );
+		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );
 
 		if ( createCache.put( entity, entity ) == null ) {
 			saveWithGeneratedId( entity, event.getEntityName(), createCache, source, false );
@@ -197,7 +197,7 @@ public class DefaultPersistEventListener
 	private void entityIsDeleted(PersistEvent event, Map createCache) {
 		final EventSource source = event.getSession();
 
-		final Object entity = source.getPersistenceContext().unproxy( event.getObject() );
+		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );
 		final EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );
 
 		if ( LOG.isTraceEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultReplicateEventListener.java
@@ -17,6 +17,7 @@ import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.spi.EventSource;
@@ -46,14 +47,15 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 	 */
 	public void onReplicate(ReplicateEvent event) {
 		final EventSource source = event.getSession();
-		if ( source.getPersistenceContext().reassociateIfUninitializedProxy( event.getObject() ) ) {
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		if ( persistenceContext.reassociateIfUninitializedProxy( event.getObject() ) ) {
 			LOG.trace( "Uninitialized proxy passed to replicate()" );
 			return;
 		}
 
-		Object entity = source.getPersistenceContext().unproxyAndReassociate( event.getObject() );
+		Object entity = persistenceContext.unproxyAndReassociate( event.getObject() );
 
-		if ( source.getPersistenceContext().isEntryFor( entity ) ) {
+		if ( persistenceContext.isEntryFor( entity ) ) {
 			LOG.trace( "Ignoring persistent instance passed to replicate()" );
 			//hum ... should we cascade anyway? throw an exception? fine like it is?
 			return;
@@ -181,7 +183,7 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 
 		new OnReplicateVisitor( source, id, entity, true ).process( entity, persister );
 
-		source.getPersistenceContext().addEntity(
+		source.getPersistenceContextInternal().addEntity(
 				entity,
 				( persister.isMutable() ? Status.MANAGED : Status.READ_ONLY ),
 				null,
@@ -201,7 +203,8 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 			EntityPersister persister,
 			ReplicationMode replicationMode,
 			EventSource source) {
-		source.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			Cascade.cascade(
 					CascadingActions.REPLICATE,
@@ -213,7 +216,7 @@ public class DefaultReplicateEventListener extends AbstractSaveEventListener imp
 			);
 		}
 		finally {
-			source.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveEventListener.java
@@ -24,7 +24,7 @@ public class DefaultSaveEventListener extends DefaultSaveOrUpdateEventListener {
 	protected Serializable performSaveOrUpdate(SaveOrUpdateEvent event) {
 		// this implementation is supposed to tolerate incorrect unsaved-value
 		// mappings, for the purpose of backward-compatibility
-		EntityEntry entry = event.getSession().getPersistenceContext().getEntry( event.getEntity() );
+		EntityEntry entry = event.getSession().getPersistenceContextInternal().getEntry( event.getEntity() );
 		if ( entry!=null && entry.getStatus() != Status.DELETED ) {
 			return entityIsPersistent(event);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.spi.CascadingAction;
 import org.hibernate.engine.spi.CascadingActions;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.Status;
@@ -66,9 +67,10 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 		}
 		else {
 			//initialize properties of the event:
-			final Object entity = source.getPersistenceContext().unproxyAndReassociate( object );
+			final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+			final Object entity = persistenceContext.unproxyAndReassociate( object );
 			event.setEntity( entity );
-			event.setEntry( source.getPersistenceContext().getEntry( entity ) );
+			event.setEntry( persistenceContext.getEntry( entity ) );
 			//return the id in the event object
 			event.setResultId( performSaveOrUpdate( event ) );
 		}
@@ -76,7 +78,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 	}
 
 	protected boolean reassociateIfUninitializedProxy(Object object, SessionImplementor source) {
-		return source.getPersistenceContext().reassociateIfUninitializedProxy( object );
+		return source.getPersistenceContextInternal().reassociateIfUninitializedProxy( object );
 	}
 
 	protected Serializable performSaveOrUpdate(SaveOrUpdateEvent event) {
@@ -175,7 +177,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 
 		Serializable id = saveWithGeneratedOrRequestedId( event );
 
-		source.getPersistenceContext().reassociateProxy( event.getObject(), id );
+		source.getPersistenceContextInternal().reassociateProxy( event.getObject(), id );
 
 		return id;
 	}
@@ -208,18 +210,19 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 
 		LOG.trace( "Updating detached instance" );
 
-		if ( event.getSession().getPersistenceContext().isEntryFor( event.getEntity() ) ) {
+		final EventSource session = event.getSession();
+		if ( session.getPersistenceContextInternal().isEntryFor( event.getEntity() ) ) {
 			//TODO: assertion only, could be optimized away
 			throw new AssertionFailure( "entity was persistent" );
 		}
 
 		Object entity = event.getEntity();
 
-		EntityPersister persister = event.getSession().getEntityPersister( event.getEntityName(), entity );
+		EntityPersister persister = session.getEntityPersister( event.getEntityName(), entity );
 
 		event.setRequestedId(
 				getUpdateId(
-						entity, persister, event.getRequestedId(), event.getSession()
+						entity, persister, event.getRequestedId(), session
 				)
 		);
 
@@ -279,7 +282,8 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 		final EventSource source = event.getSession();
 		final EntityKey key = source.generateEntityKey( event.getRequestedId(), persister );
 
-		source.getPersistenceContext().checkUniqueness( key, entity );
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		persistenceContext.checkUniqueness( key, entity );
 
 		if ( invokeUpdateLifecycle( entity, persister, source ) ) {
 			reassociate( event, event.getObject(), event.getRequestedId(), persister );
@@ -302,7 +306,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
             		entry.getState(); //TODO: half-assemble this stuff
         }*/
 
-		source.getPersistenceContext().addEntity(
+		persistenceContext.addEntity(
 				entity,
 				( persister.isMutable() ? Status.MANAGED : Status.READ_ONLY ),
 				null, // cachedState,
@@ -350,12 +354,13 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 	 */
 	private void cascadeOnUpdate(SaveOrUpdateEvent event, EntityPersister persister, Object entity) {
 		final EventSource source = event.getSession();
-		source.getPersistenceContext().incrementCascadeLevel();
+		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
+		persistenceContext.incrementCascadeLevel();
 		try {
 			Cascade.cascade( CascadingActions.SAVE_UPDATE, CascadePoint.AFTER_UPDATE, source, persister, entity );
 		}
 		finally {
-			source.getPersistenceContext().decrementCascadeLevel();
+			persistenceContext.decrementCascadeLevel();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultUpdateEventListener.java
@@ -25,7 +25,7 @@ public class DefaultUpdateEventListener extends DefaultSaveOrUpdateEventListener
 	protected Serializable performSaveOrUpdate(SaveOrUpdateEvent event) {
 		// this implementation is supposed to tolerate incorrect unsaved-value
 		// mappings, for the purpose of backward-compatibility
-		EntityEntry entry = event.getSession().getPersistenceContext().getEntry( event.getEntity() );
+		EntityEntry entry = event.getSession().getPersistenceContextInternal().getEntry( event.getEntity() );
 		if ( entry!=null ) {
 			if ( entry.getStatus()== Status.DELETED ) {
 				throw new ObjectDeletedException( "deleted instance passed to update()", null, event.getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DirtyCollectionSearchVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DirtyCollectionSearchVisitor.java
@@ -39,7 +39,7 @@ public class DirtyCollectionSearchVisitor extends AbstractVisitor {
 			final SessionImplementor session = getSession();
 			final PersistentCollection persistentCollection;
 			if ( type.isArrayType() ) {
-				persistentCollection = session.getPersistenceContext().getCollectionHolder( collection );
+				persistentCollection = session.getPersistenceContextInternal().getCollectionHolder( collection );
 				// if no array holder we found an unwrappered array (this can't occur,
 				// because we now always call wrap() before getting to here)
 				// return (ah==null) ? true : searchForDirtyCollections(ah, type);

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
@@ -36,17 +36,18 @@ public class FlushVisitor extends AbstractVisitor {
 
 		if ( collection != null ) {
 			final PersistentCollection coll;
+			final EventSource session = getSession();
 			if ( type.hasHolder() ) {
-				coll = getSession().getPersistenceContext().getCollectionHolder(collection);
+				coll = session.getPersistenceContextInternal().getCollectionHolder(collection);
 			}
 			else if ( collection == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-				coll = (PersistentCollection) type.resolve( collection, getSession(), owner );
+				coll = (PersistentCollection) type.resolve( collection, session, owner );
 			}
 			else {
 				coll = (PersistentCollection) collection;
 			}
 
-			Collections.processReachableCollection( coll, type, owner, getSession() );
+			Collections.processReachableCollection( coll, type, owner, session);
 		}
 
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
@@ -374,7 +374,7 @@ class MergeContext implements Map {
 	}
 
 	private String printEntity(Object entity) {
-		if ( session.getPersistenceContext().getEntry( entity ) != null ) {
+		if ( session.getPersistenceContextInternal().getEntry( entity ) != null ) {
 			return MessageHelper.infoString( session.getEntityName( entity ), session.getIdentifier( entity ) );
 		}
 		// Entity was not found in current persistence context. Use Object#toString() method.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/OnReplicateVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/OnReplicateVisitor.java
@@ -51,7 +51,7 @@ public class OnReplicateVisitor extends ReattachVisitor {
 			final PersistentCollection wrapper = (PersistentCollection) collection;
 			wrapper.setCurrentSession( (SessionImplementor) session );
 			if ( wrapper.wasInitialized() ) {
-				session.getPersistenceContext().addNewCollection( persister, wrapper );
+				session.getPersistenceContextInternal().addNewCollection( persister, wrapper );
 			}
 			else {
 				reattachCollection( wrapper, type );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/PostUpdateEventListenerStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/PostUpdateEventListenerStandardImpl.java
@@ -35,7 +35,7 @@ public class PostUpdateEventListenerStandardImpl implements PostUpdateEventListe
 	}
 
 	private void handlePostUpdate(Object entity, EventSource source) {
-		EntityEntry entry = source.getPersistenceContext().getEntry( entity );
+		EntityEntry entry = source.getPersistenceContextInternal().getEntry( entity );
 		// mimic the preUpdate filter
 		if ( Status.DELETED != entry.getStatus()) {
 			callbackRegistry.postUpdate(entity);

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
@@ -64,19 +64,20 @@ public abstract class ProxyVisitor extends AbstractVisitor {
 	 */
 	protected void reattachCollection(PersistentCollection collection, CollectionType type)
 	throws HibernateException {
+		final EventSource session = getSession();
 		if ( collection.wasInitialized() ) {
-			CollectionPersister collectionPersister = getSession().getFactory()
+			CollectionPersister collectionPersister = session.getFactory()
 			.getCollectionPersister( type.getRole() );
-			getSession().getPersistenceContext()
+			session.getPersistenceContext()
 				.addInitializedDetachedCollection( collectionPersister, collection );
 		}
 		else {
-			if ( !isCollectionSnapshotValid(collection) ) {
+			if ( !isCollectionSnapshotValid( collection ) ) {
 				throw new HibernateException( "could not reassociate uninitialized transient collection" );
 			}
-			CollectionPersister collectionPersister = getSession().getFactory()
+			CollectionPersister collectionPersister = session.getFactory()
 					.getCollectionPersister( collection.getRole() );
-			getSession().getPersistenceContext()
+			session.getPersistenceContext()
 				.addUninitializedDetachedCollection( collectionPersister, collection );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
@@ -88,7 +88,7 @@ public class WrapVisitor extends ProxyVisitor {
 		else {
 			CollectionPersister persister = session.getFactory().getCollectionPersister( collectionType.getRole() );
 
-			final PersistenceContext persistenceContext = session.getPersistenceContext();
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			//TODO: move into collection type, so we can use polymorphism!
 			if ( collectionType.hasHolder() ) {
 

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
@@ -50,20 +50,20 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 	}
 
 	protected static CollectionPersister getLoadedCollectionPersister( PersistentCollection collection, EventSource source ) {
-		CollectionEntry ce = source.getPersistenceContext().getCollectionEntry( collection );
+		CollectionEntry ce = source.getPersistenceContextInternal().getCollectionEntry( collection );
 		return ( ce == null ? null : ce.getLoadedPersister() );		
 	}
 
 	protected static Object getLoadedOwnerOrNull( PersistentCollection collection, EventSource source ) {
-		return source.getPersistenceContext().getLoadedCollectionOwnerOrNull( collection );
+		return source.getPersistenceContextInternal().getLoadedCollectionOwnerOrNull( collection );
 	}
 
 	protected static Serializable getLoadedOwnerIdOrNull( PersistentCollection collection, EventSource source ) {
-		return source.getPersistenceContext().getLoadedCollectionOwnerIdOrNull( collection );
+		return source.getPersistenceContextInternal().getLoadedCollectionOwnerIdOrNull( collection );
 	}
 
 	protected static Serializable getOwnerIdOrNull( Object owner, EventSource source ) {
-		EntityEntry ownerEntry = source.getPersistenceContext().getEntry( owner );
+		EntityEntry ownerEntry = source.getPersistenceContextInternal().getEntry( owner );
 		return ( ownerEntry == null ? null : ownerEntry.getId() );
 	}
 
@@ -74,7 +74,7 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 		String entityName =
 				( collectionPersister == null ? null : collectionPersister.getOwnerEntityPersister().getEntityName() );
 		if ( affectedOwner != null ) {
-			EntityEntry ee = source.getPersistenceContext().getEntry( affectedOwner );
+			EntityEntry ee = source.getPersistenceContextInternal().getEntry( affectedOwner );
 			if ( ee != null && ee.getEntityName() != null) {
 				entityName = ee.getEntityName();
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractScrollableResults.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractScrollableResults.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.hibernate.HibernateException;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.hql.internal.HolderInstantiator;
@@ -101,10 +102,11 @@ public abstract class AbstractScrollableResults implements ScrollableResultsImpl
 
 		// not absolutely necessary, but does help with aggressive release
 		//session.getJDBCContext().getConnectionManager().closeQueryStatement( ps, resultSet );
-		session.getJdbcCoordinator().getResourceRegistry().release( ps );
-		session.getJdbcCoordinator().afterStatementExecution();
+		final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
+		jdbcCoordinator.getResourceRegistry().release( ps );
+		jdbcCoordinator.afterStatementExecution();
 		try {
-			session.getPersistenceContext().getLoadContexts().cleanup( resultSet );
+			session.getPersistenceContextInternal().getLoadContexts().cleanup( resultSet );
 		}
 		catch (Throwable ignore) {
 			// ignore this error for now

--- a/hibernate-core/src/main/java/org/hibernate/internal/CriteriaImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CriteriaImpl.java
@@ -305,7 +305,7 @@ public class CriteriaImpl implements Criteria, Serializable {
 		}
 		return ( isReadOnlyInitialized() ?
 				readOnly :
-				getSession().getPersistenceContext().isDefaultReadOnly()
+				getSession().getPersistenceContextInternal().isDefaultReadOnly()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/IteratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/IteratorImpl.java
@@ -14,6 +14,7 @@ import java.util.NoSuchElementException;
 import org.hibernate.HibernateException;
 import org.hibernate.JDBCException;
 import org.hibernate.engine.HibernateIterator;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.hql.internal.HolderInstantiator;
 import org.hibernate.type.EntityType;
@@ -63,7 +64,8 @@ public final class IteratorImpl implements HibernateIterator {
 	public void close() throws JDBCException {
 		if ( ps != null ) {
 			LOG.debug( "Closing iterator" );
-			session.getJdbcCoordinator().getResourceRegistry().release( ps );
+			final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
+			jdbcCoordinator.getResourceRegistry().release( ps );
 			try {
 				session.getPersistenceContext().getLoadContexts().cleanup( rs );
 			}
@@ -71,7 +73,7 @@ public final class IteratorImpl implements HibernateIterator {
 				// ignore this error for now
 				LOG.debugf( "Exception trying to cleanup load context : %s", ignore.getMessage() );
 			}
-			session.getJdbcCoordinator().afterStatementExecution();
+			jdbcCoordinator.afterStatementExecution();
 			ps = null;
 			rs = null;
 			hasNext = false;

--- a/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsImpl.java
@@ -190,7 +190,7 @@ public class ScrollableResultsImpl extends AbstractScrollableResults implements 
 			return;
 		}
 
-		final PersistenceContext persistenceContext = getSession().getPersistenceContext();
+		final PersistenceContext persistenceContext = getSession().getPersistenceContextInternal();
 		persistenceContext.beforeLoad();
 		try {
 			final Object result = getLoader().loadSingleRow(

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2396,6 +2396,11 @@ public final class SessionImpl
 	}
 
 	@Override
+	public PersistenceContext getPersistenceContextInternal() {
+		return persistenceContext;
+	}
+
+	@Override
 	public SessionStatistics getStatistics() {
 		checkTransactionSynchStatus();
 		return new SessionStatisticsImpl( this );
@@ -3157,14 +3162,16 @@ public final class SessionImpl
 				return;
 			}
 
-			for ( Serializable pk : getPersistenceContext().getNaturalIdHelper()
+			final PersistenceContext persistenceContext = getPersistenceContextInternal();
+			final boolean debugEnabled = log.isDebugEnabled();
+			for ( Serializable pk : persistenceContext.getNaturalIdHelper()
 					.getCachedPkResolutions( entityPersister ) ) {
 				final EntityKey entityKey = generateEntityKey( pk, entityPersister );
-				final Object entity = getPersistenceContext().getEntity( entityKey );
-				final EntityEntry entry = getPersistenceContext().getEntry( entity );
+				final Object entity = persistenceContext.getEntity( entityKey );
+				final EntityEntry entry = persistenceContext.getEntry( entity );
 
 				if ( entry == null ) {
-					if ( log.isDebugEnabled() ) {
+					if ( debugEnabled ) {
 						log.debug(
 								"Cached natural-id/pk resolution linked to null EntityEntry in persistence context : "
 										+ MessageHelper.infoString( entityPersister, pk, getFactory() )
@@ -3182,7 +3189,7 @@ public final class SessionImpl
 					continue;
 				}
 
-				getPersistenceContext().getNaturalIdHelper().handleSynchronization(
+				persistenceContext.getNaturalIdHelper().handleSynchronization(
 						entityPersister,
 						pk,
 						entity

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -411,7 +411,7 @@ public abstract class Loader {
 				session,
 				queryParameters.isReadOnly( session )
 		);
-		session.getPersistenceContext().initializeNonLazyCollections();
+		session.getPersistenceContextInternal().initializeNonLazyCollections();
 		return result;
 	}
 
@@ -471,7 +471,7 @@ public abstract class Loader {
 				session,
 				queryParameters.isReadOnly( session )
 		);
-		session.getPersistenceContext().initializeNonLazyCollections();
+		session.getPersistenceContextInternal().initializeNonLazyCollections();
 		return result;
 	}
 
@@ -755,7 +755,7 @@ public abstract class Loader {
 			// now get an existing proxy for each row element (if there is one)
 			for ( int i = 0; i < entitySpan; i++ ) {
 				Object entity = row[i];
-				Object proxy = session.getPersistenceContext().proxyFor( persisters[i], keys[i], entity );
+				Object proxy = session.getPersistenceContextInternal().proxyFor( persisters[i], keys[i], entity );
 				if ( entity != proxy ) {
 					// force the proxy to resolve itself
 					( (HibernateProxy) proxy ).getHibernateLazyInitializer().setImplementation( entity );
@@ -1066,6 +1066,7 @@ public abstract class Loader {
 			final Loadable[] loadables = getEntityPersisters();
 			final String[] aliases = getAliases();
 			final String subselectQueryString = SubselectFetch.createSubselectFetchQueryFragment( queryParameters );
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			for ( Object key : keys ) {
 				final EntityKey[] rowKeys = (EntityKey[]) key;
 				for ( int i = 0; i < rowKeys.length; i++ ) {
@@ -1081,7 +1082,7 @@ public abstract class Loader {
 								namedParameterLocMap
 						);
 
-						session.getPersistenceContext()
+						persistenceContext
 								.getBatchFetchQueue()
 								.addSubselect( rowKeys[i], subselectFetch );
 					}
@@ -1196,6 +1197,7 @@ public abstract class Loader {
 		// split off from initializeEntity.  It *must* occur after
 		// endCollectionLoad to ensure the collection is in the
 		// persistence context.
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		if ( hydratedObjects != null && hydratedObjects.size() > 0 ) {
 
 			final Iterable<PostLoadEventListener> postLoadEventListeners;
@@ -1214,7 +1216,7 @@ public abstract class Loader {
 				TwoPhaseLoad.postLoad( hydratedObject, session, post, postLoadEventListeners );
 				if ( afterLoadActions != null ) {
 					for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
-						final EntityEntry entityEntry = session.getPersistenceContext().getEntry( hydratedObject );
+						final EntityEntry entityEntry = persistenceContext.getEntry( hydratedObject );
 						if ( entityEntry == null ) {
 							// big problem
 							throw new HibernateException(
@@ -1233,7 +1235,7 @@ public abstract class Loader {
 			final SharedSessionContractImplementor session,
 			final CollectionPersister collectionPersister) {
 		//this is a query and we are loading multiple instances of the same collection role
-		session.getPersistenceContext()
+		session.getPersistenceContextInternal()
 				.getLoadContexts()
 				.getCollectionLoadContext( (ResultSet) resultSetId )
 				.endLoadingCollections( collectionPersister );
@@ -1311,6 +1313,7 @@ public abstract class Loader {
 		if ( owners != null ) {
 
 			EntityType[] ownerAssociationTypes = getOwnerAssociationTypes();
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			for ( int i = 0; i < keys.length; i++ ) {
 
 				int owner = owners[i];
@@ -1318,7 +1321,6 @@ public abstract class Loader {
 					EntityKey ownerKey = keys[owner];
 					if ( keys[i] == null && ownerKey != null ) {
 
-						final PersistenceContext persistenceContext = session.getPersistenceContext();
 
 						/*final boolean isPrimaryKey;
 						final boolean isSpecialOneToOne;
@@ -1375,7 +1377,7 @@ public abstract class Loader {
 			final SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 
 		final Serializable collectionRowKey = (Serializable) persister.readKey(
 				rs,
@@ -1451,6 +1453,7 @@ public abstract class Loader {
 			// for each of the passed-in keys, to account for the possibility
 			// that the collection is empty and has no rows in the result set
 			CollectionPersister[] collectionPersisters = getCollectionPersisters();
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			for ( CollectionPersister collectionPersister : collectionPersisters ) {
 				for ( Serializable key : keys ) {
 					//handle empty collections
@@ -1461,7 +1464,7 @@ public abstract class Loader {
 						);
 					}
 
-					session.getPersistenceContext()
+					persistenceContext
 							.getLoadContexts()
 							.getCollectionLoadContext( (ResultSet) resultSetId )
 							.getLoadingCollection( collectionPersister, key );
@@ -1529,7 +1532,7 @@ public abstract class Loader {
 			final ResultSet rs,
 			final SharedSessionContractImplementor session) throws HibernateException, SQLException {
 
-		Object version = session.getPersistenceContext().getEntry( entity ).getVersion();
+		Object version = session.getPersistenceContextInternal().getEntry( entity ).getVersion();
 
 		if ( version != null ) {
 			// null version means the object is in the process of being loaded somewhere else in the ResultSet
@@ -1678,7 +1681,7 @@ public abstract class Loader {
 		}
 
 		if ( LockMode.NONE != requestedLockMode && upgradeLocks() ) {
-			final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+			final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 			if ( entry.getLockMode().lessThan( requestedLockMode ) ) {
 				//we only check the version when _upgrading_ lock modes
 				if ( persister.isVersioned() ) {
@@ -1877,7 +1880,7 @@ public abstract class Loader {
 						persister.getEntityMode(),
 						session.getFactory()
 				);
-				session.getPersistenceContext().addEntity( euk, object );
+				session.getPersistenceContextInternal().addEntity( euk, object );
 			}
 		}
 
@@ -2704,7 +2707,7 @@ public abstract class Loader {
 									.getEntityMetamodel()
 									.hasImmutableNaturalId();
 
-			final PersistenceContext persistenceContext = session.getPersistenceContext();
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			boolean defaultReadOnlyOrig = persistenceContext.isDefaultReadOnly();
 			if ( queryParameters.isReadOnlyInitialized() ) {
 				// The read-only/modifiable mode for the query was explicitly set.

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/DynamicBatchingCollectionInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/DynamicBatchingCollectionInitializerBuilder.java
@@ -84,7 +84,7 @@ public class DynamicBatchingCollectionInitializerBuilder extends BatchingCollect
 		@Override
 		public void initialize(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
 			// first, figure out how many batchable ids we have...
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getCollectionBatch( collectionPersister(), id, maxBatchSize );
 			final int numberOfIds = ArrayHelper.countNonNull( batch );
@@ -193,7 +193,7 @@ public class DynamicBatchingCollectionInitializerBuilder extends BatchingCollect
 			);
 
 			try {
-				final PersistenceContext persistenceContext = session.getPersistenceContext();
+				final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 				boolean defaultReadOnlyOrig = persistenceContext.isDefaultReadOnly();
 				if ( queryParameters.isReadOnlyInitialized() ) {
 					// The read-only/modifiable mode for the query was explicitly set.

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/LegacyBatchingCollectionInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/LegacyBatchingCollectionInitializerBuilder.java
@@ -67,7 +67,7 @@ public class LegacyBatchingCollectionInitializerBuilder extends BatchingCollecti
 
 		@Override
 		public void initialize(Serializable id, SharedSessionContractImplementor session)	throws HibernateException {
-			Serializable[] batch = session.getPersistenceContext().getBatchFetchQueue()
+			Serializable[] batch = session.getPersistenceContextInternal().getBatchFetchQueue()
 					.getCollectionBatch( collectionPersister(), id, batchSizes[0] );
 
 			for ( int i=0; i<batchSizes.length-1; i++) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/PaddedBatchingCollectionInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/PaddedBatchingCollectionInitializerBuilder.java
@@ -70,7 +70,7 @@ public class PaddedBatchingCollectionInitializerBuilder extends BatchingCollecti
 
 		@Override
 		public void initialize(Serializable id, SharedSessionContractImplementor session)	throws HibernateException {
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getCollectionBatch( collectionPersister(), id, batchSizes[0] );
 			final int numberOfIds = ArrayHelper.countNonNull( batch );

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/plan/LegacyBatchingCollectionInitializerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/plan/LegacyBatchingCollectionInitializerBuilder.java
@@ -18,7 +18,9 @@ import org.hibernate.loader.Loader;
 import org.hibernate.loader.collection.BasicCollectionLoader;
 import org.hibernate.loader.collection.CollectionInitializer;
 import org.hibernate.loader.collection.OneToManyLoader;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.collection.QueryableCollection;
+import org.hibernate.type.Type;
 
 /**
  * LoadPlan-based implementation of the the legacy batch collection initializer.
@@ -72,20 +74,22 @@ public class LegacyBatchingCollectionInitializerBuilder extends AbstractBatching
 
 		@Override
 		public void initialize(Serializable id, SharedSessionContractImplementor session)	throws HibernateException {
+			final CollectionPersister collectionPersister = getCollectionPersister();
 			Serializable[] batch = session.getPersistenceContext().getBatchFetchQueue()
-					.getCollectionBatch( getCollectionPersister(), id, batchSizes[0] );
+					.getCollectionBatch( collectionPersister, id, batchSizes[0] );
 
+			final Type keyType = collectionPersister.getKeyType();
 			for ( int i=0; i<batchSizes.length-1; i++) {
 				final int smallBatchSize = batchSizes[i];
-				if ( batch[smallBatchSize-1]!=null ) {
+				if ( batch[smallBatchSize-1] != null ) {
 					Serializable[] smallBatch = new Serializable[smallBatchSize];
 					System.arraycopy(batch, 0, smallBatch, 0, smallBatchSize);
-					loaders[i].loadCollectionBatch( session, smallBatch, getCollectionPersister().getKeyType() );
+					loaders[i].loadCollectionBatch( session, smallBatch, keyType );
 					return; //EARLY EXIT!
 				}
 			}
 
-			loaders[batchSizes.length-1].loadCollection( session, id, getCollectionPersister().getKeyType() );
+			loaders[batchSizes.length-1].loadCollection( session, id, keyType );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/DynamicBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/DynamicBatchingEntityLoaderBuilder.java
@@ -158,14 +158,15 @@ public class DynamicBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuil
 			performOrderedBatchLoad( idsInBatch, lockOptions, persister, session );
 		}
 
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		for ( Integer position : elementPositionsLoadedByBatch ) {
 			// the element value at this position in the result List should be
 			// the EntityKey for that entity; reuse it!
 			final EntityKey entityKey = (EntityKey) result.get( position );
-			Object entity = session.getPersistenceContext().getEntity( entityKey );
+			Object entity = persistenceContext.getEntity( entityKey );
 			if ( entity != null && !loadOptions.isReturnOfDeletedEntitiesEnabled() ) {
 				// make sure it is not DELETED
-				final EntityEntry entry = session.getPersistenceContext().getEntry( entity );
+				final EntityEntry entry = persistenceContext.getEntry( entity );
 				if ( entry.getStatus() == Status.DELETED || entry.getStatus() == Status.GONE ) {
 					// the entity is locally deleted, and the options ask that we not return such entities...
 					entity = null;
@@ -395,7 +396,7 @@ public class DynamicBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuil
 				Object optionalObject,
 				SharedSessionContractImplementor session,
 				LockOptions lockOptions) {
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getEntityBatch( persister(), id, maxBatchSize, persister().getEntityMode() );
 
@@ -508,7 +509,7 @@ public class DynamicBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuil
 			);
 
 			try {
-				final PersistenceContext persistenceContext = session.getPersistenceContext();
+				final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 				boolean defaultReadOnlyOrig = persistenceContext.isDefaultReadOnly();
 				if ( queryParameters.isReadOnlyInitialized() ) {
 					// The read-only/modifiable mode for the query was explicitly set.

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/LegacyBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/LegacyBatchingEntityLoaderBuilder.java
@@ -81,7 +81,7 @@ public class LegacyBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuild
 
 		@Override
 		public Object load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions) {
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getEntityBatch( persister(), id, batchSizes[0], persister().getEntityMode() );
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/PaddedBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/PaddedBatchingEntityLoaderBuilder.java
@@ -91,7 +91,7 @@ class PaddedBatchingEntityLoaderBuilder extends BatchingEntityLoaderBuilder {
 
 		@Override
 		public Object load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions) {
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getEntityBatch( persister(), id, batchSizes[0], persister().getEntityMode() );
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/LegacyBatchingEntityLoaderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/plan/LegacyBatchingEntityLoaderBuilder.java
@@ -94,7 +94,7 @@ public class LegacyBatchingEntityLoaderBuilder extends AbstractBatchingEntityLoa
 
 		@Override
 		public Object load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions) {
-			final Serializable[] batch = session.getPersistenceContext()
+			final Serializable[] batch = session.getPersistenceContextInternal()
 					.getBatchFetchQueue()
 					.getEntityBatch( persister(), id, batchSizes[0], persister().getEntityMode() );
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
@@ -100,7 +100,7 @@ public abstract class AbstractLoadPlanBasedLoader {
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer,
 			List<AfterLoadAction> afterLoadActions) throws SQLException {
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final boolean defaultReadOnlyOrig = persistenceContext.isDefaultReadOnly();
 		if ( queryParameters.isReadOnlyInitialized() ) {
 			// The read-only/modifiable mode for the query was explicitly set.

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/CollectionReferenceInitializerImpl.java
@@ -45,7 +45,7 @@ public class CollectionReferenceInitializerImpl implements CollectionReferenceIn
 
 		try {
 			// read the collection key for this reference for the current row.
-			final PersistenceContext persistenceContext = context.getSession().getPersistenceContext();
+			final PersistenceContext persistenceContext = context.getSession().getPersistenceContextInternal();
 			final Serializable collectionRowKey = (Serializable) collectionReference.getCollectionPersister().readKey(
 					resultSet,
 					aliases.getCollectionColumnAliases().getSuffixedKeyAliases(),
@@ -121,7 +121,7 @@ public class CollectionReferenceInitializerImpl implements CollectionReferenceIn
 			Serializable collectionRowKey,
 			ResultSet resultSet,
 			ResultSetProcessingContextImpl context) {
-		final Object collectionOwner = context.getSession().getPersistenceContext().getCollectionOwner(
+		final Object collectionOwner = context.getSession().getPersistenceContextInternal().getCollectionOwner(
 				collectionRowKey,
 				collectionReference.getCollectionPersister()
 		);
@@ -148,7 +148,7 @@ public class CollectionReferenceInitializerImpl implements CollectionReferenceIn
 
 	@Override
 	public void endLoading(ResultSetProcessingContextImpl context) {
-		context.getSession().getPersistenceContext()
+		context.getSession().getPersistenceContextInternal()
 				.getLoadContexts()
 				.getCollectionLoadContext( context.getResultSet() )
 				.endLoadingCollections( collectionReference.getCollectionPersister() );

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/EntityReturnReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/EntityReturnReader.java
@@ -52,7 +52,7 @@ public class EntityReturnReader implements ReturnReader {
 		final Object entityInstance = context.getProcessingState( entityReturn ).getEntityInstance();
 
 		if ( context.shouldReturnProxies() ) {
-			final Object proxy = context.getSession().getPersistenceContext().proxyFor(
+			final Object proxy = context.getSession().getPersistenceContextInternal().proxyFor(
 					entityReturn.getEntityPersister(),
 					entityKey,
 					entityInstance

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessingContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessingContextImpl.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.hibernate.LockMode;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
@@ -234,7 +235,7 @@ public class ResultSetProcessingContextImpl implements ResultSetProcessingContex
 			throw new IllegalStateException( "Could not locate fetch owner EntityKey" );
 		}
 
-		session.getPersistenceContext().addNullProperty(
+		session.getPersistenceContextInternal().addNullProperty(
 				ownerEntityKey,
 				fetchedType.getPropertyName()
 		);
@@ -351,8 +352,9 @@ public class ResultSetProcessingContextImpl implements ResultSetProcessingContex
 					namedParameterLocMap
 			);
 
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			for ( EntityKey key : entry.getValue() ) {
-				session.getPersistenceContext().getBatchFetchQueue().addSubselect( key, subselectFetch );
+				persistenceContext.getBatchFetchQueue().addSubselect( key, subselectFetch );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -730,7 +730,7 @@ public abstract class AbstractCollectionPersister
 			return null;
 		}
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 
 		SubselectFetch subselect = persistenceContext.getBatchFetchQueue()
 				.getSubselect( session.generateEntityKey( key, getOwnerEntityPersister() ) );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/NamedQueryLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/NamedQueryLoader.java
@@ -77,7 +77,7 @@ public final class NamedQueryLoader implements UniqueEntityLoader {
 
 		// now look up the object we are really interested in!
 		// (this lets us correctly handle proxies and multi-row or multi-column queries)
-		return session.getPersistenceContext().getEntity( session.generateEntityKey( id, persister ) );
+		return session.getPersistenceContextInternal().getEntity( session.generateEntityKey( id, persister ) );
 
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
@@ -263,7 +263,7 @@ public final class MessageHelper {
 			}
 			else {
 				Object collectionOwner = collection == null ? null : collection.getOwner();
-				EntityEntry entry = collectionOwner == null ? null : session.getPersistenceContext().getEntry(collectionOwner);
+				EntityEntry entry = collectionOwner == null ? null : session.getPersistenceContextInternal().getEntry(collectionOwner);
 				ownerKey = entry == null ? null : entry.getId();
 			}
 			s.append( ownerIdentifierType.toLoggableString( 

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyBackRefImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyBackRefImpl.java
@@ -97,7 +97,7 @@ public class PropertyAccessStrategyBackRefImpl implements PropertyAccessStrategy
 				return UNKNOWN;
 			}
 			else {
-				return session.getPersistenceContext().getOwnerId( entityName, propertyName, owner, mergeMap );
+				return session.getPersistenceContextInternal().getOwnerId( entityName, propertyName, owner, mergeMap );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyIndexBackRefImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyIndexBackRefImpl.java
@@ -80,7 +80,7 @@ public class PropertyAccessStrategyIndexBackRefImpl implements PropertyAccessStr
 				return PropertyAccessStrategyBackRefImpl.UNKNOWN;
 			}
 			else {
-				return session.getPersistenceContext().getIndexInOwner( entityName, propertyName, owner, mergeMap );
+				return session.getPersistenceContextInternal().getIndexInOwner( entityName, propertyName, owner, mergeMap );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -15,6 +15,7 @@ import org.hibernate.SessionException;
 import org.hibernate.TransientObjectException;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
@@ -255,7 +256,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 					getIdentifier(),
 					session.getFactory().getMetamodel().entityPersister( getEntityName() )
 			);
-			final Object entity = session.getPersistenceContext().getEntity( key );
+			final Object entity = session.getPersistenceContextInternal().getEntity( key );
 			if ( entity != null ) {
 				setImplementation( entity );
 			}
@@ -299,7 +300,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	private Object getProxyOrNull() {
 		final EntityKey entityKey = generateEntityKeyOrNull( getIdentifier(), session, getEntityName() );
 		if ( entityKey != null && session != null && session.isOpenOrWaitingForAutoClose() ) {
-			return session.getPersistenceContext().getProxy( entityKey );
+			return session.getPersistenceContextInternal().getProxy( entityKey );
 		}
 		return null;
 	}
@@ -319,7 +320,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	@Override
 	public final Object getImplementation(SharedSessionContractImplementor s) throws HibernateException {
 		final EntityKey entityKey = generateEntityKeyOrNull( getIdentifier(), s, getEntityName() );
-		return (entityKey == null ? null : s.getPersistenceContext().getEntity( entityKey ));
+		return ( entityKey == null ? null : s.getPersistenceContext().getEntity( entityKey ) );
 	}
 
 	/**
@@ -369,8 +370,9 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			this.readOnly = readOnly;
 			if ( initialized ) {
 				EntityKey key = generateEntityKeyOrNull( getIdentifier(), session, getEntityName() );
-				if ( key != null && session.getPersistenceContext().containsEntity( key ) ) {
-					session.getPersistenceContext().setReadOnly( target, readOnly );
+				final PersistenceContext persistenceContext = session.getPersistenceContext();
+				if ( key != null && persistenceContext.containsEntity( key ) ) {
+					persistenceContext.setReadOnly( target, readOnly );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -247,7 +247,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 	@Override
 	public boolean isReadOnly() {
 		return ( readOnly == null ?
-				producer.getPersistenceContext().isDefaultReadOnly() :
+				producer.getPersistenceContextInternal().isDefaultReadOnly() :
 				readOnly
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/SessionStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/SessionStatisticsImpl.java
@@ -24,19 +24,19 @@ public class SessionStatisticsImpl implements SessionStatistics {
 	}
 
 	public int getEntityCount() {
-		return session.getPersistenceContext().getNumberOfManagedEntities();
+		return session.getPersistenceContextInternal().getNumberOfManagedEntities();
 	}
 	
 	public int getCollectionCount() {
-		return session.getPersistenceContext().getCollectionEntries().size();
+		return session.getPersistenceContextInternal().getCollectionEntries().size();
 	}
 	
 	public Set getEntityKeys() {
-		return Collections.unmodifiableSet( session.getPersistenceContext().getEntitiesByKey().keySet() );
+		return Collections.unmodifiableSet( session.getPersistenceContextInternal().getEntitiesByKey().keySet() );
 	}
 	
 	public Set getCollectionKeys() {
-		return Collections.unmodifiableSet( session.getPersistenceContext().getCollectionsByKey().keySet() );
+		return Collections.unmodifiableSet( session.getPersistenceContextInternal().getCollectionsByKey().keySet() );
 	}
 	
 	public String toString() {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/AbstractEntityTuplizer.java
@@ -385,7 +385,7 @@ public abstract class AbstractEntityTuplizer implements EntityTuplizer {
 		public void setIdentifier(Object entity, Serializable id, EntityMode entityMode, SharedSessionContractImplementor session) {
 			final Object[] extractedValues = mappedIdentifierType.getPropertyValues( id, entityMode );
 			final Object[] injectionValues = new Object[extractedValues.length];
-			final PersistenceContext persistenceContext = session.getPersistenceContext();
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			for ( int i = 0; i < virtualIdComponent.getSubtypes().length; i++ ) {
 				final Type virtualPropertyType = virtualIdComponent.getSubtypes()[i];
 				final Type idClassPropertyType = mappedIdentifierType.getSubtypes()[i];
@@ -438,7 +438,7 @@ public abstract class AbstractEntityTuplizer implements EntityTuplizer {
 		}
 
 		if ( session != null ) {
-			final EntityEntry pcEntry = session.getPersistenceContext().getEntry( entity );
+			final EntityEntry pcEntry = session.getPersistenceContextInternal().getEntry( entity );
 			if ( pcEntry != null ) {
 				// entity managed; return ID.
 				return pcEntry.getId();

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -369,8 +369,9 @@ public abstract class CollectionType extends AbstractType implements Association
 	 * @return The collection owner's key
 	 */
 	public Serializable getKeyOfOwner(Object owner, SharedSessionContractImplementor session) {
+		final PersistenceContext pc = session.getPersistenceContextInternal();
 
-		EntityEntry entityEntry = session.getPersistenceContext().getEntry( owner );
+		EntityEntry entityEntry = pc.getEntry( owner );
 		if ( entityEntry == null ) {
 			// This just handles a particular case of component
 			// projection, perhaps get rid of it and throw an exception
@@ -637,7 +638,7 @@ public abstract class CollectionType extends AbstractType implements Association
 
 		}
 
-		CollectionEntry ce = session.getPersistenceContext().getCollectionEntry( result );
+		CollectionEntry ce = session.getPersistenceContextInternal().getCollectionEntry( result );
 		if ( ce != null ) {
 			ce.resetStoredSnapshot( result, targetSnapshot );
 		}
@@ -769,7 +770,7 @@ public abstract class CollectionType extends AbstractType implements Association
 	public Object getCollection(Serializable key, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) {
 
 		final CollectionPersister persister = getPersister( session );
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 
 		final CollectionKey collectionKey = new CollectionKey( persister, key );
 		// check if collection is currently being loaded

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -588,7 +588,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 		if ( componentTuplizer.hasParentProperty() && parent != null ) {
 			componentTuplizer.setParent(
 					result,
-					session.getPersistenceContext().proxyFor( parent ),
+					session.getPersistenceContextInternal().proxyFor( parent ),
 					session.getFactory()
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -739,7 +739,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 				session.getFactory()
 		);
 
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		Object result = persistenceContext.getEntity( euk );
 		if ( result == null ) {
 			result = persister.loadByUniqueKey( uniqueKeyPropertyName, key, session );

--- a/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
@@ -204,8 +204,9 @@ public class ManyToOneType extends EntityType {
 			final EntityPersister persister = getAssociatedEntityPersister( session.getFactory() );
 			if ( persister.isBatchLoadable() ) {
 				final EntityKey entityKey = session.generateEntityKey( id, persister );
-				if ( !session.getPersistenceContext().containsEntity( entityKey ) ) {
-					session.getPersistenceContext().getBatchFetchQueue().addBatchLoadableEntityKey( entityKey );
+				final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+				if ( !persistenceContext.containsEntity( entityKey ) ) {
+					persistenceContext.getBatchFetchQueue().addBatchLoadableEntityKey( entityKey );
 				}
 			}
 		}
@@ -238,7 +239,8 @@ public class ManyToOneType extends EntityType {
 	public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) throws HibernateException {
 		Object resolvedValue = super.resolve(value, session, owner, overridingEager);
 		if ( isLogicalOneToOne && value != null && getPropertyName() != null ) {
-			EntityEntry entry = session.getPersistenceContext().getEntry( owner );
+			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+			EntityEntry entry = persistenceContext.getEntry( owner );
 			if ( entry != null ) {
 				final Loadable ownerPersister = (Loadable) session.getFactory().getMetamodel().entityPersister( entry.getEntityName() );
 				EntityUniqueKey entityKey = new EntityUniqueKey(
@@ -249,7 +251,7 @@ public class ManyToOneType extends EntityType {
 						ownerPersister.getEntityMode(),
 						session.getFactory()
 				);
-				session.getPersistenceContext().addEntity( entityKey, owner );
+				persistenceContext.addEntity( entityKey, owner );
 			}
 		}
 		return resolvedValue;

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -103,7 +103,7 @@ public class OneToOneType extends EntityType {
 			final EntityPersister ownerPersister = session.getFactory().getMetamodel().entityPersister( entityName );
 			final Serializable id = session.getContextEntityIdentifier( owner );
 			final EntityKey entityKey = session.generateEntityKey( id, ownerPersister );
-			return session.getPersistenceContext().isPropertyNull( entityKey, getPropertyName() );
+			return session.getPersistenceContextInternal().isPropertyNull( entityKey, getPropertyName() );
 		}
 		else {
 			return false;

--- a/hibernate-core/src/test/java/org/hibernate/test/batchfetch/BatchFetchNotFoundIgnoreDefaultStyleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/batchfetch/BatchFetchNotFoundIgnoreDefaultStyleTest.java
@@ -283,7 +283,7 @@ public class BatchFetchNotFoundIgnoreDefaultStyleTest extends BaseCoreFunctional
 		final EntityPersister persister =
 				sessionImplementor.getFactory().getMetamodel().entityPersister( Task.class );
 		final BatchFetchQueue batchFetchQueue =
-				sessionImplementor.getPersistenceContext().getBatchFetchQueue();
+				sessionImplementor.getPersistenceContextInternal().getBatchFetchQueue();
 		assertEquals( expected, batchFetchQueue.containsEntityKey( new EntityKey( id, persister ) ) );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/collection/dereferenced/AbstractDereferencedCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/collection/dereferenced/AbstractDereferencedCollectionTest.java
@@ -49,10 +49,10 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractDereferencedCollectionTest extends BaseCoreFunctionalTestCase {
 
 	protected EntityEntry getEntityEntry(Session s, Object entity) {
-		return ( (SessionImplementor) s ).getPersistenceContext().getEntry( entity );
+		return ( (SessionImplementor) s ).getPersistenceContextInternal().getEntry( entity );
 	}
 
 	protected CollectionEntry getCollectionEntry(Session s, PersistentCollection collection) {
-		return ( (SessionImplementor) s ).getPersistenceContext().getCollectionEntry( collection );
+		return ( (SessionImplementor) s ).getPersistenceContextInternal().getCollectionEntry( collection );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/event/collection/detached/AggregatedCollectionEventListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/event/collection/detached/AggregatedCollectionEventListener.java
@@ -117,7 +117,7 @@ public class AggregatedCollectionEventListener
 			this.event = event;
 			// make a copy of the collection?
 			this.snapshotAtTimeOfEventHandling = event.getSession()
-					.getPersistenceContext()
+					.getPersistenceContextInternal()
 					.getCollectionEntry( event.getCollection() )
 					.getSnapshot();
 		}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversCollectionEventListener.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/event/spi/BaseEnversCollectionEventListener.java
@@ -44,7 +44,7 @@ public abstract class BaseEnversCollectionEventListener extends BaseEnversEventL
 	}
 
 	protected final CollectionEntry getCollectionEntry(AbstractCollectionEvent event) {
-		return event.getSession().getPersistenceContext().getCollectionEntry( event.getCollection() );
+		return event.getSession().getPersistenceContextInternal().getCollectionEntry( event.getCollection() );
 	}
 
 	protected final void onCollectionAction(

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
@@ -229,7 +229,7 @@ public abstract class AbstractCollectionMapper<T> extends AbstractPropertyMapper
 			PersistentCollection collection) {
 		// First attempt to resolve the persister from the collection entry
 		if ( collection != null ) {
-			CollectionEntry collectionEntry = session.getPersistenceContext().getCollectionEntry( collection );
+			CollectionEntry collectionEntry = session.getPersistenceContextInternal().getCollectionEntry( collection );
 			if ( collectionEntry != null ) {
 				CollectionPersister collectionPersister = collectionEntry.getCurrentPersister();
 				if ( collectionPersister != null ) {


### PR DESCRIPTION
… methods

See also branch "HHH-13465-5.3" for the backport.

This patch is rather large; best is to just see I added this new method:
 - https://github.com/hibernate/hibernate-orm/blob/e0ba73e1f7ddf95264831690ebec6b38114227bc/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java#L514-L526

And then moved most - but not all - usages of internal code to the lighter method.

There are more methods using the new method than the old ones; so it migth be easier to just check that (and if) the remaining use cases are the ones you'd expect to still use the existing method.