### PR TITLE
HHH-13843: make schema migration faster

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationCachedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationCachedImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.schema.extract.internal;
+
+import java.sql.SQLException;
+
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
+
+/**
+ * Will cache all database information by reading the tableinformation from the name space in one call.
+ * Schema migration becomes much faster when this object is used.
+ * NOTE: superclass already caches the sequence information, so perhaps cache can also be coded in superlcass
+ * @author francois
+ */
+public class DatabaseInformationCachedImpl extends DatabaseInformationImpl {
+	private NameSpaceTablesInformation defaultNameSpaceTablesInformation = null;
+	private final Namespace defaultNamespace;
+
+	/**
+	 *
+	 * @param serviceRegistry        ServiceRegistry
+	 * @param jdbcEnvironment        JdbcEnvironment
+	 * @param ddlTransactionIsolator DdlTransactionIsolator
+	 * @param defaultNamespace       NameSpace
+	 */
+	public DatabaseInformationCachedImpl(
+		ServiceRegistry serviceRegistry,
+		JdbcEnvironment jdbcEnvironment,
+		DdlTransactionIsolator ddlTransactionIsolator, Namespace defaultNamespace)
+		throws SQLException {
+		super(serviceRegistry, jdbcEnvironment, ddlTransactionIsolator, defaultNamespace.getName());
+		this.defaultNamespace = defaultNamespace;
+	}
+
+	@Override
+	public TableInformation getTableInformation(QualifiedTableName qualifiedTableName) {
+
+		if (defaultNameSpaceTablesInformation == null) {
+			// Load table information from the whole space in one go (expected to be used in case of schemaMigration, so (almost) all
+			// tables are likely to be retrieved)
+			defaultNameSpaceTablesInformation = getTablesInformation(defaultNamespace);
+		}
+		TableInformation tableInformation = defaultNameSpaceTablesInformation.getTableInformation(qualifiedTableName.getTableName().getText());
+		if (tableInformation != null) {
+			return tableInformation;
+		}
+		return super.getTableInformation(qualifiedTableName);  // result of this call can of course also be cached, does not seem to be in scope now
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -93,11 +93,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			final JdbcContext jdbcContext = tool.resolveJdbcContext( options.getConfigurationValues() );
 			final DdlTransactionIsolator ddlTransactionIsolator = tool.getDdlTransactionIsolator( jdbcContext );
 			try {
-				final DatabaseInformation databaseInformation = Helper.buildDatabaseInformation(
-						tool.getServiceRegistry(),
-						ddlTransactionIsolator,
-						metadata.getDatabase().getDefaultNamespace().getName()
-				);
+				final DatabaseInformation databaseInformation = getDatabaseInformation(ddlTransactionIsolator, metadata.getDatabase().getDefaultNamespace());
 
 				final GenerationTarget[] targets = tool.buildGenerationTargets(
 						targetDescriptor,
@@ -138,6 +134,8 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			}
 		}
 	}
+
+	protected abstract DatabaseInformation getDatabaseInformation(DdlTransactionIsolator ddlTransactionIsolator, Namespace namespace);
 
 	protected abstract NameSpaceTablesInformation performTablesMigration(
 			Metadata metadata,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
@@ -6,14 +6,18 @@
  */
 package org.hibernate.tool.schema.internal;
 
+import java.sql.SQLException;
 import java.util.Set;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.Table;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.tool.schema.extract.internal.DatabaseInformationCachedImpl;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
 import org.hibernate.tool.schema.extract.spi.TableInformation;
@@ -33,6 +37,20 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 			HibernateSchemaManagementTool tool,
 			SchemaFilter schemaFilter) {
 		super( tool, schemaFilter );
+	}
+
+	protected DatabaseInformation getDatabaseInformation(DdlTransactionIsolator ddlTransactionIsolator, Namespace namespace) {
+		final JdbcEnvironment jdbcEnvironment = tool.getServiceRegistry().getService( JdbcEnvironment.class );
+		try {
+			return new DatabaseInformationCachedImpl(
+				tool.getServiceRegistry(),
+				jdbcEnvironment,
+				ddlTransactionIsolator,
+				namespace);
+		}
+		catch (SQLException e) {
+			throw jdbcEnvironment.getSqlExceptionHelper().convert( e, "Unable to build DatabaseInformationCached" );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.Table;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
 import org.hibernate.tool.schema.extract.spi.TableInformation;
@@ -33,6 +34,10 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 			HibernateSchemaManagementTool tool,
 			SchemaFilter schemaFilter) {
 		super( tool, schemaFilter );
+	}
+
+	protected DatabaseInformation getDatabaseInformation(DdlTransactionIsolator ddlTransactionIsolator, Namespace namespace) {
+		return Helper.buildDatabaseInformation(tool.getServiceRegistry(), ddlTransactionIsolator, namespace.getName());
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
@@ -18,6 +18,7 @@ import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.extract.internal.ColumnInformationImpl;
 import org.hibernate.tool.schema.extract.internal.ForeignKeyInformationImpl;
 import org.hibernate.tool.schema.extract.internal.TableInformationImpl;
@@ -47,6 +48,13 @@ public class CheckForExistingForeignKeyTest {
 		 */
 		public SchemaMigrator() {
 			super( null, null );
+		}
+
+		@Override
+		protected DatabaseInformation getDatabaseInformation(
+			DdlTransactionIsolator ddlTransactionIsolator, Namespace namespace)
+		{
+			return null;
 		}
 
 		/**


### PR DESCRIPTION
A slowdown was noticed after upgrading to hibernate 5.4 during investigation a lot of calls for retrieving  foreignkeys from the database which caused a lot of separate calls for retrieving column-information from to the JDBC-driver.

By retrieving the DatabaseInformation for the whole nameSpace during schemaMigration, a nice speedup (and reduction in SQL-calls) can be achieved.