### PR TITLE
HHH-13724 Add testing configs and dialect for CockroachDB

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -64,6 +64,7 @@ dependencies {
 	testRuntime( libraries.mariadb )
 	testRuntime( libraries.mssql )
 	testRuntime( libraries.hana )
+	testRuntime( libraries.cockroachdb )
 
 	testCompile( project( ':hibernate-jcache' ) )
 	testRuntime( libraries.ehcache3 )

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -115,7 +115,8 @@ ext {
                         'jdbc.url'   : 'jdbc:sap://localhost:39015/'
                 ],
                 cockroachdb : [
-                        'db.dialect' : 'org.hibernate.dialect.PostgreSQL95Dialect',
+                        'db.dialect' : 'org.hibernate.dialect.CockroachDB1920Dialect',
+                        // CockroachDB uses the same pgwire protocol as PostgreSQL, so the driver is the same.
                         'jdbc.driver': 'org.postgresql.Driver',
                         'jdbc.user'  : 'root',
                         'jdbc.pass'  : '',

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -113,6 +113,13 @@ ext {
                         'jdbc.user'  : 'VLAD',
                         'jdbc.pass'  : 'V1ad_test',
                         'jdbc.url'   : 'jdbc:sap://localhost:39015/'
-                ]
+                ],
+                cockroachdb : [
+                        'db.dialect' : 'org.hibernate.dialect.PostgreSQL95Dialect',
+                        'jdbc.driver': 'org.postgresql.Driver',
+                        'jdbc.user'  : 'root',
+                        'jdbc.pass'  : '',
+                        'jdbc.url'   : 'jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable'
+                ],
         ]
 }

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -91,6 +91,7 @@ dependencies {
 	testRuntime( libraries.mssql )
 	testRuntime( libraries.informix )
 	testRuntime( libraries.hana )
+	testRuntime( libraries.cockroachdb )
 
 	asciidoclet 'org.asciidoctor:asciidoclet:1.+'
 

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -115,6 +115,7 @@ ext {
             postgresql:      'org.postgresql:postgresql:42.2.2',
             mysql:           'mysql:mysql-connector-java:8.0.17',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
+            cockroachdb:     'org.postgresql:postgresql:42.2.8',
 
             oracle:          'com.oracle.jdbc:ojdbc8:12.2.0.1',
             mssql:           'com.microsoft.sqlserver:mssql-jdbc:7.2.1.jre8',

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -145,4 +145,8 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public boolean supportsComputedIndexes() { return false; }
+
+    @Override
+    public boolean supportsNoWait() { return false; }
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -22,97 +22,97 @@ import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
  */
 public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
-    public CockroachDB1920Dialect() {
-        super();
-        registerColumnType( Types.BLOB, "bytea" );
-    }
+	public CockroachDB1920Dialect() {
+		super();
+		registerColumnType(Types.BLOB, "bytea");
+	}
 
-    @Override
-    public IdentityColumnSupport getIdentityColumnSupport() {
-        return new CockroachDB1920IdentityColumnSupport();
-    }
+	@Override
+	public IdentityColumnSupport getIdentityColumnSupport() {
+		return new CockroachDB1920IdentityColumnSupport();
+	}
 
-    @Override
-    public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
-        // CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
-        return new InlineIdsInClauseBulkIdStrategy();
-    }
+	@Override
+	public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+		// CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
+		return new InlineIdsInClauseBulkIdStrategy();
+	}
 
-    public boolean doesReadCommittedCauseWritersToBlockReaders() {
-        return true;
-    }
+	public boolean doesReadCommittedCauseWritersToBlockReaders() {
+		return true;
+	}
 
-    @Override
-    public boolean supportsExpectedLobUsagePattern() {
-        return false;
-    }
+	@Override
+	public boolean supportsExpectedLobUsagePattern() {
+		return false;
+	}
 
-    @Override
-    public SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
-        SqlTypeDescriptor descriptor;
-        switch (sqlCode) {
-            case Types.BLOB: {
-                // Make BLOBs use byte[] storage.
-                descriptor = VarbinaryTypeDescriptor.INSTANCE;
-                break;
-            }
-            case Types.CLOB: {
-                // Make CLOBs use string storage.
-                descriptor = VarcharTypeDescriptor.INSTANCE;
-                break;
-            }
-            default: {
-                descriptor = super.getSqlTypeDescriptorOverride(sqlCode);
-                break;
-            }
-        }
-        return descriptor;
-    }
+	@Override
+	public SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
+		SqlTypeDescriptor descriptor;
+		switch (sqlCode) {
+			case Types.BLOB: {
+				// Make BLOBs use byte[] storage.
+				descriptor = VarbinaryTypeDescriptor.INSTANCE;
+				break;
+			}
+			case Types.CLOB: {
+				// Make CLOBs use string storage.
+				descriptor = VarcharTypeDescriptor.INSTANCE;
+				break;
+			}
+			default: {
+				descriptor = super.getSqlTypeDescriptorOverride(sqlCode);
+				break;
+			}
+		}
+		return descriptor;
+	}
 
-    @Override
-    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
-        return false;
-    }
+	@Override
+	public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
+		return false;
+	}
 
-    @Override
-    public boolean supportsLockTimeouts() {
-        return false;
-    }
+	@Override
+	public boolean supportsLockTimeouts() {
+		return false;
+	}
 
-    @Override
-    public boolean supportsSkipLocked() {
-        // CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
-        return false;
-    }
+	@Override
+	public boolean supportsSkipLocked() {
+		// CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+		return false;
+	}
 
-    @Override
-    public boolean supportsNoWait() {
-        // CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
-        return false;
-    }
+	@Override
+	public boolean supportsNoWait() {
+		// CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+		return false;
+	}
 
-    @Override
-    public boolean supportsMixedTypeArithmetic() {
-        return false;
-    }
+	@Override
+	public boolean supportsMixedTypeArithmetic() {
+		return false;
+	}
 
-    @Override
-    public boolean canCreateSchema() {
-        return false;
-    }
+	@Override
+	public boolean canCreateSchema() {
+		return false;
+	}
 
-    @Override
-    public boolean supportsStoredProcedures() {
-        return false;
-    }
+	@Override
+	public boolean supportsStoredProcedures() {
+		return false;
+	}
 
-    @Override
-    public boolean supportsComputedIndexes() {
-        return false;
-    }
+	@Override
+	public boolean supportsComputedIndexes() {
+		return false;
+	}
 
-    @Override
-    public boolean supportsLoFunctions() {
-        return false;
-    }
+	@Override
+	public boolean supportsLoFunctions() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -24,9 +24,9 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     public CockroachDB1920Dialect() {
         super();
-        registerColumnType(Types.INTEGER, "int8");
-        registerColumnType(Types.FLOAT, "float8");
-        registerColumnType(Types.BLOB, "bytea");
+        registerColumnType( Types.INTEGER, "int8" );
+        registerColumnType( Types.FLOAT, "float8" );
+        registerColumnType( Types.BLOB, "bytea" );
     }
 
     @Override
