### PR TITLE
HHH-13689 Replace uses of the deprecated osgi plugin with the biz.aQute.bnd plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.7'
 		classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 		classpath 'de.thetaphi:forbiddenapis:2.5'
+		classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
 	}
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -26,7 +26,7 @@ apply from: rootProject.file( 'gradle/libraries.gradle' )
 apply from: rootProject.file( 'gradle/databases.gradle' )
 
 apply plugin: 'java'
-apply plugin: 'osgi'
+apply plugin: 'biz.aQute.bnd.builder'
 
 apply plugin: 'checkstyle'
 apply plugin: 'build-dashboard'

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -10,69 +10,90 @@ apply from: rootProject.file( 'gradle/java-module.gradle' )
 apply from: rootProject.file( 'gradle/publishing-repos.gradle' )
 apply from: rootProject.file( 'gradle/publishing-pom.gradle' )
 
-
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Jar
 
 jar {
-	manifest = osgiManifest {
-		// GRADLE-1411: Even if we override Imports and Exports
-		// auto-generation with instructions, classesDir and classpath
-		// need to be here (temporarily).
+	manifest {
+		attributes(
+				// Basic JAR manifest attributes
+				'Specification-Title': project.name,
+				'Specification-Version': project.version,
+				'Specification-Vendor': 'Hibernate.org',
+				'Implementation-Title': project.name,
+				'Implementation-Version': project.version,
+				'Implementation-Vendor': 'Hibernate.org',
+				'Implementation-Vendor-Id': 'org.hibernate',
+				'Implementation-Url': 'http://hibernate.org/orm',
 
-		if ( project.pluginManager.hasPlugin( 'groovy' ) ) {
-			classesDir = sourceSets.main.groovy.outputDir
-		}
-		else {
-			classesDir = sourceSets.main.java.outputDir
-		}
-		classpath = configurations.runtime
+				// Java 9 module name
+				'Automatic-Module-Name': project.java9ModuleName,
 
+				// Hibernate-specific JAR manifest attributes
+				'Hibernate-VersionFamily': project.ormVersion.family,
+				'Hibernate-JpaVersion': project.jpaVersion.name,
 
-		// Java 9 module name
-		instruction 'Automatic-Module-Name', project.java9ModuleName
-
-		// the OSGi metadata
-		symbolicName project.java9ModuleName
-		vendor 'Hibernate.org'
-		description project.description
-		docURL "http://www.hibernate.org/orm/${project.ormVersion.family}"
-
-		instruction 'Import-Package',
-					// Temporarily support JTA 1.1 -- Karaf and other frameworks still
-					// use it.  Without this, the plugin generates [1.2,2).
-					'javax.transaction;version="[1.1,2)"',
-					// Tell Gradle OSGi to still dynamically import the other packages.
-					// IMPORTANT: Do not include the * in the modules' .gradle files.
-					// If it exists more than once, the manifest will physically contain a *.
-					'*'
-
-		// Basic JAR manifest metadata
-		instruction 'Specification-Title', project.name
-		instruction 'Specification-Version', project.version
-		instruction 'Specification-Vendor', 'Hibernate.org'
-		instruction 'Implementation-Title', project.name
-		instruction 'Implementation-Version', project.version
-		instruction 'Implementation-Vendor', 'Hibernate.org'
-		instruction 'Implementation-Vendor-Id', 'org.hibernate'
-		instruction 'Implementation-Url', 'http://hibernate.org/orm'
-
-		instruction 'Hibernate-VersionFamily', project.ormVersion.family
-		instruction 'Hibernate-JpaVersion', project.jpaVersion.name
+				// BND Plugin instructions (for OSGi):
+				'Bundle-Name': project.name,
+				'Bundle-SymbolicName': project.java9ModuleName,
+				'Bundle-Vendor': 'Hibernate.org',
+				'Bundle-DocURL': "http://www.hibernate.org/orm/${project.ormVersion.family}",
+				// This is overridden in some sub-projects
+				'Import-Package': [
+						// Temporarily support JTA 1.1 -- Karaf and other frameworks still
+						// use it.  Without this, the plugin generates [1.2,2).
+						'javax.transaction;version="[1.1,2)"',
+						// Also import every package referenced in the code
+						// (note that '*' is resolved at build time to a list of packages)
+						'*'
+				].join( ',' ),
+				'-exportcontents': "*;version=${project.version}"
+		)
 	}
 }
 
 
 task sourcesJar(type: Jar) {
 	from project.sourceSets.main.allSource
-	manifest = project.tasks.jar.manifest
+	manifest {
+		attributes(
+				// Basic JAR manifest attributes
+				'Specification-Title': project.name,
+				'Specification-Version': project.version,
+				'Specification-Vendor': 'Hibernate.org',
+				'Implementation-Title': project.name,
+				'Implementation-Version': project.version,
+				'Implementation-Vendor': 'Hibernate.org',
+				'Implementation-Vendor-Id': 'org.hibernate',
+				'Implementation-Url': 'http://hibernate.org/orm',
+
+				// Hibernate-specific JAR manifest attributes
+				'Hibernate-VersionFamily': project.ormVersion.family,
+				'Hibernate-JpaVersion': project.jpaVersion.name
+		)
+	}
 	archiveClassifier.set( 'sources' )
 }
 
 task javadocJar(type: Jar) {
 	from project.tasks.javadoc.outputs
-	manifest = project.tasks.jar.manifest
+	manifest {
+		attributes(
+				// Basic JAR manifest attributes
+				'Specification-Title': project.name,
+				'Specification-Version': project.version,
+				'Specification-Vendor': 'Hibernate.org',
+				'Implementation-Title': project.name,
+				'Implementation-Version': project.version,
+				'Implementation-Vendor': 'Hibernate.org',
+				'Implementation-Vendor-Id': 'org.hibernate',
+				'Implementation-Url': 'http://hibernate.org/orm',
+
+				// Hibernate-specific JAR manifest attributes
+				'Hibernate-VersionFamily': project.ormVersion.family,
+				'Hibernate-JpaVersion': project.jpaVersion.name
+		)
+	}
 	archiveClassifier.set( 'javadoc' )
 }
 

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -136,39 +136,54 @@ dependencies {
 
 jar {
     manifest {
-        mainAttributes( 'Main-Class': 'org.hibernate.Version' )
+        attributes(
+                'Main-Class': 'org.hibernate.Version',
 
-        instructionFirst 'Import-Package',
-            'javax.security.auth;resolution:=optional',
-            'javax.security.jacc;resolution:=optional',
-            'javax.validation;resolution:=optional',
-            'javax.validation.constraints;resolution:=optional',
-            'javax.validation.groups;resolution:=optional',
-            'javax.validation.metadata;resolution:=optional',
-            // TODO: Shouldn't have to explicitly list this, but the plugin
-            // generates it with a [1.0,2) version.
-            "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
-            // optionals
-            'javax.management;resolution:=optional',
-            'javax.naming.event;resolution:=optional',
-            'javax.naming.spi;resolution:=optional',
-            'org.apache.tools.ant;resolution:=optional',
-            'org.apache.tools.ant.taskdefs;resolution:=optional',
-            'org.apache.tools.ant.types;resolution:=optional',
-            '!javax.enterprise*',
-            'javax.enterprise.context.spi;resolution:=optional',
-            'javax.enterprise.inject.spi;resolution:=optional',
-            'javax.inject;resolution:=optional',
-            'net.bytebuddy.*;resolution:=optional',
-            // We must specify the version explicitly to allow Karaf
-            // to use an older version of JAXB (the only one we can use in Karaf)
-            "javax.xml.bind.*;version=\"${project.jaxbApiVersionOsgiRange}\""
-
-//        // TODO: Uncomment once EntityManagerFactoryBuilderImpl no longer
-//        // uses ClassLoaderServiceImpl.
-//        instruction 'Export-Package',
-//            'org.hibernate.boot.registry.classloading.internal',
-//            '*'
+                // BND Plugin instructions (for OSGi):
+                'Import-Package': [
+                        'javax.security.auth;resolution:=optional',
+                        // Make javax.security.jacc optional and do not reference a version range (because that's what we used to do)
+                        'javax.security.jacc;resolution:=optional;version=!',
+                        // Make javax.validation optional and do not reference a version range (because that's what we used to do)
+                        'javax.validation;resolution:=optional;version=!',
+                        'javax.validation.constraints;resolution:=optional;version=!',
+                        'javax.validation.groups;resolution:=optional;version=!',
+                        'javax.validation.metadata;resolution:=optional;version=!',
+                        // Make javax.enterprise optional and do not reference a version range (because that's what we used to do)
+                        '!javax.enterprise*',
+                        'javax.enterprise.context.spi;resolution:=optional;version=!',
+                        'javax.enterprise.inject.spi;resolution:=optional;version=!',
+                        // For JPA, we don't want to target the automatically generated range, but a specific version
+                        "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
+                        // optionals
+                        'javax.management;resolution:=optional',
+                        'javax.naming.event;resolution:=optional',
+                        'javax.naming.spi;resolution:=optional',
+                        'org.apache.tools.ant;resolution:=optional',
+                        'org.apache.tools.ant.taskdefs;resolution:=optional',
+                        'org.apache.tools.ant.types;resolution:=optional',
+                        'javax.inject;resolution:=optional',
+                        'net.bytebuddy.*;resolution:=optional',
+                        'org.objectweb.jonas_tm;resolution:=optional',
+                        'com.ibm.websphere.jtaextensions;resolution:=optional',
+                        // We must specify the version explicitly to allow Karaf
+                        // to use an older version of JAXB (the only one we can use in Karaf)
+                        "javax.xml.bind.*;version=\"${project.jaxbApiVersionOsgiRange}\"",
+                        // Temporarily support JTA 1.1 -- Karaf and other frameworks still
+                        // use it.  Without this, the plugin generates [1.2,2).
+                        'javax.transaction;version="[1.1,2)"',
+                        // Also import every package referenced in the code
+                        '*'
+                ].join( ',' ),
+                '-exportcontents': [
+                        // Legacy resource packages containing XSDs that were traditionally not exported
+                        "!org.hibernate.xsd.cfg",
+                        "!org.hibernate.xsd.mapping",
+                        // TODO: Uncomment once EntityManagerFactoryBuilderImpl no longer uses ClassLoaderServiceImpl.
+                        //'org.hibernate.boot.registry.classloading.internal',
+                        "*;version=${project.version}"
+                ].join( ',' ),
+        )
     }
 }
 

--- a/hibernate-entitymanager/hibernate-entitymanager.gradle
+++ b/hibernate-entitymanager/hibernate-entitymanager.gradle
@@ -12,19 +12,21 @@ dependencies {
 	compile( libraries.jta )
 }
 
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// The OSGi JAR manifest support does not like a non-existent classes dir,
-// so make sure we dont use the OSGi one :)
+// Traditionally we used to not include any manifest attributes in this JAR
+// except "Manifest-Version"
+// Since it's a legacy JAR, let's continue that way until it's retired.
 
 jar {
-	manifest = null
+	manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
+	// Prevent BND from adding manifest attributes automatically
+	bnd( '-nobundles': 'true' )
 }
 
 sourcesJar {
-	manifest = null
+	manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
 }
 
 javadocJar {
-	manifest = null
+	manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
 }

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -40,16 +40,25 @@ sourceSets {
 
 jar {
     manifest {
-        instructionFirst 'Import-Package',
-            // TODO: Shouldn't have to explicitly list the JPA packages, but
-            // the plugin generates them with [1.0,2) versions.
-            "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
-            "javax.persistence.criteria;version=\"${project.jpaVersion.osgiName}\"",
-            "javax.persistence.metamodel;version=\"${project.jpaVersion.osgiName}\"",
-            "javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\"",
-            // optionals
-            'javax.naming;resolution:=optional',
-            'org.apache.tools.ant;resolution:=optional'
+        attributes(
+                // BND Plugin instructions (for OSGi):
+                'Import-Package': [
+                        // TODO: Shouldn't have to explicitly list the JPA packages, but
+                        // the plugin generates them with [1.0,2) versions.
+                        "javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
+                        "javax.persistence.criteria;version=\"${project.jpaVersion.osgiName}\"",
+                        "javax.persistence.metamodel;version=\"${project.jpaVersion.osgiName}\"",
+                        "javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\"",
+                        // optionals
+                        'javax.naming;resolution:=optional',
+                        'org.apache.tools.ant;resolution:=optional',
+                        // Temporarily support JTA 1.1 -- Karaf and other frameworks still
+                        // use it.  Without this, the plugin generates [1.2,2).
+                        'javax.transaction;version="[1.1,2)"',
+                        // Also import every package referenced in the code
+                        '*'
+                ].join( ',' )
+        )
     }
 }
 

--- a/hibernate-java8/hibernate-java8.gradle
+++ b/hibernate-java8/hibernate-java8.gradle
@@ -6,18 +6,22 @@ description = '(deprecated - use hibernate-core instead) Support for Java8-speci
 dependencies {
     compile( project( ':hibernate-core' ) )
 }
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// The OSGi JAR manifest support does not like a non-existent classes dir,
-// so make sure we dont use the OSGi one :)
+// Traditionally we used to not include any manifest attributes in this JAR
+// except "Manifest-Version"
+// Since it's a legacy JAR, let's continue that way until it's retired.
 
 jar {
-    manifest = null
+    manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
+    // Prevent BND from adding manifest attributes automatically
+    bnd( '-nobundles': 'true' )
 }
 
 sourcesJar {
-    manifest = null
+    manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
 }
 
 javadocJar {
-    manifest = null
+    manifest.attributes.removeAll { key, value -> key != "Manifest-Version" }
 }

--- a/hibernate-osgi/hibernate-osgi.gradle
+++ b/hibernate-osgi/hibernate-osgi.gradle
@@ -98,13 +98,22 @@ dependencies {
 
 jar {
 	manifest {
-		instruction 'Bundle-Activator', 'org.hibernate.osgi.HibernateBundleActivator'
-        instruction 'Provide-Capability', 'osgi.service;effective:=active;objectClass=javax.persistence.spi.PersistenceProvider'
-		instructionFirst 'Import-Package',
-			// TODO: Shouldn't have to explicitly list this, but the plugin
-			// generates it with a [1.0,2) version.
-			"javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
-			"javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\""
+		attributes(
+				// BND Plugin instructions (for OSGi):
+				'Bundle-Activator': 'org.hibernate.osgi.HibernateBundleActivator',
+				'Provide-Capability': 'osgi.service;effective:=active;objectClass=javax.persistence.spi.PersistenceProvider',
+				'Import-Package': [
+						// TODO: Shouldn't have to explicitly list this, but the plugin
+						// generates it with a [1.0,2) version.
+						"javax.persistence;version=\"${project.jpaVersion.osgiName}\"",
+						"javax.persistence.spi;version=\"${project.jpaVersion.osgiName}\"",
+						// Temporarily support JTA 1.1 -- Karaf and other frameworks still
+						// use it.  Without this, the plugin generates [1.2,2).
+						'javax.transaction;version="[1.1,2)"',
+						// Also import every package referenced in the code
+						'*'
+				].join( ',' )
+		)
 	}
 }
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13689

**DO NOT MERGE**: This pull request is based on #3078 (upgrade to Gradle 5), which should be merged first. This means the first few commits are those from #3078 , but they will disappear once #3078 is merged and I rebase the PR on master.

The OSGi plugin [is deprecated](https://docs.gradle.org/5.0-milestone-1/release-notes.html#deprecated-osgi-plugin) in Gradle 5, meaning we will have to switch to its replacement before we can think about upgrading to Gradle 6. And we will have to upgrade to Gradle 6 at some point, for JDK13+ support.

This PR addresses two points:

* Switching to the recommended replacement for the OSGi plugin, the [BND Gradle plugin](https://github.com/bndtools/bnd/tree/master/biz.aQute.bnd.gradle), and adapting the configuration (the syntax is a bit different).
* Adding more configuration to remove unwanted `Import-Packages`, unwanted package versions, etc.

I tried to keep the changes in the `MANIFEST.MF` files to a minimum. Compared to 5.4.7.Final, here is what will change:

* In `hibernate-core`, there are two new imported packages (`Import-Package` header): `com.ibm.websphere.jtaextensions` and `org.objectweb.jonas_tm`. The old plugin didn't detect the dependencies, but the new one does: we load classes from these packages dynamically, if they are present, in the transaction manager code. I made the imports optional and removed the version constraints, since I'm not sure what the version constraints are.
* In `hibernate-core`, there is a new `Private-Package` header that references two packages: `org.hibernate.xsd.cfg` and `org.hibernate.xsd.mapping`. From what I can tell, those packages only contain resources (XSD files). They weren't exported in 5.4.7.Final. The `Private-Package` header is just a byproduct of BND and does not change anything in OSGi runtimes (it's ignored).
* In `hibernate-gradle-plugin`, the `Import-Package`s for the Groovy APIs no longer point to a specific version (the "version" bit was removed). As far as I can tell, we don't have an explicit dependency to a specific version of Groovy in our own gradle files, so I think it makes sense? I can add a version manually, but I would need to know which version we want to target. Or, you know, we just leave it as is: I might be wrong, but running a Gradle plugin in an OSGi environment looks pretty niche.
* All OSGi instructions were removed from `javadoc` and `sources` JARs. Apparently they were copied there by mistake. If we wanted to restore them, it would be quite complicated with the new plugin.