### PR TITLE
HHH-8091, HHH-13748:  empty collection HQL parameter breaks dbs (5.3)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -637,6 +637,11 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 				parameterBindingMap.put( syntheticParam, syntheticBinding );
 			}
 
+			// HHH-8091
+			// "in ()" breaks some dbs; "in (null)" will always work
+			if (expansionList.length() == 0) {
+				expansionList.append("null"); 
+			}	
 			queryString = StringHelper.replace(
 					beforePlaceholder,
 					afterPlaceholder,


### PR DESCRIPTION
This is a common bug that troubled many developers. "in ()" will break in both Mariadb and MySQL. Initially we suspected it is Spring Data JPA issue. Later on we found the filed bug at https://hibernate.atlassian.net/browse/HHH-8091.

As per the comments, Hibernate 6 would fix the bug elegantly, but it might take a long time before our codebase can enjoy the new version. However, the fix is pretty simple and easy.

Recently we found another duplicated ticket at https://hibernate.atlassian.net/browse/HHH-13748. Seems a pretty common complaint.