### PR TITLE
HHH-8776 Implement JPA's FETCH graph

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
@@ -206,10 +206,6 @@ include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fet
 
 [NOTE]
 ====
-Although the JPA standard specifies that you can override an EAGER fetching association at runtime using the `javax.persistence.fetchgraph` hint,
-currently, Hibernate does not implement this feature, so EAGER associations cannot be fetched lazily.
-For more info, check out the https://hibernate.atlassian.net/browse/HHH-8776[HHH-8776] Jira issue.
-
 When executing a JPQL query, if an EAGER association is omitted, Hibernate will issue a secondary select for every association needed to be fetched eagerly,
 which can lead to N+1 query issues.
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -32,6 +32,8 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
+import org.hibernate.graph.spi.AttributeNodeImplementor;
+import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -184,8 +186,12 @@ public final class TwoPhaseLoad {
 		String entityName = persister.getEntityName();
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
+		
+		GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
+		
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
+			
 			if ( debugEnabled ) {
 				LOG.debugf(
 					"Processing attribute `%s` : value = %s",
@@ -207,7 +213,7 @@ public final class TwoPhaseLoad {
 					// IMPLEMENTATION NOTE: this is a lazy collection property on a bytecode-enhanced entity.
 					// HHH-10989: We need to resolve the collection so that a CollectionReference is added to StatefulPersistentContext.
 					// As mentioned above, hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY
-					// so do not assign the resolved, unitialized PersistentCollection back to hydratedState[i].
+					// so do not assign the resolved, uninitialized PersistentCollection back to hydratedState[i].
 					Boolean overridingEager = getOverridingEager( session, entityName, propertyNames[i], types[i], debugEnabled );
 					types[i].resolve( value, session, entity, overridingEager );
 				}
@@ -229,6 +235,10 @@ public final class TwoPhaseLoad {
 				if ( debugEnabled ) {
 					LOG.debugf( "Skipping <unknown> attribute : `%s`", propertyNames[i] );
 				}
+			}
+			
+			if ( session.getFetchGraphLoadContext() != fetchGraphContext ) {
+				session.setFetchGraphLoadContext( fetchGraphContext );
 			}
 		}
 
@@ -367,27 +377,28 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overriden by anything.
+	 * Check if eager of the association is overridden by anything.
 	 *
 	 * @param session session
 	 * @param entityName entity name
 	 * @param associationName association name
-	 *
+	 * @param associationType association type
+	 * @param isDebugEnabled if debug log level enabled
 	 * @return null if there is no overriding, true if it is overridden to eager and false if it is overridden to lazy
 	 */
 	private static Boolean getOverridingEager(
 			final SharedSessionContractImplementor session,
 			final String entityName,
 			final String associationName,
-			final Type type,
+			final Type associationType,
 			final boolean isDebugEnabled) {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
-		if ( type.isCollectionType() || type.isAssociationType()  ) {
-			final Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
+		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
+			Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
 
-			//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
-			if ( isDebugEnabled ) {
-				if ( overridingEager != null ) {
+			if ( overridingEager != null ) {
+				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+				if ( isDebugEnabled ) {
 					LOG.debugf(
 							"Overriding eager fetching using active fetch profile. EntityName: %s, associationName: %s, eager fetching: %s",
 							entityName,
@@ -395,9 +406,24 @@ public final class TwoPhaseLoad {
 							overridingEager
 					);
 				}
+				return overridingEager;
 			}
 
-			return overridingEager;
+			overridingEager = isEagerFetchGraph( session, associationName, associationType );
+
+			if ( overridingEager != null ) {
+				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+				if ( isDebugEnabled ) {
+					LOG.debugf(
+							"Overriding eager fetching using fetch graph. EntityName: %s, associationName: %s, eager fetching: %s",
+							entityName,
+							associationName,
+							overridingEager
+					);
+				}
+
+				return overridingEager;
+			}
 		}
 		return null;
 	}
@@ -416,6 +442,33 @@ public final class TwoPhaseLoad {
 				if ( fetch != null && Fetch.Style.JOIN == fetch.getStyle() ) {
 					return true;
 				}
+			}
+		}
+
+		return null;
+	}
+	
+	private static Boolean isEagerFetchGraph(SharedSessionContractImplementor session, String associationName, Type associationType) {
+		GraphImplementor<?> context = session.getFetchGraphLoadContext();
+		
+		if ( context != null ) {
+			// 'fetch graph' is in effect, so null should not be returned
+			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode(associationName);
+			if ( attributeNode != null ) {
+				// set 'fetchGraphContext' to subgraph so graph is explored further (internal loading)
+				GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
+				if ( subContext != null ) {
+					session.setFetchGraphLoadContext( subContext );
+				}
+				else {
+					session.setFetchGraphLoadContext( null );
+				}
+				// explicit 'fetch graph' applies, so fetch eagerly
+				return true;
+			}
+			else {
+				// implicit 'fetch graph' applies, so fetch lazily
+				return false;
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -30,6 +30,7 @@ import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
+import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.custom.CustomQuery;
@@ -40,6 +41,7 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
+import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -521,5 +523,32 @@ public interface SharedSessionContractImplementor
 	 * @return the PersistenceContext associated to this session.
 	 */
 	PersistenceContext getPersistenceContextInternal();
+
+	/**
+	 * Get the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}. 
+	 * Suppose fetch graph is "a(b(c))", then during {@link org.hibernate.engine.internal.TwoPhaseLoad}:
+	 * <ul>
+	 *     <li>when loading root</li>: {@link org.hibernate.graph.spi.RootGraphImplementor root} will be returned
+	 *     <li>when internally loading 'a'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a' will be returned
+	 *     <li>when internally loading 'b'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b)' will be returned
+	 *     <li>when internally loading 'c'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b(c))' will be returned
+	 * </ul>
+	 * 
+	 * @return current fetch graph context; can be null if fetch graph is not effective or the graph eager loading is done.
+	 * @see #setFetchGraphLoadContext(GraphImplementor) 
+	 * @see org.hibernate.engine.internal.TwoPhaseLoad
+	 */
+	default GraphImplementor getFetchGraphLoadContext() {
+		return null;
+	}
+
+	/**
+	 * Set the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}.
+	 * 
+	 * @param fetchGraphLoadContext new fetch graph context; can be null (this field will be set to null after root entity loading is done).
+	 * @see #getFetchGraphLoadContext()                                 
+	 */
+	default void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
@@ -16,11 +16,8 @@ public enum GraphSemantic {
 	/**
 	 * Indicates a "fetch graph" EntityGraph.  Attributes explicitly specified
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
-	 * subsequent select).
-	 * <p/>
-	 * Note: Currently, attributes that are not specified are treated as
-	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata, rather than forcing FetchType.LAZY.
+	 * subsequent select). Attributes that are not specified are treated as
+	 * FetchType.LAZY invariably.
 	 */
 	FETCH( "javax.persistence.fetchgraph" ),
 
@@ -29,7 +26,7 @@ public enum GraphSemantic {
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
 	 * subsequent select).  Attributes that are not specified are treated as
 	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata
+	 * in metadata.
 	 */
 	LOAD( "javax.persistence.loadgraph" );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1436,6 +1436,9 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
+		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
+			getProducer().setFetchGraphLoadContext( entityGraphQueryHint.getGraph() );
+		}
 	}
 
 	protected void afterQuery() {
@@ -1447,6 +1450,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
+		getProducer().setFetchGraphLoadContext( null );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
@@ -50,7 +50,7 @@ public class EntityGraphFunctionalTests extends BaseEntityManagerFunctionalTestC
 					final Issue issue = session.find(
 							Issue.class,
 							1,
-							Collections.singletonMap( GraphSemantic.FETCH.getJpaHintName(), graph )
+							Collections.singletonMap( GraphSemantic.LOAD.getJpaHintName(), graph )
 					);
 
 					assertTrue( Hibernate.isInitialized( issue ) );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-8776 (38 watchers, :))

This is a long-term issue and a serious issue (as some guy said "this has reputational impact on Hibernate"). Also I would love this feature to be implemented for it is incredibly useful for it dictates lazy loading strategy by default (yeah, even when the mapping has been specified as 'eager')!

I went through quite some back and forth and finally I think I find a simple solution (easy to understand and henceforth maintain).