### PR TITLE
HHH-12806 Eliminate all Javadoc warnings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
@@ -70,7 +70,7 @@ public interface SessionFactory extends EntityManagerFactory, HibernateEntityMan
 	 * for use.
 	 * <p/>
 	 * Note that for backwards compatibility, if a {@link org.hibernate.context.spi.CurrentSessionContext}
-	 * is not configured but JTA is configured this will default to the {@link org.hibernate.context.internal.JTASessionContext}
+	 * is not configured but JTA is configured this will default to the {@code org.hibernate.context.internal.JTASessionContext}
 	 * impl.
 	 *
 	 * @return The current session.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CacheConcurrencyStrategy.java
@@ -21,25 +21,25 @@ public enum CacheConcurrencyStrategy {
 	/**
 	 * Indicates that read-only strategy should be applied.
 	 *
-	 * @see AccessType#READ_ONLY
+	 * @see org.hibernate.cache.spi.access.AccessType#READ_ONLY
 	 */
 	READ_ONLY( AccessType.READ_ONLY ),
 	/**
 	 * Indicates that the non-strict read-write strategy should be applied.
 	 *
-	 * @see AccessType#NONSTRICT_READ_WRITE
+	 * @see org.hibernate.cache.spi.access.AccessType#NONSTRICT_READ_WRITE
 	 */
 	NONSTRICT_READ_WRITE( AccessType.NONSTRICT_READ_WRITE ),
 	/**
 	 * Indicates that the read-write strategy should be applied.
 	 *
-	 * @see AccessType#READ_WRITE
+	 * @see org.hibernate.cache.spi.access.AccessType#READ_WRITE
 	 */
 	READ_WRITE( AccessType.READ_WRITE ),
 	/**
 	 * Indicates that the transaction strategy should be applied.
 	 *
-	 * @see AccessType#TRANSACTIONAL
+	 * @see org.hibernate.cache.spi.access.AccessType#TRANSACTIONAL
 	 */
 	TRANSACTIONAL( AccessType.TRANSACTIONAL );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ObjectNameNormalizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ObjectNameNormalizer.java
@@ -51,7 +51,7 @@ public abstract class ObjectNameNormalizer {
 
 	/**
 	 * Normalizes the quoting of identifiers.  This form returns a String rather than an Identifier
-	 * to better work with the legacy code in {@link org.hibernate.mapping}
+	 * to better work with the legacy code in {@code org.hibernate.mapping} package.
 	 *
 	 * @param identifierText The identifier to be quoting-normalized.
 	 * @return The identifier accounting for any quoting that need be applied.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/JdbcDataType.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/JdbcDataType.java
@@ -20,7 +20,7 @@ package org.hibernate.boot.model.source.spi;
  *     </li>
  * </ul>
  *
- * @todo Would love to link this in with {@link org.hibernate.engine.jdbc.internal.TypeInfo}
+ * @todo Would love to link this in with {@link org.hibernate.engine.jdbc.spi.TypeInfo}
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/PluralAttributeMapKeySource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/PluralAttributeMapKeySource.java
@@ -8,18 +8,14 @@ package org.hibernate.boot.model.source.spi;
 
 /**
  * Describes source information about the key of a persistent map.  At high
- * level this broken down further into 2 categories:<ul>
- *     <li>{@link PluralAttributeMapKeySourceEntityAttribute}</li>
- *     <li>
- *         <ul>
- *             <li>{@link PluralAttributeMapKeySourceBasic}</li>
- *             <li>{@link PluralAttributeMapKeySourceEmbedded}</li>
- *             <li>{@link PluralAttributeMapKeyManyToManySource}</li>
- *         </ul>
- *     </li>
+ * level this broken down further into 3 categories:<ul>
+ * <ul>
+ *  <li>{@link PluralAttributeMapKeySourceBasic}</li>
+ *  <li>{@link PluralAttributeMapKeySourceEmbedded}</li>
+ *  <li>{@link PluralAttributeMapKeyManyToManySource}</li>
  * </ul>
  * <p/>
- * {@link PluralAttributeMapKeySourceEntityAttribute} is only relevant from
+ * {@link PluralAttributeMapKeySource} is only relevant from
  * annotations when using {@link javax.persistence.MapKey}.
  *
  * @author Steve Ebersole
@@ -39,7 +35,7 @@ public interface PluralAttributeMapKeySource extends PluralAttributeIndexSource 
 	 * (relevant only for one-to-many and many-to-many associations)?
 	 *
 	 * If this method returns {@code true}, then this object can safely
-	 * be cast to {@link PluralAttributeMapKeySourceEntityAttribute}.
+	 * be cast to {@link PluralAttributeMapKeyManyToManySource}.
 	 *
 	 * @return true, if this plural attribute index source for an attribute of the referenced
 	 * entity; false, otherwise.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/ToolingHintContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/ToolingHintContext.java
@@ -55,7 +55,7 @@ public class ToolingHintContext {
 	}
 
 	/**
-	 * The {@link org.hibernate.mapping} package accepts these as a Map, so for now
+	 * The {@code org.hibernate.mapping} package accepts these as a Map, so for now
 	 * expose the underlying Map.  But we unfortunately need to collect a Map...
 	 *
 	 * @return The underlying Map

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/package.html
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/package.html
@@ -28,9 +28,9 @@
 			</ol>
 		</p>
 		<p>
-			Note that for field-level interception, simply plugging in a new {@link BytecodeProvider}
+			Note that for field-level interception, simply plugging in a new {@link org.hibernate.bytecode.spi.BytecodeProvider}
 			is not enough for Hibernate to be able to recognize new providers.  You would additionally
-			need to make appropriate code changes to the {@link org.hibernate.intercept.Helper}
+			need to make appropriate code changes to the {@link org.hibernate.bytecode.spi.ClassLoadingStrategyHelper}
 			class.  This is because the detection of these enhanced classes is needed in a static
 			environment (i.e. outside the scope of any {@link org.hibernate.SessionFactory}.
 		</p>

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/package.html
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/package.html
@@ -33,10 +33,10 @@
 </p>
 <p>
     Note that, for an <i>asynchronous</i> cache, cache invalidation must be a two step process (lock->unlock or
-    lock->afterUpdate), since this is the only way to guarantee consistency with the database for a nontransactional
+    lock->afterUpdate), since this is the only way to guarantee consistency with the database for a non-transactional
     cache implementation. For a <i>synchronous</i> cache, cache invalidation is a single step process (evict or update).
-    Hence, these contracts ({@link org.hibernate.cache.spi.access.EntityRegionAccessStrategy} and
-    {@link org.hibernate.cache.spi.access.CollectionRegionAccessStrategy}) define a three step process to cater for both
+    Hence, these contracts ({@link org.hibernate.cache.spi.access.EntityDataAccess} and
+    {@link org.hibernate.cache.spi.access.CollectionDataAccess}) define a three step process to cater for both
     models (see the individual contracts for details).
 </p>
 <p>

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/package-info.java
@@ -18,8 +18,8 @@
  *
  * Generally a provider will integrate with Hibernate by:
  *
- * 		1. implementing the contracts in {@link org.hibernate.cache.spi}
- * 		2. implementing the contracts in {@link org.hibernate.cache.spi.support}
+ * 		1. implementing the contracts in {@code org.hibernate.cache.spi}
+ * 		2. implementing the contracts in {@code org.hibernate.cache.spi.support}
  * 		3. a mix of (1) and (2)
  *
  * The first approach allows for more control of the set up, but also requires more

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ExternalSessionFactoryConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ExternalSessionFactoryConfig.java
@@ -17,7 +17,7 @@ import org.hibernate.internal.util.config.ConfigurationHelper;
 
 /**
  * Defines support for various externally configurable SessionFactory(s), for
- * example, {@link org.hibernate.jmx.HibernateService JMX} or the JCA
+ * example, {@link org.hibernate.jmx.spi.JmxService JMX} or the JCA
  * adapter.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -36,7 +36,7 @@ import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
  *         {@link org.hibernate.resource.jdbc.spi.JdbcSessionContext} delegate
  *     </li>
  *     <li>
- *         {@link TransactionCoordinatorBuilder.Options}
+ *         {@code Options} interface in {@link TransactionCoordinatorBuilder}
  *         to drive the creation of the {@link TransactionCoordinator} delegate
  *     </li>
  *     <li>
@@ -49,7 +49,7 @@ import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
  * </ul>
  *
  * See also {@link org.hibernate.event.spi.EventSource} which extends this interface providing
- * bridge to the event generation features of {@link org.hibernate.event}
+ * bridge to the event generation features of {@code org.hibernate.event}
  *
  * @author Gavin King
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/spi/ProviderChecker.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/spi/ProviderChecker.java
@@ -66,8 +66,8 @@ public final class ProviderChecker {
 
 	/**
 	 * Extract the requested persistence provider name using the algorithm Hibernate uses.  Namely, a provider named
-	 * in the 'integration' map (under the key '{@value AvailableSettings#JPA_PERSISTENCE_PROVIDER}') is preferred, as per-spec, over
-	 * value specified in persistence unit.
+	 * in the 'integration' map (under the key '{@value org.hibernate.cfg.AvailableSettings#JPA_PERSISTENCE_PROVIDER}')
+	 * is preferred, as per-spec, over value specified in persistence unit.
 	 *
 	 * @param persistenceUnit The {@code <persistence-unit/>} descriptor.
 	 * @param integration The integration values.

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/ParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/ParameterRegistration.java
@@ -16,7 +16,7 @@ import javax.persistence.TemporalType;
  * {@link javax.persistence.Query} and {@link javax.persistence.StoredProcedureQuery} implementations.  Used to track
  * information known about the parameter.
  * <p/>
- * For parameter information as known to JPA criteria queries, see {@link org.hibernate.query.criteria.internal.expression.ParameterExpressionImpl}
+ * For parameter information as known to JPA criteria queries, see {@code org.hibernate.query.criteria.internal.expression.ParameterExpressionImpl}
  * instead.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/BidirectionalEntityReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/BidirectionalEntityReference.java
@@ -35,7 +35,7 @@ public interface BidirectionalEntityReference extends EntityReference {
 
 	/**
 	 * The query space UID returned using {@link #getQuerySpaceUid()} must
-	 * be the same as returned by {@link #getTargetEntityReference()#getQuerySpaceUid()}
+	 * be the same as returned by invoking {@link #getQuerySpaceUid()} on {@link #getTargetEntityReference()} result
 	 *
 	 * @return The query space UID.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/CollectionQuerySpace.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/CollectionQuerySpace.java
@@ -11,7 +11,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * Models a QuerySpace for a persistent collection.
  * <p/>
- * It's {@link #getDisposition()} result will be {@link Disposition#COLLECTION}
+ * It's {@link #getDisposition()} result will be {@link QuerySpace.Disposition#COLLECTION}
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/CompositeQuerySpace.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/CompositeQuerySpace.java
@@ -9,7 +9,7 @@ package org.hibernate.loader.plan.spi;
 /**
  * Models a QuerySpace for a composition (component/embeddable).
  * <p/>
- * It's {@link #getDisposition()} result will be {@link Disposition#COMPOSITE}
+ * It's {@link #getDisposition()} result will be {@link QuerySpace.Disposition#COMPOSITE}
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/EntityQuerySpace.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/spi/EntityQuerySpace.java
@@ -11,7 +11,7 @@ import org.hibernate.persister.entity.EntityPersister;
 /**
  * Models a QuerySpace specific to an entity (EntityPersister).
  * <p/>
- * It's {@link #getDisposition()} result will be {@link Disposition#ENTITY}
+ * It's {@link #getDisposition()} result will be {@link QuerySpace.Disposition#ENTITY}
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureOutputs.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureOutputs.java
@@ -19,7 +19,7 @@ public interface ProcedureOutputs extends Outputs {
 	 * Retrieve the value of an OUTPUT parameter by the parameter's registration memento.
 	 * <p/>
 	 * Should NOT be called for parameters registered as REF_CURSOR.  REF_CURSOR parameters should be
-	 * accessed via the returns (see {@link #getNextOutput}
+	 * accessed via the returns (see {@link #getCurrent()} and {@link #goToNext()}
 	 *
 	 * @param parameterRegistration The parameter's registration memento.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/SourceType.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/SourceType.java
@@ -26,8 +26,8 @@ public enum SourceType {
 	/**
 	 * "script" - External DDL script(s) are used as the exclusive source for generation.  The scripts for schema
 	 * creation and dropping come from different sources.  The creation DDL script is identified by the
-	 * {@value AvailableSettings#HBM2DDL_CREATE_SCRIPT_SOURCE} setting; the drop DDL script is identified by the
-	 * {@value AvailableSettings#HBM2DDL_DROP_SCRIPT_SOURCE} setting.
+	 * {@value org.hibernate.cfg.AvailableSettings#HBM2DDL_CREATE_SCRIPT_SOURCE} setting; the drop DDL script is
+	 * identified by the {@value org.hibernate.cfg.AvailableSettings#HBM2DDL_DROP_SCRIPT_SOURCE} setting.
 	 *
 	 * @see AvailableSettings#HBM2DDL_CREATE_SCRIPT_SOURCE
 	 * @see AvailableSettings#HBM2DDL_DROP_SCRIPT_SOURCE

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -42,7 +42,7 @@ public final class TypeFactory implements Serializable {
 	private static final CoreMessageLogger LOG = messageLogger( TypeFactory.class );
 
 	/**
-	 * @deprecated Use {@link TypeConfiguration}/{@link TypeConfiguration.Scope} instead
+	 * @deprecated Use {@link TypeConfiguration} instead
 	 */
 	@Deprecated
 	public interface TypeScope extends Serializable {

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -139,7 +139,7 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	 * TypeConfiguration.
 	 *
 	 * @apiNote This will throw an exception if the SessionFactory is not yet
-	 * bound here.  See {@link Scope} for more details regarding the stages
+	 * bound here.  See {@code Scope} class for more details regarding the stages
 	 * a TypeConfiguration goes through
 	 *
 	 * @return The MetadataBuildingContext
@@ -173,7 +173,7 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	 * Obtain the SessionFactory currently scoping the TypeConfiguration.
 	 *
 	 * @apiNote This will throw an exception if the SessionFactory is not yet
-	 * bound here.  See {@link Scope} for more details regarding the stages
+	 * bound here.  See {@code Scope} for more details regarding the stages
 	 * a TypeConfiguration goes through (this is "runtime stage")
 	 *
 	 * @return The SessionFactory
@@ -188,7 +188,7 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	/**
 	 * Obtain the ServiceRegistry scoped to the TypeConfiguration.
 	 *
-	 * @apiNote Depending on what the {@link Scope} is currently scoped to will determine where the
+	 * @apiNote Depending on what the {@code Scope} is currently scoped to will determine where the
 	 * {@link ServiceRegistry} is obtained from.
 	 *
 	 * @return The ServiceRegistry
@@ -252,22 +252,26 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 	 * regards to eventually being associated with a SessionFactory.  Goes
 	 * 3 "lifecycle" stages, pertaining to {@link #getMetadataBuildingContext()}
 	 * and {@link #getSessionFactory()}:
+	 * <ul>
 	 *
-	 * 		* "Initialization" is where the {@link TypeConfiguration} is first
-	 * 			built as the "boot model" ({@link org.hibernate.boot.model}) of
+	 * 		<li> "Initialization" is where the {@link TypeConfiguration} is first
+	 * 			built as the "boot model" (see {@code org.hibernate.boot.model} package) of
 	 * 			the user's domain model is converted into the "runtime model"
-	 * 			({@link org.hibernate.metamodel.model}).  During this phase,
+	 * 			(see {@code org.hibernate.metamodel.model} package).  During this phase,
 	 * 			{@link #getMetadataBuildingContext()} will be accessible but
 	 * 			{@link #getSessionFactory} will throw an exception.
-	 * 		* "Runtime" is where the "runtime model" is accessible while the
+	 * 		</li>	
+	 * 		<li> "Runtime" is where the "runtime model" is accessible while the
 	 * 			SessionFactory is still unclosed.  During this phase
 	 * 			{@link #getSessionFactory()} is accessible while
 	 * 			{@link #getMetadataBuildingContext()} will now throw an
 	 * 			exception
-	 * 		* "Sunset" is after the SessionFactory has been closed.  During this
+	 * 		</li>	
+	 * 		<li> "Sunset" is after the SessionFactory has been closed.  During this
 	 * 			phase both {@link #getSessionFactory()} and
 	 * 			{@link #getMetadataBuildingContext()} will now throw an exception
-	 *
+	 * 		</li>	
+	 *</ul>
 	 * Each stage or phase is consider a "scope" for the TypeConfiguration.
 	 */
 	private static class Scope implements Serializable {


### PR DESCRIPTION
This PR aims to eliminate the remaining 46 Javadoc warnings left from last similar endeavour.
The following ticket was borrowed for the purpose:

https://hibernate.atlassian.net/browse/HHH-12806

The procedure to check the Javadoc from codebase is:

1. `./gradlew :hibernate-core:javadoc`;
2. open `hibernate-core/target/docs/javadoc/index.html` in browser.

Usually Javadoc warnings are because of some misuse of Javadoc and thus detrimental to the quality of produced Javadoc. So eliminating all warnings (we have no way to disable some single warning, do we?) is worthwhile. Especially new warning won't be buried among peers.