@@ -56,11 +56,12 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
         switch (sqlCode) {
             case Types.BLOB: {
                 // Make BLOBs use byte[] storage.
-                descriptor = VarbinaryTypeDescriptor.INSTANCE; // CockroachDBBlobTypeDescriptor.INSTANCE;
+                descriptor = VarbinaryTypeDescriptor.INSTANCE;
                 break;
             }
             case Types.CLOB: {
-                descriptor = VarcharTypeDescriptor.INSTANCE; // CockroachDBClobTypeDescriptor.INSTANCE;
+                // Make CLOBs use string storage.
+                descriptor = VarcharTypeDescriptor.INSTANCE;
                 break;
             }
             default: {
@@ -90,7 +91,9 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     }
 
     @Override
-    public boolean supportsMixedTypeArithmetic() { return false; }
+    public boolean supportsMixedTypeArithmetic() {
+        return false;
+    }
 
     @Override
     public boolean canCreateSchema() { return false; }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -1,14 +1,15 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
 package org.hibernate.dialect;
 
 import org.hibernate.dialect.identity.CockroachDB1920IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
-import org.hibernate.dialect.identity.PostgreSQL10IdentityColumnSupport;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
-import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
-import org.hibernate.type.descriptor.ValueExtractor;
-import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.*;
 
 import java.sql.*;
@@ -23,9 +24,9 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     public CockroachDB1920Dialect() {
         super();
-        registerColumnType( Types.INTEGER, "int8" );
-        registerColumnType( Types.FLOAT, "float8" );
-        registerColumnType( Types.BLOB, "bytea" );
+        registerColumnType(Types.INTEGER, "int8");
+        registerColumnType(Types.FLOAT, "float8");
+        registerColumnType(Types.BLOB, "bytea");
     }
 
     @Override
@@ -35,6 +36,7 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+
         // CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
         return new InlineIdsInClauseBulkIdStrategy();
     }
@@ -51,18 +53,18 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     @Override
     public SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
         SqlTypeDescriptor descriptor;
-        switch ( sqlCode ) {
+        switch (sqlCode) {
             case Types.BLOB: {
                 // Make BLOBs use byte[] storage.
-                descriptor = CockroachDBBlobTypeDescriptor.INSTANCE;
+                descriptor = VarbinaryTypeDescriptor.INSTANCE; // CockroachDBBlobTypeDescriptor.INSTANCE;
                 break;
             }
             case Types.CLOB: {
-                descriptor = ClobTypeDescriptor.STREAM_BINDING;
+                descriptor = VarcharTypeDescriptor.INSTANCE; // CockroachDBClobTypeDescriptor.INSTANCE;
                 break;
             }
             default: {
-                descriptor = super.getSqlTypeDescriptorOverride( sqlCode );
+                descriptor = super.getSqlTypeDescriptorOverride(sqlCode);
                 break;
             }
         }
@@ -70,14 +72,10 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     }
 
     @Override
-    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
-        return false;
-    }
+    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) { return false; }
 
     @Override
-    public boolean supportsLockTimeouts() {
-        return false;
-    }
+    public boolean supportsLockTimeouts() { return false; }
 
     @Override
     public boolean supportsSkipLocked() {
@@ -91,80 +89,18 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
         return false;
     }
 
+    @Override
+    public boolean supportsMixedTypeArithmetic() { return false; }
 
     @Override
-    public boolean supportsMixedTypeArithmetic() {
-        return false;
-    }
-
-    public static final class CockroachDBBlobTypeDescriptor implements SqlTypeDescriptor {
-
-        public static final CockroachDBBlobTypeDescriptor INSTANCE = new CockroachDBBlobTypeDescriptor();
-
-        private CockroachDBBlobTypeDescriptor() {
-        }
-
-        @Override
-        public int getSqlType() {
-            return Types.BLOB;
-        }
-
-        @Override
-        public boolean canBeRemapped() {
-            return true;
-        }
-
-        @Override
-        public <X> ValueExtractor<X> getExtractor(final JavaTypeDescriptor<X> javaTypeDescriptor) {
-            return new BasicExtractor<X>( javaTypeDescriptor, this ) {
-                @Override
-                protected X doExtract(ResultSet rs, String name, WrapperOptions options) throws SQLException {
-                    return javaTypeDescriptor.wrap( rs.getBytes( name ), options );
-                }
-
-                @Override
-                protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-                    return javaTypeDescriptor.wrap( statement.getBytes( index ), options );
-                }
-
-                @Override
-                protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-                    return javaTypeDescriptor.wrap( statement.getBytes( name ), options );
-                }
-            };
-        }
-
-        @Override
-        public <X> BasicBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
-            return new BasicBinder<X>( javaTypeDescriptor, this ) {
-                @Override
-                public void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
-                        throws SQLException {
-                    st.setBytes( index, javaTypeDescriptor.unwrap( value, byte[].class, options ) );
-                }
-
-                @Override
-                protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
-                        throws SQLException {
-                    st.setBytes( name, javaTypeDescriptor.unwrap( value, byte[].class, options ) );
-                }
-            };
-        }
-    };
+    public boolean canCreateSchema() { return false; }
 
     @Override
-    public boolean canCreateSchema() {
-        return false;
-    }
+    public boolean supportsStoredProcedures() { return false; }
 
     @Override
-    public boolean supportsStoredProcedures() {
-        return false;
-    }
+    public boolean supportsComputedIndexes() { return false; }
 
     @Override
-    public boolean supportsComputedIndexes() {
-        return false;
-    }
-
+    public boolean supportsLoFunctions() { return false; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -4,6 +4,7 @@ import org.hibernate.dialect.identity.CockroachDB1920IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.PostgreSQL10IdentityColumnSupport;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
 import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -35,7 +36,7 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     @Override
     public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
         // CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
-        return new PersistentTableBulkIdStrategy();
+        return new InlineIdsInClauseBulkIdStrategy();
     }
 
     @Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -24,8 +24,6 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     public CockroachDB1920Dialect() {
         super();
-        registerColumnType( Types.INTEGER, "int8" );
-        registerColumnType( Types.FLOAT, "float8" );
         registerColumnType( Types.BLOB, "bytea" );
     }
 
@@ -36,7 +34,6 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
-
         // CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
         return new InlineIdsInClauseBulkIdStrategy();
     }
@@ -73,10 +70,14 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     }
 
     @Override
-    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) { return false; }
+    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
+        return false;
+    }
 
     @Override
-    public boolean supportsLockTimeouts() { return false; }
+    public boolean supportsLockTimeouts() {
+        return false;
+    }
 
     @Override
     public boolean supportsSkipLocked() {
@@ -96,14 +97,22 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     }
 
     @Override
-    public boolean canCreateSchema() { return false; }
+    public boolean canCreateSchema() {
+        return false;
+    }
 
     @Override
