### PR TITLE
HHH-13817 Support to-one traverseRelations for RevisionsOfEntity queries

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
@@ -58,7 +58,9 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 	protected final EnversService enversService;
 	protected final AuditReaderImplementor versionsReader;
 
-	protected final List<AuditAssociationQueryImpl<?>> associationQueries = new ArrayList<>();
+	// todo: can these association query collections be merged?
+	protected final List<AbstractAuditAssociationQuery<?>> associationQueries = new ArrayList<>();
+	protected final Map<String, AbstractAuditAssociationQuery<AuditQueryImplementor>> associationQueryMap = new HashMap<>();
 	protected final List<Pair<String, AuditProjection>> projections = new ArrayList<>();
 
 	protected AbstractAuditQuery(
@@ -200,29 +202,6 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 				joinType,
 				alias,
 				null );
-	}
-
-	@Override
-	public AuditAssociationQuery<? extends AuditQuery> traverseRelation(
-			String associationName,
-			JoinType joinType,
-			String alias,
-			AuditCriterion onClause) {
-		AuditAssociationQueryImpl<AbstractAuditQuery> result = new AuditAssociationQueryImpl<>(
-				enversService,
-				versionsReader,
-				this,
-				qb,
-				associationName,
-				joinType,
-				aliasToEntityNameMap,
-				aliasToComponentPropertyNameMap,
-				REFERENCED_ENTITY_ALIAS,
-				alias,
-				onClause
-		);
-		associationQueries.add( result );
-		return result;
 	}
 
 	// Query properties
@@ -383,4 +362,9 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 		// todo: can this be replaced by a call to getEntittyConfiguration#getEntityClassName()?
 		return entityName;
 	}
+	
+	protected void addAssociationQuery(String associationName, AbstractAuditAssociationQuery<AuditQueryImplementor> query) {
+		associationQueries.add( query );
+		associationQueryMap.put( associationName, query );
+	}	
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionAssociationQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionAssociationQuery.java
@@ -1,0 +1,120 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.internal.impl;
+
+import java.util.Map;
+
+import org.hibernate.Incubating;
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.configuration.Configuration;
+import org.hibernate.envers.internal.entities.mapper.relation.MiddleIdData;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.AuditAssociationQuery;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+
+import jakarta.persistence.criteria.JoinType;
+
+/**
+ * An {@link AuditAssociationQuery} implementation for
+ * {@link EntitiesAtRevisionQuery} and {@link EntitiesModifiedAtRevisionQuery} query types.
+ *
+ * @author Chris Cranford
+ */
+@Incubating
+public class EntitiesAtRevisionAssociationQuery<Q extends AuditQueryImplementor> extends AbstractAuditAssociationQuery<Q> {
+
+	public EntitiesAtRevisionAssociationQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Q parent,
+			QueryBuilder queryBuilder,
+			String propertyName,
+			JoinType joinType,
+			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliasToComponentPropertyNameMap,
+			String ownerAlias,
+			String userSuppliedAlias,
+			AuditCriterion onClauseCriterion) {
+		super(
+				enversService,
+				auditReader,
+				parent,
+				queryBuilder,
+				propertyName,
+				joinType,
+				aliasToEntityNameMap,
+				aliasToComponentPropertyNameMap,
+				ownerAlias,
+				userSuppliedAlias,
+				onClauseCriterion
+		);
+	}
+
+	@Override
+	protected AbstractAuditAssociationQuery<AbstractAuditAssociationQuery<Q>> createAssociationQuery(
+			String associationName,
+			JoinType joinType,
+			String alias,
+			AuditCriterion onClause) {
+		return new EntitiesAtRevisionAssociationQuery<>(
+				enversService,
+				auditReader,
+				this,
+				queryBuilder,
+				associationName,
+				joinType,
+				aliasToEntityNameMap,
+				aliasToComponentPropertyNameMap,
+				this.alias,
+				alias,
+				onClauseCriterion
+		);
+	}
+
+	@Override
+	protected Parameters createEntityJoin(Configuration configuration) {
+		Parameters onClauseParameters = super.createEntityJoin( configuration );
+
+		if ( enversService.getEntitiesConfigurations().isVersioned( entityName ) ) {
+			final String originalIdPropertyName = configuration.getOriginalIdPropertyName();
+			final String revisionPropertyPath = configuration.getRevisionNumberPath();
+
+			// filter revision of target entity
+			Parameters parametersToUse = parameters;
+			if ( joinType == JoinType.LEFT ) {
+				parametersToUse = parameters.addSubParameters( Parameters.OR );
+				parametersToUse.addNullRestriction( revisionPropertyPath, true );
+				parametersToUse = parametersToUse.addSubParameters( Parameters.AND );
+			}
+			MiddleIdData referencedIdData = new MiddleIdData(
+					configuration,
+					enversService.getEntitiesConfigurations().get( entityName ).getIdMappingData(),
+					null,
+					entityName,
+					true
+			);
+			enversService.getAuditStrategy().addEntityAtRevisionRestriction(
+					configuration,
+					queryBuilder,
+					parametersToUse,
+					revisionPropertyPath,
+					configuration.getRevisionEndFieldName(),
+					true,
+					referencedIdData,
+					revisionPropertyPath,
+					originalIdPropertyName,
+					alias,
+					queryBuilder.generateAlias(),
+					true
+			);
+		}
+
+		return onClauseParameters;
+	}
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/EntitiesAtRevisionQuery.java
@@ -9,12 +9,16 @@ package org.hibernate.envers.query.internal.impl;
 import java.util.Collection;
 import java.util.List;
 
