### PR TITLE
HHH-13848 - Fix for potential NullPointerException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
@@ -239,8 +239,7 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 	}
 
 	private JDBCException convert(SQLException e, String s) {
-		// todo : implement
-		return null;
+		return new JDBCException(s, e);
 	}
 
 	@Override


### PR DESCRIPTION
The callers of the convert() method in ResourceRegistryStandardImpl expect an exception which is then thrown. This can produce NullPointerException, which has been fixed in this commit.