### PR TITLE
HQL 'any'/'some', 'every'/'all', and 'exists' subquery operators

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -372,6 +372,7 @@ predicate
 	| expression (NOT)? BETWEEN expression AND expression	# BetweenPredicate
 	| expression (NOT)? LIKE expression (likeEscape)?		# LikePredicate
 	| expression comparisonOperator expression				# ComparisonPredicate
+	| EXISTS expression										# ExistsPredicate
 	| MEMBER OF path										# MemberOfPredicate
 	| NOT predicate											# NegatedPredicate
 	| predicate AND predicate								# AndPredicate
@@ -657,14 +658,6 @@ sumFunction
 	: SUM LEFT_PAREN DISTINCT? expression RIGHT_PAREN
 	;
 
-everyFunction
-	: (EVERY|ALL) LEFT_PAREN DISTINCT? predicate RIGHT_PAREN
-	;
-
-anyFunction
-	: (ANY|SOME) LEFT_PAREN DISTINCT? predicate RIGHT_PAREN
-	;
-
 minFunction
 	: MIN LEFT_PAREN DISTINCT? expression RIGHT_PAREN
 	;
@@ -675,6 +668,14 @@ maxFunction
 
 countFunction
 	: COUNT LEFT_PAREN DISTINCT? (expression | ASTERISK) RIGHT_PAREN
+	;
+
+everyFunction
+	: (EVERY|ALL) LEFT_PAREN (predicate | subQuery) RIGHT_PAREN
+	;
+
+anyFunction
+	: (ANY|SOME) LEFT_PAREN (predicate | subQuery) RIGHT_PAREN
 	;
 
 standardFunction

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -94,6 +94,7 @@ import org.hibernate.query.sqm.tree.domain.SqmMinIndexPath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmPolymorphicRootDescriptor;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
+import org.hibernate.query.sqm.tree.expression.SqmAny;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmByUnit;
 import org.hibernate.query.sqm.tree.expression.SqmCaseSearched;
@@ -102,6 +103,7 @@ import org.hibernate.query.sqm.tree.expression.SqmCastTarget;
 import org.hibernate.query.sqm.tree.expression.SqmCollectionSize;
 import org.hibernate.query.sqm.tree.expression.SqmDistinct;
 import org.hibernate.query.sqm.tree.expression.SqmDurationUnit;
+import org.hibernate.query.sqm.tree.expression.SqmEvery;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.query.sqm.tree.expression.SqmExtractUnit;
 import org.hibernate.query.sqm.tree.expression.SqmFormat;
@@ -130,6 +132,7 @@ import org.hibernate.query.sqm.tree.predicate.SqmAndPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmEmptinessPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmGroupedPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInListPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate;
@@ -1283,6 +1286,12 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 		// todo : handle PersistentCollectionReferenceInList labeled branch
 
 		throw new ParsingException( "Unexpected IN predicate type [" + ctx.getClass().getSimpleName() + "] : " + ctx.getText() );
+	}
+
+	@Override
+	public SqmPredicate visitExistsPredicate(HqlParser.ExistsPredicateContext ctx) {
+		final SqmExpression expression = (SqmExpression) ctx.expression().accept( this );
+		return new SqmExistsPredicate( expression, creationContext.getNodeBuilder() );
 	}
 
 	@Override
