### PR TITLE
HHH-13687 TenantSchemaResolver not called in integration test after u…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -380,10 +380,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			}
 
 			this.defaultSessionOpenOptions = withOptions();
-			this.temporarySessionOpenOptions = withOptions()
-					.autoClose( false )
-					.flushMode( FlushMode.MANUAL )
-					.connectionHandlingMode( PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_STATEMENT );
+			this.temporarySessionOpenOptions = buildTemporarySessionOpenOptions();
 			this.fastSessionServices = new FastSessionServices( this );
 
 			this.observer.sessionFactoryCreated( this );
@@ -404,6 +401,13 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 			close();
 			throw e;
 		}
+	}
+
+	private SessionBuilder buildTemporarySessionOpenOptions() {
+		return withOptions()
+				.autoClose( false )
+				.flushMode( FlushMode.MANUAL )
+				.connectionHandlingMode( PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_STATEMENT );
 	}
 
 	private void prepareEventListeners(MetadataImplementor metadata) {
@@ -481,11 +485,26 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 	}
 
 	public Session openSession() throws HibernateException {
-		return this.defaultSessionOpenOptions.openSession();
+		final CurrentTenantIdentifierResolver currentTenantIdentifierResolver = getCurrentTenantIdentifierResolver();
+		//We can only use reuse the defaultSessionOpenOptions as a constant when there is no TenantIdentifierResolver
+		if ( currentTenantIdentifierResolver != null ) {
+			return this.withOptions().openSession();
+		}
+		else {
+			return this.defaultSessionOpenOptions.openSession();
+		}
 	}
 
 	public Session openTemporarySession() throws HibernateException {
-		return this.temporarySessionOpenOptions.openSession();
+		final CurrentTenantIdentifierResolver currentTenantIdentifierResolver = getCurrentTenantIdentifierResolver();
+		//We can only use reuse the defaultSessionOpenOptions as a constant when there is no TenantIdentifierResolver
+		if ( currentTenantIdentifierResolver != null ) {
+			return buildTemporarySessionOpenOptions()
+					.openSession();
+		}
+		else {
+			return this.temporarySessionOpenOptions.openSession();
+		}
 	}
 
 	public Session getCurrentSession() throws HibernateException {
@@ -1423,8 +1442,9 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 		public StatelessSessionBuilderImpl(SessionFactoryImpl sessionFactory) {
 			this.sessionFactory = sessionFactory;
 
-			if ( sessionFactory.getCurrentTenantIdentifierResolver() != null ) {
-				tenantIdentifier = sessionFactory.getCurrentTenantIdentifierResolver().resolveCurrentTenantIdentifier();
+			CurrentTenantIdentifierResolver tenantIdentifierResolver = sessionFactory.getCurrentTenantIdentifierResolver();
+			if ( tenantIdentifierResolver != null ) {
+				tenantIdentifier = tenantIdentifierResolver.resolveCurrentTenantIdentifier();
 			}
 			queryParametersValidationEnabled = sessionFactory.getSessionFactoryOptions().isQueryParametersValidationEnabled();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/multitenancy/discriminator/DiscriminatorMultiTenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/multitenancy/discriminator/DiscriminatorMultiTenancyTest.java
@@ -193,9 +193,10 @@ public class DiscriminatorMultiTenancyTest extends BaseUnitTestCase {
 		}
 	}
 
-	public void doInHibernate(String tenant,
-			Consumer<Session> function) {
+	public void doInHibernate(String tenant, Consumer<Session> function) {
 		currentTenantResolver.currentTenantIdentifier = tenant;
-		TransactionUtil.doInHibernate( this::sessionFactory, tenant, function);
+		//Careful: do not use the #doInHibernate version of the method which takes a tenant: the goal of these tests is
+		// to verify that the CurrentTenantIdentifierResolver is being applied!
+		TransactionUtil.doInHibernate( this::sessionFactory, function);
 	}
 }


### PR DESCRIPTION
…pgrade from

This should fix :
 - https://hibernate.atlassian.net/browse/HHH-13687 TenantSchemaResolver not called in integration test after upgrade from
 - https://hibernate.atlassian.net/browse/HHH-13710 Wrong tenant-identifier in Envers temporary session
 - https://hibernate.atlassian.net/browse/HHH-13690 Multi-tenancy supporting session factories can not be created