### PR TITLE
HHH-13644 NullPointerException when calling StoredProcedureQuery.getResultStream() instead of StoredProcedureQuery.getResultList()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
@@ -916,6 +917,12 @@ public class ProcedureCallImpl<R>
 		final QueryParameterBinding binding = paramBindings.getBinding( position );
 		binding.setBindValue( value, temporalType );
 		return this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Stream getResultStream() {
+		return getResultList().stream();
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/procedure/internal/ProcedureCallImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/procedure/internal/ProcedureCallImplTest.java
@@ -1,0 +1,39 @@
+package org.hibernate.procedure.internal;
+
+import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Nathan Xu
+ */
+public class ProcedureCallImplTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13644" )
+	@RequiresDialect( H2Dialect.class )
+	public void testNoNullPointerExceptionThrown() {
+
+		EntityManager em = getOrCreateEntityManager();
+
+		em.getTransaction().begin();
+
+		em.createNativeQuery("CREATE ALIAS GET_RANDOM_VALUE FOR \"java.lang.Math.random\";").executeUpdate();
+
+		Query query = em.createStoredProcedureQuery("GET_RANDOM_VALUE");
+
+		Stream stream = query.getResultStream();
+
+		Assert.assertEquals(1, stream.count());
+
+		em.getTransaction().commit();
+
+		em.close();
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13644
The root cause is ProcedureCallImpl's getResultStream() method should inherit **javax.persistence.Query**'s default method, rather than **org.hibernate.query.Query**'s default method which is only meant for HQL.

An effective testing case was included. Let me know if we need other db dialects.