### PR TITLE
fix a boolean logic error in DefaultSaveOrUpdateEventListener

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -124,7 +124,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {


### PR DESCRIPTION
I think the following code snippet has obvious logic error:

`final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
						.isEqual( requestedId, entityEntry.getId(), factory );`

From the logging statement (only `requestedId` is used), it seems the boolean variable name is not misnomer. Seems the `!` operator at the beginning is overlooked.