### PR TITLE
HHH-13794 Fix ClassCast problem JAXBContext

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
@@ -133,6 +133,8 @@ public class XmlParserHelper {
 			builder.append( handler.getColumnNumber() );
 			builder.append( ". Message: " );
 			builder.append( handler.getMessage() );
+			builder.append( ". Exception message: " );
+			builder.append( e.getMessage() );
 			throw new XmlParsingException( builder.toString(), e );
 		}
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
@@ -119,7 +119,7 @@ public class XmlParserHelper {
 		ContextProvidingValidationEventHandler handler = new ContextProvidingValidationEventHandler();
 		try {
 			staxEventReader = new JpaNamespaceTransformingEventReader( staxEventReader );
-			JAXBContext jaxbContext = JAXBContext.newInstance( ObjectFactory.class );
+			JAXBContext jaxbContext = JAXBContext.newInstance( ObjectFactory.class.getPackageName(), getClass().getClassLoader() );
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			unmarshaller.setSchema( schema );
 			unmarshaller.setEventHandler( handler );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/xml/XmlParserHelper.java
@@ -119,7 +119,7 @@ public class XmlParserHelper {
 		ContextProvidingValidationEventHandler handler = new ContextProvidingValidationEventHandler();
 		try {
 			staxEventReader = new JpaNamespaceTransformingEventReader( staxEventReader );
-			JAXBContext jaxbContext = JAXBContext.newInstance( ObjectFactory.class.getPackageName(), getClass().getClassLoader() );
+			JAXBContext jaxbContext = JAXBContext.newInstance( ObjectFactory.class.getPackage().getName(), getClass().getClassLoader() );
 			Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
 			unmarshaller.setSchema( schema );
 			unmarshaller.setEventHandler( handler );


### PR DESCRIPTION
- Use the current (XmlParserHelper) class's classloader to create the root JAXB context, so as to avoid a class cast problem with classes loaded on different classloaders due to jaxb defaulting to the current thread's context classloader.
- Add more information to the error message in case of a problem related to reading the persistence.xml (So that a non-parsing error also gets shown instead of "message: null").