### PR TITLE
HHH-13606 LocalDateTimeTest fails for HANA on CI

### DIFF
--- a/databases/hana/matrix.gradle
+++ b/databases/hana/matrix.gradle
@@ -5,4 +5,4 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 
-jdbcDependency 'com.sap.cloud.db.jdbc:ngdbc:2.2.16'
+jdbcDependency 'com.sap.cloud.db.jdbc:ngdbc:2.4.59'


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13606

Turns out this was simply a bug in the HANA JDBC driver that has been fixed since.

Note that we already updated to version 2.4.59 of the driver in `libraries.gradle`, so we probably just forgot to update `hana/matrix.gradle`.