### PR TITLE
HHH-13857 - Avoid lazy initialization when obtaining persistent class

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -110,8 +110,7 @@ public final class Hibernate {
 	public static Class getClass(Object proxy) {
 		if ( proxy instanceof HibernateProxy ) {
 			return ( (HibernateProxy) proxy ).getHibernateLazyInitializer()
-					.getImplementation()
-					.getClass();
+					.getPersistentClass();
 		}
 		else {
 			return proxy.getClass();


### PR DESCRIPTION
Current utility code in Hibernate class forces initialization of the
proxies just to obtain the target persistent class that is used, because
it uses `getImplementation()` method of LazyInitializer.

There is a method in LazyInitializer that can do the same without
initialization (`getPersistentClass()`), so I think it should be used instead.

I created HHH-13857 to track this.