### PR TITLE
HHH-13259 Fix StackOverflowError in StringHelper

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -6,21 +6,13 @@
  */
 package org.hibernate.internal.util;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.StringTokenizer;
-import java.util.regex.Pattern;
-
 import org.hibernate.boot.model.source.internal.hbm.CommaSeparatedStringHelper;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.loader.internal.AliasConstantsHelper;
+
+import java.io.Serializable;
+import java.util.*;
 
 public final class StringHelper {
 
@@ -127,8 +119,8 @@ public final class StringHelper {
 		if ( template == null ) {
 			return null;
 		}
-		int loc = template.indexOf( placeholder );
-		if ( loc < 0 ) {
+		int loc = indexOfPlaceHolder(template, placeholder, wholeWords);
+		if ( loc < 0) {
 			return template;
 		}
 		else {
@@ -192,6 +184,23 @@ public final class StringHelper {
 				)
 		);
 		return buf.toString();
+	}
+
+	private static int indexOfPlaceHolder(String template, String placeholder, boolean wholeWords) {
+		if (wholeWords) {
+			int placeholderIndex = -1;
+			boolean isPartialPlaceholderMatch;
+			do {
+				placeholderIndex = template.indexOf(placeholder, placeholderIndex+1);
+				isPartialPlaceholderMatch = placeholderIndex != -1 &&
+						template.length() > placeholderIndex + placeholder.length() &&
+						Character.isJavaIdentifierPart(template.charAt(placeholderIndex + placeholder.length()));
+			} while (placeholderIndex != -1 && isPartialPlaceholderMatch);
+
+			return placeholderIndex;
+		} else {
+			return template.indexOf(placeholder);
+		}
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/internal/util/StringHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/internal/util/StringHelperTest.java
@@ -1,0 +1,30 @@
+package org.hibernate.internal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringHelperTest {
+
+  @Test
+  public void replaceRepeatingPlaceholdersWithoutStackOverflow() {
+    String ordinalParameters = generateOrdinalParameters(3, 19999);
+    String result = StringHelper.replace(
+            "select * from books where category in (?1) and id in(" + ordinalParameters + ") and parent_category in (?1) and id in(" + ordinalParameters + ")",
+            "?1", "?1, ?2", true, true);
+    assertEquals("select * from books where category in (?1, ?2) and id in(" + ordinalParameters + ") and parent_category in (?1, ?2) and id in(" + ordinalParameters + ")", result);
+  }
+
+  private String generateOrdinalParameters(int startPosition, int endPosition) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = startPosition; i <= endPosition; i++) {
+      builder.append("?").append(i);
+
+      if (i < endPosition) {
+        builder.append(", ");
+      }
+    }
+
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
Before fix method org.hibernate.internal.util.StringHelper#replace
matched placeholders illegally in case when ordinal parameters list was
expanded. Ex. placeholder ?1 was matched with ?11, ?12, ?13 etc. For
queries with 2 or more IN clauses with different collections there were
a situation when ?1 from the first clause matched with already expanded
placeholders from the second collection. Each match led to recursive
call of replace method. If collection in second clause was very long
then StackOverflowError occurred.

Fix adds check of partial placeholder match for wholeWords mode which
is used in expanding list parameters. Partial matches are skipped
during replace.