### PR TITLE
Changes for Hibernate RX

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -69,6 +69,30 @@ public class EntityDeleteAction extends EntityAction {
 		);
 	}
 
+	public Object getVersion() {
+		return version;
+	}
+
+	public boolean isCascadeDeleteEnabled() {
+		return isCascadeDeleteEnabled;
+	}
+
+	public Object[] getState() {
+		return state;
+	}
+
+	protected Object[] getNaturalIdValues() {
+		return naturalIdValues;
+	}
+
+	protected SoftLock getLock() {
+		return lock;
+	}
+
+	protected void setLock(SoftLock lock) {
+		this.lock = lock;
+	}
+
 	@Override
 	public void execute() throws HibernateException {
 		final Serializable id = getId();
@@ -128,7 +152,7 @@ public class EntityDeleteAction extends EntityAction {
 		}
 	}
 
-	private boolean preDelete() {
+	protected boolean preDelete() {
 		boolean veto = false;
 		final EventListenerGroup<PreDeleteEventListener> listenerGroup = listenerGroup( EventType.PRE_DELETE );
 		if ( listenerGroup.isEmpty() ) {
@@ -141,7 +165,7 @@ public class EntityDeleteAction extends EntityAction {
 		return veto;
 	}
 
-	private void postDelete() {
+	protected void postDelete() {
 		final EventListenerGroup<PostDeleteEventListener> listenerGroup = listenerGroup( EventType.POST_DELETE );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -158,7 +182,7 @@ public class EntityDeleteAction extends EntityAction {
 		}
 	}
 
-	private void postCommitDelete(boolean success) {
+	protected void postCommitDelete(boolean success) {
 		final EventListenerGroup<PostDeleteEventListener> listenerGroup = listenerGroup( EventType.POST_COMMIT_DELETE );
 		if ( listenerGroup.isEmpty() ) {
 			return;

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -214,6 +214,10 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 		return generatedId;
 	}
 
+	protected void setGeneratedId(Serializable generatedId) {
+		this.generatedId = generatedId;
+	}
+
 	/**
 	 * Access to the delayed entity key
 	 *
@@ -235,6 +239,10 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 	@Override
 	protected EntityKey getEntityKey() {
 		return entityKey != null ? entityKey : delayedEntityKey;
+	}
+
+	protected void setEntityKey(EntityKey entityKey) {
+		this.entityKey = entityKey;
 	}
 
 	private static DelayedPostInsertIdentifier generateDelayedPostInsertIdentifier() {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -29,7 +29,7 @@ import org.hibernate.stat.spi.StatisticsImplementor;
  *
  * @see EntityInsertAction
  */
-public final class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
+public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 
 	private final boolean isDelayed;
 	private final EntityKey delayedEntityKey;
@@ -141,7 +141,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 		postCommitInsert( success );
 	}
 
-	private void postInsert() {
+	protected void postInsert() {
 		final EventSource eventSource = eventSource();
 		if ( isDelayed ) {
 			eventSource.getPersistenceContextInternal().replaceDelayedEntityIdentityInsertKeys( delayedEntityKey, generatedId );
@@ -163,7 +163,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 		}
 	}
 
-	private void postCommitInsert(boolean success) {
+	protected void postCommitInsert(boolean success) {
 		final EventListenerGroup<PostInsertEventListener> listenerGroup = listenerGroup( EventType.POST_COMMIT_INSERT );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -191,7 +191,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 		}
 	}
 
-	private boolean preInsert() {
+	protected boolean preInsert() {
 		final EventListenerGroup<PreInsertEventListener> listenerGroup = listenerGroup( EventType.PRE_INSERT );
 		if ( listenerGroup.isEmpty() ) {
 			// NO_VETO
@@ -241,7 +241,7 @@ public final class EntityIdentityInsertAction extends AbstractEntityInsertAction
 		return new DelayedPostInsertIdentifier();
 	}
 
-	private EntityKey generateDelayedEntityKey() {
+	protected EntityKey generateDelayedEntityKey() {
 		if ( !isDelayed ) {
 			throw new AssertionFailure( "cannot request delayed entity-key for early-insert post-insert-id generation" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -35,7 +35,7 @@ import org.hibernate.stat.spi.StatisticsImplementor;
  *
  * @see EntityIdentityInsertAction
  */
-public final class EntityInsertAction extends AbstractEntityInsertAction {
+public class EntityInsertAction extends AbstractEntityInsertAction {
 	private Object version;
 	private Object cacheEntry;
 
@@ -60,6 +60,22 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 			SharedSessionContractImplementor session) {
 		super( id, state, instance, isVersionIncrementDisabled, persister, session );
 		this.version = version;
+	}
+
+	public Object getVersion() {
+		return version;
+	}
+
+	public void setVersion(Object version) {
+		this.version = version;
+	}
+
+	protected Object getCacheEntry() {
+		return cacheEntry;
+	}
+
+	protected void setCacheEntry(Object cacheEntry) {
+		this.cacheEntry = cacheEntry;
 	}
 
 	@Override
@@ -143,7 +159,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		markExecuted();
 	}
 
-	private boolean cacheInsert(EntityPersister persister, Object ck) {
+	protected boolean cacheInsert(EntityPersister persister, Object ck) {
 		SharedSessionContractImplementor session = getSession();
 		try {
 			session.getEventListenerManager().cachePutStart();
@@ -154,7 +170,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		}
 	}
 
-	private void postInsert() {
+	protected void postInsert() {
 		final EventListenerGroup<PostInsertEventListener> listenerGroup = listenerGroup( EventType.POST_INSERT );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -171,7 +187,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		}
 	}
 
-	private void postCommitInsert(boolean success) {
+	protected void postCommitInsert(boolean success) {
 		final EventListenerGroup<PostInsertEventListener> listenerGroup = listenerGroup( EventType.POST_COMMIT_INSERT );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -199,7 +215,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		}
 	}
 
-	private boolean preInsert() {
+	protected boolean preInsert() {
 		boolean veto = false;
 
 		final EventListenerGroup<PreInsertEventListener> listenerGroup = listenerGroup( EventType.PRE_INSERT );
@@ -233,7 +249,7 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 		postCommitInsert( success );
 	}
 
-	private boolean cacheAfterInsert(EntityDataAccess cache, Object ck) {
+	protected boolean cacheAfterInsert(EntityDataAccess cache, Object ck) {
 		SharedSessionContractImplementor session = getSession();
 		final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 		try {
@@ -256,8 +272,8 @@ public final class EntityInsertAction extends AbstractEntityInsertAction {
 
 		return false;
 	}
-	
-	private boolean isCachePutEnabled(EntityPersister persister, SharedSessionContractImplementor session) {
+
+	protected boolean isCachePutEnabled(EntityPersister persister, SharedSessionContractImplementor session) {
 		return persister.canWriteToCache()
 				&& !persister.isCacheInvalidationRequired()
 				&& session.getCacheMode().isPutEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -37,7 +37,7 @@ import org.hibernate.type.TypeHelper;
 /**
  * The action for performing entity updates.
  */
-public final class EntityUpdateAction extends EntityAction {
+public class EntityUpdateAction extends EntityAction {
 	private final Object[] state;
 	private final Object[] previousState;
 	private final Object previousVersion;
@@ -110,6 +110,58 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 
 		return persistenceContext.getNaturalIdSnapshot( id, persister );
+	}
+
+	public Object[] getState() {
+		return state;
+	}
+
+	public Object[] getPreviousState() {
+		return previousState;
+	}
+
+	public Object getPreviousVersion() {
+		return previousVersion;
+	}
+
+	public Object getNextVersion() {
+		return nextVersion;
+	}
+
+	public void setNextVersion(Object nextVersion) {
+		this.nextVersion = nextVersion;
+	}
+
+	public int[] getDirtyFields() {
+		return dirtyFields;
+	}
+
+	public boolean hasDirtyCollection() {
+		return hasDirtyCollection;
+	}
+
+	public Object getRowId() {
+		return rowId;
+	}
+
+	public Object[] getPreviousNaturalIdValues() {
+		return previousNaturalIdValues;
+	}
+
+	protected Object getCacheEntry() {
+		return cacheEntry;
+	}
+
+	protected void setCacheEntry(Object cacheEntry) {
+		this.cacheEntry = cacheEntry;
+	}
+
+	protected SoftLock getLock() {
+		return lock;
+	}
+
+	protected void setLock(SoftLock lock) {
+		this.lock = lock;
 	}
 
 	@Override
@@ -223,7 +275,7 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private boolean cacheUpdate(EntityPersister persister, Object previousVersion, Object ck) {
+	protected boolean cacheUpdate(EntityPersister persister, Object previousVersion, Object ck) {
 		final SharedSessionContractImplementor session = getSession();
 		try {
 			session.getEventListenerManager().cachePutStart();
@@ -234,7 +286,7 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private boolean preUpdate() {
+	protected boolean preUpdate() {
 		boolean veto = false;
 		final EventListenerGroup<PreUpdateEventListener> listenerGroup = listenerGroup( EventType.PRE_UPDATE );
 		if ( listenerGroup.isEmpty() ) {
@@ -254,7 +306,7 @@ public final class EntityUpdateAction extends EntityAction {
 		return veto;
 	}
 
-	private void postUpdate() {
+	protected void postUpdate() {
 		final EventListenerGroup<PostUpdateEventListener> listenerGroup = listenerGroup( EventType.POST_UPDATE );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -273,7 +325,7 @@ public final class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private void postCommitUpdate(boolean success) {
+	protected void postCommitUpdate(boolean success) {
 		final EventListenerGroup<PostUpdateEventListener> listenerGroup = listenerGroup( EventType.POST_COMMIT_UPDATE );
 		if ( listenerGroup.isEmpty() ) {
 			return;
@@ -350,7 +402,7 @@ public final class EntityUpdateAction extends EntityAction {
 		postCommitUpdate( success );
 	}
 
-	private boolean cacheAfterUpdate(EntityDataAccess cache, Object ck) {
+	protected boolean cacheAfterUpdate(EntityDataAccess cache, Object ck) {
 		final SharedSessionContractImplementor session = getSession();
 		SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractVisitor.java
@@ -121,7 +121,7 @@ public abstract class AbstractVisitor {
 	 * @param persister
 	 * @throws HibernateException
 	 */
-	void process(Object object, EntityPersister persister)
+	public void process(Object object, EntityPersister persister)
 	throws HibernateException {
 		processEntityPropertyValues(
 			persister.getPropertyValues( object ),

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -145,13 +145,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			version = entityEntry.getVersion();
 		}
 
-		/*if ( !persister.isMutable() ) {
-			throw new HibernateException(
-					"attempted to delete an object of immutable class: " +
-					MessageHelper.infoString(persister)
-				);
-		}*/
-
+		callbackRegistry.preRemove( entity );
 		if ( invokeDeleteLifecycle( source, entity, persister ) ) {
 			return;
 		}
@@ -338,8 +332,6 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 	}
 
 	protected boolean invokeDeleteLifecycle(EventSource session, Object entity, EntityPersister persister) {
-		callbackRegistry.preRemove( entity );
-
 		if ( persister.implementsLifecycle() ) {
 			LOG.debug( "Calling onDelete()" );
 			if ( ( (Lifecycle) entity ).onDelete( session ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -164,7 +164,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 				}
 
 				if ( entityState == null ) {
-					entityState = getEntityState( entity, event.getEntityName(), entry, source );
+					entityState = EntityState.getEntityState( entity, event.getEntityName(), entry, source, false );
 				}
 
 				switch ( entityState ) {
@@ -181,7 +181,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 						throw new ObjectDeletedException(
 								"deleted instance passed to merge",
 								null,
-								getLoggableName( event.getEntityName(), entity )
+								EventUtil.getLoggableName( event.getEntityName(), entity )
 						);
 				}
 			}
@@ -534,11 +534,6 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 	@Override
 	protected CascadingAction getCascadeAction() {
 		return CascadingActions.MERGE;
-	}
-
-	@Override
-	protected Boolean getAssumedUnsaved() {
-		return Boolean.FALSE;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.event.internal;
 
-import java.io.Serializable;
 import java.util.IdentityHashMap;
 import java.util.Map;
 
@@ -24,7 +23,6 @@ import org.hibernate.event.spi.PersistEventListener;
 import org.hibernate.id.ForeignGenerator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.jpa.event.spi.CallbackRegistry;
 import org.hibernate.jpa.event.spi.CallbackRegistryConsumer;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -45,11 +43,6 @@ public class DefaultPersistEventListener
 	@Override
 	protected CascadingAction getCascadeAction() {
 		return CascadingActions.PERSIST;
-	}
-
-	@Override
-	protected Boolean getAssumedUnsaved() {
-		return Boolean.TRUE;
 	}
 
 	/**
@@ -99,7 +92,7 @@ public class DefaultPersistEventListener
 		}
 
 		final EntityEntry entityEntry = source.getPersistenceContextInternal().getEntry( entity );
-		EntityState entityState = getEntityState( entity, entityName, entityEntry, source );
+		EntityState entityState = EntityState.getEntityState( entity, entityName, entityEntry, source, true );
 		if ( entityState == EntityState.DETACHED ) {
 			// JPA 2, in its version of a "foreign generated", allows the id attribute value
 			// to be manually set by the user, even though this manual value is irrelevant.
@@ -116,7 +109,7 @@ public class DefaultPersistEventListener
 					LOG.debug( "Resetting entity id attribute to null for foreign generator" );
 				}
 				persister.setIdentifier( entity, null, source );
-				entityState = getEntityState( entity, entityName, entityEntry, source );
+				entityState = EntityState.getEntityState( entity, entityName, entityEntry, source, true );
 			}
 		}
 
@@ -124,7 +117,7 @@ public class DefaultPersistEventListener
 			case DETACHED: {
 				throw new PersistentObjectException(
 						"detached entity passed to persist: " +
-								getLoggableName( event.getEntityName(), entity )
+								EventUtil.getLoggableName( event.getEntityName(), entity )
 				);
 			}
 			case PERSISTENT: {
@@ -146,7 +139,7 @@ public class DefaultPersistEventListener
 				throw new ObjectDeletedException(
 						"deleted entity passed to persist",
 						null,
-						getLoggableName( event.getEntityName(), entity )
+						EventUtil.getLoggableName( event.getEntityName(), entity )
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPostLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPostLoadEventListener.java
@@ -67,10 +67,14 @@ public class DefaultPostLoadEventListener implements PostLoadEventListener, Call
 			session.getActionQueue().registerProcess( verifyVersion );
 		}
 
+		invokeLoadLifecycle(event, session);
+
+	}
+
+	protected void invokeLoadLifecycle(PostLoadEvent event, EventSource session) {
 		if ( event.getPersister().implementsLifecycle() ) {
 			//log.debug( "calling onLoad()" );
 			( (Lifecycle) event.getEntity() ).onLoad( session, event.getId() );
 		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -82,11 +82,12 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 	}
 
 	protected Serializable performSaveOrUpdate(SaveOrUpdateEvent event) {
-		EntityState entityState = getEntityState(
+		EntityState entityState = EntityState.getEntityState(
 				event.getEntity(),
 				event.getEntityName(),
 				event.getEntry(),
-				event.getSession()
+				event.getSession(),
+				null
 		);
 
 		switch ( entityState ) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DirtyCollectionSearchVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DirtyCollectionSearchVisitor.java
@@ -25,12 +25,12 @@ public class DirtyCollectionSearchVisitor extends AbstractVisitor {
 	private boolean dirty;
 	private boolean[] propertyVersionability;
 
-	DirtyCollectionSearchVisitor(EventSource session, boolean[] propertyVersionability) {
+	public DirtyCollectionSearchVisitor(EventSource session, boolean[] propertyVersionability) {
 		super( session );
 		this.propertyVersionability = propertyVersionability;
 	}
 
-	boolean wasDirtyCollectionFound() {
+	public boolean wasDirtyCollectionFound() {
 		return dirty;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityState.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityState.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.event.internal;
+
+import org.hibernate.engine.internal.ForeignKeys;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.Status;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+
+public enum EntityState {
+	PERSISTENT, TRANSIENT, DETACHED, DELETED;
+
+	static final CoreMessageLogger LOG = CoreLogging.messageLogger( EntityState.class );
+
+	/**
+	 * Determine whether the entity is persistent, detached, or transient
+	 *
+	 * @param entity The entity to check
+	 * @param entityName The name of the entity
+	 * @param entry The entity's entry in the persistence context
+	 * @param source The originating session.
+	 *
+	 * @return The state.
+	 */
+	public static EntityState getEntityState(
+			Object entity,
+			String entityName,
+			EntityEntry entry, //pass this as an argument only to avoid double looking
+			SessionImplementor source,
+			Boolean assumedUnsaved) {
+
+		if ( entry != null ) { // the object is persistent
+
+			//the entity is associated with the session, so check its status
+			if ( entry.getStatus() != Status.DELETED ) {
+				// do nothing for persistent instances
+				if ( LOG.isTraceEnabled() ) {
+					LOG.tracev( "Persistent instance of: {0}", EventUtil.getLoggableName( entityName, entity ) );
+				}
+				return PERSISTENT;
+			}
+			// ie. e.status==DELETED
+			if ( LOG.isTraceEnabled() ) {
+				LOG.tracev( "Deleted instance of: {0}", EventUtil.getLoggableName( entityName, entity ) );
+			}
+			return DELETED;
+		}
+		// the object is transient or detached
+
+		// the entity is not associated with the session, so
+		// try interceptor and unsaved-value
+
+		if ( ForeignKeys.isTransient( entityName, entity, assumedUnsaved, source ) ) {
+			if ( LOG.isTraceEnabled() ) {
+				LOG.tracev( "Transient instance of: {0}", EventUtil.getLoggableName( entityName, entity ) );
+			}
+			return TRANSIENT;
+		}
+		if ( LOG.isTraceEnabled() ) {
+			LOG.tracev( "Detached instance of: {0}", EventUtil.getLoggableName( entityName, entity ) );
+		}
+		return DETACHED;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EventUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EventUtil.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.event.internal;
+
+public class EventUtil {
+	public static String getLoggableName(String entityName, Object entity) {
+		return entityName == null ? entity.getClass().getName() : entityName;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EvictVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EvictVisitor.java
@@ -30,7 +30,7 @@ public class EvictVisitor extends AbstractVisitor {
 	
 	private Object owner;
 
-	EvictVisitor(EventSource session, Object owner) {
+	public EvictVisitor(EventSource session, Object owner) {
 		super(session);
 		this.owner = owner;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/FlushVisitor.java
@@ -23,7 +23,7 @@ import org.hibernate.type.CollectionType;
 public class FlushVisitor extends AbstractVisitor {
 	private Object owner;
 
-	FlushVisitor(EventSource session, Object owner) {
+	public FlushVisitor(EventSource session, Object owner) {
 		super(session);
 		this.owner = owner;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
@@ -77,7 +77,7 @@ import org.jboss.logging.Logger;
  *
  * @author Gail Badner
  */
-class MergeContext implements Map {
+public class MergeContext implements Map {
 	private static final Logger LOG = Logger.getLogger( MergeContext.class );
 
 	private final EventSource session;
@@ -101,7 +101,7 @@ class MergeContext implements Map {
 	    // key is a merge entity;
 	    // value is a flag indicating if the merge entity is currently in the merge process.
 
-	MergeContext(EventSource session, EntityCopyObserver entityCopyObserver){
+	public MergeContext(EventSource session, EntityCopyObserver entityCopyObserver){
 		this.session = session;
 		this.entityCopyObserver = entityCopyObserver;
 	}
@@ -226,7 +226,7 @@ class MergeContext implements Map {
 	 * managed entity associated with <code>mergeEntity</code>
 	 * @throws IllegalStateException if internal cross-references are out of sync,
 	 */
-	/* package-private */ Object put(Object mergeEntity, Object managedEntity, boolean isOperatedOn) {
+	public Object put(Object mergeEntity, Object managedEntity, boolean isOperatedOn) {
 		if ( mergeEntity == null || managedEntity == null ) {
 			throw new NullPointerException( "null merge and managed entities are not supported by " + getClass().getName() );
 		}
@@ -347,7 +347,7 @@ class MergeContext implements Map {
 	 * @throws NullPointerException if mergeEntity is null
 	 * @throws IllegalStateException if this MergeContext does not contain a a cross-reference for mergeEntity
 	 */
-	/* package-private */ void setOperatedOn(Object mergeEntity, boolean isOperatedOn) {
+	public void setOperatedOn(Object mergeEntity, boolean isOperatedOn) {
 		if ( mergeEntity == null ) {
 			throw new NullPointerException( "null entities are not supported by " + getClass().getName() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/OnReplicateVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/OnReplicateVisitor.java
@@ -30,7 +30,7 @@ public class OnReplicateVisitor extends ReattachVisitor {
 
 	private boolean isUpdate;
 
-	OnReplicateVisitor(EventSource session, Serializable key, Object owner, boolean isUpdate) {
+	public OnReplicateVisitor(EventSource session, Serializable key, Object owner, boolean isUpdate) {
 		super( session, key, owner );
 		this.isUpdate = isUpdate;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/OnUpdateVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/OnUpdateVisitor.java
@@ -26,7 +26,7 @@ import org.hibernate.type.CollectionType;
  */
 public class OnUpdateVisitor extends ReattachVisitor {
 
-	OnUpdateVisitor(EventSource session, Serializable key, Object owner) {
+	public OnUpdateVisitor(EventSource session, Serializable key, Object owner) {
 		super( session, key, owner );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
@@ -21,7 +21,6 @@ import org.hibernate.type.EntityType;
  */
 public abstract class ProxyVisitor extends AbstractVisitor {
 
-
 	public ProxyVisitor(EventSource session) {
 		super(session);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
@@ -42,11 +42,11 @@ public class WrapVisitor extends ProxyVisitor {
 		this.id = id;
 	}
 
-	boolean isSubstitutionRequired() {
+	public boolean isSubstitutionRequired() {
 		return substitute;
 	}
 
-	WrapVisitor(EventSource session) {
+	public WrapVisitor(EventSource session) {
 		super( session );
 	}
 
@@ -152,7 +152,7 @@ public class WrapVisitor extends ProxyVisitor {
 	}
 
 	@Override
-	void process(Object object, EntityPersister persister) throws HibernateException {
+	public void process(Object object, EntityPersister persister) throws HibernateException {
 		final Object[] values = persister.getPropertyValues( object );
 		final Type[] types = persister.getPropertyTypes();
 		processEntityPropertyValues( values, types );

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -152,7 +152,7 @@ import static org.hibernate.metamodel.internal.JpaMetaModelPopulationSetting.det
  * @author Steve Ebersole
  * @author Chris Cranford
  */
-public final class SessionFactoryImpl implements SessionFactoryImplementor {
+public class SessionFactoryImpl implements SessionFactoryImplementor {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( SessionFactoryImpl.class );
 
 	private final String name;
@@ -1121,7 +1121,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 		return null;
 	}
 
-	static class SessionBuilderImpl<T extends SessionBuilder> implements SessionBuilderImplementor<T>, SessionCreationOptions {
+	public static class SessionBuilderImpl<T extends SessionBuilder> implements SessionBuilderImplementor<T>, SessionCreationOptions {
 		private static final Logger log = CoreLogging.logger( SessionBuilderImpl.class );
 
 		private final SessionFactoryImpl sessionFactory;
@@ -1145,7 +1145,7 @@ public final class SessionFactoryImpl implements SessionFactoryImplementor {
 		//todo : expose setting
 		private SessionOwnerBehavior sessionOwnerBehavior = SessionOwnerBehavior.LEGACY_NATIVE;
 
-		SessionBuilderImpl(SessionFactoryImpl sessionFactory) {
+		public SessionBuilderImpl(SessionFactoryImpl sessionFactory) {
 			this.sessionFactory = sessionFactory;
 
 			// set up default builder values...

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -558,13 +558,13 @@ public class SessionImpl
 		}
 	}
 
-	private void checkNoUnresolvedActionsBeforeOperation() {
+	protected void checkNoUnresolvedActionsBeforeOperation() {
 		if ( persistenceContext.getCascadeLevel() == 0 && actionQueue.hasUnresolvedEntityInsertActions() ) {
 			throw new IllegalStateException( "There are delayed insert actions before operation as cascade level 0." );
 		}
 	}
 
-	private void checkNoUnresolvedActionsAfterOperation() {
+	protected void checkNoUnresolvedActionsAfterOperation() {
 		if ( persistenceContext.getCascadeLevel() == 0 ) {
 			actionQueue.checkNoUnresolvedActionsAfterOperation();
 		}
@@ -3371,7 +3371,7 @@ public class SessionImpl
 		}
 	}
 
-	private CacheMode determineAppropriateLocalCacheMode(Map<String, Object> localProperties) {
+	protected CacheMode determineAppropriateLocalCacheMode(Map<String, Object> localProperties) {
 		CacheRetrieveMode retrieveMode = null;
 		CacheStoreMode storeMode = null;
 		if ( localProperties != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -194,7 +194,7 @@ import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_STORE_MODE;
  * @author Chris Cranford
  * @author Sanne Grinovero
  */
-public final class SessionImpl
+public class SessionImpl
 		extends AbstractSessionImpl
 		implements EventSource, SessionImplementor, HibernateEntityManagerImplementor {
 	private static final EntityManagerMessageLogger log = HEMLogging.messageLogger( SessionImpl.class );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -113,7 +113,7 @@ public class Column implements Selectable, Serializable, Cloneable {
 		final int lastLetter = StringHelper.lastIndexOfLetter( name );
 		final String suffix = AliasConstantsHelper.get( uniqueInteger );
 
-		String alias = name;
+		String alias = name.toLowerCase( Locale.ROOT );
 		if ( lastLetter == -1 ) {
 			alias = "column";
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -81,6 +81,9 @@ import org.hibernate.persister.walking.spi.CompositionDefinition;
 import org.hibernate.persister.walking.spi.EntityDefinition;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.sql.Alias;
+import org.hibernate.sql.Insert;
+import org.hibernate.sql.Update;
+import org.hibernate.sql.Delete;
 import org.hibernate.sql.SelectFragment;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.sql.Template;
@@ -2273,5 +2276,17 @@ public abstract class AbstractCollectionPersister
 				};
 			}
 		};
+	}
+
+	protected Insert createInsert() {
+		return new Insert( getFactory().getJdbcServices().getDialect() );
+	}
+
+	protected Update createUpdate() {
+		return new Update( getFactory().getJdbcServices().getDialect() );
+	}
+
+	protected Delete createDelete() {
+		return new Delete();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -64,8 +64,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateDeleteString() {
-		final Delete delete = new Delete()
-				.setTableName( qualifiedTableName )
+		final Delete delete = createDelete().setTableName( qualifiedTableName )
 				.addPrimaryKeyColumns( keyColumnNames );
 
 		if ( hasWhere ) {
@@ -84,8 +83,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateInsertRowString() {
-		final Insert insert = new Insert( getDialect() )
-				.setTableName( qualifiedTableName )
+		final Insert insert = createInsert().setTableName( qualifiedTableName )
 				.addColumns( keyColumnNames );
 
 		if ( hasIdentifier ) {
@@ -112,8 +110,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateUpdateRowString() {
-		final Update update = new Update( getDialect() )
-				.setTableName( qualifiedTableName );
+		final Update update = createUpdate().setTableName( qualifiedTableName );
 
 		//if ( !elementIsFormula ) {
 		update.addColumns( elementColumnNames, elementColumnIsSettable, elementColumnWriters );
@@ -147,7 +144,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateDeleteRowString() {
-		final Delete delete = new Delete().setTableName( qualifiedTableName );
+		final Delete delete = createDelete().setTableName( qualifiedTableName );
 
 		if ( hasIdentifier ) {
 			delete.addPrimaryKeyColumns( new String[] {identifierColumnName} );

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
@@ -78,10 +78,8 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateDeleteString() {
-		final Update update = new Update( getDialect() )
-				.setTableName( qualifiedTableName )
-				.addColumns( keyColumnNames, "null" )
-				.addPrimaryKeyColumns( keyColumnNames );
+		final Update update = createUpdate().setTableName( qualifiedTableName )
+				.addColumns( keyColumnNames, "null" );
 
 		if ( hasIndex && !indexContainsFormula ) {
 			for ( int i = 0 ; i < indexColumnNames.length ; i++ ) {
@@ -90,6 +88,8 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 				}
 			}
 		}
+
+		update.addPrimaryKeyColumns( keyColumnNames );
 
 		if ( hasWhere ) {
 			update.setWhere( sqlWhereString );
@@ -107,8 +107,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateInsertRowString() {
-		final Update update = new Update( getDialect() )
-				.setTableName( qualifiedTableName )
+		final Update update = createUpdate().setTableName( qualifiedTableName )
 				.addColumns( keyColumnNames );
 
 		if ( hasIndex && !indexContainsFormula ) {
@@ -134,17 +133,20 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateUpdateRowString() {
-		final Update update = new Update( getDialect() ).setTableName( qualifiedTableName );
-		update.addPrimaryKeyColumns( elementColumnNames, elementColumnIsSettable, elementColumnWriters );
-		if ( hasIdentifier ) {
-			update.addPrimaryKeyColumns( new String[] {identifierColumnName} );
-		}
+		final Update update = createUpdate().setTableName( qualifiedTableName );
+
 		if ( hasIndex && !indexContainsFormula ) {
 			for ( int i = 0 ; i < indexColumnNames.length ; i++ ) {
 				if ( indexColumnIsSettable[i] ) {
 					update.addColumn( indexColumnNames[i] );
 				}
 			}
+		}
+
+		update.addPrimaryKeyColumns( elementColumnNames, elementColumnIsSettable, elementColumnWriters );
+
+		if ( hasIdentifier ) {
+			update.addPrimaryKeyColumns( new String[] {identifierColumnName} );
 		}
 
 		return update.toStatementString();
@@ -156,8 +158,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	 */
 	@Override
 	protected String generateDeleteRowString() {
-		final Update update = new Update( getDialect() )
-				.setTableName( qualifiedTableName )
+		final Update update = createUpdate().setTableName( qualifiedTableName )
 				.addColumns( keyColumnNames, "null" );
 
 		if ( hasIndex && !indexContainsFormula ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -338,15 +338,15 @@ public abstract class AbstractEntityPersister
 
 	public abstract int getSubclassTableSpan();
 
-	protected abstract int getTableSpan();
+	public abstract int getTableSpan();
 
-	protected abstract boolean isTableCascadeDeleteEnabled(int j);
+	public abstract boolean isTableCascadeDeleteEnabled(int j);
 
-	protected abstract String getTableName(int j);
+	public abstract String getTableName(int j);
 
-	protected abstract String[] getKeyColumns(int j);
+	public abstract String[] getKeyColumns(int j);
 
-	protected abstract boolean isPropertyOfTable(int property, int j);
+	public abstract boolean isPropertyOfTable(int property, int j);
 
 	protected abstract int[] getPropertyTableNumbersInSelect();
 
@@ -377,19 +377,19 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
-	protected String getDiscriminatorAlias() {
+	public String getDiscriminatorAlias() {
 		return DISCRIMINATOR_ALIAS;
 	}
 
-	protected String getDiscriminatorFormulaTemplate() {
+	public String getDiscriminatorFormulaTemplate() {
 		return null;
 	}
 
-	protected boolean isInverseTable(int j) {
+	public boolean isInverseTable(int j) {
 		return false;
 	}
 
-	protected boolean isNullableTable(int j) {
+	public boolean isNullableTable(int j) {
 		return false;
 	}
 
@@ -413,7 +413,7 @@ public abstract class AbstractEntityPersister
 		return rootTableKeyColumnNames;
 	}
 
-	protected String[] getSQLUpdateByRowIdStrings() {
+	public String[] getSQLUpdateByRowIdStrings() {
 		if ( sqlUpdateByRowIdString == null ) {
 			throw new AssertionFailure( "no update by row id" );
 		}
@@ -423,7 +423,7 @@ public abstract class AbstractEntityPersister
 		return result;
 	}
 
-	protected String[] getSQLLazyUpdateByRowIdStrings() {
+	public String[] getSQLLazyUpdateByRowIdStrings() {
 		if ( sqlLazyUpdateByRowIdString == null ) {
 			throw new AssertionFailure( "no update by row id" );
 		}
@@ -433,28 +433,40 @@ public abstract class AbstractEntityPersister
 		return result;
 	}
 
-	protected String getSQLSnapshotSelectString() {
+	public String getSQLSnapshotSelectString() {
 		return sqlSnapshotSelectString;
 	}
 
-	protected String getSQLLazySelectString(String fetchGroup) {
+	public String getSQLLazySelectString(String fetchGroup) {
 		return sqlLazySelectStringsByFetchGroup.get( fetchGroup );
 	}
 
-	protected String[] getSQLDeleteStrings() {
+	public String[] getSQLDeleteStrings() {
 		return sqlDeleteStrings;
 	}
 
-	protected String[] getSQLInsertStrings() {
+	public String[] getSQLInsertStrings() {
 		return sqlInsertStrings;
 	}
 
-	protected String[] getSQLUpdateStrings() {
+	public String[] getSQLUpdateStrings() {
 		return sqlUpdateStrings;
 	}
 
-	protected String[] getSQLLazyUpdateStrings() {
+	public String[] getSQLLazyUpdateStrings() {
 		return sqlLazyUpdateStrings;
+	}
+
+	public ExecuteUpdateResultCheckStyle[] getInsertResultCheckStyles() {
+		return insertResultCheckStyles;
+	}
+
+	public ExecuteUpdateResultCheckStyle[] getUpdateResultCheckStyles() {
+		return updateResultCheckStyles;
+	}
+
+	public ExecuteUpdateResultCheckStyle[] getDeleteResultCheckStyles() {
+		return deleteResultCheckStyles;
 	}
 
 	/**
@@ -462,23 +474,23 @@ public abstract class AbstractEntityPersister
 	 *
 	 * @return The IDENTITY-based insertion query.
 	 */
-	protected String getSQLIdentityInsertString() {
+	public String getSQLIdentityInsertString() {
 		return sqlIdentityInsertString;
 	}
 
-	protected String getVersionSelectString() {
+	public String getVersionSelectString() {
 		return sqlVersionSelectString;
 	}
 
-	protected boolean isInsertCallable(int j) {
+	public boolean isInsertCallable(int j) {
 		return insertCallable[j];
 	}
 
-	protected boolean isUpdateCallable(int j) {
+	public boolean isUpdateCallable(int j) {
 		return updateCallable[j];
 	}
 
-	protected boolean isDeleteCallable(int j) {
+	public boolean isDeleteCallable(int j) {
 		return deleteCallable[j];
 	}
 
@@ -505,7 +517,7 @@ public abstract class AbstractEntityPersister
 	 *
 	 * @return Array of booleans indicating which table require updating.
 	 */
-	protected boolean[] getTableUpdateNeeded(final int[] dirtyProperties, boolean hasDirtyCollection) {
+	public boolean[] getTableUpdateNeeded(final int[] dirtyProperties, boolean hasDirtyCollection) {
 
 		if ( dirtyProperties == null ) {
 			return getTableHasColumns(); // for objects that came in via update()
@@ -539,15 +551,15 @@ public abstract class AbstractEntityPersister
 		return rowIdName != null;
 	}
 
-	protected boolean[][] getPropertyColumnUpdateable() {
+	public boolean[][] getPropertyColumnUpdateable() {
 		return propertyColumnUpdateable;
 	}
 
-	protected boolean[][] getPropertyColumnInsertable() {
+	public boolean[][] getPropertyColumnInsertable() {
 		return propertyColumnInsertable;
 	}
 
-	protected boolean[] getPropertySelectable() {
+	public boolean[] getPropertySelectable() {
 		return propertySelectable;
 	}
 
@@ -1381,11 +1393,11 @@ public abstract class AbstractEntityPersister
 		return rootTableKeyColumnReaderTemplates;
 	}
 
-	protected int getIdentifierColumnSpan() {
+	public int getIdentifierColumnSpan() {
 		return identifierColumnSpan;
 	}
 
-	protected String[] getIdentifierAliases() {
+	public String[] getIdentifierAliases() {
 		return identifierAliases;
 	}
 
@@ -1393,7 +1405,7 @@ public abstract class AbstractEntityPersister
 		return versionColumnName;
 	}
 
-	protected String getVersionedTableName() {
+	public String getVersionedTableName() {
 		return getTableName( 0 );
 	}
 
@@ -1624,7 +1636,7 @@ public abstract class AbstractEntityPersister
 
 	}
 
-	protected String generateIdByUniqueKeySelectString(String uniquePropertyName) {
+	public String generateIdByUniqueKeySelectString(String uniquePropertyName) {
 		Select select = new Select( getFactory().getDialect() );
 
 		if ( getFactory().getSessionFactoryOptions().isCommentsEnabled() ) {
@@ -1681,7 +1693,7 @@ public abstract class AbstractEntityPersister
 	/**
 	 * Generate the SQL that selects the version number by id
 	 */
-	protected String generateSelectVersionString() {
+	public String generateSelectVersionString() {
 		SimpleSelect select = new SimpleSelect( getFactory().getDialect() )
 				.setTableName( getVersionedTableName() );
 		if ( isVersioned() ) {
@@ -1700,11 +1712,11 @@ public abstract class AbstractEntityPersister
 		return propertyUniqueness;
 	}
 
-	protected String generateInsertGeneratedValuesSelectString() {
+	public String generateInsertGeneratedValuesSelectString() {
 		return generateGeneratedValuesSelectString( GenerationTiming.INSERT );
 	}
 
-	protected String generateUpdateGeneratedValuesSelectString() {
+	public String generateUpdateGeneratedValuesSelectString() {
 		return generateGeneratedValuesSelectString( GenerationTiming.ALWAYS );
 	}
 
@@ -1786,7 +1798,7 @@ public abstract class AbstractEntityPersister
 		return frag.toFragmentString();
 	}
 
-	protected String generateSnapshotSelectString() {
+	public String generateSnapshotSelectString() {
 
 		//TODO: should we use SELECT .. FOR UPDATE?
 
@@ -2162,11 +2174,11 @@ public abstract class AbstractEntityPersister
 		return propertyColumnWriters[i];
 	}
 
-	protected int getPropertyColumnSpan(int i) {
+	public int getPropertyColumnSpan(int i) {
 		return propertyColumnSpans[i];
 	}
 
-	protected boolean hasFormulaProperties() {
+	public boolean hasFormulaProperties() {
 		return hasFormulaProperties;
 	}
 
@@ -2587,14 +2599,14 @@ public abstract class AbstractEntityPersister
 		return true;
 	}
 
-	protected String generateUpdateString(boolean[] includeProperty, int j, boolean useRowId) {
+	public String generateUpdateString(boolean[] includeProperty, int j, boolean useRowId) {
 		return generateUpdateString( includeProperty, j, null, useRowId );
 	}
 
 	/**
 	 * Generate the SQL that updates a row by id (and version)
 	 */
-	protected String generateUpdateString(
+	public String generateUpdateString(
 			final boolean[] includeProperty,
 			final int j,
 			final Object[] oldFields,
@@ -2688,23 +2700,23 @@ public abstract class AbstractEntityPersister
 		return hasColumns ? update.toStatementString() : null;
 	}
 
-	protected final boolean checkVersion(final boolean[] includeProperty) {
+	public final boolean checkVersion(final boolean[] includeProperty) {
 		return includeProperty[getVersionProperty()]
 				|| entityMetamodel.isVersionGenerated();
 	}
 
-	protected String generateInsertString(boolean[] includeProperty, int j) {
+	public String generateInsertString(boolean[] includeProperty, int j) {
 		return generateInsertString( false, includeProperty, j );
 	}
 
-	protected String generateInsertString(boolean identityInsert, boolean[] includeProperty) {
+	public String generateInsertString(boolean identityInsert, boolean[] includeProperty) {
 		return generateInsertString( identityInsert, includeProperty, 0 );
 	}
 
 	/**
 	 * Generate the SQL that inserts a row
 	 */
-	protected String generateInsertString(boolean identityInsert, boolean[] includeProperty, int j) {
+	public String generateInsertString(boolean identityInsert, boolean[] includeProperty, int j) {
 
 		// todo : remove the identityInsert param and variations;
 		//   identity-insert strings are now generated from generateIdentityInsertString()
@@ -2803,7 +2815,7 @@ public abstract class AbstractEntityPersister
 	 *
 	 * @return The insert SQL statement string
 	 */
-	protected String generateIdentityInsertString(boolean[] includeProperty) {
+	public String generateIdentityInsertString(boolean[] includeProperty) {
 		Insert insert = identityDelegate.prepareIdentifierGeneratingInsert();
 		insert.setTableName( getTableName( 0 ) );
 
@@ -2870,7 +2882,7 @@ public abstract class AbstractEntityPersister
 	/**
 	 * Generate the SQL that deletes a row by id (and version)
 	 */
-	protected String generateDeleteString(int j) {
+	public String generateDeleteString(int j) {
 		final Delete delete = new Delete()
 				.setTableName( getTableName( j ) )
 				.addPrimaryKeyColumns( getKeyColumns( j ) );
@@ -2883,7 +2895,7 @@ public abstract class AbstractEntityPersister
 		return delete.toStatementString();
 	}
 
-	protected int dehydrate(
+	public int dehydrate(
 			Serializable id,
 			Object[] fields,
 			boolean[] includeProperty,
@@ -2898,7 +2910,7 @@ public abstract class AbstractEntityPersister
 	/**
 	 * Marshall the fields of a persistent instance to a prepared statement
 	 */
-	protected int dehydrate(
+	public int dehydrate(
 			final Serializable id,
 			final Object[] fields,
 			final Object rowId,
@@ -3079,11 +3091,11 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
-	protected boolean useInsertSelectIdentity() {
+	public boolean useInsertSelectIdentity() {
 		return !useGetGeneratedKeys() && getFactory().getDialect().getIdentityColumnSupport().supportsInsertSelectIdentity();
 	}
 
-	protected boolean useGetGeneratedKeys() {
+	public boolean useGetGeneratedKeys() {
 		return getFactory().getSessionFactoryOptions().isGetGeneratedKeysEnabled();
 	}
 
@@ -3097,7 +3109,7 @@ public abstract class AbstractEntityPersister
 	 * This form is used for PostInsertIdentifierGenerator-style ids (IDENTITY,
 	 * select, etc).
 	 */
-	protected Serializable insert(
+	public Serializable insert(
 			final Object[] fields,
 			final boolean[] notNull,
 			String sql,
@@ -3150,7 +3162,7 @@ public abstract class AbstractEntityPersister
 	 * This for is used for all non-root tables as well as the root table
 	 * in cases where the identifier value is known before the insert occurs.
 	 */
-	protected void insert(
+	public void insert(
 			final Serializable id,
 			final Object[] fields,
 			final boolean[] notNull,
@@ -3253,7 +3265,7 @@ public abstract class AbstractEntityPersister
 	/**
 	 * Perform an SQL UPDATE or SQL INSERT
 	 */
-	protected void updateOrInsert(
+	public void updateOrInsert(
 			final Serializable id,
 			final Object[] fields,
 			final Object[] oldFields,
@@ -3307,7 +3319,7 @@ public abstract class AbstractEntityPersister
 
 	private BasicBatchKey updateBatchKey;
 
-	protected boolean update(
+	public boolean update(
 			final Serializable id,
 			final Object[] fields,
 			final Object[] oldFields,
@@ -3455,7 +3467,7 @@ public abstract class AbstractEntityPersister
 	/**
 	 * Perform an SQL DELETE
 	 */
-	protected void delete(
+	public void delete(
 			final Serializable id,
 			final Object version,
 			final int j,
@@ -4511,7 +4523,7 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
-	protected final boolean isAllNull(Object[] array, int tableNumber) {
+	public final boolean isAllNull(Object[] array, int tableNumber) {
 		for ( int i = 0; i < array.length; i++ ) {
 			if ( isPropertyOfTable( i, tableNumber ) && array[i] != null ) {
 				return false;
@@ -4528,7 +4540,7 @@ public abstract class AbstractEntityPersister
 	 * Transform the array of property indexes to an array of booleans,
 	 * true when the property is dirty
 	 */
-	protected final boolean[] getPropertiesToUpdate(final int[] dirtyProperties, final boolean hasDirtyCollection) {
+	public final boolean[] getPropertiesToUpdate(final int[] dirtyProperties, final boolean hasDirtyCollection) {
 		final boolean[] propsToUpdate = new boolean[entityMetamodel.getPropertySpan()];
 		final boolean[] updateability = getPropertyUpdateability(); //no need to check laziness, dirty checking handles that
 		for ( int j = 0; j < dirtyProperties.length; j++ ) {
@@ -4552,7 +4564,7 @@ public abstract class AbstractEntityPersister
 	 * Transform the array of property indexes to an array of booleans,
 	 * true when the property is insertable and non-null
 	 */
-	protected boolean[] getPropertiesToInsert(Object[] fields) {
+	public boolean[] getPropertiesToInsert(Object[] fields) {
 		boolean[] notNull = new boolean[fields.length];
 		boolean[] insertable = getPropertyInsertability();
 		for ( int i = 0; i < fields.length; i++ ) {
@@ -4626,7 +4638,7 @@ public abstract class AbstractEntityPersister
 	 * Which properties appear in the SQL update?
 	 * (Initialized, updateable ones!)
 	 */
-	protected boolean[] getPropertyUpdateability(Object entity) {
+	public boolean[] getPropertyUpdateability(Object entity) {
 		return hasUninitializedLazyProperties( entity )
 				? getNonLazyPropertyUpdateability()
 				: getPropertyUpdateability();
@@ -4863,7 +4875,7 @@ public abstract class AbstractEntityPersister
 		return entityMetamodel.isMutable();
 	}
 
-	protected final boolean isModifiableEntity(EntityEntry entry) {
+	public final boolean isModifiableEntity(EntityEntry entry) {
 		return ( entry == null ? isMutable() : entry.isModifiableEntity() );
 	}
 
@@ -4908,7 +4920,7 @@ public abstract class AbstractEntityPersister
 		return entityMetamodel.isDynamicInsert();
 	}
 
-	protected boolean hasEmbeddedCompositeIdentifier() {
+	public boolean hasEmbeddedCompositeIdentifier() {
 		return entityMetamodel.getIdentifierProperty().isEmbedded();
 	}
 
@@ -5170,7 +5182,7 @@ public abstract class AbstractEntityPersister
 		return false;
 	}
 
-	protected int getPropertySpan() {
+	public int getPropertySpan() {
 		return entityMetamodel.getPropertySpan();
 	}
 
@@ -5526,7 +5538,7 @@ public abstract class AbstractEntityPersister
 		return generateEntityIdByNaturalIdSql( valueNullness );
 	}
 
-	protected boolean isNaturalIdNonNullable() {
+	public boolean isNaturalIdNonNullable() {
 		if ( naturalIdIsNonNullable == null ) {
 			naturalIdIsNonNullable = determineNaturalIdNullability();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -736,12 +736,12 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	protected boolean isNullableTable(int j) {
+	public boolean isNullableTable(int j) {
 		return isNullableTable[j];
 	}
 
 	@Override
-	protected boolean isInverseTable(int j) {
+	public boolean isInverseTable(int j) {
 		return isInverseTable[j];
 	}
 
@@ -799,7 +799,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		return getDiscriminatorColumnName();
 	}
 
-	protected String getDiscriminatorAlias() {
+	public String getDiscriminatorAlias() {
 		return discriminatorAlias;
 	}
 
@@ -819,19 +819,19 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 
-	protected String getTableName(int j) {
+	public String getTableName(int j) {
 		return naturalOrderTableNames[j];
 	}
 
-	protected String[] getKeyColumns(int j) {
+	public String[] getKeyColumns(int j) {
 		return naturalOrderTableKeyColumns[j];
 	}
 
-	protected boolean isTableCascadeDeleteEnabled(int j) {
+	public boolean isTableCascadeDeleteEnabled(int j) {
 		return naturalOrderCascadeDeleteEnabled[j];
 	}
 
-	protected boolean isPropertyOfTable(int property, int j) {
+	public boolean isPropertyOfTable(int property, int j) {
 		return naturalOrderPropertyTableNumbers[property] == j;
 	}
 
@@ -928,14 +928,14 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public String filterFragment(String alias) {
+	protected String filterFragment(String alias) {
 		return hasWhere()
 				? " and " + getSQLWhereString( generateFilterConditionAlias( alias ) )
 				: "";
 	}
 
 	@Override
-	public String filterFragment(String alias, Set<String> treatAsDeclarations) {
+	protected String filterFragment(String alias, Set<String> treatAsDeclarations) {
 		return filterFragment( alias );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -450,7 +450,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		}
 	}
 
-	protected boolean isInverseTable(int j) {
+	public boolean isInverseTable(int j) {
 		return isInverseTable[j];
 	}
 
@@ -470,11 +470,11 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		return discriminatorColumnReaderTemplate;
 	}
 
-	protected String getDiscriminatorAlias() {
+	public String getDiscriminatorAlias() {
 		return discriminatorAlias;
 	}
 
-	protected String getDiscriminatorFormulaTemplate() {
+	public String getDiscriminatorFormulaTemplate() {
 		return discriminatorFormulaTemplate;
 	}
 
@@ -525,19 +525,19 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		return discriminatorFormula;
 	}
 
-	protected String getTableName(int j) {
+	public String getTableName(int j) {
 		return qualifiedTableNames[j];
 	}
 
-	protected String[] getKeyColumns(int j) {
+	public String[] getKeyColumns(int j) {
 		return keyColumnNames[j];
 	}
 
-	protected boolean isTableCascadeDeleteEnabled(int j) {
+	public boolean isTableCascadeDeleteEnabled(int j) {
 		return cascadeDeleteEnabled[j];
 	}
 
-	protected boolean isPropertyOfTable(int property, int j) {
+	public boolean isPropertyOfTable(int property, int j) {
 		return propertyTableNumbers[property] == j;
 	}
 
@@ -552,7 +552,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public String filterFragment(String alias) throws MappingException {
+	protected String filterFragment(String alias) throws MappingException {
 		String result = discriminatorFilterFragment( alias );
 		if ( hasWhere() ) {
 			result += " and " + getSQLWhereString( alias );
@@ -578,7 +578,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public String filterFragment(String alias, Set<String> treatAsDeclarations) {
+	protected String filterFragment(String alias, Set<String> treatAsDeclarations) {
 		String result = discriminatorFilterFragment( alias, treatAsDeclarations );
 		if ( hasWhere() ) {
 			result += " and " + getSQLWhereString( alias );
@@ -810,7 +810,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		return subclassTableIsLazyClosure[j];
 	}
 
-	protected boolean isNullableTable(int j) {
+	public boolean isNullableTable(int j) {
 		return isNullableTable[j];
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -287,19 +287,19 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		return null;
 	}
 
-	protected String getTableName(int j) {
+	public String getTableName(int j) {
 		return tableName;
 	}
 
-	protected String[] getKeyColumns(int j) {
+	public String[] getKeyColumns(int j) {
 		return getIdentifierColumnNames();
 	}
 
-	protected boolean isTableCascadeDeleteEnabled(int j) {
+	public boolean isTableCascadeDeleteEnabled(int j) {
 		return false;
 	}
 
-	protected boolean isPropertyOfTable(int property, int j) {
+	public boolean isPropertyOfTable(int property, int j) {
 		return true;
 	}
 
@@ -310,7 +310,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public String filterFragment(String name) {
+	protected String filterFragment(String name) {
 		return hasWhere()
 				? " and " + getSQLWhereString( name )
 				: "";

--- a/hibernate-core/src/main/java/org/hibernate/sql/Delete.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Delete.java
@@ -16,13 +16,13 @@ import java.util.Map;
  */
 public class Delete {
 
-	private String tableName;
-	private String versionColumnName;
-	private String where;
+	protected String tableName;
+	protected String versionColumnName;
+	protected String where;
+	protected String comment;
 
-	private Map primaryKeyColumns = new LinkedHashMap();	
-	
-	private String comment;
+	protected Map<String,String> primaryKeyColumns = new LinkedHashMap<>();
+
 	public Delete setComment(String comment) {
 		this.comment = comment;
 		return this;
@@ -43,9 +43,9 @@ public class Delete {
 			buf.append( " where " );
 		}
 		boolean conditionsAppended = false;
-		Iterator iter = primaryKeyColumns.entrySet().iterator();
+		Iterator<Map.Entry<String,String>> iter = primaryKeyColumns.entrySet().iterator();
 		while ( iter.hasNext() ) {
-			Map.Entry e = (Map.Entry) iter.next();
+			Map.Entry<String,String> e = iter.next();
 			buf.append( e.getKey() ).append( '=' ).append( e.getValue() );
 			if ( iter.hasNext() ) {
 				buf.append( " and " );

--- a/hibernate-core/src/main/java/org/hibernate/sql/InFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/InFragment.java
@@ -25,8 +25,8 @@ public class InFragment {
 	public static final String NULL = "null";
 	public static final String NOT_NULL = "not null";
 
-	private String columnName;
-	private List<Object> values = new ArrayList<Object>();
+	protected String columnName;
+	protected List<Object> values = new ArrayList<Object>();
 
 	/**
 	 * @param value an SQL literal, NULL, or NOT_NULL

--- a/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
@@ -19,10 +19,13 @@ import org.hibernate.type.LiteralType;
  * @author Gavin King
  */
 public class Insert {
+
+	protected String tableName;
+	protected String comment;
+
+	protected Map<String,String> columns = new LinkedHashMap<>();
+
 	private Dialect dialect;
-	private String tableName;
-	private String comment;
-	private Map columns = new LinkedHashMap();
 
 	public Insert(Dialect dialect) {
 		this.dialect = dialect;
@@ -111,7 +114,7 @@ public class Insert {
 		}
 		else {
 			buf.append(" (");
-			Iterator iter = columns.keySet().iterator();
+			Iterator<String> iter = columns.keySet().iterator();
 			while ( iter.hasNext() ) {
 				buf.append( iter.next() );
 				if ( iter.hasNext() ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/InsertSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/InsertSelect.java
@@ -18,10 +18,13 @@ import org.hibernate.dialect.Dialect;
  * @author Steve Ebersole
  */
 public class InsertSelect {
-	private String tableName;
-	private String comment;
-	private List columnNames = new ArrayList();
-	private Select select;
+
+	protected String tableName;
+	protected String comment;
+
+	protected List<String> columnNames = new ArrayList<>();
+
+	protected Select select;
 
 	public InsertSelect(Dialect dialect) {
 		//This is no longer used. Deprecate & remove?
@@ -70,7 +73,7 @@ public class InsertSelect {
 		buf.append( "insert into " ).append( tableName );
 		if ( !columnNames.isEmpty() ) {
 			buf.append( " (" );
-			Iterator itr = columnNames.iterator();
+			Iterator<String> itr = columnNames.iterator();
 			while ( itr.hasNext() ) {
 				buf.append( itr.next() );
 				if ( itr.hasNext() ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/Select.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Select.java
@@ -17,15 +17,17 @@ import org.hibernate.internal.util.StringHelper;
  */
 public class Select {
 
-	private String selectClause;
-	private String fromClause;
-	private String outerJoinsAfterFrom;
-	private String whereClause;
-	private String outerJoinsAfterWhere;
-	private String orderByClause;
-	private String groupByClause;
-	private String comment;
-	private LockOptions lockOptions = new LockOptions();
+	protected String selectClause;
+	protected String fromClause;
+	protected String outerJoinsAfterFrom;
+	protected String whereClause;
+	protected String outerJoinsAfterWhere;
+	protected String orderByClause;
+	protected String groupByClause;
+	protected String comment;
+
+	protected LockOptions lockOptions = new LockOptions();
+
 	public final Dialect dialect;
 
 	private int guesstimatedBufferSize = 20;

--- a/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
@@ -31,15 +31,18 @@ public class SimpleSelect {
 
 	//private static final Alias DEFAULT_ALIAS = new Alias(10, null);
 
-	private String tableName;
-	private String orderBy;
-	private Dialect dialect;
-	private LockOptions lockOptions = new LockOptions( LockMode.READ );
-	private String comment;
+	protected String tableName;
+	protected String orderBy;
+	protected String comment;
 
-	private List<String> columns = new ArrayList<String>();
-	private Map<String, String> aliases = new HashMap<String, String>();
-	private List<String> whereTokens = new ArrayList<String>();
+	protected List<String> columns = new ArrayList<String>();
+	protected Map<String, String> aliases = new HashMap<String, String>();
+	protected List<String> whereTokens = new ArrayList<String>();
+
+	protected LockOptions lockOptions = new LockOptions( LockMode.READ );
+
+	private Dialect dialect;
+
 
 	public SimpleSelect addColumns(String[] columnNames, String[] columnAliases) {
 		for ( int i = 0; i < columnNames.length; i++ ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/Update.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Update.java
@@ -19,15 +19,15 @@ import org.hibernate.type.LiteralType;
  */
 public class Update {
 
-	private String tableName;
-	private String versionColumnName;
-	private String where;
-	private String assignments;
-	private String comment;
+	protected String tableName;
+	protected String versionColumnName;
+	protected String where;
+	protected String assignments;
+	protected String comment;
 
-	private Map primaryKeyColumns = new LinkedHashMap();
-	private Map columns = new LinkedHashMap();
-	private Map whereColumns = new LinkedHashMap();
+	protected Map<String,String> primaryKeyColumns = new LinkedHashMap<>();
+	protected Map<String,String> columns = new LinkedHashMap<>();
+	protected Map<String,String> whereColumns = new LinkedHashMap<>();
 	
 	private Dialect dialect;
 	
@@ -170,9 +170,9 @@ public class Update {
 		}
 		buf.append( "update " ).append( tableName ).append( " set " );
 		boolean assignmentsAppended = false;
-		Iterator iter = columns.entrySet().iterator();
+		Iterator<Map.Entry<String,String>> iter = columns.entrySet().iterator();
 		while ( iter.hasNext() ) {
-			Map.Entry e = (Map.Entry) iter.next();
+			Map.Entry<String,String> e = iter.next();
 			buf.append( e.getKey() ).append( '=' ).append( e.getValue() );
 			if ( iter.hasNext() ) {
 				buf.append( ", " );
@@ -192,7 +192,7 @@ public class Update {
 		}
 		iter = primaryKeyColumns.entrySet().iterator();
 		while ( iter.hasNext() ) {
-			Map.Entry e = (Map.Entry) iter.next();
+			Map.Entry<String,String> e = iter.next();
 			buf.append( e.getKey() ).append( '=' ).append( e.getValue() );
 			if ( iter.hasNext() ) {
 				buf.append( " and " );
@@ -208,7 +208,7 @@ public class Update {
 		}
 		iter = whereColumns.entrySet().iterator();
 		while ( iter.hasNext() ) {
-			final Map.Entry e = (Map.Entry) iter.next();
+			final Map.Entry<String,String> e = iter.next();
 			if ( conditionsAppended ) {
 				buf.append( " and " );
 			}


### PR DESCRIPTION
This patch contains a bunch of very minor changes that help simplify the implementation of hibernate-rx, allowing us to do away with a whole lot of copy/paste and other hacks.

There's nothing very interesting here, mostly just changes to access modifiers and removal of `final` from a handful of classes.

EDIT: I've added the following additional changes:

- Make Hibernate always generate lowercase column names in SQL `select`s. This was needed due to the behavior of the SmallRye postgres driver.
- Allow instantiation of `Delete`/`Update`/`Insert` objects to be delegated to the subclass of a persister, allowing hibernate-rx to more easily override the bind variable syntax.

EDIT 2: Today I've made some additional visibility changes, to `MergeContext`, `EntityIdentityInsertAction`, and `SessionImpl`.