### PR TITLE
HHH-12153 Fix customized simple type 'serializable' detection issue

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
@@ -305,12 +305,17 @@ class BasicAttributeVisitor extends SimpleTypeVisitor6<Boolean, Element> {
 			if ( TypeUtils.containsAnnotation( element, Constants.EMBEDDABLE ) ) {
 				return Boolean.TRUE;
 			}
-			for ( TypeMirror mirror : typeElement.getInterfaces() ) {
-				TypeElement interfaceElement = (TypeElement) context.getTypeUtils().asElement( mirror );
-				if ( "java.io.Serializable".equals( interfaceElement.getQualifiedName().toString() ) ) {
-					return Boolean.TRUE;
+			
+			do {
+				for ( TypeMirror mirror : typeElement.getInterfaces() ) {
+					TypeElement interfaceElement = (TypeElement) context.getTypeUtils().asElement( mirror );
+					if ( "java.io.Serializable".equals( interfaceElement.getQualifiedName().toString() ) ) {
+						return Boolean.TRUE;
+					}
 				}
-			}
+				typeElement = TypeUtils.getSuperclassTypeElement( typeElement );
+			} 
+			while ( typeElement != null );
 		}
 		return Boolean.FALSE;
 	}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/AbstractSerializableSimpleType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/AbstractSerializableSimpleType.java
@@ -1,0 +1,18 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+import java.io.Serializable;
+
+public class AbstractSerializableSimpleType implements Serializable {
+	
+	private Integer value;
+	
+	public AbstractSerializableSimpleType(Integer value) {
+		this.value = value;
+	}
+	
+	@Override
+	public String toString() {
+		return value == null ? "" : value.toString();
+	}
+	
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/AbstractSimpleType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/AbstractSimpleType.java
@@ -1,0 +1,16 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+public abstract class AbstractSimpleType {
+
+	private Integer value;
+		
+	public AbstractSimpleType(Integer value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return value == null ? "" : value.toString();
+	}
+		
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSerializableSimpleType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSerializableSimpleType.java
@@ -1,0 +1,9 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+public class ConcreteSerializableSimpleType extends AbstractSerializableSimpleType {
+	
+	public ConcreteSerializableSimpleType(Integer value) {
+		super( value );
+	}
+	
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSerializableSimpleTypeImplementingSerializable.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSerializableSimpleTypeImplementingSerializable.java
@@ -1,0 +1,10 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+import java.io.Serializable;
+
+public class ConcreteSerializableSimpleTypeImplementingSerializable extends ConcreteSerializableSimpleType implements Serializable {
+
+	public ConcreteSerializableSimpleTypeImplementingSerializable(Integer value) {
+		super( value );
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSimpleType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/ConcreteSimpleType.java
@@ -1,0 +1,9 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+public class ConcreteSimpleType extends AbstractSimpleType {
+	
+	public ConcreteSimpleType(Integer value) {
+		super( value );
+	}
+	
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/EntityWithSimpleTypes.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/EntityWithSimpleTypes.java
@@ -1,0 +1,20 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class EntityWithSimpleTypes {
+	
+	@Id
+	private Long id;
+
+	private Integer integerValue;
+	
+	private ConcreteSimpleType concreteSimpleType;
+
+	private ConcreteSerializableSimpleType concreteSerializableSimpleType;
+
+	private ConcreteSerializableSimpleTypeImplementingSerializable concreteSerializableSimpleTypeImplementingSerializable;
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/JpaUserTypeTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/usertype/jpa/JpaUserTypeTest.java
@@ -1,0 +1,38 @@
+package org.hibernate.jpamodelgen.test.usertype.jpa;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+
+public class JpaUserTypeTest extends CompilationTest {
+
+	@Test
+	@WithClasses({
+			ConcreteSimpleType.class,
+			ConcreteSerializableSimpleType.class,
+			EntityWithSimpleTypes.class,
+			AbstractSerializableSimpleType.class,
+			AbstractSimpleType.class
+	})
+	public void testCustomUserTypeInMetaModel() {
+		
+		assertMetamodelClassGeneratedFor( EntityWithSimpleTypes.class );
+		
+		assertPresenceOfFieldInMetamodelFor(
+				EntityWithSimpleTypes.class, "integerValue"
+		);
+		
+		assertPresenceOfFieldInMetamodelFor(
+				EntityWithSimpleTypes.class, "concreteSerializableSimpleType"
+		);
+		
+		assertPresenceOfFieldInMetamodelFor(
+				EntityWithSimpleTypes.class, "concreteSerializableSimpleTypeImplementingSerializable"
+		);
+		
+	}
+	
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-12153

Simple fix. Just fix the logic loophole that we only check customized simple type per se without navigating its ancestor types.