### PR TITLE
HHH-13580 + HHH-13582 MySQL test failures

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -109,8 +109,7 @@ ext {
             hsqldb:          "org.hsqldb:hsqldb:2.3.2",
             derby:           "org.apache.derby:derby:10.11.1.1",
             postgresql:      'org.postgresql:postgresql:42.2.2',
-            //Upgrade MySQL Driver only when this issue gets fixed: https://bugs.mysql.com/bug.php?id=85941
-            mysql:           'mysql:mysql-connector-java:5.1.46',
+            mysql:           'mysql:mysql-connector-java:8.0.17',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
 
             oracle:          'com.oracle.jdbc:ojdbc8:12.2.0.1',

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/EntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/EntityTest.java
@@ -24,9 +24,7 @@ import org.hibernate.Transaction;
 import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.MySQL57Dialect;
-import org.hibernate.dialect.MySQL8Dialect;
-import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.Oracle10gDialect;
 import org.hibernate.query.Query;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
@@ -373,7 +371,7 @@ public class EntityTest extends BaseNonConfigCoreFunctionalTestCase {
 	@SkipForDialect(value = Oracle10gDialect.class, comment = "oracle12c returns time in getDate.  For now, skip.")
 	public void testTemporalType() throws Exception {
 
-		final ZoneId zoneId = ( Dialect.getDialect() instanceof MySQL8Dialect ) ? ZoneId.of( "UTC")
+		final ZoneId zoneId = ( Dialect.getDialect() instanceof MySQL5Dialect ) ? ZoneId.of( "UTC")
 				: ZoneId.systemDefault();
 
 		Flight airFrance = doInHibernate( this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jdbc/autocommit/MySQLSkipAutoCommitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/resource/transaction/jdbc/autocommit/MySQLSkipAutoCommitTest.java
@@ -30,11 +30,20 @@ public class MySQLSkipAutoCommitTest extends AbstractSkipAutoCommitTest {
 		if ( getDialect() instanceof MariaDBDialect ) {
 			dataSource = ReflectionUtil.newInstance( "org.mariadb.jdbc.MariaDbDataSource" );
 		}
-		else if ( getDialect() instanceof MySQL8Dialect ) {
-			dataSource = ReflectionUtil.newInstance( "com.mysql.cj.jdbc.MysqlDataSource" );
-		}
 		else if ( getDialect() instanceof MySQLDialect ) {
-			dataSource = ReflectionUtil.newInstance( "com.mysql.jdbc.jdbc2.optional.MysqlDataSource" );
+			try {
+				// ConnectorJ 8
+				dataSource = ReflectionUtil.newInstance( "com.mysql.cj.jdbc.MysqlDataSource" );
+			}
+			catch (IllegalArgumentException e) {
+				try {
+					// ConnectorJ 5
+					dataSource = ReflectionUtil.newInstance( "com.mysql.jdbc.jdbc2.optional.MysqlDataSource" );
+				} catch (Exception e2) {
+					e2.addSuppressed( e );
+					throw e;
+				}
+			}
 		}
 		ReflectionUtil.setProperty( dataSource, "url", Environment.getProperties().getProperty( AvailableSettings.URL ) );
 		ReflectionUtil.setProperty( dataSource, "user", Environment.getProperties().getProperty( AvailableSettings.USER ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
@@ -9,6 +9,7 @@ package org.hibernate.test.temporal;
 import java.sql.Time;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -36,7 +37,11 @@ public class TimePropertyTest extends BaseCoreFunctionalTestCase {
 	@Test
 	public void testTimeAsDate() {
 		final Entity eOrig = new Entity();
-		eOrig.tAsDate = new Time( new Date().getTime() );
+		Calendar calendar = Calendar.getInstance();
+		// See javadoc for java.sql.Time: 'The date components should be set to the "zero epoch" value of January 1, 1970 and should not be accessed'
+		// Other dates can potentially lead to errors in JDBC drivers, in particular MySQL ConnectorJ 8.x.
+		calendar.set( 1970, Calendar.JANUARY, 1 );
+		eOrig.tAsDate = new Time( calendar.getTimeInMillis() );
 
 		Session s = openSession();
 		s.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalDateTest.java
@@ -23,6 +23,7 @@ import javax.persistence.Id;
 
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
@@ -34,7 +35,13 @@ import org.junit.runners.Parameterized;
  * Tests for storage of LocalDate properties.
  */
 @TestForIssue(jiraKey = "HHH-10371")
-@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA systematically returns the wrong date when the JVM default timezone is not UTC")
+@SkipForDialect(value = AbstractHANADialect.class,
+		comment = "HANA systematically returns the wrong date when the JVM default timezone is not UTC")
+@SkipForDialect(value = MySQL5Dialect.class,
+		comment = "HHH-13582: MySQL ConnectorJ 8.x returns the wrong date"
+				+ " when the JVM default timezone is different from the server timezone:"
+				+ " https://bugs.mysql.com/bug.php?id=91112"
+)
 public class LocalDateTest extends AbstractJavaTimeTypeTest<LocalDate, LocalDateTest.EntityWithLocalDate> {
 
 	private static class ParametersBuilder extends AbstractParametersBuilder<ParametersBuilder> {

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
@@ -23,6 +23,7 @@ import javax.persistence.Id;
 
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
 
@@ -186,6 +187,12 @@ public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTime
 	@Override
 	@Test
 	@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA seems to return a java.sql.Timestamp instead of a java.sql.Time")
+	@SkipForDialect(value = MySQL5Dialect.class,
+			comment = "HHH-13580 MySQL seems to store the whole timestamp, not just the time,"
+					+ " which for some timezones results in a date other than 1970-01-01 being returned"
+					+ " (typically 1969-12-31), even though the time is always right."
+					+ " Since java.sql.Time holds the whole timestamp, not just the time,"
+					+ " its equals() method ends up returning false in this test.")
 	public void writeThenNativeRead() {
 		super.writeThenNativeRead();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -25,6 +25,7 @@ import javax.persistence.Id;
 
 import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.type.descriptor.sql.BigIntTypeDescriptor;
 import org.hibernate.type.descriptor.sql.TimestampTypeDescriptor;
@@ -215,6 +216,12 @@ public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetT
 	@Override
 	@Test
 	@SkipForDialect(value = AbstractHANADialect.class, comment = "HANA seems to return a java.sql.Timestamp instead of a java.sql.Time")
+	@SkipForDialect(value = MySQL5Dialect.class,
+			comment = "HHH-13580 MySQL seems to store the whole timestamp, not just the time,"
+					+ " which for some timezones results in a date other than 1970-01-01 being returned"
+					+ " (typically 1969-12-31), even though the time is always right."
+					+ " Since java.sql.Time holds the whole timestamp, not just the time,"
+					+ " its equals() method ends up returning false in this test.")
 	public void writeThenNativeRead() {
 		super.writeThenNativeRead();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.junit.runners.Parameterized;
 
 /**
- * Tests for storage of LocalTime properties.
+ * Tests for storage of OffsetTime properties.
  */
 public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetTimeTest.EntityWithOffsetTime> {
 

--- a/hibernate-spatial/databases/mysql56/matrix.gradle
+++ b/hibernate-spatial/databases/mysql56/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency "mysql:mysql-connector-java:5.1.15"
+jdbcDependency "mysql:mysql-connector-java:8.0.17"

--- a/hibernate-spatial/databases/mysql8/matrix.gradle
+++ b/hibernate-spatial/databases/mysql8/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency "mysql:mysql-connector-java:8.0.12"
+jdbcDependency "mysql:mysql-connector-java:8.0.17"


### PR DESCRIPTION
* [HHH-13580](https://hibernate.atlassian.net/browse/HHH-13580): LocalTimeTest#writeThenNativeRead* and OffsetTimeTest#writeThenNativeRead* failing on MySQL
* [HHH-13582](https://hibernate.atlassian.net/browse/HHH-13582): LocalDateTest failures on MySQL

See commit messages for details.

To be backported to 5.3, but you already know that :)