### PR TITLE
HHH-13698 : Hibernate does not recognize MySQL 8 error code 3572 as P…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -532,7 +532,8 @@ public class MySQLDialect extends Dialect {
 			@Override
 			public JDBCException convert(SQLException sqlException, String message, String sql) {
 				switch ( sqlException.getErrorCode() ) {
-					case 1205: {
+					case 1205:
+					case 3572: {
 						return new PessimisticLockException( message, sqlException, sql );
 					}
 					case 1207:


### PR DESCRIPTION
…essimisticLockException

https://hibernate.atlassian.net/browse/HHH-13698

```o.h.test.jpa.lock.LockExceptionTests#testLockTimeoutRefresh``` reproduces the failure with MySQL 8.