### PR TITLE
HHH-13694 fix numeric overflow exception for large sequence min values

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorOracleDatabaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorOracleDatabaseImpl.java
@@ -37,12 +37,17 @@ public class SequenceInformationExtractorOracleDatabaseImpl extends SequenceInfo
 
 	@Override
 	protected String sequenceMinValueColumn() {
-		return null;
+		return "min_value";
+	}
+
+	@Override
+	protected String sequenceMaxValueColumn() {
+		return "max_value";
 	}
 
 	@Override
 	protected Long resultSetMinValue(ResultSet resultSet) throws SQLException {
-		BigDecimal asDecimal = resultSet.getBigDecimal( "min_value" );
+		BigDecimal asDecimal = resultSet.getBigDecimal( sequenceMinValueColumn() );
 
 		// BigDecimal.longValue() may return a result with the opposite sign
 		if ( asDecimal.compareTo( BigDecimal.valueOf( Long.MIN_VALUE ) ) == -1 ) {
@@ -54,7 +59,14 @@ public class SequenceInformationExtractorOracleDatabaseImpl extends SequenceInfo
 
 	@Override
 	protected Long resultSetMaxValue(ResultSet resultSet) throws SQLException {
-		return resultSet.getBigDecimal( "max_value" ).longValue();
+		BigDecimal asDecimal = resultSet.getBigDecimal( sequenceMaxValueColumn() );
+
+		// BigDecimal.longValue() may return a result with the opposite sign
+		if ( asDecimal.compareTo( BigDecimal.valueOf( Long.MAX_VALUE ) ) == 1 ) {
+			return Long.MAX_VALUE;
+		}
+
+		return asDecimal.longValue();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorOracleDatabaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorOracleDatabaseImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.tool.schema.extract.internal;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -13,6 +14,7 @@ import java.sql.SQLException;
  * @author Vlad Mihalcea
  */
 public class SequenceInformationExtractorOracleDatabaseImpl extends SequenceInformationExtractorLegacyImpl {
+
 	/**
 	 * Singleton access
 	 */
@@ -35,7 +37,19 @@ public class SequenceInformationExtractorOracleDatabaseImpl extends SequenceInfo
 
 	@Override
 	protected String sequenceMinValueColumn() {
-		return "min_value";
+		return null;
+	}
+
+	@Override
+	protected Long resultSetMinValue(ResultSet resultSet) throws SQLException {
+		BigDecimal asDecimal = resultSet.getBigDecimal( "min_value" );
+
+		// BigDecimal.longValue() may return a result with the opposite sign
+		if ( asDecimal.compareTo( BigDecimal.valueOf( Long.MIN_VALUE ) ) == -1 ) {
+			return Long.MIN_VALUE;
+		}
+
+		return asDecimal.longValue();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/OracleDialectSequenceInformationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/OracleDialectSequenceInformationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.functional;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.Oracle12cDialect;
+import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorOracleDatabaseImpl;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.SequenceInformation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInAutoCommit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RequiresDialect(value = { Oracle12cDialect.class })
+@TestForIssue(jiraKey = "HHH-13694")
+public class OracleDialectSequenceInformationTest extends BaseUnitTestCase {
+
+	private final String SEQUENCE_NAME = "SEQ_MIN_TEST";
+
+	@Before
+	public void prepareTest() throws Exception {
+		doInAutoCommit(
+				"DROP SEQUENCE " + SEQUENCE_NAME,
+				"CREATE SEQUENCE " + SEQUENCE_NAME + " MINVALUE -99999999999999999999999999 MAXVALUE -1 INCREMENT BY -1" );
+	}
+
+	@After
+	public void cleanupTest() throws Exception {
+		doInAutoCommit(
+				"DROP SEQUENCE " + SEQUENCE_NAME );
+	}
+
+	@Test
+	public void testExtractSequenceWithMinValueLowerThanLongMinValue() throws SQLException {
+		Dialect dialect = new Oracle12cDialect();
+
+		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+		StandardServiceRegistry ssr = ssrb.build();
+
+		try ( Connection connection = ssr.getService( JdbcServices.class )
+				.getBootstrapJdbcConnectionAccess()
+				.obtainConnection() ) {
+
+			JdbcEnvironment jdbcEnvironment = new JdbcEnvironmentImpl( connection.getMetaData(), dialect );
+			SequenceInformationExtractorOracleDatabaseImpl sequenceExtractor = SequenceInformationExtractorOracleDatabaseImpl.INSTANCE;
+			Iterable<SequenceInformation> sequenceInformations = sequenceExtractor.extractMetadata(
+					new ExtractionContext.EmptyExtractionContext() {
+
+						@Override
+						public Connection getJdbcConnection() {
+							return connection;
+						}
+
+						@Override
+						public JdbcEnvironment getJdbcEnvironment() {
+							return jdbcEnvironment;
+						}
+					} );
+
+			// lets skip system sequences
+			Optional<SequenceInformation> foundSequence = StreamSupport.stream( sequenceInformations.spliterator(), false )
+					.filter( sequence -> SEQUENCE_NAME.equals( sequence.getSequenceName().getSequenceName().getText().toUpperCase() ) )
+					.findFirst();
+
+			assertTrue( SEQUENCE_NAME + " not found", foundSequence.isPresent() );
+
+			SequenceInformation sequence = foundSequence.get();
+
+			assertEquals( -1L, sequence.getIncrementValue().longValue() );
+			assertEquals( Long.MIN_VALUE, sequence.getMinValue().longValue() );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/OracleDialectSequenceInformationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/functional/OracleDialectSequenceInformationTest.java
@@ -11,16 +11,11 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
-import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.Oracle12cDialect;
-import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorOracleDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 import org.hibernate.tool.schema.extract.spi.SequenceInformation;
@@ -34,35 +29,48 @@ import static org.junit.Assert.assertTrue;
 
 @RequiresDialect(value = { Oracle12cDialect.class })
 @TestForIssue(jiraKey = "HHH-13694")
-public class OracleDialectSequenceInformationTest extends BaseUnitTestCase {
+public class OracleDialectSequenceInformationTest extends BaseNonConfigCoreFunctionalTestCase {
 
-	private final String SEQUENCE_NAME = "SEQ_MIN_TEST";
+	private final String MIN_SEQUENCE_NAME = "SEQ_MIN_TEST";
+	private final String MAX_SEQUENCE_NAME = "SEQ_MAX_TEST";
 
 	@Before
 	public void prepareTest() throws Exception {
 		doInAutoCommit(
-				"DROP SEQUENCE " + SEQUENCE_NAME,
-				"CREATE SEQUENCE " + SEQUENCE_NAME + " MINVALUE -99999999999999999999999999 MAXVALUE -1 INCREMENT BY -1" );
+				"DROP SEQUENCE " + MIN_SEQUENCE_NAME,
+				"CREATE SEQUENCE " + MIN_SEQUENCE_NAME + " MINVALUE -99999999999999999999999999 MAXVALUE -1 INCREMENT BY -1",
+				"DROP SEQUENCE " + MAX_SEQUENCE_NAME,
+				"CREATE SEQUENCE " + MAX_SEQUENCE_NAME + " MINVALUE 0 MAXVALUE 99999999999999999999999999 INCREMENT BY 1" );
 	}
 
 	@After
 	public void cleanupTest() throws Exception {
 		doInAutoCommit(
-				"DROP SEQUENCE " + SEQUENCE_NAME );
+				"DROP SEQUENCE " + MIN_SEQUENCE_NAME, 
+				"DROP SEQUENCE " + MAX_SEQUENCE_NAME );
 	}
 
 	@Test
 	public void testExtractSequenceWithMinValueLowerThanLongMinValue() throws SQLException {
-		Dialect dialect = new Oracle12cDialect();
+		SequenceInformation sequence = fetchSequenceInformation( MIN_SEQUENCE_NAME );
 
-		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
-		StandardServiceRegistry ssr = ssrb.build();
+		assertEquals( -1L, sequence.getIncrementValue().longValue() );
+		assertEquals( Long.MIN_VALUE, sequence.getMinValue().longValue() );
+	}
+	
+	@Test
+	public void testExtractSequenceWithMaxValueGreaterThanLongMaxValue() throws SQLException {
+		SequenceInformation sequence = fetchSequenceInformation( MAX_SEQUENCE_NAME );
 
-		try ( Connection connection = ssr.getService( JdbcServices.class )
+		assertEquals( 1L, sequence.getIncrementValue().longValue() );
+		assertEquals( Long.MAX_VALUE, sequence.getMaxValue().longValue() );
+	}
+	
+	private SequenceInformation fetchSequenceInformation(String sequenceName) throws SQLException {
+		try ( Connection connection = sessionFactory().getJdbcServices()
 				.getBootstrapJdbcConnectionAccess()
 				.obtainConnection() ) {
-
-			JdbcEnvironment jdbcEnvironment = new JdbcEnvironmentImpl( connection.getMetaData(), dialect );
+			JdbcEnvironment jdbcEnvironment = sessionFactory().getJdbcServices().getJdbcEnvironment();
 			SequenceInformationExtractorOracleDatabaseImpl sequenceExtractor = SequenceInformationExtractorOracleDatabaseImpl.INSTANCE;
 			Iterable<SequenceInformation> sequenceInformations = sequenceExtractor.extractMetadata(
 					new ExtractionContext.EmptyExtractionContext() {
@@ -80,19 +88,12 @@ public class OracleDialectSequenceInformationTest extends BaseUnitTestCase {
 
 			// lets skip system sequences
 			Optional<SequenceInformation> foundSequence = StreamSupport.stream( sequenceInformations.spliterator(), false )
-					.filter( sequence -> SEQUENCE_NAME.equals( sequence.getSequenceName().getSequenceName().getText().toUpperCase() ) )
+					.filter( sequence -> sequenceName.equals( sequence.getSequenceName().getSequenceName().getText().toUpperCase() ) )
 					.findFirst();
 
-			assertTrue( SEQUENCE_NAME + " not found", foundSequence.isPresent() );
+			assertTrue( sequenceName + " not found", foundSequence.isPresent() );
 
-			SequenceInformation sequence = foundSequence.get();
-
-			assertEquals( -1L, sequence.getIncrementValue().longValue() );
-			assertEquals( Long.MIN_VALUE, sequence.getMinValue().longValue() );
-		}
-		finally {
-			StandardServiceRegistryBuilder.destroy( ssr );
+			return foundSequence.get();
 		}
 	}
-
 }


### PR DESCRIPTION
Fixes a numeric overflow exception for Oracle sequence min values that
exceed `Long.minValue()`. In that case `Long.minValue()` is returned
instead.