### PR TITLE
Bring AbstractProductQuery#getSingleResult in line with the spec for some databases

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1572,10 +1572,16 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 	public R getSingleResult() {
 		try {
 			final List<R> list = list();
-			if ( list.size() == 0 ) {
-				throw new NoResultException( "No entity found for query" );
+			switch ( list.size() ) {
+				case 0:
+					throw new NoResultException( "No entity found for query" );
+
+				case 1:
+					return list.get( 0 );
+
+				default:
+					throw new NonUniqueResultException( list.size() );
 			}
-			return uniqueElement( list );
 		}
 		catch ( HibernateException e ) {
 			throw getExceptionConverter().convert( e, getLockOptions() );


### PR DESCRIPTION
Due to the way the elements are compared, the method has come into alignment with the spec by accident, reporting a NonUniqueResultException as prescribed by the spec for cases where the query returns multiple rows.

One exception to this is HSQL.
Under certain circumstances, a HSQL query can return the same (==) object twice.