### PR TITLE
HHH-4384 Allow join column override if @JoinColumn is absent on @OneToOne(mappedBy = "").

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3JoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3JoinColumn.java
@@ -253,7 +253,7 @@ public class Ejb3JoinColumn extends Ejb3Column {
 			String suffixForDefaultColumnName,
 			MetadataBuildingContext buildingContext) {
 		if ( ann != null ) {
-			if ( BinderHelper.isEmptyAnnotationValue( mappedBy ) ) {
+			if ( ! BinderHelper.isEmptyOrNullAnnotationValue( mappedBy ) ) {
 				throw new AnnotationException(
 						"Illegal attempt to define a @JoinColumn with a mappedBy association: "
 								+ BinderHelper.getRelativePath( propertyHolder, propertyName )

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OverrideOneToOneJoinColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OverrideOneToOneJoinColumnTest.java
@@ -1,0 +1,56 @@
+package org.hibernate.test.annotations.onetoone;
+
+import org.hibernate.AnnotationException;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.mapping.ForeignKey;
+import org.hibernate.mapping.Table;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Aresnii Skvortsov
+ */
+@TestForIssue(jiraKey = "HHH-4384")
+public class OverrideOneToOneJoinColumnTest extends BaseUnitTestCase {
+	@Test
+	public void allowIfJoinColumnIsAbsent() {
+		StandardServiceRegistry ssr = new StandardServiceRegistryBuilder().build();
+		try {
+			Metadata metadata = new MetadataSources(ssr)
+				.addInputStream(getClass().getResourceAsStream("override-absent-join-column.orm.xml"))
+				.buildMetadata();
+
+			Table childTable = metadata.getDatabase().getDefaultNamespace().locateTable(Identifier.toIdentifier("Son"));
+			ForeignKey fatherFk = (ForeignKey) childTable.getForeignKeyIterator().next();
+			assertEquals("Overridden join column name should be applied", fatherFk.getColumn(0).getName(), "id_father");
+		} finally {
+			StandardServiceRegistryBuilder.destroy(ssr);
+		}
+	}
+
+	@Test
+	public void disallowOnSideWithMappedBy() {
+		StandardServiceRegistry ssr = new StandardServiceRegistryBuilder().build();
+		try {
+			new MetadataSources(ssr)
+				.addInputStream(getClass().getResourceAsStream("join-column-on-mapped-by.orm.xml"))
+				.buildMetadata();
+			fail("Should disallow @JoinColumn override on side with mappedBy");
+		} catch (AnnotationException ex) {
+			assertTrue("Should disallow exactly because of @JoinColumn override on side with mappedBy",
+					   ex
+						   .getMessage()
+						   .startsWith("Illegal attempt to define a @JoinColumn with a mappedBy association:")
+			);
+		} finally {
+			StandardServiceRegistryBuilder.destroy(ssr);
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/test/annotations/onetoone/join-column-on-mapped-by.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/annotations/onetoone/join-column-on-mapped-by.orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm"
+				 version="2.0">
+	<package>org.hibernate.test.annotations.onetoone</package>
+	<entity class="Party"/>
+	<entity class="PartyAffiliate">
+		<association-override name="party">
+			<join-column name="id_party"/>
+		</association-override>
+	</entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/test/annotations/onetoone/override-absent-join-column.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/annotations/onetoone/override-absent-join-column.orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm"
+				 version="2.0">
+	<package>org.hibernate.test.annotations.onetoone</package>
+	<entity class="Father">
+		<attributes>
+			<id name="id">
+				<generated-value strategy="AUTO"/>
+			</id>
+			<basic name="name"/>
+		</attributes>
+	</entity>
+	<entity class="Son">
+		<association-override name="father">
+			<join-column name="id_father"/>
+		</association-override>
+		<attributes>
+			<id name="id">
+				<generated-value strategy="AUTO"/>
+			</id>
+			<basic name="name"/>
+			<one-to-one name="father"/>
+		</attributes>
+	</entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-4384

Tests: this case and disallow if mappedBy > "".

If isEmptyAnnotationValue is left, it breaks many other cases, incl. ManyToOne.