### PR TITLE
HHH-13722 : add test case

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/ChildEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/ChildEntity.java
@@ -1,0 +1,18 @@
+package org.hibernate.test.mapping.joinformula;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class ChildEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "PARENT_ID")
+    private Long parentId;
+
+    @Column
+    private String name;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/JoinFormulaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/JoinFormulaTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hibernate.test.mapping.joinformula;
+
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * This template demonstrates how to develop a test case for Hibernate ORM, using its built-in unit test framework.
+ * Although ORMStandaloneTestCase is perfectly acceptable as a reproducer, usage of this class is much preferred.
+ * Since we nearly always include a regression test with bug fixes, providing your reproducer using this method
+ * simplifies the process.
+ * <p>
+ * What's even better?  Fork hibernate-orm itself, add your test case directly to a module's unit tests, then
+ * submit it as a PR!
+ */
+public class JoinFormulaTest
+        extends BaseCoreFunctionalTestCase {
+
+    // Add your entities here.
+    @Override
+    protected Class[] getAnnotatedClasses() {
+        return new Class[]{
+                ParentEntity.class,
+                ChildEntity.class
+        };
+    }
+
+    // If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
+    @Override
+    protected String[] getMappings() {
+        return new String[]{
+//				"Foo.hbm.xml",
+//				"Bar.hbm.xml"
+        };
+    }
+
+    // If those mappings reside somewhere other than resources/org/hibernate/test, change this.
+    @Override
+    protected String getBaseForMappings() {
+        return "org/hibernate/test/";
+    }
+
+    // Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
+    @Override
+    protected void configure(Configuration configuration) {
+        super.configure(configuration);
+
+        configuration.setProperty(AvailableSettings.SHOW_SQL, Boolean.TRUE.toString());
+        configuration.setProperty(AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString());
+        //configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
+    }
+
+    // Add your tests, using standard JUnit.
+    @Test
+    public void hhh13722Test() {
+        // BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
+        Session s = openSession();
+        Transaction tx = s.beginTransaction();
+        // Do stuff...
+        tx.commit();
+        s.close();
+    }
+}
+
+

--- a/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/ParentEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/mapping/joinformula/ParentEntity.java
@@ -1,0 +1,31 @@
+package org.hibernate.test.mapping.joinformula;
+
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinColumnsOrFormulas;
+import org.hibernate.annotations.JoinFormula;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+@Entity
+public class ParentEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(targetEntity = ChildEntity.class, optional = false)
+    @JoinColumnsOrFormulas({
+            @JoinColumnOrFormula(column = @JoinColumn(name = "ID", referencedColumnName = "PARENT_ID", insertable = false, updatable = false)),
+            @JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "NAME", value = "'Tom'"))
+    })
+    private ChildEntity tom;
+    @OneToOne(targetEntity = ChildEntity.class, optional = false)
+    @JoinColumnsOrFormulas({
+            @JoinColumnOrFormula(column = @JoinColumn(name = "ID", referencedColumnName = "PARENT_ID", insertable = false, updatable = false)),
+            @JoinColumnOrFormula(formula = @JoinFormula(referencedColumnName = "NAME", value = "'Ben'"))
+    })
+    private ChildEntity ben;
+
+}


### PR DESCRIPTION
Hi,
I added a test case for [HHH-13722 ArrayStoreException in Constraint.generateName](https://hibernate.atlassian.net/browse/HHH-13722).
The error occurs during hibernate initialization. So the test just breaks with the exception reported in JIRA.
I started the test with

    sh gradlew :hibernate-core:test --tests org.hibernate.test.mapping.joinformula* --stacktrace

Then the exception can be viewed in `hibernate-orm/hibernate-core/target/reports/tests/test/classes/org.hibernate.test.mapping.joinformula.JoinFormulaTest.html`

Hope this helps.

Regards
Andy