### PR TITLE
HHH-13638

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -436,7 +436,7 @@ public class MapBinder extends CollectionBinder {
 				referencedEntityColumns = referencedProperty.getColumnIterator();
 			}
 			fromAndWhere = getFromAndWhereFormula(
-					associatedClass.getTable().getName(),
+					associatedClass.getTable().getQualifiedTableName().toString(),
 					element.getColumnIterator(),
 					referencedEntityColumns
 			);

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -11,11 +11,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -193,7 +194,14 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	 * @return Map of "equality" hashCode to List of objects
 	 */
 	private Map<Integer, List<Object>> groupByEqualityHash(List<Object> searchedBag, Type elementType) {
-		return searchedBag.stream().collect( Collectors.groupingBy( elementType::getHashCode ) );
+		if ( searchedBag.isEmpty() ) {
+			return Collections.emptyMap();
+		}
+		Map<Integer, List<Object>> map = new HashMap<>();
+		for (Object o : searchedBag) {
+			map.computeIfAbsent( elementType.getHashCode( o ), k -> new ArrayList<>() ).add( o );
+		}
+		return map;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
@@ -332,6 +332,7 @@ public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 							|| "getTransaction".equals( methodName )
 							|| "isTransactionInProgress".equals( methodName )
 							|| "setFlushMode".equals( methodName )
+							|| "setHibernateFlushMode".equals( methodName )
 							|| "getFactory".equals( methodName )
 							|| "getSessionFactory".equals( methodName )
 							|| "getTenantIdentifier".equals( methodName ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -957,7 +957,7 @@ public class ActionQueue {
 					throw he;
 				}
 				catch (Exception e) {
-					throw new HibernateException( "Unable to perform beforeTransactionCompletion callback", e );
+					throw new HibernateException( "Unable to perform beforeTransactionCompletion callback: " + e.getMessage(), e );
 				}
 			}
 		}
@@ -987,7 +987,7 @@ public class ActionQueue {
 					// continue loop
 				}
 				catch (Exception e) {
-					throw new HibernateException( "Unable to perform afterTransactionCompletion callback", e );
+					throw new HibernateException( "Unable to perform afterTransactionCompletion callback: " + e.getMessage(), e );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -957,7 +957,7 @@ public class ActionQueue {
 					throw he;
 				}
 				catch (Exception e) {
-					throw new AssertionFailure( "Unable to perform beforeTransactionCompletion callback", e );
+					throw new HibernateException( "Unable to perform beforeTransactionCompletion callback", e );
 				}
 			}
 		}
