### PR TITLE
HHH-13759 InlineDirtyChecking causes exception when embedded field is private in a superclass

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -27,6 +27,8 @@ ext {
 
     agroalVersion = '1.7'
 
+    assertjVersion = '3.14.0'
+
     geolatteVersion = '1.4.0'
 
     // Wildfly version targeted by module ZIP; Arquillian/Shrinkwrap versions used for CDI testing and testing the module ZIP
@@ -146,6 +148,8 @@ ext {
 
             cdi: "javax.enterprise:cdi-api:${cdiVersion}",
             weld: "org.jboss.weld.se:weld-se-shaded:${weldVersion}",
+
+            assertj: "org.assertj:assertj-core:${assertjVersion}",
 
             // Arquillian/Shrinkwrap
             arquillian_junit_container: "org.jboss.arquillian.junit:arquillian-junit-container:${arquillianVersion}",

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -64,6 +64,7 @@ dependencies {
     testCompile( libraries.mockito )
     testCompile( libraries.mockito_inline )
     testCompile( libraries.jodaTime )
+    testCompile( libraries.assertj )
 
     testCompile( libraries.cdi ) {
         // we need to force it to make sure we influence the one coming from arquillian

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/InlineDirtyCheckingHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/InlineDirtyCheckingHandler.java
@@ -62,7 +62,10 @@ final class InlineDirtyCheckingHandler implements Implementation, ByteCodeAppend
 			}
 
 			if ( enhancementContext.isCompositeClass( persistentField.getType().asErasure() )
-					&& persistentField.hasAnnotation( Embedded.class ) ) {
+					&& persistentField.hasAnnotation( Embedded.class )
+					// If the field is a private field in a hierarchy, we might not be able to access it from
+					// the managedtClass
+					&& persistentField.asDefined().isAccessibleTo( managedCtClass )) {
 
 				implementation = Advice.withCustomMapping()
 						.bind( CodeTemplates.FieldValue.class, persistentField.getFieldDescription() )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndMappedSuperclassTest.java
@@ -1,0 +1,220 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.lang.reflect.Method;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_INSTANCE_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_CLEAR_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_CLEAR_OWNER;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_SET_OWNER;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
+
+@TestForIssue(jiraKey = "HHH-13759")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableAndMappedSuperclassTest {
+
+	@Test
+	public void shouldDeclareFieldsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredFields( ENTITY_ENTRY_FIELD_NAME, PREVIOUS_FIELD_NAME, NEXT_FIELD_NAME, TRACKER_FIELD_NAME );
+	}
+
+	@Test
+	public void shouldDeclareMethodsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "id", PERSISTENT_FIELD_WRITER_PREFIX + "id" )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "name", PERSISTENT_FIELD_WRITER_PREFIX + "name" )
+				.hasDeclaredMethods( ENTITY_INSTANCE_GETTER_NAME, ENTITY_ENTRY_GETTER_NAME )
+				.hasDeclaredMethods( PREVIOUS_GETTER_NAME, PREVIOUS_SETTER_NAME, NEXT_GETTER_NAME, NEXT_SETTER_NAME )
+				.hasDeclaredMethods( TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
+	}
+
+	@Test
+	public void shouldDeclareFieldsInEmbeddedClass() {
+		assertThat( Component.class )
+				.hasDeclaredFields( TRACKER_COMPOSITE_FIELD_NAME );
+	}
+
+	@Test
+	public void shouldDeclareMethodsInEmbeddedClass() {
+		assertThat(Component.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "component", PERSISTENT_FIELD_WRITER_PREFIX + "component" )
+				.hasDeclaredMethods( TRACKER_COMPOSITE_SET_OWNER, TRACKER_COMPOSITE_CLEAR_OWNER );
+	}
+
+	@Test
+	public void shouldCreateTheTracker() throws Exception {
+		CardGame entity = new CardGame( "MTG", "Magic the Gathering" );
+		assertThat( entity )
+				.extracting( NEXT_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( PREVIOUS_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( ENTITY_ENTRY_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( TRACKER_FIELD_NAME ).isInstanceOf( SimpleFieldTracker.class );
+		assertThat( entity.getFirstPlayerToken() )
+				.as( "Maybe you've fixed an issue: if the field is an instance of the tracker, see HHH-13764")
+				.extracting( TRACKER_COMPOSITE_FIELD_NAME ).isNull();
+		// When HHH-13764 is solved. The assertion should be:
+		//		.extracting( TRACKER_COMPOSITE_FIELD_NAME ).isInstanceOf( CompositeOwnerTracker.class);
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "name", "firstPlayerToken" } );
+		assertThat( entity.getFirstPlayerToken() )
+				.as( "Maybe you've fixed an issue: if the content is { \"firstPlayerToken\" }," +
+							 "please, update this test accordingly. See HHH-13764")
+		//When HHH-13764 is solved. The assertion should be:
+		//		.extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" ).isEqualTo( new String[] { "firstPlayerToken" } );
+				.extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" ).isNull();
+	}
+
+	@Test
+	public void shouldResetTheTracker() throws Exception {
+		CardGame entity = new CardGame( "7WD", "7 Wonders duel" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( false );
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[0] );
+	}
+
+	@Test
+	public void shouldUpdateTheTracker() throws Exception {
+		CardGame entity = new CardGame( "SPL", "Splendor" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		entity.setName( "Splendor: Cities of Splendor" );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "name", "firstPlayerToken" } );
+
+		trackerClearMethod.invoke( entity );
+
+		entity.setFirstPlayerToken( new Component( "FIRST PLAYER!!!!!!!!" ) );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "firstPlayerToken" } );
+		assertThat( entity.getFirstPlayerToken() )
+				.as( "Maybe you've fixed an issue: if the content is { \"firstPlayerToken\" }," +
+							 "please, update this test accordingly. See HHH-13764")
+		//When HHH-13764 is solved. The assertion should be:
+		//		.extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" ).isEqualTo( new String[] { "firstPlayerToken" } );
+				.extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" ).isNull();
+	}
+
+	@MappedSuperclass
+	public static abstract class TableTopGame {
+
+		@Embedded
+		private Component firstPlayerToken;
+
+		public Component getFirstPlayerToken() {
+			return firstPlayerToken;
+		}
+
+		public void setFirstPlayerToken(Component firstPlayerToken) {
+			this.firstPlayerToken = firstPlayerToken;
+		}
+	}
+
+	@Embeddable
+	public static class Component {
+
+		@Column(name = "first_player_token")
+		private String component;
+
+		public Component() {
+		}
+
+		private Component(String component) {
+			this.component = component;
+		}
+
+		public String getComponent() {
+			return component;
+		}
+
+		public void setComponent(String component) {
+			this.component = component;
+		}
+	}
+
+	@Entity(name = "CardGame")
+	public static class CardGame extends TableTopGame {
+
+		@Id
+		private String id;
+		private String name;
+
+		public CardGame() {
+		}
+
+		private CardGame(String id, String name) {
+			this.id = id;
+			this.name = name;
+			setFirstPlayerToken( createEmbeddedValue( name ) );
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+			setFirstPlayerToken( createEmbeddedValue( name ) );
+		}
+
+		private Component createEmbeddedValue(String name) {
+			return new Component( name + " first player token");
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableTest.java
@@ -1,0 +1,208 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.lang.reflect.Method;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_INSTANCE_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_CLEAR_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_CLEAR_OWNER;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_COMPOSITE_SET_OWNER;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
+
+@TestForIssue(jiraKey = "HHH-13759")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableTest {
+
+	@Test
+	public void shouldDeclareFieldsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredFields( ENTITY_ENTRY_FIELD_NAME, PREVIOUS_FIELD_NAME, NEXT_FIELD_NAME, TRACKER_FIELD_NAME );
+	}
+
+	@Test
+	public void shouldDeclareMethodsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "id", PERSISTENT_FIELD_WRITER_PREFIX + "id" )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "name", PERSISTENT_FIELD_WRITER_PREFIX + "name" )
+				.hasDeclaredMethods( ENTITY_INSTANCE_GETTER_NAME, ENTITY_ENTRY_GETTER_NAME )
+				.hasDeclaredMethods( PREVIOUS_GETTER_NAME, PREVIOUS_SETTER_NAME, NEXT_GETTER_NAME, NEXT_SETTER_NAME )
+				.hasDeclaredMethods( TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
+	}
+
+	@Test
+	public void shouldDeclareFieldsInEmbeddedClass() {
+		assertThat( Component.class )
+				.hasDeclaredFields( TRACKER_COMPOSITE_FIELD_NAME );
+	}
+
+	@Test
+	public void shouldDeclareMethodsInEmbeddedClass() {
+		assertThat( Component.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "component", PERSISTENT_FIELD_WRITER_PREFIX + "component" )
+				.hasDeclaredMethods( TRACKER_COMPOSITE_SET_OWNER, TRACKER_COMPOSITE_CLEAR_OWNER );
+	}
+
+	@Test
+	public void shouldCreateTheTracker() throws Exception {
+		CardGame entity = new CardGame( "MTG", "Magic the Gathering" );
+		assertThat( entity )
+				.extracting( NEXT_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( PREVIOUS_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( ENTITY_ENTRY_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( TRACKER_FIELD_NAME ).isInstanceOf( SimpleFieldTracker.class );
+		assertThat( entity.getFirstPlayerToken() )
+				.extracting( TRACKER_COMPOSITE_FIELD_NAME ).isInstanceOf( CompositeOwnerTracker.class );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "name", "firstPlayerToken" } );
+		assertThat( entity.getFirstPlayerToken() ).extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" )
+				.isEqualTo( new String[] { "firstPlayerToken" } );
+	}
+
+	@Test
+	public void shouldResetTheTracker() throws Exception {
+		CardGame entity = new CardGame( "7WD", "7 WOnders duel" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( false );
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[0] );
+	}
+
+	@Test
+	public void shouldUpdateTheTracker() throws Exception {
+		Assertions.setAllowExtractingPrivateFields( true );
+		CardGame entity = new CardGame( "SPL", "Splendor" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		entity.setName( "Splendor: Cities of Splendor" );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "name", "firstPlayerToken" } );
+
+		trackerClearMethod.invoke( entity );
+
+		entity.setFirstPlayerToken( new Component( "FIRST PLAYER!!!!!!!!" ) );
+		assertThat( entity ).extracting( TRACKER_GET_NAME )
+				.isEqualTo( new String[] { "firstPlayerToken" } );
+
+		assertThat( entity.getFirstPlayerToken() ).extracting( TRACKER_COMPOSITE_FIELD_NAME + ".names" )
+				.isEqualTo( new String[] { "firstPlayerToken" } );
+	}
+
+	@Embeddable
+	public static class Component {
+		@Column(name = "first_player_token")
+		private String component;
+
+		public Component() {
+		}
+
+		private Component(String component) {
+			this.component = component;
+		}
+
+		public String getComponent() {
+			return component;
+		}
+
+		public void setComponent(String component) {
+			this.component = component;
+		}
+	}
+
+	@Entity(name = "CardGame")
+	public static class CardGame {
+
+		@Id
+		private String id;
+		private String name;
+
+		@Embedded
+		private Component firstPlayerToken;
+
+		public CardGame() {
+		}
+
+		private CardGame(String id, String name) {
+			this.id = id;
+			this.name = name;
+			this.firstPlayerToken = createEmbeddedValue( name );
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+			this.firstPlayerToken = createEmbeddedValue( name );
+		}
+
+		public Component getFirstPlayerToken() {
+			return firstPlayerToken;
+		}
+
+		public void setFirstPlayerToken(Component firstPlayerToken) {
+			this.firstPlayerToken = firstPlayerToken;
+		}
+
+		private Component createEmbeddedValue(String name) {
+			return new Component( name + " first player token" );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithMappedSuperClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithMappedSuperClassTest.java
@@ -1,0 +1,162 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.lang.reflect.Method;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_INSTANCE_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_CLEAR_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_FIELD_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
+
+@TestForIssue(jiraKey = "HHH-13759")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithMappedSuperClassTest {
+
+	@Test
+	public void shouldDeclareFieldsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredFields( ENTITY_ENTRY_FIELD_NAME, PREVIOUS_FIELD_NAME, NEXT_FIELD_NAME, TRACKER_FIELD_NAME );
+	}
+
+	@Test
+	public void shouldDeclareMethodsInEntityClass() {
+		assertThat( CardGame.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "id", PERSISTENT_FIELD_WRITER_PREFIX + "id" )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "name", PERSISTENT_FIELD_WRITER_PREFIX + "name" )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "code", PERSISTENT_FIELD_WRITER_PREFIX + "code" )
+				.hasDeclaredMethods( ENTITY_INSTANCE_GETTER_NAME, ENTITY_ENTRY_GETTER_NAME )
+				.hasDeclaredMethods( PREVIOUS_GETTER_NAME, PREVIOUS_SETTER_NAME, NEXT_GETTER_NAME, NEXT_SETTER_NAME )
+				.hasDeclaredMethods( TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
+	}
+
+	@Test
+	public void shouldCreateTheTracker() throws Exception {
+		CardGame entity = new CardGame( "MTG", "Magic the Gathering" );
+		assertThat( entity )
+				.extracting( NEXT_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( PREVIOUS_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( ENTITY_ENTRY_FIELD_NAME ).isNull();
+		assertThat( entity )
+				.extracting( TRACKER_FIELD_NAME ).isInstanceOf( SimpleFieldTracker.class );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[] { "name", "code" } );
+	}
+
+	@Test
+	public void shouldResetTheTracker() throws Exception {
+		CardGame entity = new CardGame( "7WD", "7 Wonders duel" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( false );
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[0] );
+	}
+
+	@Test
+	public void shouldUpdateTheTracker() throws Exception {
+		CardGame entity = new CardGame( "SPL", "Splendor" );
+		assertThat( entity.getCode() ).isEqualTo( "XsplX" );
+
+		Method trackerClearMethod = CardGame.class.getMethod( TRACKER_CLEAR_NAME );
+		trackerClearMethod.invoke( entity );
+
+		entity.setName( "Splendor: Cities of Splendor" );
+
+		assertThat( entity.getCode() )
+				.as( "Field 'code' should have not change" ).isEqualTo( "XsplX" );
+		assertThat( entity ).extracting( TRACKER_HAS_CHANGED_NAME ).isEqualTo( true );
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[] { "name" } );
+
+		entity.setName( "Cities of Splendor" );
+
+		assertThat( entity ).extracting( TRACKER_GET_NAME ).isEqualTo( new String[] { "name", "code" } );
+	}
+
+	@MappedSuperclass
+	public static abstract class TableTopGame {
+
+		private String code;
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+	}
+
+	@Entity(name = "CardGame")
+	public static class CardGame extends TableTopGame {
+		@Id
+		private String id;
+
+		private String name;
+
+		public CardGame() {
+		}
+
+		private CardGame(String id, String name) {
+			this.id = id;
+			this.name = name;
+			setCode( createCode( name ) );
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+			setCode( createCode( name ) );
+		}
+
+		private String createCode(String name) {
+			return "X" + name.substring( 0, 3 ).toLowerCase() + "X";
+		}
+
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13759
Original issue: https://github.com/quarkusio/quarkus/issues/5756

This patch will make sure that there is no expcetion and it will behave the same way as when we put the `@Embedded` annotation on the getter/setter.

This lead me to create another issue for that scenario: https://hibernate.atlassian.net/browse/HHH-13764

Maybe somebody with more experince with ByteBuddy can suggest a solution. I think we should intercept the call to the setter but I haven't figure out how to do that yet.