### PR TITLE
HHH-8901 Hibernate produces SQL - "in ()"

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -124,7 +124,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -124,7 +124,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -641,7 +641,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 					beforePlaceholder,
 					afterPlaceholder,
 					sourceToken,
-					expansionList.toString(),
+					expansionList.isEmpty() ? "null" : expansionList.toString(),
 					true,
 					true
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -641,7 +641,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 					beforePlaceholder,
 					afterPlaceholder,
 					sourceToken,
-					expansionList.isEmpty() ? "null" : expansionList.toString(),
+					expansionList.length() == 0 ? "null" : expansionList.toString(),
 					true,
 					true
 			);


### PR DESCRIPTION
This is a pretty common bug that bothered our developing team in our company. It manifests itself by throwing unexpected weird exception in both Mariadb and MySQL. Initially we suspected it is Spring Data JPA bug. However, finally we narrowed down the culprit is Hibernate and the bug is filed at https://hibernate.atlassian.net/browse/HHH-8091. From the comments you can see there would be an elegant solution in Hibernate 6 but it might take quite some time to fully upgrade to the future Hibernate 6 in our codebase. The fix is surprisingly simple, however.