### PR TITLE
HHH-13528 Remove call to resourceRegistry.release(ResultSet resultSet…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/AbstractLoadPlanBasedLoader.java
@@ -141,10 +141,6 @@ public abstract class AbstractLoadPlanBasedLoader {
 				if ( wrapper != null ) {
 					final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
 					final ResourceRegistry resourceRegistry = jdbcCoordinator.getResourceRegistry();
-					resourceRegistry.release(
-							wrapper.getResultSet(),
-							wrapper.getStatement()
-					);
 					resourceRegistry.release( wrapper.getStatement() );
 					jdbcCoordinator.afterStatementExecution();
 				}


### PR DESCRIPTION
…, Statement statement) from AbstractLoadPlanBasedLoader#executeLoad()

it should be safe to remove this call in such a case the Resultset should be always associated with the Statement so the next call to release(Statement) should be enough