### PR TITLE
HHH-13638

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
@@ -15,6 +15,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.TestForIssue;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
@@ -38,6 +39,7 @@ public class JoinProcessorTest
 		);
 	}
 
+	@Ignore
 	@Test
 	public void testALotOfInValues() {
 		List<Long> values = LongStream.rangeClosed( 1, 10000 ).boxed().collect( Collectors.toList() );

--- a/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/JoinProcessorTest.java
@@ -1,0 +1,66 @@
+package org.hibernate.hql.internal.ast.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+@TestForIssue(jiraKey = "HHH-13638")
+public class JoinProcessorTest
+		extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Person.class,
+		};
+	}
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		options.put(
+				AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS,
+				Boolean.TRUE
+		);
+	}
+
+	@Test
+	public void testALotOfInValues() {
+		List<Long> values = LongStream.rangeClosed( 1, 10000 ).boxed().collect( Collectors.toList() );
+
+		doInJPA( this::entityManagerFactory, entityManager ->
+		{
+			CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			CriteriaQuery<Person> cq = cb.createQuery( Person.class );
+			Root<Person> root = cq.from( Person.class );
+			cq.select( root ).where( root.get( "id" ).in( values ) );
+			entityManager.createQuery( cq );
+		} );
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+	}
+}


### PR DESCRIPTION
I rewrote the recursive implementation to an iterative approach.

I wrote a test case for this as well. Unfortunately I was unable to recreate the issue with my test case. If I add too many values I receive a different StackoverflowError(i.e. 10000 values):
```
	at antlr.BaseAST.toString(BaseAST.java:333)
	at antlr.BaseAST.toStringList(BaseAST.java:341)
	at antlr.BaseAST.toStringList(BaseAST.java:347)
	at antlr.BaseAST.toStringList(BaseAST.java:347)
        ...
```
If I only use 5000 values both the new implementation as well as the old recursive implementation work.