@@ -2885,10 +2894,12 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	@Override
 	public SqmExpression visitEveryFunction(HqlParser.EveryFunctionContext ctx) {
 
-		final SqmExpression<?> arg = (SqmExpression) ctx.predicate().accept( this );
-		SqmTypedNode<?> argument = ctx.DISTINCT() != null
-				? new SqmDistinct<>(arg, getCreationContext().getNodeBuilder())
-				: arg;
+		if ( ctx.subQuery()!=null ) {
+			SqmSubQuery<?> subquery = (SqmSubQuery<?>) ctx.subQuery().accept(this);
+			return new SqmEvery( subquery, subquery.getNodeType(), creationContext.getNodeBuilder() );
+		}
+
+		final SqmExpression<?> argument = (SqmExpression) ctx.predicate().accept( this );
 
 		return getFunctionDescriptor("every").generateSqmExpression(
 				argument,
@@ -2901,10 +2912,12 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 	@Override
 	public SqmExpression visitAnyFunction(HqlParser.AnyFunctionContext ctx) {
 
-		final SqmExpression<?> arg = (SqmExpression) ctx.predicate().accept( this );
-		SqmTypedNode<?> argument = ctx.DISTINCT() != null
-				? new SqmDistinct<>(arg, getCreationContext().getNodeBuilder())
-				: arg;
+		if ( ctx.subQuery()!=null ) {
+			SqmSubQuery<?> subquery = (SqmSubQuery<?>) ctx.subQuery().accept(this);
+			return new SqmAny( subquery, subquery.getNodeType(), creationContext.getNodeBuilder() );
+		}
+
+		final SqmExpression<?> argument = (SqmExpression) ctx.predicate().accept( this );
 
 		return getFunctionDescriptor("any").generateSqmExpression(
 				argument,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SemanticQueryWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SemanticQueryWalker.java
@@ -22,6 +22,7 @@ import org.hibernate.query.sqm.tree.domain.SqmMinElementPath;
 import org.hibernate.query.sqm.tree.domain.SqmMinIndexPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
+import org.hibernate.query.sqm.tree.expression.SqmAny;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmByUnit;
 import org.hibernate.query.sqm.tree.expression.SqmCaseSearched;
@@ -31,6 +32,7 @@ import org.hibernate.query.sqm.tree.expression.SqmCoalesce;
 import org.hibernate.query.sqm.tree.expression.SqmCollectionSize;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
 import org.hibernate.query.sqm.tree.expression.SqmDurationUnit;
+import org.hibernate.query.sqm.tree.expression.SqmEvery;
 import org.hibernate.query.sqm.tree.expression.SqmFormat;
 import org.hibernate.query.sqm.tree.expression.SqmFunction;
 import org.hibernate.query.sqm.tree.expression.SqmParameterizedEntityType;
@@ -61,6 +63,7 @@ import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmBooleanExpressionPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmEmptinessPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmGroupedPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInListPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate;
@@ -187,6 +190,9 @@ public interface SemanticQueryWalker<T> {
 
 	T visitSearchedCaseExpression(SqmCaseSearched<?> expression);
 
+	T visitAny(SqmAny<?> sqmAny);
+	T visitEvery(SqmEvery<?> sqmEvery);
+
 	T visitPositionalParameterExpression(SqmPositionalParameter<?> expression);
 
 	T visitNamedParameterExpression(SqmNamedParameter<?> expression);
@@ -253,6 +259,8 @@ public interface SemanticQueryWalker<T> {
 	T visitInSubQueryPredicate(SqmInSubQueryPredicate<?> predicate);
 
 	T visitBooleanExpressionPredicate(SqmBooleanExpressionPredicate predicate);
+
+	T visitExistsPredicate(SqmExistsPredicate sqmExistsPredicate);
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
@@ -28,6 +28,7 @@ import org.hibernate.query.sqm.tree.domain.SqmMinIndexPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
+import org.hibernate.query.sqm.tree.expression.SqmAny;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmByUnit;
 import org.hibernate.query.sqm.tree.expression.SqmCaseSearched;
@@ -38,6 +39,7 @@ import org.hibernate.query.sqm.tree.expression.SqmCollectionSize;
 import org.hibernate.query.sqm.tree.expression.SqmDistinct;
 import org.hibernate.query.sqm.tree.expression.SqmDurationUnit;
 import org.hibernate.query.sqm.tree.expression.SqmEnumLiteral;
+import org.hibernate.query.sqm.tree.expression.SqmEvery;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.query.sqm.tree.expression.SqmExtractUnit;
 import org.hibernate.query.sqm.tree.expression.SqmFieldLiteral;
@@ -67,6 +69,7 @@ import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmBooleanExpressionPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmEmptinessPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmGroupedPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInListPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate;
@@ -812,6 +815,11 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 	}
 
 	@Override
+	public Object visitExistsPredicate(SqmExistsPredicate sqmExistsPredicate) {
+		return null;
+	}
+
+	@Override
 	public Object visitOrderByClause(SqmOrderByClause orderByClause) {
 		return null;
 	}
@@ -888,6 +896,16 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 
 	@Override
 	public Object visitSearchedCaseExpression(SqmCaseSearched expression) {
+		return null;
+	}
+
+	@Override
+	public Object visitAny(SqmAny<?> sqmAny) {
+		return null;
+	}
+
+	@Override
+	public Object visitEvery(SqmEvery<?> sqmEvery) {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/BaseSemanticQueryWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/BaseSemanticQueryWalker.java
@@ -25,6 +25,7 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
+import org.hibernate.query.sqm.tree.expression.SqmAny;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmByUnit;
 import org.hibernate.query.sqm.tree.expression.SqmCaseSearched;
@@ -34,6 +35,7 @@ import org.hibernate.query.sqm.tree.expression.SqmCoalesce;
 import org.hibernate.query.sqm.tree.expression.SqmCollectionSize;
 import org.hibernate.query.sqm.tree.expression.SqmDurationUnit;
 import org.hibernate.query.sqm.tree.expression.SqmEnumLiteral;
+import org.hibernate.query.sqm.tree.expression.SqmEvery;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.query.sqm.tree.expression.SqmFieldLiteral;
 import org.hibernate.query.sqm.tree.expression.SqmFormat;
@@ -63,6 +65,7 @@ import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmBooleanExpressionPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmEmptinessPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmGroupedPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInListPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate;
@@ -387,6 +390,12 @@ public abstract class BaseSemanticQueryWalker implements SemanticQueryWalker<Obj
 	}
 
 	@Override
+	public Object visitExistsPredicate(SqmExistsPredicate predicate) {
+		predicate.getExpression().accept( this );
+		return predicate;
+	}
+
+	@Override
 	public Object visitOrderByClause(SqmOrderByClause orderByClause) {
 		if ( orderByClause == null ) {
 			return null;
@@ -581,6 +590,16 @@ public abstract class BaseSemanticQueryWalker implements SemanticQueryWalker<Obj
 	@Override
 	public Object visitSimpleCaseExpression(SqmCaseSimple<?,?> expression) {
 		return expression;
+	}
+
+	@Override
+	public Object visitAny(SqmAny<?> sqmAny) {
+		return sqmAny;
+	}
+
+	@Override
+	public Object visitEvery(SqmEvery<?> sqmEvery) {
+		return sqmEvery;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -528,7 +528,9 @@ public abstract class BaseSqmToSqlAstConverter
 	protected void consumeFromClauseRoot(SqmRoot<?> sqmRoot) {
 		log.tracef( "Resolving SqmRoot [%s] to TableGroup", sqmRoot );
 
-		assert ! fromClauseIndex.isResolved( sqmRoot );
+		if ( fromClauseIndex.isResolved( sqmRoot ) ) {
+			log.tracef( "Already resolved SqmRoot [%s] to TableGroup", sqmRoot );
+		}
 
 		final EntityPersister entityDescriptor = resolveEntityPersister( sqmRoot.getReferencedPathSource() );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -66,6 +66,7 @@ import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
 import org.hibernate.query.sqm.tree.expression.Conversion;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
+import org.hibernate.query.sqm.tree.expression.SqmAny;
 import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.query.sqm.tree.expression.SqmByUnit;
 import org.hibernate.query.sqm.tree.expression.SqmCaseSearched;
@@ -74,6 +75,7 @@ import org.hibernate.query.sqm.tree.expression.SqmCastTarget;
 import org.hibernate.query.sqm.tree.expression.SqmDistinct;
 import org.hibernate.query.sqm.tree.expression.SqmDurationUnit;
 import org.hibernate.query.sqm.tree.expression.SqmEnumLiteral;
+import org.hibernate.query.sqm.tree.expression.SqmEvery;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.query.sqm.tree.expression.SqmExtractUnit;
 import org.hibernate.query.sqm.tree.expression.SqmFieldLiteral;
@@ -100,6 +102,7 @@ import org.hibernate.query.sqm.tree.insert.SqmInsertSelectStatement;
 import org.hibernate.query.sqm.tree.predicate.SqmAndPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmExistsPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmGroupedPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInListPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate;
@@ -129,6 +132,7 @@ import org.hibernate.sql.ast.tree.cte.CteColumn;
 import org.hibernate.sql.ast.tree.cte.CteConsumer;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.cte.CteTable;
+import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
@@ -136,6 +140,7 @@ import org.hibernate.sql.ast.tree.expression.CastTarget;
 import org.hibernate.sql.ast.tree.expression.Distinct;
 import org.hibernate.sql.ast.tree.expression.Duration;
 import org.hibernate.sql.ast.tree.expression.DurationUnit;
+import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Format;
@@ -148,6 +153,7 @@ import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableGroupJoinProducer;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
 import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
 import org.hibernate.sql.ast.tree.predicate.InListPredicate;
 import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
@@ -1954,6 +1960,22 @@ public abstract class BaseSqmToSqlAstConverter
 	}
 
 	@Override
+	public Object visitAny(SqmAny<?> sqmAny) {
+		return new Any(
+				visitSubQueryExpression( sqmAny.getSubquery() ),
+				null //resolveMappingExpressable( sqmAny.getNodeType() )
+		);
+	}
+
+	@Override
+	public Object visitEvery(SqmEvery<?> sqmEvery) {
+		return new Every(
+				visitSubQueryExpression( sqmEvery.getSubquery() ),
+				null //resolveMappingExpressable( sqmEvery.getNodeType() )
+		);
+	}
+
+	@Override
 	public Object visitEnumLiteral(SqmEnumLiteral sqmEnumLiteral) {
 		return new QueryLiteral<>(
 				sqmEnumLiteral.getEnumValue(),
@@ -2209,5 +2231,10 @@ public abstract class BaseSqmToSqlAstConverter
 				(QuerySpec) predicate.getSubQueryExpression().accept( this ),
 				predicate.isNegated()
 		);
+	}
+
+	@Override
+	public Object visitExistsPredicate(SqmExistsPredicate predicate) {
+		return new ExistsPredicate( (QuerySpec) predicate.getExpression().accept( this ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAny.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAny.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.query.sqm.tree.expression;
+
+import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.SemanticQueryWalker;
+import org.hibernate.query.sqm.SqmExpressable;
+import org.hibernate.query.sqm.tree.select.SqmSubQuery;
+
+/**
+ * @author Gavin King
+ */
+public class SqmAny<T> extends AbstractSqmExpression<T> {
+
+	private final SqmSubQuery<T> subquery;
+
+	public SqmAny(SqmSubQuery<T> subquery, SqmExpressable<T> type, NodeBuilder criteriaBuilder) {
+		super(type, criteriaBuilder);
+		this.subquery = subquery;
+	}
+
+	public SqmSubQuery<T> getSubquery() {
+		return subquery;
+	}
+
+	@Override
+	public <X> X accept(SemanticQueryWalker<X> walker) {
+		return walker.visitAny( this );
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEvery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEvery.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.query.sqm.tree.expression;
+
+import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.SemanticQueryWalker;
+import org.hibernate.query.sqm.SqmExpressable;
+import org.hibernate.query.sqm.tree.select.SqmSubQuery;
+
+/**
+ * @author Gavin King
+ */
+public class SqmEvery<T> extends AbstractSqmExpression<T> {
+
+	private final SqmSubQuery<T> subquery;
+
+	public SqmEvery(SqmSubQuery<T> subquery, SqmExpressable<T> type, NodeBuilder criteriaBuilder) {
+		super(type, criteriaBuilder);
+		this.subquery = subquery;
+	}
+
+	public SqmSubQuery<T> getSubquery() {
+		return subquery;
+	}
+
+	@Override
+	public <X> X accept(SemanticQueryWalker<X> walker) {
+		return walker.visitEvery( this );
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmExistsPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmExistsPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.query.sqm.tree.predicate;
+
+import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.SemanticQueryWalker;
+import org.hibernate.query.sqm.tree.expression.SqmExpression;
+
+/**
+ * @author Gavin King
+ */
+public class SqmExistsPredicate extends AbstractNegatableSqmPredicate {
+	private final SqmExpression<?> expression;
+
+	public SqmExistsPredicate(
+			SqmExpression<?> expression,
+			NodeBuilder nodeBuilder) {
+		super( nodeBuilder );
+		this.expression = expression;
+
+		expression.applyInferableType( expression.getNodeType() );
+	}
+
+	public SqmExpression<?> getExpression() {
+		return expression;
+	}
+
+	@Override
+	public <T> T accept(SemanticQueryWalker<T> walker) {
+		return walker.visitExistsPredicate( this );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
@@ -9,6 +9,7 @@ package org.hibernate.sql.ast;
 import org.hibernate.Incubating;
 import org.hibernate.query.sqm.tree.expression.Conversion;
 import org.hibernate.sql.ast.spi.SqlSelection;
+import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
@@ -18,6 +19,7 @@ import org.hibernate.sql.ast.tree.expression.Distinct;
 import org.hibernate.sql.ast.tree.expression.Duration;
 import org.hibernate.sql.ast.tree.expression.DurationUnit;
 import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
+import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Format;
 import org.hibernate.sql.ast.tree.expression.JdbcLiteral;
@@ -36,6 +38,7 @@ import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
 import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
 import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
 import org.hibernate.sql.ast.tree.predicate.InListPredicate;
@@ -98,6 +101,10 @@ public interface SqlAstWalker {
 
 	void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression);
 
+	void visitAny(Any any);
+
+	void visitEvery(Every every);
+
 	void visitSelfRenderingExpression(SelfRenderingExpression expression);
 
 	void visitSqlSelectionExpression(SqlSelectionExpression expression);
@@ -123,6 +130,8 @@ public interface SqlAstWalker {
 	void visitInListPredicate(InListPredicate inListPredicate);
 
 	void visitInSubQueryPredicate(InSubQueryPredicate inSubQueryPredicate);
+
+	void visitExistsPredicate(ExistsPredicate existsPredicate);
 
 	void visitJunction(Junction junction);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.SqlAstTreeLogger;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
+import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
@@ -24,6 +25,7 @@ import org.hibernate.sql.ast.tree.expression.Distinct;
 import org.hibernate.sql.ast.tree.expression.Duration;
 import org.hibernate.sql.ast.tree.expression.DurationUnit;
 import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
+import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Format;
 import org.hibernate.sql.ast.tree.expression.JdbcLiteral;
@@ -43,6 +45,7 @@ import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
 import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
 import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
 import org.hibernate.sql.ast.tree.predicate.InListPredicate;
@@ -460,7 +463,17 @@ public class SqlTreePrinter implements SqlAstWalker {
 		throw new NotYetImplementedFor6Exception();
 	}
 
-//	@Override
+	@Override
+	public void visitAny(Any any) {
+
+	}
+
+	@Override
+	public void visitEvery(Every every) {
+
+	}
+
+	//	@Override
 //	public void visitCoalesceFunction(CoalesceFunction coalesceExpression) {
 //		throw new NotYetImplementedFor6Exception();
 //	}
@@ -547,6 +560,11 @@ public class SqlTreePrinter implements SqlAstWalker {
 					visitQuerySpec( inSubQueryPredicate.getSubQuery() );
 				}
 		);
+	}
+
+	@Override
+	public void visitExistsPredicate(ExistsPredicate existsPredicate) {
+
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
@@ -23,6 +23,7 @@ import org.hibernate.query.UnaryArithmeticOperator;
 import org.hibernate.query.sqm.tree.expression.Conversion;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstWalker;
+import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
@@ -32,6 +33,7 @@ import org.hibernate.sql.ast.tree.expression.Distinct;
 import org.hibernate.sql.ast.tree.expression.Duration;
 import org.hibernate.sql.ast.tree.expression.DurationUnit;
 import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
+import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Format;
@@ -53,6 +55,7 @@ import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 import org.hibernate.sql.ast.tree.from.VirtualTableGroup;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
 import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
 import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
 import org.hibernate.sql.ast.tree.predicate.InListPredicate;
@@ -887,8 +890,19 @@ public abstract class AbstractSqlAstWalker
 		appendSql( " end" );
 	}
 
+	@Override
+	public void visitAny(Any any) {
+		appendSql( "some " );
+		any.getSubquery().accept( this );
+	}
 
-//	@Override
+	@Override
+	public void visitEvery(Every every) {
+		appendSql( "all " );
+		every.getSubquery().accept( this );
+	}
+
+	//	@Override
 //	public void visitGenericParameter(GenericParameter parameter) {
 //		visitJdbcParameterBinder( parameter.getParameterBinder() );
 //
@@ -1061,6 +1075,12 @@ public abstract class AbstractSqlAstWalker
 		}
 		appendSql( " in " );
 		visitQuerySpec( inSubQueryPredicate.getSubQuery() );
+	}
+
+	@Override
+	public void visitExistsPredicate(ExistsPredicate existsPredicate) {
+		appendSql( "exists " );
+		existsPredicate.getExpression().accept( this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
@@ -7,6 +7,7 @@
 package org.hibernate.sql.ast.spi;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.mapping.MappingModelExpressable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 import org.hibernate.sql.ast.SqlAstWalker;
@@ -44,6 +45,11 @@ public interface SqlSelection {
 	default int getJdbcResultSetIndex() {
 		return getValuesArrayPosition() + 1;
 	}
+
+	/**
+	 * Get the type of the expression
+	 */
+	MappingModelExpressable getExpressionType();
 
 	void accept(SqlAstWalker sqlAstWalker);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Any.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Any.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.expression;
+
+import org.hibernate.metamodel.mapping.MappingModelExpressable;
+import org.hibernate.sql.ast.SqlAstWalker;
+import org.hibernate.sql.ast.tree.select.QuerySpec;
+
+/**
+ * @author Gavin King
+ */
+public class Any implements Expression {
+
+	private QuerySpec subquery;
+	private MappingModelExpressable<?> type;
+
+	public Any(QuerySpec subquery, MappingModelExpressable<?> type) {
+		this.subquery = subquery;
+		this.type = type;
+	}
+
+	public QuerySpec getSubquery() {
+		return subquery;
+	}
+
+	@Override
+	public MappingModelExpressable getExpressionType() {
+		return type;
+	}
+
+	@Override
+	public void accept(SqlAstWalker walker) {
+		walker.visitAny( this );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Every.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Every.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.expression;
+
+import org.hibernate.metamodel.mapping.MappingModelExpressable;
+import org.hibernate.sql.ast.SqlAstWalker;
+import org.hibernate.sql.ast.tree.select.QuerySpec;
+
+/**
+ * @author Gavin King
+ */
+public class Every implements Expression {
+
+	private QuerySpec subquery;
+	private MappingModelExpressable<?> type;
+
+	public Every(QuerySpec subquery, MappingModelExpressable<?> type) {
+		this.subquery = subquery;
+		this.type = type;
+	}
+
+	public QuerySpec getSubquery() {
+		return subquery;
+	}
+
+	@Override
+	public MappingModelExpressable getExpressionType() {
+		return type;
+	}
+
+	@Override
+	public void accept(SqlAstWalker walker) {
+		walker.visitEvery( this );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
@@ -18,12 +18,10 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
-import org.hibernate.sql.results.internal.SqlSelectionImpl;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -103,6 +101,15 @@ public class QueryLiteral<T> implements Literal, DomainResultProducer<T> {
 				getLiteralValue(),
 				startPosition,
 				executionContext.getSession()
+		);
+	}
+
+	@Override
+	public void applySqlSelections(DomainResultCreationState creationState) {
+		creationState.getSqlAstCreationState().getSqlExpressionResolver().resolveSqlSelection(
+				this,
+				type.getBasicType().getJavaTypeDescriptor(),
+				creationState.getSqlAstCreationState().getCreationContext().getDomainModel().getTypeConfiguration()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ExistsPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ExistsPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.predicate;
+
+import org.hibernate.sql.ast.SqlAstWalker;
+import org.hibernate.sql.ast.tree.expression.Expression;
+
+/**
+ * @author Gavin King
+ */
+public class ExistsPredicate implements Predicate {
+
+	private Expression expression;
+
+	public ExistsPredicate(Expression expression) {
+		this.expression = expression;
+	}
+
+	public Expression getExpression() {
+		return expression;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return false;
+	}
+
+	@Override
+	public void accept(SqlAstWalker sqlTreeWalker) {
+		sqlTreeWalker.visitExistsPredicate( this );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
@@ -25,7 +25,6 @@ import org.hibernate.sql.ast.tree.predicate.PredicateContainer;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.basic.BasicResult;
-import org.hibernate.sql.results.internal.SqlSelectionImpl;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -122,15 +121,14 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 	@Override
 	public MappingModelExpressable getExpressionType() {
 		SqlSelection first = selectClause.getSqlSelections().get(0);
-		return ( (SqlSelectionImpl) first ).getWrappedSqlExpression().getExpressionType();
+		return first.getExpressionType();
 	}
 
 	@Override
 	public void applySqlSelections(DomainResultCreationState creationState) {
 		SqlSelection first = selectClause.getSqlSelections().get(0);
 		TypeConfiguration typeConfiguration = creationState.getSqlAstCreationState().getCreationContext().getDomainModel().getTypeConfiguration();
-		JavaTypeDescriptor descriptor = ( (SqlSelectionImpl) first ).getWrappedSqlExpression().getExpressionType()
-				.getJdbcMappings( typeConfiguration ).get(0).getJavaTypeDescriptor();
+		JavaTypeDescriptor descriptor = first.getExpressionType().getJdbcMappings( typeConfiguration ).get(0).getJavaTypeDescriptor();
 		creationState.getSqlAstCreationState().getSqlExpressionResolver().resolveSqlSelection(
 				this,
 				descriptor,
@@ -142,8 +140,7 @@ public class QuerySpec implements SqlAstNode, PredicateContainer, Expression, Ct
 	public DomainResult createDomainResult(String resultVariable, DomainResultCreationState creationState) {
 		SqlSelection first = selectClause.getSqlSelections().get(0);
 		TypeConfiguration typeConfiguration = creationState.getSqlAstCreationState().getCreationContext().getDomainModel().getTypeConfiguration();
-		JavaTypeDescriptor descriptor = ( (SqlSelectionImpl) first ).getWrappedSqlExpression().getExpressionType()
-				.getJdbcMappings( typeConfiguration ).get(0).getJavaTypeDescriptor();
+		JavaTypeDescriptor descriptor = first.getExpressionType().getJdbcMappings( typeConfiguration ).get(0).getJavaTypeDescriptor();
 
 		final SqlExpressionResolver sqlExpressionResolver = creationState.getSqlAstCreationState().getSqlExpressionResolver();
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.sql.results.internal;
 
+import org.hibernate.metamodel.mapping.MappingModelExpressable;
 import org.hibernate.metamodel.mapping.SqlExpressable;
 import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.ast.spi.SqlSelection;
@@ -63,6 +64,11 @@ public class SqlSelectionImpl implements SqlSelection {
 	@Override
 	public int getValuesArrayPosition() {
 		return valuesArrayPosition;
+	}
+
+	@Override
+	public MappingModelExpressable getExpressionType() {
+		return getWrappedSqlExpression().getExpressionType();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql;
+
+import org.hibernate.testing.junit5.SessionFactoryBasedFunctionalTest;
+import org.hibernate.testing.orm.domain.gambit.SimpleEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Gavin King
+ */
+public class SubqueryOperatorsTest extends SessionFactoryBasedFunctionalTest {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				SimpleEntity.class,
+		};
+	}
+
+	@Test
+	public void testEvery() {
+		inTransaction(
+				session -> {
+					List results = session.createQuery(
+							"from SimpleEntity o where o.someString >= every (select someString from SimpleEntity)" )
+							.list();
+					assertThat( results.size(), is( 1 ) );
+				} );
+	}
+
+	@Test
+	public void testAny() {
+		inTransaction(
+				session -> {
+					List results = session.createQuery(
+							"from SimpleEntity o where o.someString >= any (select someString from SimpleEntity)" )
+							.list();
+					assertThat( results.size(), is( 2 ) );
+				} );
+	}
+
+	@Test
+	public void testExists() {
+		inTransaction(
+				session -> {
+					List results = session.createQuery(
+							"from SimpleEntity o where exists (select someString from SimpleEntity where someString>o.someString)" )
+							.list();
+					assertThat( results.size(), is( 1 ) );
+					results = session.createQuery(
+							"from SimpleEntity o where not exists (select someString from SimpleEntity where someString>o.someString)" )
+							.list();
+					assertThat( results.size(), is( 1 ) );
+				} );
+	}
+
+	@BeforeEach
+	public void setUp() {
+		inTransaction(
+				session -> {
+					SimpleEntity entity = new SimpleEntity(
+							1,
+							Calendar.getInstance().getTime(),
+							null,
+							Integer.MAX_VALUE,
+							Long.MAX_VALUE,
+							"aaa"
+					);
+					session.save( entity );
+
+					SimpleEntity second_entity = new SimpleEntity(
+							2,
+							Calendar.getInstance().getTime(),
+							null,
+							Integer.MIN_VALUE,
+							Long.MAX_VALUE,
+							"zzz"
+					);
+					session.save( second_entity );
+
+				} );
+	}
+
+	@AfterEach
+	public void tearDown() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete SimpleEntity" ).executeUpdate();
+				} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
@@ -53,6 +53,33 @@ public class SubqueryOperatorsTest extends SessionFactoryBasedFunctionalTest {
 	}
 
 	@Test
+	public void testSubqueryInVariousClauses() {
+		inTransaction(
+				session -> {
+					List res0 = session.createQuery(
+							"select (select 1) as one, (select 'foo') as foo order by one, foo, (select 2)" )
+							.list();
+					assertThat( res0.size(), is( 1 ) );
+					List res1 = session.createQuery(
+							"select (select 1) as one, (select 'foo') as foo from SimpleEntity o order by one, foo, (select 2)" )
+							.list();
+					assertThat( res1.size(), is( 2 ) );
+					List res2 = session.createQuery(
+							"select (select x.id from SimpleEntity x where x.id = o.id) as xid from SimpleEntity o order by xid" )
+							.list();
+					assertThat( res2.size(), is( 2 ) );
+					List res3 = session.createQuery(
+							"from SimpleEntity o where o.someString = (select 'aaa') and o.id >= (select 0)" )
+							.list();
+					assertThat( res3.size(), is( 1 ) );
+					List res4 = session.createQuery(
+							"from SimpleEntity o where o.id = (select y.id from SimpleEntity y where y.id = o.id)" )
+							.list();
+					assertThat( res4.size(), is( 2 ) );
+				} );
+	}
+
+	@Test
 	public void testExists() {
 		inTransaction(
 				session -> {


### PR DESCRIPTION
This PR adds support to Hibernate 6 for the following subquery operators:

- `exists` and `not exists` predicates
- `any`/`some` and `every`/`all` expressions used on RHS of comparison operators

Note that `any`/`some` and `every`/`all` collide with the HQL aggregate functions of the same name, but can be distinguished by the syntactic form of their arguments.

UPDATE: 

- also allows subqueries to occur in the `select` list.