### PR TITLE
HHH-12965 Avoid creating foreign keys between audit and main tables

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/IdMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/IdMetadataGenerator.java
@@ -311,9 +311,7 @@ public final class IdMetadataGenerator {
 		// HHH-11107
 		// Use FK hbm magic value 'none' to skip making foreign key constraints between the Envers
 		// schema and the base table schema when a @ManyToOne is present in an identifier.
-		if ( mapper == null ) {
-			manyToOneElement.addAttribute( "foreign-key", "none" );
-		}
+		manyToOneElement.addAttribute( "foreign-key", "none" );
 
 		MetadataTools.addColumns( manyToOneElement, value.getColumnIterator() );
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/id/VirtualEntitySingleIdMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/id/VirtualEntitySingleIdMapper.java
@@ -67,6 +67,48 @@ public class VirtualEntitySingleIdMapper extends SingleIdMapper {
 	}
 
 	@Override
+	public void mapToEntityFromEntity(Object objTo, Object objFrom) {
+		if ( objTo == null || objFrom == null ) {
+			return;
+		}
+
+		AccessController.doPrivileged(
+				new PrivilegedAction<Object>() {
+					@Override
+					public Object run() {
+						final Getter getter = ReflectionTools.getGetter(
+								objFrom.getClass(),
+								propertyData,
+								getServiceRegistry()
+						);
+
+						final Setter setter = ReflectionTools.getSetter(
+								objTo.getClass(),
+								propertyData,
+								getServiceRegistry()
+						);
+
+						// Get the value from the containing entity
+						final Object value = getter.get( objFrom );
+						if ( value == null ) {
+							return null;
+						}
+
+						if ( !value.getClass().equals( propertyData.getVirtualReturnClass() ) ) {
+							setter.set( objTo, getAssociatedEntityIdMapper().mapToIdFromEntity( value ), null );
+						}
+						else {
+							// This means we're setting the object
+							setter.set( objTo, value, null );
+						}
+
+						return null;
+					}
+				}
+		);
+	}
+
+	@Override
 	public boolean mapToEntityFromMap(Object obj, Map data) {
 		if ( data == null || obj == null ) {
 			return false;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/ForeignKeyExclusionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/ForeignKeyExclusionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.manytoone.foreignkey;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+/**
+ * Tests that no foreign key should be generated from audit schema to main schema.
+ *
+ * @author Chris Cranford
+ */
+@TestForIssue(jiraKey = "HHH-12965")
+public class ForeignKeyExclusionTest extends BaseEnversJPAFunctionalTestCase {
+
+	private RootLayer rootLayer;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { RootLayer.class, MiddleLayer.class, LeafLayer.class };
+	}
+
+	@Test
+	public void testRemovingAuditedEntityWithIdClassAndManyToOneForeignKeyConstraint() {
+		// Revision 1 - Add Root/Middle/Leaf layers
+		this.rootLayer = doInJPA( this::entityManagerFactory, entityManager -> {
+			final RootLayer rootLayer = new RootLayer();
+			rootLayer.setMiddleLayers( new ArrayList<>() );
+
+			MiddleLayer middleLayer = new MiddleLayer();
+			rootLayer.getMiddleLayers().add( middleLayer );
+			middleLayer.setRootLayer( rootLayer );
+			middleLayer.setValidFrom( LocalDate.of( 2019, 3, 19 ) );
+			middleLayer.setLeafLayers( new ArrayList<>() );
+
+			LeafLayer leafLayer = new LeafLayer();
+			leafLayer.setMiddleLayer( middleLayer );
+			middleLayer.getLeafLayers().add( leafLayer );
+
+			entityManager.persist( rootLayer );
+			return rootLayer;
+		} );
+
+		// Revision 2 - Delete Root/Middle/Leaf layers
+		// This causes FK violation
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final RootLayer rootLayer = entityManager.find( RootLayer.class, this.rootLayer.getId() );
+			entityManager.remove( rootLayer );
+		} );
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/LeafLayer.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/LeafLayer.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.manytoone.foreignkey;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Chris Cranford
+ */
+@Entity(name = "LeafLayer")
+@Audited
+public class LeafLayer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+	@ManyToOne(optional = false)
+	@JoinColumns({
+			@JoinColumn(name = "middle_layer_valid_from_fk", referencedColumnName = "valid_from"),
+			@JoinColumn(name = "middle_layer_root_layer_fk", referencedColumnName = "root_layer_fk") })
+	private MiddleLayer middleLayer;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public MiddleLayer getMiddleLayer() {
+		return middleLayer;
+	}
+
+	public void setMiddleLayer(MiddleLayer middleLayer) {
+		this.middleLayer = middleLayer;
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/MiddleLayer.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/MiddleLayer.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.manytoone.foreignkey;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Chris Cranford
+ */
+@Audited
+@Entity
+@IdClass(MiddleLayerPK.class)
+public class MiddleLayer {
+	@Id
+	@Column(name = "valid_from", nullable = false)
+	private LocalDate validFrom;
+	@Id
+	@ManyToOne
+	@JoinColumn(name = "root_layer_fk")
+	private RootLayer rootLayer;
+	@OneToMany(mappedBy = "middleLayer", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<LeafLayer> leafLayers;
+
+	public LocalDate getValidFrom() {
+		return validFrom;
+	}
+
+	public void setValidFrom(LocalDate validFrom) {
+		this.validFrom = validFrom;
+	}
+
+	public RootLayer getRootLayer() {
+		return rootLayer;
+	}
+
+	public void setRootLayer(RootLayer rootLayer) {
+		this.rootLayer = rootLayer;
+	}
+
+	public List<LeafLayer> getLeafLayers() {
+		return leafLayers;
+	}
+
+	public void setLeafLayers(List<LeafLayer> leafLayers) {
+		this.leafLayers = leafLayers;
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/MiddleLayerPK.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/MiddleLayerPK.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.manytoone.foreignkey;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * @author Chris Cranford
+ */
+public class MiddleLayerPK implements Serializable {
+	private Long rootLayer;
+	private LocalDate validFrom;
+
+	public Long getRootLayer() {
+		return rootLayer;
+	}
+
+	public void setRootLayer(Long rootLayer) {
+		this.rootLayer = rootLayer;
+	}
+
+	public LocalDate getValidFrom() {
+		return validFrom;
+	}
+
+	public void setValidFrom(LocalDate validFrom) {
+		this.validFrom = validFrom;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		MiddleLayerPK that = (MiddleLayerPK) o;
+		return Objects.equals( rootLayer, that.rootLayer ) &&
+				Objects.equals( validFrom, that.validFrom );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( rootLayer, validFrom );
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/RootLayer.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/foreignkey/RootLayer.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.test.integration.manytoone.foreignkey;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Chris Cranford
+ */
+@Entity(name = "RootLayer")
+@Audited
+public class RootLayer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+	@OneToMany(mappedBy = "rootLayer", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<MiddleLayer> middleLayers;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public List<MiddleLayer> getMiddleLayers() {
+		return middleLayers;
+	}
+
+	public void setMiddleLayers(List<MiddleLayer> middleLayers) {
+		this.middleLayers = middleLayers;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12965?filter=18160

* Fixes a corner case not addressed by HHH-10667
* Avoids creating foreign-key constraints for any many-to-one