### PR TITLE
HHH-13874 - Deprecating methods that will be removed soon

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -156,6 +156,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		return columns.iterator();
 	}
 
+	@Deprecated
 	public Iterator<Column> columnIterator() {
 		return columns.iterator();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -156,6 +156,14 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		return columns.iterator();
 	}
 
+	/**
+	 * This is a duplicate method, that has been removed in v.6.0.
+	 * {@link #getColumnIterator()} is the one that will stay.
+	 *
+	 * @author TheGeekyAsian
+	 *
+	 * @deprecated (Since 6.0) use {@link #getColumnIterator()} instead.
+	 */
 	@Deprecated
 	public Iterator<Column> columnIterator() {
 		return columns.iterator();

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -160,8 +160,6 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	 * This is a duplicate method, that has been removed in v.6.0.
 	 * {@link #getColumnIterator()} is the one that will stay.
 	 *
-	 * @author TheGeekyAsian
-	 *
 	 * @deprecated (Since 6.0) use {@link #getColumnIterator()} instead.
 	 */
 	@Deprecated

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -236,6 +236,7 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		return NO_MAPPINGS;
 	}
 
+	@Deprecated
 	protected String[] getXmlFiles() {
 		// todo : rename to getOrmXmlFiles()
 		return NO_MAPPINGS;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -236,6 +236,12 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		return NO_MAPPINGS;
 	}
 
+	/**
+	 *
+	 * @author TheGeekyAsian
+	 *
+	 * @deprecated (Since 6.0) this method will be renamed to getOrmXmlFile().
+	 */
 	@Deprecated
 	protected String[] getXmlFiles() {
 		// todo : rename to getOrmXmlFiles()

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -238,8 +238,6 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 
 	/**
 	 *
-	 * @author TheGeekyAsian
-	 *
 	 * @deprecated (Since 6.0) this method will be renamed to getOrmXmlFile().
 	 */
 	@Deprecated


### PR DESCRIPTION
Two methods that are dropped in v6.0 are now marked as deprecated in this commit.

As discussed in the removal PR https://github.com/hibernate/hibernate-orm/pull/3229