### PR TITLE
HHH-13852 - Work for method renaming in BaseCoreFunctionalTestCase

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -20,10 +20,13 @@ import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
+import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.bytecode.internal.SessionFactoryObserverForBytecodeEnhancer;
+import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.cache.spi.TimestampsCacheFactory;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.dialect.function.SQLFunction;
@@ -459,6 +462,9 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	@Override
 	public SessionFactory build() {
 		metadata.validate();
+		final StandardServiceRegistry serviceRegistry = metadata.getMetadataBuildingOptions().getServiceRegistry();
+		BytecodeProvider bytecodeProvider = serviceRegistry.getService( BytecodeProvider.class );
+		addSessionFactoryObservers( new SessionFactoryObserverForBytecodeEnhancer( bytecodeProvider ) );
 		return new SessionFactoryImpl( metadata, buildSessionFactoryOptions() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.internal;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+import org.hibernate.cfg.Environment;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public final class BytecodeProviderInitiator implements StandardServiceInitiator<BytecodeProvider> {
+
+	/**
+	 * Singleton access
+	 */
+	public static final StandardServiceInitiator<BytecodeProvider> INSTANCE = new BytecodeProviderInitiator();
+
+	@Override
+	public BytecodeProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		// TODO in 6 this will no longer use Environment, which is configured via global environment variables,
+		// but move to a component which can be reconfigured differently in each registry.
+		return Environment.getBytecodeProvider();
+	}
+
+	@Override
+	public Class<BytecodeProvider> getServiceInitiated() {
+		return BytecodeProvider.class;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.internal;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
+import org.hibernate.cfg.Environment;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public final class ProxyFactoryFactoryInitiator implements StandardServiceInitiator<ProxyFactoryFactory> {
+
+	/**
+	 * Singleton access
+	 */
+	public static final StandardServiceInitiator<ProxyFactoryFactory> INSTANCE = new ProxyFactoryFactoryInitiator();
+
+	@Override
+	public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		return Environment.getBytecodeProvider().getProxyFactoryFactory();
+	}
+
+	@Override
+	public Class<ProxyFactoryFactory> getServiceInitiated() {
+		return ProxyFactoryFactory.class;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
@@ -9,10 +9,16 @@ package org.hibernate.bytecode.internal;
 import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.bytecode.spi.ProxyFactoryFactory;
-import org.hibernate.cfg.Environment;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
+/**
+ * Most commonly the {@link ProxyFactoryFactory} will depend directly on the chosen {@link BytecodeProvider},
+ * however by registering them as two separate services we can allow to override either one
+ * or both of them.
+ * @author Sanne Grinovero
+ */
 public final class ProxyFactoryFactoryInitiator implements StandardServiceInitiator<ProxyFactoryFactory> {
 
 	/**
@@ -22,7 +28,8 @@ public final class ProxyFactoryFactoryInitiator implements StandardServiceInitia
 
 	@Override
 	public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
-		return Environment.getBytecodeProvider().getProxyFactoryFactory();
+		final BytecodeProvider bytecodeProvider = registry.getService( BytecodeProvider.class );
+		return bytecodeProvider.getProxyFactoryFactory();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/SessionFactoryObserverForBytecodeEnhancer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/SessionFactoryObserverForBytecodeEnhancer.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.internal;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.SessionFactoryObserver;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+
+public final class SessionFactoryObserverForBytecodeEnhancer implements SessionFactoryObserver {
+
+	private final BytecodeProvider bytecodeProvider;
+
+	public SessionFactoryObserverForBytecodeEnhancer(BytecodeProvider bytecodeProvider) {
+		this.bytecodeProvider = bytecodeProvider;
+	}
+
+	@Override
+	public void sessionFactoryCreated(final SessionFactory factory) {
+		this.bytecodeProvider.resetCaches();
+	}
+
+	@Override
+	public void sessionFactoryClosing(final SessionFactory factory) {
+		this.bytecodeProvider.resetCaches();
+	}
+
+	@Override
+	public void sessionFactoryClosed(final SessionFactory factory) {
+		this.bytecodeProvider.resetCaches();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -159,7 +159,7 @@ public final class ByteBuddyState {
 
 	/**
 	 * Wipes out all known caches used by ByteBuddy. This implies it might trigger the need
-	 * to re-create some helpers if used at runtime, especially as this state is shared by
+	 * to re-create some helpers if used at runtime, especially as this state might be shared by
 	 * multiple SessionFactory instances, but at least ensures we cleanup anything which is no
 	 * longer needed after a SessionFactory close.
 	 * The assumption is that closing SessionFactories is a rare event; in this perspective the cost

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
@@ -8,6 +8,7 @@ package org.hibernate.bytecode.spi;
 
 import org.hibernate.bytecode.enhance.spi.EnhancementContext;
 import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.service.Service;
 
 /**
  * Contract for providers of bytecode services to Hibernate.
@@ -19,7 +20,7 @@ import org.hibernate.bytecode.enhance.spi.Enhancer;
  *
  * @author Steve Ebersole
  */
-public interface BytecodeProvider {
+public interface BytecodeProvider extends Service {
 	/**
 	 * Retrieve the specific factory for this provider capable of
 	 * generating run-time proxies for lazy-loading purposes.

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ProxyFactoryFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ProxyFactoryFactory.java
@@ -6,11 +6,9 @@
  */
 package org.hibernate.bytecode.spi;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.proxy.ProxyFactory;
-import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.Service;
 
 /**
  * An interface for factories of {@link ProxyFactory proxy factory} instances.
@@ -20,7 +18,7 @@ import org.hibernate.service.ServiceRegistry;
  *
  * @author Steve Ebersole
  */
-public interface ProxyFactoryFactory {
+public interface ProxyFactoryFactory extends Service {
 	/**
 	 * Build a proxy factory specifically for handling runtime
 	 * lazy loading.

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -198,11 +198,16 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 	public void remove(SharedSessionContractImplementor session, Object key) {
 		if ( getStorageAccess().getFromCache( key, session ) instanceof SoftLock ) {
 			log.debugf( "Skipping #remove call in read-write access to maintain SoftLock : %s", key );
-			// don'tm do anything... we want the SoftLock to remain in place
+			// don't do anything... we want the SoftLock to remain in place
 		}
 		else {
 			super.remove( session, key );
 		}
+	}
+
+	@Override
+	public void removeAll(SharedSessionContractImplementor session) {
+		// A no-op
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/EntityReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/EntityReadWriteAccess.java
@@ -151,9 +151,4 @@ public class EntityReadWriteAccess extends AbstractReadWriteAccess implements En
 	public SoftLock lockRegion() {
 		return null;
 	}
-
-	@Override
-	public void unlockRegion(SoftLock lock) {
-
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
@@ -351,8 +351,15 @@ public final class Environment implements AvailableSettings {
 
 		LOG.bytecodeProvider( providerName );
 
-		// todo : allow a custom class name - just check if the config is a FQN
-		//		currently we assume it is only ever the Strings "javassist" or "bytebuddy"...
+		// there is no need to support plugging in a custom BytecodeProvider via FQCN:
+		// - the static helper methods on this class are deprecated
+		// - it's possible to plug a custom BytecodeProvider directly into the ServiceRegistry
+		//
+		// This also allows integrators to inject a BytecodeProvider instance which has some
+		// state; particularly useful to inject proxy definitions which have been prepared in
+		// advance.
+		// See also https://hibernate.atlassian.net/browse/HHH-13804 and how this was solved in
+		// Quarkus.
 
 		LOG.unknownBytecodeProvider( providerName, BYTECODE_PROVIDER_NAME_DEFAULT );
 		return new org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl();

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -753,8 +753,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	 * @throws HibernateException
 	 */
 	public void close() throws HibernateException {
-		//This is an idempotent operation so we can do it even before the checks (it won't hurt):
-		Environment.getBytecodeProvider().resetCaches();
 		synchronized (this) {
 			if ( isClosed ) {
 				if ( getSessionFactoryOptions().getJpaCompliance().isJpaClosedComplianceEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3799,7 +3799,7 @@ public abstract class AbstractEntityPersister
 		final String[] deleteStrings;
 		if ( isImpliedOptimisticLocking && loadedState != null ) {
 			// we need to utilize dynamic delete statements
-			deleteStrings = generateSQLDeletStrings( loadedState );
+			deleteStrings = generateSQLDeleteStrings( loadedState );
 		}
 		else {
 			// otherwise, utilize the static delete statements
@@ -3817,7 +3817,7 @@ public abstract class AbstractEntityPersister
 				|| entityMetamodel.getOptimisticLockStyle() == OptimisticLockStyle.ALL;
 	}
 
-	private String[] generateSQLDeletStrings(Object[] loadedState) {
+	private String[] generateSQLDeleteStrings(Object[] loadedState) {
 		int span = getTableSpan();
 		String[] deleteStrings = new String[span];
 		for ( int j = span - 1; j >= 0; j-- ) {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.proxy.pojo;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.hibernate.MappingException;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.ReflectHelper;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Subclass;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.property.access.spi.Setter;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.tuple.entity.PojoEntityTuplizer;
+
+/**
+ * Most of this code was originally an internal detail of {@link PojoEntityTuplizer},
+ * then extracted to make it easier for integrators to initialize a custom
+ * {@link org.hibernate.proxy.ProxyFactory}.
+ */
+public final class ProxyFactoryHelper {
+
+	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( ProxyFactoryHelper.class );
+
+	private ProxyFactoryHelper() {
+		//not meant to be instantiated
+	}
+
+	public static Set<Class> extractProxyInterfaces(final PersistentClass persistentClass, final String entityName) {
+		/*
+		 * We need to preserve the order of the interfaces they were put into the set, since javassist will choose the
+		 * first one's class-loader to construct the proxy class with. This is also the reason why HibernateProxy.class
+		 * should be the last one in the order (on JBossAS7 its class-loader will be org.hibernate module's class-
+		 * loader, which will not see the classes inside deployed apps.  See HHH-3078
+		 */
+		final Set<Class> proxyInterfaces = new java.util.LinkedHashSet<Class>();
+		final Class mappedClass = persistentClass.getMappedClass();
+		final Class proxyInterface = persistentClass.getProxyInterface();
+
+		if ( proxyInterface != null && !mappedClass.equals( proxyInterface ) ) {
+			if ( !proxyInterface.isInterface() ) {
+				throw new MappingException(
+						"proxy must be either an interface, or the class itself: " + entityName
+				);
+			}
+			proxyInterfaces.add( proxyInterface );
+		}
+
+		if ( mappedClass.isInterface() ) {
+			proxyInterfaces.add( mappedClass );
+		}
+
+		Iterator<Subclass> subclasses = persistentClass.getSubclassIterator();
+		while ( subclasses.hasNext() ) {
+			final Subclass subclass = subclasses.next();
+			final Class subclassProxy = subclass.getProxyInterface();
+			final Class subclassClass = subclass.getMappedClass();
+			if ( subclassProxy != null && !subclassClass.equals( subclassProxy ) ) {
+				if ( !subclassProxy.isInterface() ) {
+					throw new MappingException(
+							"proxy must be either an interface, or the class itself: " + subclass.getEntityName()
+					);
+				}
+				proxyInterfaces.add( subclassProxy );
+			}
+		}
+
+		proxyInterfaces.add( HibernateProxy.class );
+		return proxyInterfaces;
+	}
+
+	public static void validateProxyability(final PersistentClass persistentClass) {
+		Iterator properties = persistentClass.getPropertyIterator();
+		Class clazz = persistentClass.getMappedClass();
+		while ( properties.hasNext() ) {
+			Property property = (Property) properties.next();
+			Method method = property.getGetter( clazz ).getMethod();
+			if ( method != null && Modifier.isFinal( method.getModifiers() ) ) {
+				LOG.gettersOfLazyClassesCannotBeFinal( persistentClass.getEntityName(), property.getName() );
+			}
+			method = property.getSetter( clazz ).getMethod();
+			if ( method != null && Modifier.isFinal( method.getModifiers() ) ) {
+				LOG.settersOfLazyClassesCannotBeFinal( persistentClass.getEntityName(), property.getName() );
+			}
+		}
+	}
+
+	public static Method extractProxySetIdentifierMethod(final Setter idSetter, final Class proxyInterface) {
+		Method idSetterMethod = idSetter == null ? null : idSetter.getMethod();
+
+		Method proxySetIdentifierMethod = idSetterMethod == null || proxyInterface == null ?
+				null :
+				ReflectHelper.getMethod( proxyInterface, idSetterMethod );
+		return proxySetIdentifierMethod;
+	}
+
+	public static Method extractProxyGetIdentifierMethod(final Getter idGetter, final Class proxyInterface) {
+		Method idGetterMethod = idGetter == null ? null : idGetter.getMethod();
+
+		Method proxyGetIdentifierMethod = idGetterMethod == null || proxyInterface == null ?
+				null :
+				ReflectHelper.getMethod( proxyInterface, idGetterMethod );
+		return proxyGetIdentifierMethod;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.internal.ProxyFactoryFactoryInitiator;
 import org.hibernate.cache.internal.RegionFactoryInitiator;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
 import org.hibernate.engine.jdbc.batch.internal.BatchBuilderInitiator;
@@ -51,6 +52,8 @@ public final class StandardServiceInitiators {
 
 	private static List<StandardServiceInitiator> buildStandardServiceInitiatorList() {
 		final ArrayList<StandardServiceInitiator> serviceInitiators = new ArrayList<StandardServiceInitiator>();
+
+		serviceInitiators.add( ProxyFactoryFactoryInitiator.INSTANCE );
 
 		serviceInitiators.add( CfgXmlAccessServiceInitiator.INSTANCE );
 		serviceInitiators.add( ConfigurationServiceInitiator.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.hibernate.boot.cfgxml.internal.CfgXmlAccessServiceInitiator;
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.bytecode.internal.BytecodeProviderInitiator;
 import org.hibernate.bytecode.internal.ProxyFactoryFactoryInitiator;
 import org.hibernate.cache.internal.RegionFactoryInitiator;
 import org.hibernate.engine.config.internal.ConfigurationServiceInitiator;
@@ -53,6 +54,7 @@ public final class StandardServiceInitiators {
 	private static List<StandardServiceInitiator> buildStandardServiceInitiatorList() {
 		final ArrayList<StandardServiceInitiator> serviceInitiators = new ArrayList<StandardServiceInitiator>();
 
+		serviceInitiators.add( BytecodeProviderInitiator.INSTANCE );
 		serviceInitiators.add( ProxyFactoryFactoryInitiator.INSTANCE );
 
 		serviceInitiators.add( CfgXmlAccessServiceInitiator.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.bytecode.spi.BasicProxyFactory;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -124,7 +125,8 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 
 	protected Instantiator buildInstantiator(Component component) {
 		if ( component.isEmbedded() && ReflectHelper.isAbstractClass( this.componentClass ) ) {
-			return new ProxiedInstantiator( this.componentClass );
+			ProxyFactoryFactory proxyFactoryFactory = component.getServiceRegistry().getService( ProxyFactoryFactory.class );
+			return new ProxiedInstantiator( this.componentClass, proxyFactoryFactory );
 		}
 		if ( optimizer == null ) {
 			return new PojoInstantiator( this.componentClass, null );
@@ -151,16 +153,14 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 		private final Class proxiedClass;
 		private final BasicProxyFactory factory;
 
-		public ProxiedInstantiator(Class componentClass) {
+		public ProxiedInstantiator(Class componentClass, ProxyFactoryFactory proxyFactoryFactory) {
 			proxiedClass = componentClass;
 			if ( proxiedClass.isInterface() ) {
-				factory = Environment.getBytecodeProvider()
-						.getProxyFactoryFactory()
+				factory = proxyFactoryFactory
 						.buildBasicProxyFactory( null, new Class[] { proxiedClass } );
 			}
 			else {
-				factory = Environment.getBytecodeProvider()
-						.getProxyFactoryFactory()
+				factory = proxyFactoryFactory
 						.buildBasicProxyFactory( proxiedClass, null );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/PojoComponentTuplizer.java
@@ -5,12 +5,14 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.tuple.component;
+
 import java.io.Serializable;
 import java.lang.reflect.Method;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.bytecode.spi.BasicProxyFactory;
+import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.bytecode.spi.ProxyFactoryFactory;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
@@ -68,9 +70,8 @@ public class PojoComponentTuplizer extends AbstractComponentTuplizer {
 			optimizer = null;
 		}
 		else {
-			// TODO: here is why we need to make bytecode provider global :(
-			// TODO : again, fix this after HHH-1907 is complete
-			optimizer = Environment.getBytecodeProvider().getReflectionOptimizer(
+			final BytecodeProvider bytecodeProvider = component.getServiceRegistry().getService( BytecodeProvider.class );
+			optimizer = bytecodeProvider.getReflectionOptimizer(
 					componentClass, getterNames, setterNames, propTypes
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -18,6 +18,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.bytecode.spi.ProxyFactoryFactory;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
@@ -76,16 +77,13 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 			optimizer = null;
 		}
 		else {
-			// todo : YUCK!!!
-			optimizer = Environment.getBytecodeProvider().getReflectionOptimizer(
+			final BytecodeProvider bytecodeProvider = entityMetamodel.getSessionFactory().getServiceRegistry().getService( BytecodeProvider.class );
+			optimizer = bytecodeProvider.getReflectionOptimizer(
 					mappedClass,
 					getterNames,
 					setterNames,
 					propTypes
 			);
-//			optimizer = getFactory().getSettings().getBytecodeProvider().getReflectionOptimizer(
-//					mappedClass, getterNames, setterNames, propTypes
-//			);
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -7,15 +7,12 @@
 package org.hibernate.tuple.entity;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.EntityMode;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.HibernateException;
-import org.hibernate.MappingException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.spi.BytecodeProvider;
@@ -29,14 +26,12 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.mapping.Subclass;
 import org.hibernate.property.access.spi.Getter;
 import org.hibernate.property.access.spi.Setter;
-import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.ProxyFactory;
+import org.hibernate.proxy.pojo.ProxyFactoryHelper;
 import org.hibernate.tuple.Instantiator;
 import org.hibernate.type.CompositeType;
 
@@ -91,76 +86,21 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 	protected ProxyFactory buildProxyFactory(PersistentClass persistentClass, Getter idGetter, Setter idSetter) {
 		// determine the id getter and setter methods from the proxy interface (if any)
 		// determine all interfaces needed by the resulting proxy
+		final String entityName = getEntityName();
+		final Class mappedClass = persistentClass.getMappedClass();
+		final Class proxyInterface = persistentClass.getProxyInterface();
 
-		/*
-		 * We need to preserve the order of the interfaces they were put into the set, since javassist will choose the
-		 * first one's class-loader to construct the proxy class with. This is also the reason why HibernateProxy.class
-		 * should be the last one in the order (on JBossAS7 its class-loader will be org.hibernate module's class-
-		 * loader, which will not see the classes inside deployed apps.  See HHH-3078
-		 */
-		Set<Class> proxyInterfaces = new java.util.LinkedHashSet<Class>();
+		final Set<Class> proxyInterfaces = ProxyFactoryHelper.extractProxyInterfaces( persistentClass, entityName );
 
-		Class mappedClass = persistentClass.getMappedClass();
-		Class proxyInterface = persistentClass.getProxyInterface();
+		ProxyFactoryHelper.validateProxyability( persistentClass );
 
-		if ( proxyInterface != null && !mappedClass.equals( proxyInterface ) ) {
-			if ( !proxyInterface.isInterface() ) {
-				throw new MappingException(
-						"proxy must be either an interface, or the class itself: " + getEntityName()
-				);
-			}
-			proxyInterfaces.add( proxyInterface );
-		}
-
-		if ( mappedClass.isInterface() ) {
-			proxyInterfaces.add( mappedClass );
-		}
-
-		Iterator<Subclass> subclasses = persistentClass.getSubclassIterator();
-		while ( subclasses.hasNext() ) {
-			final Subclass subclass = subclasses.next();
-			final Class subclassProxy = subclass.getProxyInterface();
-			final Class subclassClass = subclass.getMappedClass();
-			if ( subclassProxy != null && !subclassClass.equals( subclassProxy ) ) {
-				if ( !subclassProxy.isInterface() ) {
-					throw new MappingException(
-							"proxy must be either an interface, or the class itself: " + subclass.getEntityName()
-					);
-				}
-				proxyInterfaces.add( subclassProxy );
-			}
-		}
-
-		proxyInterfaces.add( HibernateProxy.class );
-
-		Iterator properties = persistentClass.getPropertyIterator();
-		Class clazz = persistentClass.getMappedClass();
-		while ( properties.hasNext() ) {
-			Property property = (Property) properties.next();
-			Method method = property.getGetter( clazz ).getMethod();
-			if ( method != null && Modifier.isFinal( method.getModifiers() ) ) {
-				LOG.gettersOfLazyClassesCannotBeFinal( persistentClass.getEntityName(), property.getName() );
-			}
-			method = property.getSetter( clazz ).getMethod();
-			if ( method != null && Modifier.isFinal( method.getModifiers() ) ) {
-				LOG.settersOfLazyClassesCannotBeFinal( persistentClass.getEntityName(), property.getName() );
-			}
-		}
-
-		Method idGetterMethod = idGetter == null ? null : idGetter.getMethod();
-		Method idSetterMethod = idSetter == null ? null : idSetter.getMethod();
-
-		Method proxyGetIdentifierMethod = idGetterMethod == null || proxyInterface == null ?
-				null :
-				ReflectHelper.getMethod( proxyInterface, idGetterMethod );
-		Method proxySetIdentifierMethod = idSetterMethod == null || proxyInterface == null ?
-				null :
-				ReflectHelper.getMethod( proxyInterface, idSetterMethod );
+		Method proxyGetIdentifierMethod = ProxyFactoryHelper.extractProxyGetIdentifierMethod( idGetter, proxyInterface );
+		Method proxySetIdentifierMethod = ProxyFactoryHelper.extractProxySetIdentifierMethod( idSetter, proxyInterface );
 
 		ProxyFactory pf = buildProxyFactoryInternal( persistentClass, idGetter, idSetter );
 		try {
 			pf.postInstantiate(
-					getEntityName(),
+					entityName,
 					mappedClass,
 					proxyInterfaces,
 					proxyGetIdentifierMethod,
@@ -171,7 +111,7 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 			);
 		}
 		catch (HibernateException he) {
-			LOG.unableToCreateProxyFactory( getEntityName(), he );
+			LOG.unableToCreateProxyFactory( entityName, he );
 			pf = null;
 		}
 		return pf;

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -18,6 +18,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
 import org.hibernate.classic.Lifecycle;
@@ -182,9 +183,8 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 			PersistentClass persistentClass,
 			Getter idGetter,
 			Setter idSetter) {
-		// TODO : YUCK!!!  fix after HHH-1907 is complete
-		return Environment.getBytecodeProvider().getProxyFactoryFactory().buildProxyFactory( getFactory() );
-//		return getFactory().getSettings().getBytecodeProvider().getProxyFactoryFactory().buildProxyFactory();
+		ProxyFactoryFactory proxyFactory = getFactory().getServiceRegistry().getService( ProxyFactoryFactory.class );
+		return proxyFactory.buildProxyFactory( getFactory() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -49,15 +49,11 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 	private final boolean lifecycleImplementor;
 	private final ReflectionOptimizer optimizer;
 
-	private final boolean isBytecodeEnhanced;
-
-
 	public PojoEntityTuplizer(EntityMetamodel entityMetamodel, PersistentClass mappedEntity) {
 		super( entityMetamodel, mappedEntity );
 		this.mappedClass = mappedEntity.getMappedClass();
 		this.proxyInterface = mappedEntity.getProxyInterface();
 		this.lifecycleImplementor = Lifecycle.class.isAssignableFrom( mappedClass );
-		this.isBytecodeEnhanced = entityMetamodel.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading();
 
 		String[] getterNames = new String[propertySpan];
 		String[] setterNames = new String[propertySpan];

--- a/hibernate-core/src/test/java/org/hibernate/cache/spi/ReadWriteCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cache/spi/ReadWriteCacheTest.java
@@ -1,0 +1,310 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.spi;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.EmptyInterceptor;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Frank Doherty
+ */
+public class ReadWriteCacheTest extends BaseCoreFunctionalTestCase {
+
+	private static final String ORIGINAL_TITLE = "Original Title";
+	private static final String UPDATED_TITLE = "Updated Title";
+
+	private long bookId;
+	private CountDownLatch endLatch;
+	private AtomicBoolean interceptTransaction;
+
+	@Override
+	public void buildSessionFactory() {
+		buildSessionFactory( getCacheConfig() );
+	}
+
+	@Before
+	public void init() {
+		endLatch = new CountDownLatch( 1 );
+		interceptTransaction = new AtomicBoolean();
+	}
+
+	@Override
+	public void rebuildSessionFactory() {
+		rebuildSessionFactory( getCacheConfig() );
+	}
+
+	@Test
+	public void testDelete() throws InterruptedException {
+		bookId = 1L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Delete Book" );
+			Book book = session.get( Book.class, bookId );
+			session.delete( book );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			assertBookNotFound( bookId, session );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13792")
+	public void testDeleteHQL() throws InterruptedException {
+		bookId = 2L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Delete Book using HQL" );
+			int numRows = session.createQuery( "delete from Book where id = :id" )
+					.setParameter( "id", bookId )
+					.executeUpdate();
+			assertEquals( 1, numRows );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			assertBookNotFound( bookId, session );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13792")
+	public void testDeleteNativeQuery() throws InterruptedException {
+		bookId = 3L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Delete Book using NativeQuery" );
+			int numRows = session.createNativeQuery( "delete from Book where id = :id" )
+					.setParameter( "id", bookId )
+					.addSynchronizedEntityClass( Book.class )
+					.executeUpdate();
+			assertEquals( 1, numRows );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			assertBookNotFound( bookId, session );
+		} );
+	}
+
+	@Test
+	public void testUpdate() throws InterruptedException {
+		bookId = 4L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Update Book" );
+			Book book = session.get( Book.class, bookId );
+			book.setTitle( UPDATED_TITLE );
+			session.save( book );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			loadBook( bookId, session );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13792")
+	public void testUpdateHQL() throws InterruptedException {
+		bookId = 5L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Update Book using HQL" );
+			int numRows = session.createQuery( "update Book set title = :title where id = :id" )
+					.setParameter( "title", UPDATED_TITLE )
+					.setParameter( "id", bookId )
+					.executeUpdate();
+			assertEquals( 1, numRows );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			loadBook( bookId, session );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13792")
+	public void testUpdateNativeQuery() throws InterruptedException {
+		bookId = 6L;
+
+		doInHibernate( this::sessionFactory, session -> {
+			createBook( bookId, session );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			log.info( "Update Book using NativeQuery" );
+			int numRows = session.createNativeQuery( "update Book set title = :title where id = :id" )
+					.setParameter( "title", UPDATED_TITLE )
+					.setParameter( "id", bookId )
+					.addSynchronizedEntityClass( Book.class )
+					.executeUpdate();
+			assertEquals( 1, numRows );
+			interceptTransaction.set( true );
+		} );
+
+		endLatch.await();
+		interceptTransaction.set( false );
+
+		doInHibernate( this::sessionFactory, session -> {
+			loadBook( bookId, session );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Book.class,
+		};
+	}
+
+	@Override
+	protected String getCacheConcurrencyStrategy() {
+		return "read-write";
+	}
+
+	private void assertBookNotFound(long bookId, Session session) {
+		log.info( "Load Book" );
+		Book book = session.get( Book.class, bookId );
+		assertNull( book );
+	}
+
+	private void createBook(long bookId, Session session) {
+		log.info( "Create Book" );
+		Book book = new Book();
+		book.setId( bookId );
+		book.setTitle( ORIGINAL_TITLE );
+		session.save( book );
+	}
+
+	private Consumer<Configuration> getCacheConfig() {
+		return configuration -> configuration.setInterceptor( new TransactionInterceptor() );
+	}
+
+	private void loadBook(long bookId, Session session) {
+		log.info( "Load Book" );
+		Book book = session.get( Book.class, bookId );
+		assertNotNull( book );
+		assertEquals( "Found old value", UPDATED_TITLE, book.getTitle() );
+	}
+
+	@Entity(name = "Book")
+	@Cacheable
+	@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	private static final class Book {
+
+		@Id
+		private Long id;
+
+		private String title;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public String toString() {
+			return "Book[id=" + id + ",title=" + title + "]";
+		}
+	}
+
+	private final class TransactionInterceptor extends EmptyInterceptor {
+		@Override
+		public void beforeTransactionCompletion(Transaction tx) {
+			if ( interceptTransaction.get() ) {
+				try {
+					log.info( "Fetch Book" );
+
+					executeSync( () -> {
+						Session session = sessionFactory()
+								.openSession();
+						Book book = session.get( Book.class, bookId );
+						assertNotNull( book );
+						log.infof( "Fetched %s", book );
+						session.close();
+					} );
+
+					assertTrue( sessionFactory().getCache()
+										.containsEntity( Book.class, bookId ) );
+				}
+				finally {
+					endLatch.countDown();
+				}
+			}
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/AnyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/AnyTest.java
@@ -234,7 +234,7 @@ public class AnyTest extends BaseCoreFunctionalTestCase {
 
 	// Simply having this orm.xml file in the classpath reproduces HHH-4261.
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/any/orm.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/bytecode/ProxyBreakingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/bytecode/ProxyBreakingTest.java
@@ -37,7 +37,7 @@ public class ProxyBreakingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/bytecode/Hammer.hbm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/idclass/xml/IdClassXmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/idclass/xml/IdClassXmlTest.java
@@ -44,7 +44,7 @@ public class IdClassXmlTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/idclass/xml/HabitatSpeciesLink.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/loader/LoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/loader/LoaderTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class LoaderTest extends BaseCoreFunctionalTestCase {
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/loader/Loader.hbm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
@@ -151,7 +151,7 @@ public class OptionalOneToOnePKJCTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/onetoone/orm.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
@@ -663,7 +663,7 @@ public class QueryAndSQLTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/query/orm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/ElementCollectionConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/ElementCollectionConverterTest.java
@@ -24,7 +24,7 @@ public class ElementCollectionConverterTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/reflection/element-collection-converter-orm.xml" };
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
@@ -130,7 +130,7 @@ public class Ejb3XmlTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/xml/ejb3/orm.xml",
 				"org/hibernate/test/annotations/xml/ejb3/orm2.xml",

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
@@ -54,7 +54,7 @@ public class OrmVersion1SupportedTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/xml/ejb3/orm2.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmTest.java
@@ -80,7 +80,7 @@ public class HbmTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[]{
 				"org/hibernate/test/annotations/xml/hbm/Government.hbm.xml",
 				"org/hibernate/test/annotations/xml/hbm/CloudType.hbm.xml",

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmWithIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmWithIdentityTest.java
@@ -42,7 +42,7 @@ public class HbmWithIdentityTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/xml/hbm/A.hbm.xml",
 				"org/hibernate/test/annotations/xml/hbm/B.hbm.xml",

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -203,7 +203,7 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 				configuration.addPackage( annotatedPackage );
 			}
 		}
-		String[] xmlFiles = getXmlFiles();
+		String[] xmlFiles = getOrmXmlFiles();
 		if ( xmlFiles != null ) {
 			for ( String xmlFile : xmlFiles ) {
 				try ( InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream( xmlFile ) ) {
@@ -236,8 +236,7 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		return NO_MAPPINGS;
 	}
 
-	protected String[] getXmlFiles() {
-		// todo : rename to getOrmXmlFiles()
+	protected String[] getOrmXmlFiles() {
 		return NO_MAPPINGS;
 	}
 


### PR DESCRIPTION
Currently, in BaseCoreFunctionalTestCase a method named getXmlFiles()has a TODO placed that suggests the method name to be changed to getOrmXmlFiles().

Since the method is a protected methods, there is a possibility it is being used by other clients. Hence, changing the method name in minor versions might break the code for clients.

Although, this long-awaited change can be done as an improvement in wip/v6.0