### PR TITLE
Fix JavaModulePathIT when testing with javassist

### DIFF
--- a/hibernate-integrationtest-java-modules/src/main/java/module-info.java
+++ b/hibernate-integrationtest-java-modules/src/main/java/module-info.java
@@ -7,7 +7,8 @@
 module org.hibernate.orm.integrationtest.java.module {
 	exports org.hibernate.orm.integrationtest.java.module.service;
 	opens org.hibernate.orm.integrationtest.java.module.entity to
-			org.hibernate.orm.core;
+			org.hibernate.orm.core,
+			javassist; // Necessary for javassist, but not for bytebuddy (the default)
 
 	requires java.persistence;
 	/*


### PR DESCRIPTION
Works when executing the tests locally with JDK11 with this command:

```
./gradlew :hibernate-integrationtest-java-modules:test --stacktrace --info -Dhibernate.bytecode.provider=javassist
```