### PR TITLE
HHH-8776 Fix 'fetch graph' implementation

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
@@ -206,10 +206,6 @@ include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fet
 
 [NOTE]
 ====
-Although the JPA standard specifies that you can override an EAGER fetching association at runtime using the `javax.persistence.fetchgraph` hint,
-currently, Hibernate does not implement this feature, so EAGER associations cannot be fetched lazily.
-For more info, check out the https://hibernate.atlassian.net/browse/HHH-8776[HHH-8776] Jira issue.
-
 When executing a JPQL query, if an EAGER association is omitted, Hibernate will issue a secondary select for every association needed to be fetched eagerly,
 which can lead to N+1 query issues.
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -457,6 +457,7 @@ public final class TwoPhaseLoad {
 			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
 			if ( attributeNode != null ) {
 				if ( associationType.isCollectionType() ) {
+					// to do: deal with Map's key and value
 					session.setFetchGraphLoadContext( null );
 				}
 				else {
@@ -464,7 +465,8 @@ public final class TwoPhaseLoad {
 					GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
 					if ( subContext != null ) {
 						session.setFetchGraphLoadContext( subContext );
-					} else {
+					}
+					else {
 						session.setFetchGraphLoadContext( null );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -32,6 +32,8 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
+import org.hibernate.graph.spi.AttributeNodeImplementor;
+import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -184,8 +186,12 @@ public final class TwoPhaseLoad {
 		String entityName = persister.getEntityName();
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
+		
+		GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
+		
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
+			
 			if ( debugEnabled ) {
 				LOG.debugf(
 					"Processing attribute `%s` : value = %s",
@@ -207,7 +213,7 @@ public final class TwoPhaseLoad {
 					// IMPLEMENTATION NOTE: this is a lazy collection property on a bytecode-enhanced entity.
 					// HHH-10989: We need to resolve the collection so that a CollectionReference is added to StatefulPersistentContext.
 					// As mentioned above, hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY
-					// so do not assign the resolved, unitialized PersistentCollection back to hydratedState[i].
+					// so do not assign the resolved, uninitialized PersistentCollection back to hydratedState[i].
 					Boolean overridingEager = getOverridingEager( session, entityName, propertyNames[i], types[i], debugEnabled );
 					types[i].resolve( value, session, entity, overridingEager );
 				}
@@ -229,6 +235,10 @@ public final class TwoPhaseLoad {
 				if ( debugEnabled ) {
 					LOG.debugf( "Skipping <unknown> attribute : `%s`", propertyNames[i] );
 				}
+			}
+			
+			if ( session.getFetchGraphLoadContext() != fetchGraphContext ) {
+				session.setFetchGraphLoadContext( fetchGraphContext );
 			}
 		}
 
@@ -367,27 +377,45 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overriden by anything.
+	 * Check if eager of the association is overridden by anything.
 	 *
 	 * @param session session
 	 * @param entityName entity name
 	 * @param associationName association name
-	 *
+	 * @param associationType association type
+	 * @param isDebugEnabled if debug log level enabled
 	 * @return null if there is no overriding, true if it is overridden to eager and false if it is overridden to lazy
 	 */
 	private static Boolean getOverridingEager(
 			final SharedSessionContractImplementor session,
 			final String entityName,
 			final String associationName,
-			final Type type,
+			final Type associationType,
 			final boolean isDebugEnabled) {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
-		if ( type.isCollectionType() || type.isAssociationType()  ) {
-			final Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
+		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
 
-			//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
-			if ( isDebugEnabled ) {
-				if ( overridingEager != null ) {
+			Boolean overridingEager = isEagerFetchGraph( session, associationName, associationType );
+
+			if ( overridingEager != null ) {
+				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+				if ( isDebugEnabled ) {
+					LOG.debugf(
+							"Overriding eager fetching using fetch graph. EntityName: %s, associationName: %s, eager fetching: %s",
+							entityName,
+							associationName,
+							overridingEager
+					);
+				}
+
+				return overridingEager;
+			}
+			
+			overridingEager = isEagerFetchProfile( session, entityName, associationName );
+
+			if ( overridingEager != null ) {
+				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+				if ( isDebugEnabled ) {
 					LOG.debugf(
 							"Overriding eager fetching using active fetch profile. EntityName: %s, associationName: %s, eager fetching: %s",
 							entityName,
@@ -395,9 +423,8 @@ public final class TwoPhaseLoad {
 							overridingEager
 					);
 				}
+				return overridingEager;
 			}
-
-			return overridingEager;
 		}
 		return null;
 	}
@@ -416,6 +443,37 @@ public final class TwoPhaseLoad {
 				if ( fetch != null && Fetch.Style.JOIN == fetch.getStyle() ) {
 					return true;
 				}
+			}
+		}
+
+		return null;
+	}
+	
+	private static Boolean isEagerFetchGraph(SharedSessionContractImplementor session, String associationName, Type associationType) {
+		GraphImplementor<?> context = session.getFetchGraphLoadContext();
+		
+		if ( context != null ) {
+			// 'fetch graph' is in effect, so null should not be returned
+			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
+			if ( attributeNode != null ) {
+				if ( associationType.isCollectionType() ) {
+					session.setFetchGraphLoadContext( null );
+				}
+				else {
+					// set 'fetchGraphContext' to sub-graph so graph is explored further (internal loading)
+					GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
+					if ( subContext != null ) {
+						session.setFetchGraphLoadContext( subContext );
+					} else {
+						session.setFetchGraphLoadContext( null );
+					}
+				}
+				// explicit 'fetch graph' applies, so fetch eagerly
+				return true;
+			}
+			else {
+				// implicit 'fetch graph' applies, so fetch lazily
+				return false;
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -377,7 +377,11 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overridden by anything.
+	 * Check if eager of the association is overridden (i.e. skipping metamodel strategy), including (order sensitive):
+	 * <ol>
+	 *     <li>fetch graph</li>
+	 *     <li>fetch profile</li>
+	 * </ol>
 	 *
 	 * @param session session
 	 * @param entityName entity name
@@ -395,6 +399,7 @@ public final class TwoPhaseLoad {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
 		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
 
+			// check 'fetch graph' first; skip 'fetch profile' if 'fetch graph' takes effect
 			Boolean overridingEager = isEagerFetchGraph( session, associationName, associationType );
 
 			if ( overridingEager != null ) {
@@ -411,6 +416,7 @@ public final class TwoPhaseLoad {
 				return overridingEager;
 			}
 			
+			// check 'fetch profile' next; skip 'metamodel' if 'fetch profile' takes effect
 			overridingEager = isEagerFetchProfile( session, entityName, associationName );
 
 			if ( overridingEager != null ) {
@@ -426,6 +432,7 @@ public final class TwoPhaseLoad {
 				return overridingEager;
 			}
 		}
+		// let 'metamodel' decide eagerness
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -187,11 +187,10 @@ public final class TwoPhaseLoad {
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
 		
-		GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
+		final GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
 		
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
-			
 			if ( debugEnabled ) {
 				LOG.debugf(
 					"Processing attribute `%s` : value = %s",
@@ -457,11 +456,11 @@ public final class TwoPhaseLoad {
 	}
 	
 	private static Boolean isEagerFetchGraph(SharedSessionContractImplementor session, String associationName, Type associationType) {
-		GraphImplementor<?> context = session.getFetchGraphLoadContext();
+		final GraphImplementor<?> context = session.getFetchGraphLoadContext();
 		
 		if ( context != null ) {
 			// 'fetch graph' is in effect, so null should not be returned
-			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
+			final AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
 			if ( attributeNode != null ) {
 				if ( associationType.isCollectionType() ) {
 					// to do: deal with Map's key and value
@@ -469,7 +468,7 @@ public final class TwoPhaseLoad {
 				}
 				else {
 					// set 'fetchGraphContext' to sub-graph so graph is explored further (internal loading)
-					GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
+					final GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
 					if ( subContext != null ) {
 						session.setFetchGraphLoadContext( subContext );
 					}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -41,7 +41,6 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
-import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -30,6 +30,7 @@ import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
+import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.custom.CustomQuery;
@@ -40,6 +41,7 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
+import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -521,5 +523,32 @@ public interface SharedSessionContractImplementor
 	 * @return the PersistenceContext associated to this session.
 	 */
 	PersistenceContext getPersistenceContextInternal();
+
+	/**
+	 * Get the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}. 
+	 * Suppose fetch graph is "a(b(c))", then during {@link org.hibernate.engine.internal.TwoPhaseLoad}:
+	 * <ul>
+	 *     <li>when loading root</li>: {@link org.hibernate.graph.spi.RootGraphImplementor root} will be returned
+	 *     <li>when internally loading 'a'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a' will be returned
+	 *     <li>when internally loading 'b'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b)' will be returned
+	 *     <li>when internally loading 'c'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b(c))' will be returned
+	 * </ul>
+	 * 
+	 * @return current fetch graph context; can be null if fetch graph is not effective or the graph eager loading is done.
+	 * @see #setFetchGraphLoadContext(GraphImplementor) 
+	 * @see org.hibernate.engine.internal.TwoPhaseLoad
+	 */
+	default GraphImplementor getFetchGraphLoadContext() {
+		return null;
+	}
+
+	/**
+	 * Set the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}.
+	 * 
+	 * @param fetchGraphLoadContext new fetch graph context; can be null (this field will be set to null after root entity loading is done).
+	 * @see #getFetchGraphLoadContext()                                 
+	 */
+	default void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
@@ -16,11 +16,8 @@ public enum GraphSemantic {
 	/**
 	 * Indicates a "fetch graph" EntityGraph.  Attributes explicitly specified
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
-	 * subsequent select).
-	 * <p/>
-	 * Note: Currently, attributes that are not specified are treated as
-	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata, rather than forcing FetchType.LAZY.
+	 * subsequent select). Attributes that are not specified are treated as
+	 * FetchType.LAZY invariably.
 	 */
 	FETCH( "javax.persistence.fetchgraph" ),
 
@@ -29,7 +26,7 @@ public enum GraphSemantic {
 	 * as AttributeNodes are treated as FetchType.EAGER (via join fetch or
 	 * subsequent select).  Attributes that are not specified are treated as
 	 * FetchType.LAZY or FetchType.EAGER depending on the attribute's definition
-	 * in metadata
+	 * in metadata.
 	 */
 	LOAD( "javax.persistence.loadgraph" );
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1116,8 +1116,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	void unableToJoinTransaction(String transactionStrategy);
 
 	@LogMessage(level = INFO)
-	@Message(value = "Error performing load command : %s", id = 327)
-	void unableToLoadCommand(HibernateException e);
+	@Message(value = "Error performing load command", id = 327)
+	void unableToLoadCommand(@Cause HibernateException e);
 
 	@LogMessage(level = WARN)
 	@Message(value = "Unable to load/access derby driver class sysinfo to check versions : %s", id = 328)

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1436,6 +1436,9 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
+		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
+			getProducer().setFetchGraphLoadContext( entityGraphQueryHint.getGraph() );
+		}
 	}
 
 	protected void afterQuery() {
@@ -1447,6 +1450,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
+		getProducer().setFetchGraphLoadContext( null );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/graph/EntityGraphFunctionalTests.java
@@ -50,7 +50,7 @@ public class EntityGraphFunctionalTests extends BaseEntityManagerFunctionalTestC
 					final Issue issue = session.find(
 							Issue.class,
 							1,
-							Collections.singletonMap( GraphSemantic.FETCH.getJpaHintName(), graph )
+							Collections.singletonMap( GraphSemantic.LOAD.getJpaHintName(), graph )
 					);
 
 					assertTrue( Hibernate.isInitialized( issue ) );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/CompanyWithFetchProfile.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/CompanyWithFetchProfile.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.graphs;
+
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.FetchProfile;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * @author Nathan Xu
+ */
+@Entity
+@FetchProfile(
+		name = "company.location",
+		fetchOverrides = {
+				@FetchProfile.FetchOverride(
+						entity = CompanyWithFetchProfile.class,
+						association = "location",
+						mode = FetchMode.JOIN
+				)
+		}
+)
+public class CompanyWithFetchProfile {
+	@Id @GeneratedValue
+	public long id;
+	
+	@OneToMany
+	public Set<Employee> employees = new HashSet<Employee>();
+	
+	@OneToOne(fetch = FetchType.LAZY)
+	public Location location;
+	
+	@ElementCollection
+	public Set<Market> markets = new HashSet<Market>();
+	
+	@ElementCollection(fetch = FetchType.EAGER)
+	public Set<String> phoneNumbers = new HashSet<String>();
+
+	public Location getLocation() {
+		return location;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mapped_by_id/FetchGraphFindByIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mapped_by_id/FetchGraphFindByIdTest.java
@@ -1,0 +1,133 @@
+package org.hibernate.jpa.test.graphs.mapped_by_id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.jpa.test.graphs.*;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.Subgraph;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Nathan Xu
+ */
+public class FetchGraphFindByIdTest extends BaseEntityManagerFunctionalTestCase {
+
+	private long companyId;
+	
+	@Test
+	@TestForIssue(jiraKey = "HHH-8776")
+	public void testFetchGraphByFind() {
+		EntityManager entityManager = getOrCreateEntityManager();
+		entityManager.getTransaction().begin();
+
+		EntityGraph<Company> entityGraph = entityManager.createEntityGraph( Company.class );
+		entityGraph.addAttributeNodes( "location" );
+		entityGraph.addAttributeNodes( "markets" );
+
+		Map<String, Object> properties = Collections.singletonMap( "javax.persistence.fetchgraph", entityGraph );
+
+		Company company = entityManager.find( Company.class, companyId, properties );
+
+		entityManager.getTransaction().commit();
+		entityManager.close();
+
+		assertFalse( Hibernate.isInitialized( company.employees ) );
+		assertTrue( Hibernate.isInitialized( company.location ) );
+		assertTrue( Hibernate.isInitialized( company.markets ) );
+		// With "fetchgraph", non-specified attributes effect 'lazy' mode.  So, here,
+		// @ElementCollection(fetch = FetchType.EAGER) should not be initialized.
+		assertFalse( Hibernate.isInitialized( company.phoneNumbers ) );
+
+		entityManager = getOrCreateEntityManager();
+		entityManager.getTransaction().begin();
+
+		Subgraph<Employee> subgraph = entityGraph.addSubgraph( "employees" );
+		subgraph.addAttributeNodes( "managers" );
+		subgraph.addAttributeNodes( "friends" );
+		Subgraph<Manager> subSubgraph = subgraph.addSubgraph( "managers", Manager.class );
+		subSubgraph.addAttributeNodes( "managers" );
+		subSubgraph.addAttributeNodes( "friends" );
+
+		company = entityManager.find( Company.class, companyId, properties );
+
+		entityManager.getTransaction().commit();
+		entityManager.close();
+
+		assertTrue( Hibernate.isInitialized( company.employees ) );
+		assertTrue( Hibernate.isInitialized( company.location ) );
+		assertEquals( 12345, company.location.zip );
+		assertTrue( Hibernate.isInitialized( company.markets ) );
+		// With "fetchgraph", non-specified attributes effect 'lazy' mode.  So, here,
+		// @ElementCollection(fetch = FetchType.EAGER) should not be initialized.
+		assertFalse( Hibernate.isInitialized( company.phoneNumbers ) );
+
+		boolean foundManager = false;
+		Iterator<Employee> employeeItr = company.employees.iterator();
+		while (employeeItr.hasNext()) {
+			Employee employee = employeeItr.next();
+			assertTrue( Hibernate.isInitialized( employee.managers ) );
+			assertTrue( Hibernate.isInitialized( employee.friends ) );
+			// test 1 more level
+			Iterator<Manager> managerItr =  employee.managers.iterator();
+			while (managerItr.hasNext()) {
+				foundManager = true;
+				Manager manager = managerItr.next();
+				assertTrue( Hibernate.isInitialized( manager.managers ) );
+				assertTrue( Hibernate.isInitialized( manager.friends ) );
+			}
+		}
+		assertTrue(foundManager);
+	}
+
+	@Before
+	public void createData() {
+		EntityManager entityManager = getOrCreateEntityManager();
+		entityManager.getTransaction().begin();
+
+		Manager manager1 = new Manager();
+		entityManager.persist( manager1 );
+
+		Manager manager2 = new Manager();
+		manager2.managers.add( manager1 );
+		entityManager.persist( manager2 );
+
+		Employee employee = new Employee();
+		employee.managers.add( manager1 );
+		entityManager.persist( employee );
+
+		Location location = new Location();
+		location.address = "123 somewhere";
+		location.zip = 12345;
+		entityManager.persist( location );
+
+		Company company = new Company();
+		company.employees.add( employee );
+		company.employees.add( manager1 );
+		company.employees.add( manager2 );
+		company.location = location;
+		company.markets.add( Market.SERVICES );
+		company.markets.add( Market.TECHNOLOGY );
+		company.phoneNumbers.add( "012-345-6789" );
+		company.phoneNumbers.add( "987-654-3210" );
+		entityManager.persist( company );
+		companyId = company.id;
+
+		entityManager.getTransaction().commit();
+		entityManager.close();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Company.class, Employee.class, Manager.class, Location.class, Course.class, Student.class };
+	}
+	
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mapped_by_id/LoadGraphFindByIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mapped_by_id/LoadGraphFindByIdTest.java
@@ -12,7 +12,6 @@ import javax.persistence.Entity;
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;


### PR DESCRIPTION
I found our 'fetch graph' implementation is almost perfect (e.g. load plan, SQL generation are perfectly in line with 'fetch graph' JPA spec), the only missing part is in TwoPhaseLoad. We have added 'fetch profile' overwriting (w.r.t meta model) logic there. Seems we are missing the 'fetch graph' overwriting counterpart there.

Testing code for both 'find' and 'query' are added.
