### PR TITLE
Fix hibernate-core compilation error on wip/6.0

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -74,7 +74,8 @@ dependencies {
     compile( libraries.jaxb_runtime )
 
 	// Antlr
-	antlr( libraries.antlr )
+    compile( libraries.antlr )
+    antlr( libraries.antlr )
 
 	// xjc plugin
     xjc( libraries.jaxb_runtime )


### PR DESCRIPTION
the existing 'antlr( libraries.antlr )' is only meant for generating antlr sources. We still need to add compile dependency to ensure the compiling of the generated antlr sources succeed.
