### PR TITLE
HHH-13855 - Remove unnecessary delared variable JtaManager in HibernatePersistenceProviderAdaptor

### DIFF
--- a/hibernate-jipijapa/src/main/java/org/jboss/as/jpa/hibernate5/HibernatePersistenceProviderAdaptor.java
+++ b/hibernate-jipijapa/src/main/java/org/jboss/as/jpa/hibernate5/HibernatePersistenceProviderAdaptor.java
@@ -43,17 +43,11 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
 	@SuppressWarnings("WeakerAccess")
 	public static final String HIBERNATE_EXTENDED_BEANMANAGER = "org.hibernate.resource.beans.container.spi.ExtendedBeanManager";
 
-	private volatile JtaManager jtaManager;
 	private volatile Platform platform;
 	private static final String NONE = SharedCacheMode.NONE.name();
 
 	@Override
-	public void injectJtaManager(JtaManager jtaManager) {
-		// todo : why?  `this.jtaManager` is never used aside from setting here in this method
-		if ( this.jtaManager != jtaManager ) {
-			this.jtaManager = jtaManager;
-		}
-	}
+	public void injectJtaManager(JtaManager jtaManager) { }
 
 	@Override
 	public void injectPlatform(Platform platform) {


### PR DESCRIPTION
In the HibernatePersistenceProviderAdaptor, there is an unnecessary declaration of JtaManager. The sole purpose of having this variable is only to use in the overridden method named InjectJtaManager.

This was be improved by removing the JtaManager as there is no use of the variable, as of now at least.