### PR TITLE
Wip/6.0 Remove an unnoticed negation operator in DefaultSaveOrUpdateEventListener

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -123,7 +123,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {


### PR DESCRIPTION
This is an issue I've found long time ago. I risked exposing my ignorance to create a PR targeting v6 to have it fixed. Seems it is not noticed simply because it is not used often.