### PR TITLE
HHH-11888 : Different Behavior on insertable of @JoinColumn of @OneToMany field between Hibernate4/Hibernate5

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -196,10 +196,12 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 				}
 				final String columnName = joinColumn == null || joinColumn.isNameDeferred() ? "tata_" + column.getName() : joinColumn
 						.getName();
-				value.addColumn( new Column( columnName ) );
 				if ( joinColumn != null ) {
 					applyComponentColumnSizeValueToJoinColumn( column, joinColumn );
 					joinColumn.linkWithValue( value );
+				}
+				else {
+					value.addColumn( new Column( columnName ) );
 				}
 				column.setValue( value );
 			}


### PR DESCRIPTION
…Many field between Hibernate4/Hibernate5

Different Behavior on "insertable" of "@JoinColumn" of "@OneToMany" field between Hibernate4/Hibernate5
First the 'joincolumn' was added to 'SampleValue' with default insertable/updatable as true and later while linking it with sampleValue, it was added again with overridden insertable and updatable values and hence the exception "Same column is added more than once with different values for isInsertable" was being thrown as it was already added with different values.
With this fix, column is added to sampleValue only once with correct insertable and updatable values

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-11888
<!-- Hibernate GitHub Bot issue links end -->