### PR TITLE
fix for HHH-13651

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -67,6 +67,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	public PersistentBag(SessionImplementor session) {
 		this( (SharedSessionContractImplementor) session );
 	}
+
 	/**
 	 * Constructs a PersistentBag
 	 *
@@ -94,7 +95,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	 * @param coll The base elements.
 	 *
 	 * @deprecated {@link #PersistentBag(SharedSessionContractImplementor, Collection)}
-	 *             should be used instead.
+	 * should be used instead.
 	 */
 	@Deprecated
 	public PersistentBag(SessionImplementor session, Collection coll) {
@@ -127,7 +128,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 			throws HibernateException, SQLException {
 		// note that if we load this collection from a cartesian product
 		// the multiplicity would be broken ... so use an idbag instead
-		final Object element = persister.readElement( rs, owner, descriptor.getSuffixedElementAliases(), getSession() ) ;
+		final Object element = persister.readElement( rs, owner, descriptor.getSuffixedElementAliases(), getSession() );
 		if ( element != null ) {
 			bag.add( element );
 		}
@@ -140,7 +141,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	}
 
 	@Override
-	@SuppressWarnings( "unchecked" )
+	@SuppressWarnings("unchecked")
 	public boolean equalsSnapshot(CollectionPersister persister) throws HibernateException {
 		final Type elementType = persister.getElementType();
 		final List<Object> sn = (List<Object>) getSnapshot();
@@ -180,7 +181,8 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 						instance,
 						instancesBag,
 						elementType,
-						countOccurrences( instance, instancesSn, elementType ) ) ) {
+						countOccurrences( instance, instancesSn, elementType )
+				) ) {
 					return false;
 				}
 			}
@@ -198,8 +200,8 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 			return Collections.emptyMap();
 		}
 		Map<Integer, List<Object>> map = new HashMap<>();
-		for (Object o : searchedBag) {
-			map.computeIfAbsent( nullableHashCode(o , elementType), k -> new ArrayList<>() ).add( o );
+		for ( Object o : searchedBag ) {
+			map.computeIfAbsent( nullableHashCode( o, elementType ), k -> new ArrayList<>() ).add( o );
 		}
 		return map;
 	}
@@ -209,17 +211,19 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	 * this fix the regression found in HHH-13651 -  NPE on flushing when ElementCollection field contains null element
 	 * the previous implementation (pre - 5.4.4) allowed null element is the collections without
 	 * issue and knew to handle null element in the list to compute snapshot equality
+	 *
 	 * @param o
 	 * @param elementType
+	 *
 	 * @return the default elementType hashcode of the object or null if the object is null)
 	 * as it behave before fixing HHH-11032 in 5.4.4
 	 */
-	private Integer nullableHashCode(Object o, Type elementType){
-		if(o==null){
+	private Integer nullableHashCode(Object o, Type elementType) {
+		if ( o == null ) {
 			return null;
 		}
 		else {
-			return elementType.getHashCode(o);
+			return elementType.getHashCode( o );
 		}
 	}
 
@@ -272,7 +276,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 			throws HibernateException {
 		final int length = bag.size();
 		final Serializable[] result = new Serializable[length];
-		for ( int i=0; i<length; i++ ) {
+		for ( int i = 0; i < length; i++ ) {
 			result[i] = persister.getElementType().disassemble( bag.get( i ), getSession(), null );
 		}
 		return result;
@@ -314,13 +318,13 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 		final ArrayList deletes = new ArrayList();
 		final List sn = (List) getSnapshot();
 		final Iterator olditer = sn.iterator();
-		int i=0;
+		int i = 0;
 		while ( olditer.hasNext() ) {
 			final Object old = olditer.next();
 			final Iterator newiter = bag.iterator();
 			boolean found = false;
-			if ( bag.size()>i && elementType.isSame( old, bag.get( i++ ) ) ) {
-			//a shortcut if its location didn't change!
+			if ( bag.size() > i && elementType.isSame( old, bag.get( i++ ) ) ) {
+				//a shortcut if its location didn't change!
 				found = true;
 			}
 			else {
@@ -376,7 +380,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 	@Override
 	public boolean isEmpty() {
-		return readSize() ? getCachedSize()==0 : bag.isEmpty();
+		return readSize() ? getCachedSize() == 0 : bag.isEmpty();
 	}
 
 	@Override
@@ -439,7 +443,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean addAll(Collection values) {
-		if ( values.size()==0 ) {
+		if ( values.size() == 0 ) {
 			return false;
 		}
 		if ( !isOperationQueueEnabled() ) {
@@ -450,14 +454,14 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 			for ( Object value : values ) {
 				queueOperation( new SimpleAdd( value ) );
 			}
-			return values.size()>0;
+			return values.size() > 0;
 		}
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public boolean removeAll(Collection c) {
-		if ( c.size()>0 ) {
+		if ( c.size() > 0 ) {
 			initialize( true );
 			if ( bag.removeAll( c ) ) {
 				elementRemoved = true;
@@ -494,7 +498,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 		}
 		else {
 			initialize( true );
-			if ( ! bag.isEmpty() ) {
+			if ( !bag.isEmpty() ) {
 				bag.clear();
 				dirty();
 			}
@@ -503,7 +507,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 	@Override
 	public Object getIndex(Object entry, int i, CollectionPersister persister) {
-		throw new UnsupportedOperationException("Bags don't have indexes");
+		throw new UnsupportedOperationException( "Bags don't have indexes" );
 	}
 
 	@Override
@@ -616,7 +620,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 	@Override
 	public boolean entryExists(Object entry, int i) {
-		return entry!=null;
+		return entry != null;
 	}
 
 	@Override
@@ -630,8 +634,9 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	 * JVM instance comparison to do the equals.
 	 * The semantic is broken not to have to initialize a
 	 * collection for a simple equals() operation.
-	 * @see java.lang.Object#equals(java.lang.Object)
 	 *
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 * <p>
 	 * {@inheritDoc}
 	 */
 	@Override
@@ -657,7 +662,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 
 		@Override
 		public Object getOrphan() {
-			throw new UnsupportedOperationException("queued clear cannot be used with orphan delete");
+			throw new UnsupportedOperationException( "queued clear cannot be used with orphan delete" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -199,9 +199,28 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 		}
 		Map<Integer, List<Object>> map = new HashMap<>();
 		for (Object o : searchedBag) {
-			map.computeIfAbsent( elementType.getHashCode( o ), k -> new ArrayList<>() ).add( o );
+			map.computeIfAbsent( nullableHashCode(o , elementType), k -> new ArrayList<>() ).add( o );
 		}
 		return map;
+	}
+
+	/**
+	 * return the hashcode of the object or null if the object is null
+	 * this fix the regression found in HHH-13651 -  NPE on flushing when ElementCollection field contains null element
+	 * the previous implementation (pre - 5.4.4) allowed null element is the collections without
+	 * issue and knew to handle null element in the list to compute snapshot equality
+	 * @param o
+	 * @param elementType
+	 * @return the default elementType hashcode of the object or null if the object is null)
+	 * as it behave before fixing HHH-11032 in 5.4.4
+	 */
+	private Integer nullableHashCode(Object o, Type elementType){
+		if(o==null){
+			return null;
+		}
+		else {
+			return elementType.getHashCode(o);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
I added support for null element in embedded collection snapshot equality calculation as it was before (version < 5.4.4 or version < 5.3.11).
This prevent to get a NPE while calculating the equality because the current code try to compute hashcode for null object.