### PR TITLE
HHH-13711: drop constraints enabled for H2

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -435,10 +435,8 @@ public class H2Dialect extends Dialect {
 	}
 	
 	@Override
-	public boolean dropConstraints() {
-		// We don't need to drop constraints before dropping tables, that just leads to error
-		// messages about missing tables when we don't have a schema in the database
-		return false;
+	public boolean supportsIfExistsAfterAlterTable() {
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -260,11 +260,6 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsIfExistsAfterTableName() {
-		return true;
-	}
-
-	@Override
 	public boolean supportsIfExistsBeforeConstraintName() {
 		return true;
 	}
@@ -434,8 +429,25 @@ public class H2Dialect extends Dialect {
 		return false;
 	}
 	
+	// Do not drop constraints explicitly, just do this by cascading instead.
 	@Override
-	public boolean supportsIfExistsAfterAlterTable() {
+	public boolean dropConstraints() {
+		return false;
+	}
+
+	@Override
+	public String getCascadeConstraintsString() {
+		return " CASCADE ";
+	}
+
+	// CASCADE has to be AFTER IF EXISTS in case it's after the tablename
+	@Override
+	public boolean supportsIfExistsAfterTableName() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsIfExistsBeforeTableName() {
 		return true;
 	}
 


### PR DESCRIPTION
Since H2 1.4.200, drop constraints should be enabled (see details and demo [here](https://hibernate.atlassian.net/projects/HHH/issues/HHH-13711)).

When the demo is run with the submitted change, no error is produced anymore.
This change is also compatible with earlier H2 versions (the demo was successfully tested with 1.4.197, 1.4.198 and 1.4.199; the older versions, not listed [here](https://www.h2database.com/html/changelog.html), have not been tested).