### PR TITLE
HHH-13800 Fix typos in Javadoc

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/BasicQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/BasicQueryContract.java
@@ -83,7 +83,7 @@ public interface BasicQueryContract<T extends BasicQueryContract> {
 	T setCacheMode(CacheMode cacheMode);
 
 	/**
-	 * Are the results of this query eligible for second level query caching?  This is different that second level
+	 * Are the results of this query eligible for second level query caching?  This is different than second level
 	 * caching of any returned entities and collections.
 	 *
 	 * NOTE: the query being "eligible" for caching does not necessarily mean its results will be cached.  Second level
@@ -156,7 +156,7 @@ public interface BasicQueryContract<T extends BasicQueryContract> {
 
 	/**
 	 * Obtain the JDBC fetch size hint in effect for this query.  This value is eventually passed along to the JDBC
-	 * query via {@link java.sql.Statement#setFetchSize(int)}.  As defined b y JDBC, this value is a hint to the
+	 * query via {@link java.sql.Statement#setFetchSize(int)}.  As defined by JDBC, this value is a hint to the
 	 * driver to indicate how many rows to fetch from the database when more rows are needed.
 	 *
 	 * NOTE : JDBC expressly defines this value as a hint.  It may or may not have any effect on the actual

--- a/hibernate-core/src/main/java/org/hibernate/Criteria.java
+++ b/hibernate-core/src/main/java/org/hibernate/Criteria.java
@@ -334,7 +334,7 @@ public interface Criteria extends CriteriaSpecification {
 	 * @param withClause The criteria to be added to the join condition (<tt>ON</tt> clause)
 	 *
 	 * @return the created "sub criteria"
-	 * 
+	 *
 	 * @throws HibernateException Indicates a problem creating the sub criteria
 	 */
 	public Criteria createCriteria(String associationPath, String alias, JoinType joinType, Criterion withClause) throws HibernateException;
@@ -490,13 +490,13 @@ public interface Criteria extends CriteriaSpecification {
 	 */
 	public Criteria setComment(String comment);
 	
-	  
+	
 	/**
 	 * Add a DB query hint to the SQL.  These differ from JPA's {@link javax.persistence.QueryHint}, which is specific
 	 * to the JPA implementation and ignores DB vendor-specific hints.  Instead, these are intended solely for the
 	 * vendor-specific hints, such as Oracle's optimizers.  Multiple query hints are supported; the Dialect will
 	 * determine concatenation and placement.
-	 * 
+	 *
 	 * @param hint The database specific query hint to add.
 	 * @return this (for method chaining)
 	 */
@@ -550,7 +550,7 @@ public interface Criteria extends CriteriaSpecification {
 	 * query results.
 	 *
 	 * @throws HibernateException Indicates a problem either translating the criteria to SQL,
-	 * exeucting the SQL or processing the SQL results.
+	 * executing the SQL or processing the SQL results.
 	 */
 	public ScrollableResults scroll(ScrollMode scrollMode) throws HibernateException;
 

--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -47,7 +47,7 @@ public final class Hibernate {
 	/**
 	 * Force initialization of a proxy or persistent collection.
 	 * <p/>
-	 * Note: This only ensures intialization of a proxy object or collection;
+	 * Note: This only ensures initialization of a proxy object or collection;
 	 * it is not guaranteed that the elements INSIDE the collection will be initialized/materialized.
 	 *
 	 * @param proxy a persistable object, proxy, persistent collection or <tt>null</tt>

--- a/hibernate-core/src/main/java/org/hibernate/MappingException.java
+++ b/hibernate-core/src/main/java/org/hibernate/MappingException.java
@@ -7,7 +7,7 @@
 package org.hibernate;
 
 /**
- * An exception that occurs while reading mapping sources (xml/annotations),usually as a result of something
+ * An exception that occurs while reading mapping sources (xml/annotations), usually as a result of something
  * screwy in the O-R mappings.
  *
  * @author Gavin King

--- a/hibernate-core/src/main/java/org/hibernate/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/Query.java
@@ -240,7 +240,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	Query<R> setCacheMode(CacheMode cacheMode);
 
 	/**
-	 * Are the results of this query eligible for second level query caching?  This is different that second level
+	 * Are the results of this query eligible for second level query caching?  This is different than second level
 	 * caching of any returned entities and collections.
 	 *
 	 * NOTE: the query being "eligible" for caching does not necessarily mean its results will be cached.  Second level

--- a/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
@@ -104,7 +104,7 @@ public interface SessionFactory extends EntityManagerFactory, HibernateEntityMan
 	StatelessSession openStatelessSession(Connection connection);
 
 	/**
-	 * Retrieve the statistics fopr this factory.
+	 * Retrieve the statistics for this factory.
 	 *
 	 * @return The statistics.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactoryObserver.java
@@ -24,7 +24,7 @@ public interface SessionFactoryObserver extends Serializable {
 	}
 
 	/**
-	 * Callback to indicate that the given factory is about close.  The passed factory reference should be usable
+	 * Callback to indicate that the given factory is about to close.  The passed factory reference should be usable
 	 * since it is only about to close.
 	 * <p/>
 	 * NOTE : defined as default to allow for existing SessionFactoryObserver impls to work

--- a/hibernate-core/src/main/java/org/hibernate/StaleStateException.java
+++ b/hibernate-core/src/main/java/org/hibernate/StaleStateException.java
@@ -8,7 +8,7 @@ package org.hibernate;
 
 /**
  * Thrown when a version number or timestamp check failed, indicating that the Session contained
- * stale data (when using long transactions with versioning). Also occurs if we try delete or update
+ * stale data (when using long transactions with versioning). Also occurs if we try to delete or update
  * a row that does not exist.
  *
  * Note that this exception often indicates that the user failed to specify the correct

--- a/hibernate-core/src/main/java/org/hibernate/UnknownEntityTypeException.java
+++ b/hibernate-core/src/main/java/org/hibernate/UnknownEntityTypeException.java
@@ -10,7 +10,7 @@ package org.hibernate;
  * Indicates an attempt was made to refer to an unknown entity name/class.
  * <p/>
  * NOTE : extends MappingException because that's what core used to do and that's how
- * HEM expectes it.  Longer term I think it makes more sense to have a different
+ * HEM expects it.  Longer term I think it makes more sense to have a different
  * hierarchy for runtime-"mapping" exceptions.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -60,7 +60,7 @@ public final class EntityUpdateAction extends EntityAction {
 	 * @param previousVersion The previous (stored) version
 	 * @param nextVersion The incremented version
 	 * @param instance The entity instance
-	 * @param rowId The entity's rowid
+	 * @param rowId The entity's row id
 	 * @param persister The entity's persister
 	 * @param session The session
 	 */
@@ -129,12 +129,12 @@ public final class EntityUpdateAction extends EntityAction {
 			// multiple actions queued during the same flush
 			previousVersion = persister.getVersion( instance );
 		}
-		
+
 		final Object ck;
 		if ( persister.canWriteToCache() ) {
 			final EntityDataAccess cache = persister.getCacheAccessStrategy();
 			ck = cache.generateCacheKey(
-					id, 
+					id,
 					persister,
 					factory,
 					session.getTenantIdentifier()
@@ -146,16 +146,16 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 
 		if ( !veto ) {
-			persister.update( 
-					id, 
-					state, 
-					dirtyFields, 
-					hasDirtyCollection, 
-					previousState, 
-					previousVersion, 
-					instance, 
-					rowId, 
-					session 
+			persister.update(
+					id,
+					state,
+					dirtyFields,
+					hasDirtyCollection,
+					previousState,
+					previousVersion,
+					instance,
+					rowId,
+					session
 			);
 		}
 
@@ -163,7 +163,7 @@ public final class EntityUpdateAction extends EntityAction {
 		if ( entry == null ) {
 			throw new AssertionFailure( "possible nonthreadsafe access to session" );
 		}
-		
+
 		if ( entry.getStatus()==Status.MANAGED || persister.isVersionPropertyGenerated() ) {
 			// get the updated snapshot of the entity state by cloning current state;
 			// it is safe to copy in place, since by this time no-one else (should have)
@@ -326,7 +326,7 @@ public final class EntityUpdateAction extends EntityAction {
 					persister,
 					factory,
 					session.getTenantIdentifier()
-					
+
 			);
 
 			if ( success &&

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
@@ -281,7 +281,7 @@ public class UnresolvedEntityInsertActions {
 	}
 
 	/**
-	 * Deerialize a {@link UnresolvedEntityInsertActions} object.
+	 * Deserialize an {@link UnresolvedEntityInsertActions} object.
 	 *
 	 * @param ois - the input stream.
 	 * @param session - the session.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
@@ -71,7 +71,7 @@ public enum CacheConcurrencyStrategy {
 		if ( null == accessType ) {
 			return NONE;
 		}
-		
+
 		switch ( accessType ) {
 			case READ_ONLY: {
 				return READ_ONLY;

--- a/hibernate-core/src/main/java/org/hibernate/annotations/DiscriminatorOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/DiscriminatorOptions.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Optional annotation to express Hibernate specific discrimintor properties.
+ * Optional annotation to express Hibernate specific discriminator properties.
  *
  * @author Hardy Ferentschik
  */

--- a/hibernate-core/src/main/java/org/hibernate/annotations/ManyToAny.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ManyToAny.java
@@ -34,7 +34,7 @@ public @interface ManyToAny {
 	String metaDef() default "";
 
 	/**
-	 * Metadata dicriminator column description, This column will hold the meta value corresponding to the
+	 * Metadata discriminator column description, This column will hold the meta value corresponding to the
 	 * targeted entity.
 	 */
 	Column metaColumn();

--- a/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLock.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/OptimisticLock.java
@@ -12,7 +12,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Whether or not a change of the annotated property will trigger a entity version increment.
+ * Whether or not a change of the annotated property will trigger an entity version increment.
  *
  * If the annotation is not present, the property is involved in the optimistic lock strategy (default).
  *

--- a/hibernate-core/src/main/java/org/hibernate/annotations/QueryHints.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/QueryHints.java
@@ -103,11 +103,11 @@ public class QueryHints {
 	 * Accepts a {@link javax.persistence.LockModeType} or a {@link org.hibernate.LockMode}
 	 */
 	public static final String NATIVE_LOCKMODE = "org.hibernate.lockMode";
-	
+
 	/**
 	 * Hint providing a "fetchgraph" EntityGraph.  Attributes explicitly specified as AttributeNodes are treated as
 	 * FetchType.EAGER (via join fetch or subsequent select).
-	 * 
+	 *
 	 * Note: Currently, attributes that are not specified are treated as FetchType.LAZY or FetchType.EAGER depending
 	 * on the attribute's definition in metadata, rather than forcing FetchType.LAZY.
 	 *
@@ -115,7 +115,7 @@ public class QueryHints {
 	 */
 	@Deprecated
 	public static final String FETCHGRAPH = GraphSemantic.FETCH.getJpaHintName();
-	
+
 	/**
 	 * Hint providing a "loadgraph" EntityGraph.  Attributes explicitly specified as AttributeNodes are treated as
 	 * FetchType.EAGER (via join fetch or subsequent select).  Attributes that are not specified are treated as
@@ -129,7 +129,7 @@ public class QueryHints {
 	/**
 	 * Hint to enable/disable the follow-on-locking mechanism provided by {@link org.hibernate.dialect.Dialect#useFollowOnLocking(QueryParameters)}.
 	 * A value of {@code true} enables follow-on-locking, whereas a value of {@code false} disables it.
-	 * If the value is {@code null}, the the {@code Dialect} strategy is going to be used instead.
+	 * If the value is {@code null}, the {@code Dialect} strategy is going to be used instead.
 	 *
 	 * @since 5.2
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/Metadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/Metadata.java
@@ -38,7 +38,7 @@ import org.hibernate.mapping.Table;
  */
 public interface Metadata extends Mapping {
 	/**
-	 * Get the builder for {@link org.hibernate.SessionFactory} instances based on this metamodel,
+	 * Get the builder for {@link org.hibernate.SessionFactory} instances based on this metamodel.
 	 *
 	 * @return The builder for {@link org.hibernate.SessionFactory} instances.
 	 */
@@ -67,7 +67,7 @@ public interface Metadata extends Mapping {
 	Database getDatabase();
 
 	/**
-	 * Retrieves the PersistentClass entity metadata representation for known all entities.
+	 * Retrieves the PersistentClass entity metadata representation for all known entities.
 	 *
 	 * Returned collection is immutable
 	 *
@@ -86,7 +86,7 @@ public interface Metadata extends Mapping {
 	PersistentClass getEntityBinding(String entityName);
 
 	/**
-	 * Retrieves the Collection metadata representation for known all collections.
+	 * Retrieves the Collection metadata representation for all known collections.
 	 *
 	 * Returned collection is immutable
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
@@ -201,7 +201,7 @@ public interface MetadataBuilder {
 	 * setting if using property-based configuration.
 	 *
 	 *
-	 * @param enable {@code true} to enable; {@code false} to disable;don't call for
+	 * @param enable {@code true} to enable; {@code false} to disable; don't call for
 	 * default.
 	 *
 	 * @return {@code this}, for method chaining
@@ -382,7 +382,7 @@ public interface MetadataBuilder {
 	MetadataBuilder applyAuxiliaryDatabaseObject(AuxiliaryDatabaseObject auxiliaryDatabaseObject);
 
 	/**
-	 * Adds an AttributeConverter by a AttributeConverterDefinition
+	 * Adds an AttributeConverter by an AttributeConverterDefinition
 	 *
 	 * @param definition The definition
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataSources.java
@@ -284,7 +284,7 @@ public class MetadataSources implements Serializable {
 	}
 
 	/**
-	 * Read mappings as a application resourceName (i.e. classpath lookup).
+	 * Read mappings as an application resourceName (i.e. classpath lookup).
 	 *
 	 * @param name The resource name
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -653,7 +653,7 @@ public interface SessionFactoryBuilder {
 	/**
 	 * Apply a fetch size to the JDBC driver for fetching results.
 	 *
-	 * @param size The fetch saize to be passed to the driver.
+	 * @param size The fetch size to be passed to the driver.
 	 *
 	 * @return {@code this}, for method chaining
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
@@ -104,7 +104,7 @@ public class ArchiveHelper {
 	 *
 	 * @return The resolved URL reference
 	 *
-	 * @throws IllegalArgumentException is something goes wrong
+	 * @throws IllegalArgumentException if something goes wrong
 	 */
 	public static URL getURLFromPath(String jarPath) {
 		URL jarUrl;
@@ -126,7 +126,7 @@ public class ArchiveHelper {
 
 	/**
 	 * Extracts the bytes out of an InputStream.  This form is the same as {@link #getBytesFromInputStream}
-	 * except that any {@link IOException} are wrapped as (runtime) {@link ArchiveException}
+	 * except that any {@link IOException} is wrapped as (runtime) {@link ArchiveException}
 	 *
 	 * @param inputStream The stream from which to extract bytes.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/DatabaseIdentifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/DatabaseIdentifier.java
@@ -16,7 +16,7 @@ import org.hibernate.internal.util.StringHelper;
 public class DatabaseIdentifier extends Identifier {
 
 	/**
-	 * Constructs a datatabase identifier instance.
+	 * Constructs a database identifier instance.
 	 * It is assumed that <code>text</code> is unquoted.
 	 *
 	 * @param text The identifier text.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/Identifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/Identifier.java
@@ -133,7 +133,7 @@ public class Identifier implements Comparable<Identifier> {
 	}
 
 	/**
-	 * Is this a quoted identifier>
+	 * Is this a quoted identifier?
 	 *
 	 * @return True if this is a quote identifier; false otherwise.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ObjectNameNormalizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ObjectNameNormalizer.java
@@ -24,7 +24,7 @@ public abstract class ObjectNameNormalizer {
 	 * This implements the rules set forth in JPA 2 (section "2.13 Naming of Database Objects") which
 	 * states that the double-quote (") is the character which should be used to denote a <tt>quoted
 	 * identifier</tt>.  Here, we handle recognizing that and converting it to the more elegant
-	 * bactick (`) approach used in Hibernate..  Additionally we account for applying what JPA2 terms
+	 * backtick (`) approach used in Hibernate..  Additionally we account for applying what JPA2 terms
 	 * "globally quoted identifiers".
 	 *
 	 * @param identifierText The identifier to be quoting-normalized.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/ManagedResources.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/ManagedResources.java
@@ -16,7 +16,7 @@ import org.hibernate.cfg.AttributeConverterDefinition;
  * Represents the result of the first step of the process of building {@link org.hibernate.boot.MetadataSources}
  * reference into a {@link org.hibernate.boot.Metadata} reference.
  * <p/>
- * Essentially it represents thecombination of:<ol>
+ * Essentially it represents the combination of:<ol>
  *     <li>domain classes, packages and mapping files defined via MetadataSources</li>
  *     <li>attribute converters defined via MetadataBuildingOptions</li>
  *     <li>classes, converters, packages and mapping files auto-discovered as part of scanning</li>

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/QualifiedName.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/QualifiedName.java
@@ -15,7 +15,7 @@ import org.hibernate.boot.model.naming.Identifier;
  *     <li>{@link java.sql.DatabaseMetaData#getCatalogSeparator()}</li>
  * </ol>
  * <p/>
- * Also, be careful about the usage of {@link #render}.  If the intention is get get the name
+ * Also, be careful about the usage of {@link #render}.  If the intention is to get the name
  * as used in the database, the {@link org.hibernate.engine.jdbc.env.spi.JdbcEnvironment} ->
  * {@link org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter#format} should be
  * used instead.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/FilterSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/FilterSource.java
@@ -33,7 +33,7 @@ public interface FilterSource {
 	public String getCondition();
 
 	/**
-	 * Should Hibernate perform automatic alias injection into the supplied condition string?  The default it to
+	 * Should Hibernate perform automatic alias injection into the supplied condition string?  The default is to
 	 * perform auto injection *unless* explicit alias(es) are supplied.
 	 *
 	 * @return {@code true} indicates auto injection should occur; {@code false} that it should not

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/MetadataSourceProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/MetadataSourceProcessor.java
@@ -38,7 +38,7 @@ public interface MetadataSourceProcessor {
 	/**
 	 * Process all "root" named queries.  These are named queries not defined on
 	 * a specific entity (which will be handled later during
-	 * {@link #processEntityHierarchies}.
+	 * {@link #processEntityHierarchies}).
 	 * <p/>
 	 * This step has no prerequisites.  The returns associated with named native
 	 * queries can depend on entity binding being complete, but those are handled

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/NaturalIdUniqueKeyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/NaturalIdUniqueKeyBinder.java
@@ -13,7 +13,7 @@ import org.hibernate.mapping.Property;
  */
 public interface NaturalIdUniqueKeyBinder {
 	/**
-	 * Adds a attribute binding.  The attribute is a (top-level) part of the natural-id
+	 * Adds an attribute binding.  The attribute is a (top-level) part of the natural-id
 	 *
 	 * @param attributeBinding The attribute binding that is part of the natural-id
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -85,7 +85,7 @@ public interface SessionFactoryOptions {
 	}
 
 	/**
-	 * The name to be used for the SessionFactory.  This is use both in:<ul>
+	 * The name to be used for the SessionFactory.  This is used both in:<ul>
 	 *     <li>in-VM serialization</li>
 	 *     <li>JNDI binding, depending on {@link #isSessionFactoryNameAlsoJndiName}</li>
 	 * </ul>

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
@@ -31,7 +31,7 @@ public interface EnhancementContext {
 	public ClassLoader getLoadingClassLoader();
 
 	/**
-	 * Does the given class descriptor represent a entity class?
+	 * Does the given class descriptor represent an entity class?
 	 *
 	 * @param classDescriptor The descriptor of the class to check.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
@@ -24,7 +24,7 @@ public final class EnhancerConstants {
 	public static final String PERSISTENT_FIELD_WRITER_PREFIX = "$$_hibernate_write_";
 
 	/**
-	 * Name of the method used to get reference the the entity instance (this in the case of enhanced classes).
+	 * Name of the method used to get reference of the entity instance (this in the case of enhanced classes).
 	 */
 	public static final String ENTITY_INSTANCE_GETTER_NAME = "$$_hibernate_getEntityInstance";
 
@@ -118,7 +118,7 @@ public final class EnhancerConstants {
 	public static final String TRACKER_FIELD_NAME = "$$_hibernate_tracker";
 
 	/**
-	 * Name of method that add changed fields
+	 * Name of method to add changed fields
 	 */
 	public static final String TRACKER_CHANGER_NAME = "$$_hibernate_trackChange";
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeDescriptor.java
@@ -65,7 +65,7 @@ public class LazyAttributeDescriptor {
 	}
 
 	/**
-	 * Access to the index of the attribute in terms of its position withing the lazy attributes of the persister
+	 * Access to the index of the attribute in terms of its position within the lazy attributes of the persister
 	 *
 	 * @return The persister lazy attribute index
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ClassTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ClassTransformer.java
@@ -23,7 +23,7 @@ public interface ClassTransformer extends javax.persistence.spi.ClassTransformer
 	/**
 	 * Invoked when a class is being loaded or redefined to add hooks for persistence bytecode manipulation.
 	 *
-	 * @param loader the defining class loaderof the class being transformed.  It may be null if using bootstrap loader
+	 * @param loader the defining class loader of the class being transformed.  It may be null if using bootstrap loader
 	 * @param className The name of the class being transformed
 	 * @param classBeingRedefined If an already loaded class is being redefined, then pass this as a parameter
 	 * @param protectionDomain ProtectionDomain of the class being (re)-defined

--- a/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
@@ -9,7 +9,7 @@ package org.hibernate.cache;
 import org.hibernate.cfg.Environment;
 
 /**
- * Indicates a condition where a second-level cache implementation was expected to be to available, but
+ * Indicates a condition where a second-level cache implementation was expected to be available, but
  * none was found on the classpath.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/DomainDataRegionConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/DomainDataRegionConfig.java
@@ -25,7 +25,7 @@ public interface DomainDataRegionConfig {
 	String getRegionName();
 
 	/**
-	 * Retrieve the list of all entity to be stored in this region
+	 * Retrieve the list of all entity data to be stored in this region
 	 */
 	List<EntityDataCachingConfig> getEntityCaching();
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
@@ -37,7 +37,7 @@ final class CacheKeyImplementation implements Serializable {
 	 * @param id The identifier associated with the cached data
 	 * @param type The Hibernate type mapping
 	 * @param entityOrRoleName The entity or collection-role name.
-	 * @param tenantId The tenant identifier associated this data.
+	 * @param tenantId The tenant identifier associated with this data.
 	 * @param factory The session factory for which we are caching
 	 */
 	CacheKeyImplementation(

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CachedDomainDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CachedDomainDataAccess.java
@@ -157,7 +157,7 @@ public interface CachedDomainDataAccess {
 	 * <p/>
 	 * The semantic here is whether the cache contains data visible for the
 	 * current call context.  This should be viewed as a "best effort", meaning
-	 * blocking should be avoid if possible.
+	 * blocking should be avoided if possible.
 	 *
 	 * @param key The cache key
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/EntityDataAccess.java
@@ -62,7 +62,7 @@ public interface EntityDataAccess extends CachedDomainDataAccess {
 	 * @param key The item key
 	 * @param value The item
 	 * @param version The item's version value
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
 	boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version);
@@ -92,7 +92,7 @@ public interface EntityDataAccess extends CachedDomainDataAccess {
 	 * @param value The item
 	 * @param currentVersion The item's current version value
 	 * @param previousVersion The item's previous version value
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
 	boolean update(
@@ -113,7 +113,7 @@ public interface EntityDataAccess extends CachedDomainDataAccess {
 	 * @param currentVersion The item's current version value
 	 * @param previousVersion The item's previous version value
 	 * @param lock The lock previously obtained from {@link #lockItem}
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
 	boolean afterUpdate(

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/NaturalIdDataAccess.java
@@ -19,7 +19,7 @@ import org.hibernate.persister.entity.EntityPersister;
  *     <li><b>LOADS</b> : {@link #putFromLoad}</li>
  * </ul>
  * Note the special case of <b>UPDATES</b> above.  Because the cache key itself has changed here we need to remove the
- * old entry as well as
+ * old entry as well
  * <p/>
  * There is another usage pattern that is used to invalidate entries
  * afterQuery performing "bulk" HQL/SQL operations:
@@ -44,7 +44,7 @@ public interface NaturalIdDataAccess extends CachedDomainDataAccess {
 	 * @param naturalIdValues the sequence of values which unequivocally identifies a cached element on this region
 	 * @param rootEntityDescriptor the persister of the element being cached
 	 *
-	 * @return a key which can be used to identify this an element unequivocally on this same region
+	 * @return a key which can be used to identify an element unequivocally on this same region
 	 */
 	Object generateCacheKey(
 			Object[] naturalIdValues,
@@ -69,7 +69,7 @@ public interface NaturalIdDataAccess extends CachedDomainDataAccess {
 	 * @param key The item key
 	 * @param value The item
 	 *
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 *
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
@@ -84,7 +84,7 @@ public interface NaturalIdDataAccess extends CachedDomainDataAccess {
 	 * @param key The item key
 	 * @param value The item
 	 *
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 *
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
@@ -99,7 +99,7 @@ public interface NaturalIdDataAccess extends CachedDomainDataAccess {
 	 * @param key The item key
 	 * @param value The item
 	 *
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 *
 	 * @throws CacheException Propagated from underlying cache provider
 	 */
@@ -115,7 +115,7 @@ public interface NaturalIdDataAccess extends CachedDomainDataAccess {
 	 * @param value The item
 	 * @param lock The lock previously obtained from {@link #lockItem}
 	 *
-	 * @return Were the contents of the cache actual changed by this operation?
+	 * @return Were the contents of the cache actually changed by this operation?
 	 *
 	 * @throws CacheException Propagated from underlying cache provider
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/CacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/CacheEntry.java
@@ -41,7 +41,7 @@ public interface CacheEntry extends Serializable {
 	 * Get the underlying disassembled state
 	 *
 	 * todo : this was added to support initializing an entity's EntityEntry snapshot during reattach;
-	 * this should be refactored to instead expose a method to assemble a EntityEntry based on this
+	 * this should be refactored to instead expose a method to assemble an EntityEntry based on this
 	 * state for return.
 	 *
 	 * @return The disassembled state

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -232,7 +232,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 		boolean isUnlockable(SoftLock lock);
 
 		/**
-		 * Locks this entry, stamping it with the UUID and lockId given, with the lock timeout occuring at the specified
+		 * Locks this entry, stamping it with the UUID and lockId given, with the lock timeout occurring at the specified
 		 * time.  The returned Lock object can be used to unlock the entry in the future.
 		 */
 		SoftLockImpl lock(long timeout, UUID uuid, long lockId);

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
@@ -157,7 +157,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 	}
 
 	/**
-	 * Set the property be processed.  property can be null
+	 * Set the property to be processed.  property can be null
 	 *
 	 * @param property The property
 	 */
@@ -207,7 +207,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 	 		//  - the property uses some restricted values
 	 		//  - the user has overridden the column
 			// also change getOverriddenJoinColumn and getOverriddenJoinTable as well
-	 		
+
 //			if ( propertyName.contains( ".key." ) ) {
 //				//support for legacy @AttributeOverride declarations
 //				//TODO cache the underlying regexp

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedClassType.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedClassType.java
@@ -14,7 +14,7 @@ package org.hibernate.cfg;
  */
 public enum AnnotatedClassType {
 	/**
-	 * has no revelent top level annotation
+	 * has no relevant top level annotation
 	 */
 	NONE,
 	/**
@@ -22,7 +22,7 @@ public enum AnnotatedClassType {
 	 */
 	ENTITY,
 	/**
-	 * has a @Embeddable annotation
+	 * has an @Embeddable annotation
 	 */
 	EMBEDDABLE,
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1020,7 +1020,7 @@ public final class AnnotationBinder {
 		 * and we create an identifier mapper containing the id properties of the main entity
 		 *
 		 * In JPA 2, there is a shortcut if the id class is the Pk of the associated class pointed to by the id
-		 * it ought to be treated as an embedded and not a real IdClass (at least in the Hibernate's internal way
+		 * it ought to be treated as an embedded and not a real IdClass (at least in the Hibernate's internal way)
 		 */
 		XClass classWithIdClass = inheritanceState.getClassWithIdClass( false );
 		if ( classWithIdClass != null ) {
@@ -3186,7 +3186,7 @@ public final class AnnotationBinder {
 			//try to find a hidden true one to one (FK == PK columns)
 			KeyValue identifier = propertyHolder.getIdentifier();
 			if ( identifier == null ) {
-				//this is a @OneToOne in a @EmbeddedId (the persistentClass.identifier is not set yet, it's being built)
+				//this is a @OneToOne in an @EmbeddedId (the persistentClass.identifier is not set yet, it's being built)
 				//by definition the PK cannot refers to itself so it cannot map to itself
 				mapToPK = false;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -199,7 +199,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 *     * delayed access to the BeanManager reference.  Here, Hibernate
 	 *      will not access the reference passed as the BeanManager during
 	 *      bootstrap until it is first needed.  Note however that this has
-	 *      the effect of delaying any deployement problems until after
+	 *      the effect of delaying any deployment problems until after
 	 *      bootstrapping.
 	 *
 	 * This setting is used to configure Hibernate ORM's access to
@@ -255,7 +255,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String HIBERNATE_CLASSLOADER = "hibernate.classLoader.hibernate";
 
 	/**
-	 * Names the {@link ClassLoader} used when Hibernate is unable to locates classes on the
+	 * Names the {@link ClassLoader} used when Hibernate is unable to locate classes on the
 	 * {@link #APP_CLASSLOADER} or {@link #HIBERNATE_CLASSLOADER}.
 	 * @since 4.0
 	 * @deprecated Use {@link #CLASSLOADERS} instead
@@ -276,7 +276,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 *         <b>enabled</b> - Do the build
 	 *     </li>
 	 *     <li>
-	 *         <b>disabled</b> - Do not so the build
+	 *         <b>disabled</b> - Do not do the build
 	 *     </li>
 	 *     <li>
 	 *         <b>ignoreUnsupported</b> - Do the build, but ignore any non-JPA features that would otherwise
@@ -336,7 +336,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	/**
 	 * Names the connection user.  This might mean one of 2 things in out-of-the-box Hibernate
 	 * {@link org.hibernate.engine.jdbc.connections.spi.ConnectionProvider}: <ul>
-	 *     <li>The username used to pass along to creating the JDBC connection</li>
+	 *     <li>The username used to pass along to create the JDBC connection</li>
 	 *     <li>The username used to obtain a JDBC connection from a data source</li>
 	 * </ul>
 	 */
@@ -1336,7 +1336,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String HBM2DDL_DB_MINOR_VERSION = "javax.persistence.database-minor-version";
 
 	/**
-	 * Specifies whether schema generation commands for schema creation are to be determine based on object/relational
+	 * Specifies whether schema generation commands for schema creation are to be determined based on object/relational
 	 * mapping metadata, DDL scripts, or a combination of the two.  See {@link SourceType} for valid set of values.
 	 * If no value is specified, a default is assumed as follows:<ul>
 	 *     <li>
@@ -1352,7 +1352,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String HBM2DDL_CREATE_SOURCE = "javax.persistence.schema-generation.create-source";
 
 	/**
-	 * Specifies whether schema generation commands for schema dropping are to be determine based on object/relational
+	 * Specifies whether schema generation commands for schema dropping are to be determined based on object/relational
 	 * mapping metadata, DDL scripts, or a combination of the two.  See {@link SourceType} for valid set of values.
 	 * If no value is specified, a default is assumed as follows:<ul>
 	 *     <li>
@@ -1742,7 +1742,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 * handling.  Implicitly Hibernate will not pass the NULL, the intention being to allow
 	 * any default argument values to be applied.
 	 * <p/>
-	 * This defines a global setting, which can them be controlled per parameter via
+	 * This defines a global setting, which can then be controlled per parameter via
 	 * {@link org.hibernate.procedure.ParameterRegistration#enablePassingNulls(boolean)}
 	 * <p/>
 	 * Values are {@code true} (pass the NULLs) or {@code false} (do not pass the NULLs).
@@ -1804,7 +1804,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 * a JPA {@link javax.persistence.EntityManager}).
 	 * <p>
 	 * <p/>
-	 * Values are {@code true} permits the refresh, {@code false} does not permit the detached instance refresh and an {@link IllegalArgumentException} is thrown.
+	 * Values are: {@code true} permits the refresh, {@code false} does not permit the detached instance refresh and an {@link IllegalArgumentException} is thrown.
 	 * <p/>
 	 * The default value is {@code false} when the Session is bootstrapped via JPA {@link javax.persistence.EntityManagerFactory}, otherwise is {@code true}
 	 *
@@ -1971,7 +1971,7 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 * Determine if the scope of {@link javax.persistence.TableGenerator#name()} and {@link javax.persistence.SequenceGenerator#name()} should be
 	 * considered globally or locally defined.
 	 *
-	 * If enabled, the names will considered globally scoped so defining two different generators with the same name
+	 * If enabled, the names will be considered globally scoped so defining two different generators with the same name
 	 * will cause a name collision and an exception will be thrown during the bootstrap phase.
 	 *
 	 * @see JpaCompliance#isGlobalGeneratorScopeEnabled()

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ClassPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ClassPropertyHolder.java
@@ -259,7 +259,7 @@ public class ClassPropertyHolder extends AbstractPropertyHolder {
 
 	/**
 	 * Needed for proper compliance with naming strategy, the property table
-	 * can be overriden if the properties are part of secondary tables
+	 * can be overridden if the properties are part of secondary tables
 	 */
 	private Map<String, Join> getJoinsPerRealTableName() {
 		if ( joinsPerRealTableName == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3JoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Ejb3JoinColumn.java
@@ -49,7 +49,7 @@ import org.hibernate.mapping.Value;
 @SuppressWarnings("unchecked")
 public class Ejb3JoinColumn extends Ejb3Column {
 	/**
-	 * property name repated to this column
+	 * property name related to this column
 	 */
 	private String referencedColumn;
 	private String mappedBy;
@@ -769,7 +769,7 @@ public class Ejb3JoinColumn extends Ejb3Column {
 			// was the column explicitly quoted in the mapping/annotation
 			// TODO: in metamodel, we need to better split global quoting and explicit quoting w/ respect to logical names
 			boolean isLogicalColumnQuoted = StringHelper.isQuoted( getLogicalColumnName() );
-			
+
 			final ObjectNameNormalizer nameNormalizer = getBuildingContext().getObjectNameNormalizer();
 			final String logicalColumnName = nameNormalizer.normalizeIdentifierQuotingAsString( getLogicalColumnName() );
 			final String referencedColumn = nameNormalizer.normalizeIdentifierQuotingAsString( getReferencedColumn() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
@@ -29,7 +29,7 @@ import org.jboss.logging.Logger;
  * Hibernate has two property scopes:
  * <ul>
  * <li><b>Factory-level</b> properties may be passed to the <tt>SessionFactory</tt> when it
- * instantiated. Each instance might have different property values. If no
+ * is instantiated. Each instance might have different property values. If no
  * properties are specified, the factory calls <tt>Environment.getProperties()</tt>.
  * <li><b>System-level</b> properties are shared by all factory instances and are always
  * determined by the <tt>Environment</tt> properties.
@@ -58,7 +58,7 @@ import org.jboss.logging.Logger;
  * <tr>
  *   <td><tt>hibernate.connection.provider_class</tt></td>
  *   <td>classname of <tt>ConnectionProvider</tt>
- *   subclass (if not specified hueristics are used)</td>
+ *   subclass (if not specified heuristics are used)</td>
  * </tr>
  * <tr><td><tt>hibernate.connection.username</tt></td><td>database username</td></tr>
  * <tr><td><tt>hibernate.connection.password</tt></td><td>database password</td></tr>
@@ -83,7 +83,7 @@ import org.jboss.logging.Logger;
  * </tr>
  * <tr>
  *   <td><tt>hibernate.connection.datasource</tt></td>
- *   <td>databasource JNDI name (when using <tt>javax.sql.Datasource</tt>)</td>
+ *   <td>datasource JNDI name (when using <tt>javax.sql.Datasource</tt>)</td>
  * </tr>
  * <tr>
  *   <td><tt>hibernate.jndi.url</tt></td><td>JNDI <tt>InitialContext</tt> URL</td>
@@ -105,7 +105,7 @@ import org.jboss.logging.Logger;
  * </tr>
  * <tr>
  *   <td><tt>hibernate.jdbc.use_scrollable_resultset</tt></td>
- *   <td>enable use of JDBC2 scrollable resultsets (you only need this specify
+ *   <td>enable use of JDBC2 scrollable resultsets (you only need to specify
  *   this property when using user supplied connections)</td>
  * </tr>
  * <tr>
@@ -231,9 +231,9 @@ public final class Environment implements AvailableSettings {
 	}
 
 	/**
-	 * This will be removed soon; currently just returns false as no known JVM exibits this bug
+	 * This will be removed soon; currently just returns false as no known JVM exhibits this bug
 	 * and is also able to run this version of Hibernate ORM.
-	 * @deprecated removed as unneccessary
+	 * @deprecated removed as unnecessary
 	 * @return false
 	 */
 	@Deprecated

--- a/hibernate-core/src/main/java/org/hibernate/cfg/FkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/FkSecondPass.java
@@ -20,7 +20,7 @@ public abstract class FkSecondPass implements SecondPass {
 	 * unique counter is needed to differentiate 2 instances of FKSecondPass
 	 * as they are compared.
 	 * Fairly hacky but IBM VM sometimes returns the same hashCode for 2 different objects
-	 * TODO is it doable to rely on the Ejb3JoinColumn names? Not sure at they could be inferred
+	 * TODO is it doable to rely on the Ejb3JoinColumn names? Not sure as they could be inferred
 	 */
 	private int uniqueCounter;
 	private static AtomicInteger globalCounter = new AtomicInteger();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ImprovedNamingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ImprovedNamingStrategy.java
@@ -33,7 +33,7 @@ public class ImprovedNamingStrategy implements NamingStrategy, Serializable {
 		return addUnderscores( StringHelper.unqualify(className) );
 	}
 	/**
-	 * Return the full property path with underscore seperators, mixed
+	 * Return the full property path with underscore separators, mixed
 	 * case converted to underscores
 	 */
 	public String propertyToColumnName(String propertyName) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/NamingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/NamingStrategy.java
@@ -83,7 +83,7 @@ public interface NamingStrategy {
 	 * Return the logical column name used to refer to a column in the metadata
 	 * (like index, unique constraints etc)
 	 * A full bijection is required between logicalNames and physical ones
-	 * logicalName have to be case insersitively unique for a given table
+	 * logicalName have to be case insensitively unique for a given table
 	 *
 	 * @param columnName given column name if any
 	 * @param propertyName property name of this column

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -86,7 +86,7 @@ public class OneToOneSecondPass implements SecondPass {
 		final String propertyName = inferredData.getPropertyName();
 		value.setPropertyName( propertyName );
 		String referencedEntityName = ToOneBinder.getReferenceEntityName( inferredData, targetEntity, buildingContext );
-		value.setReferencedEntityName( referencedEntityName );  
+		value.setReferencedEntityName( referencedEntityName );
 		AnnotationBinder.defineFetchingStrategy( value, inferredData.getProperty() );
 		//value.setFetchMode( fetchMode );
 		value.setCascadeDeleteEnabled( cascadeOnDelete );
@@ -218,7 +218,7 @@ public class OneToOneSecondPass implements SecondPass {
 				else {
 					propertyHolder.addProperty( prop, inferredData.getDeclaringClass() );
 				}
-				
+
 				value.setReferencedPropertyName( mappedBy );
 
 				// HHH-6813
@@ -234,7 +234,7 @@ public class OneToOneSecondPass implements SecondPass {
 				}
 				boolean referenceToPrimaryKey  = referencesDerivedId || mappedBy == null;
 				value.setReferenceToPrimaryKey( referenceToPrimaryKey );
-				
+
 				// If the other side is a derived ID, prevent an infinite
 				// loop of attempts to resolve identifiers.
 				if ( referencesDerivedId ) {
@@ -263,8 +263,8 @@ public class OneToOneSecondPass implements SecondPass {
 	}
 
 	/**
-	 * Builds the <code>Join</code> instance for the mapped by side of a <i>OneToOne</i> association using 
-	 * a join tables.
+	 * Builds the <code>Join</code> instance for the mapped by side of a <i>OneToOne</i> association using
+	 * a join table.
 	 * <p>
 	 * Note:<br/>
 	 * <ul>

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolder.java
@@ -44,7 +44,7 @@ public interface PropertyHolder {
 	boolean isOrWithinEmbeddedId();
 
 	/**
-	 * Return true if this component is withing an @ElementCollection.
+	 * Return true if this component is within an @ElementCollection.
 	 */
 	boolean isWithinElementCollection();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolderBuilder.java
@@ -17,7 +17,7 @@ import org.hibernate.mapping.Join;
 import org.hibernate.mapping.PersistentClass;
 
 /**
- * This factory is here ot build a PropertyHolder and prevent .mapping interface adding
+ * This factory is here to build a PropertyHolder and prevent .mapping interface adding
  *
  * @author Emmanuel Bernard
  */
@@ -58,7 +58,7 @@ public final class PropertyHolderBuilder {
 	}
 
 	/**
-	 * buid a property holder on top of a collection
+	 * build a property holder on top of a collection
 	 */
 	public static CollectionPropertyHolder buildPropertyHolder(
 			Collection collection,

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyInferredData.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyInferredData.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
 
 /**
- * Retrieve all inferred data from an annnoted element
+ * Retrieve all inferred data from an annotated element
  *
  * @author Emmanuel Bernard
  * @author Paolo Perrotta
@@ -37,7 +37,7 @@ public class PropertyInferredData implements PropertyData {
 	}
 
 	/**
-	 * Take the annoted element for lazy process
+	 * Take the annotated element for lazy process
 	 */
 	public PropertyInferredData(XClass declaringClass, XProperty property, String propertyAccessor, ReflectionManager reflectionManager) {
 		this.declaringClass = declaringClass;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -424,7 +424,7 @@ public class EntityBinder {
 					);
 				}
 			}
-			persistentClass.addFilter(filterName, cond, filter.deduceAliasInjectionPoints(), 
+			persistentClass.addFilter(filterName, cond, filter.deduceAliasInjectionPoints(),
 					toAliasTableMap(filter.aliases()), toAliasEntityMap(filter.aliases()));
 		}
 		LOG.debugf( "Import with entity name %s", name );
@@ -460,7 +460,7 @@ public class EntityBinder {
 				new NamedEntityGraphDefinition( annotation, name, persistentClass.getEntityName() )
 		);
 	}
-	
+
 	public void bindDiscriminatorValue() {
 		if ( StringHelper.isEmpty( discriminatorValue ) ) {
 			Value discriminator = persistentClass.getDiscriminator();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
@@ -454,7 +454,7 @@ public class SimpleValueBinder {
 
 	public void fillSimpleValue() {
 		LOG.debugf( "Starting fillSimpleValue for %s", propertyName );
-                
+
 		if ( attributeConverterDescriptor != null ) {
 			if ( ! BinderHelper.isEmptyAnnotationValue( explicitType ) ) {
 				throw new AnnotationException(
@@ -531,7 +531,7 @@ public class SimpleValueBinder {
 		if ( timeStampVersionType != null ) {
 			simpleValue.setTypeName( timeStampVersionType );
 		}
-		
+
 		if ( simpleValue.getTypeName() != null && simpleValue.getTypeName().length() > 0
 				&& simpleValue.getMetadata().getTypeResolver().basic( simpleValue.getTypeName() ) == null ) {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -2998,7 +2998,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 
 	/**
 	 * Copy a string attribute from an XML element to an annotation descriptor. The name of the annotation attribute is
-	 * explicitely given.
+	 * explicitly given.
 	 *
 	 * @param annotation annotation where to copy to the attribute.
 	 * @param element XML element from where to copy the attribute.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -59,7 +59,7 @@ public class XMLContext implements Serializable {
 
 	/**
 	 * @param doc The xml document to add
-	 * @return Add a xml document to this context and return the list of added class names.
+	 * @return Add an xml document to this context and return the list of added class names.
 	 */
 	@SuppressWarnings( "unchecked" )
 	public List<String> addDocument(Document doc) {
@@ -108,7 +108,7 @@ public class XMLContext implements Serializable {
 		unitElement = root.element( "access" );
 		setAccess( unitElement, entityMappingDefault );
 		defaultElements.add( root );
-		
+
 		setLocalAttributeConverterDefinitions( root.elements( "converter" ) );
 
 		List<Element> entities = root.elements( "entity" );
@@ -190,7 +190,7 @@ public class XMLContext implements Serializable {
 		addedClasses.addAll( localAddedClasses );
 		return localAddedClasses;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private void setLocalAttributeConverterDefinitions(List<Element> converterElements) {
 		for ( Element converterElement : converterElements ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/BeanValidationEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/BeanValidationEventListener.java
@@ -57,7 +57,7 @@ public class BeanValidationEventListener
 	 * Constructor used in an environment where validator factory is injected (JPA2).
 	 *
 	 * @param factory The {@code ValidatorFactory} to use to create {@code Validator} instance(s)
-	 * @param settings Configued properties
+	 * @param settings Configured properties
 	 */
 	public BeanValidationEventListener(ValidatorFactory factory, Map settings, ClassLoaderService classLoaderService) {
 		init( factory, settings, classLoaderService );

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentBag.java
@@ -519,7 +519,7 @@ public class PersistentBag extends AbstractPersistentCollection implements List 
 	 *
 	 * @param o The object to check
 	 *
-	 * @return The number of occurences.
+	 * @return The number of occurrences.
 	 */
 	@SuppressWarnings("UnusedDeclaration")
 	public int occurrences(Object o) {

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
@@ -160,7 +160,7 @@ public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 	/**
 	 * Mainly for subclass usage.  This impl always returns true.
 	 *
-	 * @return Whether or not the the session should be flushed prior transaction completion.
+	 * @return Whether or not the the session should be flushed prior to transaction completion.
 	 */
 	protected boolean isAutoFlushEnabled() {
 		return true;

--- a/hibernate-core/src/main/java/org/hibernate/criterion/AbstractEmptinessExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/AbstractEmptinessExpression.java
@@ -36,7 +36,7 @@ public abstract class AbstractEmptinessExpression implements Criterion {
 	/**
 	 * Should empty rows be excluded?
 	 *
-	 * @return {@code true} Indicates the expression should be 'exists'; {@code false} indicates 'not exists'
+	 * @return {@code true} Indicates the expression should 'exists'; {@code false} indicates 'not exists'
 	 */
 	protected abstract boolean excludeEmpty();
 

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Criterion.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Criterion.java
@@ -13,10 +13,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.TypedValue;
 
 /**
- * An object-oriented representation of a query criterion that may be used 
+ * An object-oriented representation of a query criterion that may be used
  * as a restriction in a <tt>Criteria</tt> query.
- * Built-in criterion types are provided by the <tt>Restrictions</tt> factory 
- * class. This interface might be implemented by application classes that 
+ * Built-in criterion types are provided by the <tt>Restrictions</tt> factory
+ * class. This interface might be implemented by application classes that
  * define custom restriction criteria.
  *
  * @see Restrictions
@@ -29,18 +29,18 @@ public interface Criterion extends Serializable {
 	 * Render the SQL fragment
 	 *
 	 * @param criteria The local criteria
-	 * @param criteriaQuery The overal criteria query
+	 * @param criteriaQuery The overall criteria query
 	 *
 	 * @return The generated SQL fragment
 	 * @throws org.hibernate.HibernateException Problem during rendering.
 	 */
 	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException;
-	
+
 	/**
 	 * Return typed values for all parameters in the rendered SQL fragment
 	 *
 	 * @param criteria The local criteria
-	 * @param criteriaQuery The overal criteria query
+	 * @param criteriaQuery The overall criteria query
 	 *
 	 * @return The types values (for binding)
 	 * @throws HibernateException Problem determining types.

--- a/hibernate-core/src/main/java/org/hibernate/criterion/EnhancedProjection.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/EnhancedProjection.java
@@ -21,7 +21,7 @@ public interface EnhancedProjection extends Projection {
 	 * Get the SQL column aliases used by this projection for the columns it writes for inclusion into the
 	 * <tt>SELECT</tt> clause ({@link #toSqlString}.  Hibernate always uses column aliases to extract data from the
 	 * JDBC {@link java.sql.ResultSet}, so it is important that these be implemented correctly in order for
-	 * Hibernate to be able to extract these val;ues correctly.
+	 * Hibernate to be able to extract these values correctly.
 	 *
 	 * @param position Just as in {@link #toSqlString}, represents the number of <b>columns</b> rendered
 	 * prior to this projection.

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Example.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Example.java
@@ -123,7 +123,7 @@ public class Example implements Criterion {
 	/**
 	 * Set the property selector to use.
 	 *
-	 * The property selector operates separate from excluding a property.
+	 * The property selector operates separately from excluding a property.
 	 *
 	 * @param selector The selector to use
 	 *
@@ -285,11 +285,11 @@ public class Example implements Criterion {
 	}
 
 	protected void addComponentTypedValues(
-			String path, 
-			Object component, 
+			String path,
+			Object component,
 			CompositeType type,
 			List<TypedValue> list,
-			Criteria criteria, 
+			Criteria criteria,
 			CriteriaQuery criteriaQuery) {
 		if ( component != null ) {
 			final String[] propertyNames = type.getPropertyNames();
@@ -418,7 +418,7 @@ public class Example implements Criterion {
 		 * @param propertyName The name of the property
 		 * @param type The type of the property
 		 *
-		 * @return {@code true} indicates the property should be included; {@code false} indiates it should not.
+		 * @return {@code true} indicates the property should be included; {@code false} indicates it should not.
 		 */
 		public boolean include(Object propertyValue, String propertyName, Type type);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Projection.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Projection.java
@@ -81,7 +81,7 @@ public interface Projection extends Serializable {
 	 * Get the SQL column aliases used by this projection for the columns it writes for inclusion into the
 	 * <tt>SELECT</tt> clause ({@link #toSqlString}.  Hibernate always uses column aliases to extract data from the
 	 * JDBC {@link java.sql.ResultSet}, so it is important that these be implemented correctly in order for
-	 * Hibernate to be able to extract these val;ues correctly.
+	 * Hibernate to be able to extract these values correctly.
 	 *
 	 * @param position Just as in {@link #toSqlString}, represents the number of <b>columns</b> rendered
 	 * prior to this projection.

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
@@ -375,7 +375,7 @@ public class Restrictions {
 	}
 
 	/**
-	 * Return the conjuction of two expressions
+	 * Return the conjunction of two expressions
 	 *
 	 * @param lhs One expression
 	 * @param rhs The other expression
@@ -386,7 +386,7 @@ public class Restrictions {
 		return new LogicalExpression(lhs, rhs, "and");
 	}
 	/**
-	 * Return the conjuction of multiple expressions
+	 * Return the conjunction of multiple expressions
 	 *
 	 * @param predicates The predicates making up the initial junction
 	 *
@@ -397,7 +397,7 @@ public class Restrictions {
 	}
 
 	/**
-	 * Return the disjuction of two expressions
+	 * Return the disjunction of two expressions
 	 *
 	 * @param lhs One expression
 	 * @param rhs The other expression
@@ -409,7 +409,7 @@ public class Restrictions {
 	}
 
 	/**
-	 * Return the disjuction of multiple expressions
+	 * Return the disjunction of multiple expressions
 	 *
 	 * @param predicates The predicates making up the initial junction
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Cache71Dialect.java
@@ -49,7 +49,7 @@ import org.hibernate.type.StandardBasicTypes;
 /**
  * Cach&eacute; 2007.1 dialect.
  *
- * This class is required in order to use Hibernate with Intersystems Cach&eacute; SQL.  Compatible with
+ * This class is required in order to use Hibernate with InterSystems Cach&eacute; SQL.  Compatible with
  * Cach&eacute; 2007.1.
  *
  * <h2>PREREQUISITES</h2>

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1111,11 +1111,11 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Apply s limit clause to the query.
+	 * Apply a limit clause to the query.
 	 * <p/>
 	 * Typically dialects utilize {@link #supportsVariableLimit() variable}
 	 * limit clauses when they support limits.  Thus, when building the
-	 * select command we do not actually need to know the limit or the offest
+	 * select command we do not actually need to know the limit or the offset
 	 * since we will just be using placeholders.
 	 * <p/>
 	 * Here we do still pass along whether or not an offset was specified
@@ -1262,7 +1262,7 @@ public abstract class Dialect implements ConversionContext {
 
 	/**
 	 * Get the string to append to SELECT statements to acquire WRITE locks
-	 * for this dialect.  Location of the of the returned string is treated
+	 * for this dialect.  Location of the returned string is treated
 	 * the same as getForUpdateString.
 	 *
 	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
@@ -1290,7 +1290,7 @@ public abstract class Dialect implements ConversionContext {
 
 	/**
 	 * Get the string to append to SELECT statements to acquire READ locks
-	 * for this dialect.  Location of the of the returned string is treated
+	 * for this dialect.  Location of the returned string is treated
 	 * the same as getForUpdateString.
 	 *
 	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
@@ -1303,7 +1303,7 @@ public abstract class Dialect implements ConversionContext {
 	/**
 	 * Get the string to append to SELECT statements to acquire READ locks
 	 * for this dialect given the aliases of the columns to be read locked.
-	 * Location of the of the returned string is treated
+	 * Location of the returned string is treated
 	 * the same as getForUpdateString.
 	 *
 	 * @param aliases The columns to be read locked.
@@ -1418,7 +1418,7 @@ public abstract class Dialect implements ConversionContext {
 
 	/**
 	 * Some dialects support an alternative means to <tt>SELECT FOR UPDATE</tt>,
-	 * whereby a "lock hint" is appends to the table name in the from clause.
+	 * whereby a "lock hint" is appended to the table name in the from clause.
 	 * <p/>
 	 * contributed by <a href="http://sourceforge.net/users/heschulz">Helge Schulz</a>
 	 *
@@ -1433,7 +1433,7 @@ public abstract class Dialect implements ConversionContext {
 	}
 	/**
 	 * Some dialects support an alternative means to <tt>SELECT FOR UPDATE</tt>,
-	 * whereby a "lock hint" is appends to the table name in the from clause.
+	 * whereby a "lock hint" is appended to the table name in the from clause.
 	 * <p/>
 	 * contributed by <a href="http://sourceforge.net/users/heschulz">Helge Schulz</a>
 	 *
@@ -1701,7 +1701,7 @@ public abstract class Dialect implements ConversionContext {
 	 * <p/>
 	 * It is strongly recommended that specific Dialect implementations override this
 	 * method, since interpretation of a SQL error is much more accurate when based on
-	 * the a vendor-specific ErrorCode rather than the SQLState.
+	 * the vendor-specific ErrorCode rather than the SQLState.
 	 * <p/>
 	 * Specific Dialects may override to return whatever is most appropriate for that vendor.
 	 *
@@ -2454,7 +2454,7 @@ public abstract class Dialect implements ConversionContext {
 
 	/**
 	 * Does this dialect require that references to result variables
-	 * (i.e, select expresssion aliases) in an ORDER BY clause be
+	 * (i.e, select expression aliases) in an ORDER BY clause be
 	 * replaced by column positions (1-origin) as defined
 	 * by the select clause?
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Ingres9Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Ingres9Dialect.java
@@ -31,7 +31,7 @@ import org.hibernate.type.StandardBasicTypes;
  * <li>Added support for pooled sequences</li>
  * <li>Added support for SELECT queries with limit and offset</li>
  * <li>Added getIdentitySelectString</li>
- * <li>Modified concatination operator</li>
+ * <li>Modified concatenation operator</li>
  * </ul>
  *
  * @author Enrico Schenk

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -42,7 +42,7 @@ import org.hibernate.type.StandardBasicTypes;
  *         Perform string casts to varchar; removes space padding.
  *     </li>
  * </ul>
- * 
+ *
  * @author Ian Booth
  * @author Bruce Lunsford
  * @author Max Rydahl Andersen

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
@@ -29,8 +29,8 @@ public class MimerSQLDialect extends Dialect {
 	private static final int BINARY_MAX_LENGTH = 2000;
 
 	/**
-	 * Even thoug Mimer SQL supports character and binary columns up to 15 000 in lenght,
-	 * this is also the maximum width of the table (exluding LOBs). To avoid breaking the limit all the
+	 * Even though Mimer SQL supports character and binary columns up to 15 000 in length,
+	 * this is also the maximum width of the table (excluding LOBs). To avoid breaking the limit all the
 	 * time we limit the length of the character columns to CHAR_MAX_LENTH, NATIONAL_CHAR_LENGTH for national
 	 * characters, and BINARY_MAX_LENGTH for binary types.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
@@ -24,7 +24,7 @@ import org.hibernate.sql.JoinFragment;
  */
 public class Oracle10gDialect extends Oracle9iDialect {
 	/**
-	 * Constructs a Oracle10gDialect
+	 * Constructs an Oracle10gDialect
 	 */
 	public Oracle10gDialect() {
 		super();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -120,7 +120,7 @@ public class Oracle8iDialect extends Dialect {
 	private static final int PARAM_LIST_SIZE_LIMIT = 1000;
 
 	/**
-	 * Constructs a Oracle8iDialect
+	 * Constructs an Oracle8iDialect
 	 */
 	public Oracle8iDialect() {
 		super();
@@ -340,7 +340,7 @@ public class Oracle8iDialect extends Dialect {
 	 * implementation...
 	 *
 	 * @param sqlType The {@link java.sql.Types} mapping type code
-	 * @return The appropriate select cluse fragment
+	 * @return The appropriate select clause fragment
 	 */
 	public String getBasicSelectClauseNullString(int sqlType) {
 		return super.getSelectClauseNullString( sqlType );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9Dialect.java
@@ -51,7 +51,7 @@ public class Oracle9Dialect extends Dialect {
 	);
 
 	/**
-	 * Constructs a Oracle9Dialect
+	 * Constructs an Oracle9Dialect
 	 */
 	public Oracle9Dialect() {
 		super();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -160,7 +160,7 @@ public class PostgreSQL81Dialect extends Dialect {
 		registerFunction( "user", new NoArgSQLFunction("user", StandardBasicTypes.STRING, false) );
 		registerFunction( "current_database", new NoArgSQLFunction("current_database", StandardBasicTypes.STRING, true) );
 		registerFunction( "current_schema", new NoArgSQLFunction("current_schema", StandardBasicTypes.STRING, true) );
-		
+
 		registerFunction( "to_char", new StandardSQLFunction("to_char", StandardBasicTypes.STRING) );
 		registerFunction( "to_date", new StandardSQLFunction("to_date", StandardBasicTypes.DATE) );
 		registerFunction( "to_timestamp", new StandardSQLFunction("to_timestamp", StandardBasicTypes.TIMESTAMP) );
@@ -417,7 +417,7 @@ public class PostgreSQL81Dialect extends Dialect {
 
 	/**
 	 * Constraint-name extractor for Postgres constraint violation exceptions.
-	 * Orginally contributed by Denny Bartelt.
+	 * Originally contributed by Denny Bartelt.
 	 */
 	private static final ViolatedConstraintNameExtracter EXTRACTER = new TemplatedViolatedConstraintNameExtracter() {
 		@Override
@@ -439,7 +439,7 @@ public class PostgreSQL81Dialect extends Dialect {
 			}
 		}
 	};
-	
+
 	@Override
 	public SQLExceptionConversionDelegate buildSQLExceptionConversionDelegate() {
 		return new SQLExceptionConversionDelegate() {
@@ -518,7 +518,7 @@ public class PostgreSQL81Dialect extends Dialect {
 					);
 		}
 	}
-	
+
 	// Overridden informational metadata ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
@@ -590,12 +590,12 @@ public class PostgreSQL81Dialect extends Dialect {
 	public boolean supportsRowValueConstructorSyntax() {
 		return true;
 	}
-	
+
 	@Override
 	public String getForUpdateNowaitString() {
 		return getForUpdateString() + " nowait ";
 	}
-	
+
 	@Override
 	public String getForUpdateNowaitString(String aliases) {
 		return getForUpdateString( aliases ) + " nowait ";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
@@ -224,7 +224,7 @@ public class RDMSOS2200Dialect extends Dialect {
 		 * The TIMESTAMP literal format is: YYYY-MM-DD HH:MM:SS[.[FFFFFF]]
 		 *
 		 * Note that $l (dollar-L) will use the length value if provided.
-		 * Also new for Hibernate3 is the $p percision and $s (scale) parameters
+		 * Also new for Hibernate3 is the $p precision and $s (scale) parameters
 		 */
 		registerColumnType( Types.BIT, "SMALLINT" );
 		registerColumnType( Types.TINYINT, "SMALLINT" );
@@ -256,7 +256,7 @@ public class RDMSOS2200Dialect extends Dialect {
 	// Dialect method overrides ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	/**
-	 * RDMS does not support qualifing index names with the schema name.
+	 * RDMS does not support qualifying index names with the schema name.
 	 * <p/>
 	 * {@inheritDoc}
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/ResultColumnReferenceStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/ResultColumnReferenceStrategy.java
@@ -25,7 +25,7 @@ public enum ResultColumnReferenceStrategy {
 	 * approaches.  One is to reference the result column by the alias it is given in the
 	 * result source (if it is given an alias).  This strategy says to use this approach.
 	 * <p/>
-	 * The other QNSI SQL compliant approach is {@link #ORDINAL}.
+	 * The other ANSI SQL compliant approach is {@link #ORDINAL}.
 	 */
 	ALIAS,
 	/**
@@ -33,7 +33,7 @@ public enum ResultColumnReferenceStrategy {
 	 * approaches.  One is to reference the result column by the ordinal position at which
 	 * it appears in the result source.  This strategy says to use this approach.
 	 * <p/>
-	 * The other QNSI SQL compliant approach is {@link #ALIAS}.
+	 * The other ANSI SQL compliant approach is {@link #ALIAS}.
 	 */
 	ORDINAL;
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
@@ -25,7 +25,7 @@ import org.hibernate.type.StandardBasicTypes;
  * @author Jay Nance
  */
 public class TeradataDialect extends Dialect implements IdTableSupport {
-	
+
 	private static final int PARAM_LIST_SIZE_LIMIT = 1024;
 
 	/**
@@ -65,7 +65,7 @@ public class TeradataDialect extends Dialect implements IdTableSupport {
 
 		// bit_length feels a bit broken to me. We have to cast to char in order to
 		// pass when a numeric value is supplied. But of course the answers given will
-		// be wildly different for these two datatypes. 1234.5678 will be 9 bytes as
+		// be wildly different for these two data types. 1234.5678 will be 9 bytes as
 		// a char string but will be 8 or 16 bytes as a true numeric.
 		// Jay Nance 2006-09-22
 		registerFunction(
@@ -144,7 +144,7 @@ public class TeradataDialect extends Dialect implements IdTableSupport {
 	public String getDropIdTableCommand() {
 		return "drop table";
 	}
-	
+
 	@Override
 	public String getTruncateIdTableCommand() {
 		return "delete from";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/AbstractAnsiTrimEmulationFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/AbstractAnsiTrimEmulationFunction.java
@@ -102,7 +102,7 @@ public abstract class AbstractAnsiTrimEmulationFunction implements SQLFunction {
 			}
 
 			final String potentialTrimCharacter = (String) args.get( potentialTrimCharacterArgIndex );
-			if ( "from".equalsIgnoreCase( potentialTrimCharacter ) ) { 
+			if ( "from".equalsIgnoreCase( potentialTrimCharacter ) ) {
 				trimCharacter = "' '";
 				trimSource = (String) args.get( potentialTrimCharacterArgIndex + 1 );
 			}
@@ -152,7 +152,7 @@ public abstract class AbstractAnsiTrimEmulationFunction implements SQLFunction {
 	/**
 	 * Resolve the function definition which should be used to trim both leading and trailing spaces.
 	 * <p/>
-	 * In this form, the imput arguments is missing the <tt>FROM</tt> keyword.
+	 * In this form, the input arguments is missing the <tt>FROM</tt> keyword.
 	 *
 	 * @return The sql function
 	 */
@@ -163,7 +163,7 @@ public abstract class AbstractAnsiTrimEmulationFunction implements SQLFunction {
 	 * <p/>
 	 * The same as {#link resolveBothSpaceTrimFunction} except that here the<tt>FROM</tt> is included and
 	 * will need to be accounted for during {@link SQLFunction#render} processing.
-	 * 
+	 *
 	 * @return The sql function
 	 */
 	protected abstract SQLFunction resolveBothSpaceTrimFromFunction();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/AvgWithArgumentCastFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/AvgWithArgumentCastFunction.java
@@ -9,7 +9,7 @@ package org.hibernate.dialect.function;
 import java.sql.Types;
 
 /**
- * Some databases strictly return the type of the of the aggregation value for <tt>AVG</tt> which is
+ * Some databases strictly return the type of the aggregation value for <tt>AVG</tt> which is
  * problematic in the case of averaging integers because the decimals will be dropped.  The usual workaround
  * is to cast the integer argument as some form of double/decimal.
  *

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ConvertFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ConvertFunction.java
@@ -14,7 +14,7 @@ import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
 
 /**
- * A Cach&eacute; defintion of a convert function.
+ * A Cach&eacute; definition of a convert function.
  *
  * @author Jonathan Levinson
  */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
@@ -40,7 +40,7 @@ public class SelectLockingStrategy extends AbstractSelectLockingStrategy {
 	 * Construct a locking strategy based on SQL SELECT statements.
 	 *
 	 * @param lockable The metadata for the entity to be locked.
-	 * @param lockMode Indictates the type of lock to be acquired.
+	 * @param lockMode Indicates the type of lock to be acquired.
 	 */
 	public SelectLockingStrategy(Lockable lockable, LockMode lockMode) {
 		super( lockable, lockMode );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -49,7 +49,7 @@ public class UpdateLockingStrategy implements LockingStrategy {
 	 * Construct a locking strategy based on SQL UPDATE statements.
 	 *
 	 * @param lockable The metadata for the entity to be locked.
-	 * @param lockMode Indictates the type of lock to be acquired.  Note that
+	 * @param lockMode Indicates the type of lock to be acquired.  Note that
 	 * read-locks are not valid for this strategy.
 	 */
 	public UpdateLockingStrategy(Lockable lockable, LockMode lockMode) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -395,7 +395,7 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 	}
 
 	/**
-	 * Geneartes a list of {@code IgnoreRange} objects that represent nested sections of the
+	 * Generates a list of {@code IgnoreRange} objects that represent nested sections of the
 	 * provided SQL buffer that should be ignored when performing regular expression matches.
 	 *
 	 * @param sql The SQL buffer.

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/ImmutableEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/ImmutableEntityEntry.java
@@ -22,7 +22,7 @@ import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * An EntityEntry implementation for immutable entities.  Note that this implementation is not completely
- * immutable in terms of its internal state; the term immutable here refers to the entity is describes.
+ * immutable in terms of its internal state; the term immutable here refers to the entity it describes.
  *
  * @author Gavin King
  * @author Emmanuel Bernard <emmanuel@hibernate.org>

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/JoinSequence.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/JoinSequence.java
@@ -156,9 +156,9 @@ public class JoinSequence {
 	}
 
 	/**
-	 * Embedds an implied from element into this sequence
+	 * Embeds an implied from element into this sequence
 	 *
-	 * @param fromElement The implied from element to embedd
+	 * @param fromElement The implied from element to embed
 	 * @return The Join memento
 	 */
 	public JoinSequence addJoin(ImpliedFromElement fromElement) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
@@ -25,8 +25,8 @@ import org.hibernate.service.spi.Stoppable;
  * <p/>
  * The {@link DataSource} to use may be specified by either:<ul>
  * <li>injection via {@link #setDataSource}</li>
- * <li>decaring the {@link DataSource} instance using the {@link Environment#DATASOURCE} config property</li>
- * <li>decaring the JNDI name under which the {@link DataSource} can be found via {@link Environment#DATASOURCE} config property</li>
+ * <li>declaring the {@link DataSource} instance using the {@link Environment#DATASOURCE} config property</li>
+ * <li>declaring the JNDI name under which the {@link DataSource} can be found via {@link Environment#DATASOURCE} config property</li>
  * </ul>
  *
  * @author Gavin King

--- a/hibernate-core/src/main/java/org/hibernate/engine/profile/Association.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/profile/Association.java
@@ -18,7 +18,7 @@ public class Association {
 	private final String role;
 
 	/**
-	 * Constructs a association defining what is to be fetched.
+	 * Constructs an association defining what is to be fetched.
 	 *
 	 * @param owner The entity owning the association
 	 * @param associationPath The path of the association, from the entity

--- a/hibernate-core/src/main/java/org/hibernate/engine/profile/Fetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/profile/Fetch.java
@@ -37,7 +37,7 @@ public class Fetch {
 	/**
 	 * The type or style of fetch.  For the moment we limit this to
 	 * join and select, though technically subselect would be valid
-	 * here as as well; however, to support subselect here would
+	 * here as well; however, to support subselect here would
 	 * require major changes to the subselect loading code (which is
 	 * needed for other things as well anyway).
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/HQLQueryPlan.java
@@ -263,7 +263,7 @@ public class HQLQueryPlan implements Serializable {
 
 	/**
 	 * If we're able to guess a likely size of the results we can optimize allocation
-	 * of our datastructures.
+	 * of our data structures.
 	 * Essentially if we detect the user is not using pagination, we attempt to use the FetchSize
 	 * as a reasonable hint. If fetch size is not being set either, it is reasonable to expect
 	 * that we're going to have a single hit. In such a case it would be tempting to return a constant

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/ParameterParser.java
@@ -54,7 +54,7 @@ public class ParameterParser {
 		void jpaPositionalParameter(int identifier, int position);
 
 		/**
-		 * Called when a character that is not a parameter (or part of a parameter dfinition) is recognized.
+		 * Called when a character that is not a parameter (or part of a parameter definition) is recognized.
 		 *
 		 * @param character The recognized character
 		 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -502,7 +502,7 @@ public class ActionQueue {
 	}
 
 	/**
-	 * Performs cleanup of any held cache softlocks.
+	 * Performs cleanup of any held cache soft locks.
 	 *
 	 * @param success Was the transaction successful.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -52,7 +52,7 @@ public class BatchFetchQueue {
 	 * type at a time.
 	 */
 	private Map <String,LinkedHashSet<EntityKey>> batchLoadableEntityKeys;
-	
+
 	/**
 	 * Used to hold information about the collections that are currently eligible for batch-fetching.  Ultimately
 	 * used by {@link #getCollectionBatch} to build collection load batches.
@@ -97,7 +97,7 @@ public class BatchFetchQueue {
 	}
 
 	/**
-	 * Adds a subselect fetch decriptor for the given entity key.
+	 * Adds a subselect fetch descriptor for the given entity key.
 	 *
 	 * @param key The entity for which to register the subselect fetch.
 	 * @param subquery The fetch descriptor.
@@ -146,7 +146,7 @@ public class BatchFetchQueue {
 			keysForEntity.add( key );
 		}
 	}
-	
+
 
 	/**
 	 * After evicting or deleting or loading an entity, we don't
@@ -244,7 +244,7 @@ public class BatchFetchQueue {
 		}
 		return false;
 	}
-	
+
 
 	// collection batch support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -311,7 +311,7 @@ public class BatchFetchQueue {
 			for ( Entry<CollectionEntry, PersistentCollection> me : map.entrySet() ) {
 				final CollectionEntry ce = me.getKey();
 				final PersistentCollection collection = me.getValue();
-				
+
 				if ( ce.getLoadedKey() == null ) {
 					// the loadedKey of the collectionEntry might be null as it might have been reset to null
 					// (see for example Collections.processDereferencedCollection()

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingAction.java
@@ -25,7 +25,7 @@ public interface CascadingAction {
 	/**
 	 * Cascade the action to the child object.
 	 *
-	 * @param session The session within which the cascade is occuring.
+	 * @param session The session within which the cascade is occurring.
 	 * @param child The child to which cascading should be performed.
 	 * @param entityName The child's entity name
 	 * @param anything Anything ;)  Typically some form of cascade-local cache
@@ -44,7 +44,7 @@ public interface CascadingAction {
 	 * Given a collection, get an iterator of the children upon which the
 	 * current cascading action should be visited.
 	 *
-	 * @param session The session within which the cascade is occuring.
+	 * @param session The session within which the cascade is occurring.
 	 * @param collectionType The mapping type of the collection.
 	 * @param collection The collection instance.
 	 * @return The children iterator.
@@ -73,7 +73,7 @@ public interface CascadingAction {
 	 * Called (in the case of {@link #requiresNoCascadeChecking} returning true) to validate
 	 * that no cascade on the given property is considered a valid semantic.
 	 *
-	 * @param session The session witin which the cascade is occurring.
+	 * @param session The session within which the cascade is occurring.
 	 * @param parent The property value owner
 	 * @param persister The entity persister for the owner
 	 * @param propertyType The property type

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
@@ -464,7 +464,7 @@ public class CascadingActions {
 	 * Given a collection, get an iterator of all its children, loading them
 	 * from the database if necessary.
 	 *
-	 * @param session The session within which the cascade is occuring.
+	 * @param session The session within which the cascade is occurring.
 	 * @param collectionType The mapping type of the collection.
 	 * @param collection The collection instance.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExceptionConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExceptionConverter.java
@@ -26,11 +26,11 @@ public interface ExceptionConverter {
 	RuntimeException convertCommitException(RuntimeException e);
 
 	/**
-	 * Converts a Hibernate-specific exception into a JPA-specified exception; note that the JPA sepcification makes use
+	 * Converts a Hibernate-specific exception into a JPA-specified exception; note that the JPA specification makes use
 	 * of exceptions outside its exception hierarchy, though they are all runtime exceptions.
 	 * <p/>
 	 *
-	 * @param e The Hibernate excepton.
+	 * @param e The Hibernate exception.
 	 * @param lockOptions The lock options in effect at the time of exception (can be null)
 	 *
 	 * @return The JPA-specified exception
@@ -38,11 +38,11 @@ public interface ExceptionConverter {
 	RuntimeException convert(HibernateException e, LockOptions lockOptions);
 
 	/**
-	 * Converts a Hibernate-specific exception into a JPA-specified exception; note that the JPA sepcification makes use
+	 * Converts a Hibernate-specific exception into a JPA-specified exception; note that the JPA specification makes use
 	 * of exceptions outside its exception hierarchy, though they are all runtime exceptions.
 	 * <p/>
 	 *
-	 * @param e The Hibernate excepton.
+	 * @param e The Hibernate exception.
 	 *
 	 * @return The JPA-specified exception
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/NamedQueryDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/NamedQueryDefinition.java
@@ -14,7 +14,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.LockOptions;
 
 /**
- * Definition of a named query, defined in the mapping metadata.  Additional, as of JPA 2.1, named query definition
+ * Definition of a named query, defined in the mapping metadata.  Additionally, as of JPA 2.1, named query definition
  * can also come from a compiled query.
  *
  * @author Gavin King

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/NamedSQLQueryDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/NamedSQLQueryDefinition.java
@@ -15,7 +15,7 @@ import org.hibernate.engine.query.spi.sql.NativeSQLQueryReturn;
 
 /**
  * Definition of a named native SQL query, defined in the mapping metadata.
- * 
+ *
  * @author Max Andersen
  * @author Steve Ebersole
  */
@@ -27,7 +27,7 @@ public class NamedSQLQueryDefinition extends NamedQueryDefinition {
 	private String resultSetRef;
 
 	/**
-	 * This form was initially used to construct a NamedSQLQueryDefinition from the binder code when a the
+	 * This form was initially used to construct a NamedSQLQueryDefinition from the binder code when the
 	 * result-set mapping information is not explicitly  provided in the query definition
 	 * (i.e., no resultset-mapping used).
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -71,7 +71,7 @@ public interface PersistenceContext {
 
 	/**
 	 * Take ownership of a previously unowned collection, if one.  This method returns {@code null} if no such
-	 * collection was previous added () or was previously removed.
+	 * collection was previously added () or was previously removed.
 	 * <p/>
 	 * This should indicate the owner is being loaded and we are ready to "link" them.
 	 *
@@ -87,7 +87,7 @@ public interface PersistenceContext {
 	 * @return The batch fetch queue in effect for this persistence context
 	 */
 	BatchFetchQueue getBatchFetchQueue();
-	
+
 	/**
 	 * Clear the state of the persistence context
 	 */
@@ -128,9 +128,9 @@ public interface PersistenceContext {
 	/**
 	 * Retrieve the cached database snapshot for the requested entity key.
 	 * <p/>
-	 * This differs from {@link #getDatabaseSnapshot} is two important respects:<ol>
+	 * This differs from {@link #getDatabaseSnapshot} in two important respects:<ol>
 	 * <li>no snapshot is obtained from the database if not already cached</li>
-	 * <li>an entry of {@link #NO_ROW} here is interpretet as an exception</li>
+	 * <li>an entry of {@link #NO_ROW} here is interpreted as an exception</li>
 	 * </ol>
 	 * @param key The entity key for which to retrieve the cached snapshot
 	 * @return The cached snapshot
@@ -269,7 +269,7 @@ public interface PersistenceContext {
 	 * Is the given collection associated with this persistence context?
 	 */
 	boolean containsCollection(PersistentCollection collection);
-	
+
 	/**
 	 * Is the given proxy associated with this persistence context?
 	 */
@@ -438,7 +438,7 @@ public interface PersistenceContext {
 	 * array, since the array instance is not created until endLoad().
 	 */
 	void addCollectionHolder(PersistentCollection holder);
-	
+
 	/**
 	 * Remove the mapping of collection to holder during eviction
 	 * of the owning entity
@@ -539,7 +539,7 @@ public interface PersistenceContext {
 	 * How deep are we cascaded?
 	 */
 	int getCascadeLevel();
-	
+
 	/**
 	 * Called before cascading
 	 */
@@ -555,14 +555,14 @@ public interface PersistenceContext {
 	 */
 	@SuppressWarnings( {"UnusedDeclaration"})
 	boolean isFlushing();
-	
+
 	/**
-	 * Called before and after the flushcycle
+	 * Called before and after the flush cycle
 	 */
 	void setFlushing(boolean flushing);
 
 	/**
-	 * Call this before begining a two-phase load
+	 * Call this before beginning a two-phase load
 	 */
 	void beforeLoad();
 
@@ -570,7 +570,7 @@ public interface PersistenceContext {
 	 * Call this after finishing a two-phase load
 	 */
 	void afterLoad();
-	
+
 	/**
 	 * Is in a two-phase load?
 	 */
@@ -744,7 +744,7 @@ public interface PersistenceContext {
 	 * Checks if a certain {@link EntityKey} was registered as nullifiable on this {@link PersistenceContext}.
 	 *
 	 * @param sek a supplier for the EntityKey; this allows to not always needing to create the key;
-	 * for example is the map is known to be empty there is no need to create one to check.
+	 * for example if the map is known to be empty there is no need to create one to check.
 	 * @return true if the EntityKey had been registered before using {@link #registerNullifiableEntityKey(EntityKey)}
 	 * @see #registerNullifiableEntityKey(EntityKey)
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -108,7 +108,7 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	/**
-	 * Returns the underlying delegate. Be careful that is has a different behavior from the {@link #getDelegate()}
+	 * Returns the underlying delegate. Be careful that it has a different behavior from the {@link #getDelegate()}
 	 * method coming from the EntityManager interface which returns the current session.
 	 *
 	 * @see SessionDelegatorBaseImpl#getDelegate()

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -108,7 +108,7 @@ public interface SessionFactoryImplementor extends Mapping, SessionFactory, Quer
 	Interceptor getInterceptor();
 
 	/**
-	 * Access to the cachres of HQL/JPQL and native query plans.
+	 * Access to the caches of HQL/JPQL and native query plans.
 	 *
 	 * @return The query plan cache
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -122,7 +122,7 @@ public interface SharedSessionContractImplementor
 	/**
 	 * Checks whether the session is closed.  Provided separately from
 	 * {@link #isOpen()} as this method does not attempt any JTA synchronization
-	 * registration, where as {@link #isOpen()} does; which makes this one
+	 * registration, whereas {@link #isOpen()} does; which makes this one
 	 * nicer to use for most internal purposes.
 	 *
 	 * @return {@code true} if the session is closed; {@code false} otherwise.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/UnsavedValueStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/UnsavedValueStrategy.java
@@ -17,7 +17,7 @@ public interface UnsavedValueStrategy {
 	 *
 	 * @param test The value to be tested
 	 *
-	 * @return {@code true} indicates the value corresponds to unsaved data (aka, transient state; {@code false}
+	 * @return {@code true} indicates the value corresponds to unsaved data (aka, transient state); {@code false}
 	 * indicates the value does not corresponds to unsaved data (aka, detached state); {@code null} indicates that
 	 * this strategy was not able to determine conclusively.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionObserver.java
@@ -15,7 +15,7 @@ public interface TransactionObserver {
 	/**
 	 * Callback for processing the beginning of a transaction.
 	 * <p/>
-	 * Do not rely on this being called as the transaction mat be started in a manner other than through the
+	 * Do not rely on this being called as the transaction may be started in a manner other than through the
 	 * {@link org.hibernate.Transaction} API.
 	 */
 	public void afterBegin();

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -414,7 +414,7 @@ public abstract class AbstractSaveEventListener
 	/**
 	 * Handles the calls needed to perform pre-save cascades for the given entity.
 	 *
-	 * @param source The session from whcih the save event originated.
+	 * @param source The session from which the save event originated.
 	 * @param persister The entity's persister instance.
 	 * @param entity The entity to be saved.
 	 * @param anything Generally cascade-specific data
@@ -448,7 +448,7 @@ public abstract class AbstractSaveEventListener
 	 *
 	 * @param source The session from which the event originated.
 	 * @param persister The entity's persister instance.
-	 * @param entity The entity beng saved.
+	 * @param entity The entity being saved.
 	 * @param anything Generally cascade-specific data
 	 */
 	protected void cascadeAfterSave(

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -91,7 +91,7 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 	/**
 	 * Try to initialize a collection from the cache
 	 *
-	 * @param id The id of the collection of initialize
+	 * @param id The id of the collection to initialize
 	 * @param persister The collection persister
 	 * @param collection The collection to initialize
 	 * @param source The originating session

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
@@ -22,7 +22,7 @@ import org.hibernate.pretty.MessageHelper;
 /**
  * An {@link org.hibernate.event.spi.EntityCopyObserver} implementation that allows multiple representations of
  * the same persistent entity to be merged and provides logging of the entity copies that
- * that are detected.
+ * are detected.
  *
  * @author Gail Badner
  */

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
@@ -46,7 +46,7 @@ import org.jboss.logging.Logger;
  * <ul>
  *     <li>Methods that return collections (e.g., {@link #keySet()},
  *          {@link #values()}, {@link #entrySet()}) return an
- *          unnmodifiable view of the collection;</li>
+ *          unmodifiable view of the collection;</li>
  *     <li>If {@link #put(Object mergeEntity, Object) managedEntity} or
  *         {@link #put(Object mergeEntity, Object managedEntity, boolean isOperatedOn)}
  *         is executed and this MergeMap already contains a cross-reference for

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractPreDatabaseOperationEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractPreDatabaseOperationEvent.java
@@ -28,8 +28,8 @@ public abstract class AbstractPreDatabaseOperationEvent
 	 * Constructs an event containing the pertinent information.
 	 *
 	 * @param source The session from which the event originated.
-	 * @param entity The entity to be invloved in the database operation.
-	 * @param id The entity id to be invloved in the database operation.
+	 * @param entity The entity to be involved in the database operation.
+	 * @param id The entity id to be involved in the database operation.
 	 * @param persister The entity's persister.
 	 */
 	public AbstractPreDatabaseOperationEvent(

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/DeleteEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/DeleteEvent.java
@@ -55,7 +55,7 @@ public class DeleteEvent extends AbstractEvent {
 	}
 
 	/**
-     * Returns the encapsulated entity to be deleed.
+     * Returns the encapsulated entity to be deleted.
      *
      * @return The entity to be deleted.
      */
@@ -66,11 +66,11 @@ public class DeleteEvent extends AbstractEvent {
 	public String getEntityName() {
 		return entityName;
 	}
-	
+
 	public boolean isCascadeDeleteEnabled() {
 		return cascadeDeleteEnabled;
 	}
-	
+
 	public boolean isOrphanRemovalBeforeUpdates() {
 		return orphanRemovalBeforeUpdates;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostInsertEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostInsertEventListener.java
@@ -9,8 +9,8 @@ package org.hibernate.event.spi;
 import java.io.Serializable;
 
 /**
- * Called after insterting an item in the datastore
- * 
+ * Called after inserting an item in the datastore
+ *
  * @author Gavin King
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PreDeleteEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PreDeleteEvent.java
@@ -46,7 +46,7 @@ public class PreDeleteEvent
 
 	/**
 	 * Getter for property 'deletedState'.  This is the entity state at the
-	 * time of deletion (useful for optomistic locking and such).
+	 * time of deletion (useful for optimistic locking and such).
 	 *
 	 * @return Value for property 'deletedState'.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraphNode.java
@@ -32,7 +32,7 @@ public abstract class AbstractGraphNode<J> implements GraphNodeImplementor<J> {
 
 	protected void verifyMutability() {
 		if ( !isMutable() ) {
-			throw new IllegalStateException( "Cannot mutable immutable graph node" );
+			throw new IllegalStateException( "Cannot mutate immutable graph node" );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/package-info.java
@@ -8,7 +8,7 @@
 /**
  * Hibernate's (extended) support for JPA's entity graphs
  *
- * @apiNote This entire package (including sub-ppackages) is considered incubating
+ * @apiNote This entire package (including sub-packages) is considered incubating
  */
 @Incubating
 package org.hibernate.graph;

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlToken.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlToken.java
@@ -8,7 +8,7 @@ package org.hibernate.hql.internal.ast;
 
 /**
  * A custom token class for the HQL grammar.
- * <p><i>NOTE:<i> This class must be public becuase it is instantiated by the ANTLR library.  Ignore any suggestions
+ * <p><i>NOTE:<i> This class must be public because it is instantiated by the ANTLR library.  Ignore any suggestions
  * by various code 'analyzers' about this class being package local.</p>
  */
 public class HqlToken extends antlr.CommonToken {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/ParameterTranslationsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/ParameterTranslationsImpl.java
@@ -32,7 +32,7 @@ public class ParameterTranslationsImpl implements ParameterTranslations {
 	 * specifications.
 	 * </p>
 	 * Note: the order in the incoming list denotes the parameter's
-	 * psudeo-position within the resulting sql statement.
+	 * pseudo-position within the resulting sql statement.
 	 *
 	 * @param parameterSpecifications The parameter specifications
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/QueryTranslatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/QueryTranslatorImpl.java
@@ -93,7 +93,7 @@ public class QueryTranslatorImpl implements FilterTranslator {
 
 	private ParameterTranslations paramTranslations;
 	private List<ParameterSpecification> collectedParameterSpecifications;
-	
+
 	private EntityGraphQueryHint entityGraphQueryHint;
 
 
@@ -117,7 +117,7 @@ public class QueryTranslatorImpl implements FilterTranslator {
 		this.enabledFilters = enabledFilters;
 		this.factory = factory;
 	}
-	
+
 	public QueryTranslatorImpl(
 			String queryIdentifier,
 			String query,

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
@@ -109,7 +109,7 @@ public class DotNode extends FromReferenceNode implements DisplayableNode, Selec
 	private boolean fetch;
 
 	/**
-	 * The type of dereference that hapened
+	 * The type of dereference that happened
 	 */
 	private DereferenceType dereferenceType = DereferenceType.UNKNOWN;
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/FromElementType.java
@@ -548,7 +548,7 @@ class FromElementType {
 
 		// indexed, many-to-many collections must be treated specially here if the property to
 		// be mapped touches on the index as we must adjust the alias to use the alias from
-		// the association table (which i different than the one passed in
+		// the association table (which i different than the one passed in)
 		if ( queryableCollection.isManyToMany()
 				&& queryableCollection.hasIndex()
 				&& SPECIAL_MANY2MANY_TREATMENT_FUNCTION_NAMES.contains( propertyName ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ImpliedFromElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/ImpliedFromElement.java
@@ -14,7 +14,7 @@ package org.hibernate.hql.internal.ast.tree;
 public class ImpliedFromElement extends FromElement {
 	/**
 	 * True if this from element was implied from a path in the FROM clause, but not
-	 * explicitly declard in the from clause.
+	 * explicitly declared in the from clause.
 	 */
 	private boolean impliedInFromClause;
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/SelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/SelectClause.java
@@ -46,7 +46,7 @@ public class SelectClause extends SelectExpressionList {
 	/**
 	 * Does this SelectClause represent a scalar query
 	 *
-	 * @return True if this is a scalara select clause; false otherwise.
+	 * @return True if this is a scalar select clause; false otherwise.
 	 */
 	public boolean isScalarSelect() {
 		return scalarSelect;
@@ -110,7 +110,7 @@ public class SelectClause extends SelectExpressionList {
 	 *
 	 * @param fromClause The from clause linked to this select clause.
 	 *
-	 * @throws SemanticException indicates a semntic issue with the explicit select clause.
+	 * @throws SemanticException indicates a semantic issue with the explicit select clause.
 	 */
 	public void initializeExplicitSelectClause(FromClause fromClause) throws SemanticException {
 		if ( prepared ) {

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/UnaryOperatorNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/UnaryOperatorNode.java
@@ -14,8 +14,8 @@ package org.hibernate.hql.internal.ast.tree;
  */
 public interface UnaryOperatorNode extends OperatorNode {
 	/**
-	 * Retrievs the node representing the operator's single operand.
-	 * 
+	 * Retrieves the node representing the operator's single operand.
+	 *
 	 * @return The operator's single operand.
 	 */
 	public Node getOperand();

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/ASTUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/ASTUtil.java
@@ -89,7 +89,7 @@ public final class ASTUtil {
 
 	/**
 	 * Creates a 'binary operator' subtree, given the information about the
-	 * parent and the two child nodex.
+	 * parent and the two child nodes.
 	 *
 	 * @param factory The AST factory.
 	 * @param parentType The type of the parent node.
@@ -143,7 +143,7 @@ public final class ASTUtil {
 	 * Determine if a given node (test) is contained anywhere in the subtree
 	 * of another given node (fixture).
 	 *
-	 * @param fixture The node against which to testto be checked for children.
+	 * @param fixture The node against which to test to be checked for children.
 	 * @param test The node to be tested as being a subtree child of the parent.
 	 *
 	 * @return True if child is contained in the parent's collection of children.

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/FromParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/FromParser.java
@@ -315,7 +315,7 @@ public class FromParser implements Parser {
 
 	public void end(QueryTranslatorImpl q) {
 		if ( afterMemberDeclarations ) {
-			//The exception throwned by the AST query translator contains the error token location, respensent by line and colum, 
+			//The exception throwned by the AST query translator contains the error token location, represented by line and column,
 			//but it hard to get that info here.
 			throw new QueryException( "alias not specified for IN" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/classic/QueryTranslatorImpl.java
@@ -179,7 +179,7 @@ public class QueryTranslatorImpl extends BasicLoader implements FilterTranslator
 	 *
 	 * @throws org.hibernate.MappingException Indicates problems resolving
 	 * things referenced in the query.
-	 * @throws org.hibernate.QueryException Generally some form of syntatic
+	 * @throws org.hibernate.QueryException Generally some form of syntactic
 	 * failure.
 	 */
 	void compile(QueryTranslatorImpl superquery) throws QueryException, MappingException {
@@ -231,7 +231,7 @@ public class QueryTranslatorImpl extends BasicLoader implements FilterTranslator
 	 *
 	 * @throws org.hibernate.MappingException Indicates problems resolving
 	 * things referenced in the query.
-	 * @throws org.hibernate.QueryException Generally some form of syntatic
+	 * @throws org.hibernate.QueryException Generally some form of syntactic
 	 * failure.
 	 */
 	private void compile() throws QueryException, MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
@@ -46,7 +46,7 @@ public final class IdentifierGeneratorHelper {
 
 	/**
 	 * Marker object returned from {@link IdentifierGenerator#generate} to indicate that the entity's identifier will
-	 * be generated as part of the datbase insertion.
+	 * be generated as part of the database insertion.
 	 */
 	public static final Serializable POST_INSERT_INDICATOR = new Serializable() {
 		@Override
@@ -80,7 +80,7 @@ public final class IdentifierGeneratorHelper {
 	}
 
 	/**
-	 * Extract the value from the result set (which is assumed to already have been positioned to the apopriate row)
+	 * Extract the value from the result set (which is assumed to already have been positioned to the appropriate row)
 	 * and wrp it in the appropriate Java numeric type.
 	 *
 	 * @param rs The result set from which to extract the value.

--- a/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
@@ -47,7 +47,7 @@ import org.hibernate.type.Type;
 
 /**
  * A hilo <tt>IdentifierGenerator</tt> that returns a <tt>Long</tt>, constructed using
- * a hi/lo algorithm. The hi value MUST be fetched in a seperate transaction
+ * a hi/lo algorithm. The hi value MUST be fetched in a separate transaction
  * to the <tt>Session</tt> transaction so the generator must be able to obtain
  * a new connection and commit it. Hence this implementation may not
  * be used  when the user is supplying connections. In this

--- a/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
@@ -53,7 +53,7 @@ public interface PersistentIdentifierGenerator extends IdentifierGenerator, Expo
 	String CATALOG = "catalog";
 
 	/**
-	 * The key under whcih to find the {@link org.hibernate.boot.model.naming.ObjectNameNormalizer} in the config param map.
+	 * The key under which to find the {@link org.hibernate.boot.model.naming.ObjectNameNormalizer} in the config param map.
 	 */
 	String IDENTIFIER_NORMALIZER = "identifier_normalizer";
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/InitialValueAwareOptimizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/InitialValueAwareOptimizer.java
@@ -7,7 +7,7 @@
 package org.hibernate.id.enhanced;
 
 /**
- * Marker interface for optimizer which wish to know the user-specified initial value.
+ * Marker interface for optimizer which wishes to know the user-specified initial value.
  * <p/>
  * Used instead of constructor injection since that is already a public understanding and
  * because not all optimizers care.

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -284,7 +284,7 @@ public class TableGenerator implements PersistentIdentifierGenerator, Configurab
 	}
 
 	/**
-	 * The value in {@link #getSegmentColumnName segment column} which
+	 * The value in {@link #getSegmentColumnName segment column}
 	 * corresponding to this generator instance.  In other words this value
 	 * indicates the row in which this generator instance will store values.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/IdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/IdentifierGeneratorFactory.java
@@ -40,7 +40,7 @@ public interface IdentifierGeneratorFactory {
 	 *
 	 * @param strategy The generation strategy.
 	 * @param type The mapping type for the identifier values.
-	 * @param config Any configuraion properties given in the generator mapping.
+	 * @param config Any configuration properties given in the generator mapping.
 	 *
 	 * @return The appropriate generator instance.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/IdentifierGeneratingInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/IdentifierGeneratingInsert.java
@@ -11,7 +11,7 @@ import org.hibernate.sql.Insert;
 /**
  * Nothing more than a distinguishing subclass of Insert used to indicate
  * intent.  Some subclasses of this also provided some additional
- * functionality or semantic to the genernated SQL statement string.
+ * functionality or semantic to the generated SQL statement string.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -193,7 +193,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			this.transactionCoordinator = sharedOptions.getTransactionCoordinator();
 			this.jdbcCoordinator = sharedOptions.getJdbcCoordinator();
 
-			// todo : "wrap" the transaction to no-op cmmit/rollback attempts?
+			// todo : "wrap" the transaction to no-op comit/rollback attempts?
 			this.currentHibernateTransaction = sharedOptions.getTransaction();
 
 			if ( sharedOptions.shouldAutoJoinTransactions() ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/BytesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/BytesHelper.java
@@ -71,17 +71,16 @@ public final class BytesHelper {
 		fromLong(longValue, bytes, 0);
 		return bytes;
 	}
-	
+
 	/**
 	 * Interpret a long as its binary form
 	 *
 	 * @param longValue The long to interpret to binary
 	 * @param dest the destination array.
      * @param destPos starting position in the destination array.
-	 * @return The binary
 	 */
 	public static void fromLong(long longValue, byte[] dest, int destPos) {
-		
+
 		dest[destPos] = (byte) ( longValue >> 56 );
 		dest[destPos + 1] = (byte) ( ( longValue << 8 ) >> 56 );
 		dest[destPos + 2] = (byte) ( ( longValue << 16 ) >> 56 );
@@ -102,7 +101,7 @@ public final class BytesHelper {
 	public static long asLong(byte[] bytes) {
 		return asLong(bytes, 0);
 	}
-	
+
 	/**
 	 * Interpret the binary representation of a long.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
@@ -16,7 +16,7 @@ import java.security.PrivilegedAction;
 import org.hibernate.HibernateException;
 
 /**
- * An object that is shallow-coneable
+ * An object that is shallow-cloneable
  *
  * @author Steve Ebersole
  */
@@ -87,7 +87,7 @@ public class Cloneable {
 		}
 		finally {
 			if ( beanInfo != null ) {
-				// release the jdk internal caches everytime to ensure this
+				// release the jdk internal caches every time to ensure this
 				// plays nicely with destroyable class-loaders
 				Introspector.flushFromCaches( getClass() );
 			}
@@ -107,7 +107,7 @@ public class Cloneable {
 		}
 		finally {
 			if ( beanInfo != null ) {
-				// release the jdk internal caches everytime to ensure this
+				// release the jdk internal caches every time to ensure this
 				// plays nicely with destroyable class-loaders
 				Introspector.flushFromCaches( getClass() );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ConfigHelper.java
@@ -30,7 +30,7 @@ public final class ConfigHelper {
 	/**
 	 * Try to locate a local URL representing the incoming path.  The first attempt
 	 * assumes that the incoming path is an actual URL string (file://, etc).  If this
-	 * does not work, then the next attempts try to locate this UURL as a java system
+	 * does not work, then the next attempts try to locate this URL as a java system
 	 * resource.
 	 *
 	 * @param path The path representing the config location.

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -191,7 +191,7 @@ public final class ReflectHelper {
 	 * Is this member publicly accessible.
 	 *
 	 * @param clazz The class which defines the member
-	 * @param member The memeber.
+	 * @param member The member.
 	 * @return True if the member is publicly accessible, false otherwise.
 	 */
 	public static boolean isPublic(Class clazz, Member member) {
@@ -299,7 +299,7 @@ public final class ReflectHelper {
 	 * Determine is the given class is declared final.
 	 *
 	 * @param clazz The class to check.
-	 * @return True if the class is final, flase otherwise.
+	 * @return True if the class is final, false otherwise.
 	 */
 	public static boolean isFinalClass(Class clazz) {
 		return Modifier.isFinal( clazz.getModifiers() );

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -548,7 +548,7 @@ public final class StringHelper {
 
 	/**
 	 * Generates a root alias by truncating the "root name" defined by
-	 * the incoming decription and removing/modifying any non-valid
+	 * the incoming description and removing/modifying any non-valid
 	 * alias characters.
 	 *
 	 * @param description The root name from which to generate a root alias.

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/Stack.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/Stack.java
@@ -48,7 +48,7 @@ public interface Stack<T> {
 	boolean isEmpty();
 
 	/**
-	 * Remmove all elements from the stack
+	 * Remove all elements from the stack
 	 */
 	void clear();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -262,7 +262,7 @@ public final class ConfigurationHelper {
 	 * replace a property by a starred version
 	 *
 	 * @param props properties to check
-	 * @param key proeprty to mask
+	 * @param key property to mask
 	 *
 	 * @return cloned and masked properties
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/xml/Origin.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/xml/Origin.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
  */
 public interface Origin extends Serializable {
 	/**
-	 * Retrieve the type of origin.  This is not a discrete set, but might be somethign like
+	 * Retrieve the type of origin.  This is not a discrete set, but might be something like
 	 * {@code file} for file protocol URLs, or {@code resource} for classpath resource lookups.
 	 *
 	 * @return The origin type.

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/xml/XMLHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/xml/XMLHelper.java
@@ -14,7 +14,7 @@ import org.dom4j.io.SAXReader;
 import org.xml.sax.EntityResolver;
 
 /**
- * Small helper class that lazy loads DOM and SAX reader and keep them for fast use afterwards.
+ * Small helper class that lazily loads DOM and SAX reader and keep them for fast use afterwards.
  *
  * @deprecated Currently only used for integration with HCANN.  The rest of Hibernate uses StAX now
  * for XML processing.  See {@link org.hibernate.boot.jaxb.internal.stax}

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/BatchedTooManyRowsAffectedException.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/BatchedTooManyRowsAffectedException.java
@@ -9,8 +9,8 @@ package org.hibernate.jdbc;
 
 /**
  * Much like {@link TooManyRowsAffectedException}, indicates that more
- * rows than what we were expcecting were affected.  Additionally, this form
- * occurs from a batch and carries along the batch positon that failed.
+ * rows than what we were expecting were affected.  Additionally, this form
+ * occurs from a batch and carries along the batch position that failed.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/WorkExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/WorkExecutor.java
@@ -28,8 +28,8 @@ public class WorkExecutor<T> {
 	 * @param work The @link ReturningWork} instance encapsulating the discrete work
 	 * @param connection The connection on which to perform the work.
 	 *
-	 * @return null>.
-	 * 
+	 * @return null.
+	 *
 	 * @throws SQLException Thrown during execution of the underlying JDBC interaction.
 	 * @throws org.hibernate.HibernateException Generally indicates a wrapped SQLException.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/jpa/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/AvailableSettings.java
@@ -236,7 +236,7 @@ public interface AvailableSettings {
 	 *         <b>enabled</b> - Do the build
 	 *     </li>
 	 *     <li>
-	 *         <b>disabled</b> - Do not so the build
+	 *         <b>disabled</b> - Do not do the build
 	 *     </li>
 	 *     <li>
 	 *         <b>ignoreUnsupported</b> - Do the build, but ignore any non-JPA features that would otherwise

--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernateEntityManager.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernateEntityManager.java
@@ -17,7 +17,7 @@ import org.hibernate.query.QueryProducer;
  *
  * @author Gavin King
  *
- * @deprecated (snce 5.2) Use Session (or SessionImplementor), as it now extends EntityManager directly
+ * @deprecated (since 5.2) Use Session (or SessionImplementor), as it now extends EntityManager directly
  */
 @Deprecated
 public interface HibernateEntityManager extends EntityManager, QueryProducer {

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/XmlHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/XmlHelper.java
@@ -29,7 +29,7 @@ public final class XmlHelper {
 	 *
 	 * @param element The parent element
 	 * @param tagName The name of the desired child
-	 * @return An interator of children or null if element is null.
+	 * @return An iterator of children or null if element is null.
 	 */
 	public static Iterator getChildrenByTagName(
 			Element element,

--- a/hibernate-core/src/main/java/org/hibernate/loader/CollectionAliases.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/CollectionAliases.java
@@ -22,7 +22,7 @@ public interface CollectionAliases {
 	public String[] getSuffixedKeyAliases();
 
 	/**
-	 * Returns the suffixed result-set column-aliases for the collumns
+	 * Returns the suffixed result-set column-aliases for the columns
 	 * making up the collection's index (map or list).
 	 *
 	 * @return The index result-set column aliases.

--- a/hibernate-core/src/main/java/org/hibernate/loader/GeneratedCollectionAliases.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/GeneratedCollectionAliases.java
@@ -66,7 +66,7 @@ public class GeneratedCollectionAliases implements CollectionAliases {
 	}
 
 	/**
-	 * Returns the suffixed result-set column-aliases for the collumns making up the collection's index (map or list).
+	 * Returns the suffixed result-set column-aliases for the columns making up the collection's index (map or list).
 	 *
 	 * @return The index result-set column aliases.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/JoinWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/JoinWalker.java
@@ -570,7 +570,7 @@ public class JoinWalker {
 	 * @param componentType The component type to be walked.
 	 * @param propertyNumber The property number for the component property (relative to
 	 * persister).
-	 * @param begin todo unknowm
+	 * @param begin todo unknown
 	 * @param persister The owner of the component property
 	 * @param alias The root alias
 	 * @param path The property access path
@@ -661,7 +661,7 @@ public class JoinWalker {
 			if ( types[i].isAssociationType() ) {
 				AssociationType associationType = (AssociationType) types[i];
 
-				// simple, because we can't have a one-to-one or a collection 
+				// simple, because we can't have a one-to-one or a collection
 				// (or even a property-ref) in a composite-element:
 				String[] aliasedLhsColumns = StringHelper.qualify( alias, lhsColumns );
 
@@ -707,11 +707,11 @@ public class JoinWalker {
 	 * is the "first" join in a series
 	 */
 	protected JoinType getJoinType(boolean nullable, int currentDepth) {
-		//TODO: this is too conservative; if all preceding joins were 
+		//TODO: this is too conservative; if all preceding joins were
 		//      also inner joins, we could use an inner join here
 		//
 		// IMPL NOTE : currentDepth might be less-than zero if this is the
-		// 		root of a many-to-many collection initializer 
+		// 		root of a many-to-many collection initializer
 		return !nullable && currentDepth <= 0
 				? JoinType.INNER_JOIN
 				: JoinType.LEFT_OUTER_JOIN;
@@ -743,7 +743,7 @@ public class JoinWalker {
 				return false;
 			}
 			if ( type.isEntityType() ) {
-				//TODO: look at the owning property and check that it 
+				//TODO: look at the owning property and check that it
 				//      isn't lazy (by instrumentation)
 				EntityType entityType = (EntityType) type;
 				EntityPersister persister = getFactory().getEntityPersister( entityType.getAssociatedEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/BasicCollectionLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/BasicCollectionLoader.java
@@ -18,7 +18,7 @@ import org.jboss.logging.Logger;
 /**
  * Loads a collection of values or a many-to-many association.
  * <br>
- * The collection persister must implement <tt>QueryableCOllection<tt>. For
+ * The collection persister must implement <tt>QueryableCollection<tt>. For
  * other collections, create a customized subclass of <tt>Loader</tt>.
  *
  * @see OneToManyLoader

--- a/hibernate-core/src/main/java/org/hibernate/loader/collection/OneToManyLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/collection/OneToManyLoader.java
@@ -18,7 +18,7 @@ import org.jboss.logging.Logger;
 /**
  * Loads one-to-many associations<br>
  * <br>
- * The collection persister must implement <tt>QueryableCOllection<tt>. For
+ * The collection persister must implement <tt>QueryableCollection<tt>. For
  * other collections, create a customized subclass of <tt>Loader</tt>.
  *
  * @see BasicCollectionLoader

--- a/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/criteria/CriteriaQueryTranslator.java
@@ -606,7 +606,7 @@ public class CriteriaQueryTranslator implements CriteriaQuery {
 	}
 
 	/**
-	 * Get the a typed value for the given property value.
+	 * Get the typed value for the given property value.
 	 */
 	@Override
 	public TypedValue getTypedValue(Criteria subcriteria, String propertyName, Object value) throws HibernateException {

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/ColumnCollectionAliases.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/ColumnCollectionAliases.java
@@ -12,7 +12,7 @@ import org.hibernate.loader.CollectionAliases;
 import org.hibernate.persister.collection.SQLLoadableCollection;
 
 /**
- * CollectionAliases that uses columnnames instead of generated aliases.
+ * CollectionAliases that uses column names instead of generated aliases.
  * Aliases can still be overwritten via <return-property>
  *
  * @author Max Rydahl Andersen
@@ -62,7 +62,7 @@ public class ColumnCollectionAliases implements CollectionAliases {
 	}
 
 	/**
-	 * Returns the suffixed result-set column-aliases for the collumns making up the collection's index (map or list).
+	 * Returns the suffixed result-set column-aliases for the columns making up the collection's index (map or list).
 	 *
 	 * @return The index result-set column aliases.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/CustomLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/CustomLoader.java
@@ -533,7 +533,7 @@ public class CustomLoader extends Loader {
 	 * *after* {@link #list(SharedSessionContractImplementor, QueryParameters)} has already been called.  It's a bit of a
 	 * chicken-and-the-egg issue since {@link #autoDiscoverTypes(ResultSet)} needs the {@link ResultSet}.
 	 * <p/>
-	 * As a hacky workaround, overriden here to provide the {@link #resultTypes}.
+	 * As a hacky workaround, overridden here to provide the {@link #resultTypes}.
 	 *
 	 * see HHH-3051
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/EntityFetchReturn.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/EntityFetchReturn.java
@@ -9,7 +9,7 @@ import org.hibernate.LockMode;
 import org.hibernate.loader.EntityAliases;
 
 /**
- * Spefically a fetch return that refers to an entity association.
+ * Specifically a fetch return that refers to an entity association.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/FetchReturn.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/FetchReturn.java
@@ -20,7 +20,7 @@ public abstract class FetchReturn extends NonScalarReturn {
 	 * Creates a return descriptor for an association fetch.
 	 *
 	 * @param owner The return descriptor for the owner of the fetch
-	 * @param ownerProperty The name of the property represernting the association being fetched
+	 * @param ownerProperty The name of the property representing the association being fetched
 	 * @param alias The alias for the fetch
 	 * @param lockMode The lock mode to apply to the fetched association.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/sql/SQLQueryParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/sql/SQLQueryParser.java
@@ -74,7 +74,7 @@ public class SQLQueryParser {
 		return processedSql;
 	}
 
-	// TODO: should "record" how many properties we have reffered to - and if we 
+	// TODO: should "record" how many properties we have reffered to - and if we
 	//       don't get'em'all we throw an exception! Way better than trial and error ;)
 	protected String substituteBrackets(String sqlQuery) throws QueryException {
 
@@ -125,7 +125,7 @@ public class SQLQueryParser {
 						result.append(schemaName);
 						result.append(".");
 					}
-				} 
+				}
 				// Catalog replacement
 				else if ( CATALOG_PLACEHOLDER.equals( aliasPath ) ) {
 					final String catalogName = factory.getSettings().getDefaultCatalogName();
@@ -145,10 +145,10 @@ public class SQLQueryParser {
 						// it is a simple table alias {foo}
 						result.append( aliasPath );
 						aliasesFound++;
-					} 
+					}
 					else {
 						// passing through anything we do not know : to support jdbc escape sequences HB-898
-						result.append( '{' ).append(aliasPath).append( '}' );					
+						result.append( '{' ).append(aliasPath).append( '}' );
 					}
 				}
 				else {
@@ -158,7 +158,7 @@ public class SQLQueryParser {
 						String propertyName = aliasPath.substring( firstDot + 1 );
 						result.append( resolveCollectionProperties( aliasName, propertyName ) );
 						aliasesFound++;
-					} 
+					}
 					else if ( context.isEntityAlias( aliasName ) ) {
 						// it is a property reference {foo.bar}
 						String propertyName = aliasPath.substring( firstDot + 1 );
@@ -179,7 +179,7 @@ public class SQLQueryParser {
 		// Possibly handle :something parameters for the query ?
 
 		return result.toString();
-	}	
+	}
 
 	private String resolveCollectionProperties(
 			String aliasName,
@@ -193,11 +193,11 @@ public class SQLQueryParser {
 			if( !fieldResults.isEmpty() ) {
 				throw new QueryException("Using return-propertys together with * syntax is not supported.");
 			}
-			
+
 			String selectFragment = collectionPersister.selectFragment( aliasName, collectionSuffix );
 			aliasesFound++;
-			return selectFragment 
-						+ ", " 
+			return selectFragment
+						+ ", "
 						+ resolveProperties( aliasName, propertyName );
 		}
 		else if ( "element.*".equals( propertyName ) ) {
@@ -211,7 +211,7 @@ public class SQLQueryParser {
 			if ( columnAliases==null ) {
 				columnAliases = collectionPersister.getCollectionPropertyColumnAliases( propertyName, collectionSuffix );
 			}
-			
+
 			if ( columnAliases == null || columnAliases.length == 0 ) {
 				throw new QueryException(
 						"No column name found for property [" + propertyName + "] for alias [" + aliasName + "]",
@@ -228,7 +228,7 @@ public class SQLQueryParser {
 			}
 			aliasesFound++;
 			return columnAliases[0];
-		
+
 		}
 	}
 	private String resolveProperties(String aliasName, String propertyName) {
@@ -239,7 +239,7 @@ public class SQLQueryParser {
 		if ( "*".equals( propertyName ) ) {
 			if( !fieldResults.isEmpty() ) {
 				throw new QueryException("Using return-propertys together with * syntax is not supported.");
-			}			
+			}
 			aliasesFound++;
 			return persister.selectFragment( aliasName, suffix ) ;
 		}
@@ -265,14 +265,14 @@ public class SQLQueryParser {
 						"SQL queries only support properties mapped to a single column - property [" + propertyName + "] is mapped to " + columnAliases.length + " columns.",
 						originalQueryString
 				);
-			}			
+			}
 			aliasesFound++;
 			return columnAliases[0];
 		}
 	}
 
 	/**
-	 * Substitues JDBC parameter placeholders (?) for all encountered
+	 * Substitutes JDBC parameter placeholders (?) for all encountered
 	 * parameter specifications.  It also tracks the positions of these
 	 * parameter specifications within the query string.  This accounts for
 	 * ordinal-params, named-params, and ejb3-positional-params.

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/spi/QuerySpaceTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/spi/QuerySpaceTreePrinter.java
@@ -64,7 +64,7 @@ public class QuerySpaceTreePrinter {
 	 * An indentation is defined as the number of characters defined by {@link TreePrinterHelper#INDENTATION}.
 	 *
 	 * @param spaces The {@link QuerySpaces} object.
-	 * @param depth The intial number of indentations
+	 * @param depth The initial number of indentations
 	 * @param aliasResolutionContext The context for resolving table and column aliases
 	 *        for the {@link QuerySpace} references in <code>spaces</code>; if null,
 	 *        table and column aliases are not included in returned value..
@@ -89,7 +89,7 @@ public class QuerySpaceTreePrinter {
 	 * An indentation is defined as the number of characters defined by {@link TreePrinterHelper#INDENTATION}.
 	 *
 	 * @param spaces The {@link QuerySpaces} object.
-	 * @param depth The intial number of indentations
+	 * @param depth The initial number of indentations
 	 * @param aliasResolutionContext The context for resolving table and column aliases
 	 *        for the {@link QuerySpace} references in <code>spaces</code>; if null,
 	 *        table and column aliases are not included in returned value.
@@ -114,7 +114,7 @@ public class QuerySpaceTreePrinter {
 	 * An indentation is defined as the number of characters defined by {@link TreePrinterHelper#INDENTATION}.
 	 *
 	 * @param spaces The {@link QuerySpaces} object.
-	 * @param depth The intial number of indentations
+	 * @param depth The initial number of indentations
 	 * @param aliasResolutionContext The context for resolving table and column aliases
 	 *        for the {@link QuerySpace} references in <code>spaces</code>; if null,
 	 *        table and column aliases are not included in returned value.
@@ -233,7 +233,7 @@ public class QuerySpaceTreePrinter {
 	 *     <li>query space class name</li>
 	 *     <li>unique ID</li>
 	 *     <li>entity name (for {@link EntityQuerySpace}</li>
-	 *     <li>collection role (for {@link CollectionQuerySpace}</li>	 *
+	 *     <li>collection role (for {@link CollectionQuerySpace}</li>
 	 * </ul>
 	 * @param space The query space
 	 * @return a String containing details about the {@link QuerySpace}

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BasicCollectionLoadQueryDetails.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BasicCollectionLoadQueryDetails.java
@@ -23,7 +23,7 @@ public class BasicCollectionLoadQueryDetails extends AbstractCollectionLoadQuery
 	 * Constructs a BasicCollectionLoadQueryDetails object from the given inputs.
 	 *
 	 * @param loadPlan The load plan
-	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * @param buildingParameters Any influencers that would affect the generated SQL (mostly we are concerned with those
 	 * that add additional joins here)
 	 * @param factory The SessionFactory
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BatchingLoadQueryDetailsFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/BatchingLoadQueryDetailsFactory.java
@@ -31,11 +31,11 @@ public class BatchingLoadQueryDetailsFactory {
 	}
 
 	/**
-	 * Returns a EntityLoadQueryDetails object from the given inputs.
+	 * Returns an EntityLoadQueryDetails object from the given inputs.
 	 *
 	 * @param loadPlan The load plan
 	 * @param keyColumnNames The columns to load the entity by (the PK columns or some other unique set of columns)
-	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * @param buildingParameters Any influencers that would affect the generated SQL (mostly we are concerned with those
 	 * that add additional joins here)
 	 * @param factory The SessionFactory
 	 *
@@ -72,7 +72,7 @@ public class BatchingLoadQueryDetailsFactory {
 	 * Returns a EntityLoadQueryDetails object based on an existing one and additional elements specific to this one.
 	 *
 	 * @param entityLoadQueryDetailsTemplate the template
-	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * @param buildingParameters Any influencers that would affect the generated SQL (mostly we are concerned with those
 	 * that add additional joins here)
 	 * @return The EntityLoadQueryDetails
 	 */
@@ -90,7 +90,7 @@ public class BatchingLoadQueryDetailsFactory {
 	 *
 	 * @param collectionPersister The collection persister.
 	 * @param loadPlan The load plan.
-	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * @param buildingParameters Any influencers that would affect the generated SQL (mostly we are concerned with those
 	 * that add additional joins here)
 	 *
 	 * @return The EntityLoadQueryDetails

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/EntityLoadQueryDetails.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/internal/EntityLoadQueryDetails.java
@@ -55,7 +55,7 @@ public class EntityLoadQueryDetails extends AbstractLoadQueryDetails {
 	 *
 	 * @param loadPlan The load plan
 	 * @param keyColumnNames The columns to load the entity by (the PK columns or some other unique set of columns)
-	 * @param buildingParameters And influencers that would affect the generated SQL (mostly we are concerned with those
+	 * @param buildingParameters Any influencers that would affect the generated SQL (mostly we are concerned with those
 	 * that add additional joins here)
 	 * @param factory The SessionFactory
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -41,7 +41,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
 	/**
 	 * If a constraint is not explicitly named, this is called to generate
 	 * a unique hash using the table and column names.
@@ -92,10 +92,10 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	 * (full alphanumeric), guaranteeing
 	 * that the length of the name will always be smaller than the 30
 	 * character identifier restriction enforced by a few dialects.
-	 * 
+	 *
 	 * @param s
 	 *            The name to be hashed.
-	 * @return String The hased name.
+	 * @return String The hashed name.
 	 */
 	public static String hashedName(String s) {
 		try {
@@ -214,7 +214,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	public String toString() {
 		return getClass().getName() + '(' + getTable().getName() + getColumns() + ") as " + name;
 	}
-	
+
 	/**
 	 * @return String The prefix to use in generated constraint names.  Examples:
 	 * "UK_", "FK_", and "PK_".

--- a/hibernate-core/src/main/java/org/hibernate/mapping/FetchProfile.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/FetchProfile.java
@@ -65,7 +65,7 @@ public class FetchProfile {
 	 *
 	 * @param entity The entity which contains the association to be fetched
 	 * @param association The association to fetch
-	 * @param style The style of fetch t apply
+	 * @param style The style of fetch to apply
 	 */
 	public void addFetch(String entity, String association, String style) {
 		fetches.add( new Fetch( entity, association, style ) );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -19,14 +19,14 @@ import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.internal.util.collections.SingletonIterator;
 
 /**
- * A sublass in a table-per-class-hierarchy mapping
+ * A subclass in a table-per-class-hierarchy mapping
  * @author Gavin King
  */
 public class Subclass extends PersistentClass {
 	private PersistentClass superclass;
 	private Class classPersisterClass;
 	private final int subclassId;
-	
+
 	public Subclass(PersistentClass superclass, MetadataBuildingContext metadataBuildingContext) {
 		super( metadataBuildingContext );
 		this.superclass = superclass;
@@ -36,11 +36,11 @@ public class Subclass extends PersistentClass {
 	int nextSubclassId() {
 		return getSuperclass().nextSubclassId();
 	}
-	
+
 	public int getSubclassId() {
 		return subclassId;
 	}
-	
+
 	@Override
 	public String getNaturalIdCacheRegionName() {
 		return getSuperclass().getNaturalIdCacheRegionName();
@@ -243,7 +243,7 @@ public class Subclass extends PersistentClass {
 	}
 
 	public boolean hasSubselectLoadableCollections() {
-		return super.hasSubselectLoadableCollections() || 
+		return super.hasSubselectLoadableCollections() ||
 			getSuperclass().hasSubselectLoadableCollections();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -222,7 +222,7 @@ public class Table implements RelationalModel, Serializable, Exportable {
 	/**
 	 * Return the column which is identified by column provided as argument.
 	 *
-	 * @param column column with atleast a name.
+	 * @param column column with at least a name.
 	 * @return the underlying column or null if not inside this table. Note: the instance *can* be different than the input parameter, but the name will be the same.
 	 */
 	public Column getColumn(Column column) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -77,7 +77,7 @@ class MetadataContext {
 	private List<Object> orderedMappings = new ArrayList<>();
 
 	/**
-	 * Stack of PersistentClass being process. Last in the list is the highest in the stack.
+	 * Stack of PersistentClass being processed. Last in the list is the highest in the stack.
 	 */
 	private List<PersistentClass> stackOfPersistentClassesBeingProcessed = new ArrayList<>();
 
@@ -159,7 +159,7 @@ class MetadataContext {
 
 	/**
 	 * Given a Hibernate {@link PersistentClass}, locate the corresponding JPA {@link org.hibernate.type.EntityType}
-	 * implementation.  May retur null if the given {@link PersistentClass} has not yet been processed.
+	 * implementation.  May return null if the given {@link PersistentClass} has not yet been processed.
 	 *
 	 * @param persistentClass The Hibernate (config time) metamodel instance representing an entity.
 	 *
@@ -171,7 +171,7 @@ class MetadataContext {
 
 	/**
 	 * Given a Java {@link Class}, locate the corresponding JPA {@link org.hibernate.type.EntityType}.  May
-	 * return null which could means that no such mapping exists at least at this time.
+	 * return null which could mean that no such mapping exists at least at this time.
 	 *
 	 * @param javaType The java class.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/param/DynamicFilterParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/DynamicFilterParameterSpecification.java
@@ -17,7 +17,7 @@ import org.hibernate.type.Type;
 
 /**
  * A specialized ParameterSpecification impl for dealing with a dynamic filter parameters.
- * 
+ *
  * @see org.hibernate.Session#enableFilter(String)
  *
  * @author Steve Ebersole
@@ -32,7 +32,7 @@ public class DynamicFilterParameterSpecification implements ParameterSpecificati
 	 *
 	 * @param filterName The name of the filter
 	 * @param parameterName The name of the parameter
-	 * @param definedParameterType The paremeter type specified on the filter metadata
+	 * @param definedParameterType The parameter type specified on the filter metadata
 	 */
 	public DynamicFilterParameterSpecification(
 			String filterName,

--- a/hibernate-core/src/main/java/org/hibernate/param/ParameterBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/ParameterBinder.java
@@ -25,7 +25,7 @@ public interface ParameterBinder {
 	 * @param position The position from which to start binding value(s).
 	 *
 	 * @return The number of sql bind positions "eaten" by this bind operation.
-	 * @throws java.sql.SQLException Indicates problems performing the JDBC biind operation.
+	 * @throws java.sql.SQLException Indicates problems performing the JDBC bind operation.
 	 */
 	int bind(PreparedStatement statement, QueryParameters qp, SharedSessionContractImplementor session, int position) throws SQLException;
 

--- a/hibernate-core/src/main/java/org/hibernate/param/ParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/ParameterSpecification.java
@@ -18,7 +18,7 @@ import org.hibernate.type.Type;
  */
 public interface ParameterSpecification extends ParameterBinder {
 	/**
-	 * Get the type which we are expeting for a bind into this parameter based
+	 * Get the type which we are expecting for a bind into this parameter based
 	 * on translated contextual information.
 	 *
 	 * @return The expected type.

--- a/hibernate-core/src/main/java/org/hibernate/param/PositionalParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/PositionalParameterSpecification.java
@@ -44,7 +44,7 @@ public class PositionalParameterSpecification extends AbstractExplicitParameterS
 	 *
 	 * @param statement The statement into which the value should be bound.
 	 * @param qp The defined values for the current query execution.
-	 * @param session The session against which the current execution is occuring.
+	 * @param session The session against which the current execution is occurring.
 	 * @param position The position from which to start binding value(s).
 	 *
 	 * @return The number of sql bind positions "eaten" by this bind operation.

--- a/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
@@ -15,7 +15,7 @@ import org.hibernate.type.Type;
 import org.hibernate.type.VersionType;
 
 /**
- * Parameter bind specification used for optimisitc lock version seeding (from insert statements).
+ * Parameter bind specification used for optimistic lock version seeding (from insert statements).
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -143,7 +143,7 @@ public interface CollectionPersister extends CollectionDefinition {
 	/**
 	 * Is this a many-to-many association?  Note that this is mainly
 	 * a convenience feature as the single persister does not
-	 * conatin all the information needed to handle a many-to-many
+	 * contain all the information needed to handle a many-to-many
 	 * itself, as internally it is looked at as two many-to-ones.
 	 */
 	boolean isManyToMany();
@@ -160,7 +160,7 @@ public interface CollectionPersister extends CollectionDefinition {
 	boolean isLazy();
 	/**
 	 * Is this collection "inverse", so state changes are not
-	 * propogated to the database.
+	 * propagated to the database.
 	 */
 	boolean isInverse();
 	/**
@@ -201,7 +201,7 @@ public interface CollectionPersister extends CollectionDefinition {
 			Serializable key,
 			SharedSessionContractImplementor session)
 		throws HibernateException;
-	
+
 	/**
 	 * Process queued operations within the PersistentCollection.
 	 */
@@ -210,7 +210,7 @@ public interface CollectionPersister extends CollectionDefinition {
 			Serializable key,
 			SharedSessionContractImplementor session)
 			throws HibernateException;
-	
+
 	/**
 	 * Get the name of this collection role (the fully qualified class name,
 	 * extended by a "property path")
@@ -253,22 +253,22 @@ public interface CollectionPersister extends CollectionDefinition {
 	 * foreign key constraint definition?
 	 */
 	boolean isCascadeDeleteEnabled();
-	
+
 	/**
-	 * Does this collection cause version increment of the 
+	 * Does this collection cause version increment of the
 	 * owning entity?
 	 */
 	boolean isVersioned();
-	
+
 	/**
 	 * Can the elements of this collection change?
 	 */
 	boolean isMutable();
-	
+
 	//public boolean isSubselectLoadable();
-	
+
 	void postInstantiate() throws MappingException;
-	
+
 	SessionFactoryImplementor getFactory();
 
 	boolean isAffectedByEnabledFilters(SharedSessionContractImplementor session);
@@ -308,7 +308,7 @@ public interface CollectionPersister extends CollectionDefinition {
 	 * @return The key column aliases.
 	 */
 	String getIdentifierColumnAlias(String suffix);
-	
+
 	boolean isExtraLazy();
 	int getSize(Serializable key, SharedSessionContractImplementor session);
 	boolean indexExists(Serializable key, Object index, SharedSessionContractImplementor session);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1441,7 +1441,7 @@ public abstract class AbstractEntityPersister
 
 	public String getDiscriminatorAlias(String suffix) {
 		// NOTE: this assumes something about how propertySelectFragment is implemented by the subclass!
-		// was toUnqotedAliasStrings( getdiscriminatorColumnName() ) before - now tried
+		// toUnqotedAliasStrings( getdiscriminatorColumnName() ) before - now tried
 		// to remove that unqoting and missing aliases..
 		return entityMetamodel.hasSubclasses() ?
 				new Alias( suffix ).toAliasString( getDiscriminatorAlias() ) :
@@ -2794,7 +2794,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	/**
-	 * Used to generate an insery statement against the root table in the
+	 * Used to generate an insert statement against the root table in the
 	 * case of identifier generation strategies where the insert statement
 	 * executions actually generates the identifier value.
 	 *
@@ -2972,7 +2972,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	/**
-	 * Unmarshall the fields of a persistent instance from a result set,
+	 * Unmarshal the fields of a persistent instance from a result set,
 	 * without resolving associations or collections. Question: should
 	 * this really be here, or should it be sent back to Loader?
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -396,7 +396,7 @@ public interface EntityPersister extends EntityDefinition {
 	 * Performs a load of multiple entities (of this type) by identifier simultaneously.
 	 *
 	 * @param ids The identifiers to load
-	 * @param session The originating Sesison
+	 * @param session The originating Session
 	 * @param loadOptions The options for loading
 	 *
 	 * @return The loaded, matching entities

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -47,8 +47,8 @@ import org.hibernate.type.Type;
 /**
  * The default implementation of the <tt>EntityPersister</tt> interface.
  * Implements the "table-per-class-hierarchy" or "roll-up" mapping strategy
- * for an entity class and its inheritence hierarchy.  This is implemented
- * as a single table holding all classes in the hierarchy with a discrimator
+ * for an entity class and its inheritance hierarchy.  This is implemented
+ * as a single table holding all classes in the hierarchy with a discriminator
  * column used to determine which concrete class is referenced.
  *
  * @author Gavin King

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -46,7 +46,7 @@ import org.hibernate.type.Type;
 
 /**
  * Implementation of the "table-per-concrete-class" or "roll-down" mapping
- * strategy for an entity and its inheritence hierarchy.
+ * strategy for an entity and its inheritance hierarchy.
  *
  * @author Gavin King
  */

--- a/hibernate-core/src/main/java/org/hibernate/persister/spi/UnknownPersisterException.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/spi/UnknownPersisterException.java
@@ -9,8 +9,8 @@ package org.hibernate.persister.spi;
 import org.hibernate.HibernateException;
 
 /**
- * Indicates that the persister to use is not known and couyld not be determined.
- * 
+ * Indicates that the persister to use is not known and could not be determined.
+ *
  * @author Steve Ebersole
  */
 public class UnknownPersisterException extends HibernateException {

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ParameterRegistration.java
@@ -30,7 +30,7 @@ public interface ParameterRegistration<T> extends ProcedureParameter<T> {
 
 	/**
 	 * The position at which this parameter was registered.  Can be {@code null} which should indicate that
-	 * named registration was used (and therefore {@link #getName()} should return non-null.
+	 * named registration was used (and therefore {@link #getName()} should return non-null).
 	 *
 	 * @return The name;
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedSetterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedSetterImpl.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Field;
 
 /**
  * A specialized Setter implementation for handling setting values into
- * a into a bytecode-enhanced Class.  The reason we need specialized handling
+ * a bytecode-enhanced Class.  The reason we need specialized handling
  * is to render the fact that we need to account for certain enhancement features
  * during the setting process.
  *

--- a/hibernate-core/src/main/java/org/hibernate/proxy/LazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/LazyInitializer.java
@@ -54,7 +54,7 @@ public interface LazyInitializer {
 	Class getPersistentClass();
 
 	/**
-	 * Is the proxy uninitialzed?
+	 * Is the proxy uninitialized?
 	 *
 	 * @return True if uninitialized; false otherwise.
 	 */
@@ -94,7 +94,7 @@ public interface LazyInitializer {
 	boolean isReadOnlySettingAvailable();
 
 	/**
-	 * Is the proxy read-only?.
+	 * Is the proxy read-only?
 	 *
 	 * The read-only/modifiable setting is not available when the proxy is
 	 * detached or its associated session is closed.
@@ -103,7 +103,7 @@ public interface LazyInitializer {
 	 *
 	 * @return true, if this proxy is read-only; false, otherwise
 	 * @throws org.hibernate.TransientObjectException if the proxy is detached (getSession() == null)
-	 * @throws org.hibernate.SessionException if the proxy is associated with a sesssion that is closed
+	 * @throws org.hibernate.SessionException if the proxy is associated with a session that is closed
 	 *
 	 * @see org.hibernate.proxy.LazyInitializer#isReadOnlySettingAvailable()
 	 * @see org.hibernate.Session#isReadOnly(Object entityOrProxy)
@@ -125,7 +125,7 @@ public interface LazyInitializer {
 	 *                  if false, the associated proxy is made modifiable.
 	 * @throws org.hibernate.TransientObjectException if the proxy is not association with a session
 	 * @throws org.hibernate.SessionException if the proxy is associated with a session that is closed
-	 * 
+	 *
 	 * @see org.hibernate.Session#setReadOnly(Object entityOrProxy, boolean readOnly)
 	 */
 	void setReadOnly(boolean readOnly);
@@ -141,9 +141,9 @@ public interface LazyInitializer {
 	 * Associate the proxy with the given session.
 	 * <p/>
 	 * Care should be given to make certain that the proxy is added to the session's persistence context as well
-	 * to maintain the symetry of the association.  That must be done seperately as this method simply sets an
+	 * to maintain the symmetry of the association.  That must be done separately as this method simply sets an
 	 * internal reference.  We do also check that if there is already an associated session that the proxy
-	 * reference was removed from that previous session's persistence contet.
+	 * reference was removed from that previous session's persistence context.
 	 *
 	 * @param session The session
 	 * @throws HibernateException Indicates that the proxy was still contained in the persistence context of the
@@ -159,7 +159,7 @@ public interface LazyInitializer {
 	 * {@link org.hibernate.Session#clear} processing; most other use-cases should call {@link #setSession} instead.
 	 */
 	void unsetSession();
-	
+
 	void setUnwrap(boolean unwrap);
 	boolean isUnwrap();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/ParameterContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/ParameterContainer.java
@@ -8,7 +8,7 @@ package org.hibernate.query.criteria.internal;
 import javax.persistence.criteria.Selection;
 
 /**
- * Contract for query components capable of eirther being a parameter or containing parameters.
+ * Contract for query components capable of either being a parameter or containing parameters.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/BinaryArithmeticOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/BinaryArithmeticOperation.java
@@ -16,7 +16,7 @@ import org.hibernate.query.criteria.internal.compile.RenderingContext;
 import org.hibernate.query.criteria.internal.predicate.ImplicitNumericExpressionTypeDeterminer;
 
 /**
- * Models standard arithmetc operations with two operands.
+ * Models standard arithmetic operations with two operands.
  *
  * @author Steve Ebersole
  */
@@ -105,7 +105,7 @@ public class BinaryArithmeticOperation<N extends Number>
 	public static Class<? extends Number> determineReturnType(
 			Class<? extends Number> defaultType,
 			Expression<? extends Number> expression) {
-		return expression == null || expression.getJavaType() == null 
+		return expression == null || expression.getJavaType() == null
 				? defaultType
 				: expression.getJavaType();
 	}
@@ -125,7 +125,7 @@ public class BinaryArithmeticOperation<N extends Number>
 	}
 
 	/**
-	 * Creates an arithmethic operation based on 2 expressions.
+	 * Creates an arithmetic operation based on 2 expressions.
 	 *
 	 * @param criteriaBuilder The builder for query components.
 	 * @param resultType The operation result type
@@ -146,7 +146,7 @@ public class BinaryArithmeticOperation<N extends Number>
 	}
 
 	/**
-	 * Creates an arithmethic operation based on an expression and a literal.
+	 * Creates an arithmetic operation based on an expression and a literal.
 	 *
 	 * @param criteriaBuilder The builder for query components.
 	 * @param javaType The operation result type

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SubqueryComparisonModifierExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/expression/SubqueryComparisonModifierExpression.java
@@ -15,7 +15,7 @@ import org.hibernate.query.criteria.internal.Renderable;
 import org.hibernate.query.criteria.internal.compile.RenderingContext;
 
 /**
- * Represents a {@link Modifier#ALL}, {@link Modifier#ANY}, {@link Modifier#SOME} modifier appplied to a subquery as
+ * Represents a {@link Modifier#ALL}, {@link Modifier#ANY}, {@link Modifier#SOME} modifier applied to a subquery as
  * part of a comparison.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/NullnessPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/NullnessPredicate.java
@@ -30,7 +30,7 @@ public class NullnessPredicate
 	private final Expression<?> operand;
 
 	/**
-	 * Constructs the affirmitive form of nullness checking (<i>IS NULL</i>).  To
+	 * Constructs the affirmative form of nullness checking (<i>IS NULL</i>).  To
 	 * construct the negative form (<i>IS NOT NULL</i>) call {@link #not} on the
 	 * constructed instance.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/TruthValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/TruthValue.java
@@ -13,7 +13,7 @@ package org.hibernate.query.criteria.internal.predicate;
  * boolean expression (the syntax is like <tt>a > b IS TRUE</tt>.  <tt>IS TRUE</tt> is the assumed default.
  * <p/>
  * JPA defines support for only <tt>IS TRUE</tt> and <tt>IS FALSE</tt>, not <tt>IS UNKNOWN</tt> (<tt>a > NULL</tt>
- * is an example where the result would be UNKNOWN).  All 3 are provided here for completness.
+ * is an example where the result would be UNKNOWN).  All 3 are provided here for completeness.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/LogicalConnection.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/LogicalConnection.java
@@ -19,7 +19,7 @@ public interface LogicalConnection {
 	 * Is this (logical) JDBC Connection still open/active.  In other words, has {@link #close} not been called yet?
 	 *
 	 * @return {@code true} if still open ({@link #close} has not been called yet); {@code false} if not open
-	 * (({@link #close} has been called).
+	 * ({@link #close} has been called).
 	 */
 	boolean isOpen();
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorOwner.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorOwner.java
@@ -52,7 +52,7 @@ public interface TransactionCoordinatorOwner {
 	 * An after-completion callback from the coordinator to its owner.
 	 *
 	 * @param successful Was the transaction successful?
-	 * @param delayed Is this a delayed after transaction completion call (aka after a timeout)?
+	 * @param delayed Is this delayed after transaction completion call (aka after a timeout)?
 	 */
 	void afterTransactionCompletion(boolean successful, boolean delayed);
 

--- a/hibernate-core/src/main/java/org/hibernate/service/UnknownServiceException.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/UnknownServiceException.java
@@ -8,7 +8,7 @@ package org.hibernate.service;
 import org.hibernate.HibernateException;
 
 /**
- * Indicates that an unkown service was requested from the registry.
+ * Indicates that an unknown service was requested from the registry.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/ServiceDependencyException.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/ServiceDependencyException.java
@@ -8,7 +8,7 @@ package org.hibernate.service.internal;
 import org.hibernate.HibernateException;
 
 /**
- * Indictes a problem processing service dependencies.
+ * Indicates a problem processing service dependencies.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/Manageable.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/Manageable.java
@@ -35,7 +35,7 @@ public interface Manageable {
 	}
 
 	/**
-	 * The the management bean (MBean) for this service.
+	 * The management bean (MBean) for this service.
 	 *
 	 * @return The management bean.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/OptionallyManageable.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/OptionallyManageable.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Extension to Manageable for things that are optionally Manageable depending
  * on some internal state.  E.g. services that wrap other services wanting to
- * delegate manageablity if the wrapped service is Manageable.
+ * delegate manageability if the wrapped service is Manageable.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
@@ -30,7 +30,7 @@ public interface Wrapped {
 	 *
 	 * @return The unwrapped reference
 	 *
-	 * @throws UnknownUnwrapTypeException if the servicebe unwrapped as the indicated type
+	 * @throws UnknownUnwrapTypeException if the service cannot be unwrapped as the indicated type
 	 */
 	public <T> T unwrap(Class<T> unwrapType);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/OracleJoinFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/OracleJoinFragment.java
@@ -153,7 +153,7 @@ public class OracleJoinFragment extends JoinFragment {
 	 * This method is a bit of a hack, and assumes
 	 * that the column on the "right" side of the
 	 * join appears on the "left" side of the
-	 * operator, which is extremely wierd if this
+	 * operator, which is extremely weird if this
 	 * was a normal join condition, but is natural
 	 * for a filter.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/sql/SelectValues.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SelectValues.java
@@ -15,7 +15,7 @@ import org.jboss.logging.Logger;
 
 /**
  * Models a SELECT values lists.  Eventually, rather than Strings, pass in the Column/Formula representations (something
- * like {@link org.hibernate.sql.ordering.antlr.ColumnReference}/{@link org.hibernate.sql.ordering.antlr.FormulaReference}
+ * like {@link org.hibernate.sql.ordering.antlr.ColumnReference}/{@link org.hibernate.sql.ordering.antlr.FormulaReference})
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/sql/ordering/antlr/NodeSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ordering/antlr/NodeSupport.java
@@ -9,7 +9,7 @@ package org.hibernate.sql.ordering.antlr;
 import antlr.CommonAST;
 
 /**
- * Basic implementation of a {@link Node} briding to the Antlr {@link CommonAST} hierarchy.
+ * Basic implementation of a {@link Node} bridging to the Antlr {@link CommonAST} hierarchy.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/DeprecatedNaturalIdCacheStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/DeprecatedNaturalIdCacheStatisticsImpl.java
@@ -63,7 +63,7 @@ public class DeprecatedNaturalIdCacheStatisticsImpl implements NaturalIdCacheSta
 	}
 
 	/**
-	 * average time in ms taken by the excution of this query onto the DB
+	 * average time in ms taken by the execution of this query onto the DB
 	 */
 	@Override
 	public long getExecutionAvgTime() {
@@ -84,7 +84,7 @@ public class DeprecatedNaturalIdCacheStatisticsImpl implements NaturalIdCacheSta
 	}
 
 	/**
-	 * max time in ms taken by the excution of this query onto the DB
+	 * max time in ms taken by the execution of this query onto the DB
 	 */
 	@Override
 	public long getExecutionMaxTime() {
@@ -92,7 +92,7 @@ public class DeprecatedNaturalIdCacheStatisticsImpl implements NaturalIdCacheSta
 	}
 
 	/**
-	 * min time in ms taken by the excution of this query onto the DB
+	 * min time in ms taken by the execution of this query onto the DB
 	 */
 	@Override
 	public long getExecutionMinTime() {

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/NaturalIdStatisticsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/NaturalIdStatisticsImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.stat.NaturalIdStatistics;
 
 /**
  * NaturalId cache statistics of a specific entity
- * 
+ *
  * @author Eric Dalquist
  */
 public class NaturalIdStatisticsImpl extends AbstractCacheableDataStatistics implements NaturalIdStatistics, Serializable {
@@ -53,7 +53,7 @@ public class NaturalIdStatisticsImpl extends AbstractCacheableDataStatistics imp
 	}
 
 	/**
-	 * average time in ms taken by the excution of this query onto the DB
+	 * average time in ms taken by the execution of this query onto the DB
 	 */
 	@Override
 	public long getExecutionAvgTime() {
@@ -74,7 +74,7 @@ public class NaturalIdStatisticsImpl extends AbstractCacheableDataStatistics imp
 	}
 
 	/**
-	 * max time in ms taken by the excution of this query onto the DB
+	 * max time in ms taken by the execution of this query onto the DB
 	 */
 	@Override
 	public long getExecutionMaxTime() {

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SingleLineSqlCommandExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SingleLineSqlCommandExtractor.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.hibernate.internal.util.StringHelper;
 
 /**
- * Class responsible for extracting SQL statements from import script. Treads each line as a complete SQL statement.
+ * Class responsible for extracting SQL statements from import script. Treats each line as a complete SQL statement.
  * Comment lines shall start with {@code --}, {@code //} or {@code /*} character sequence.
  *
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/DatabaseInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/DatabaseInformation.java
@@ -54,7 +54,7 @@ public interface DatabaseInformation {
 	/**
 	 * Obtain reference to the named TableInformation
 	 *
-	 * @param tableName The qualfied table name
+	 * @param tableName The qualified table name
 	 *
 	 * @return The table information.  May return {@code null} if not found.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/SequenceInformationExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/SequenceInformationExtractor.java
@@ -9,7 +9,7 @@ package org.hibernate.tool.schema.extract.spi;
 import java.sql.SQLException;
 
 /**
- * Because JDBC (at least up to an including Java 7, JDBC 4) still does not have support for obtaining information
+ * Because JDBC (at least up to and including Java 7, JDBC 4) still does not have support for obtaining information
  * about sequences from DatabaseMetaData.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/transform/AliasToBeanConstructorResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/AliasToBeanConstructorResultTransformer.java
@@ -22,12 +22,12 @@ public class AliasToBeanConstructorResultTransformer implements ResultTransforme
 	/**
 	 * Instantiates a AliasToBeanConstructorResultTransformer.
 	 *
-	 * @param constructor The contructor in which to wrap the tuples.
+	 * @param constructor The constructor in which to wrap the tuples.
 	 */
 	public AliasToBeanConstructorResultTransformer(Constructor constructor) {
 		this.constructor = constructor;
 	}
-	
+
 	/**
 	 * Wrap the incoming tuples in a call to our configured constructor.
 	 */
@@ -37,7 +37,7 @@ public class AliasToBeanConstructorResultTransformer implements ResultTransforme
 			return constructor.newInstance( tuple );
 		}
 		catch ( Exception e ) {
-			throw new QueryException( 
+			throw new QueryException(
 					"could not instantiate class [" + constructor.getDeclaringClass().getName() + "] from tuple",
 					e
 			);
@@ -64,7 +64,7 @@ public class AliasToBeanConstructorResultTransformer implements ResultTransforme
 	 * defined constructor.
 	 *
 	 * @param other The other instance to check for equality.
-	 * @return True if both have the same defined constuctor; false otherwise.
+	 * @return True if both have the same defined constructor; false otherwise.
 	 */
 	@Override
 	public boolean equals(Object other) {

--- a/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
@@ -177,7 +177,7 @@ public class CacheableResultTransformer implements ResultTransformer {
 	 * @param transformer - the transformer for the re-transformation
 	 * @param includeInTuple indicates the indexes of
 	 *
-	 * @return transformedResults, with each element re-transformed (if nececessary)
+	 * @return transformedResults, with each element re-transformed (if necessary)
 	 */
 	@SuppressWarnings( {"unchecked"})
 	public List retransformResults(
@@ -230,7 +230,7 @@ public class CacheableResultTransformer implements ResultTransformer {
 	 *       tuple, then, on return, elements corresponding to
 	 *       excluded tuple elements will be null.
 	 * @param results - results that were previously transformed
-	 * @return results, with each element untransformed (if nececessary)
+	 * @return results, with each element untransformed (if necessary)
 	 */
 	@SuppressWarnings( {"unchecked"})
 	public List untransformToTuples(List results) {

--- a/hibernate-core/src/main/java/org/hibernate/transform/ToListResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/ToListResultTransformer.java
@@ -9,7 +9,7 @@ package org.hibernate.transform;
 import java.util.Arrays;
 
 /**
- * Tranforms each result row from a tuple into a {@link java.util.List} whose elements are each tuple value
+ * Transforms each result row from a tuple into a {@link java.util.List} whose elements are each tuple value
  */
 public class ToListResultTransformer extends BasicTransformerAdapter {
 	public static final ToListResultTransformer INSTANCE = new ToListResultTransformer();
@@ -19,7 +19,7 @@ public class ToListResultTransformer extends BasicTransformerAdapter {
 	 */
 	private ToListResultTransformer() {
 	}
-	
+
 	@Override
 	public Object transformTuple(Object[] tuple, String[] aliases) {
 		return Arrays.asList( tuple );

--- a/hibernate-core/src/main/java/org/hibernate/transform/Transformers.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/Transformers.java
@@ -10,7 +10,7 @@ package org.hibernate.transform;
 final public class Transformers {
 
 	private Transformers() {}
-	
+
 	/**
 	 * Each row of results is a <tt>Map</tt> from alias to values/entities
 	 */
@@ -18,16 +18,16 @@ final public class Transformers {
 			AliasToEntityMapResultTransformer.INSTANCE;
 
 	/**
-	 * Each row of results is a <tt>List</tt> 
+	 * Each row of results is a <tt>List</tt>
 	 */
 	public static final ToListResultTransformer TO_LIST = ToListResultTransformer.INSTANCE;
-	
+
 	/**
-	 * Creates a resulttransformer that will inject aliased values into 
+	 * Creates a resulttransformer that will inject aliased values into
 	 * instances of Class via property methods or fields.
 	 */
 	public static ResultTransformer aliasToBean(Class target) {
 		return new AliasToBeanResultTransformer(target);
 	}
-	
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/Tuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/Tuplizer.java
@@ -69,9 +69,9 @@ public interface Tuplizer {
 	 * @return The new, empty entity instance.
 	 */
 	public Object instantiate();
-	
+
 	/**
-	 * Is the given object considered an instance of the the entity (acconting
+	 * Is the given object considered an instance of the the entity (accounting
 	 * for entity-mode) managed by this tuplizer.
 	 *
 	 * @param object The object to be checked.

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizer.java
@@ -17,7 +17,7 @@ import org.hibernate.tuple.Tuplizer;
  * </p>
  * ComponentTuplizer implementations should have the following constructor signature:
  *      (org.hibernate.mapping.Component)
- * 
+ *
  * @author Gavin King
  * @author Steve Ebersole
  */
@@ -35,13 +35,13 @@ public interface ComponentTuplizer extends Tuplizer, Serializable {
      * Set the value of the parent property.
      *
      * @param component The component instance on which to set the parent.
-     * @param parent The parent to be set on the comonent.
+     * @param parent The parent to be set on the component.
      * @param factory The current session factory.
      */
 	public void setParent(Object component, Object parent, SessionFactoryImplementor factory);
 
 	/**
-	 * Does the component managed by this tuuplizer contain a parent property?
+	 * Does the component managed by this tuplizer contain a parent property?
 	 *
 	 * @return True if the component does contain a parent property; false otherwise.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityTuplizer.java
@@ -19,7 +19,7 @@ import org.hibernate.proxy.ProxyFactory;
 import org.hibernate.tuple.Tuplizer;
 
 /**
- * Defines further responsibilities reagarding tuplization based on
+ * Defines further responsibilities regarding tuplization based on
  * a mapped entity.
  * <p/>
  * EntityTuplizer implementations should have the following constructor signatures:
@@ -169,7 +169,7 @@ public interface EntityTuplizer extends Tuplizer {
 	 *
 	 * @param entity The entity from which to extract.
 	 * @param mergeMap a map of instances being merged to merged instances
-	 * @param session The session in which the resuest is being made.
+	 * @param session The session in which the result set is being made.
 	 * @return The insertable property values.
 	 * @throws HibernateException Indicates a problem access the properties
 	 */
@@ -240,7 +240,7 @@ public interface EntityTuplizer extends Tuplizer {
 	/**
 	 * Given an entity instance, determine the most appropriate (most targeted) entity-name which represents it.
 	 * This is called in situations where we already know an entity name for the given entityInstance; we are being
-	 * asked to determine if there is a more appropriate entity-name to use, specifically within an inheritence
+	 * asked to determine if there is a more appropriate entity-name to use, specifically within an inheritance
 	 * hierarchy.
 	 * <p/>
 	 * For example, consider a case where a user calls <tt>session.update( "Animal", cat );</tt>.  Here, the
@@ -248,7 +248,7 @@ public interface EntityTuplizer extends Tuplizer {
 	 * of <tt>Cat</tt> which is a subclass of <tt>Animal</tt>.  In this case, we would return <tt>Cat</tt> as the
 	 * entity-name.
 	 * <p/>
-	 * <tt>null</tt> may be returned from calls to this method.  The meaining of <tt>null</tt> in that case is assumed
+	 * <tt>null</tt> may be returned from calls to this method.  The meaning of <tt>null</tt> in that case is assumed
 	 * to be that we should use whatever explicit entity-name the user provided (<tt>Animal</tt> rather than <tt>Cat</tt>
 	 * in the example above).
 	 *
@@ -257,7 +257,7 @@ public interface EntityTuplizer extends Tuplizer {
 	 *
 	 * @return The most appropriate entity name to use.
 	 *
-	 * @throws HibernateException If we are unable to determine an entity-name within the inheritence hierarchy.
+	 * @throws HibernateException If we are unable to determine an entity-name within the inheritance hierarchy.
 	 */
 	String determineConcreteSubclassEntityName(Object entityInstance, SessionFactoryImplementor factory);
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityTuplizerFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityTuplizerFactory.java
@@ -93,7 +93,7 @@ public class EntityTuplizerFactory implements Serializable {
 	}
 
 	/**
-	 * Construct am instance of the default tuplizer for the given entity-mode.
+	 * Construct an instance of the default tuplizer for the given entity-mode.
 	 *
 	 * @param entityMode The entity mode for which to build a default tuplizer.
 	 * @param metamodel The entity metadata.

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -92,7 +92,7 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 	protected ProxyFactory buildProxyFactory(PersistentClass persistentClass, Getter idGetter, Setter idSetter) {
 		// determine the id getter and setter methods from the proxy interface (if any)
 		// determine all interfaces needed by the resulting proxy
-		
+
 		/*
 		 * We need to preserve the order of the interfaces they were put into the set, since javassist will choose the
 		 * first one's class-loader to construct the proxy class with. This is also the reason why HibernateProxy.class

--- a/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
@@ -33,7 +33,7 @@ public class ArrayType extends CollectionType {
 	private final Class arrayClass;
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public ArrayType(TypeFactory.TypeScope typeScope, String role, String propertyRef, Class elementClass) {
@@ -104,23 +104,23 @@ public class ArrayType extends CollectionType {
 	public Object replaceElements(
 		Object original,
 		Object target,
-		Object owner, 
+		Object owner,
 		Map copyCache,
 		SharedSessionContractImplementor session) throws HibernateException {
-		
+
 		int length = Array.getLength(original);
 		if ( length!=Array.getLength(target) ) {
 			//note: this affects the return value!
 			target=instantiateResult(original);
 		}
-		
+
 		Type elemType = getElementType( session.getFactory() );
 		for ( int i=0; i<length; i++ ) {
 			Array.set( target, i, elemType.replace( Array.get(original, i), null, session, owner, copyCache ) );
 		}
-		
+
 		return target;
-	
+
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/BagType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BagType.java
@@ -19,7 +19,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 public class BagType extends CollectionType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public BagType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -68,7 +68,7 @@ public abstract class CollectionType extends AbstractType implements Association
 	private volatile CollectionPersister persister;
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public CollectionType(TypeFactory.TypeScope typeScope, String role, String foreignKeyPropertyName) {
@@ -683,7 +683,7 @@ public abstract class CollectionType extends AbstractType implements Association
 
 	/**
 	 * Instantiate a new "underlying" collection exhibiting the same capacity
-	 * charactersitcs and the passed "original".
+	 * characteristics and the passed "original".
 	 *
 	 * @param original The original collection.
 	 * @return The newly instantiated collection.
@@ -699,7 +699,7 @@ public abstract class CollectionType extends AbstractType implements Association
 	 * but with the given anticipated size (i.e. accounting for initial capacity
 	 * and perhaps load factor).
 	 *
-	 * @param anticipatedSize The anticipated size of the instaniated collection
+	 * @param anticipatedSize The anticipated size of the instantiated collection
 	 * after we are done populating it.
 	 * @return A newly instantiated collection to be wrapped.
 	 */
@@ -874,7 +874,7 @@ public abstract class CollectionType extends AbstractType implements Association
 
 	/**
 	 * We always need to dirty check the collection because we sometimes
-	 * need to incremement version number of owner and also because of
+	 * need to increment version number of owner and also because of
 	 * how assemble/disassemble is implemented for uks
 	 */
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -56,7 +56,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public ComponentType(TypeFactory.TypeScope typeScope, ComponentMetamodel metamodel) {
@@ -433,7 +433,7 @@ public class ComponentType extends AbstractType implements CompositeType, Proced
 			component = new Object[propertySpan];
 		}
 		if ( component instanceof Object[] ) {
-			// A few calls to hashCode pass the property values already in an 
+			// A few calls to hashCode pass the property values already in an
 			// Object[] (ex: QueryKey hash codes for cached queries).
 			// It's easiest to just check for the condition here prior to
 			// trying reflection.

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomCollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomCollectionType.java
@@ -22,7 +22,7 @@ import org.hibernate.usertype.UserCollectionType;
 
 /**
  * A custom type for mapping user-written classes that implement <tt>PersistentCollection</tt>
- * 
+ *
  * @see org.hibernate.collection.spi.PersistentCollection
  * @see org.hibernate.usertype.UserCollectionType
  * @author Gavin King
@@ -33,7 +33,7 @@ public class CustomCollectionType extends CollectionType {
 	private final boolean customLogging;
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public CustomCollectionType(

--- a/hibernate-core/src/main/java/org/hibernate/type/EmbeddedComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EmbeddedComponentType.java
@@ -18,7 +18,7 @@ import org.hibernate.tuple.component.ComponentMetamodel;
 public class EmbeddedComponentType extends ComponentType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public EmbeddedComponentType(TypeFactory.TypeScope typeScope, ComponentMetamodel metamodel) {

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -68,7 +68,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	 * reference the PK of the associated entity.
 	 * @param eager Is eager fetching enabled.
 	 * @param unwrapProxy Is unwrapping of proxies allowed for this association; unwrapping
-	 * says to return the "implementation target" of lazy prooxies; typically only possible
+	 * says to return the "implementation target" of lazy proxies; typically only possible
 	 * with lazy="no-proxy".
 	 *
 	 * @deprecated Use {@link #EntityType(org.hibernate.type.TypeFactory.TypeScope, String, boolean, String, boolean, boolean)} instead.
@@ -93,7 +93,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	 * reference the PK of the associated entity.
 	 * @param eager Is eager fetching enabled.
 	 * @param unwrapProxy Is unwrapping of proxies allowed for this association; unwrapping
-	 * says to return the "implementation target" of lazy prooxies; typically only possible
+	 * says to return the "implementation target" of lazy proxies; typically only possible
 	 * with lazy="no-proxy".
 	 */
 	protected EntityType(
@@ -236,7 +236,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	 * entity persister (nor to the session factory, to look it up) which is really
 	 * needed to "do the right thing" here...
 	 *
-	 * @return The entiyt class.
+	 * @return The entity class.
 	 */
 	@Override
 	public final Class getReturnedClass() {
@@ -567,7 +567,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	public abstract boolean isOneToOne();
 
 	/**
-	 * Is the association modeled here a 1-1 according to the logical moidel?
+	 * Is the association modeled here a 1-1 according to the logical model?
 	 *
 	 * @return True if a 1-1 in the logical model; false otherwise.
 	 */
@@ -670,7 +670,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	 * Resolve an identifier via a load.
 	 *
 	 * @param id The entity id to resolve
-	 * @param session The orginating session.
+	 * @param session The originating session.
 	 *
 	 * @return The resolved identifier (i.e., loaded entity).
 	 *
@@ -711,7 +711,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	 * Load an instance by a unique key that is not the primary key.
 	 *
 	 * @param entityName The name of the entity to load
-	 * @param uniqueKeyPropertyName The name of the property defining the uniqie key.
+	 * @param uniqueKeyPropertyName The name of the property defining the unique key.
 	 * @param key The unique key property value.
 	 * @param session The originating session.
 	 *
@@ -742,7 +742,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 		Object result = persistenceContext.getEntity( euk );
 		if ( result == null ) {
 			result = persister.loadByUniqueKey( uniqueKeyPropertyName, key, session );
-			
+
 			// If the entity was not in the Persistence Context, but was found now,
 			// add it to the Persistence Context
 			if (result != null) {

--- a/hibernate-core/src/main/java/org/hibernate/type/IdentifierBagType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/IdentifierBagType.java
@@ -18,7 +18,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 public class IdentifierBagType extends CollectionType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public IdentifierBagType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/ListType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ListType.java
@@ -18,7 +18,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 public class ListType extends CollectionType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public ListType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/MapType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/MapType.java
@@ -21,7 +21,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 public class MapType extends CollectionType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public MapType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/OrderedMapType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OrderedMapType.java
@@ -13,7 +13,7 @@ import java.util.LinkedHashMap;
 public class OrderedMapType extends MapType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public OrderedMapType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/OrderedSetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OrderedSetType.java
@@ -13,7 +13,7 @@ import java.util.LinkedHashSet;
 public class OrderedSetType extends SetType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public OrderedSetType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {

--- a/hibernate-core/src/main/java/org/hibernate/type/SerializationException.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SerializationException.java
@@ -8,7 +8,7 @@ package org.hibernate.type;
 import org.hibernate.HibernateException;
 
 /**
- * Thrown when a property cannot be serializaed/deserialized
+ * Thrown when a property cannot be serialized/deserialized
  * @author Gavin King
  */
 public class SerializationException extends HibernateException {

--- a/hibernate-core/src/main/java/org/hibernate/type/SetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SetType.java
@@ -17,7 +17,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 public class SetType extends CollectionType {
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public SetType(TypeFactory.TypeScope typeScope, String role, String propertyRef) {
@@ -49,5 +49,5 @@ public class SetType extends CollectionType {
 				? new HashSet()
 				: new HashSet( anticipatedSize + (int)( anticipatedSize * .75f ), .75f );
 	}
-	
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/SortedMapType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SortedMapType.java
@@ -21,7 +21,7 @@ public class SortedMapType extends MapType {
 	private final Comparator comparator;
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public SortedMapType(TypeFactory.TypeScope typeScope, String role, String propertyRef, Comparator comparator) {

--- a/hibernate-core/src/main/java/org/hibernate/type/SortedSetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SortedSetType.java
@@ -20,7 +20,7 @@ public class SortedSetType extends SetType {
 	private final Comparator comparator;
 
 	/**
-	 * @deprecated Use the other contructor
+	 * @deprecated Use the other constructor
 	 */
 	@Deprecated
 	public SortedSetType(TypeFactory.TypeScope typeScope, String role, String propertyRef, Comparator comparator) {

--- a/hibernate-core/src/main/java/org/hibernate/type/Type.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/Type.java
@@ -269,7 +269,7 @@ public interface Type extends Serializable {
 	 *
 	 * @param dbState the database state, in a "hydrated" form, with identifiers unresolved
 	 * @param currentState the current state of the object
-	 * @param checkable which columns are actually updatable
+	 * @param checkable which columns are actually checkable
 	 * @param session The session from which the request originated.
 	 *
 	 * @return true if the field has been modified

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -419,7 +419,7 @@ public final class TypeFactory implements Serializable {
 	 *
 	 * @param metaType meta type
 	 * @param identifierType identifier type
-	 * @param lazy is teh underlying proeprty lazy
+	 * @param lazy is the underlying property lazy
 	 * @return AnyType
 	 */
 	public Type any(Type metaType, Type identifierType, boolean lazy) {

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeResolver.java
@@ -99,7 +99,7 @@ public class TypeResolver implements Serializable {
 	 * 	<li>
 	 * 		look for 'typeName' as a class name and<ol>
 	 *			<li>if it names a {@link Type} implementor, return an instance</li>
-	 *			<li>if it names a {@link CompositeUserType} or a {@link UserType}, return an instance of class wrapped intot the appropriate {@link Type} adapter</li>
+	 *			<li>if it names a {@link CompositeUserType} or a {@link UserType}, return an instance of class wrapped into the appropriate {@link Type} adapter</li>
 	 * 			<li>if it implements {@link org.hibernate.classic.Lifecycle}, return the corresponding entity type</li>
 	 * 			<li>if it implements {@link Serializable}, return the corresponding serializable type</li>
 	 * 		</ol>

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterMutabilityPlanImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterMutabilityPlanImpl.java
@@ -10,7 +10,7 @@ import org.hibernate.metamodel.model.convert.spi.JpaAttributeConverter;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 
 /**
- * The standard aproach for defining a MutabilityPlan for converted (AttributeConverter)
+ * The standard approach for defining a MutabilityPlan for converted (AttributeConverter)
  * values is to always assume that they are immutable to make sure that dirty checking,
  * deep copying and second-level caching all work properly no matter what.  That was work
  * done under https://hibernate.atlassian.net/browse/HHH-10111

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
@@ -239,7 +239,7 @@ public final class DataHelper {
 	}
 
 	/**
-	 * Extract a portion of the bytes from the given stream., wrapping them in a new stream.
+	 * Extract a portion of the bytes from the given stream, wrapping them in a new stream.
 	 *
 	 * @param inputStream The stream of bytes.
 	 * @param start The start position/offset (0-based, per general stream/reader contracts).
@@ -292,7 +292,7 @@ public final class DataHelper {
 	/**
 	 * Make sure we allocate a buffer sized not bigger than 2048,
 	 * not higher than what is actually needed, and at least one.
-	 * 
+	 *
 	 * @param lengthHint the expected size of the full value
 	 * @return the buffer size
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
@@ -145,7 +145,7 @@ public interface CompositeUserType {
 	 *
 	 * @param value the object to be cached
 	 * @param session
-	 * @return a cachable representation of the object
+	 * @return a cacheable representation of the object
 	 * @throws HibernateException
 	 */
 	Serializable disassemble(Object value, SharedSessionContractImplementor session) throws HibernateException;
@@ -157,7 +157,7 @@ public interface CompositeUserType {
 	 * @param cached the object to be cached
 	 * @param session
 	 * @param owner the owner of the cached object
-	 * @return a reconstructed object from the cachable representation
+	 * @return a reconstructed object from the cacheable representation
 	 * @throws HibernateException
 	 */
 	Object assemble(Serializable cached, SharedSessionContractImplementor session, Object owner) throws HibernateException;

--- a/hibernate-core/src/main/java/org/hibernate/usertype/LoggableUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/LoggableUserType.java
@@ -17,7 +17,7 @@ public interface LoggableUserType {
 	/**
 	 * Generate a loggable string representation of the collection (value).
 	 *
-	 * @param value The collection to be logged; guarenteed to be non-null and initialized.
+	 * @param value The collection to be logged; guaranteed to be non-null and initialized.
 	 * @param factory The factory.
 	 * @return The loggable string representation.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/usertype/UserCollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/UserCollectionType.java
@@ -65,7 +65,7 @@ public interface UserCollectionType {
 	 * but with the given anticipated size (i.e. accounting for initial size
 	 * and perhaps load factor).
 	 *
-	 * @param anticipatedSize The anticipated size of the instaniated collection
+	 * @param anticipatedSize The anticipated size of the instantiated collection
 	 * after we are done populating it.  Note, may be negative to indicate that
 	 * we not yet know anything about the anticipated size (i.e., when initializing
 	 * from a result set row by row).

--- a/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
@@ -132,7 +132,7 @@ public interface UserType {
 	 * identifier values. (optional operation)
 	 *
 	 * @param value the object to be cached
-	 * @return a cachable representation of the object
+	 * @return a cacheable representation of the object
 	 * @throws HibernateException
 	 */
 	Serializable disassemble(Object value) throws HibernateException;
@@ -143,7 +143,7 @@ public interface UserType {
 	 *
 	 * @param cached the object to be cached
 	 * @param owner the owner of the cached object
-	 * @return a reconstructed object from the cachable representation
+	 * @return a reconstructed object from the cacheable representation
 	 * @throws HibernateException
 	 */
 	Object assemble(Serializable cached, Object owner) throws HibernateException;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13800

Tons of stuff, but not difficult to review. Typos elsewhere (like in the line comment) are ignored. The scope of Javadoc has been 
big enough. Maybe I should have narrowed the scope to exclude 'internal' packages.