### PR TITLE
HHH-13466 : ClassCastException when changing a Collection association to a Set if @PreUpdate listener exists

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -32,7 +32,11 @@ import org.hibernate.type.Type;
  */
 public class PersistentBag extends AbstractPersistentCollection implements List {
 
+	// TODO: Why is this.bag protected? Can it be changed to private?
 	protected List bag;
+
+	// The Collection provided to a PersistentBag constructor,
+	private Collection providedCollection;
 
 	/**
 	 * Constructs a PersistentBag.  Needed for SOAP libraries, etc
@@ -70,6 +74,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	@SuppressWarnings("unchecked")
 	public PersistentBag(SharedSessionContractImplementor session, Collection coll) {
 		super( session );
+		providedCollection = coll;
 		if ( coll instanceof List ) {
 			bag = (List) coll;
 		}
@@ -99,7 +104,12 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 	@Override
 	public boolean isWrapper(Object collection) {
-		return bag==collection;
+		if ( providedCollection == null || providedCollection == bag ) {
+			return bag == collection;
+		}
+		else {
+			return providedCollection == collection;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
@@ -37,8 +37,12 @@ import org.hibernate.type.Type;
  * @author Gavin King
  */
 public class PersistentIdentifierBag extends AbstractPersistentCollection implements List {
+	// TODO: why are values and identifiers protected? Can they be changed to private?
 	protected List<Object> values;
 	protected Map<Integer, Object> identifiers;
+
+	// The Collection provided to a PersistentIdentifierBag constructor,
+	private Collection providedValues;
 
 	/**
 	 * Constructs a PersistentIdentifierBag.  This form needed for SOAP libraries, etc
@@ -76,6 +80,7 @@ public class PersistentIdentifierBag extends AbstractPersistentCollection implem
 	@SuppressWarnings("unchecked")
 	public PersistentIdentifierBag(SharedSessionContractImplementor session, Collection coll) {
 		super( session );
+		providedValues = coll;
 		if (coll instanceof List) {
 			values = (List<Object>) coll;
 		}
@@ -124,7 +129,12 @@ public class PersistentIdentifierBag extends AbstractPersistentCollection implem
 
 	@Override
 	public boolean isWrapper(Object collection) {
-		return values==collection;
+		if ( providedValues == null || providedValues == values ) {
+			return values == collection;
+		}
+		else {
+			return providedValues == collection;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PreUpdateNewBidirectionalCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PreUpdateNewBidirectionalCollectionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.callbacks;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.PreUpdate;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@TestForIssue(jiraKey = "HHH-XXXXX")
+public class PreUpdateNewBidirectionalCollectionTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Person.class, Tag.class };
+	}
+
+	@Test
+	public void testPreUpdateModifications() {
+		Person person = new Person();
+		person.id = 1;
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( person );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Person p = entityManager.find( Person.class, person.id );
+			assertNotNull( p );
+				   final Tag tag = new Tag();
+				   tag.id = 2;
+				   tag.description = "description";
+				   tag.person = p;
+				   final Set<Tag> tags = new HashSet<Tag>();
+				   tags.add( tag );
+				   p.tags = tags;
+				   entityManager.merge( p );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Person p = entityManager.find( Person.class, person.id );
+				   assertEquals( 1, p.tags.size() );
+				   assertEquals( "description", p.tags.iterator().next().description );
+		} );
+	}
+
+	@Entity(name = "Person")
+	@EntityListeners( PersonListener.class )
+	private static class Person {
+		@Id
+		private int id;
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		private Instant createdAt;
+
+		public Instant getCreatedAt() {
+			return createdAt;
+		}
+
+		public void setCreatedAt(Instant createdAt) {
+			this.createdAt = createdAt;
+		}
+
+		private Instant lastUpdatedAt;
+
+		public Instant getLastUpdatedAt() {
+			return lastUpdatedAt;
+		}
+
+		public void setLastUpdatedAt(Instant lastUpdatedAt) {
+			this.lastUpdatedAt = lastUpdatedAt;
+		}
+
+		@OneToMany(mappedBy = "person", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private Collection<Tag> tags = new ArrayList<Tag>();
+	}
+
+	@Entity(name = "Tag")
+	public static class Tag {
+
+		@Id
+		private int id;
+
+		private String description;
+
+		@ManyToOne
+		private Person person;
+	}
+
+	public static class PersonListener {
+		@PreUpdate
+		void onPreUpdate(Object o) {
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PreUpdateNewUnidirectionalCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/callbacks/PreUpdateNewUnidirectionalCollectionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.callbacks;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@TestForIssue(jiraKey = "HHH-XXXXX")
+public class PreUpdateNewUnidirectionalCollectionTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Person.class, Tag.class };
+	}
+
+	@Test
+	public void testPreUpdateModifications() {
+		Person person = new Person();
+		person.id = 1;
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( person );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Person p = entityManager.find( Person.class, person.id );
+			assertNotNull( p );
+				   final Tag tag = new Tag();
+				   tag.id = 2;
+				   tag.description = "description";
+				   final Set<Tag> tags = new HashSet<Tag>();
+				   tags.add( tag );
+				   p.tags = tags;
+				   entityManager.merge( p );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Person p = entityManager.find( Person.class, person.id );
+				   assertEquals( 1, p.tags.size() );
+				   assertEquals( "description", p.tags.iterator().next().description );
+		} );
+	}
+
+	@Entity(name = "Person")
+	@EntityListeners( PersonListener.class )
+	private static class Person {
+		@Id
+		private int id;
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		private Instant createdAt;
+
+		public Instant getCreatedAt() {
+			return createdAt;
+		}
+
+		public void setCreatedAt(Instant createdAt) {
+			this.createdAt = createdAt;
+		}
+
+		private Instant lastUpdatedAt;
+
+		public Instant getLastUpdatedAt() {
+			return lastUpdatedAt;
+		}
+
+		public void setLastUpdatedAt(Instant lastUpdatedAt) {
+			this.lastUpdatedAt = lastUpdatedAt;
+		}
+
+		@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		private Collection<Tag> tags = new ArrayList<Tag>();
+	}
+
+	@Entity(name = "Tag")
+	public static class Tag {
+
+		@Id
+		private int id;
+
+		private String description;
+	}
+
+	public static class PersonListener {
+		@PreUpdate
+		void onPreUpdate(Object o) {
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13466

The bug happens because an entity's reference to a `PersistentCollection` was modified to refer to a `HashSet`. 

During flush, the pre-update listener is executed, `DefaultFlushEntityEventListener#copyState` detects a dirty collection because of [this block](https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java#L377-L382), specifically this line:

`( state[index] != newState[index] && !types[index].isEqual( state[index], newState[index] ) )`

`state[index]` refers to the wrapped collection (`PersistentBag`);
`newState[index]` refers to the unwrapped collection (a `Set`), read from the entity after the pre-update listener executes.

The reason why `types[index].isEqual( state[index], newState[index] ) == false ` is because, in `CollectionType#isEqual`,  `( (PersistentCollection) x ).isWrapper( y ) ) == false`. 

`PersistentBag#isWrapper` returns `false` because it doesn't wrap the `Set`; instead it wraps a `List` with the elements that were extracted from the `Set` by the `PersistentBag` constructor.

The fix adds a new field to `PersistentBag`, `providedCollection`. which is explicitly provided to a `PersistentBag` constructor. This is the collection that is directly accessible to the application, so it makes sense that, if `providedCollection` is not `null`, then that is the `Collection` for which `PersistentBag#isWrapper` should return `true`, even if it was a `Set` that was provided.

Without this change, `FlushVisitor#processCollection` throws the CCE when it tries to cast the `Set` to a `PersistentCollection`.

I tried to find a way to look up the `PersistentCollection` from `FlushVisitor#processCollection`. Looking up the collection by `CollectionKey` won't work because it returns the original, unmodified collection. I also looked at iterating `PersistentContext#getCollectionEntries` values, but, its not possible to locate the `PersistentCollection` because `PersistentCollection.isWrapper( collection )` returns `false`, for the same reason as above. 