### PR TITLE
HHH-13645 : StatsNamedContainer#getOrCompute throws NullPointerException when computed value is null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/StatsNamedContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/StatsNamedContainer.java
@@ -71,12 +71,17 @@ final class StatsNamedContainer<V> {
 		}
 		else {
 			final V v2 = function.apply( key );
-			final V v3 = map.putIfAbsent( key, v2 );
-			if ( v3 == null ) {
-				return v2;
+			if ( v2 == null ) {
+				return null;
 			}
 			else {
-				return v3;
+				final V v3 = map.putIfAbsent( key, v2 );
+				if ( v3 == null ) {
+					return v2;
+				}
+				else {
+					return v3;
+				}
 			}
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/stat/internal/StatsNamedContainerNullComputedValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/stat/internal/StatsNamedContainerNullComputedValueTest.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.stat.internal;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+@TestForIssue(jiraKey = "HHH-13645")
+public class StatsNamedContainerNullComputedValueTest {
+
+	@Test
+	public void testNullComputedValue() {
+		final StatsNamedContainer statsNamedContainer = new StatsNamedContainer<Integer>();
+		assertNull(
+				statsNamedContainer.getOrCompute(
+						"key",
+						v -> {
+							return null;
+						}
+				)
+		);
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/stats/StatisticsWithNoQueryCachingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/stats/StatisticsWithNoQueryCachingTest.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.stats;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Gail Badner
+ */
+public class StatisticsWithNoQueryCachingTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true"  );
+		configuration.setProperty( AvailableSettings.USE_QUERY_CACHE, "false"  );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13645")
+	public void testUncachedRegion() {
+		final Statistics statistics = sessionFactory().getStatistics();
+		assertNull( statistics.getCacheRegionStatistics( "hibernate.test.unknown" ) );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13645