### PR TITLE
Fix SQLException: Connection is closed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -99,13 +99,15 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 	
 	/**
 	 * Check connection is closed, avoid exception while physicalConnection is null but it was closed.
+	 *
 	 * @return true while connection is closed
 	 */
 	private boolean isPhysicalConnectionClosed() {
 		try {
 			return physicalConnection == null || physicalConnection.isClosed();
-		} catch (SQLException e) {
-			return true ;
+		}
+		catch (SQLException e) {
+			return true;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -96,9 +96,21 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 		);
 		this.closed = closed;
 	}
+	
+	 /**
+	   * Check connection is closed, avoid exception while physicalConnection is null but it was closed.
+	   * @return true while connection is closed
+	   */
+	private boolean isPhysicalConnectionClosed(){
+		try {
+			return physicalConnection == null || physicalConnection.isClosed();
+		} catch (SQLException e) {
+			return true ;
+		}
+	}
 
 	private Connection acquireConnectionIfNeeded() {
-		if ( physicalConnection == null ) {
+		if ( isPhysicalConnectionClosed() ) {
 			// todo : is this the right place for these observer calls?
 			try {
 				physicalConnection = jdbcConnectionAccess.obtainConnection();

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -97,11 +97,11 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 		this.closed = closed;
 	}
 	
-	 /**
-	   * Check connection is closed, avoid exception while physicalConnection is null but it was closed.
-	   * @return true while connection is closed
-	   */
-	private boolean isPhysicalConnectionClosed(){
+	/**
+	 * Check connection is closed, avoid exception while physicalConnection is null but it was closed.
+	 * @return true while connection is closed
+	 */
+	private boolean isPhysicalConnectionClosed() {
 		try {
 			return physicalConnection == null || physicalConnection.isClosed();
 		} catch (SQLException e) {


### PR DESCRIPTION
Fix SQLException: Connection is closed

In some case, the physicalConnection was not null , but it was closed by connection pool. All follow operations will throw SQLException if we not check the connection state.