### PR TITLE
HHH-8901, HHH-13748: generated SQL("in ()") breaks most dbs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/InExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/InExpression.java
@@ -46,12 +46,16 @@ public class InExpression implements Criterion {
 			if ( columns.length > 1 ) {
 				singleValueParam = '(' + singleValueParam + ')';
 			}
-			final String params = values.length > 0
+			String params = values.length > 0
 					? StringHelper.repeat( singleValueParam + ", ", values.length - 1 ) + singleValueParam
 					: "";
 			String cols = String.join( ", ", columns );
 			if ( columns.length > 1 ) {
 				cols = '(' + cols + ')';
+			}
+			// HHH-8901
+			if ( ! criteriaQuery.getFactory().getDialect().supportsEmptyInList() && params.isEmpty() ) {
+				params = "null";
 			}
 			return cols + " in (" + params + ')';
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/InPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/InPredicate.java
@@ -194,6 +194,10 @@ public class InPredicate<T>
 						.append( ( (Renderable) value ).render( renderingContext ) );
 				sep = ", ";
 			}
+			// HHH-8901
+			if ( ! renderingContext.getDialect().supportsEmptyInList() && getValues().isEmpty() ) {
+				buffer.append( "null" );
+			}
 			buffer.append( ')' );
 		}
 		return buffer.toString();

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -637,6 +637,11 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 				parameterBindingMap.put( syntheticParam, syntheticBinding );
 			}
 
+			// HHH-8901
+			if ( ! dialect.supportsEmptyInList() && expansionList.length() == 0 ) {
+				expansionList.append( "null" );
+			}
+
 			queryString = StringHelper.replace(
 					beforePlaceholder,
 					afterPlaceholder,

--- a/hibernate-core/src/test/java/org/hibernate/test/criteria/InTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/criteria/InTest.java
@@ -8,11 +8,15 @@ package org.hibernate.test.criteria;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
@@ -39,6 +43,26 @@ public class InTest extends BaseCoreFunctionalTestCase {
 		List persons = session.createCriteria( Person.class ).add(
 				Restrictions.in( "class", Woman.class ) ).list();
 		assertEquals( 1, persons.size() );
+		tx.rollback();
+		session.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-8901" )
+	@RequiresDialectFeature(DialectChecks.NotSupportsEmptyInListCheck.class)
+	public void testEmptyInListForDialectNotSupportsEmptyInList() {
+		Session session = openSession();
+		Transaction tx = session.beginTransaction();
+		session.save( new Woman() );
+		session.save( new Man() );
+		session.flush();
+		tx.commit();
+		session.close();
+		session = openSession();
+		tx = session.beginTransaction();
+		List persons = session.createCriteria( Person.class ).add(
+				Restrictions.in( "name", Collections.emptySet() ) ).list();
+		assertEquals( 0, persons.size() );
 		tx.rollback();
 		session.close();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -6,6 +6,18 @@
  */
 package org.hibernate.test.hql;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
@@ -13,11 +25,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
@@ -53,19 +65,6 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.loader.MultipleBagFetchException;
 import org.hibernate.persister.entity.DiscriminatorType;
 import org.hibernate.stat.QueryStatistics;
-import org.hibernate.transform.DistinctRootEntityResultTransformer;
-import org.hibernate.transform.Transformers;
-import org.hibernate.type.ComponentType;
-import org.hibernate.type.ManyToOneType;
-import org.hibernate.type.Type;
-
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.FailureExpected;
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.test.any.IntegerPropertyValue;
 import org.hibernate.test.any.PropertySet;
 import org.hibernate.test.any.PropertyValue;
@@ -75,23 +74,19 @@ import org.hibernate.test.cid.LineItem;
 import org.hibernate.test.cid.LineItem.Id;
 import org.hibernate.test.cid.Order;
 import org.hibernate.test.cid.Product;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.transform.DistinctRootEntityResultTransformer;
+import org.hibernate.transform.Transformers;
+import org.hibernate.type.ComponentType;
+import org.hibernate.type.ManyToOneType;
+import org.hibernate.type.Type;
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.hibernate.testing.transaction.TransactionUtil2.inTransaction;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests the integration of the new AST parser into the loading of query results using
@@ -664,6 +659,35 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HHH-8901" )
+	@RequiresDialectFeature(DialectChecks.NotSupportsEmptyInListCheck.class)
+	public void testEmptyInListForDialectsNotSupportsEmptyInList() {
+		Session session = openSession();
+		session.beginTransaction();
+		Human human = new Human();
+		human.setName( new Name( "Lukasz", null, "Antoniak" ) );
+		human.setNickName( "NONE" );
+		session.save( human );
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+		session.beginTransaction();
+		List results = session.createQuery( "from Human h where h.nickName in (:nickNames)" )
+				.setParameter("nickNames", Collections.emptySet() )
+				.list();
+		assertEquals( 0, results.size() );
+		session.getTransaction().commit();
+		session.close();
+
+		session = openSession();
+		session.beginTransaction();
+		session.delete( human );
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@Test
 	@TestForIssue( jiraKey = "HHH-2851")
 	public void testMultipleRefsToSameParam() {
 		Session s = openSession();
@@ -982,7 +1006,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		else {
 			s.createQuery( "from Animal where lower(upper('foo') || upper(:bar)) like 'f%'" ).setString( "bar", "xyz" ).list();
 		}
-		
+
 		if ( getDialect() instanceof AbstractHANADialect ) {
 			s.createQuery( "from Animal where abs(cast(1 as double) - cast(:param as double)) = 1.0" )
 					.setLong( "param", 1 ).list();

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -55,6 +55,12 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class NotSupportsEmptyInListCheck implements DialectCheck {
+		public boolean isMatch(Dialect dialect) {
+			return !dialect.supportsEmptyInList();
+		}
+	}
+
 	public static class CaseSensitiveCheck implements DialectCheck {
 		public boolean isMatch(Dialect dialect) {
 			return dialect.areStringComparisonsCaseInsensitive();


### PR DESCRIPTION
This is a common bug that troubled many developers. "in ()" will break in most of dbs. Initially we suspected it is Spring Data JPA issue. Later on we found the filed bug at https://hibernate.atlassian.net/browse/HHH-8091.

As per the comments, Hibernate 6 would fix the bug elegantly, but it might take a long time before our codebase can enjoy the new version. However, the fix is pretty simple and easy.

Recently we found another duplicated ticket at https://hibernate.atlassian.net/browse/HHH-13748. Seems a pretty common complaint.