### PR TITLE
HHH-13758 - Limit Handler for SQL server doesn't work with CTE queries with strings literals

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -585,7 +585,7 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 		int index = offset;
 		boolean inString = false;
 		for ( ; index < sql.length(); ++index ) {
-			if ( sql.charAt( index ) == '\'' ) {
+			if ( sql.charAt( index ) == '\'' && !inString ) {
 				inString = true;
 			}
 			else if ( sql.charAt( index ) == '\'' && inString ) {


### PR DESCRIPTION
Fixes [HHH-13758](https://hibernate.atlassian.net/browse/HHH-13758)