### PR TITLE
HHH-13670 - Reproducer Missing from clause in query with joined inheritance, regression in 5.4.5

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
@@ -509,7 +509,7 @@ public class HqlSqlWalker extends HqlSqlBaseWalker implements ErrorReporter, Par
 			SqlGenerator sql = new SqlGenerator( getSessionFactoryHelper().getFactory() );
 			sql.whereExpr( hqlSqlWithNode.getFirstChild() );
 
-			fromElement.setWithClauseFragment( "(" + sql.getSQL() + ")" );
+			fromElement.setWithClauseFragment( hqlSqlWithNode.getFirstChild(), "(" + sql.getSQL() + ")" );
 		}
 		catch (SemanticException e) {
 			throw e;

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElement.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import antlr.collections.AST;
 import org.hibernate.QueryException;
 import org.hibernate.engine.internal.JoinSequence;
 import org.hibernate.hql.internal.CollectionProperties;
@@ -69,6 +70,7 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 	private boolean useWhereFragment = true;
 	private List<FromElement> destinations;
 	private boolean manyToMany;
+	private AST withClauseAst;
 	private String withClauseFragment;
 	private boolean dereferencedBySuperclassProperty;
 	private boolean dereferencedBySubclassProperty;
@@ -627,11 +629,16 @@ public class FromElement extends HqlSqlWalkerNode implements DisplayableNode, Pa
 		isAllPropertyFetch = fetch;
 	}
 
+	public AST getWithClauseAst() {
+		return withClauseAst;
+	}
+
 	public String getWithClauseFragment() {
 		return withClauseFragment;
 	}
 