+import jakarta.persistence.criteria.JoinType;
+
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.configuration.Configuration;
 import org.hibernate.envers.internal.entities.mapper.relation.MiddleIdData;
 import org.hibernate.envers.internal.entities.mapper.relation.query.QueryConstants;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.query.AuditAssociationQuery;
+import org.hibernate.envers.query.AuditQuery;
 import org.hibernate.envers.query.criteria.AuditCriterion;
 import org.hibernate.query.Query;
 
@@ -121,8 +125,8 @@ public class EntitiesAtRevisionQuery extends AbstractAuditQuery {
 			);
 		}
 
-		for (final AuditAssociationQueryImpl<?> associationQuery : associationQueries) {
-			associationQuery.addCriterionsToQuery( versionsReader );
+		for ( AbstractAuditAssociationQuery<?> associationQuery : associationQueries ) {
+			associationQuery.addCriterionToQuery( versionsReader );
 		}
 
 		Query query = buildQuery();
@@ -133,5 +137,31 @@ public class EntitiesAtRevisionQuery extends AbstractAuditQuery {
 		}
 		List queryResult = query.list();
 		return applyProjections( queryResult, revision );
+	}
+
+	@Override
+	public AuditAssociationQuery<? extends AuditQuery> traverseRelation(
+			String associationName,
+			JoinType joinType,
+			String alias,
+			AuditCriterion onClauseCriterion) {
+		AbstractAuditAssociationQuery<AuditQueryImplementor> query = associationQueryMap.get( associationName );
+		if ( query == null ) {
+			query = new EntitiesAtRevisionAssociationQuery<>(
+					enversService,
+					versionsReader,
+					this,
+					qb,
+					associationName,
+					joinType,
+					aliasToEntityNameMap,
+					aliasToComponentPropertyNameMap,
+					REFERENCED_ENTITY_ALIAS,
+					alias,
+					onClauseCriterion
+			);
+			addAssociationQuery( associationName, query );
+		}
+		return query;
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/RevisionsOfEntityAssociationQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/RevisionsOfEntityAssociationQuery.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.query.internal.impl;
+
+import java.util.Map;
+
+import org.hibernate.Incubating;
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.envers.internal.tools.query.QueryBuilder;
+import org.hibernate.envers.query.AuditAssociationQuery;
+import org.hibernate.envers.query.criteria.AuditCriterion;
+
+import jakarta.persistence.criteria.JoinType;
+
+/**
+ * An {@link AuditAssociationQuery} implementation for {@link RevisionsOfEntityQuery}.
+ *
+ * @author Chris Cranford
+ */
+@Incubating
+public class RevisionsOfEntityAssociationQuery<Q extends AuditQueryImplementor> extends AbstractAuditAssociationQuery<Q> {
+
+	public RevisionsOfEntityAssociationQuery(
+			EnversService enversService,
+			AuditReaderImplementor auditReader,
+			Q parent,
+			QueryBuilder queryBuilder,
+			String propertyName,
+			JoinType joinType,
+			Map<String, String> aliasToEntityNameMap,
+			Map<String, String> aliastoComponentPropertyNameMap,
+			String ownerAlias,
+			String userSuppliedAlias,
+			AuditCriterion onClauseCriterion) {
+		super(
+				enversService,
+				auditReader,
+				parent,
+				queryBuilder,
+				propertyName,
+				joinType,
+				aliasToEntityNameMap,
+				aliastoComponentPropertyNameMap,
+				ownerAlias,
+				userSuppliedAlias,
+				onClauseCriterion
+		);
+	}
+
+	@Override
+	protected AbstractAuditAssociationQuery<AbstractAuditAssociationQuery<Q>> createAssociationQuery(
+			String associationName,
+			JoinType joinType,
+			String alias,
+			AuditCriterion onClauseCriterion) {
+		return new RevisionsOfEntityAssociationQuery<>(
+				enversService,
+				auditReader,
+				this,
+				queryBuilder,
+				associationName,
+				joinType,
+				aliasToEntityNameMap,
+				aliasToComponentPropertyNameMap,
+				this.alias,
+				alias,
+				onClauseCriterion
+		);
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/BaseEnversFunctionalTestCase.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/BaseEnversFunctionalTestCase.java
@@ -13,10 +13,15 @@ import java.util.Map;
 import org.hibernate.Session;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.configuration.Configuration;
 import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.internal.SessionImpl;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+
+import org.hibernate.service.ServiceRegistry;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -59,6 +64,11 @@ public abstract class BaseEnversFunctionalTestCase extends BaseNonConfigCoreFunc
 		}
 
 		return AuditReaderFactory.get( getSession() );
+	}
+
+	protected Configuration getConfiguration() {
+		ServiceRegistry registry = getSession().unwrap(SessionImpl.class ).getSessionFactory().getServiceRegistry();
+		return registry.getService( EnversService.class ).getConfig();
 	}
 
 	@Override

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.envers.integration.query;
+
+import java.util.Map;
+
+import org.hibernate.envers.configuration.EnversSettings;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue( jiraKey = "HHH-13817" )
+public class AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest extends AssociationRevisionsOfEntitiesQueryTest {
+    @Override
+    protected void addSettings(Map settings) {
+        super.addSettings( settings );
+        settings.put( EnversSettings.STORE_DATA_AT_DELETE, true );
+    }
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.envers.integration.query;
+
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.criteria.JoinType;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.orm.test.envers.BaseEnversFunctionalTestCase;
+import org.hibernate.orm.test.envers.Priority;
+import org.junit.Test;
+
+import org.hibernate.testing.TestForIssue;
+
+/**
+ * @author Chris Cranford
+ */
+@TestForIssue( jiraKey = "HHH-13817" )
+public class AssociationRevisionsOfEntitiesQueryTest extends BaseEnversFunctionalTestCase {
+    @Override
+    protected Class[] getAnnotatedClasses() {
+        return new Class<?>[] { Template.class, TemplateType.class };
+    }
+
+    @Test
+    @Priority(10)
+    public void initData() {
+        doInHibernate( this::sessionFactory, session -> {
+            final TemplateType type1 = new TemplateType( 1, "Type1" );
+            final TemplateType type2 = new TemplateType( 2, "Type2" );
+            session.save( type1 );
+            session.save( type2 );
+
+            final Template template = new Template( 1, "Template1", type1 );
+            session.save( template );
+        } );
+
+        doInHibernate( this::sessionFactory, session -> {
+            final TemplateType type = session.find( TemplateType.class, 2 );
+            final Template template = session.find( Template.class, 1 );
+            template.setName( "Template1-Updated" );
+            template.setTemplateType( type );
+            session.update( template );
+        } );
+
+        doInHibernate( this::sessionFactory, session -> {
+            final Template template = session.find( Template.class, 1 );
+            session.remove( template );
+        } );
+    }
+
+    @Test
+    public void testRevisionsOfEntityWithAssociationQueries() {
+        doInHibernate( this::sessionFactory, session -> {
+            List<?> results = getAuditReader().createQuery()
+                    .forRevisionsOfEntity( Template.class, true, true )
+                    .add( AuditEntity.id().eq( 1 ) )
+                    .traverseRelation( "templateType", JoinType.INNER )
+                    .add( AuditEntity.property( "name" ).eq( "Type1" ) )
+                    .up()
+                    .getResultList();
+            assertEquals( 1, results.size() );
+            assertEquals( "Template1", ( (Template) results.get( 0 ) ).getName() );
+        } );
+
+        doInHibernate( this::sessionFactory, session -> {
+            List<?> results = getAuditReader().createQuery()
+                    .forRevisionsOfEntity( Template.class, true, true )
+                    .add( AuditEntity.id().eq( 1 ) )
+                    .traverseRelation( "templateType", JoinType.INNER )
+                    .add( AuditEntity.property("name" ).eq("Type2" ) )
+                    .up()
+                    .getResultList();
+
+            assertEquals( getConfiguration().isStoreDataAtDelete() ? 2 : 1, results.size() );
+            for ( Object result : results ) {
+                assertEquals( "Template1-Updated", ( (Template) result ).getName() );
+            }
+        } );
+    }
+
+    @Test
+    public void testAssociationQueriesNotAllowedWhenNotSelectingJustEntities() {
+        try {
+            doInHibernate( this::sessionFactory, session -> {
+                getAuditReader().createQuery()
+                        .forRevisionsOfEntity( Template.class, false, true )
+                        .add( AuditEntity.id().eq( 1 ) )
+                        .traverseRelation("templateType", JoinType.INNER )
+                        .add( AuditEntity.property( "name" ).eq( "Type1" ) )
+                        .up()
+                        .getResultList();
+            } );
+
+            fail( "Test should have thrown IllegalStateException due to selectEntitiesOnly=false" );
+        }
+        catch ( Exception e ) {
+            assertTyping( IllegalStateException.class, e );
+        }
+    }    
+    
+    @Entity(name = "TemplateType")
+    @Audited
+    public static class TemplateType {
+        @Id
+        private Integer id;
+        private String name;
+
+        TemplateType() {
+            this( null, null );
+        }
+
+        TemplateType(Integer id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Entity(name = "Template")
+    @Audited
+    public static class Template {
+        @Id
+        private Integer id;
+        private String name;
+        @ManyToOne
+        private TemplateType templateType;
+
+        Template() {
+            this( null, null, null );
+        }
+
+        Template(Integer id, String name, TemplateType type) {
+            this.id = id;
+            this.name = name;
+            this.templateType = type;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public TemplateType getTemplateType() {
+            return templateType;
+        }
+
+        public void setTemplateType(TemplateType templateType) {
+            this.templateType = templateType;
+        }
+    }    
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/projects/HHH/issues/HHH-13817

This PR offers preliminary support for `traverseRelation` calls for `RevisionsOfEntityQuery` types.  The support for traversing to-many associations across the various query types will be introduced in another pull request as there is currently no support for that across all query types.