-    public boolean supportsStoredProcedures() { return false; }
+    public boolean supportsStoredProcedures() {
+        return false;
+    }
 
     @Override
-    public boolean supportsComputedIndexes() { return false; }
+    public boolean supportsComputedIndexes() {
+        return false;
+    }
 
     @Override
-    public boolean supportsLoFunctions() { return false; }
+    public boolean supportsLoFunctions() {
+        return false;
+    }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -1,0 +1,35 @@
+package org.hibernate.dialect;
+
+import org.hibernate.dialect.identity.CockroachDB1920IdentityColumnSupport;
+import org.hibernate.dialect.identity.IdentityColumnSupport;
+import org.hibernate.dialect.identity.PostgreSQL10IdentityColumnSupport;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
+
+/**
+ * An SQL dialect for CockroachDB 19.2 and later. This is the first dialect for CockroachDB. It extends
+ * {@link PostgreSQL95Dialect} because CockroachDB is aiming for Postgres compatibility.
+ */
+public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
+
+    @Override
+    public IdentityColumnSupport getIdentityColumnSupport() {
+        return new CockroachDB1920IdentityColumnSupport();
+    }
+
+    @Override
+    public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+        // CockroachDB 19.2.0 does not support temporary tables, so we must override the Postgres behavior.
+        return new PersistentTableBulkIdStrategy();
+    }
+
+    @Override
+    public boolean supportsExpectedLobUsagePattern() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLockTimeouts() {
+        return false;
+    }
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -35,7 +35,11 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
 
     @Override