@@ -987,7 +987,7 @@ public class ActionQueue {
 					// continue loop
 				}
 				catch (Exception e) {
-					throw new AssertionFailure( "Exception releasing cache locks", e );
+					throw new HibernateException( "Unable to perform afterTransactionCompletion callback", e );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -255,15 +255,6 @@ public interface SharedSessionContractImplementor
 	Object internalLoad(String entityName, Serializable id, boolean eager, boolean nullable)
 			throws HibernateException;
 
-	default Object internalLoad(
-			String entityName,
-			Serializable id,
-			boolean eager,
-			boolean nullable,
-			Boolean unwrapProxy) throws HibernateException {
-		return internalLoad( entityName, id, eager, nullable );
-	}
-
 	/**
 	 * Load an instance immediately. This method is only called when lazily initializing a proxy.
 	 * Do not return the proxy.

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1001,18 +1001,7 @@ public final class SessionImpl
 			String entityName,
 			Serializable id,
 			boolean eager,
-			boolean nullable) throws HibernateException {
-		return internalLoad( entityName, id, eager, nullable, null );
-
-	}
-
-	@Override
-	public final Object internalLoad(
-			String entityName,
-			Serializable id,
-			boolean eager,
-			boolean nullable,
-			Boolean unwrapProxy) {
+			boolean nullable) {
 		final EffectiveEntityGraph effectiveEntityGraph = getLoadQueryInfluencers().getEffectiveEntityGraph();
 		final GraphSemantic semantic = effectiveEntityGraph.getSemantic();
 		final RootGraphImplementor<?> graph = effectiveEntityGraph.getGraph();

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -46,6 +46,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.OuterJoinLoadable;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.tuple.entity.EntityMetamodel;
 
@@ -298,35 +299,74 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 			// caller did not request forceful eager loading, see if we can create
 			// some form of proxy
 
+			final boolean allowBytecodeProxy = getFactory()
+					.getSessionFactoryOptions()
+					.isEnhancementAsProxyEnabled();
+
+			final boolean entityHasHibernateProxyFactory = persister.getEntityMetamodel()
+					.getTuplizer()
+					.getProxyFactory() != null;
+
 			// first, check to see if we can use "bytecode proxies"
 
 			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 			final BytecodeEnhancementMetadata bytecodeEnhancementMetadata = entityMetamodel.getBytecodeEnhancementMetadata();
 			if ( allowBytecodeProxy && bytecodeEnhancementMetadata.isEnhancedForLazyLoading() ) {
 
-				// we cannot use bytecode proxy for entities with subclasses
-				if ( !entityMetamodel.hasSubclasses() ) {
+				// if the entity defines a HibernateProxy factory, see if there is an
+				// existing proxy associated with the PC - and if so, use it
+				if ( entityHasHibernateProxyFactory ) {
+					final PersistenceContext persistenceContext = getPersistenceContext();
+					final Object proxy = persistenceContext.getProxy( entityKey );
+
+					if ( proxy != null ) {
+						LOG.trace( "Entity proxy found in session cache" );
+
+						final LazyInitializer li = ( (HibernateProxy) proxy ).getHibernateLazyInitializer();
+						if ( li.isUnwrap() ) {
+							return li.getImplementation();
+						}
+
+						return persistenceContext.narrowProxy( proxy, persister, entityKey, null );
+					}
+
+					// specialized handling for entities with subclasses with a HibernateProxy factory
+					if ( persister.getEntityMetamodel().hasSubclasses() ) {
+						// entities with subclasses that define a ProxyFactory can create
+						// a HibernateProxy.
+						LOG.debugf( "Creating a HibernateProxy for to-one association with subclasses to honor laziness" );
+						return createProxy( entityKey );
+					}
 					return bytecodeEnhancementMetadata.createEnhancedProxy( entityKey, false, this );
 				}
-			}
-
-			// we could not use bytecode proxy, check to see if we can use HibernateProxy
-			if ( persister.hasProxy() ) {
-				final PersistenceContext persistenceContext = getPersistenceContext();
-				final Object existingProxy = persistenceContext.getProxy( entityKey );
-				if ( existingProxy != null ) {
-					return persistenceContext.narrowProxy( existingProxy, persister, entityKey, null );
-				}
 				else {
-					final Object proxy = persister.createProxy( id, this );
-					persistenceContext.addProxy( entityKey, proxy );
-					return proxy;
+					if ( !entityMetamodel.hasSubclasses() ) {
+						return bytecodeEnhancementMetadata.createEnhancedProxy( entityKey, false, this );
+					}
+				}
+			}
+			else {
+				if ( persister.hasProxy() ) {
+					final PersistenceContext persistenceContext = getPersistenceContext();
+					final Object existingProxy = persistenceContext.getProxy( entityKey );
+					if ( existingProxy != null ) {
+						return persistenceContext.narrowProxy( existingProxy, persister, entityKey, null );
+					}
+					else {
+						return createProxy( entityKey );
+					}
 				}
 			}
 		}
 
 		// otherwise immediately materialize it
 		return get( entityName, id );
+	}
+
+	private Object createProxy(EntityKey entityKey) {
+		final Object proxy = entityKey.getPersister().createProxy( entityKey.getIdentifier(), this );
+		getPersistenceContext().addProxy( entityKey, proxy );
+		return proxy;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -299,14 +299,6 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 			// caller did not request forceful eager loading, see if we can create
 			// some form of proxy
 
-			final boolean allowBytecodeProxy = getFactory()
-					.getSessionFactoryOptions()
-					.isEnhancementAsProxyEnabled();
-
-			final boolean entityHasHibernateProxyFactory = persister.getEntityMetamodel()
-					.getTuplizer()
-					.getProxyFactory() != null;
-
 			// first, check to see if we can use "bytecode proxies"
 
 			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
@@ -315,7 +307,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 				// if the entity defines a HibernateProxy factory, see if there is an
 				// existing proxy associated with the PC - and if so, use it
-				if ( entityHasHibernateProxyFactory ) {
+				if ( persister.getEntityMetamodel().getTuplizer().getProxyFactory() != null ) {
 					final PersistenceContext persistenceContext = getPersistenceContext();
 					final Object proxy = persistenceContext.getProxy( entityKey );
 
@@ -331,7 +323,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 					}
 
 					// specialized handling for entities with subclasses with a HibernateProxy factory
-					if ( persister.getEntityMetamodel().hasSubclasses() ) {
+					if ( entityMetamodel.hasSubclasses() ) {
 						// entities with subclasses that define a ProxyFactory can create
 						// a HibernateProxy.
 						LOG.debugf( "Creating a HibernateProxy for to-one association with subclasses to honor laziness" );

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1730,16 +1730,21 @@ public abstract class Loader {
 		// see if the entity defines reference caching, and if so use the cached reference (if one).
 		if ( session.getCacheMode().isGetEnabled() && persister.canUseReferenceCacheEntries() ) {
 			final EntityDataAccess cache = persister.getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey(
-					key.getIdentifier(),
-					persister,
-					session.getFactory(),
-					session.getTenantIdentifier()
+			if ( cache != null ) {
+				final Object ck = cache.generateCacheKey(
+						key.getIdentifier(),
+						persister,
+						session.getFactory(),
+						session.getTenantIdentifier()
+				);
+				final Object cachedEntry = CacheHelper.fromSharedCache( session, ck, cache );
+				if ( cachedEntry != null ) {
+					CacheEntry entry = (CacheEntry) persister.getCacheEntryStructure().destructure(
+							cachedEntry,
+							factory
 					);
-			final Object cachedEntry = CacheHelper.fromSharedCache( session, ck, cache );
-			if ( cachedEntry != null ) {
-				CacheEntry entry = (CacheEntry) persister.getCacheEntryStructure().destructure( cachedEntry, factory );
-				return ( (ReferenceCacheEntryImpl) entry ).getReference();
+					return ( (ReferenceCacheEntryImpl) entry ).getReference();
+				}
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessingContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessingContextImpl.java
@@ -46,7 +46,6 @@ public class ResultSetProcessingContextImpl implements ResultSetProcessingContex
 	private final AliasResolutionContext aliasResolutionContext;
 	private final boolean readOnly;
 	private final boolean shouldUseOptionalEntityInformation;
-	private final boolean forceFetchLazyAttributes;
 	private final boolean shouldReturnProxies;
 	private final QueryParameters queryParameters;
 	private final NamedParameterContext namedParameterContext;
@@ -74,7 +73,6 @@ public class ResultSetProcessingContextImpl implements ResultSetProcessingContex
 			final AliasResolutionContext aliasResolutionContext,
 			final boolean readOnly,
 			final boolean shouldUseOptionalEntityInformation,
-			final boolean forceFetchLazyAttributes,
 			final boolean shouldReturnProxies,
 			final QueryParameters queryParameters,
 			final NamedParameterContext namedParameterContext,
@@ -85,7 +83,6 @@ public class ResultSetProcessingContextImpl implements ResultSetProcessingContex
 		this.aliasResolutionContext = aliasResolutionContext;
 		this.readOnly = readOnly;
 		this.shouldUseOptionalEntityInformation = shouldUseOptionalEntityInformation;
-		this.forceFetchLazyAttributes = forceFetchLazyAttributes;
 		this.shouldReturnProxies = shouldReturnProxies;
 		this.queryParameters = queryParameters;
 		this.namedParameterContext = namedParameterContext;

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/ResultSetProcessorImpl.java
@@ -99,9 +99,6 @@ public class ResultSetProcessorImpl implements ResultSetProcessor {
 			maxRows = Integer.MAX_VALUE;
 		}
 
-		// Handles the "FETCH ALL PROPERTIES" directive in HQL
-		final boolean forceFetchLazyAttributes = false;
-
 		final ResultSetProcessingContextImpl context = new ResultSetProcessingContextImpl(
 				resultSet,
 				session,
@@ -109,7 +106,6 @@ public class ResultSetProcessorImpl implements ResultSetProcessor {
 				aliasResolutionContext,
 				readOnly,
 				shouldUseOptionalEntityInstance,
-				forceFetchLazyAttributes,
 				returnProxies,
 				queryParameters,
 				namedParameterContext,

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -688,8 +688,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 				getAssociatedEntityName(),
 				id,
 				eager,
-				isNullable(),
-				unwrapProxy
+				isNullable()
 		);
 
 		if ( proxyOrEntity instanceof HibernateProxy ) {

--- a/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
@@ -1,0 +1,66 @@
+package org.hibernate.hql.internal.ast.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+@TestForIssue(jiraKey = "HHH-13638")
+public class JoinProcessorTest
+		extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Person.class,
+		};
+	}
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		options.put(
+				AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS,
+				Boolean.TRUE
+		);
+	}
+
+	@Test
+	public void testALotOfInValues() {
+		List<Long> values = LongStream.rangeClosed( 1, 10000 ).boxed().collect( Collectors.toList() );
+
+		doInJPA( this::entityManagerFactory, entityManager ->
+		{
+			CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			CriteriaQuery<Person> cq = cb.createQuery( Person.class );
+			Root<Person> root = cq.from( Person.class );
+			cq.select( root ).where( root.get( "id" ).in( values ) );
+			entityManager.createQuery( cq );
+		} );
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/jpa/PersistenceUnitOverridesTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/jpa/PersistenceUnitOverridesTests.java
@@ -18,13 +18,19 @@ import javax.persistence.spi.PersistenceProvider;
 import javax.persistence.spi.PersistenceUnitInfo;
 import javax.sql.DataSource;
 
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.internal.ast.HqlSqlWalker;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.hibernate.persister.entity.EntityPersister;
 
@@ -88,6 +94,7 @@ public class PersistenceUnitOverridesTests extends BaseUnitTestCase {
 		final DataSource integrationDataSource = new DataSourceStub( "integrationDataSource" );
 
 		final HibernatePersistenceProvider provider = new HibernatePersistenceProvider();
+		puInfo.getProperties().setProperty( AvailableSettings.HQL_BULK_ID_STRATEGY, MultiTableBulkIdStrategyStub.class.getName() );
 
 		final EntityManagerFactory emf = provider.createContainerEntityManagerFactory(
 				puInfo,
@@ -273,6 +280,7 @@ public class PersistenceUnitOverridesTests extends BaseUnitTestCase {
 		final Map integrationOverrides = new HashMap();
 		//noinspection unchecked
 		integrationOverrides.put( AvailableSettings.JPA_JTA_DATASOURCE, integrationDataSource );
+		integrationOverrides.put( AvailableSettings.HQL_BULK_ID_STRATEGY, new MultiTableBulkIdStrategyStub() );
 
 		final EntityManagerFactory emf = provider.createContainerEntityManagerFactory(
 				new PersistenceUnitInfoAdapter(),
@@ -318,6 +326,7 @@ public class PersistenceUnitOverridesTests extends BaseUnitTestCase {
 		final DataSource override = new DataSourceStub( "integrationDataSource" );
 		final Map<String,Object> integrationSettings = new HashMap<>();
 		integrationSettings.put( AvailableSettings.JPA_NON_JTA_DATASOURCE, override );
+		integrationSettings.put( AvailableSettings.HQL_BULK_ID_STRATEGY, new MultiTableBulkIdStrategyStub() );
 
 		final PersistenceProvider provider = new HibernatePersistenceProvider();
 
@@ -500,6 +509,36 @@ public class PersistenceUnitOverridesTests extends BaseUnitTestCase {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+	}
+
+	public static class MultiTableBulkIdStrategyStub implements MultiTableBulkIdStrategy {
+
+		@Override
+		public void prepare(
+				JdbcServices jdbcServices,
+				JdbcConnectionAccess connectionAccess,
+				MetadataImplementor metadata,
+				SessionFactoryOptions sessionFactoryOptions) {
+
+		}
+
+		@Override
+		public void release(
+				JdbcServices jdbcServices, JdbcConnectionAccess connectionAccess) {
+
+		}
+
+		@Override
+		public UpdateHandler buildUpdateHandler(
+				SessionFactoryImplementor factory, HqlSqlWalker walker) {
+			return null;
+		}
+
+		@Override
+		public DeleteHandler buildDeleteHandler(
+				SessionFactoryImplementor factory, HqlSqlWalker walker) {
+			return null;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/actionqueue/CustomAfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/actionqueue/CustomAfterCompletionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.actionqueue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.HibernateException;
+import org.hibernate.action.spi.AfterTransactionCompletionProcess;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CustomAfterCompletionTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13666")
+	public void success() {
+		inSession( session -> {
+			AtomicBoolean called = new AtomicBoolean( false );
+			session.getActionQueue().registerProcess( new AfterTransactionCompletionProcess() {
+				@Override
+				public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session) {
+					called.set( true );
+				}
+			} );
+			Assert.assertFalse( called.get() );
+			inTransaction( session, theSession -> {
+				theSession.persist( new SimpleEntity( "jack" ) );
+			} );
+			Assert.assertTrue( called.get() );
+		} );
+
+		// Check that the transaction was committed
+		inTransaction( session -> {
+			long count = session.createQuery( "select count(*) from SimpleEntity", Long.class )
+					.uniqueResult();
+			assertEquals( 1L, count );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13666")
+	public void failure() {
+		try {
+			inSession( session -> {
+				session.getActionQueue().registerProcess( new AfterTransactionCompletionProcess() {
+					@Override
+					public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session) {
+						throw new RuntimeException( "My exception" );
+					}
+				} );
+				inTransaction( session, theSession -> {
+					theSession.persist( new SimpleEntity( "jack" ) );
+				} );
+			} );
+			Assert.fail( "Expected exception to be thrown" );
+		}
+		catch (Exception e) {
+			assertThat( e, instanceOf( HibernateException.class ) );
+			assertThat( e.getMessage(), containsString( "Unable to perform afterTransactionCompletion callback" ) );
+			Throwable cause = e.getCause();
+			assertThat( cause, instanceOf( RuntimeException.class ) );
+			assertThat( cause.getMessage(), containsString( "My exception" ) );
+
+			// Make sure that the original message is appended to the wrapping exception's message, for convenience
+			assertThat( e.getMessage(), containsString( "My exception" ) );
+		}
+
+		// Check that the transaction was committed
+		inTransaction( session -> {
+			long count = session.createQuery( "select count(*) from SimpleEntity", Long.class )
+					.uniqueResult();
+			assertEquals( 1L, count );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { SimpleEntity.class };
+	}
+
+	@Override
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+
+	@Entity(name = "SimpleEntity")
+	public static class SimpleEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		SimpleEntity() {
+		}
+
+		SimpleEntity(String name) {
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/actionqueue/CustomBeforeCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/actionqueue/CustomBeforeCompletionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.actionqueue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.HibernateException;
+import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CustomBeforeCompletionTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13666")
+	public void success() {
+		inSession( session -> {
+			AtomicBoolean called = new AtomicBoolean( false );
+			session.getActionQueue().registerProcess( new BeforeTransactionCompletionProcess() {
+				@Override
+				public void doBeforeTransactionCompletion(SessionImplementor session) {
+					called.set( true );
+				}
+			} );
+			Assert.assertFalse( called.get() );
+			inTransaction( session, theSession -> {
+				theSession.persist( new SimpleEntity( "jack" ) );
+			} );
+			Assert.assertTrue( called.get() );
+		} );
+
+		// Check that the transaction was committed
+		inTransaction( session -> {
+			long count = session.createQuery( "select count(*) from SimpleEntity", Long.class )
+					.uniqueResult();
+			assertEquals( 1L, count );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13666")
+	public void failure() {
+		try {
+			inSession( session -> {
+				session.getActionQueue().registerProcess( new BeforeTransactionCompletionProcess() {
+					@Override
+					public void doBeforeTransactionCompletion(SessionImplementor session) {
+						throw new RuntimeException( "My exception" );
+					}
+				} );
+				inTransaction( session, theSession -> {
+					theSession.persist( new SimpleEntity( "jack" ) );
+				} );
+			} );
+			Assert.fail( "Expected exception to be thrown" );
+		}
+		catch (Exception e) {
+			assertThat( e, instanceOf( HibernateException.class ) );
+			assertThat( e.getMessage(), containsString( "Unable to perform beforeTransactionCompletion callback" ) );
+			Throwable cause = e.getCause();
+			assertThat( cause, instanceOf( RuntimeException.class ) );
+			assertThat( cause.getMessage(), containsString( "My exception" ) );
+
+			// Make sure that the original message is appended to the wrapping exception's message, for convenience
+			assertThat( e.getMessage(), containsString( "My exception" ) );
+		}
+
+		// Check that the transaction was rolled back
+		inTransaction( session -> {
+			long count = session.createQuery( "select count(*) from SimpleEntity", Long.class )
+					.uniqueResult();
+			assertEquals( 0L, count );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { SimpleEntity.class };
+	}
+
+	@Override
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+
+	@Entity(name = "SimpleEntity")
+	public static class SimpleEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		SimpleEntity() {
+		}
+
+		SimpleEntity(String name) {
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollinWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollinWithInheritanceTest.java
@@ -1,0 +1,282 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.query.Query;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(BytecodeEnhancerRunner.class)
+public class QueryScrollinWithInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( EmployeeParent.class );
+		sources.addAnnotatedClass( Employee.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testScrollableWithStatelessSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+
+		try {
+			statelessSession.beginTransaction();
+			Query<Employee> query = statelessSession.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				scrollableResults.get( 0 );
+			}
+			statelessSession.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( statelessSession.getTransaction().isActive() ) {
+				statelessSession.getTransaction().rollback();
+			}
+			statelessSession.close();
+		}
+	}
+
+	@Test
+	public void testScrollableWithSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final Session session = sessionFactory().openSession();
+
+		try {
+			session.beginTransaction();
+			Query<Employee> query = session.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				scrollableResults.get( 0 );
+			}
+			session.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( session.getTransaction().isActive() ) {
+				session.getTransaction().rollback();
+			}
+			session.close();
+		}
+	}
+
+	@Before
+	public void prepareTestData() {
+		inTransaction(
+				session -> {
+					Employee e1 = new Employee( "ENG1" );
+					Employee e2 = new Employee( "ENG2" );
+					OtherEntity other1 = new OtherEntity( "test1" );
+					OtherEntity other2 = new OtherEntity( "test2" );
+					e1.getOtherEntities().add( other1 );
+					e1.getOtherEntities().add( other2 );
+					e1.getParentOtherEntities().add( other1 );
+					e1.getParentOtherEntities().add( other2 );
+					other1.employee = e1;
+					other2.employee = e1;
+					other1.employeeParent = e1;
+					other2.employeeParent = e2;
+					session.persist( other1 );
+					session.persist( other2 );
+					session.persist( e1 );
+					session.persist( e2 );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from EmployeeParent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "EmployeeParent")
+	@Table(name = "EmployeeParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class EmployeeParent {
+
+		@Id
+		private String dept;
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employeeParent", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> parentOtherEntities = new HashSet<>();
+
+		public Set<OtherEntity> getParentOtherEntities() {
+			if ( parentOtherEntities == null ) {
+				parentOtherEntities = new LinkedHashSet();
+			}
+			return parentOtherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pParentOtherEntites) {
+			parentOtherEntities = pParentOtherEntites;
+		}
+
+		public String getDept() {
+			return dept;
+		}
+
+		protected void setDept(String dept) {
+			this.dept = dept;
+		}
+
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	public static class Employee extends EmployeeParent {
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employee", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> otherEntities = new HashSet<>();
+
+		public Employee(String dept) {
+			this();
+			setDept( dept );
+		}
+
+		protected Employee() {
+			// this form used by Hibernate
+		}
+
+		public Set<OtherEntity> getOtherEntities() {
+			if ( otherEntities == null ) {
+				otherEntities = new LinkedHashSet();
+			}
+			return otherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pOtherEntites) {
+			otherEntities = pOtherEntites;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "Employee_Id")
+		protected Employee employee = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "EmployeeParent_Id")
+		protected EmployeeParent employeeParent = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceEagerManyToOneTest.java
@@ -81,7 +81,7 @@ public class QueryScrollingWithInheritanceEagerManyToOneTest extends BaseNonConf
 		try {
 			statelessSession.beginTransaction();
 			Query<Employee> query = statelessSession.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -89,7 +89,7 @@ public class QueryScrollingWithInheritanceEagerManyToOneTest extends BaseNonConf
 					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
 					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
 					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
+				*/
 				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
 			}
 			else {
@@ -143,7 +143,7 @@ public class QueryScrollingWithInheritanceEagerManyToOneTest extends BaseNonConf
 		try {
 			session.beginTransaction();
 			Query<Employee> query = session.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -151,7 +151,7 @@ public class QueryScrollingWithInheritanceEagerManyToOneTest extends BaseNonConf
 					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
 					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
 					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
+				*/
 				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
 			}
 			else {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceEagerManyToOneTest.java
@@ -1,0 +1,323 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.query.Query;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(BytecodeEnhancerRunner.class)
+public class QueryScrollingWithInheritanceEagerManyToOneTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "false" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( EmployeeParent.class );
+		sources.addAnnotatedClass( Employee.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testScrollableWithStatelessSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+
+		try {
+			statelessSession.beginTransaction();
+			Query<Employee> query = statelessSession.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( true ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			statelessSession.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 2L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( statelessSession.getTransaction().isActive() ) {
+				statelessSession.getTransaction().rollback();
+			}
+			statelessSession.close();
+		}
+	}
+
+	@Test
+	public void testScrollableWithSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final Session session = sessionFactory().openSession();
+
+		try {
+			session.beginTransaction();
+			Query<Employee> query = session.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( true ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			session.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 2L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( session.getTransaction().isActive() ) {
+				session.getTransaction().rollback();
+			}
+			session.close();
+		}
+	}
+
+	@Before
+	public void prepareTestData() {
+		inTransaction(
+				session -> {
+					Employee e1 = new Employee( "ENG1" );
+					Employee e2 = new Employee( "ENG2" );
+					OtherEntity other1 = new OtherEntity( "test1" );
+					OtherEntity other2 = new OtherEntity( "test2" );
+					e1.getOtherEntities().add( other1 );
+					e1.getOtherEntities().add( other2 );
+					e1.getParentOtherEntities().add( other1 );
+					e1.getParentOtherEntities().add( other2 );
+					other1.employee = e1;
+					other2.employee = e1;
+					other1.employeeParent = e1;
+					other2.employeeParent = e2;
+					session.persist( other1 );
+					session.persist( other2 );
+					session.persist( e1 );
+					session.persist( e2 );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from EmployeeParent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "EmployeeParent")
+	@Table(name = "EmployeeParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class EmployeeParent {
+
+		@Id
+		private String dept;
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employeeParent", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> parentOtherEntities = new HashSet<>();
+
+		public Set<OtherEntity> getParentOtherEntities() {
+			if ( parentOtherEntities == null ) {
+				parentOtherEntities = new LinkedHashSet();
+			}
+			return parentOtherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pParentOtherEntites) {
+			parentOtherEntities = pParentOtherEntites;
+		}
+
+		public String getDept() {
+			return dept;
+		}
+
+		protected void setDept(String dept) {
+			this.dept = dept;
+		}
+
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	public static class Employee extends EmployeeParent {
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employee", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> otherEntities = new HashSet<>();
+
+		public Employee(String dept) {
+			this();
+			setDept( dept );
+		}
+
+		protected Employee() {
+			// this form used by Hibernate
+		}
+
+		public Set<OtherEntity> getOtherEntities() {
+			if ( otherEntities == null ) {
+				otherEntities = new LinkedHashSet();
+			}
+			return otherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pOtherEntites) {
+			otherEntities = pOtherEntites;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "Employee_Id")
+		protected Employee employee = null;
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		//@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "EmployeeParent_Id")
+		protected EmployeeParent employeeParent = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceTest.java
@@ -1,0 +1,306 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.query.Query;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(BytecodeEnhancerRunner.class)
+public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( EmployeeParent.class );
+		sources.addAnnotatedClass( Employee.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testScrollableWithStatelessSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+
+		try {
+			statelessSession.beginTransaction();
+			Query<Employee> query = statelessSession.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+						assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( false ) );
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			statelessSession.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( statelessSession.getTransaction().isActive() ) {
+				statelessSession.getTransaction().rollback();
+			}
+			statelessSession.close();
+		}
+	}
+
+	@Test
+	public void testScrollableWithSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final Session session = sessionFactory().openSession();
+
+		try {
+			session.beginTransaction();
+			Query<Employee> query = session.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( false ) );
+						assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( false ) );
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			session.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( session.getTransaction().isActive() ) {
+				session.getTransaction().rollback();
+			}
+			session.close();
+		}
+	}
+
+	@Before
+	public void prepareTestData() {
+		inTransaction(
+				session -> {
+					Employee e1 = new Employee( "ENG1" );
+					Employee e2 = new Employee( "ENG2" );
+					OtherEntity other1 = new OtherEntity( "test1" );
+					OtherEntity other2 = new OtherEntity( "test2" );
+					e1.getOtherEntities().add( other1 );
+					e1.getOtherEntities().add( other2 );
+					e1.getParentOtherEntities().add( other1 );
+					e1.getParentOtherEntities().add( other2 );
+					other1.employee = e1;
+					other2.employee = e1;
+					other1.employeeParent = e1;
+					other2.employeeParent = e2;
+					session.persist( other1 );
+					session.persist( other2 );
+					session.persist( e1 );
+					session.persist( e2 );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from EmployeeParent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "EmployeeParent")
+	@Table(name = "EmployeeParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class EmployeeParent {
+
+		@Id
+		private String dept;
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employeeParent", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> parentOtherEntities = new HashSet<>();
+
+		public Set<OtherEntity> getParentOtherEntities() {
+			if ( parentOtherEntities == null ) {
+				parentOtherEntities = new LinkedHashSet();
+			}
+			return parentOtherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pParentOtherEntites) {
+			parentOtherEntities = pParentOtherEntites;
+		}
+
+		public String getDept() {
+			return dept;
+		}
+
+		protected void setDept(String dept) {
+			this.dept = dept;
+		}
+
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	public static class Employee extends EmployeeParent {
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employee", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> otherEntities = new HashSet<>();
+
+		public Employee(String dept) {
+			this();
+			setDept( dept );
+		}
+
+		protected Employee() {
+			// this form used by Hibernate
+		}
+
+		public Set<OtherEntity> getOtherEntities() {
+			if ( otherEntities == null ) {
+				otherEntities = new LinkedHashSet();
+			}
+			return otherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pOtherEntites) {
+			otherEntities = pOtherEntites;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "Employee_Id")
+		protected Employee employee = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "EmployeeParent_Id")
+		protected EmployeeParent employeeParent = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/QueryScrollingWithInheritanceTest.java
@@ -80,7 +80,7 @@ public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunction
 		try {
 			statelessSession.beginTransaction();
 			Query<Employee> query = statelessSession.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -134,7 +134,7 @@ public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunction
 		try {
 			session.beginTransaction();
 			Query<Employee> query = session.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatefulTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatefulTest.java
@@ -1,0 +1,476 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.EntityMode;
+import org.hibernate.EntityNameResolver;
+import org.hibernate.Hibernate;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.annotations.Tuplizer;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.ProxyFactory;
+import org.hibernate.stat.Statistics;
+import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.tuple.entity.EntityTuplizer;
+import org.hibernate.tuple.entity.PojoEntityTuplizer;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue( jiraKey = "HHH-13640" )
+@RunWith(BytecodeEnhancerRunner.class)
+public class LazyToOnesNoProxyFactoryWithSubclassesStatefulTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( Animal.class );
+		sources.addAnnotatedClass( Primate.class );
+		sources.addAnnotatedClass( Human.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+	
+	@Test
+	public void testNewEnhancedProxyAssociation() {
+		inTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+
+					session.persist( human );
+					session.persist( otherEntity );
+				}
+		);
+
+		inSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@Test
+	public void testExistingInitializedAssociationLeafSubclass() {
+		inTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					otherEntity.primate = human;
+					otherEntity.human = human;
+					session.persist( human );
+					session.persist( otherEntity );
+				}
+		);
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		inSession(
+				session -> {
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.animal ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "primate" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.primate ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.primate ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.human ) );
+					assertSame( otherEntity.human, otherEntity.animal );
+					assertSame( otherEntity.human, otherEntity.primate );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+				}
+		);
+
+		assertEquals( 2, stats.getPrepareStatementCount() );
+	}
+
+	@Test
+	public void testExistingEnhancedProxyAssociationLeafSubclassOnly() {
+		inTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+					otherEntity.otherHuman = human;
+					session.persist( human );
+					session.persist( otherEntity );
+				}
+		);
+
+		inSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertNull( otherEntity.animal );
+					assertNull( otherEntity.primate );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.human ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "otherHuman" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.otherHuman ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.otherHuman ) );
+					assertSame( otherEntity.human, otherEntity.otherHuman );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Human" ).executeUpdate();
+					session.createQuery( "delete from Primate" ).executeUpdate();
+					session.createQuery( "delete from Animal" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "Animal")
+	@Table(name = "Animal")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Tuplizer(impl=NoProxyFactoryPojoEntityTuplizer.class)
+	public static abstract class Animal {
+
+		@Id
+		private String name;
+
+		private int age;
+
+		public String getName() {
+			return name;
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		public int getAge() {
+			return age;
+		}
+
+		public void setAge(int age) {
+			this.age = age;
+		}
+	}
+
+	@Entity(name = "Primate")
+	@Table(name = "Primate")
+	public static class Primate extends Animal {
+
+		public Primate(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Primate() {
+			// this form used by Hibernate
+		}
+	}
+
+	@Entity(name = "Human")
+	@Table(name = "Human")
+	public static class Human extends Primate {
+
+		private String sex;
+
+		public Human(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Human() {
+			// this form used by Hibernate
+		}
+
+		public String getSex() {
+			return sex;
+		}
+
+		public void setSex(String sex) {
+			this.sex = sex;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Animal animal = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Primate primate = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human human = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human otherHuman = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Human getHuman() {
+			return human;
+		}
+
+		public void setHuman(Human human) {
+			this.human = human;
+		}
+	}
+
+	public static class NoProxyFactoryPojoEntityTuplizer implements EntityTuplizer {
+
+		private final PojoEntityTuplizer pojoEntityTuplizer;
+
+		public NoProxyFactoryPojoEntityTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
+			pojoEntityTuplizer = new PojoEntityTuplizer( entityMetamodel, mappedEntity );
+		}
+
+		@Override
+		public EntityMode getEntityMode() {
+			return pojoEntityTuplizer.getEntityMode();
+		}
+
+		@Override
+		public Object instantiate(Serializable id) throws HibernateException {
+			return pojoEntityTuplizer.instantiate( id );
+		}
+
+		@Override
+		public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
+			return pojoEntityTuplizer.instantiate( id, session );
+
+		}
+
+		@Override
+		public Serializable getIdentifier(Object entity) throws HibernateException {
+			return pojoEntityTuplizer.getIdentifier( entity );
+		}
+
+		@Override
+		public Serializable getIdentifier(Object entity, SharedSessionContractImplementor session) {
+			return pojoEntityTuplizer.getIdentifier( entity, session );
+		}
+
+		@Override
+		public void setIdentifier(Object entity, Serializable id) throws HibernateException {
+			pojoEntityTuplizer.setIdentifier( entity, id );
+		}
+
+		@Override
+		public void setIdentifier(Object entity, Serializable id, SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.setIdentifier( entity, id, session );
+		}
+
+		@Override
+		public void resetIdentifier(Object entity, Serializable currentId, Object currentVersion) {
+			pojoEntityTuplizer.resetIdentifier( entity, currentId, currentVersion );
+		}
+
+		@Override
+		public void resetIdentifier(
+				Object entity,
+				Serializable currentId,
+				Object currentVersion,
+				SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.resetIdentifier( entity, currentId, currentVersion, session );
+		}
+
+		@Override
+		public Object getVersion(Object entity) throws HibernateException {
+			return pojoEntityTuplizer.getVersion( entity );
+		}
+
+		@Override
+		public void setPropertyValue(Object entity, int i, Object value) throws HibernateException {
+			pojoEntityTuplizer. setPropertyValue( entity, i, value );
+		}
+
+		@Override
+		public void setPropertyValue(Object entity, String propertyName, Object value) throws HibernateException {
+			pojoEntityTuplizer.setPropertyValue( entity, propertyName, value );
+		}
+
+		@Override
+		public Object[] getPropertyValuesToInsert(
+				Object entity,
+				Map mergeMap,
+				SharedSessionContractImplementor session) throws HibernateException {
+			return pojoEntityTuplizer.getPropertyValuesToInsert( entity, mergeMap, session );
+		}
+
+		@Override
+		public Object getPropertyValue(Object entity, String propertyName) throws HibernateException {
+			return pojoEntityTuplizer.getPropertyValue( entity, propertyName );
+		}
+
+		@Override
+		public void afterInitialize(Object entity, SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.afterInitialize( entity, session );
+
+		}
+
+		@Override
+		public boolean hasProxy() {
+			return pojoEntityTuplizer.hasProxy();
+		}
+
+		@Override
+		public Object createProxy(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
+			return pojoEntityTuplizer.createProxy( id, session );
+		}
+
+		@Override
+		public boolean isLifecycleImplementor() {
+			return pojoEntityTuplizer.isLifecycleImplementor();
+		}
+
+		@Override
+		public Class getConcreteProxyClass() {
+			return pojoEntityTuplizer.getConcreteProxyClass();
+		}
+
+		@Override
+		public EntityNameResolver[] getEntityNameResolvers() {
+			return pojoEntityTuplizer.getEntityNameResolvers();
+		}
+
+		@Override
+		public String determineConcreteSubclassEntityName(
+				Object entityInstance, SessionFactoryImplementor factory) {
+			return pojoEntityTuplizer.determineConcreteSubclassEntityName( entityInstance, factory );
+		}
+
+		@Override
+		public Getter getIdentifierGetter() {
+			return pojoEntityTuplizer.getIdentifierGetter();
+		}
+
+		@Override
+		public Getter getVersionGetter() {
+			return pojoEntityTuplizer.getVersionGetter();
+		}
+
+		@Override
+		public ProxyFactory getProxyFactory() {
+			return null;
+		}
+
+		@Override
+		public Object[] getPropertyValues(Object entity) {
+			return pojoEntityTuplizer.getPropertyValues( entity );
+		}
+
+		@Override
+		public void setPropertyValues(Object entity, Object[] values) {
+			pojoEntityTuplizer.setPropertyValues( entity, values );
+		}
+
+		@Override
+		public Object getPropertyValue(Object entity, int i) {
+			return pojoEntityTuplizer.getPropertyValue( entity, i );
+		}
+
+		@Override
+		public Object instantiate() {
+			return pojoEntityTuplizer.instantiate();
+		}
+
+		@Override
+		public boolean isInstance(Object object) {
+			return pojoEntityTuplizer.isInstance( object );
+		}
+
+		@Override
+		public Class getMappedClass() {
+			return pojoEntityTuplizer.getMappedClass();
+		}
+
+		@Override
+		public Getter getGetter(int i) {
+			return pojoEntityTuplizer.getGetter( i );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.java
@@ -1,0 +1,476 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.EntityMode;
+import org.hibernate.EntityNameResolver;
+import org.hibernate.Hibernate;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.annotations.Tuplizer;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.ProxyFactory;
+import org.hibernate.stat.Statistics;
+import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.tuple.entity.EntityTuplizer;
+import org.hibernate.tuple.entity.PojoEntityTuplizer;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue( jiraKey = "HHH-13640" )
+@RunWith(BytecodeEnhancerRunner.class)
+public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( Animal.class );
+		sources.addAnnotatedClass( Primate.class );
+		sources.addAnnotatedClass( Human.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testNewEnhancedProxyAssociation() {
+		inStatelessTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@Test
+	public void testExistingInitializedAssociationLeafSubclass() {
+		inStatelessSession(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					otherEntity.primate = human;
+					otherEntity.human = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		inStatelessSession(
+				session -> {
+
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.animal ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "primate" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.primate ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.primate ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertTrue( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.human ) );
+					assertSame( otherEntity.human, otherEntity.animal );
+					assertSame( otherEntity.human, otherEntity.primate );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+				}
+		);
+
+		assertEquals( 2, stats.getPrepareStatementCount() );
+	}
+
+	@Test
+	public void testExistingEnhancedProxyAssociationLeafSubclassOnly() {
+		inStatelessSession(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+					otherEntity.otherHuman = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertNull( otherEntity.animal );
+					assertNull( otherEntity.primate );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.human ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "otherHuman" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.otherHuman ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.otherHuman ) );
+					assertSame( otherEntity.human, otherEntity.otherHuman );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Human" ).executeUpdate();
+					session.createQuery( "delete from Primate" ).executeUpdate();
+					session.createQuery( "delete from Animal" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "Animal")
+	@Table(name = "Animal")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Tuplizer(impl=NoProxyFactoryPojoEntityTuplizer.class)
+	public static abstract class Animal {
+
+		@Id
+		private String name;
+
+		private int age;
+
+		public String getName() {
+			return name;
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		public int getAge() {
+			return age;
+		}
+
+		public void setAge(int age) {
+			this.age = age;
+		}
+	}
+
+	@Entity(name = "Primate")
+	@Table(name = "Primate")
+	public static class Primate extends Animal {
+
+		public Primate(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Primate() {
+			// this form used by Hibernate
+		}
+	}
+
+	@Entity(name = "Human")
+	@Table(name = "Human")
+	public static class Human extends Primate {
+
+		private String sex;
+
+		public Human(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Human() {
+			// this form used by Hibernate
+		}
+
+		public String getSex() {
+			return sex;
+		}
+
+		public void setSex(String sex) {
+			this.sex = sex;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Animal animal = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Primate primate = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human human = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human otherHuman = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Human getHuman() {
+			return human;
+		}
+
+		public void setHuman(Human human) {
+			this.human = human;
+		}
+	}
+
+	public static class NoProxyFactoryPojoEntityTuplizer implements EntityTuplizer {
+
+		private final PojoEntityTuplizer pojoEntityTuplizer;
+
+		public NoProxyFactoryPojoEntityTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
+			pojoEntityTuplizer = new PojoEntityTuplizer( entityMetamodel, mappedEntity );
+		}
+
+		@Override
+		public EntityMode getEntityMode() {
+			return pojoEntityTuplizer.getEntityMode();
+		}
+
+		@Override
+		public Object instantiate(Serializable id) throws HibernateException {
+			return pojoEntityTuplizer.instantiate( id );
+		}
+
+		@Override
+		public Object instantiate(Serializable id, SharedSessionContractImplementor session) {
+			return pojoEntityTuplizer.instantiate( id, session );
+
+		}
+
+		@Override
+		public Serializable getIdentifier(Object entity) throws HibernateException {
+			return pojoEntityTuplizer.getIdentifier( entity );
+		}
+
+		@Override
+		public Serializable getIdentifier(Object entity, SharedSessionContractImplementor session) {
+			return pojoEntityTuplizer.getIdentifier( entity, session );
+		}
+
+		@Override
+		public void setIdentifier(Object entity, Serializable id) throws HibernateException {
+			pojoEntityTuplizer.setIdentifier( entity, id );
+		}
+
+		@Override
+		public void setIdentifier(Object entity, Serializable id, SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.setIdentifier( entity, id, session );
+		}
+
+		@Override
+		public void resetIdentifier(Object entity, Serializable currentId, Object currentVersion) {
+			pojoEntityTuplizer.resetIdentifier( entity, currentId, currentVersion );
+		}
+
+		@Override
+		public void resetIdentifier(
+				Object entity,
+				Serializable currentId,
+				Object currentVersion,
+				SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.resetIdentifier( entity, currentId, currentVersion, session );
+		}
+
+		@Override
+		public Object getVersion(Object entity) throws HibernateException {
+			return pojoEntityTuplizer.getVersion( entity );
+		}
+
+		@Override
+		public void setPropertyValue(Object entity, int i, Object value) throws HibernateException {
+			pojoEntityTuplizer. setPropertyValue( entity, i, value );
+		}
+
+		@Override
+		public void setPropertyValue(Object entity, String propertyName, Object value) throws HibernateException {
+			pojoEntityTuplizer.setPropertyValue( entity, propertyName, value );
+		}
+
+		@Override
+		public Object[] getPropertyValuesToInsert(
+				Object entity,
+				Map mergeMap,
+				SharedSessionContractImplementor session) throws HibernateException {
+			return pojoEntityTuplizer.getPropertyValuesToInsert( entity, mergeMap, session );
+		}
+
+		@Override
+		public Object getPropertyValue(Object entity, String propertyName) throws HibernateException {
+			return pojoEntityTuplizer.getPropertyValue( entity, propertyName );
+		}
+
+		@Override
+		public void afterInitialize(Object entity, SharedSessionContractImplementor session) {
+			pojoEntityTuplizer.afterInitialize( entity, session );
+
+		}
+
+		@Override
+		public boolean hasProxy() {
+			return pojoEntityTuplizer.hasProxy();
+		}
+
+		@Override
+		public Object createProxy(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
+			return pojoEntityTuplizer.createProxy( id, session );
+		}
+
+		@Override
+		public boolean isLifecycleImplementor() {
+			return pojoEntityTuplizer.isLifecycleImplementor();
+		}
+
+		@Override
+		public Class getConcreteProxyClass() {
+			return pojoEntityTuplizer.getConcreteProxyClass();
+		}
+
+		@Override
+		public EntityNameResolver[] getEntityNameResolvers() {
+			return pojoEntityTuplizer.getEntityNameResolvers();
+		}
+
+		@Override
+		public String determineConcreteSubclassEntityName(
+				Object entityInstance, SessionFactoryImplementor factory) {
+			return pojoEntityTuplizer.determineConcreteSubclassEntityName( entityInstance, factory );
+		}
+
+		@Override
+		public Getter getIdentifierGetter() {
+			return pojoEntityTuplizer.getIdentifierGetter();
+		}
+
+		@Override
+		public Getter getVersionGetter() {
+			return pojoEntityTuplizer.getVersionGetter();
+		}
+
+		@Override
+		public ProxyFactory getProxyFactory() {
+			return null;
+		}
+
+		@Override
+		public Object[] getPropertyValues(Object entity) {
+			return pojoEntityTuplizer.getPropertyValues( entity );
+		}
+
+		@Override
+		public void setPropertyValues(Object entity, Object[] values) {
+			pojoEntityTuplizer.setPropertyValues( entity, values );
+		}
+
+		@Override
+		public Object getPropertyValue(Object entity, int i) {
+			return pojoEntityTuplizer.getPropertyValue( entity, i );
+		}
+
+		@Override
+		public Object instantiate() {
+			return pojoEntityTuplizer.instantiate();
+		}
+
+		@Override
+		public boolean isInstance(Object object) {
+			return pojoEntityTuplizer.isInstance( object );
+		}
+
+		@Override
+		public Class getMappedClass() {
+			return pojoEntityTuplizer.getMappedClass();
+		}
+
+		@Override
+		public Getter getGetter(int i) {
+			return pojoEntityTuplizer.getGetter( i );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyMergeWithSubclassesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyMergeWithSubclassesTest.java
@@ -1,0 +1,865 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue( jiraKey = "HHH-13640" )
+@RunWith(BytecodeEnhancerRunner.class )
+@EnhancementOptions(lazyLoading = true)
+public class LazyToOnesProxyMergeWithSubclassesTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( Animal.class );
+		sources.addAnnotatedClass( Primate.class );
+		sources.addAnnotatedClass( Human.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void mergeUpdatedHibernateProxy() {
+
+		checkAgeInNewSession( 1 );
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		final OtherEntity withInitializedHibernateProxy = doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().getSex();
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					return otherEntity;
+				}
+		);
+
+		assertEquals( 2, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 1 );
+		stats.clear();
+
+		// merge updated HibernateProxy to updated HibernateProxy
+
+		withInitializedHibernateProxy.getHuman().setAge( 2 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().setAge( 3 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					final Human humanImpl = (Human) ( (HibernateProxy) otherEntity.getHuman() )
+							.getHibernateLazyInitializer()
+							.getImplementation();
+
+					session.merge( withInitializedHibernateProxy );
+					// TODO: Reference to associated HibernateProxy is changed
+					//       to the HibernateProxy's implementation.
+					assertSame( humanImpl, otherEntity.getHuman() );
+					assertEquals( 2, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 2 );
+		stats.clear();
+
+		// merge updated HibernateProxy to updated enhanced entity
+
+		withInitializedHibernateProxy.getHuman().setAge( 4 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertSame( human, otherEntity.getHuman() );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					human.setAge( 5 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					session.merge( withInitializedHibernateProxy );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertSame( human, otherEntity.getHuman() );
+					assertEquals( 4, human.getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 4 );
+		stats.clear();
+
+		// merge updated HibernateProxy to uninitialized HibernateProxy
+
+		withInitializedHibernateProxy.getHuman().setAge( 6 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					final Human humanHibernateProxy = otherEntity.getHuman();
+
+					session.merge( withInitializedHibernateProxy );
+
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					// TODO: Reference to associated HibernateProxy is changed
+					//       reference to the HibernateProxy's implementation.
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+					assertSame(
+							otherEntity.getHuman(),
+							( (HibernateProxy) humanHibernateProxy ).getHibernateLazyInitializer().getImplementation()
+					);
+
+					assertEquals( 6, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 6 );
+		stats.clear();
+
+		// merge updated HibernateProxy To uninitialized enhanced proxy
+
+		withInitializedHibernateProxy.getHuman().setAge( 7 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+
+					session.merge( withInitializedHibernateProxy );
+					assertSame( human, otherEntity.getHuman() );
+					assertTrue( Hibernate.isInitialized( human ) );
+
+					assertEquals( 7, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 7 );
+	}
+
+	@Test
+	public void mergeUpdatedEnhancedProxy() {
+
+		checkAgeInNewSession( 1 );
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		final OtherEntity withInitializedEnhancedProxy = doInHibernate(
+				this::sessionFactory,
+				session -> {
+
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().getSex();
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					return otherEntity;
+				}
+		);
+
+		assertEquals( 2, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 1 );
+		stats.clear();
+
+		// merge updated enhanced proxy to updated HibernateProxy
+
+		withInitializedEnhancedProxy.getHuman().setAge( 2 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().setAge( 3 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					final Human humanImpl = (Human) ( (HibernateProxy) otherEntity.getHuman() )
+							.getHibernateLazyInitializer()
+							.getImplementation();
+
+					session.merge( withInitializedEnhancedProxy );
+					// TODO: Reference to HibernateProxy is changed
+					//       to the HibernateProxy's implementation.
+					assertSame( humanImpl, otherEntity.getHuman() );
+
+					assertEquals( 2, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 2 );
+		stats.clear();
+
+		// merge updated enhanced proxy to updated enhanced proxy
+
+		withInitializedEnhancedProxy.getHuman().setAge( 4 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertSame( human, otherEntity.getHuman() );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					human.setAge( 5 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					session.merge( withInitializedEnhancedProxy );
+					assertEquals( 4, human.getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 4 );
+		stats.clear();
+
+		// merge updated enhanced proxy to uninitialized HibernateProxy
+
+		withInitializedEnhancedProxy.getHuman().setAge( 6 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					session.merge( withInitializedEnhancedProxy );
+
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					// TODO: Reference in managed entity gets changed from a HibernateProxy
+					// to an initialized entity. This happens without enhancement as well.
+					//assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+					assertEquals( 6, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 6 );
+		stats.clear();
+
+		// merge updated enhanced proxy to uninitialized enhanced proxy
+
+		withInitializedEnhancedProxy.getHuman().setAge( 7 );
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+
+					session.merge( withInitializedEnhancedProxy );
+					assertSame( human, otherEntity.getHuman() );
+					assertTrue( Hibernate.isInitialized( human ) );
+
+					assertEquals( 7, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 7 );
+	}
+
+	@Test
+	public void mergeUninitializedHibernateProxy() {
+
+		checkAgeInNewSession( 1 );
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		final OtherEntity withUninitializedHibernateProxy = doInHibernate(
+				this::sessionFactory,
+				session -> {
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					return otherEntity;
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 1 );
+		stats.clear();
+
+		// merge uninitialized HibernateProxy to updated HibernateProxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().setAge( 3 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					final Human humanImpl = (Human) ( (HibernateProxy) otherEntity.getHuman() )
+							.getHibernateLazyInitializer()
+							.getImplementation();
+
+					session.merge( withUninitializedHibernateProxy );
+					//assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					// TODO: Reference to HibernateProxy is changed
+					//       to the HibernateProxy's implementation.
+					assertSame( humanImpl, otherEntity.getHuman() );
+
+					assertEquals( 3, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 3 );
+		stats.clear();
+
+		// merge uninitialized HibernateProxy to updated enhanced proxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertSame( human, otherEntity.getHuman() );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					human.setAge( 5 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					session.merge( withUninitializedHibernateProxy );
+					assertEquals( 5, human.getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+		stats.clear();
+
+		// merge uninitialized HibernateProxy to uninitialized HibernateProxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					session.merge( withUninitializedHibernateProxy );
+
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+		stats.clear();
+
+		// merge uninitialized HibernateProxy to uninitialized enhanced proxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+
+					session.merge( withUninitializedHibernateProxy );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+	}
+
+	@Test
+	public void testmergeUninitializedEnhancedProxy() {
+
+		checkAgeInNewSession( 1 );
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		final OtherEntity withUninitializedEnhancedProxy = doInHibernate(
+				this::sessionFactory,
+				session -> {
+
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+					return otherEntity;
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 1 );
+		stats.clear();
+
+		// merge uninitialized enhanced proxy to updated HibernateProxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					otherEntity.getHuman().setAge( 3 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					final Human humanImpl = (Human) ( (HibernateProxy) otherEntity.getHuman() )
+							.getHibernateLazyInitializer()
+							.getImplementation();
+
+					session.merge( withUninitializedEnhancedProxy );
+					// TODO: Reference to HibernateProxy is changed
+					//       to the HibernateProxy's implementation.
+					assertSame( humanImpl, otherEntity.getHuman() );
+
+					assertEquals( 3, otherEntity.getHuman().getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 3 );
+		stats.clear();
+
+		// merge uninitialized enhanced proxy to updated enhanced entity
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertSame( human, otherEntity.getHuman() );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					human.setAge( 5 );
+					assertTrue( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertEquals( 2, stats.getPrepareStatementCount() );
+
+					session.merge( withUninitializedEnhancedProxy );
+					assertEquals( 5, human.getAge() );
+				}
+		);
+
+		assertEquals( 3, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+		stats.clear();
+
+		// merge uninitialized enhanced proxy to uninitialized HibernateProxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+
+					session.merge( withUninitializedEnhancedProxy );
+
+					assertFalse( Hibernate.isInitialized( otherEntity.getHuman() ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.getHuman() ) );
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+		stats.clear();
+
+		// merge uninitialized enhanced proxy to uninitialized enhanced proxy
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.getReference( Human.class, "A Human" );
+					assertFalse( Hibernate.isInitialized( human ) );
+					assertFalse( HibernateProxy.class.isInstance( human ) );
+					assertEquals( 0, stats.getPrepareStatementCount() );
+
+					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+
+					session.merge( withUninitializedEnhancedProxy );
+					assertSame( human, otherEntity.getHuman() );
+					assertFalse( Hibernate.isInitialized( human ) );
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+		stats.clear();
+
+		checkAgeInNewSession( 5 );
+	}
+
+	private void checkAgeInNewSession(int expectedAge) {
+
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
+					final Human human = session.get( Human.class, "A Human" );
+					assertEquals( expectedAge, human.getAge() );
+				}
+		);
+
+	}
+
+	@Before
+	public void setupData() {
+		inTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					otherEntity.primate = human;
+					otherEntity.human = human;
+					otherEntity.human.setAge( 1 );
+
+					session.persist( human );
+					session.persist( otherEntity );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Human" ).executeUpdate();
+					session.createQuery( "delete from Primate" ).executeUpdate();
+					session.createQuery( "delete from Animal" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "Animal")
+	@Table(name = "Animal")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class Animal {
+
+		@Id
+		private String name;
+
+		private int age;
+
+		public String getName() {
+			return name;
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		public int getAge() {
+			return age;
+		}
+
+		public void setAge(int age) {
+			this.age = age;
+		}
+	}
+
+	@Entity(name = "Primate")
+	@Table(name = "Primate")
+	public static class Primate extends Animal {
+
+		public Primate(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Primate() {
+			// this form used by Hibernate
+		}
+	}
+
+	@Entity(name = "Human")
+	@Table(name = "Human")
+	public static class Human extends Primate {
+
+		private String sex;
+
+		public Human(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Human() {
+			// this form used by Hibernate
+		}
+
+		public String getSex() {
+			return sex;
+		}
+
+		public void setSex(String sex) {
+			this.sex = sex;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Animal animal = null;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Primate primate = null;
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human human = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Human getHuman() {
+			return human;
+		}
+
+		public void setHuman(Human human) {
+			this.human = human;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyWithSubclassesStatelessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyWithSubclassesStatelessTest.java
@@ -1,0 +1,332 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gail Badner
+ */
+@TestForIssue( jiraKey = "HHH-13640" )
+@RunWith(BytecodeEnhancerRunner.class)
+public class LazyToOnesProxyWithSubclassesStatelessTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( Animal.class );
+		sources.addAnnotatedClass( Primate.class );
+		sources.addAnnotatedClass( Human.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testNewHibernateProxyAssociation() {
+		inStatelessTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.animal ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.animal ) );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@Test
+	public void testNewEnhancedProxyAssociation() {
+		inStatelessTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+
+	}
+
+	@Test
+	public void testExistingProxyAssociation() {
+		inStatelessTransaction(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					otherEntity.primate = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.animal ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "primate" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.primate ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.primate ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@Test
+	public void testExistingHibernateProxyAssociationLeafSubclass() {
+		inStatelessSession(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.animal = human;
+					otherEntity.primate = human;
+					otherEntity.human = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		inStatelessSession(
+				session -> {
+
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.animal ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.animal ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "primate" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.primate ) );
+					assertTrue( HibernateProxy.class.isInstance( otherEntity.primate ) );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+
+		assertEquals( 1, stats.getPrepareStatementCount() );
+	}
+
+	@Test
+	public void testExistingEnhancedProxyAssociationLeafSubclassOnly() {
+		inStatelessSession(
+				session -> {
+					Human human = new Human( "A Human" );
+					OtherEntity otherEntity = new OtherEntity( "test1" );
+					otherEntity.human = human;
+					session.insert( human );
+					session.insert( otherEntity );
+				}
+		);
+
+		inStatelessSession(
+				session -> {
+					final Statistics stats = sessionFactory().getStatistics();
+					stats.clear();
+
+					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
+					assertNull( otherEntity.animal );
+					assertNull( otherEntity.primate );
+					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
+					assertFalse( Hibernate.isInitialized( otherEntity.human ) );
+					assertFalse( HibernateProxy.class.isInstance( otherEntity.human ) );
+					assertEquals( 1, stats.getPrepareStatementCount() );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Human" ).executeUpdate();
+					session.createQuery( "delete from Primate" ).executeUpdate();
+					session.createQuery( "delete from Animal" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "Animal")
+	@Table(name = "Animal")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class Animal {
+
+		@Id
+		private String name;
+
+		private int age;
+
+		public String getName() {
+			return name;
+		}
+
+		protected void setName(String name) {
+			this.name = name;
+		}
+
+		public int getAge() {
+			return age;
+		}
+
+		public void setAge(int age) {
+			this.age = age;
+		}
+	}
+
+	@Entity(name = "Primate")
+	@Table(name = "Primate")
+	public static class Primate extends Animal {
+
+		public Primate(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Primate() {
+			// this form used by Hibernate
+		}
+	}
+
+	@Entity(name = "Human")
+	@Table(name = "Human")
+	public static class Human extends Primate {
+
+		private String sex;
+
+		public Human(String name) {
+			this();
+			setName( name );
+		}
+
+		protected Human() {
+			// this form used by Hibernate
+		}
+
+		public String getSex() {
+			return sex;
+		}
+
+		public void setSex(String sex) {
+			this.sex = sex;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Animal animal = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Primate primate = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		private Human human = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Human getHuman() {
+			return human;
+		}
+
+		public void setHuman(Human human) {
+			this.human = human;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/ProxyInitializeAndUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/ProxyInitializeAndUpdateTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -155,7 +156,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
-					session.merge( animalInitialized );
+					final Animal animalMerged = (Animal) session.merge( animalInitialized );
+					assertSame( animal, animalMerged );
 					assertTrue( Hibernate.isInitialized( animal ) );
 					assertEquals( 4, animal.getAge() );
 					assertEquals( "other", animal.getSex() );
@@ -204,7 +206,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 					assertTrue( Hibernate.isInitialized( animal ) );
 					animal.setAge( 5 );
 					animal.setSex( "male" );
-					session.merge( animalInitialized );
+					final Animal animalMerged = (Animal) session.merge( animalInitialized );
+					assertSame( animal, animalMerged );
 					assertEquals( 4, animal.getAge() );
 					assertEquals( "other", animal.getSex() );
 				}
@@ -245,7 +248,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
-					session.merge( animalUninitialized );
+					final Animal animalMerged = (Animal) session.merge( animalUninitialized );
+					assertSame( animal, animalMerged );
 					assertFalse( Hibernate.isInitialized( animal ) );
 				}
 		);
@@ -283,11 +287,13 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 
 		inTransaction(
 				session -> {
-					final Animal animal = session.get( Animal.class, "animal" );
-					assertTrue( Hibernate.isInitialized( animal ) );
+					final Animal animal = session.load( Animal.class, "animal" );
+					assertFalse( Hibernate.isInitialized( animal ) );
 					animal.setSex( "other" );
+					assertTrue( Hibernate.isInitialized( animal ) );
 					animal.setAge( 4 );
-					session.merge( animalUninitialized );
+					final Animal animalMerged = (Animal) session.merge( animalUninitialized );
+					assertSame( animal, animalMerged );
 					assertTrue( Hibernate.isInitialized( animal ) );
 					assertEquals( "other", animal.getSex() );
 					assertEquals( 4, animal.getAge() );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
@@ -1,0 +1,326 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.query.Query;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@RunWith(BytecodeEnhancerRunner.class)
+public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+		ssrb.applySetting( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( EmployeeParent.class );
+		sources.addAnnotatedClass( Employee.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testScrollableWithStatelessSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+
+		try {
+			statelessSession.beginTransaction();
+			Query<Employee> query = statelessSession.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( true ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			statelessSession.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 2L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( statelessSession.getTransaction().isActive() ) {
+				statelessSession.getTransaction().rollback();
+			}
+			statelessSession.close();
+		}
+	}
+
+	@Test
+	public void testScrollableWithSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final Session session = sessionFactory().openSession();
+
+		try {
+			session.beginTransaction();
+			Query<Employee> query = session.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( true ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			session.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 2L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( session.getTransaction().isActive() ) {
+				session.getTransaction().rollback();
+			}
+			session.close();
+		}
+	}
+
+	@Before
+	public void prepareTestData() {
+		inTransaction(
+				session -> {
+					Employee e1 = new Employee( "ENG1" );
+					Employee e2 = new Employee( "ENG2" );
+					OtherEntity other1 = new OtherEntity( "test1" );
+					OtherEntity other2 = new OtherEntity( "test2" );
+					e1.getOtherEntities().add( other1 );
+					e1.getOtherEntities().add( other2 );
+					e1.getParentOtherEntities().add( other1 );
+					e1.getParentOtherEntities().add( other2 );
+					other1.employee = e1;
+					other2.employee = e1;
+					other1.employeeParent = e1;
+					other2.employeeParent = e2;
+					session.persist( other1 );
+					session.persist( other2 );
+					session.persist( e1 );
+					session.persist( e2 );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from EmployeeParent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "EmployeeParent")
+	@Table(name = "EmployeeParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class EmployeeParent {
+
+		@Id
+		private String dept;
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employeeParent", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> parentOtherEntities = new HashSet<>();
+
+		public Set<OtherEntity> getParentOtherEntities() {
+			if ( parentOtherEntities == null ) {
+				parentOtherEntities = new LinkedHashSet();
+			}
+			return parentOtherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pParentOtherEntites) {
+			parentOtherEntities = pParentOtherEntites;
+		}
+
+		public String getDept() {
+			return dept;
+		}
+
+		protected void setDept(String dept) {
+			this.dept = dept;
+		}
+
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	public static class Employee extends EmployeeParent {
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employee", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> otherEntities = new HashSet<>();
+
+		public Employee(String dept) {
+			this();
+			setDept( dept );
+		}
+
+		protected Employee() {
+			// this form used by Hibernate
+		}
+
+		public Set<OtherEntity> getOtherEntities() {
+			if ( otherEntities == null ) {
+				otherEntities = new LinkedHashSet();
+			}
+			return otherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pOtherEntites) {
+			otherEntities = pOtherEntites;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyToOne(LazyToOneOption.NO_PROXY)
+		@JoinColumn(name = "Employee_Id")
+		protected Employee employee = null;
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@JoinColumn(name = "EmployeeParent_Id")
+		protected EmployeeParent employeeParent = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
@@ -81,7 +81,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 		try {
 			statelessSession.beginTransaction();
 			Query<Employee> query = statelessSession.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -89,7 +89,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
 					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
 					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
+				*/
 				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
 			}
 			else {
@@ -145,7 +145,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 		try {
 			session.beginTransaction();
 			Query<Employee> query = session.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -153,7 +153,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
 					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
 					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
+				*/
 				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
 			}
 			else {

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */
-package org.hibernate.test.bytecode.enhancement.lazy;
+package org.hibernate.test.bytecode.enhancement.lazy.proxy;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -19,6 +19,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.Hibernate;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
@@ -47,7 +48,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * @author Andrea Boriero
  */
 @RunWith(BytecodeEnhancerRunner.class)
-public class QueryScrollinWithInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+public class QueryScrollingWithInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCase {
 	@Override
 	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
 		super.configureStandardServiceRegistryBuilder( ssrb );
@@ -96,7 +97,29 @@ public class QueryScrollinWithInheritanceTest extends BaseNonConfigCoreFunctiona
 			}
 
 			while ( scrollableResults.next() ) {
-				scrollableResults.get( 0 );
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( false ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
 			}
 			statelessSession.getTransaction().commit();
 			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
@@ -138,7 +161,29 @@ public class QueryScrollinWithInheritanceTest extends BaseNonConfigCoreFunctiona
 			}
 
 			while ( scrollableResults.next() ) {
-				scrollableResults.get( 0 );
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( false ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
 			}
 			session.getTransaction().commit();
 			assertThat( stats.getPrepareStatementCount(), is( 1L ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
@@ -81,7 +81,7 @@ public class QueryScrollingWithInheritanceProxyTest extends BaseNonConfigCoreFun
 		try {
 			statelessSession.beginTransaction();
 			Query<Employee> query = statelessSession.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -145,7 +145,7 @@ public class QueryScrollingWithInheritanceProxyTest extends BaseNonConfigCoreFun
 		try {
 			session.beginTransaction();
 			Query<Employee> query = session.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/cache/DirectReferenceCacheEntriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/cache/DirectReferenceCacheEntriesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cfg.cache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Immutable;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-13665")
+public class DirectReferenceCacheEntriesTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { TheEntity.class };
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.USE_DIRECT_REFERENCE_CACHE_ENTRIES, "true" );
+	}
+
+	@Before
+	public void setUp() {
+		doInHibernate( this::sessionFactory, session -> {
+			TheEntity theEntity = new TheEntity();
+			theEntity.setId( 1L );
+			session.persist( theEntity );
+		} );
+	}
+
+	@Test
+	public void testSelectANonCachablenEntity() {
+		doInHibernate( this::sessionFactory, session -> {
+			session.createQuery( "select t from TheEntity t", TheEntity.class ).getResultList();
+		} );
+	}
+
+	@Entity(name = "TheEntity")
+	@Table(name = "THE_ENTITY")
+	@Immutable
+	public static class TheEntity {
+		@Id
+		public Long id;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.flush;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * Test for issue https://hibernate.atlassian.net/browse/HHH-13663
+ * 
+ * @author Luca Domenichini
+ */
+@TestForIssue(jiraKey = "HHH-13663")
+public class TestHibernateFlushModeOnThreadLocalInactiveTransaction extends BaseCoreFunctionalTestCase {
+	
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty(AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, "thread");
+	}
+
+	@Test
+	public void testHibernateFlushModeOnInactiveTransaction() {
+		Session s = openSession();
+		//s.setFlushMode(FlushMode.AUTO); // this does not throw (API is deprecated)
+		s.setHibernateFlushMode(FlushMode.AUTO); // this should not throw even within an inactive transaction
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
@@ -21,17 +21,17 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-13663")
 public class TestHibernateFlushModeOnThreadLocalInactiveTransaction extends BaseCoreFunctionalTestCase {
-	
+
 	@Override
 	protected void configure(Configuration configuration) {
-		configuration.setProperty(AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, "thread");
+		configuration.setProperty( AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, "thread" );
 	}
 
 	@Test
 	public void testHibernateFlushModeOnInactiveTransaction() {
 		Session s = openSession();
 		//s.setFlushMode(FlushMode.AUTO); // this does not throw (API is deprecated)
-		s.setHibernateFlushMode(FlushMode.AUTO); // this should not throw even within an inactive transaction
+		s.setHibernateFlushMode( FlushMode.AUTO ); // this should not throw even within an inactive transaction
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/flush/TestHibernateFlushModeOnThreadLocalInactiveTransaction.java
@@ -29,9 +29,10 @@ public class TestHibernateFlushModeOnThreadLocalInactiveTransaction extends Base
 
 	@Test
 	public void testHibernateFlushModeOnInactiveTransaction() {
-		Session s = openSession();
-		//s.setFlushMode(FlushMode.AUTO); // this does not throw (API is deprecated)
-		s.setHibernateFlushMode( FlushMode.AUTO ); // this should not throw even within an inactive transaction
+		try ( Session s = sessionFactory().getCurrentSession() ) {
+			//s.setFlushMode( FlushMode.AUTO ); // this does not throw (API is deprecated)
+			s.setHibernateFlushMode( FlushMode.AUTO ); // this should not throw even within an inactive transaction
+		}
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
@@ -1,0 +1,318 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.hqlfetchscroll;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.query.Query;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+		super.configureStandardServiceRegistryBuilder( ssrb );
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		super.configureSessionFactoryBuilder( sfb );
+		sfb.applyStatisticsSupport( true );
+		sfb.applySecondLevelCacheSupport( false );
+		sfb.applyQueryCacheSupport( false );
+	}
+
+	@Override
+	protected void applyMetadataSources(MetadataSources sources) {
+		super.applyMetadataSources( sources );
+		sources.addAnnotatedClass( EmployeeParent.class );
+		sources.addAnnotatedClass( Employee.class );
+		sources.addAnnotatedClass( OtherEntity.class );
+	}
+
+	@Test
+	public void testScrollableWithStatelessSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+
+		try {
+			statelessSession.beginTransaction();
+			Query<Employee> query = statelessSession.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( false ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			statelessSession.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( statelessSession.getTransaction().isActive() ) {
+				statelessSession.getTransaction().rollback();
+			}
+			statelessSession.close();
+		}
+	}
+
+	@Test
+	public void testScrollableWithSession() {
+		final StatisticsImplementor stats = sessionFactory().getStatistics();
+		stats.clear();
+		ScrollableResults scrollableResults = null;
+		final Session session = sessionFactory().openSession();
+
+		try {
+			session.beginTransaction();
+			Query<Employee> query = session.createQuery(
+					"select distinct e from Employee e left join fetch e.otherEntities",
+					Employee.class
+			);
+			if ( getDialect() instanceof DB2Dialect ) {
+				/*
+					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
+					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
+					set type of TYPE_FORWARD_ONLY and db2 does not support it.
+			 	*/
+				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
+			}
+			else {
+				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
+			}
+
+			while ( scrollableResults.next() ) {
+				final Employee employee = (Employee) scrollableResults.get( 0 );
+				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
+				assertThat( Hibernate.isInitialized( employee.getOtherEntities() ), is( true ) );
+				if ( "ENG1".equals( employee.getDept() ) ) {
+					assertThat( employee.getOtherEntities().size(), is( 2 ) );
+					for ( OtherEntity otherEntity : employee.getOtherEntities() ) {
+						if ( "test1".equals( otherEntity.id ) ) {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( otherEntity.employeeParent, is( employee ) );
+						}
+						else {
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employee" ), is( true ) );
+							assertThat( otherEntity.employee, is( employee ) );
+							assertThat( Hibernate.isPropertyInitialized( otherEntity, "employeeParent" ), is( true ) );
+							assertThat( Hibernate.isInitialized( otherEntity.employeeParent ), is( false ) );
+						}
+					}
+				}
+				else {
+					assertThat( employee.getOtherEntities().size(), is( 0 ) );
+				}
+			}
+			session.getTransaction().commit();
+			assertThat( stats.getPrepareStatementCount(), is( 1L ) );
+		}
+		finally {
+			if ( scrollableResults != null ) {
+				scrollableResults.close();
+			}
+			if ( session.getTransaction().isActive() ) {
+				session.getTransaction().rollback();
+			}
+			session.close();
+		}
+	}
+
+	@Before
+	public void prepareTestData() {
+		inTransaction(
+				session -> {
+					Employee e1 = new Employee( "ENG1" );
+					Employee e2 = new Employee( "ENG2" );
+					OtherEntity other1 = new OtherEntity( "test1" );
+					OtherEntity other2 = new OtherEntity( "test2" );
+					e1.getOtherEntities().add( other1 );
+					e1.getOtherEntities().add( other2 );
+					e1.getParentOtherEntities().add( other1 );
+					e1.getParentOtherEntities().add( other2 );
+					other1.employee = e1;
+					other2.employee = e1;
+					other1.employeeParent = e1;
+					other2.employeeParent = e2;
+					session.persist( other1 );
+					session.persist( other2 );
+					session.persist( e1 );
+					session.persist( e2 );
+				}
+		);
+	}
+
+	@After
+	public void cleanUpTestData() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from OtherEntity" ).executeUpdate();
+					session.createQuery( "delete from Employee" ).executeUpdate();
+					session.createQuery( "delete from EmployeeParent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Entity(name = "EmployeeParent")
+	@Table(name = "EmployeeParent")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static abstract class EmployeeParent {
+
+		@Id
+		private String dept;
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employeeParent", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> parentOtherEntities = new HashSet<>();
+
+		public Set<OtherEntity> getParentOtherEntities() {
+			if ( parentOtherEntities == null ) {
+				parentOtherEntities = new LinkedHashSet();
+			}
+			return parentOtherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pParentOtherEntites) {
+			parentOtherEntities = pParentOtherEntites;
+		}
+
+		public String getDept() {
+			return dept;
+		}
+
+		protected void setDept(String dept) {
+			this.dept = dept;
+		}
+
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "Employee")
+	public static class Employee extends EmployeeParent {
+
+		@OneToMany(targetEntity = OtherEntity.class, mappedBy = "employee", fetch = FetchType.LAZY)
+		protected Set<OtherEntity> otherEntities = new HashSet<>();
+
+		public Employee(String dept) {
+			this();
+			setDept( dept );
+		}
+
+		protected Employee() {
+			// this form used by Hibernate
+		}
+
+		public Set<OtherEntity> getOtherEntities() {
+			if ( otherEntities == null ) {
+				otherEntities = new LinkedHashSet();
+			}
+			return otherEntities;
+		}
+
+		public void setOtherEntities(Set<OtherEntity> pOtherEntites) {
+			otherEntities = pOtherEntites;
+		}
+	}
+
+	@Entity(name = "OtherEntity")
+	@Table(name = "OtherEntity")
+	public static class OtherEntity {
+
+		@Id
+		private String id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "Employee_Id")
+		protected Employee employee = null;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "EmployeeParent_Id")
+		protected EmployeeParent employeeParent = null;
+
+		protected OtherEntity() {
+			// this form used by Hibernate
+		}
+
+		public OtherEntity(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
@@ -74,7 +74,7 @@ public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunction
 		try {
 			statelessSession.beginTransaction();
 			Query<Employee> query = statelessSession.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {
@@ -138,7 +138,7 @@ public class QueryScrollingWithInheritanceTest extends BaseNonConfigCoreFunction
 		try {
 			session.beginTransaction();
 			Query<Employee> query = session.createQuery(
-					"select distinct e from Employee e left join fetch e.otherEntities",
+					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
 			if ( getDialect() instanceof DB2Dialect ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/manytomany/mapkey/ManyToManyWithMaykeyAndSchemaDefinitionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/manytomany/mapkey/ManyToManyWithMaykeyAndSchemaDefinitionTest.java
@@ -1,0 +1,135 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.manytomany.mapkey;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.MapKey;
+import javax.persistence.Table;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Andrea Boriero
+ */
+@TestForIssue(jiraKey = "HHH-4235")
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
+public class ManyToManyWithMaykeyAndSchemaDefinitionTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.HBM2DDL_CREATE_SCHEMAS, "true" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { EntityA.class, EntityB.class };
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+					EntityA entityA = new EntityA();
+					entityA.setId( 1L );
+
+					EntityB entityB = new EntityB();
+					entityB.setId( 1L );
+					entityA.setEntityBs( "B", entityB );
+					session.persist( entityB );
+					session.persist( entityA );
+				}
+		);
+	}
+
+	@Test
+	public void testRetrievingTheMapGeneratesACorrectlyQuery() {
+
+		inTransaction(
+				session -> {
+					EntityA entityA = session.get( EntityA.class, 1L );
+					Collection<EntityB> values = entityA.getEntityBMap().values();
+					assertThat( values.size(), is( 1 ) );
+				}
+		);
+
+	}
+
+
+	@Entity(name = "EntityA")
+	@Table(name = "entitya", schema = "myschema")
+	public static class EntityA {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@ManyToMany
+		@MapKey(name = "id")
+		@JoinTable(name = "entitya_entityb", schema = "myschema", joinColumns = @JoinColumn(name = "entitya_pk"), inverseJoinColumns = @JoinColumn(name = "entityb_pk"))
+		private Map<String, EntityB> entityBMap = new HashMap<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public void setEntityBs(String key, EntityB entityB) {
+			this.entityBMap.put( key, entityB );
+		}
+
+		public Map<String, EntityB> getEntityBMap() {
+			return entityBMap;
+		}
+	}
+
+	@Entity(name = "EntityB")
+	@Table(name = "entityb", schema = "myschema")
+	public static class EntityB {
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/AfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/AfterCompletionTest.java
@@ -98,10 +98,6 @@ public class AfterCompletionTest extends BaseNonConfigCoreFunctionalTestCase {
 		}
 	}
 
-	private void registerAfterCallbackCompletionHandler(Session session) {
-		( (SessionImplementor) session ).getActionQueue().registerProcess( new AfterCallbackCompletionHandler() );
-	}
-
 	public static class BeforeCallbackCompletionHandler implements BeforeTransactionCompletionProcess {
 		@Override
 		public void doBeforeTransactionCompletion(SessionImplementor session) {

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/BeforeCompletionFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/BeforeCompletionFailureTest.java
@@ -118,10 +118,6 @@ public class BeforeCompletionFailureTest extends BaseNonConfigCoreFunctionalTest
 		return new SimpleEntity( id, "key", "name" );
 	}
 
-	private void runTest() {
-
-	}
-
 	@Entity(name = "SimpleEntity")
 	public static class SimpleEntity {
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/JtaAfterCompletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/JtaAfterCompletionTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Chris Cranford
  */
-public class AfterCompletionTest extends BaseNonConfigCoreFunctionalTestCase {
+public class JtaAfterCompletionTest extends BaseNonConfigCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { SimpleEntity.class };

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/JtaBeforeCompletionFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/JtaBeforeCompletionFailureTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Steve Ebersole
  */
-public class BeforeCompletionFailureTest extends BaseNonConfigCoreFunctionalTestCase {
+public class JtaBeforeCompletionFailureTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
 	protected Class[] getAnnotatedClasses() {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/jta/JtaTransactionAfterCallbackTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/jta/JtaTransactionAfterCallbackTest.java
@@ -31,6 +31,8 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jta.TestingJtaBootstrap;
 import org.hibernate.testing.jta.TestingJtaPlatformImpl;
 
+import org.hibernate.test.tm.JtaAfterCompletionTest;
+
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -39,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * An envers specific quest that verifies the {@link AuditProcessManager} gets flushed.
  *
- * There is a similar test called {@link org.hibernate.test.tm.AfterCompletionTest}
+ * There is a similar test called {@link JtaAfterCompletionTest}
  * in hibernate-core which verifies that the callbacks fires.
  *
  * The premise behind this test is to verify that when a JTA transaction is aborted by


### PR DESCRIPTION
I  rewrote the recursive implementation to an iterative approach. 

I wrote a test case for this as well. Unfortunately I was unable to recreate the issue with my test case. If I add too many values I receive a different StackoverflowError(i.e. 10000 values):
```java.lang.StackOverflowError
	at antlr.BaseAST.toString(BaseAST.java:333)
	at antlr.BaseAST.toStringList(BaseAST.java:341)
	at antlr.BaseAST.toStringList(BaseAST.java:347)
	at antlr.BaseAST.toStringList(BaseAST.java:347)
        ...
 ```
If I only use 5000 values both the new implementation as well as the old recursive implementation work. 