-	public void setWithClauseFragment(String withClauseFragment) {
+	public void setWithClauseFragment(AST ast, String withClauseFragment) {
+		this.withClauseAst = ast;
 		this.withClauseFragment = withClauseFragment;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh13670/HHH13670Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh13670/HHH13670Test.java
@@ -1,0 +1,146 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query.hhh13670;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Tuple;
+import java.util.List;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@TestForIssue(jiraKey = "HHH-13670")
+public class HHH13670Test extends BaseCoreFunctionalTestCase {
+
+    @Before
+    public void setUp() {
+        doInJPA(this::sessionFactory, em -> {
+            SubA a_1 = new SubA(1L);
+            SubA a_2 = new SubA(2L);
+            SubA a_3 = new SubA(3L);
+            SubA a_14 = em.getReference(SubA.class, 10L);
+            SubB b_4 = new SubB(4L, null);
+            SubB b_5 = new SubB(5L, a_3);
+            SubB b_6 = new SubB(6L, b_4);
+            SubB b_7 = new SubB(7L, a_14);
+
+            em.merge(a_1);
+            em.merge(a_2);
+            em.merge(a_3);
+            em.merge(b_4);
+            em.merge(b_5);
+            em.merge(b_6);
+            em.merge(b_7);
+        });
+    }
+
+    @Test
+    public void testRootTypeJoinWithGroupJoins() {
+        doInJPA(this::sessionFactory, em -> {
+            List<Tuple> resultList = em.createQuery("SELECT subB_0.id, subA_0.id, subB_0.id, subA_0.id FROM SubB subB_0 LEFT JOIN Super subA_0 ON subA_0.id = subB_0.parent.id ORDER BY subB_0.id ASC, subA_0.id ASC", Tuple.class)
+                    .getResultList();
+
+            assertEquals("Rows omitted despite optional association should have rendered a left join", 4, resultList.size());
+
+            assertEquals((Long) 4L , resultList.get(0).get(0));
+            assertEquals((Long) 5L , resultList.get(1).get(0));
+            assertEquals((Long) 6L , resultList.get(2).get(0));
+            assertEquals((Long) 7L , resultList.get(3).get(0));
+
+            assertNull(resultList.get(0).get(1, Long.class));
+            assertEquals((Long) 3L , resultList.get(1).get(1, Long.class));
+            assertEquals((Long) 4L , resultList.get(2).get(1, Long.class));
+            assertNull("Missing entry in foreign table should not be returned", resultList.get(3).get(1, Long.class));
+        });
+    }
+
+    @Test
+    public void testSubTypeJoinWithTableGroupJoins() {
+        doInJPA(this::sessionFactory, em -> {
+            List<Tuple> resultList = em.createQuery("SELECT subB_0.id, subA_0.id, subB_0.id, subA_0.id FROM SubB subB_0 LEFT JOIN SubA subA_0 ON subA_0.id = subB_0.parent.id ORDER BY subB_0.id ASC, subA_0.id ASC", Tuple.class)
+                    .getResultList();
+
+            assertEquals("Rows omitted despite optional association should have rendered a left join", 4, resultList.size());
+
+            assertEquals((Long) 4L, resultList.get(0).get(0));
+            assertEquals((Long) 5L, resultList.get(1).get(0));
+            assertEquals((Long) 6L, resultList.get(2).get(0));
+            assertEquals((Long) 7L, resultList.get(3).get(0));
+
+            assertNull(resultList.get(0).get(1, Long.class));
+            assertEquals((Long) 3L, resultList.get(1).get(1, Long.class));
+            assertNull("Another subtype than queried for was returned", resultList.get(2).get(1));
+            assertNull("Missing entry in foreign table should not be returned", resultList.get(3).get(1, Long.class));
+        });
+    }
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { Super.class, SubA.class, SubB.class };
+    }
+
+    @Override
+    protected void configure(Configuration configuration) {
+        super.afterConfigurationBuilt( configuration );
+        // Uncomment to fix tests
+//        configuration.setProperty( AvailableSettings.OMIT_JOIN_OF_SUPERCLASS_TABLES, "false" );
+    }
+
+    @Entity(name = "Super")
+    @Inheritance(strategy = InheritanceType.JOINED)
+    public static class Super<SubType extends Super> {
+
+        @Id
+        @Column
+        Long id;
+
+        @JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+        @ManyToOne(targetEntity = Super.class, fetch = FetchType.LAZY)
+        SubType parent;
+
+    }
+
+    @Entity(name = "SubA")
+    public static class SubA extends Super {
+
+        SubA() {}
+
+        SubA(Long id) {
+            this.id = id;
+        }
+
+    }
+
+    @Entity(name = "SubB")
+    public static class SubB extends Super<SubA> {
+
+        SubB() {}
+
+        SubB(Long id, Super parent) {
+            this.id = id;
+            ((Super) this).parent = parent;
+        }
+
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh13670/HHH13670Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh13670/HHH13670Test.java
@@ -55,6 +55,13 @@ public class HHH13670Test extends BaseCoreFunctionalTestCase {
     }
 
     @Test
+    public void testDereferenceSuperClassAttributeInWithClause() {
+        doInJPA(this::sessionFactory, em -> {
+            em.createQuery("SELECT subB_0.id FROM SubB subB_0 LEFT JOIN subB_0.other subA_0 ON subA_0.id = subB_0.parent.id", Tuple.class).getResultList();
+        });
+    }
+
+    @Test
     public void testRootTypeJoinWithGroupJoins() {
         doInJPA(this::sessionFactory, em -> {
             List<Tuple> resultList = em.createQuery("SELECT subB_0.id, subA_0.id, subB_0.id, subA_0.id FROM SubB subB_0 LEFT JOIN Super subA_0 ON subA_0.id = subB_0.parent.id ORDER BY subB_0.id ASC, subA_0.id ASC", Tuple.class)
@@ -99,13 +106,6 @@ public class HHH13670Test extends BaseCoreFunctionalTestCase {
         return new Class<?>[] { Super.class, SubA.class, SubB.class };
     }
 
-    @Override
-    protected void configure(Configuration configuration) {
-        super.afterConfigurationBuilt( configuration );
-        // Uncomment to fix tests
-//        configuration.setProperty( AvailableSettings.OMIT_JOIN_OF_SUPERCLASS_TABLES, "false" );
-    }
-
     @Entity(name = "Super")
     @Inheritance(strategy = InheritanceType.JOINED)
     public static class Super<SubType extends Super> {
@@ -133,6 +133,9 @@ public class HHH13670Test extends BaseCoreFunctionalTestCase {
 
     @Entity(name = "SubB")
     public static class SubB extends Super<SubA> {
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        Super other;
 
         SubB() {}
 


### PR DESCRIPTION
Reproducer for https://hibernate.atlassian.net/browse/HHH-13670, which is an issue with dereferencing attributes for joined inheritance entities in queries introduced with https://hibernate.atlassian.net/browse/HHH-12993 . 

As a result, the tests pass on releases 5.4.6 and before or with `AvailableSettings.OMIT_JOIN_OF_SUPERCLASS_TABLES` disabled.

Test is derived from my test case here https://github.com/Blazebit/blaze-persistence/pull/885

I don't have time to work on a fix now, but I believe @beikov is interested into looking into this.