### PR TITLE
HHH-13842 - Remove the TODO along with the commented code block

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -164,11 +164,9 @@ jar {
             // to use an older version of JAXB (the only one we can use in Karaf)
             "javax.xml.bind.*;version=\"${project.jaxbApiVersionOsgiRange}\""
 
-//        // TODO: Uncomment once EntityManagerFactoryBuilderImpl no longer
-//        // uses ClassLoaderServiceImpl.
-//        instruction 'Export-Package',
-//            'org.hibernate.boot.registry.classloading.internal',
-//            '*'
+        instruction 'Export-Package',
+            'org.hibernate.boot.registry.classloading.internal',
+            '*'
     }
 }
 

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -163,10 +163,6 @@ jar {
             // We must specify the version explicitly to allow Karaf
             // to use an older version of JAXB (the only one we can use in Karaf)
             "javax.xml.bind.*;version=\"${project.jaxbApiVersionOsgiRange}\""
-
-        instruction 'Export-Package',
-            'org.hibernate.boot.registry.classloading.internal',
-            '*'
     }
 }
 


### PR DESCRIPTION
A snippet in the hibernate-core.gradle had a TODO task. It said

TODO: Uncomment once EntityManagerFactoryBuilderImpl no longer uses ClassLoaderServiceImpl.
The EntityManagerFactoryBuilderImpl used ClassLoaderServiceImpl until version 4.3, which was removed in the version 5.0.  

This has been removed in this commit.