### PR TITLE
HHH-8535 - Throw exception when HIBERNATE_SEQUENCES has null value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -585,7 +585,7 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 													statementLogger,
 													statsCollector
 											)) {
-												boolean hasNullValue = false;
+												boolean wasNullValue = false;
 
 												selectPS.setString( 1, segmentValue );
 												final ResultSet selectRS = executeQuery( selectPS, statsCollector );
@@ -621,11 +621,11 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 													}
 													value.initialize( selectRS, defaultValue );
 
-													hasNullValue = selectRS.wasNull();
+													wasNullValue = selectRS.wasNull();
 												}
 												selectRS.close();
 
-												if (hasNullValue) {
+												if (wasNullValue) {
 													throw new HibernateException("null '" + valueColumnName + "' for "
 														+ segmentColumnName + " '" + segmentValue + "'");
 												}

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -585,6 +585,8 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 													statementLogger,
 													statsCollector
 											)) {
+												boolean hasNullValue = false;
+
 												selectPS.setString( 1, segmentValue );
 												final ResultSet selectRS = executeQuery( selectPS, statsCollector );
 												if ( !selectRS.next() ) {
@@ -618,8 +620,15 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 														defaultValue = 1;
 													}
 													value.initialize( selectRS, defaultValue );
+
+													hasNullValue = selectRS.wasNull();
 												}
 												selectRS.close();
+
+												if (hasNullValue) {
+													throw new HibernateException("null '" + valueColumnName + "' for "
+														+ segmentColumnName + " '" + segmentValue + "'");
+												}
 											}
 											catch (SQLException e) {
 												LOG.unableToReadOrInitHiValue( e );

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullValueExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullValueExceptionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.idgen.enhanced.table;
+
+import static org.hibernate.id.IdentifierGeneratorHelper.BasicHolder;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+import static org.junit.Assert.assertEquals;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.id.enhanced.TableGenerator;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Steve Ebersole
+ */
+public class NullValueExceptionTest extends BaseCoreFunctionalTestCase {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Override
+	public String[] getMappings() {
+		return new String[] { "idgen/enhanced/table/Basic.hbm.xml" };
+	}
+
+	@Test
+	public void testNormalBoundary() {
+		expectedException.expect(HibernateException.class);
+		expectedException.expectMessage("null 'next_val' for sequence_name 'test'");
+
+		EntityPersister persister = sessionFactory().getEntityPersister( Entity.class.getName() );
+		assertClassAssignability( TableGenerator.class, persister.getIdentifierGenerator().getClass() );
+		TableGenerator generator = ( TableGenerator ) persister.getIdentifierGenerator();
+
+		Session s = openSession();
+
+		// This situation can only happen via human being or bad
+		// migration/clone script. Simulate this record being updated
+		// post table generation.
+		s.beginTransaction();
+		s.createNativeQuery(
+			"UPDATE ID_TBL_BSC_TBL SET next_val = null where sequence_name = 'test'"
+		).executeUpdate();
+		s.getTransaction().commit();
+
+		s.beginTransaction();
+		Entity entity = new Entity( "" + 1 );
+		s.save( entity );
+		s.getTransaction().commit();
+
+		s.close();
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullValueExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/NullValueExceptionTest.java
@@ -6,22 +6,18 @@
  */
 package org.hibernate.test.idgen.enhanced.table;
 
-import static org.hibernate.id.IdentifierGeneratorHelper.BasicHolder;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.id.enhanced.TableGenerator;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-/**
- * @author Steve Ebersole
- */
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+
 public class NullValueExceptionTest extends BaseCoreFunctionalTestCase {
 
 	@Rule


### PR DESCRIPTION
 - When using `org.hibernate.id.enhanced.TableGenerator` and an inadvertent
   `null` `next_value` value is stored for a valid `sequence_name` it
   will lead to an infinite loop when generating a new id. This
   scenario can only happen due to human error, or bad script.

 - Proposed solution: If a row is found for the `sequence_name` but a `null` value is
   stored then throw an exception stating such.

 - Alternative solution: Set the `null` value back to the 
   default for this sequence, but there are dangerous assumptions there. A 
   flag allowing a user to configure whether or not to throw an exception or 
   set the value back to default feels to be overkill for a scenario that rarely occurs.

 - JIRA: https://hibernate.atlassian.net/browse/HHH-8535