### PR TITLE
HHH-13876 Fix an obvious bug in StandardStack implementation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/StandardStack.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/StandardStack.java
@@ -47,7 +47,7 @@ public class StandardStack<T> implements Stack<T> {
 		if ( internalStack.size() < 2 ) {
 			return null;
 		}
-		return internalStack.get( internalStack.size() - 2 );
+		return internalStack.get( 1 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/util/collections/StandardStackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/util/collections/StandardStackTest.java
@@ -1,0 +1,27 @@
+package org.hibernate.test.util.collections;
+
+import org.hibernate.internal.util.collections.StandardStack;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class StandardStackTest {
+
+	@Test
+	public void testGetPrevious() {
+
+		StandardStack<String> stack = new StandardStack<>();
+
+		stack.push( "previous" );
+
+		assertEquals( "previous", stack.getCurrent() );
+		assertNull( stack.getPrevious() );
+
+		stack.push( "current" );
+
+		assertEquals( "current", stack.getCurrent() );
+		assertEquals( "previous", stack.getPrevious() );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13876

The bug is obvious. However, it is never used in v5 and its implementation has been refactored in v6.