### PR TITLE
HHH-13373, HHH-13472 fix the bug in SequenceInformationExtractorMariaDBDatabaseImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.type.StandardBasicTypes;
 
 /**
  * An SQL dialect for MariaDB 10.3 and later, provides sequence support, lock-timeouts, etc.
- * 
+ *
  * @author Philippe Marschall
  */
 public class MariaDB103Dialect extends MariaDB102Dialect {
@@ -57,7 +57,7 @@ public class MariaDB103Dialect extends MariaDB102Dialect {
 
 	@Override
 	public String getQuerySequencesString() {
-		return "select table_name from information_schema.TABLES where table_type='SEQUENCE'";
+		return "select table_name from information_schema.TABLES where table_schema = database() and table_type = 'SEQUENCE'";
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/MariaDBExtractSequenceMatadataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/MariaDBExtractSequenceMatadataTest.java
@@ -1,16 +1,14 @@
 package org.hibernate.test.dialect.functional;
 
+import java.sql.*;
+
+import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.MariaDB103Dialect;
-import org.hibernate.testing.FailureExpected;
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.testing.*;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Assert;
 import org.junit.Test;
-
-import java.sql.ResultSet;
-import java.sql.Statement;
-
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 
 /**
  * @author Nathan Xu
@@ -19,49 +17,57 @@ import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 @FailureExpected(jiraKey = "HHH-13373", message = "currently db user has no privilege to create secondary db and sequence within it")
 public class MariaDBExtractSequenceMatadataTest extends BaseCoreFunctionalTestCase {
 
-	private String secondaryDbName = "test_db";
-	private String secondarySequenceName = "test_sequence";
+	private static String primaryDbName;
+	private static String primarySequenceName = "seq_HHH13373";
+
+	private static String secondaryDbName = "secondary_db_HHH13373";
+	private static String secondarySequenceName = "secondary_seq_HHH13373";
 	
-	@Override
-	protected void prepareTest() throws Exception {
-		doInHibernate( this::sessionFactory, session -> {
-			String currentDbName = session.doReturningWork( connection -> {
-				try ( Statement stmt = connection.createStatement() ) {
-					try ( ResultSet resultSet = stmt.executeQuery( "SELECT DATABASE()" ) ) {
-						return resultSet.getString( 0 );
-					}
+	@BeforeClassOnce
+	public static void setUpDBs() throws Exception {
+		try ( Connection conn = getConnection() ) {
+			try ( Statement stmt = conn.createStatement() ) {
+				try ( ResultSet resultSet = stmt.executeQuery( "SELECT DATABASE()" ) ) {
+					assert resultSet.next();
+					primaryDbName = resultSet.getString( 1 );
 				}
-			});
-			session.doWork( connection -> {
-				try ( Statement stmt = connection.createStatement() ) {
-					stmt.execute( "CREATE DATABASE " + secondaryDbName );
-					stmt.execute( "USE " + secondaryDbName );
-					stmt.execute( "CREATE SEQUENCE " + secondarySequenceName );
-					stmt.execute( "USE " + currentDbName );
-					stmt.execute( "DROP SEQUENCE IF EXISTS " + secondarySequenceName );
-				}
-			} );
-		} );
+				stmt.execute( "CREATE DATABASE " + secondaryDbName );
+				stmt.execute( "USE " + secondaryDbName );
+				stmt.execute( "CREATE SEQUENCE " + secondarySequenceName );
+				stmt.execute( "USE " + primaryDbName );
+				stmt.execute( "DROP SEQUENCE IF EXISTS " + secondarySequenceName );
+				stmt.execute( "CREATE SEQUENCE IF NOT EXISTS " + primarySequenceName );
+			}
+		}
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-13373")
 	public void testHibernateLaunchedSuccessfully() {
-		doInHibernate( this::sessionFactory, s -> {} );
+		JdbcEnvironment jdbcEnvironment = serviceRegistry().getService( JdbcEnvironment.class );
+		Assert.assertFalse( jdbcEnvironment.getExtractedDatabaseMetaData().getSequenceInformationList().isEmpty() );
 	}
 
-	@Override
-	protected void cleanupTest() {
-		doInHibernate( this::sessionFactory, session -> {
-			session.doWork( connection -> {
-				try ( Statement stmt = connection.createStatement() ) {
-					stmt.execute(  "DROP DATABASE " + secondaryDbName );
-				}
-				catch (Exception e) {
-					// Ignore
-				}
-			} );
-		} );
+	@AfterClassOnce
+	public static void tearDownDBs() {
+		try ( Connection conn = getConnection() ) {
+			try ( Statement stmt = conn.createStatement() ) {
+				stmt.execute(  "DROP DATABASE " + secondaryDbName );
+			}
+			catch ( Exception e ) {
+				// Ignore
+			}
+		}
+		catch ( Exception e ) {
+			// Ignore
+		}
+	}
+	
+	private static Connection getConnection() throws SQLException {
+		String url = Environment.getProperties().getProperty( Environment.URL );
+		String user = Environment.getProperties().getProperty( Environment.USER );
+		String password = Environment.getProperties().getProperty( Environment.PASS );
+		return DriverManager.getConnection( url, user, password );
 	}
 	
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/MariaDBExtractSequenceMatadataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/MariaDBExtractSequenceMatadataTest.java
@@ -1,0 +1,67 @@
+package org.hibernate.test.dialect.functional;
+
+import org.hibernate.dialect.MariaDB103Dialect;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * @author Nathan Xu
+ */
+@RequiresDialect(MariaDB103Dialect.class)
+@FailureExpected(jiraKey = "HHH-13373", message = "currently db user has no privilege to create secondary db and sequence within it")
+public class MariaDBExtractSequenceMatadataTest extends BaseCoreFunctionalTestCase {
+
+	private String secondaryDbName = "test_db";
+	private String secondarySequenceName = "test_sequence";
+	
+	@Override
+	protected void prepareTest() throws Exception {
+		doInHibernate( this::sessionFactory, session -> {
+			String currentDbName = session.doReturningWork( connection -> {
+				try ( Statement stmt = connection.createStatement() ) {
+					try ( ResultSet resultSet = stmt.executeQuery( "SELECT DATABASE()" ) ) {
+						return resultSet.getString( 0 );
+					}
+				}
+			});
+			session.doWork( connection -> {
+				try ( Statement stmt = connection.createStatement() ) {
+					stmt.execute( "CREATE DATABASE " + secondaryDbName );
+					stmt.execute( "USE " + secondaryDbName );
+					stmt.execute( "CREATE SEQUENCE " + secondarySequenceName );
+					stmt.execute( "USE " + currentDbName );
+					stmt.execute( "DROP SEQUENCE IF EXISTS " + secondarySequenceName );
+				}
+			} );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13373")
+	public void testHibernateLaunchedSuccessfully() {
+		doInHibernate( this::sessionFactory, s -> {} );
+	}
+
+	@Override
+	protected void cleanupTest() {
+		doInHibernate( this::sessionFactory, session -> {
+			session.doWork( connection -> {
+				try ( Statement stmt = connection.createStatement() ) {
+					stmt.execute(  "DROP DATABASE " + secondaryDbName );
+				}
+				catch (Exception e) {
+					// Ignore
+				}
+			} );
+		} );
+	}
+	
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13373
https://hibernate.atlassian.net/browse/HHH-13472

I think this is a serious bug which manifests itself in face of multiple dbs. Suppose some db has some sequence whose name is not shared in another db, SequenceInformationExtractorMariaDBDatabaseImpl will be broken for internally it relies on 'UNIION ALL' to fetch all sequence info as per the names fetched from all dbs, regardless of whether the sequence exists in the current db or not.

However, testing is difficult, unless the 'hibernate_orm_test' user has privilege to create other db and sequence there.