### PR TITLE
HHH-13551 StrategyRegistrationProvider does not properly handle implementations from different classloader

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.Hashtable;
 import java.util.Properties;
+import java.util.ServiceConfigurationError;
 import java.util.Set;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
@@ -1870,5 +1871,9 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = WARN)
 	@Message(value = "Multiple configuration properties defined to create schema. Choose at most one among 'javax.persistence.create-database-schemas', 'hibernate.hbm2ddl.create_namespaces', 'hibernate.hbm2dll.create_namespaces' (this last being deprecated).", id = 504)
 	void multipleSchemaCreationSettingsDefined();
+
+	@LogMessage(level = WARN)
+	@Message(value = "Ignoring ServiceConfigurationError caught while trying to instantiate service '%s'.", id = 505)
+	void ignoringServiceConfigurationError(Class<?> serviceContract, @Cause ServiceConfigurationError error);
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/IsolatedClassLoader.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/IsolatedClassLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.hibernate.bytecode.spi.ByteCodeHelper;
+
+/**
+ * A classloader isolated from the application classloader,
+ * simulating a separate classloader that can create duplicate classes.
+ * This can result in a Service implementation extending
+ * a Service interface that is essentially the same as the one manipulated by ORM,
+ * but is a different Class instance and is thus deemed different by the JVM.
+ */
+class IsolatedClassLoader extends ClassLoader {
+	/**
+	 * Another classloader from which resources will be read.
+	 * Classes available in that classloader will be duplicated in the isolated classloader.
+	 */
+	private final ClassLoader resourceSource;
+
+	IsolatedClassLoader(ClassLoader resourceSource) {
+		super( getTopLevelClassLoader( resourceSource ) );
+		this.resourceSource = resourceSource;
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		InputStream is = getResourceAsStream( name.replace( '.', '/' ) + ".class" );
+		if ( is == null ) {
+			throw new ClassNotFoundException( name + " not found" );
+		}
+
+		try {
+			byte[] bytecode = ByteCodeHelper.readByteCode( is );
+			return defineClass( name, bytecode, 0, bytecode.length );
+		}
+		catch( Throwable t ) {
+			throw new ClassNotFoundException( name + " not found", t );
+		}
+	}
+
+	@Override
+	public URL getResource(String name) {
+		return resourceSource.getResource( name );
+	}
+
+	@Override
+	public Enumeration<URL> getResources(String name) throws IOException {
+		return resourceSource.getResources( name );
+	}
+
+	private static ClassLoader getTopLevelClassLoader(ClassLoader classFileSource) {
+		ClassLoader result = classFileSource;
+		while ( result.getParent() != null ) {
+			result = result.getParent();
+		}
+		return result;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/MyService.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/MyService.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+import org.hibernate.service.Service;
+
+public interface MyService extends Service {
+}

--- a/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/MyServiceImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/registry/classloading/internal/MyServiceImpl.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.registry.classloading.internal;
+
+public class MyServiceImpl implements MyService {
+}

--- a/hibernate-core/src/test/resources/META-INF/services/org.hibernate.boot.registry.classloading.internal.MyService
+++ b/hibernate-core/src/test/resources/META-INF/services/org.hibernate.boot.registry.classloading.internal.MyService
@@ -1,0 +1,1 @@
+org.hibernate.boot.registry.classloading.internal.MyServiceImpl


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13551

I'm honestly not sure this is a legitimate bug. My personal opinion is that users should not expose to Hibernate ORM two classloaders that have a different version of the same class. But I suppose one can view things differently, so here is a fix.

The major risk is that we'll be catching exceptions that should have been thrown and noticed by the user, because their service really is misconfigured (a `META-INF/service/*` file that contains invalid class names, for example). I tried to mitigate the problem by logging the exceptions we ignore at the WARN level, but even then I'm really not sure it's a good idea...

Maybe we should add a feature flag? But then the feature wouldn't make much sense if it's disabled by default...