### PR TITLE
Wip/6.0 -  Avoid extra join for ToOne with JoinTable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -419,7 +419,9 @@ public class LoaderSelectBuilder {
 		referencedMappingContainer.visitFetchables( processor, null );
 
 		return fetches;
-	}	private SelectStatement generateSelect(SubselectFetch subselect) {
+	}
+
+	private SelectStatement generateSelect(SubselectFetch subselect) {
 		// todo (6.0) : i think we may even be able to convert this to a join by piecing together
 		//		parts from the subselect-fetch sql-ast..
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelHelper.java
@@ -21,7 +21,7 @@ import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnRefere
  * @author Steve Ebersole
  */
 public class MappingModelHelper {
-	public static Expression buildColumnReferenceExpression(
+	public static Expression buildColumnReferenceExpressionForMutationStatement(
 			ModelPart modelPart,
 			SqlExpressionResolver sqlExpressionResolver,
 			SessionFactoryImplementor sessionFactory) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
@@ -119,7 +119,7 @@ public class BasicValuedCollectionPart implements CollectionPart, BasicValuedMod
 				exprResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( tableGroup.getPrimaryTableReference(), columnExpression ),
 						sqlAstProcessingState -> new ColumnReference(
-								tableGroup.getPrimaryTableReference().getIdentificationVariable(),
+								tableGroup.getPrimaryTableReference(),
 								columnExpression,
 								mapper,
 								creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedSingularAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedSingularAttributeMapping.java
@@ -122,7 +122,7 @@ public class BasicValuedSingularAttributeMapping extends AbstractSingularAttribu
 								getMappedColumnExpression()
 						),
 						sqlAstProcessingState -> new ColumnReference(
-								tableReference.getIdentificationVariable(),
+								tableReference,
 								getMappedColumnExpression(),
 								jdbcMapping,
 								creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()
@@ -150,7 +150,7 @@ public class BasicValuedSingularAttributeMapping extends AbstractSingularAttribu
 								getMappedColumnExpression()
 						),
 						sqlAstProcessingState -> new ColumnReference(
-								tableReference.getIdentificationVariable(),
+								tableReference,
 								getMappedColumnExpression(),
 								jdbcMapping,
 								creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CollectionIdentifierDescriptorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CollectionIdentifierDescriptorImpl.java
@@ -126,7 +126,7 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 								columnName
 						),
 						p -> new ColumnReference(
-								tableGroup.getPrimaryTableReference().getIdentificationVariable(),
+								tableGroup.getPrimaryTableReference(),
 								columnName,
 								type,
 								sessionFactory
@@ -164,7 +164,7 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 								columnName
 						),
 						p -> new ColumnReference(
-								tableGroup.getPrimaryTableReference().getIdentificationVariable(),
+								tableGroup.getPrimaryTableReference(),
 								columnName,
 								type,
 								sessionFactory

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
@@ -198,7 +198,7 @@ public class EmbeddedAttributeMapping
 										attrColumnExpr
 								),
 								sqlAstProcessingState -> new ColumnReference(
-										tableReference.getIdentificationVariable(),
+										tableReference,
 										attrColumnExpr,
 										jdbcMapping,
 										sqlAstCreationState.getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedIdentifierMappingImpl.java
@@ -172,7 +172,7 @@ public class EmbeddedIdentifierMappingImpl
 										attrColumnExpr
 								),
 								sqlAstProcessingState -> new ColumnReference(
-										tableReference.getIdentificationVariable(),
+										tableReference,
 										attrColumnExpr,
 										jdbcMapping,
 										sqlAstCreationState.getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityDiscriminatorMappingImpl.java
@@ -42,7 +42,7 @@ public class EntityDiscriminatorMappingImpl extends AbstractEntityDiscriminatorM
 								getMappedColumnExpression()
 						),
 						sqlAstProcessingState -> new ColumnReference(
-								tableReference.getIdentificationVariable(),
+								tableReference,
 								getMappedColumnExpression(),
 								getJdbcMapping(),
 								creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
@@ -180,7 +180,7 @@ public class MappingModelCreationHelper {
 				final Expression expression = expressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( rootTableReference, pkColumnName ),
 						sqlAstProcessingState -> new ColumnReference(
-								rootTableReference.getIdentificationVariable(),
+								rootTableReference,
 								pkColumnName,
 								( (BasicValuedMapping) entityPersister.getIdentifierType() ).getJdbcMapping(),
 								creationProcess.getCreationContext().getSessionFactory()
@@ -213,7 +213,7 @@ public class MappingModelCreationHelper {
 				final Expression expression = expressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( rootTableReference, pkColumnName ),
 						sqlAstProcessingState -> new ColumnReference(
-								rootTable,
+								rootTableReference,
 								pkColumnName,
 								( (BasicValuedModelPart) entityPersister.getIdentifierType() ).getJdbcMapping(),
 								creationProcess.getCreationContext().getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -319,17 +319,20 @@ public class PluralAttributeMappingImpl extends AbstractAttributeMapping impleme
 		);
 
 		final TableGroup tableGroup = tableGroupBuilder.build();
+		final Predicate predicate = getKeyDescriptor().generateJoinPredicate(
+				lhs,
+				tableGroup,
+				joinType,
+				sqlExpressionResolver,
+				creationContext
+		);
+		predicate.forceTableReferenceJoinRendering();
+
 		final TableGroupJoin tableGroupJoin = new TableGroupJoin(
 				navigablePath,
 				joinType,
 				tableGroup,
-				getKeyDescriptor().generateJoinPredicate(
-						lhs,
-						tableGroup,
-						joinType,
-						sqlExpressionResolver,
-						creationContext
-				)
+				predicate
 		);
 
 		lhs.addTableGroupJoin( tableGroupJoin );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
@@ -77,7 +77,6 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 		final TableReference tableReference = tableGroup.resolveTableReference( keyColumnContainingTable );
-		final String identificationVariable = tableReference.getIdentificationVariable();
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
 				sqlExpressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey(
@@ -86,7 +85,7 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 						),
 						s -> {
 							return new ColumnReference(
-									identificationVariable,
+									tableReference,
 									keyColumnExpression,
 									jdbcMapping,
 									creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()
@@ -179,7 +178,7 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 							targetColumnExpression
 					),
 					s -> new ColumnReference(
-							targetTableKeyReference.getIdentificationVariable(),
+							targetTableKeyReference,
 							targetColumnExpression,
 							jdbcMapping,
 							creationContext.getSessionFactory()
@@ -198,7 +197,7 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 							targetColumnExpression
 					),
 					s -> new ColumnReference(
-							targetTableKeyReference.getIdentificationVariable(),
+							targetTableKeyReference,
 							targetColumnExpression,
 							jdbcMapping,
 							creationContext.getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingularAssociationAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingularAssociationAttributeMapping.java
@@ -242,6 +242,7 @@ public class SingularAssociationAttributeMapping extends AbstractSingularAttribu
 				sqlExpressionResolver,
 				creationContext
 		);
+		predicate.forceTableReferenceJoinRendering();
 		tableGroupJoin.applyPredicate( predicate );
 
 		return tableGroupJoin;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1352,7 +1352,7 @@ public abstract class AbstractEntityPersister
 										rootPkColumnName
 								),
 								sqlAstProcessingState -> new ColumnReference(
-										rootTableReference.getIdentificationVariable(),
+										rootTableReference,
 										rootPkColumnName,
 										jdbcMapping,
 										getFactory()
@@ -1366,7 +1366,7 @@ public abstract class AbstractEntityPersister
 										fkColumnName
 								),
 								sqlAstProcessingState -> new ColumnReference(
-										joinedTableReference.getIdentificationVariable(),
+										joinedTableReference,
 										fkColumnName,
 										jdbcMapping,
 										getFactory()

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -1329,7 +1329,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		final List<JdbcMapping> jdbcMappings = getIdentifierMapping().getJdbcMappings( getFactory().getTypeConfiguration() );
 
 		return new ColumnReference(
-				tableReference.getIdentificationVariable(),
+				tableReference,
 				getIdentifierColumnNames()[0],
 				jdbcMappings.get( 0 ),
 				getFactory()

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -919,7 +919,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 				sqlExpressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( tableGroup.getPrimaryTableReference(), getDiscriminatorColumnName() ),
 						sqlAstProcessingState -> new ColumnReference(
-								tableGroup.getPrimaryTableReference().getIdentificationVariable(),
+								tableGroup.getPrimaryTableReference(),
 								getDiscriminatorColumnName(),
 								( (BasicType) getDiscriminatorType() ).getJdbcMapping(),
 								getFactory()

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
@@ -117,7 +117,7 @@ public class SimpleDeleteQueryPlan implements NonSelectQueryPlan {
 					}
 
 					final ForeignKeyDescriptor fkDescriptor = attributeMapping.getKeyDescriptor();
-					final Expression fkColumnExpression = MappingModelHelper.buildColumnReferenceExpression(
+					final Expression fkColumnExpression = MappingModelHelper.buildColumnReferenceExpressionForMutationStatement(
 							fkDescriptor,
 							null,
 							factory
@@ -125,7 +125,7 @@ public class SimpleDeleteQueryPlan implements NonSelectQueryPlan {
 
 					final QuerySpec matchingIdSubQuery = new QuerySpec( false );
 
-					final Expression fkTargetColumnExpression = MappingModelHelper.buildColumnReferenceExpression(
+					final Expression fkTargetColumnExpression = MappingModelHelper.buildColumnReferenceExpressionForMutationStatement(
 							fkDescriptor,
 							sqmInterpretation.getSqlExpressionResolver(),
 							factory

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/RestrictedDeleteExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/RestrictedDeleteExecutionDelegate.java
@@ -401,7 +401,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 					final ForeignKeyDescriptor fkDescriptor = attributeMapping.getKeyDescriptor();
 
 					return new InSubQueryPredicate(
-							MappingModelHelper.buildColumnReferenceExpression(
+							MappingModelHelper.buildColumnReferenceExpressionForMutationStatement(
 									fkDescriptor,
 									null,
 									sessionFactory

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/BasicValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/BasicValuedPathInterpretation.java
@@ -55,7 +55,7 @@ public class BasicValuedPathInterpretation<T> implements AssignableSqmPathInterp
 						mapping.getMappedColumnExpression()
 				),
 				sacs -> new ColumnReference(
-						tableReference.getIdentificationVariable(),
+						tableReference,
 						mapping.getMappedColumnExpression(),
 						mapping.getJdbcMapping(),
 						sqlAstCreationState.getCreationContext().getSessionFactory()
@@ -112,6 +112,11 @@ public class BasicValuedPathInterpretation<T> implements AssignableSqmPathInterp
 	@Override
 	public ModelPart getExpressionType() {
 		return mapping;
+	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+		columnReference.forceTableReferenceJoinRendering();
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedPathInterpretation.java
@@ -88,6 +88,11 @@ public class EmbeddableValuedPathInterpretation<T> implements AssignableSqmPathI
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		sqlExpression.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlExpression.accept( sqlTreeWalker );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
@@ -36,9 +36,9 @@ public class EntityValuedPathInterpretation<T> implements SqmPathInterpretation<
 				mapping);
 	}
 
-	private EntityValuedModelPart mapping = null;
-	private TableGroup tableGroup = null;
-	private SqmEntityValuedSimplePath sqmPath = null;
+	private EntityValuedModelPart mapping;
+	private TableGroup tableGroup;
+	private SqmEntityValuedSimplePath sqmPath;
 
 	private EntityValuedPathInterpretation(
 			SqmEntityValuedSimplePath sqmPath,
@@ -69,6 +69,11 @@ public class EntityValuedPathInterpretation<T> implements SqmPathInterpretation<
 	@Override
 	public ModelPart getExpressionType() {
 		return null;
+	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
@@ -65,6 +65,11 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
+
+	@Override
 	public DomainResult createDomainResult(
 			String resultVariable,
 			DomainResultCreationState creationState) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
@@ -348,15 +348,17 @@ public abstract class AbstractSqlAstWalker
 		}
 
 		for ( TableReferenceJoin tableJoin : joins ) {
-			sqlAppender.appendSql( EMPTY_STRING );
-			sqlAppender.appendSql( tableJoin.getJoinType().getText() );
-			sqlAppender.appendSql( " join " );
+			if ( tableJoin.getJoinedTableReference().isForceRendering() ) {
+				sqlAppender.appendSql( EMPTY_STRING );
+				sqlAppender.appendSql( tableJoin.getJoinType().getText() );
+				sqlAppender.appendSql( " join " );
 
-			renderTableReference( tableJoin.getJoinedTableReference() );
+				renderTableReference( tableJoin.getJoinedTableReference() );
 
-			if ( tableJoin.getJoinPredicate() != null && !tableJoin.getJoinPredicate().isEmpty() ) {
-				sqlAppender.appendSql( " on " );
-				tableJoin.getJoinPredicate().accept( this );
+				if ( tableJoin.getJoinPredicate() != null && !tableJoin.getJoinPredicate().isEmpty() ) {
+					sqlAppender.appendSql( " on " );
+					tableJoin.getJoinPredicate().accept( this );
+				}
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/BinaryArithmeticExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/BinaryArithmeticExpression.java
@@ -39,6 +39,12 @@ public class BinaryArithmeticExpression implements Expression, DomainResultProdu
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		lhsOperand.forceTableReferenceJoinRendering();
+		rhsOperand.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker walker) {
 		walker.visitBinaryArithmeticExpression( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSearchedExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSearchedExpression.java
@@ -92,6 +92,14 @@ public class CaseSearchedExpression implements Expression, DomainResultProducer 
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		whenFragments.forEach( whenFragment -> whenFragment.getPredicate().forceTableReferenceJoinRendering() );
+		if ( otherwise != null ) {
+			otherwise.forceTableReferenceJoinRendering();
+		}
+	}
+
+	@Override
 	public void accept(SqlAstWalker walker) {
 		walker.visitCaseSearchedExpression( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSimpleExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSimpleExpression.java
@@ -42,6 +42,18 @@ public class CaseSimpleExpression implements Expression, DomainResultProducer {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		fixture.forceTableReferenceJoinRendering();
+		whenFragments.forEach( whenFragment -> {
+			whenFragment.getCheckValue().forceTableReferenceJoinRendering();
+			whenFragment.getResult().forceTableReferenceJoinRendering();
+		} );
+		if ( otherwise != null ) {
+			otherwise.forceTableReferenceJoinRendering();
+		}
+	}
+
+	@Override
 	public void accept(SqlAstWalker walker) {
 		walker.visitCaseSimpleExpression( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
@@ -35,6 +35,7 @@ public class ColumnReference implements Expression, Assignable {
 	private final String columnExpression;
 	private final String referenceExpression;
 	private final JdbcMapping jdbcMapping;
+	private TableReference tableReference;
 
 	public ColumnReference(
 			String qualifier,
@@ -55,6 +56,7 @@ public class ColumnReference implements Expression, Assignable {
 			JdbcMapping jdbcMapping,
 			SessionFactoryImplementor sessionFactory) {
 		this( tableReference.getIdentificationVariable(), columnExpression, jdbcMapping, sessionFactory );
+		this.tableReference = tableReference;
 	}
 
 	public String getQualifier() {
@@ -136,5 +138,12 @@ public class ColumnReference implements Expression, Assignable {
 	@Override
 	public List<ColumnReference> getColumnReferences() {
 		return Collections.singletonList( this );
+	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+		if ( tableReference != null ) {
+			tableReference.forceRendering();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/EntityTypeLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/EntityTypeLiteral.java
@@ -34,6 +34,11 @@ public class EntityTypeLiteral implements Expression {
 		return entityTypeDescriptor;
 	}
 
+	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
+
 //	@Override
 //	public SqlSelection createSqlSelection(
 //			int jdbcPosition,

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
@@ -33,4 +33,6 @@ public interface Expression extends SqlAstNode, SqlSelectionProducer {
 			TypeConfiguration typeConfiguration) {
 		throw new NotYetImplementedFor6Exception( getClass() );
 	}
+
+	void forceTableReferenceJoinRendering();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/JdbcLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/JdbcLiteral.java
@@ -58,6 +58,11 @@ public class JdbcLiteral<T> implements Literal, MappingModelExpressable<T>, Doma
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitJdbcLiteral( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
@@ -53,6 +53,11 @@ public class QueryLiteral<T> implements Literal, DomainResultProducer<T> {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
+
+	@Override
 	public void accept(SqlAstWalker walker) {
 		walker.visitQueryLiteral( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlSelectionExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlSelectionExpression.java
@@ -46,4 +46,9 @@ public class SqlSelectionExpression implements Expression {
 	public MappingModelExpressable getExpressionType() {
 		return theExpression.getExpressionType();
 	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlTuple.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlTuple.java
@@ -30,6 +30,11 @@ public class SqlTuple implements Expression {
 		return valueMapping;
 	}
 
+	@Override
+	public void forceTableReferenceJoinRendering() {
+		expressions.forEach( expression -> expression.forceTableReferenceJoinRendering() );
+	}
+
 	public List<? extends Expression> getExpressions(){
 		return expressions;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/UnaryOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/UnaryOperation.java
@@ -45,6 +45,11 @@ public class UnaryOperation implements Expression, DomainResultProducer {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		operand.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker walker) {
 		walker.visitUnaryOperationExpression( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReference.java
@@ -27,6 +27,7 @@ public class TableReference implements SqlAstNode, ColumnReferenceQualifier {
 
 	private final boolean isOptional;
 	private final SessionFactoryImplementor sessionFactory;
+	private boolean forceRendering;
 
 	private final Map<String, ColumnReference> columnReferenceResolutionMap = new HashMap<>();
 
@@ -39,6 +40,14 @@ public class TableReference implements SqlAstNode, ColumnReferenceQualifier {
 		this.identificationVariable = identificationVariable;
 		this.isOptional = isOptional;
 		this.sessionFactory = sessionFactory;
+	}
+
+	public boolean isForceRendering() {
+		return forceRendering;
+	}
+
+	public void forceRendering() {
+		this.forceRendering = true;
 	}
 
 	public String getTableExpression() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/BetweenPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/BetweenPredicate.java
@@ -51,6 +51,13 @@ public class BetweenPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		expression.forceTableReferenceJoinRendering();
+		lowerBound.forceTableReferenceJoinRendering();
+		upperBound.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitBetweenPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ComparisonPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ComparisonPredicate.java
@@ -45,6 +45,12 @@ public class ComparisonPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		leftHandExpression.forceTableReferenceJoinRendering();
+		rightHandExpression.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitRelationalPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/FilterPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/FilterPredicate.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.sql.ast.tree.predicate;
 
+import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.sql.ast.SqlAstWalker;
 
 /**
@@ -21,6 +22,11 @@ public class FilterPredicate implements Predicate {
 	@Override
 	public boolean isEmpty() {
 		return true;
+	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+		throw new NotYetImplementedFor6Exception( getClass() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/GroupedPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/GroupedPredicate.java
@@ -28,6 +28,11 @@ public class GroupedPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		subPredicate.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitGroupedPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/InListPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/InListPredicate.java
@@ -70,6 +70,12 @@ public class InListPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		testExpression.forceTableReferenceJoinRendering();
+		listExpressions.forEach( expression -> expression.forceTableReferenceJoinRendering() );
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitInListPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/InSubQueryPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/InSubQueryPredicate.java
@@ -42,6 +42,11 @@ public class InSubQueryPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		testExpression.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitInSubQueryPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/Junction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/Junction.java
@@ -51,6 +51,11 @@ public class Junction implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		predicates.forEach( predicate -> predicate.forceTableReferenceJoinRendering() );
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitJunction( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/LikePredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/LikePredicate.java
@@ -61,6 +61,13 @@ public class LikePredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		matchExpression.forceTableReferenceJoinRendering();
+		pattern.forceTableReferenceJoinRendering();
+		escapeCharacter.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitLikePredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/NegatedPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/NegatedPredicate.java
@@ -28,6 +28,11 @@ public class NegatedPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		predicate.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitNegatedPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/NullnessPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/NullnessPredicate.java
@@ -35,6 +35,11 @@ public class NullnessPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		expression.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitNullnessPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/Predicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/Predicate.java
@@ -13,4 +13,5 @@ import org.hibernate.sql.ast.tree.SqlAstNode;
  */
 public interface Predicate extends SqlAstNode {
 	boolean isEmpty();
+	void forceTableReferenceJoinRendering();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/SelfRenderingPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/SelfRenderingPredicate.java
@@ -30,6 +30,11 @@ public class SelfRenderingPredicate implements Predicate {
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+		selfRenderingExpression.forceTableReferenceJoinRendering();
+	}
+
+	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
 		sqlTreeWalker.visitSelfRenderingPredicate( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
@@ -66,7 +66,13 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 
 	@Override
 	public void applyPredicate(Predicate predicate) {
-		this.whereClauseRestrictions = SqlAstTreeHelper.combinePredicates( this.whereClauseRestrictions, predicate );
+		if ( predicate != null ) {
+			this.whereClauseRestrictions = SqlAstTreeHelper.combinePredicates(
+					this.whereClauseRestrictions,
+					predicate
+			);
+			predicate.forceTableReferenceJoinRendering();
+		}
 	}
 
 	public List<SortSpecification> getSortSpecifications() {
@@ -84,6 +90,7 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 			sortSpecifications = new ArrayList<>();
 		}
 		sortSpecifications.add( specification );
+		specification.getSortExpression().forceTableReferenceJoinRendering();
 	}
 
 	public Expression getLimitClauseExpression() {
@@ -92,6 +99,9 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 
 	public void setLimitClauseExpression(Expression limitClauseExpression) {
 		this.limitClauseExpression = limitClauseExpression;
+		if ( limitClauseExpression != null ) {
+			limitClauseExpression.forceTableReferenceJoinRendering();
+		}
 	}
 
 	public Expression getOffsetClauseExpression() {
@@ -100,6 +110,9 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 
 	public void setOffsetClauseExpression(Expression offsetClauseExpression) {
 		this.offsetClauseExpression = offsetClauseExpression;
+		if ( offsetClauseExpression != null ) {
+			offsetClauseExpression.forceTableReferenceJoinRendering();
+		}
 	}
 
 	@Override
@@ -113,5 +126,10 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 	@Override
 	public MappingModelExpressable getExpressionType() {
 		return null;
+	}
+
+	@Override
+	public void forceTableReferenceJoinRendering() {
+
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcParameter.java
@@ -68,6 +68,11 @@ public abstract class AbstractJdbcParameter
 	}
 
 	@Override
+	public void forceTableReferenceJoinRendering() {
+
+	}
+
+	@Override
 	public void bindParameterValue(
 			PreparedStatement statement,
 			int startPosition,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
@@ -45,6 +45,7 @@ public class SqlSelectionImpl implements SqlSelection {
 		this.valuesArrayPosition = valuesArrayPosition;
 		this.sqlExpression = sqlExpression;
 		this.jdbcMapping = jdbcMapping;
+		sqlExpression.forceTableReferenceJoinRendering();
 	}
 
 	public Expression getWrappedSqlExpression() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/Address.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/Address.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa.test.jointable;
+package org.hibernate.orm.test.jointable;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/ManyToOneJoinTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/ManyToOneJoinTableTest.java
@@ -4,19 +4,23 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa.test.jointable;
+package org.hibernate.orm.test.jointable;
 
 import java.util.LinkedList;
 
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryProducer;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -25,12 +29,19 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Christian Beikov
  */
+
 @DomainModel(
 		annotatedClasses = {
 				Person.class,
 				Address.class
 		}
 )
+@ServiceRegistry(
+		settings = {
+				@ServiceRegistry.Setting( name = AvailableSettings.HBM2DDL_DATABASE_ACTION, value = "create-drop" )
+		}
+)
+@SessionFactory
 public class ManyToOneJoinTableTest implements SessionFactoryProducer {
 	private SQLStatementInterceptor sqlStatementInterceptor;
 
@@ -52,7 +63,8 @@ public class ManyToOneJoinTableTest implements SessionFactoryProducer {
 					assertThat( sqlQueries.size(), is( 1 ) );
 					// Ideally, we could detect that *ToOne join tables aren't used, but that requires tracking the uses of properties
 					// Since *ToOne join tables are treated like secondary or subclass/superclass tables, the proper fix will allow many more optimizations
-					assertFalse( sqlQueries.getFirst().contains( "join" ) );
+					String generatedSQl = sqlQueries.getFirst();
+					assertFalse( "The generated sql contains a useless join: " + generatedSQl, generatedSQl.contains( "join" ) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jointable/Person.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa.test.jointable;
+package org.hibernate.orm.test.jointable;
 
 import javax.persistence.*;
 import java.util.Set;


### PR DESCRIPTION
Hi @sebersole, short description of the PR.

A the method `forceTableReferenceJoinRendering`  is added to `Predicate` and `Expression`

This method is called when a predicate or  an expression is added to the `QuerySpec` (selection,where clause, limit...) and by `SingularAssociationAttributeMapping#createTableGroupJoin` on the join predicate (we need to render the join in such a case).

A `TableReference` field is added to `ColumnReference` so that when `ColumnReference#forceTableReferenceJoinRendering` is called  the new `Tablereference#forceRendering` field is set to true.

This field `Tablereference#forceRendering` is used by the `AbstractSqlAstWalker#renderTableReferenceJoins` method to check if `tableJoin.getJoinedTableReference()` should be rendered in the generated sql.

Any suggestion is more than welcome :)
