### PR TITLE
Refactoring: use NamingHelper inside of Constraint

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -77,9 +77,9 @@ public class NamingHelper {
 		// Use a concatenation that guarantees uniqueness, even if identical names
 		// exist between all table and column identifiers.
 
-		StringBuilder sb = new StringBuilder()
-				.append( "table`" ).append( tableName ).append( "`" )
-				.append( "references`" ).append( referencedTableName ).append( "`" );
+		StringBuilder sb = new StringBuilder(64)
+				.append( "table`" ).append( tableName ).append( '`' )
+				.append( "references`" ).append( referencedTableName ).append( '`' );
 
 		// Ensure a consistent ordering of columns, regardless of the order
 		// they were bound.
@@ -89,7 +89,7 @@ public class NamingHelper {
 		Arrays.sort( alphabeticalColumns, comparing(Identifier::getCanonicalName) );
 
 		for ( Identifier columnName : alphabeticalColumns ) {
-			sb.append( "column`" ).append( columnName ).append( "`" );
+			sb.append( "column`" ).append( columnName ).append( '`' );
 		}
 		return prefix + hashedName( sb.toString() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -13,7 +13,6 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 import org.hibernate.HibernateException;
@@ -87,15 +86,7 @@ public class NamingHelper {
 		// Clone the list, as sometimes a set of order-dependent Column
 		// bindings are given.
 		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort(
-				alphabeticalColumns,
-				new Comparator<Identifier>() {
-					@Override
-					public int compare(Identifier o1, Identifier o2) {
-						return o1.getCanonicalName().compareTo( o2.getCanonicalName() );
-					}
-				}
-		);
+		Arrays.sort( alphabeticalColumns, comparing(Identifier::getCanonicalName) );
 
 		for ( Identifier columnName : alphabeticalColumns ) {
 			sb.append( "column`" ).append( columnName ).append( "`" );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -86,7 +86,7 @@ public class NamingHelper {
 		// Clone the list, as sometimes a set of order-dependent Column
 		// bindings are given.
 		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort( alphabeticalColumns, comparing(Identifier::getCanonicalName) );
+		Arrays.sort( alphabeticalColumns );
 
 		for ( Identifier columnName : alphabeticalColumns ) {
 			sb.append( "column`" ).append( columnName ).append( '`' );
@@ -111,7 +111,7 @@ public class NamingHelper {
 		// Clone the list, as sometimes a set of order-dependent Column
 		// bindings are given.
 		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort( alphabeticalColumns, comparing(Identifier::getCanonicalName) );
+		Arrays.sort( alphabeticalColumns );
 		for ( Identifier columnName : alphabeticalColumns ) {
 			sb.append( "column`" ).append( columnName ).append( '`' );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -112,7 +112,7 @@ public class NamingHelper {
 		// Use a concatenation that guarantees uniqueness, even if identical names
 		// exist between all table and column identifiers.
 
-		StringBuilder sb = new StringBuilder( "table`" + tableName + "`" );
+		StringBuilder sb = new StringBuilder(64).append( "table`" ).append( tableName ).append( '`' );
 
 		// Ensure a consistent ordering of columns, regardless of the order
 		// they were bound.
@@ -129,7 +129,7 @@ public class NamingHelper {
 				}
 		);
 		for ( Identifier columnName : alphabeticalColumns ) {
-			sb.append( "column`" ).append( columnName ).append( "`" );
+			sb.append( "column`" ).append( columnName ).append( '`' );
 		}
 		return prefix + hashedName( sb.toString() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.naming;
 
+import static java.util.Comparator.comparing;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -119,15 +120,7 @@ public class NamingHelper {
 		// Clone the list, as sometimes a set of order-dependent Column
 		// bindings are given.
 		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort(
-				alphabeticalColumns,
-				new Comparator<Identifier>() {
-					@Override
-					public int compare(Identifier o1, Identifier o2) {
-						return o1.getCanonicalName().compareTo( o2.getCanonicalName() );
-					}
-				}
-		);
+		Arrays.sort( alphabeticalColumns, comparing(Identifier::getCanonicalName) );
 		for ( Identifier columnName : alphabeticalColumns ) {
 			sb.append( "column`" ).append( columnName ).append( '`' );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -142,13 +142,9 @@ public class NamingHelper {
 	private String generateColumnsHash(String prefix, StringBuilder sb, Identifier[] columnNames) {
 		// Ensure a consistent ordering of columns, regardless of the order
 		// they were bound.
-		// Clone the list, as sometimes a set of order-dependent Column
-		// bindings are given.
-		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort( alphabeticalColumns );
-		for ( Identifier columnName : alphabeticalColumns ) {
-			sb.append( "column`" ).append( columnName ).append( '`' );
-		}
+		Arrays.stream( columnNames )
+				.sorted()
+				.forEachOrdered( columnName -> sb.append( "column`" ).append( columnName ).append( '`' ) );
 		return prefix + hashedName( sb.toString() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -81,17 +81,7 @@ public class NamingHelper {
 				.append( "table`" ).append( tableName ).append( '`' )
 				.append( "references`" ).append( referencedTableName ).append( '`' );
 
-		// Ensure a consistent ordering of columns, regardless of the order
-		// they were bound.
-		// Clone the list, as sometimes a set of order-dependent Column
-		// bindings are given.
-		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort( alphabeticalColumns );
-
-		for ( Identifier columnName : alphabeticalColumns ) {
-			sb.append( "column`" ).append( columnName ).append( '`' );
-		}
-		return prefix + hashedName( sb.toString() );
+		return generateColumnsHash( prefix, sb, columnNames );
 	}
 
 	/**
@@ -105,17 +95,7 @@ public class NamingHelper {
 		// exist between all table and column identifiers.
 
 		StringBuilder sb = new StringBuilder(64).append( "table`" ).append( tableName ).append( '`' );
-
-		// Ensure a consistent ordering of columns, regardless of the order
-		// they were bound.
-		// Clone the list, as sometimes a set of order-dependent Column
-		// bindings are given.
-		Identifier[] alphabeticalColumns = columnNames.clone();
-		Arrays.sort( alphabeticalColumns );
-		for ( Identifier columnName : alphabeticalColumns ) {
-			sb.append( "column`" ).append( columnName ).append( '`' );
-		}
-		return prefix + hashedName( sb.toString() );
+		return generateColumnsHash( prefix, sb, columnNames );
 	}
 
 	/**
@@ -157,5 +137,18 @@ public class NamingHelper {
 		catch ( NoSuchAlgorithmException|UnsupportedEncodingException e ) {
 			throw new HibernateException( "Unable to generate a hashed name!", e );
 		}
+	}
+
+	private String generateColumnsHash(String prefix, StringBuilder sb, Identifier[] columnNames) {
+		// Ensure a consistent ordering of columns, regardless of the order
+		// they were bound.
+		// Clone the list, as sometimes a set of order-dependent Column
+		// bindings are given.
+		Identifier[] alphabeticalColumns = columnNames.clone();
+		Arrays.sort( alphabeticalColumns );
+		for ( Identifier columnName : alphabeticalColumns ) {
+			sb.append( "column`" ).append( columnName ).append( '`' );
+		}
+		return prefix + hashedName( sb.toString() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -132,6 +132,7 @@ import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.model.IdGeneratorStrategyInterpreter;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.model.TypeDefinition;
+import org.hibernate.boot.model.naming.NamingHelper;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.InFlightMetadataCollector.EntityTableXref;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -153,7 +154,6 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.loader.PropertyPath;
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Component;
-import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.DependantValue;
 import org.hibernate.mapping.Join;
 import org.hibernate.mapping.JoinedSubclass;
@@ -2361,13 +2361,13 @@ public final class AnnotationBinder {
 		if ( naturalIdAnn != null ) {
 			if ( joinColumns != null ) {
 				for ( Ejb3Column column : joinColumns ) {
-					String keyName = "UK_" + Constraint.hashedName( column.getTable().getName() + "_NaturalID" );
+					String keyName = "UK_" + NamingHelper.INSTANCE.hashedName( column.getTable().getName() + "_NaturalID" );
 					column.addUniqueKey( keyName, inSecondPass );
 				}
 			}
 			else {
 				for ( Ejb3Column column : columns ) {
-					String keyName = "UK_" + Constraint.hashedName( column.getTable().getName() + "_NaturalID" );
+					String keyName = "UK_" + NamingHelper.INSTANCE.hashedName( column.getTable().getName() + "_NaturalID" );
 					column.addUniqueKey( keyName, inSecondPass );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -47,10 +47,11 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	 * @return String The generated name
 	 */
 	public static String generateName(String prefix, Table table, Column... columns) {
+		String tableName = table.getName();
 		// Use a concatenation that guarantees uniqueness, even if identical names
 		// exist between all table and column identifiers.
 
-		StringBuilder sb = new StringBuilder( "table`" + table.getName() + "`" );
+		StringBuilder sb = new StringBuilder( "table`" + tableName + "`" );
 
 		// Ensure a consistent ordering of columns, regardless of the order
 		// they were bound.
@@ -59,7 +60,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		Column[] alphabeticalColumns = columns.clone();
 		Arrays.sort( alphabeticalColumns, comparing(Column::getName) );
 		for ( Column column : alphabeticalColumns ) {
-			String columnName = column == null ? "" : column.getName();
+			String columnName = column.getName();
 			sb.append( "column`" ).append( columnName ).append( "`" );
 		}
 		return prefix + hashedName( sb.toString() );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -6,18 +6,14 @@
  */
 package org.hibernate.mapping;
 import java.io.Serializable;
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-
-import org.hibernate.HibernateException;
 import org.hibernate.annotations.common.util.StringHelper;
+import org.hibernate.boot.model.naming.NamingHelper;
 import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.Mapping;
@@ -89,20 +85,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	 * @return String The hased name.
 	 */
 	public static String hashedName(String s) {
-		try {
-			MessageDigest md = MessageDigest.getInstance( "MD5" );
-			md.reset();
-			md.update( s.getBytes() );
-			byte[] digest = md.digest();
-			BigInteger bigInt = new BigInteger( 1, digest );
-			// By converting to base 35 (full alphanumeric), we guarantee
-			// that the length of the name will always be smaller than the 30
-			// character identifier restriction enforced by a few dialects.
-			return bigInt.toString( 35 );
-		}
-		catch ( NoSuchAlgorithmException e ) {
-			throw new HibernateException( "Unable to generate a hashed Constraint name!", e );
-		}
+		return NamingHelper.INSTANCE.hashedName(s);
 	}
 
 	private static class ColumnComparator implements Comparator<Column> {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -5,10 +5,10 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.mapping;
+import static java.util.Comparator.comparing;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -57,7 +57,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		// Clone the list, as sometimes a set of order-dependent Column
 		// bindings are given.
 		Column[] alphabeticalColumns = columns.clone();
-		Arrays.sort( alphabeticalColumns, ColumnComparator.INSTANCE );
+		Arrays.sort( alphabeticalColumns, comparing(Column::getName) );
 		for ( Column column : alphabeticalColumns ) {
 			String columnName = column == null ? "" : column.getName();
 			sb.append( "column`" ).append( columnName ).append( "`" );
@@ -86,14 +86,6 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	 */
 	public static String hashedName(String s) {
 		return NamingHelper.INSTANCE.hashedName(s);
-	}
-
-	private static class ColumnComparator implements Comparator<Column> {
-		public static ColumnComparator INSTANCE = new ColumnComparator();
-
-		public int compare(Column col1, Column col2) {
-			return col1.getName().compareTo( col2.getName() );
-		}
 	}
 
 	public void addColumn(Column column) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -51,7 +51,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		// Use a concatenation that guarantees uniqueness, even if identical names
 		// exist between all table and column identifiers.
 
-		StringBuilder sb = new StringBuilder( "table`" + tableName + "`" );
+		StringBuilder sb = new StringBuilder(64).append( "table`" ).append( tableName ).append( '`' );
 
 		// Ensure a consistent ordering of columns, regardless of the order
 		// they were bound.
@@ -61,7 +61,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		Arrays.sort( alphabeticalColumns, comparing(Column::getName) );
 		for ( Column column : alphabeticalColumns ) {
 			String columnName = column.getName();
-			sb.append( "column`" ).append( columnName ).append( "`" );
+			sb.append( "column`" ).append( columnName ).append( '`');
 		}
 		return prefix + hashedName( sb.toString() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/boot/model/naming/NamingHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/model/naming/NamingHelperTest.java
@@ -63,6 +63,25 @@ public class NamingHelperTest extends BaseUnitTestCase {
 		assertEquals( "FKdgopp1hqnm8c1o6sfbb3tbeh", fkNameUtf8 );
 	}
 
+	@Test
+	public void generateHashedConstraintName() {
+		Identifier booksDe = new Identifier( "Bücher", false );
+		Identifier authorsDe = new Identifier( "Autoren", false );
+		Identifier authorId = new Identifier( "autor_id", false );
+
+		defaultCharset.set( StandardCharsets.ISO_8859_1 );
+
+		String fkNameLatin1 = NamingHelper.INSTANCE.generateHashedConstraintName( "FK", booksDe, authorsDe, authorId );
+
+		assertEquals( "FKd6orrc2532pa8rwprvo2cck63", fkNameLatin1 );
+
+		defaultCharset.set( StandardCharsets.UTF_8 );
+
+		String fkNameUtf8 = NamingHelper.INSTANCE.generateHashedConstraintName( "FK", booksDe, authorsDe, authorId );
+
+		assertEquals( "FK608iqfbuucbi84fp6fe3ypqbi", fkNameUtf8 );
+	}
+
 	public static class DefaultCharset extends ExternalResource {
 
 		private Charset prev;


### PR DESCRIPTION
Here is a small refactoring that can improve speed a little bit and removes duplicated code.
There is a lot of code duplication between `Constraint` and `NamingHelper` related to generation of constraint name.
I did step by step refactoring and it turned out that `Constraint` can just reuse the `NamingHelper`.
I kept an API and all tests passed.
There is a tricky part in #23833fd because the `Column` class doesn't have an `Identifier` (IMHO it worth to create one) so we'll create them manually.
Also I worried that the Table.name and Column.name fields can be in uppercase while the NamingHelper always lowercase them before hashing. This may change the generated hash.
But I checked and it turned out that the Table.name and Column.name fields are always in lowercase.

So this PR should be safe to merge.