### PR TITLE
HHH-13808: Fix String format in log

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
@@ -160,7 +160,7 @@ public class AttributeNodeImpl<J>
 
 		final SubGraphImplementor<? extends J> previous = subGraphMap.put( subType, (SubGraphImplementor) subGraph );
 		if ( previous != null ) {
-			log.debugf( "Adding sub-graph [%s] over-wrote existing [%]", subGraph, previous );
+			log.debugf( "Adding sub-graph [%s] over-wrote existing [%s]", subGraph, previous );
 		}
 	}
 


### PR DESCRIPTION
Use %s in the log string format, to avoid java.util.UnknownFormatConversionException: Conversion = ']' when enabling debug logs.

Fixes HHH-13808
