### PR TITLE
HHH-8776 make Hibernate comply with JPA's FETCH graph semantic

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
@@ -206,10 +206,6 @@ include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fet
 
 [NOTE]
 ====
-Although the JPA standard specifies that you can override an EAGER fetching association at runtime using the `javax.persistence.fetchgraph` hint,
-currently, Hibernate does not implement this feature, so EAGER associations cannot be fetched lazily.
-For more info, check out the https://hibernate.atlassian.net/browse/HHH-8776[HHH-8776] Jira issue.
-
 When executing a JPQL query, if an EAGER association is omitted, Hibernate will issue a secondary select for every association needed to be fetched eagerly,
 which can lead to N+1 query issues.
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
@@ -16,11 +16,8 @@ public enum GraphSemantic {
 	/**
 	 * Indicates a "fetch graph" EntityGraph.  Attributes explicitly specified
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
-	 * subsequent select).
-	 * <p/>
-	 * Note: Currently, attributes that are not specified are treated as
-	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata, rather than forcing FetchType.LAZY.
+	 * subsequent select). Attributes that are not specified are treated as
+	 * FetchType.LAZY invariably.
 	 */
 	FETCH( "javax.persistence.fetchgraph" ),
 
@@ -29,7 +26,7 @@ public enum GraphSemantic {
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
 	 * subsequent select).  Attributes that are not specified are treated as
 	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata
+	 * in metadata.
 	 */
 	LOAD( "javax.persistence.loadgraph" );
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractEntityGraphVisitationStrategy.java
@@ -272,7 +272,7 @@ public abstract class AbstractEntityGraphVisitationStrategy
 				&& currentGraph.findAttributeNode( attributeDefinition.getName() ) != null ) {
 			currentSource().buildCollectionAttributeFetch( attributeDefinition, fetchStrategy );
 		}
-		
+
 		super.foundCircularAssociation( attributeDefinition );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-8776

This is an important PR for it aims to make Hibernate adhere to JPA's entity graph feature (FETCH graph semantic dictates that loading should be lazy by default invariably).

We did right for load event handling and SQL generation, but went out of sync in later preload event processing or TwoPhaseLoader. 

The implementation is straightforward:

- enrich existing **getOverridingEager()** method in the same class to add the logic to return entity graph's default value, right after existing **FetchProfile** overriding logic.

Testing case is attached.