### PR TITLE
Log usage of deprecated Dialect classes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -83,6 +83,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.*;
 
+import static org.hibernate.internal.log.DeprecationLogger.DEPRECATION_LOGGER;
 import static org.hibernate.type.descriptor.DateTimeUtils.*;
 
 /**
@@ -136,7 +137,7 @@ public abstract class Dialect implements ConversionContext {
 	// constructors and factory methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	protected Dialect() {
-		LOG.usingDialect( this );
+		logSelectedDialect();
 
 		registerColumnType( Types.BIT, 1, "bit" );
 		registerColumnType( Types.BIT, "bit($l)" );
@@ -223,6 +224,22 @@ public abstract class Dialect implements ConversionContext {
 
 		uniqueDelegate = new DefaultUniqueDelegate( this );
 		defaultSizeStrategy = new DefaultSizeStrategyImpl();
+	}
+
+	private void logSelectedDialect() {
+		LOG.usingDialect( this );
+
+		Class<? extends Dialect> dialect = getClass();
+		if ( dialect.isAnnotationPresent(Deprecated.class) ) {
+			Class<?> superDialect = dialect.getSuperclass();
+			if ( !superDialect.isAnnotationPresent(Deprecated.class)
+				&& !superDialect.equals(Dialect.class) ) {
+				DEPRECATION_LOGGER.deprecatedDialect( dialect.getSimpleName(), superDialect.getName() );
+			}
+			else {
+				DEPRECATION_LOGGER.deprecatedDialect( dialect.getSimpleName() );
+			}
+		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -182,15 +182,6 @@ public interface CoreMessageLogger extends BasicLogger {
 	void deprecatedForceDescriminatorAnnotation();
 
 	@LogMessage(level = WARN)
-	@Message(value = "The Oracle9Dialect dialect has been deprecated; use either Oracle9iDialect or Oracle10gDialect instead",
-			id = 63)
-	void deprecatedOracle9Dialect();
-
-	@LogMessage(level = WARN)
-	@Message(value = "The OracleDialect dialect has been deprecated; use Oracle8iDialect instead", id = 64)
-	void deprecatedOracleDialect();
-
-	@LogMessage(level = WARN)
 	@Message(value = "DEPRECATED : use [%s] instead with custom [%s] implementation", id = 65)
 	void deprecatedUuidGenerator(String name, String name2);
 
@@ -1520,15 +1511,6 @@ public interface CoreMessageLogger extends BasicLogger {
 	@LogMessage(level = WARN)
 	@Message(value = "Setting entity-identifier value binding where one already existed : %s.", id = 429)
 	void entityIdentifierValueBindingExists(String name);
-
-	@LogMessage(level = WARN)
-	@Message(value = "The DerbyDialect dialect has been deprecated; use one of the version-specific dialects instead",
-			id = 430)
-	void deprecatedDerbyDialect();
-
-	@LogMessage(level = WARN)
-	@Message(value = "Unable to determine H2 database version, certain features may not work", id = 431)
-	void undeterminedH2Version();
 
 	@LogMessage(level = WARN)
 	@Message(value = "There were not column names specified for index %s on table %s", id = 432)

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
@@ -249,4 +249,15 @@ public interface DeprecationLogger extends BasicLogger {
 					"5.3 in upgrading.  It will be removed in a later version."
 	)
 	void logUseOfDeprecatedZeroBasedJdbcStyleParams();
+
+	@LogMessage(level = WARN)
+	@Message(value = "%s has been deprecated",
+			id = 90000025)
+	void deprecatedDialect(String dialect);
+
+	@LogMessage(level = WARN)
+	@Message(value = "%s has been deprecated; use %s instead",
+			id = 90000025)
+	void deprecatedDialect(String dialect, String replacement);
+
 }


### PR DESCRIPTION
The database-version-specific dialects are now `@Deprecated`. So produce a log message to this effect.