### PR TITLE
HHH-13581 + HHH-13605 MariaDB test failures

### DIFF
--- a/databases/mariadb/matrix.gradle
+++ b/databases/mariadb/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency 'org.mariadb.jdbc:mariadb-java-client:1.5.7'
+jdbcDependency 'org.mariadb.jdbc:mariadb-java-client:2.2.4'

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LocalTimeTest.java
@@ -15,6 +15,7 @@ import java.sql.Types;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -54,6 +55,18 @@ public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTime
 					yearWhenPersistedWithoutHibernate,
 					monthWhenPersistedWithoutHibernate, dayWhenPersistedWithoutHibernate
 			);
+		}
+
+		@Override
+		protected Iterable<? extends ZoneId> getHibernateJdbcTimeZonesToTest() {
+			// The MariaDB Connector/J JDBC driver has a bug in ResultSet#getTime(int, Calendar)
+			// that prevents our explicit JDBC timezones from being recognized
+			// See https://hibernate.atlassian.net/browse/HHH-13581
+			// See https://jira.mariadb.org/browse/CONJ-724
+			if ( MariaDBDialect.class.isInstance( getDialect() ) ) {
+				return Collections.emptySet();
+			}
+			return super.getHibernateJdbcTimeZonesToTest();
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/OffsetTimeTest.java
@@ -17,6 +17,7 @@ import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -57,6 +58,18 @@ public class OffsetTimeTest extends AbstractJavaTimeTypeTest<OffsetTime, OffsetT
 					yearWhenPersistedWithoutHibernate,
 					monthWhenPersistedWithoutHibernate, dayWhenPersistedWithoutHibernate
 			);
+		}
+
+		@Override
+		protected Iterable<? extends ZoneId> getHibernateJdbcTimeZonesToTest() {
+			// The MariaDB Connector/J JDBC driver has a bug in ResultSet#getTime(int, Calendar)
+			// that prevents our explicit JDBC timezones from being recognized
+			// See https://hibernate.atlassian.net/browse/HHH-13581
+			// See https://jira.mariadb.org/browse/CONJ-724
+			if ( MariaDBDialect.class.isInstance( getDialect() ) ) {
+				return Collections.emptySet();
+			}
+			return super.getHibernateJdbcTimeZonesToTest();
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13581
https://hibernate.atlassian.net/browse/HHH-13605

As mentioned in [HHH-13581](https://hibernate.atlassian.net/browse/HHH-13581), the problem is in the JDBC driver.

To be backported to 5.3.