### PR TITLE
HHH-13677 Make org.hibernate.flushMode config take effect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -256,6 +256,8 @@ public final class SessionImpl
 		// NOTE : pulse() already handles auto-join-ability correctly
 		getTransactionCoordinator().pulse();
 
+		getSession().setHibernateFlushMode( ConfigurationHelper.getFlushMode( getSessionProperty( AvailableSettings.FLUSH_MODE ), FlushMode.AUTO ) );
+
 		if ( log.isTraceEnabled() ) {
 			log.tracef( "Opened Session [%s] at timestamp: %s", getSessionIdentifier(), getTimestamp() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/internal/FlushModeConfigTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/internal/FlushModeConfigTest.java
@@ -1,0 +1,60 @@
+package org.hibernate.internal;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.TestForIssue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-13677" )
+@RunWith( Parameterized.class )
+public class FlushModeConfigTest {
+
+	@Parameters
+	public static FlushMode[] parameters() {
+		return FlushMode.values();
+	}
+
+	@Parameter
+	public FlushMode flushMode;
+
+	private StandardServiceRegistryImpl serviceRegistry;
+
+	@Before
+	public void setUp() {
+		serviceRegistry = (StandardServiceRegistryImpl) new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.FLUSH_MODE, flushMode.name() )
+				.build();
+	}
+
+	@Test
+	public void testFlushModeSettingTakingEffect() {
+		try ( final SessionFactory sessionFactory = new MetadataSources(serviceRegistry).buildMetadata().buildSessionFactory() ) {
+			try ( final Session session = sessionFactory.openSession() ) {
+				assertEquals( flushMode, session.getHibernateFlushMode() );
+			}
+		}
+	}
+
+	@After
+	public void tearDown() {
+		serviceRegistry.destroy();
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13677

We ignored setting flush mode during session building. This PR simply grabs the setting from `fastSessionService`. Testing case added.