### PR TITLE
Set CRITERIA_LITERAL_HANDLING_MODE in Dialects

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -115,6 +115,7 @@ public class DerbyDialect extends Dialect {
 				: new DerbyLimitHandler( getVersion() >= 1060 );
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, NO_BATCH );
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	public int getDefaultDecimalPrecision() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
@@ -124,6 +124,7 @@ public class FirebirdDialect extends Dialect {
 		registerColumnType( Types.NCLOB, "blob sub_type text" ); // Firebird doesn't have NCLOB, but Jaybird emulates NCLOB support
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, NO_BATCH );
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -112,6 +112,7 @@ public class HSQLDialect extends Dialect {
 		}
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	private static int reflectedVersion(int version) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
@@ -44,6 +44,7 @@ public class InterbaseDialect extends Dialect {
 		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp" );
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, NO_BATCH );
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLDialect.java
@@ -70,6 +70,7 @@ public class MimerSQLDialect extends Dialect {
 
 		getDefaultProperties().setProperty( Environment.USE_STREAMS_FOR_BINARY, "true" );
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, "50" );
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -7,6 +7,7 @@
 package org.hibernate.dialect;
 
 import org.hibernate.*;
+import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.SQLServerIdentityColumnSupport;
@@ -102,6 +103,8 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 		registerKeyword( "top" );
 		registerKeyword( "key" );
+
+		getDefaultProperties().setProperty( Environment.CRITERIA_LITERAL_HANDLING_MODE, "literal" );
 	}
 
 	@Override


### PR DESCRIPTION
On the abandoned branch, some dialects set `QUERY_LITERAL_RENDERING`, but these settings got lost when I merged the code, because I could not find the setting.

Does this look right to you, @sebersole?