### PR TITLE
HHH-13635 - Handle MSSQL2012 with Tomcat DBCP2

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
@@ -51,7 +51,8 @@ public class DefaultSchemaNameResolver implements SchemaNameResolver {
 					if ( schema == null ) {
 						log.debugf( "Unable to use Java 1.7 Connection#getSchema" );
 						return SchemaNameResolverFallbackDelegate.INSTANCE;
-					} else {
+					}
+					else {
 						return new SchemaNameResolverJava17Delegate();
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
@@ -48,7 +48,7 @@ public class DefaultSchemaNameResolver implements SchemaNameResolver {
 					// then the getSchemaMethod is not null but the call to getSchema() throws an java.lang.AbstractMethodError
 					// or returns null
 					String schema = connection.getSchema();
-					if (schema == null) {
+					if ( schema == null ) {
 						log.debugf( "Unable to use Java 1.7 Connection#getSchema" );
 						return SchemaNameResolverFallbackDelegate.INSTANCE;
 					} else {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
@@ -46,8 +46,14 @@ public class DefaultSchemaNameResolver implements SchemaNameResolver {
 				try {
 					// If the JDBC driver does not implement the Java 7 spec, but the JRE is Java 7
 					// then the getSchemaMethod is not null but the call to getSchema() throws an java.lang.AbstractMethodError
-					connection.getSchema();
-					return new SchemaNameResolverJava17Delegate();
+					// or returns null
+					String schema = connection.getSchema();
+					if (schema == null) {
+						log.debugf( "Unable to use Java 1.7 Connection#getSchema" );
+						return SchemaNameResolverFallbackDelegate.INSTANCE;
+					} else {
+						return new SchemaNameResolverJava17Delegate();
+					}
 				}
 				catch (java.lang.AbstractMethodError e) {
 					log.debugf( "Unable to use Java 1.7 Connection#getSchema" );

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/DefaultSchemaNameResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/DefaultSchemaNameResolverTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class DefaultSchemaNameResolverTest {
 	private static final String SCHEMA_NAME = "theSchemaName";
-	private static final String UNSUPPORTED_SCHEMA_NAME = "theSchemaName";
+	private static final String UNSUPPORTED_SCHEMA_NAME = "unsupportedSchemaName";
 	private static final String GET_CURRENT_SCHEMA_NAME_COMMAND = "get the schema name";
 
 	@Test
@@ -96,7 +96,7 @@ public class DefaultSchemaNameResolverTest {
 					throw new AbstractMethodError( "getSchema is not implemented" );
 				}
 
-				return SCHEMA_NAME;
+				return schemaName;
 			}
 			else if ( method.getName().equals( "createStatement" ) && args == null ) {
 				return StatementProxy.generateProxy( new StatementProxy() );

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/DefaultSchemaNameResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/DefaultSchemaNameResolverTest.java
@@ -96,7 +96,7 @@ public class DefaultSchemaNameResolverTest {
 					throw new AbstractMethodError( "getSchema is not implemented" );
 				}
 
-				return schemaName;
+				return SCHEMA_NAME;
 			}
 			else if ( method.getName().equals( "createStatement" ) && args == null ) {
 				return StatementProxy.generateProxy( new StatementProxy() );


### PR DESCRIPTION
Fix for cases where the connection pool silently ignores AbstractMethodError and returns null.

Supported configuration: hibernate-core 5.2.17.FINAL with tomcat dbcp 8.5.24
Unsupported configuration: hibernate-core 5.2.17.FINAL with tomcat dbcp 9.0.22

Caused by:
https://github.com/apache/commons-dbcp/commit/81aea944160608838cb2d7cdfb0d9b6893a655d9#diff-7f3cce021bf5e1a92eb5ffd1eb16cd29R144