### PR TITLE
HHH-13179 Subclass 2nd level caching now works for XML mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -523,6 +523,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final SingleTableSubclass subEntityDescriptor = new SingleTableSubclass( superEntityDescriptor, metadataBuildingContext );
+			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
 			bindDiscriminatorSubclassEntity( (SubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );
@@ -581,6 +582,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final JoinedSubclass subEntityDescriptor = new JoinedSubclass( superEntityDescriptor, metadataBuildingContext );
+			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
 			bindJoinedSubclassEntity( (JoinedSubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );
@@ -657,6 +659,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final UnionSubclass subEntityDescriptor = new UnionSubclass( superEntityDescriptor, metadataBuildingContext );
+			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
 			bindUnionSubclassEntity( (SubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -523,7 +523,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final SingleTableSubclass subEntityDescriptor = new SingleTableSubclass( superEntityDescriptor, metadataBuildingContext );
-			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
+			subEntityDescriptor.setCached( superEntityDescriptor.isCached() );
 			bindDiscriminatorSubclassEntity( (SubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );
@@ -582,7 +582,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final JoinedSubclass subEntityDescriptor = new JoinedSubclass( superEntityDescriptor, metadataBuildingContext );
-			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
+			subEntityDescriptor.setCached( superEntityDescriptor.isCached() );
 			bindJoinedSubclassEntity( (JoinedSubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );
@@ -659,7 +659,7 @@ public class ModelBinder {
 			PersistentClass superEntityDescriptor) {
 		for ( IdentifiableTypeSource subType : entitySource.getSubTypes() ) {
 			final UnionSubclass subEntityDescriptor = new UnionSubclass( superEntityDescriptor, metadataBuildingContext );
-			subEntityDescriptor.setCached(superEntityDescriptor.isCached());
+			subEntityDescriptor.setCached( superEntityDescriptor.isCached() );
 			bindUnionSubclassEntity( (SubclassEntitySourceImpl) subType, subEntityDescriptor );
 			superEntityDescriptor.addSubclass( subEntityDescriptor );
 			entitySource.getLocalMetadataBuildingContext().getMetadataCollector().addEntityBinding( subEntityDescriptor );

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassNonUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassNonUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class DiscriminatorSubclassNonUIPerson extends DiscriminatorSubclassPerson {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.java
@@ -1,0 +1,14 @@
+package org.hibernate.test.cache.hhh13179;
+
+public abstract class DiscriminatorSubclassPerson {
+
+   private Long oid;
+
+   public Long getOid() {
+      return oid;
+   }
+
+   public void setOid(Long oid) {
+      this.oid = oid;
+   }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class DiscriminatorSubclassUIPerson extends DiscriminatorSubclassPerson {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/HHH13179Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/HHH13179Test.java
@@ -20,6 +20,7 @@ import org.hibernate.Transaction;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.stat.CacheRegionStatistics;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Assert;
@@ -28,7 +29,7 @@ import org.junit.Test;
 /**
  * Check that second level caching works for hbm mapped joined subclass inheritance structures
  */
-@TestForIssue( jiraKey = "HHH-13179")
+@TestForIssue(jiraKey = "HHH-13179")
 public class HHH13179Test extends BaseCoreFunctionalTestCase {
 
 	// Add your entities here.
@@ -56,6 +57,7 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 				"org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.hbm.xml"
 		};
 	}
+
 	// If those mappings reside somewhere other than resources/org/hibernate/test, change this.
 	@Override
 	protected String getBaseForMappings() {
@@ -79,14 +81,15 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		Transaction tx = s.beginTransaction();
 
 		String regionName = "org.hibernate.test.cache.hhh13179.JoinedSubclassPerson";
-		
+
 		// sanity check
-		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(
+				regionName );
+		Assert.assertEquals( "Cache put should be 0", 0, cacheRegionStatistics.getPutCount() );
 
 		JoinedSubclassPerson person1 = new JoinedSubclassUIPerson();
-		person1.setOid(1L);
-		s.save(person1);
+		person1.setOid( 1L );
+		s.save( person1 );
 
 		tx.commit();
 
@@ -95,11 +98,11 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		tx = s.beginTransaction();
 
-		JoinedSubclassPerson person2 = s.get(JoinedSubclassPerson.class, 1L);
+		JoinedSubclassPerson person2 = s.get( JoinedSubclassPerson.class, 1L );
 
-		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
-		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics( regionName );
+		Assert.assertEquals( "Cache hit should be 1", 1, cacheRegionStatistics.getHitCount() );
+		Assert.assertEquals( "Cache put should be 1", 1, cacheRegionStatistics.getPutCount() );
 
 		tx.commit();
 		s.close();
@@ -114,12 +117,13 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		String regionName = "org.hibernate.test.cache.hhh13179.UnionSubclassPerson";
 
 		// sanity check
-		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(
+				regionName );
+		Assert.assertEquals( "Cache put should be 0", 0, cacheRegionStatistics.getPutCount() );
 
 		UnionSubclassPerson person1 = new UnionSubclassUIPerson();
-		person1.setOid(1L);
-		s.save(person1);
+		person1.setOid( 1L );
+		s.save( person1 );
 
 		tx.commit();
 
@@ -128,11 +132,11 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		tx = s.beginTransaction();
 
-		UnionSubclassPerson person2 = s.get(UnionSubclassPerson.class, 1L);
+		UnionSubclassPerson person2 = s.get( UnionSubclassPerson.class, 1L );
 
-		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
-		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics( regionName );
+		Assert.assertEquals( "Cache hit should be 1", 1, cacheRegionStatistics.getHitCount() );
+		Assert.assertEquals( "Cache put should be 1", 1, cacheRegionStatistics.getPutCount() );
 
 		tx.commit();
 		s.close();
@@ -147,12 +151,13 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		String regionName = "org.hibernate.test.cache.hhh13179.DiscriminatorSubclassPerson";
 
 		// sanity check
-		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(
+				regionName );
+		Assert.assertEquals( "Cache put should be 0", 0, cacheRegionStatistics.getPutCount() );
 
 		DiscriminatorSubclassPerson person1 = new DiscriminatorSubclassUIPerson();
-		person1.setOid(1L);
-		s.save(person1);
+		person1.setOid( 1L );
+		s.save( person1 );
 
 		tx.commit();
 
@@ -161,11 +166,11 @@ public class HHH13179Test extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		tx = s.beginTransaction();
 
-		DiscriminatorSubclassPerson person2 = s.get(DiscriminatorSubclassPerson.class, 1L);
+		DiscriminatorSubclassPerson person2 = s.get( DiscriminatorSubclassPerson.class, 1L );
 
-		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
-		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
-		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics( regionName );
+		Assert.assertEquals( "Cache hit should be 1", 1, cacheRegionStatistics.getHitCount() );
+		Assert.assertEquals( "Cache put should be 1", 1, cacheRegionStatistics.getPutCount() );
 
 		tx.commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/HHH13179Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/HHH13179Test.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hibernate.test.cache.hhh13179;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Check that second level caching works for hbm mapped joined subclass inheritance structures
+ */
+@TestForIssue( jiraKey = "HHH-13179")
+public class HHH13179Test extends BaseCoreFunctionalTestCase {
+
+	// Add your entities here.
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				JoinedSubclassPerson.class,
+				JoinedSubclassUIPerson.class,
+				JoinedSubclassNonUIPerson.class,
+				UnionSubclassPerson.class,
+				UnionSubclassUIPerson.class,
+				UnionSubclassNonUIPerson.class,
+				DiscriminatorSubclassPerson.class,
+				DiscriminatorSubclassUIPerson.class,
+				DiscriminatorSubclassNonUIPerson.class
+		};
+	}
+
+	// If you use *.hbm.xml mappings, instead of annotations, add the mappings here.
+	@Override
+	protected String[] getMappings() {
+		return new String[] {
+				"org/hibernate/test/cache/hhh13179/JoinedSubclassPerson.hbm.xml",
+				"org/hibernate/test/cache/hhh13179/UnionSubclassPerson.hbm.xml",
+				"org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.hbm.xml"
+		};
+	}
+	// If those mappings reside somewhere other than resources/org/hibernate/test, change this.
+	@Override
+	protected String getBaseForMappings() {
+		return "";
+	}
+
+	// Add in any settings that are specific to your test.  See resources/hibernate.properties for the defaults.
+	@Override
+	protected void configure(Configuration configuration) {
+		super.configure( configuration );
+
+		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
+		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
+		configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
+	}
+
+	@Test
+	public void testJoinedSubclassCaching() {
+		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		String regionName = "org.hibernate.test.cache.hhh13179.JoinedSubclassPerson";
+		
+		// sanity check
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+
+		JoinedSubclassPerson person1 = new JoinedSubclassUIPerson();
+		person1.setOid(1L);
+		s.save(person1);
+
+		tx.commit();
+
+		s.close();
+
+		s = openSession();
+		tx = s.beginTransaction();
+
+		JoinedSubclassPerson person2 = s.get(JoinedSubclassPerson.class, 1L);
+
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
+		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+
+		tx.commit();
+		s.close();
+	}
+
+	@Test
+	public void testUnionSubclassCaching() {
+		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		String regionName = "org.hibernate.test.cache.hhh13179.UnionSubclassPerson";
+
+		// sanity check
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+
+		UnionSubclassPerson person1 = new UnionSubclassUIPerson();
+		person1.setOid(1L);
+		s.save(person1);
+
+		tx.commit();
+
+		s.close();
+
+		s = openSession();
+		tx = s.beginTransaction();
+
+		UnionSubclassPerson person2 = s.get(UnionSubclassPerson.class, 1L);
+
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
+		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+
+		tx.commit();
+		s.close();
+	}
+
+	@Test
+	public void testDiscriminatorSubclassCaching() {
+		// BaseCoreFunctionalTestCase automatically creates the SessionFactory and provides the Session.
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		String regionName = "org.hibernate.test.cache.hhh13179.DiscriminatorSubclassPerson";
+
+		// sanity check
+		CacheRegionStatistics cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache put should be 0", 0, cacheRegionStatistics.getPutCount());
+
+		DiscriminatorSubclassPerson person1 = new DiscriminatorSubclassUIPerson();
+		person1.setOid(1L);
+		s.save(person1);
+
+		tx.commit();
+
+		s.close();
+
+		s = openSession();
+		tx = s.beginTransaction();
+
+		DiscriminatorSubclassPerson person2 = s.get(DiscriminatorSubclassPerson.class, 1L);
+
+		cacheRegionStatistics = s.getSessionFactory().getStatistics().getCacheRegionStatistics(regionName);
+		Assert.assertEquals("Cache hit should be 1", 1, cacheRegionStatistics.getHitCount());
+		Assert.assertEquals("Cache put should be 1", 1, cacheRegionStatistics.getPutCount());
+
+		tx.commit();
+		s.close();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassNonUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassNonUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class JoinedSubclassNonUIPerson extends JoinedSubclassPerson {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassPerson.java
@@ -1,0 +1,14 @@
+package org.hibernate.test.cache.hhh13179;
+
+public abstract class JoinedSubclassPerson {
+
+   private Long oid;
+
+   public Long getOid() {
+      return oid;
+   }
+
+   public void setOid(Long oid) {
+      this.oid = oid;
+   }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/JoinedSubclassUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class JoinedSubclassUIPerson extends JoinedSubclassPerson {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassNonUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassNonUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class UnionSubclassNonUIPerson extends UnionSubclassPerson {
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassPerson.java
@@ -1,0 +1,14 @@
+package org.hibernate.test.cache.hhh13179;
+
+public abstract class UnionSubclassPerson {
+
+   private Long oid;
+
+   public Long getOid() {
+      return oid;
+   }
+
+   public void setOid(Long oid) {
+      this.oid = oid;
+   }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassUIPerson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cache/hhh13179/UnionSubclassUIPerson.java
@@ -1,0 +1,4 @@
+package org.hibernate.test.cache.hhh13179;
+
+public class UnionSubclassUIPerson extends UnionSubclassPerson {
+}

--- a/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/DiscriminatorSubclassPerson.hbm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+  "-//Hibernate/Hibernate Mapping DTD//EN"
+  "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping default-lazy="false">
+  <class name="org.hibernate.test.cache.hhh13179.DiscriminatorSubclassPerson" table="DISCRIMINATOR_SUBCLASS_PERSON">
+    <cache usage="read-write"/>
+
+    <id name="oid" column="PERSON_ID" type="long" unsaved-value="null">
+      <generator class="org.hibernate.id.Assigned"/>
+    </id>
+
+    <discriminator column="type" type="string" />
+
+    <subclass name="org.hibernate.test.cache.hhh13179.DiscriminatorSubclassUIPerson" discriminator-value="UI_PERSON">
+    </subclass>
+
+    <subclass name="org.hibernate.test.cache.hhh13179.DiscriminatorSubclassNonUIPerson" discriminator-value="NON_UI_PERSON">
+    </subclass>
+
+  </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/JoinedSubclassPerson.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/JoinedSubclassPerson.hbm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+  "-//Hibernate/Hibernate Mapping DTD//EN"
+  "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping default-lazy="false">
+  <class name="org.hibernate.test.cache.hhh13179.JoinedSubclassPerson" table="JOINED_SUBCLASS_PERSON">
+    <cache usage="read-write"/>
+
+    <id name="oid" column="PERSON_ID" type="long" unsaved-value="null">
+      <generator class="org.hibernate.id.Assigned"/>
+    </id>
+
+    <joined-subclass name="org.hibernate.test.cache.hhh13179.JoinedSubclassUIPerson" table="JOINED_SUBCLASS_UI_PERSON">
+      <key column="PERSON_ID"/>
+    </joined-subclass>
+
+
+    <joined-subclass name="org.hibernate.test.cache.hhh13179.JoinedSubclassNonUIPerson" table="JOINED_SUBCLASS_NON_UI_PERSON">
+      <key column="PERSON_ID"/>
+    </joined-subclass>
+
+  </class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/UnionSubclassPerson.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/cache/hhh13179/UnionSubclassPerson.hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+  "-//Hibernate/Hibernate Mapping DTD//EN"
+  "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping default-lazy="false">
+  <class name="org.hibernate.test.cache.hhh13179.UnionSubclassPerson" table="UNION_SUBCLASS_PERSON">
+    <cache usage="read-write"/>
+
+    <id name="oid" column="PERSON_ID" type="long" unsaved-value="null">
+      <generator class="org.hibernate.id.Assigned"/>
+    </id>
+
+    <union-subclass name="org.hibernate.test.cache.hhh13179.UnionSubclassUIPerson" table="UNION_SUBCLASS_UI_PERSON">
+    </union-subclass>
+
+    <union-subclass name="org.hibernate.test.cache.hhh13179.UnionSubclassNonUIPerson" table="UNION_SUBCLASS_NON_UI_PERSON">
+    </union-subclass>
+
+  </class>
+</hibernate-mapping>


### PR DESCRIPTION
Fixes HHH-13179 and HHH-13173, regressions in 5.3 and forward.

Possibly originates from HHH-12146 - Support enabling caching at any level within a mapped hierarchy.