### PR TITLE
HHH-8776 make Hibernate respect JPA's FETCH entity graph semantic

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
@@ -206,10 +206,6 @@ include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fet
 
 [NOTE]
 ====
-Although the JPA standard specifies that you can override an EAGER fetching association at runtime using the `javax.persistence.fetchgraph` hint,
-currently, Hibernate does not implement this feature, so EAGER associations cannot be fetched lazily.
-For more info, check out the https://hibernate.atlassian.net/browse/HHH-8776[HHH-8776] Jira issue.
-
 When executing a JPQL query, if an EAGER association is omitted, Hibernate will issue a secondary select for every association needed to be fetched eagerly,
 which can lead to N+1 query issues.
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
@@ -16,11 +16,8 @@ public enum GraphSemantic {
 	/**
 	 * Indicates a "fetch graph" EntityGraph.  Attributes explicitly specified
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
-	 * subsequent select).
-	 * <p/>
-	 * Note: Currently, attributes that are not specified are treated as
-	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata, rather than forcing FetchType.LAZY.
+	 * subsequent select). Attributes that are not specified are treated as
+	 * FetchType.LAZY invariably
 	 */
 	FETCH( "javax.persistence.fetchgraph" ),
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -1176,7 +1176,7 @@ public abstract class Loader {
 					.listeners();
 
 				for ( Object hydratedObject : hydratedObjects ) {
-					TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
+					TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners, null );
 				}
 
 			}

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/AbstractRowReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/exec/process/internal/AbstractRowReader.java
@@ -257,7 +257,8 @@ public abstract class AbstractRowReader implements RowReader {
 					context.isReadOnly(),
 					session,
 					preLoadEvent,
-					listeners
+					listeners,
+					registration.getEntityReference()
 			);
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
@@ -24,8 +24,9 @@ import javax.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
+import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.testing.TestForIssue;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class EntityGraphFunctionalTests extends BaseEntityManagerFunctionalTestC
 					final Issue issue = session.find(
 							Issue.class,
 							1,
-							Collections.singletonMap( GraphSemantic.FETCH.getJpaHintName(), graph )
+							Collections.singletonMap( GraphSemantic.LOAD.getJpaHintName(), graph )
 					);
 
 					assertTrue( Hibernate.isInitialized( issue ) );
@@ -59,6 +60,29 @@ public class EntityGraphFunctionalTests extends BaseEntityManagerFunctionalTestC
 					assertTrue( Hibernate.isInitialized( issue.getAssignee() ) );
 
 					assertFalse( Hibernate.isInitialized( issue.getAssignee().getAssignedIssues() ) );
+				}
+		);
+	}
+	
+	@Test
+	@TestForIssue( jiraKey = "HHH-8776")
+	public void testFetchGraphSemanticDefaultLazy() {
+		
+		inTransaction(
+				entityManagerFactory(),
+				session -> {
+					final RootGraph<Issue> graph = GraphParser.parse( Issue.class, "comments", session );
+					
+					final Issue issue = session.find(
+							Issue.class,
+							1,
+							Collections.singletonMap( GraphSemantic.FETCH.getJpaHintName(), graph )
+					);
+					
+					assertTrue( Hibernate.isInitialized( issue ) );
+					assertTrue( Hibernate.isInitialized( issue.comments ) );
+					assertTrue( issue.reporter instanceof HibernateProxy );
+					assertTrue( issue.assignee instanceof HibernateProxy );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
@@ -31,9 +31,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.core.Is.is;
 import static org.hibernate.testing.transaction.TransactionUtil2.inTransaction;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Steve Ebersole
@@ -79,10 +80,10 @@ public class EntityGraphFunctionalTests extends BaseEntityManagerFunctionalTestC
 							Collections.singletonMap( GraphSemantic.FETCH.getJpaHintName(), graph )
 					);
 					
-					assertTrue( Hibernate.isInitialized( issue ) );
-					assertTrue( Hibernate.isInitialized( issue.comments ) );
-					assertTrue( issue.reporter instanceof HibernateProxy );
-					assertTrue( issue.assignee instanceof HibernateProxy );
+					assertThat( Hibernate.isInitialized( issue ), is( true ) );
+					assertThat( Hibernate.isInitialized( issue.comments ), is( true ) );
+					assertThat( issue.reporter, instanceOf( HibernateProxy.class ));
+					assertThat( issue.assignee, instanceOf( HibernateProxy.class ));
 				}
 		);
 	}


### PR DESCRIPTION
We did respect JPA's FETCH semantic when generating SQL, but at second phase loading stage, we ignored the information and load association purely based on its type. The fixing includes the following steps:

1. pass **HydratedEntityRegistration**'s **entityReference** from AbstractRowReader to **TwoPhaseLoad**'s **initializeEntity** method;
2. in **TwoPhaseLoad** class, grab the info to access to **FetchStrategy** for relevant property as a default value (could be null) which can be still overridden by fetching profile.

The relevant content in user guide doc is updated (actually it is the motivation to fix this PR in the first place). Testing case attached.