-    public boolean supportsLockTimeouts() {
-        return false;
-    }
+    public boolean supportsLockTimeouts() { return false; }
+
+    @Override
+    public boolean supportsSkipLocked() { return false; }
+
+    @Override
+    public boolean supportsMixedTypeArithmetic() { return false; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -6,15 +6,15 @@
  */
 package org.hibernate.dialect;
 
+import java.sql.DatabaseMetaData;
+import java.sql.Types;
 import org.hibernate.dialect.identity.CockroachDB1920IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
-import org.hibernate.type.descriptor.sql.*;
-
-import java.sql.*;
-
-import java.sql.DatabaseMetaData;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+import org.hibernate.type.descriptor.sql.VarbinaryTypeDescriptor;
+import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
 
 /**
  * An SQL dialect for CockroachDB 19.2 and later. This is the first dialect for CockroachDB. It extends
@@ -81,13 +81,13 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public boolean supportsSkipLocked() {
-        // CockroachDB doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+        // CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
         return false;
     }
 
     @Override
     public boolean supportsNoWait() {
-        // CockroachDB doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+        // CockroachDB 19.2.0 doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
         return false;
     }
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -6,6 +6,8 @@ import org.hibernate.dialect.identity.PostgreSQL10IdentityColumnSupport;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
 
+import java.sql.DatabaseMetaData;
+
 /**
  * An SQL dialect for CockroachDB 19.2 and later. This is the first dialect for CockroachDB. It extends
  * {@link PostgreSQL95Dialect} because CockroachDB is aiming for Postgres compatibility.
@@ -27,6 +29,10 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     public boolean supportsExpectedLobUsagePattern() {
         return false;
     }
+
+    @Override
+    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) { return false; }
+
 
     @Override
     public boolean supportsLockTimeouts() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -39,14 +39,13 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
         return new InlineIdsInClauseBulkIdStrategy();
     }
 
-    @Override
-    public boolean supportsExpectedLobUsagePattern() {
+    public boolean doesReadCommittedCauseWritersToBlockReaders() {
         return true;
     }
 
     @Override
-    public boolean useInputStreamToInsertBlob() {
-        return true;
+    public boolean supportsExpectedLobUsagePattern() {
+        return false;
     }
 
     @Override
@@ -71,16 +70,32 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     }
 
     @Override
-    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) { return false; }
+    public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) {
+        return false;
+    }
 
     @Override
-    public boolean supportsLockTimeouts() { return false; }
+    public boolean supportsLockTimeouts() {
+        return false;
+    }
 
     @Override
-    public boolean supportsSkipLocked() { return false; }
+    public boolean supportsSkipLocked() {
+        // CockroachDB doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+        return false;
+    }
 
     @Override
-    public boolean supportsMixedTypeArithmetic() { return false; }
+    public boolean supportsNoWait() {
+        // CockroachDB doesn't support this: https://github.com/cockroachdb/cockroach/issues/40476
+        return false;
+    }
+
+
+    @Override
+    public boolean supportsMixedTypeArithmetic() {
+        return false;
+    }
 
     public static final class CockroachDBBlobTypeDescriptor implements SqlTypeDescriptor {
 
@@ -138,15 +153,18 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     };
 
     @Override
-    public boolean canCreateSchema() { return false; }
+    public boolean canCreateSchema() {
+        return false;
+    }
 
     @Override
-    public boolean supportsStoredProcedures() { return false; }
+    public boolean supportsStoredProcedures() {
+        return false;
+    }
 
     @Override
-    public boolean supportsComputedIndexes() { return false; }
-
-    @Override
-    public boolean supportsNoWait() { return false; }
+    public boolean supportsComputedIndexes() {
+        return false;
+    }
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -138,4 +138,7 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public boolean canCreateSchema() { return false; }
+
+    @Override
+    public boolean supportsStoredProcedures() { return false; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -72,7 +72,6 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
     @Override
     public boolean supportsJdbcConnectionLobCreation(DatabaseMetaData databaseMetaData) { return false; }
 
-
     @Override
     public boolean supportsLockTimeouts() { return false; }
 
@@ -136,4 +135,7 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
             };
         }
     };
+
+    @Override
+    public boolean canCreateSchema() { return false; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB1920Dialect.java
@@ -141,4 +141,7 @@ public class CockroachDB1920Dialect extends PostgreSQL95Dialect {
 
     @Override
     public boolean supportsStoredProcedures() { return false; }
+
+    @Override
+    public boolean supportsComputedIndexes() { return false; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -85,7 +84,6 @@ import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ReflectHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.io.StreamCopier;
 import org.hibernate.loader.BatchLoadSizingStrategy;
@@ -2986,7 +2984,7 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Does this dialect/database support mixed type arithmetic (e.g. <int> + <float>).
+	 * Does this dialect/database support mixed type arithmetic (e.g. int + float).
 	 *
 	 * @return {@code true} if mixed type arithmetic is supported
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2977,6 +2977,15 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
+	 * Does this dialect/database support LO_CREATE and related functions.
+	 *
+	 * @return {@code true} if LO_CREATE and related functions are supported
+	 */
+	public boolean supportsLoFunctions() {
+		return false;
+	}
+
+	/**
 	 * Does this dialect/database support mixed type arithmetic (e.g. <int> + <float>).
 	 *
 	 * @return {@code true} if mixed type arithmetic is supported

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2976,6 +2976,13 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
+	/**
+	 * Does this dialect/database support mixed type arithmetic (e.g. <int> + <float>).
+	 *
+	 * @return {@code true} if mixed type arithmetic is supported
+	 */
+	public boolean supportsMixedTypeArithmetic() { return true; }
+
 	public boolean isLegacyLimitHandlerBehaviorEnabled() {
 		return legacyLimitHandlerBehavior;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3062,4 +3062,6 @@ public abstract class Dialect implements ConversionContext {
 
 	public boolean supportsStoredProcedures() { return true; }
 
+	public boolean supportsComputedIndexes() { return true; }
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3060,4 +3060,6 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
+	public boolean supportsStoredProcedures() { return true; }
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2988,7 +2988,9 @@ public abstract class Dialect implements ConversionContext {
 	 *
 	 * @return {@code true} if mixed type arithmetic is supported
 	 */
-	public boolean supportsMixedTypeArithmetic() { return true; }
+	public boolean supportsMixedTypeArithmetic() {
+		return true;
+	}
 
 	public boolean isLegacyLimitHandlerBehaviorEnabled() {
 		return legacyLimitHandlerBehavior;
@@ -3067,8 +3069,12 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
-	public boolean supportsStoredProcedures() { return true; }
+	public boolean supportsStoredProcedures() {
+		return true;
+	}
 
-	public boolean supportsComputedIndexes() { return true; }
+	public boolean supportsComputedIndexes() {
+		return true;
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -650,5 +650,7 @@ public class PostgreSQL81Dialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsLoFunctions() { return true; }
+	public boolean supportsLoFunctions() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -649,4 +649,6 @@ public class PostgreSQL81Dialect extends Dialect {
 		return true;
 	}
 
+	@Override
+	public boolean supportsLoFunctions() { return true; }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -6,29 +6,10 @@
  */
 package org.hibernate.dialect.identity;
 
-import java.sql.Types;
-
 public class CockroachDB1920IdentityColumnSupport extends IdentityColumnSupportImpl {
     @Override
     public boolean supportsIdentityColumns() {
         // Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
-        return false;
-    }
-
-    @Override
-    public String getIdentitySelectString(String table, String column, int type) {
-        return "select currval('" + table + '_' + column + "_seq')";
-    }
-
-    @Override
-    public String getIdentityColumnString(int type) {
-        return type == Types.BIGINT ?
-                "bigserial not null" :
-                "serial not null";
-    }
-
-    @Override
-    public boolean hasDataTypeInIdentityColumn() {
         return false;
     }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -6,10 +6,30 @@
  */
 package org.hibernate.dialect.identity;
 
+import java.sql.Types;
+
 public class CockroachDB1920IdentityColumnSupport extends IdentityColumnSupportImpl {
     @Override
     public boolean supportsIdentityColumns() {
         // Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
+        return false;
+    }
+
+    @Override
+    // CockroachDB does not create a sequence for id columns
+    public String getIdentitySelectString(String table, String column, int type) {
+        return "select 1";
+    }
+
+    @Override
+    public String getIdentityColumnString(int type) {
+        return type == Types.SMALLINT ?
+                "serial4 not null" :
+                "serial8 not null";
+    }
+
+    @Override
+    public boolean hasDataTypeInIdentityColumn() {
         return false;
     }
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -1,3 +1,9 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
 package org.hibernate.dialect.identity;
 
 import java.sql.Types;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -9,27 +9,27 @@ package org.hibernate.dialect.identity;
 import java.sql.Types;
 
 public class CockroachDB1920IdentityColumnSupport extends IdentityColumnSupportImpl {
-    @Override
-    public boolean supportsIdentityColumns() {
-        // Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
-        return false;
-    }
+	@Override
+	public boolean supportsIdentityColumns() {
+		// Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
+		return false;
+	}
 
-    @Override
-    // CockroachDB does not create a sequence for id columns
-    public String getIdentitySelectString(String table, String column, int type) {
-        return "select 1";
-    }
+	@Override
+	// CockroachDB does not create a sequence for id columns
+	public String getIdentitySelectString(String table, String column, int type) {
+		return "select 1";
+	}
 
-    @Override
-    public String getIdentityColumnString(int type) {
-        return type == Types.SMALLINT ?
-                "serial4 not null" :
-                "serial8 not null";
-    }
+	@Override
+	public String getIdentityColumnString(int type) {
+		return type == Types.SMALLINT ?
+				"serial4 not null" :
+				"serial8 not null";
+	}
 
-    @Override
-    public boolean hasDataTypeInIdentityColumn() {
-        return false;
-    }
+	@Override
+	public boolean hasDataTypeInIdentityColumn() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -1,0 +1,28 @@
+package org.hibernate.dialect.identity;
+
+import java.sql.Types;
+
+public class CockroachDB1920IdentityColumnSupport extends IdentityColumnSupportImpl {
+    @Override
+    public boolean supportsIdentityColumns() {
+        // Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
+        return false;
+    }
+
+    @Override
+    public String getIdentitySelectString(String table, String column, int type) {
+        return "select currval('" + table + '_' + column + "_seq')";
+    }
+
+    @Override
+    public String getIdentityColumnString(int type) {
+        return type == Types.BIGINT ?
+                "bigserial not null" :
+                "serial not null";
+    }
+
+    @Override
+    public boolean hasDataTypeInIdentityColumn() {
+        return false;
+    }
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
@@ -107,6 +107,16 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 						: value;
 				return (X) clob;
 			}
+			else if (String.class.isAssignableFrom( type )) {
+				if ( ClobImplementer.class.isInstance( value ) ) {
+					// if the incoming Clob is a wrapper, just pass along its CharacterStream
+					return (X)  ( (ClobImplementer) value ).getUnderlyingStream().asString();
+				}
+				else {
+					// otherwise we need to build a CharacterStream...
+					return (X) DataHelper.extractString( value.getCharacterStream() );
+				}
+			}
 		}
 		catch ( SQLException e ) {
 			throw new HibernateException( "Unable to access clob stream", e );
@@ -128,6 +138,9 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 		else if ( Reader.class.isAssignableFrom( value.getClass() ) ) {
 			Reader reader = (Reader) value;
 			return options.getLobCreator().createClob( DataHelper.extractString( reader ) );
+		}
+		else if (String.class.isAssignableFrom(( value.getClass()))) {
+			return options.getLobCreator().createClob((String) value);
 		}
 
 		throw unknownWrap( value.getClass() );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
@@ -107,13 +107,13 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 						: value;
 				return (X) clob;
 			}
-			else if (String.class.isAssignableFrom( type )) {
+			else if ( String.class.isAssignableFrom( type ) ) {
 				if ( ClobImplementer.class.isInstance( value ) ) {
-					// if the incoming Clob is a wrapper, just pass along its CharacterStream
-					return (X)  ( (ClobImplementer) value ).getUnderlyingStream().asString();
+					// if the incoming Clob is a wrapper, just get the underlying String.
+					return (X) ( (ClobImplementer) value ).getUnderlyingStream().asString();
 				}
 				else {
-					// otherwise we need to build a CharacterStream...
+					// otherwise we need to extract the String.
 					return (X) DataHelper.extractString( value.getCharacterStream() );
 				}
 			}
@@ -139,8 +139,8 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 			Reader reader = (Reader) value;
 			return options.getLobCreator().createClob( DataHelper.extractString( reader ) );
 		}
-		else if (String.class.isAssignableFrom(( value.getClass()))) {
-			return options.getLobCreator().createClob((String) value);
+		else if ( String.class.isAssignableFrom( value.getClass() ) ) {
+			return options.getLobCreator().createClob( (String) value );
 		}
 
 		throw unknownWrap( value.getClass() );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
@@ -126,7 +126,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
+					st.setCharacterStream( index, characterStream.asReader() );
 				}
 
 				@Override
@@ -137,7 +137,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
+					st.setCharacterStream( name, characterStream.asReader() );
 				}
 			};
 		}

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
  */
 @TestForIssue(jiraKey = "HHH-12973")
 @RequiresDialect(PostgreSQL82Dialect.class)
-@SkipForDialect(CockroachDB1920Dialect.class)
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Does not use sequences by default.")
 public class PostgreSQLSequenceGeneratorWithSerialTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Rule

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
@@ -22,6 +22,7 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.id.SequenceMismatchStrategy;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
@@ -29,6 +30,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.logger.LoggerInspectionRule;
 import org.hibernate.testing.logger.Triggerable;
@@ -47,6 +49,7 @@ import static org.junit.Assert.assertTrue;
  */
 @TestForIssue(jiraKey = "HHH-12973")
 @RequiresDialect(PostgreSQL82Dialect.class)
+@SkipForDialect(CockroachDB1920Dialect.class)
 public class PostgreSQLSequenceGeneratorWithSerialTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Rule

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -19,6 +19,7 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
 import javax.persistence.metamodel.EntityType;
 
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.jpa.test.metamodel.Address;
@@ -40,6 +41,7 @@ import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate;
 
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
@@ -232,6 +234,7 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value= CockroachDB1920Dialect.class, comment = "CockroachDB does not support current_time")
 	public void testDateTimeFunctions() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -234,7 +234,6 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value= CockroachDB1920Dialect.class, comment = "CockroachDB does not support current_time")
 	public void testDateTimeFunctions() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
@@ -246,6 +246,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5803" )
+	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
 	public void testQuotientConversion() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.jpa.test.criteria.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -28,6 +26,9 @@ import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the various predicates.
@@ -246,7 +247,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5803" )
-	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
+	@RequiresDialectFeature( DialectChecks.SupportsMixedTypeArithmetic.class )
 	public void testQuotientConversion() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
@@ -246,7 +246,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5803" )
-	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
+	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
 	public void testQuotientConversion() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -61,6 +61,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	private static final Logger log = Logger.getLogger( LockTest.class );
 
 	@Test
+	@RequiresDialectFeature(value = DialectChecks.SupportNoWait.class)
 	public void testFindWithTimeoutHint() {
 		final Lock lock = new Lock();
 		lock.setName( "name" );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -61,7 +61,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	private static final Logger log = Logger.getLogger( LockTest.class );
 
 	@Test
-	@RequiresDialectFeature(value = DialectChecks.SupportNoWait.class)
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testFindWithTimeoutHint() {
 		final Lock lock = new Lock();
 		lock.setName( "name" );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
-@SkipForDialect(CockroachDB1920Dialect.class)
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/41335")
 @TestForIssue( jiraKey = "HHH-13493")
 public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
@@ -49,9 +49,10 @@ public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCa
 
 				fail("Should have thrown lock timeout exception!");
 			} catch (Exception expected) {
+				expected.printStackTrace();
 				assertTrue(
 					ExceptionUtil.rootCause(expected)
-						.getMessage().contains("canceling statement due to user request")
+						.getMessage().contains("csanceling statement due to user request")
 				);
 			}
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
@@ -7,11 +7,13 @@
 package org.hibernate.jpa.test.lock;
 
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.util.ExceptionUtil;
 import org.hibernate.type.IntegerType;
@@ -27,6 +29,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
+@SkipForDialect(CockroachDB1920Dialect.class)
 @TestForIssue( jiraKey = "HHH-13493")
 public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCase {
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
@@ -52,7 +52,7 @@ public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCa
 				expected.printStackTrace();
 				assertTrue(
 					ExceptionUtil.rootCause(expected)
-						.getMessage().contains("csanceling statement due to user request")
+						.getMessage().contains("canceling statement due to user request")
 				);
 			}
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -21,6 +21,7 @@ import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Root;
 
 import org.hibernate.LockMode;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.jpa.AvailableSettings;
@@ -28,10 +29,7 @@ import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
 
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.*;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.junit.Test;
 
@@ -145,6 +143,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(CockroachDB1920Dialect.class)
 	public void testPessimisticForcedIncrementOverall() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();
@@ -170,6 +169,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(CockroachDB1920Dialect.class)
 	public void testPessimisticForcedIncrementSpecific() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -143,7 +143,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(CockroachDB1920Dialect.class)
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testPessimisticForcedIncrementOverall() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();
@@ -169,7 +169,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(CockroachDB1920Dialect.class)
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testPessimisticForcedIncrementSpecific() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -13,10 +13,12 @@ import java.util.Map;
 import javax.persistence.LockModeType;
 
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.hibernate.testing.transaction.TransactionUtil;
@@ -67,6 +69,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 
 	@Test(timeout = 1000 * 30) //30 seconds
 	@TestForIssue(jiraKey = "HHH-11617")
+	@SkipForDialect(CockroachDB1920Dialect.class)
 	public void testStatementIsClosed() {
 
 		TransactionUtil.doInJPA( this::entityManagerFactory, em1 -> {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -69,7 +69,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 
 	@Test(timeout = 1000 * 30) //30 seconds
 	@TestForIssue(jiraKey = "HHH-11617")
-	@SkipForDialect(CockroachDB1920Dialect.class)
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testStatementIsClosed() {
 
 		TransactionUtil.doInJPA( this::entityManagerFactory, em1 -> {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
@@ -119,7 +119,6 @@ public class NativeQueryOrdinalParametersTest extends BaseEntityManagerFunctiona
 	@Test
 	@TestForIssue(jiraKey = "HHH-12532")
 	@RequiresDialect(PostgreSQL82Dialect.class)
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB does not support recursive CTE")
 	public void testCteNativeQueryOrdinalParameter() {
 
 		Node root1 = new Node();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
@@ -18,12 +18,14 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.spi.NativeQueryImplementor;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.After;
 import org.junit.Before;
@@ -117,6 +119,7 @@ public class NativeQueryOrdinalParametersTest extends BaseEntityManagerFunctiona
 	@Test
 	@TestForIssue(jiraKey = "HHH-12532")
 	@RequiresDialect(PostgreSQL82Dialect.class)
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB does not support recursive CTE")
 	public void testCteNativeQueryOrdinalParameter() {
 
 		Node root1 = new Node();

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
@@ -15,7 +15,7 @@ import org.hibernate.testing.SkipForDialect;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
-@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses temporary tables directly")
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/5807")
 public class GlobalTemporaryTableBulkCompositeIdTest extends AbstractBulkCompositeIdTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.test.bulkid;
 
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
@@ -8,11 +9,13 @@ import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses temporary tables directly")
 public class GlobalTemporaryTableBulkCompositeIdTest extends AbstractBulkCompositeIdTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AndLobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AndLobTest.java
@@ -18,10 +18,13 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.converter.AttributeConverterTypeAdapter;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +62,8 @@ public class AndLobTest extends BaseUnitTestCase {
 
 		final Type type = metadata.getEntityBinding( EntityImpl.class.getName() ).getProperty( "status" ).getType();
 		final AttributeConverterTypeAdapter concreteType = assertTyping( AttributeConverterTypeAdapter.class, type );
-		assertEquals( Types.BLOB, concreteType.getSqlTypeDescriptor().getSqlType() );
+		SqlTypeDescriptor sqlTypeDescriptor = concreteType.getSqlTypeDescriptor();
+		assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(BlobTypeDescriptor.BLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 	}
 
 	@Converter

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
@@ -29,6 +29,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.hql.internal.ast.tree.JavaConstantNode;
 import org.hibernate.internal.util.ConfigHelper;
@@ -46,6 +47,9 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.boot.MetadataBuildingContextTestingImpl;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.hibernate.testing.util.ExceptionUtil;
+import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.ClobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.junit.Test;
 
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
@@ -110,7 +114,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 		}
 		AbstractStandardBasicType basicType = assertTyping( AbstractStandardBasicType.class, type );
 		assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-		assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+		SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+		assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 	}
 
 	@Test
@@ -161,7 +166,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			}
 			AbstractStandardBasicType basicType = assertTyping( AbstractStandardBasicType.class, type );
 			assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-			assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+			SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+			assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( ssr );
@@ -190,7 +196,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			}
 			AttributeConverterTypeAdapter basicType = assertTyping( AttributeConverterTypeAdapter.class, type );
 			assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-			assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+			SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+			assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( ssr );

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -6,30 +6,6 @@
  */
 package org.hibernate.test.hql;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
@@ -87,6 +63,32 @@ import org.hibernate.type.ComponentType;
 import org.hibernate.type.ManyToOneType;
 import org.hibernate.type.Type;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests the integration of the new AST parser into the loading of query results using
@@ -976,6 +978,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
 	public void testExpressionWithParamInFunction() {
 		Session s = openSession();
 		s.beginTransaction();
@@ -2948,6 +2951,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
 	@SuppressWarnings( {"UnusedAssignment", "UnusedDeclaration"})
 	public void testSelectExpressions() {
 		createTestBaseData();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -978,7 +978,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
+	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
 	public void testExpressionWithParamInFunction() {
 		Session s = openSession();
 		s.beginTransaction();
@@ -2951,7 +2951,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(value = DialectChecks.SupportsMixedTypeArithmetic.class)
+	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
 	@SuppressWarnings( {"UnusedAssignment", "UnusedDeclaration"})
 	public void testSelectExpressions() {
 		createTestBaseData();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -3285,6 +3285,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB doesn't support current_time")
 	public void testStandardFunctions() throws Exception {
 		Session session = openSession();
 		Transaction t = session.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -3285,7 +3285,6 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB doesn't support current_time")
 	public void testStandardFunctions() throws Exception {
 		Session session = openSession();
 		Transaction t = session.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/id/NonUniqueIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/id/NonUniqueIdTest.java
@@ -32,15 +32,19 @@ public class NonUniqueIdTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Before
 	public void setup() {
+		// Drop and recreate table so it has no primary key. The drop is done in a separate transaction because
+		// some databases do not support dropping and recreating in the same transaction.
 		doInHibernate(
 				this::sessionFactory,
 				session -> {
-					// drop and recreate table so it has no primary key
-
 					session.createNativeQuery(
 							"DROP TABLE CATEGORY"
 					).executeUpdate();
-
+				}
+		);
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
 					session.createNativeQuery(
 							"create table CATEGORY( id integer not null, name varchar(255) )"
 					).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
@@ -45,24 +45,7 @@ import org.hibernate.criterion.Example;
 import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.InterbaseDialect;
-import org.hibernate.dialect.MckoiDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle12cDialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PointbaseDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SAPDBDialect;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.dialect.TeradataDialect;
-import org.hibernate.dialect.TimesTenDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
@@ -391,6 +374,7 @@ public class FooBarTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB does stricter type inference")
 	public void testQuery() throws Exception {
 		Session s = openSession();
 		Transaction txn = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
@@ -374,7 +374,7 @@ public class FooBarTest extends LegacyTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "CockroachDB does stricter type inference")
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/43007")
 	public void testQuery() throws Exception {
 		Session s = openSession();
 		Transaction txn = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/MasterDetailTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/MasterDetailTest.java
@@ -21,11 +21,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.criterion.Example;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.MckoiDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SAPDBDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.jdbc.AbstractWork;
@@ -196,6 +192,7 @@ public class MasterDetailTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testSelfManyToOne() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -220,6 +217,7 @@ public class MasterDetailTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testExample() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
@@ -30,10 +30,13 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.jdbc.Work;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
@@ -249,6 +252,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testMultiTable() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -392,6 +396,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testMultiTableGeneratedId() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -515,6 +520,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testMultiTableCollections() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -587,6 +593,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testMultiTableManyToOne() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.dialect.*;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
@@ -33,12 +34,6 @@ import org.hibernate.ReplicationMode;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.IngresDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.TeradataDialect;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.jdbc.AbstractWork;
@@ -1095,6 +1090,7 @@ public class ParentChildTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testLocking() throws Exception {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();
@@ -1209,7 +1205,8 @@ public class ParentChildTest extends LegacyTestCase {
 		s.close();
 	}
 
-	 @Test
+	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses READ_COMMITTED isolation")
 	public void testLoadAfterNonExists() throws HibernateException, SQLException {
 		Session session = openSession();
 		if ( ( getDialect() instanceof MySQLDialect ) || ( getDialect() instanceof IngresDialect ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -1206,7 +1206,7 @@ public class ParentChildTest extends LegacyTestCase {
 	}
 
 	@Test
-//	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses READ_COMMITTED isolation")
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses READ_COMMITTED isolation")
 	public void testLoadAfterNonExists() throws HibernateException, SQLException {
 		Session session = openSession();
 		if ( ( getDialect() instanceof MySQLDialect ) || ( getDialect() instanceof IngresDialect ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -1206,7 +1206,7 @@ public class ParentChildTest extends LegacyTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses READ_COMMITTED isolation")
+//	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses READ_COMMITTED isolation")
 	public void testLoadAfterNonExists() throws HibernateException, SQLException {
 		Session session = openSession();
 		if ( ( getDialect() instanceof MySQLDialect ) || ( getDialect() instanceof IngresDialect ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
@@ -20,7 +20,9 @@ import javax.persistence.Table;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -90,6 +92,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testUsingStringLobAnnotatedPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<TestEntity> results = session.createNativeQuery(
@@ -116,6 +119,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testSelectStringLobAnnotatedInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -133,6 +137,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testUsingLobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -150,6 +155,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testSelectClobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<byte[]> results = session.createNativeQuery(

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
@@ -18,10 +18,12 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.util.ExceptionUtil;
@@ -94,6 +96,7 @@ public class PostgreSqlLobStringTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses lo_from_bytea")
 	public void testBadClobDataSavedAsStringworksAfterUpdate() {
 		doInHibernate( this::sessionFactory, session -> {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
@@ -22,9 +22,7 @@ import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.*;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.util.ExceptionUtil;
 import org.junit.Test;
@@ -41,6 +39,7 @@ import static org.junit.Assert.fail;
  */
 @TestForIssue(jiraKey = "HHH-11614")
 @RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 public class PostgreSqlLobStringTest extends BaseCoreFunctionalTestCase {
 
 	private final String value1 = "abc";
@@ -96,7 +95,6 @@ public class PostgreSqlLobStringTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses lo_from_bytea")
 	public void testBadClobDataSavedAsStringworksAfterUpdate() {
 		doInHibernate( this::sessionFactory, session -> {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
@@ -12,7 +12,9 @@ import org.hibernate.Session;
 import org.hibernate.dialect.*;
 import org.hibernate.query.Query;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
@@ -68,7 +70,7 @@ public abstract class AbstractSkipLockedTest
 
 	@Test
 	@RequiresDialect({ PostgreSQL95Dialect.class })
-	@SkipForDialect(CockroachDB1920Dialect.class)
+	@RequiresDialectFeature(DialectChecks.SupportSkipLocked.class)
 	public void testPostgreSQLSkipLocked() {
 
 		doInHibernate( this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
@@ -9,14 +9,11 @@ import javax.persistence.Id;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
-import org.hibernate.dialect.MySQL57Dialect;
-import org.hibernate.dialect.MySQL8Dialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PostgreSQL95Dialect;
-import org.hibernate.dialect.SQLServer2005Dialect;
+import org.hibernate.dialect.*;
 import org.hibernate.query.Query;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
 
@@ -71,6 +68,7 @@ public abstract class AbstractSkipLockedTest
 
 	@Test
 	@RequiresDialect({ PostgreSQL95Dialect.class })
+	@SkipForDialect(CockroachDB1920Dialect.class)
 	public void testPostgreSQLSkipLocked() {
 
 		doInHibernate( this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
@@ -201,6 +201,7 @@ public class LockModeTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-12257")
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testRefreshWithExplicitHigherLevelLockMode() {
 		doInHibernate( this::sessionFactory, session -> {
 						   A a = session.get( A.class, id );

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
@@ -9,7 +9,9 @@ import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQL95Dialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.junit.Before;
@@ -54,6 +56,7 @@ public class PessimisticWriteLockTimeoutTest
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL81Dialect.class,
 			SQLServer2005Dialect.class } )
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testNoWait()
 			throws NoSuchFieldException, IllegalAccessException {
 
@@ -79,6 +82,7 @@ public class PessimisticWriteLockTimeoutTest
 
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL95Dialect.class })
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testSkipLocked()
 			throws NoSuchFieldException, IllegalAccessException {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/optlock/OptimisticLockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/optlock/OptimisticLockTest.java
@@ -8,20 +8,17 @@ package org.hibernate.test.optlock;
 
 
 import javax.persistence.PersistenceException;
-
 import org.hibernate.JDBCException;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.StaleStateException;
 import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.SQLServerDialect;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
 import static org.junit.Assert.fail;
 
 /**
@@ -178,7 +175,7 @@ public class OptimisticLockTest extends BaseCoreFunctionalTestCase {
 			}
 		}
 		else if ( !(cause instanceof StaleObjectStateException) && !(cause instanceof StaleStateException) ) {
-			fail( "expected StaleObjectStateException or StaleStateException exception but is" + cause );
+			fail( "expected StaleObjectStateException or StaleStateException exception but is " + cause );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
@@ -25,6 +25,8 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.type.StringType;
 
 import org.hibernate.testing.RequiresDialect;
@@ -42,6 +44,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialectFeature(DialectChecks.SupportsStoredProcedures.class)
 public class PostgreSQLStoredProcedureTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
-@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteDefaultSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
@@ -26,6 +26,8 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 
@@ -47,6 +49,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
+@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteDefaultSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
-@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteSpecifiedSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
@@ -24,6 +24,8 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 
@@ -45,6 +47,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
+@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteSpecifiedSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
@@ -31,6 +31,8 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 
@@ -48,6 +50,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
 public class PostgreSQLMultipleSchemaSequenceTest extends BaseUnitTestCase {
 
 	private File output;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL81Dialect.class)
-@RequiresDialectFeature(value = DialectChecks.SupportSchemaCreation.class)
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class PostgreSQLMultipleSchemaSequenceTest extends BaseUnitTestCase {
 
 	private File output;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithFunctionIndexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithFunctionIndexTest.java
@@ -22,6 +22,8 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
@@ -38,6 +40,7 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-10191")
 @RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialectFeature(DialectChecks.SupportsComputedIndexes.class)
 public class SchemaUpdateWithFunctionIndexTest extends BaseNonConfigCoreFunctionalTestCase {
 	protected ServiceRegistry serviceRegistry;
 	protected MetadataImplementor metadata;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-1872")
 @RequiresDialect(PostgreSQL81Dialect.class)
-@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses CREATE OR REPLACE VIEW")
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/24897")
 public class SchemaUpdateWithViewsTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	protected ServiceRegistry serviceRegistry;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
@@ -20,8 +20,10 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
@@ -38,6 +40,7 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-1872")
 @RequiresDialect(PostgreSQL81Dialect.class)
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses CREATE OR REPLACE VIEW")
 public class SchemaUpdateWithViewsTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	protected ServiceRegistry serviceRegistry;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
@@ -16,8 +16,10 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.tool.hbm2ddl.SchemaValidator;
 import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
 
@@ -36,6 +38,7 @@ import org.junit.Test;
 		@RequiresDialect(PostgreSQL81Dialect.class),
 		@RequiresDialect(H2Dialect.class)
 })
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses * in view creation")
 public class ViewValidationTest extends BaseCoreFunctionalTestCase {
 	private StandardServiceRegistry ssr;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 		@RequiresDialect(PostgreSQL81Dialect.class),
 		@RequiresDialect(H2Dialect.class)
 })
-@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Uses * in view creation")
+@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/10028")
 public class ViewValidationTest extends BaseCoreFunctionalTestCase {
 	private StandardServiceRegistry ssr;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
@@ -16,9 +16,11 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB1920Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.test.util.jdbc.TimeZoneConnectionProvider;
 import org.junit.Test;
@@ -58,6 +60,7 @@ public class JdbcTimestampWithoutUTCTimeZoneTest
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Missing function to_char")
 	public void testTimeZone() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person person = new Person();

--- a/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
@@ -60,7 +60,7 @@ public class JdbcTimestampWithoutUTCTimeZoneTest
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "Missing function to_char")
+	@SkipForDialect(value = CockroachDB1920Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/3781")
 	public void testTimeZone() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person person = new Person();

--- a/hibernate-core/src/test/java/org/hibernate/test/typeoverride/TypeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/typeoverride/TypeOverrideTest.java
@@ -13,18 +13,10 @@ import static org.junit.Assert.assertSame;
 
 import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SybaseASE15Dialect;
-import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
-import org.hibernate.type.descriptor.sql.IntegerTypeDescriptor;
-import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
-import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
+import org.hibernate.type.descriptor.sql.*;
 import org.junit.Test;
 
 /**
@@ -47,7 +39,13 @@ public class TypeOverrideTest extends BaseCoreFunctionalTestCase {
 		assertSame( IntegerTypeDescriptor.INSTANCE, remapSqlTypeDescriptor( IntegerTypeDescriptor.INSTANCE ) );
 
 		// A few dialects explicitly override BlobTypeDescriptor.DEFAULT
-		if ( PostgreSQL81Dialect.class.isInstance( getDialect() ) || PostgreSQLDialect.class.isInstance( getDialect() ) )  {
+		if ( CockroachDB1920Dialect.class.isInstance( getDialect() ))  {
+			assertSame(
+					VarbinaryTypeDescriptor.INSTANCE,
+					getDialect().remapSqlTypeDescriptor( BlobTypeDescriptor.DEFAULT )
+			);
+		}
+		else if ( PostgreSQL81Dialect.class.isInstance( getDialect() ) || PostgreSQLDialect.class.isInstance( getDialect() ) )  {
 			assertSame(
 					BlobTypeDescriptor.BLOB_BINDING,
 					getDialect().remapSqlTypeDescriptor( BlobTypeDescriptor.DEFAULT )

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
@@ -53,10 +53,15 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery("drop table if exists MATERIAL_RATINGS cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists BUILDING_RATINGS cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists ASSOCIATION_TABLE cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists MAIN_TABLE cascade").executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
@@ -53,10 +53,10 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery("drop table if exists MATERIAL_RATINGS cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists BUILDING_RATINGS cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists ASSOCIATION_TABLE cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists MAIN_TABLE cascade").executeUpdate();
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
@@ -50,7 +50,12 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery("DROP TABLE if exists MAIN_TABLE cascade").executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -8,10 +8,7 @@ package org.hibernate.test.where.hbm;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import org.hibernate.FlushMode;
 import org.hibernate.Hibernate;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.After;
@@ -38,10 +35,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery("drop table if exists MATERIAL_RATINGS cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists BUILDING_RATINGS cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists ASSOCIATION_TABLE cascade").executeUpdate();
-					session.createSQLQuery("drop table if exists MAIN_TABLE cascade").executeUpdate();
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 
@@ -162,7 +159,7 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-12875")
+	@TestForIssue( jiraKey = "HHH-12875" )
 	public void testInitializeFromUniqueAssociationTable() {
 		doInHibernate(
 				this::sessionFactory, session -> {
@@ -191,7 +188,7 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-12875")
+	@TestForIssue( jiraKey = "HHH-12875" )
 	public void testInitializeFromNonUniqueAssociationTable() {
 		doInHibernate(
 				this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -38,10 +38,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery("drop table MATERIAL_RATINGS").executeUpdate();
-					session.createSQLQuery("drop table BUILDING_RATINGS").executeUpdate();
-					session.createSQLQuery("drop table ASSOCIATION_TABLE").executeUpdate();
-					session.createSQLQuery("drop table MAIN_TABLE").executeUpdate();
+					session.createSQLQuery("drop table if exists MATERIAL_RATINGS cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists BUILDING_RATINGS cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists ASSOCIATION_TABLE cascade").executeUpdate();
+					session.createSQLQuery("drop table if exists MAIN_TABLE cascade").executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -9,6 +9,7 @@ package org.hibernate.test.where.hbm;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hibernate.FlushMode;
 import org.hibernate.Hibernate;
 
 import org.hibernate.testing.TestForIssue;
@@ -37,10 +38,15 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery("drop table MATERIAL_RATINGS").executeUpdate();
+					session.createSQLQuery("drop table BUILDING_RATINGS").executeUpdate();
+					session.createSQLQuery("drop table ASSOCIATION_TABLE").executeUpdate();
+					session.createSQLQuery("drop table MAIN_TABLE").executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +
@@ -147,10 +153,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	public void cleanup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "delete from MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "delete from BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "delete from ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "delete from MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "drop table MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
@@ -41,11 +41,15 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-
 					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
 					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
 					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
 					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
@@ -41,10 +41,10 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
@@ -41,7 +41,7 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "DROP TABLE IF EXISTS MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
@@ -41,9 +41,12 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-
 					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
+				}
+		);
 
+		doInHibernate(
+				this::sessionFactory, session -> {
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +
 									"ID integer not null, NAME varchar(255) not null, CODE varchar(10) not null, " +

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -282,6 +282,10 @@ abstract public class DialectChecks {
 		public boolean isMatch(Dialect dialect) { return dialect.supportsMixedTypeArithmetic(); }
 	}
 
+	public static class SupportsStoredProcedures implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return  dialect.supportsStoredProcedures(); }
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -286,6 +286,10 @@ abstract public class DialectChecks {
 		public boolean isMatch(Dialect dialect) { return  dialect.supportsStoredProcedures(); }
 	}
 
+	public static class SupportsComputedIndexes implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return  dialect.supportsComputedIndexes(); }
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -290,6 +290,10 @@ abstract public class DialectChecks {
 		public boolean isMatch(Dialect dialect) { return  dialect.supportsComputedIndexes(); }
 	}
 
+	public static class SupportsLoFunctions implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return  dialect.supportsLoFunctions(); }
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -278,6 +278,10 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class SupportsMixedTypeArithmetic implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return dialect.supportsMixedTypeArithmetic(); }
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {


### PR DESCRIPTION
This adds a CockroachDB dialect and build configuration for testing with CockroachDB.

Tests that use features that CockroachDB does not support yet are annotated with SkipForDialect.