### PR TITLE
HHH-13856 - Long-awaited TODOs done as an improvement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/DB2UniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/DB2UniqueDelegate.java
@@ -35,7 +35,7 @@ public class DB2UniqueDelegate extends DefaultUniqueDelegate {
 					dialect,
 					uniqueKey.getName(),
 					uniqueKey.getTable(),
-					uniqueKey.columnIterator(),
+					uniqueKey.getColumnIterator(),
 					uniqueKey.getColumnOrderMap(),
 					true,
 					metadata
@@ -63,7 +63,7 @@ public class DB2UniqueDelegate extends DefaultUniqueDelegate {
 	}
 	
 	private boolean hasNullable(org.hibernate.mapping.UniqueKey uniqueKey) {
-		final Iterator<org.hibernate.mapping.Column> iter = uniqueKey.columnIterator();
+		final Iterator<org.hibernate.mapping.Column> iter = uniqueKey.getColumnIterator();
 		while ( iter.hasNext() ) {
 			if ( iter.next().isNullable() ) {
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
@@ -60,7 +60,7 @@ public class DefaultUniqueDelegate implements UniqueDelegate {
 	protected String uniqueConstraintSql(UniqueKey uniqueKey) {
 		final StringBuilder sb = new StringBuilder();
 		sb.append( "unique (" );
-		final Iterator<org.hibernate.mapping.Column> columnIterator = uniqueKey.columnIterator();
+		final Iterator<org.hibernate.mapping.Column> columnIterator = uniqueKey.getColumnIterator();
 		while ( columnIterator.hasNext() ) {
 			final org.hibernate.mapping.Column column = columnIterator.next();
 			sb.append( column.getQuotedName( dialect ) );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -151,12 +151,8 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	public Column getColumn(int i) {
 		return  columns.get( i );
 	}
-	//todo duplicated method, remove one
+	
 	public Iterator<Column> getColumnIterator() {
-		return columns.iterator();
-	}
-
-	public Iterator<Column> columnIterator() {
 		return columns.iterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -373,7 +373,7 @@ public class Table implements RelationalModel, Serializable, Exportable {
 	}
 
 	private boolean isSameAsPrimaryKeyColumns(UniqueKey uniqueKey) {
-		if ( primaryKey == null || ! primaryKey.columnIterator().hasNext() ) {
+		if ( primaryKey == null || ! primaryKey.getColumnIterator().hasNext() ) {
 			// happens for many-to-many tables
 			return false;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/any/AnyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/any/AnyTest.java
@@ -234,7 +234,7 @@ public class AnyTest extends BaseCoreFunctionalTestCase {
 
 	// Simply having this orm.xml file in the classpath reproduces HHH-4261.
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/any/orm.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/bytecode/ProxyBreakingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/bytecode/ProxyBreakingTest.java
@@ -37,7 +37,7 @@ public class ProxyBreakingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/bytecode/Hammer.hbm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/idclass/xml/IdClassXmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/idclass/xml/IdClassXmlTest.java
@@ -44,7 +44,7 @@ public class IdClassXmlTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/idclass/xml/HabitatSpeciesLink.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/loader/LoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/loader/LoaderTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class LoaderTest extends BaseCoreFunctionalTestCase {
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/loader/Loader.hbm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetoone/OptionalOneToOnePKJCTest.java
@@ -166,7 +166,7 @@ public class OptionalOneToOnePKJCTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/onetoone/orm.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
@@ -649,7 +649,7 @@ public class QueryAndSQLTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/query/orm.xml"
 		};

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/ElementCollectionConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/ElementCollectionConverterTest.java
@@ -24,7 +24,7 @@ public class ElementCollectionConverterTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/reflection/element-collection-converter-orm.xml" };
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
@@ -130,7 +130,7 @@ public class Ejb3XmlTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/xml/ejb3/orm.xml",
 				"org/hibernate/test/annotations/xml/ejb3/orm2.xml",

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
@@ -54,7 +54,7 @@ public class OrmVersion1SupportedTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/test/annotations/xml/ejb3/orm2.xml" };
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmTest.java
@@ -80,7 +80,7 @@ public class HbmTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[]{
 				"org/hibernate/test/annotations/xml/hbm/Government.hbm.xml",
 				"org/hibernate/test/annotations/xml/hbm/CloudType.hbm.xml",

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmWithIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/hbm/HbmWithIdentityTest.java
@@ -42,7 +42,7 @@ public class HbmWithIdentityTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected String[] getXmlFiles() {
+	protected String[] getOrmXmlFiles() {
 		return new String[] {
 				"org/hibernate/test/annotations/xml/hbm/A.hbm.xml",
 				"org/hibernate/test/annotations/xml/hbm/B.hbm.xml",

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
@@ -633,7 +633,7 @@ public final class AuditMetadataGenerator {
 
 				// Adding the "key" element with all id columns...
 				final Element keyMapping = mappingData.getFirst().addElement( "key" );
-				MetadataTools.addColumns( keyMapping, pc.getTable().getPrimaryKey().columnIterator(), metadata );
+				MetadataTools.addColumns( keyMapping, pc.getTable().getPrimaryKey().getColumnIterator(), metadata );
 
 				// ... and the revision number column, read from the revision info relation mapping.
 				keyMapping.add( (Element) cloneAndSetupRevisionInfoRelationMapping().element( "column" ).clone() );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -204,7 +204,7 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 				configuration.addPackage( annotatedPackage );
 			}
 		}
-		String[] xmlFiles = getXmlFiles();
+		String[] xmlFiles = getOrmXmlFiles();
 		if ( xmlFiles != null ) {
 			for ( String xmlFile : xmlFiles ) {
 				try ( InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream( xmlFile ) ) {
@@ -237,8 +237,7 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		return NO_MAPPINGS;
 	}
 
-	protected String[] getXmlFiles() {
-		// todo : rename to getOrmXmlFiles()
+	protected String[] getOrmXmlFiles() {
 		return NO_MAPPINGS;
 	}
 


### PR DESCRIPTION
1. TODO: Remove duplicate method from ConstraintConstaint.java currently has two duplicate methods. 1. getColumnIterator()2. columnIterator()

Both the methods return the same value i.e. column.iterator().

One of them needs to be removed in order to reduce and clean the duplication. 

2. TODO: Change method name for getXmlFiles in BaseCoreFunctionalTestCaseCurrently, in BaseCoreFunctionalTestCase a method named getXmlFiles()has a TODO placed that suggests the method name to be changed to getOrmXmlFiles().

Since the method has a protected scope, there is a possibility it is being used by other clients. Hence, changing the method name in minor versions might break the code for clients.