### PR TITLE
HHH-12338 - Incorrect metamodel for basic collections

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
@@ -138,6 +138,23 @@ public class MetaAttributeGenerationVisitor extends SimpleTypeVisitor6<Annotatio
 				accessTypeInfo.setDefaultAccessType( entity.getEntityAccessTypeInfo().getAccessType() );
 			}
 		}
+		if ( TypeUtils.containsAnnotation(
+				element,
+				Constants.BASIC,
+				Constants.CONVERT,
+				Constants.HIBERNATE_TYPE
+		) && !TypeUtils.containsAnnotation(
+				element,
+				Constants.ONE_TO_MANY,
+				Constants.MANY_TO_MANY,
+				Constants.ELEMENT_COLLECTION
+		) ) {
+			return new AnnotationMetaSingleAttribute(
+					entity,
+					element,
+					TypeUtils.toTypeString( declaredType )
+			);
+		}
 		if ( collection.equals( Constants.MAP_ATTRIBUTE ) ) {
 			return createAnnotationMetaAttributeForMap( declaredType, element, collection, targetEntity );
 		}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CollectionAsBasicTypeTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CollectionAsBasicTypeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.collectionbasictype;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+
+import org.junit.Test;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertAttributeTypeInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertListAttributeTypeInMetaModelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+
+/**
+ * @author helloztt
+ */
+public class CollectionAsBasicTypeTest extends CompilationTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12338")
+	@WithClasses({Goods.class, Product.class})
+	public void testConvert() throws ClassNotFoundException, NoSuchFieldException {
+		assertMetamodelClassGeneratedFor(Product.class);
+		assertMetamodelClassGeneratedFor(Goods.class);
+		assertListAttributeTypeInMetaModelFor(
+				Goods.class,
+				"productList",
+				Product.class,
+				"ListAttribute generic type should be Product"
+		);
+		assertAttributeTypeInMetaModelFor(
+				Goods.class,
+				"tags",
+				Goods.class.getDeclaredField("tags").getGenericType(),
+				"Wrong meta model type"
+		);
+
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12338")
+	@WithClasses({Person.class})
+	public void testListType() throws ClassNotFoundException, NoSuchFieldException {
+		assertMetamodelClassGeneratedFor(Person.class);
+
+		assertAttributeTypeInMetaModelFor(
+				Person.class,
+				"phones",
+				Person.class.getDeclaredField("phones").getGenericType(),
+				"Wrong meta model type"
+		);
+
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12338")
+	@WithClasses({PersonPhone.class})
+	public void testListTypeWithImport() throws ClassNotFoundException, NoSuchFieldException {
+		assertMetamodelClassGeneratedFor(PersonPhone.class);
+
+		assertAttributeTypeInMetaModelFor(
+				PersonPhone.class,
+				"phones",
+				PersonPhone.class.getDeclaredField("phones").getGenericType(),
+				"Wrong meta model type"
+		);
+
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-12338")
+	@WithClasses({PhoneBook.class})
+	public void testMapType() throws ClassNotFoundException, NoSuchFieldException {
+		assertMetamodelClassGeneratedFor(PhoneBook.class);
+
+		assertAttributeTypeInMetaModelFor(
+				PhoneBook.class,
+				"phones",
+				PhoneBook.class.getDeclaredField("phones").getGenericType(),
+				"Wrong meta model type"
+		);
+
+	}
+}


### PR DESCRIPTION
This fix is needed so that we can map List, Set, or Map entity attributes to JSON columns or to map List entity attributes to ARRAY columns, as explained [in this Hibernate Types project issue](https://github.com/vladmihalcea/hibernate-types/issues/137).

Initially, this was integrated into 5.2.17, but it was causing the [HHH-12581](https://hibernate.atlassian.net/browse/HHH-12581) issue, so it got reverted completely.

I this it's worth addressing it via a fix instead of removing this functionality altogether.

@sebersole @Naros If you have time to review it, I'd really appreciate it.