### PR TITLE
HHH-13663 Session#setHibernateFlushMode() method not callable without an active transaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
@@ -332,6 +332,7 @@ public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 							|| "getTransaction".equals( methodName )
 							|| "isTransactionInProgress".equals( methodName )
 							|| "setFlushMode".equals( methodName )
+							|| "setHibernateFlushMode".equals( methodName )
 							|| "getFactory".equals( methodName )
 							|| "getSessionFactory".equals( methodName )
 							|| "getTenantIdentifier".equals( methodName ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnInactiveTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnInactiveTransaction.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.flush;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * Test for issue https://hibernate.atlassian.net/browse/HHH-13663
+ * 
+ * @author Luca Domenichini
+ */
+@TestForIssue(jiraKey = "HHH-13663")
+public class TestHibernateFlushModeOnInactiveTransaction extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testHibernateFlushModeOnInactiveTransaction() {
+		Session s = openSession();
+		//s.setFlushMode(FlushMode.AUTO); // this does not throw (API is deprecated)
+		s.setHibernateFlushMode(FlushMode.AUTO); // this should not throw even within an inactive transaction
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
@@ -8,6 +8,8 @@ package org.hibernate.test.flush;
 
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -18,7 +20,12 @@ import org.junit.Test;
  * @author Luca Domenichini
  */
 @TestForIssue(jiraKey = "HHH-13663")
-public class TestHibernateFlushModeOnInactiveTransaction extends BaseCoreFunctionalTestCase {
+public class TestHibernateFlushModeOnThreadLocalInactiveTransaction extends BaseCoreFunctionalTestCase {
+	
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty(AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, "thread");
+	}
 
 	@Test
 	public void testHibernateFlushModeOnInactiveTransaction() {


### PR DESCRIPTION
This PR addresses issue HHH-13663, by letting setHibernateFlushMode() run even within an inactive transaction, as it's deprecated counterpart setFlushMode() does.