### PR TITLE
On MariaDB limit queried sequences to those for the current database

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -80,7 +80,7 @@ public class MariaDBDialect extends MySQLDialect {
 	@Override
 	public String getQuerySequencesString() {
 		return getSequenceSupport().supportsSequences()
-				? "select table_name from information_schema.TABLES where table_type='SEQUENCE'"
+				? "select table_name from information_schema.TABLES where table_schema = database() and table_type='SEQUENCE'"
 				: super.getQuerySequencesString(); //fancy way to write "null"
 	}
 


### PR DESCRIPTION
This change reproduces the [fix](https://github.com/hibernate/hibernate-orm/pull/3147) by @NathanQingyangXu in the new Hibernate 6 `MariaDBDialect`.