### PR TITLE
HHH-13590 : TransientObjectException merging a non-proxy association to a proxy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -374,7 +374,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			Object managed,
 			EntityPersister persister,
 			EventSource source) {
-		if ( incoming instanceof HibernateProxy ) {
+		if ( managed instanceof HibernateProxy ) {
 			return source.getPersistenceContext().unproxy( managed );
 		}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13590