### PR TITLE
Wip/6.0 Fix various obvious log message verbiage issues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -128,7 +128,7 @@ public class EntityDeleteAction extends EntityAction {
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityEntry entry = persistenceContext.removeEntry( instance );
 		if ( entry == null ) {
-			throw new AssertionFailure( "possible nonthreadsafe access to session" );
+			throw new AssertionFailure( "possible non-threadsafe access to session" );
 		}
 		entry.postDelete();
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -211,7 +211,7 @@ public class EntityUpdateAction extends EntityAction {
 
 		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( instance );
 		if ( entry == null ) {
-			throw new AssertionFailure( "possible nonthreadsafe access to session" );
+			throw new AssertionFailure( "possible non-threadsafe access to session" );
 		}
 
 		if ( entry.getStatus()==Status.MANAGED || persister.isVersionPropertyGenerated() ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
@@ -118,7 +118,7 @@ public class ArchiveHelper {
 				jarUrl = new URL( "file:" + jarPath );
 			}
 			catch (MalformedURLException ee) {
-				throw new IllegalArgumentException( "Unable to find jar:" + jarPath, ee );
+				throw new IllegalArgumentException( "Unable to find jar: " + jarPath, ee );
 			}
 		}
 		return jarUrl;

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/FileInputStreamAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/FileInputStreamAccess.java
@@ -46,7 +46,7 @@ public class FileInputStreamAccess implements InputStreamAccess {
 		catch (FileNotFoundException e) {
 			// should never ever ever happen, but...
 			throw new ArchiveException(
-					"File believed to exist based on File.exists threw error when passed to FileInputStream ctor",
+					"File believed to exist based on File#exists() threw error when passed to FileInputStream constructor",
 					e
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarProtocolArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarProtocolArchiveDescriptor.java
@@ -39,7 +39,7 @@ public class JarProtocolArchiveDescriptor implements ArchiveDescriptor {
 		final String urlFile = url.getFile();
 		final int subEntryIndex = urlFile.lastIndexOf( '!' );
 		if ( subEntryIndex == -1 ) {
-			throw new AssertionFailure( "JAR URL does not contain '!/' :" + url );
+			throw new AssertionFailure( "JAR URL does not contain '!/' : " + url );
 		}
 
 		final String subEntry;

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
@@ -168,7 +168,7 @@ public class ConfigLoader {
 		}
 		catch (FileNotFoundException e) {
 			throw new ConfigurationException(
-					"Unable locate specified properties file [" + file.getAbsolutePath() + "]",
+					"Unable to locate specified properties file [" + file.getAbsolutePath() + "]",
 					e
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
@@ -73,7 +73,7 @@ public class JaxbCfgProcessor {
 			}
 		}
 		catch ( XMLStreamException e ) {
-			throw new HibernateException( "Unable to create stax reader", e );
+			throw new HibernateException( "Unable to create StAX reader", e );
 		}
 	}
 
@@ -104,7 +104,7 @@ public class JaxbCfgProcessor {
 			}
 		}
 		catch ( Exception e ) {
-			throw new HibernateException( "Error accessing stax stream", e );
+			throw new HibernateException( "Error accessing StAX stream", e );
 		}
 
 		if ( event == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
@@ -42,7 +42,7 @@ public class ClassLoaderAccessImpl implements ClassLoaderAccess {
 	}
 
 	public void injectTempClassLoader(ClassLoader jpaTempClassLoader) {
-		log.debugf( "ClassLoaderAccessImpl#injectTempClassLoader(%s) [was %s]", jpaTempClassLoader, this.jpaTempClassLoader );
+		log.debugf( "ClassLoaderAccessImpl#injectTempClassLoader(%s); was [%s]", jpaTempClassLoader, this.jpaTempClassLoader );
 		this.jpaTempClassLoader = jpaTempClassLoader;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -298,7 +298,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		if ( matchingPersistentClass != null ) {
 			throw new DuplicateMappingException(
 					String.format(
-							"The [%s] and [%s] entities share the same JPA entity name: [%s] which is not allowed!",
+							"The [%s] and [%s] entities share the same JPA entity name: [%s], which is not allowed!",
 							matchingPersistentClass.getClassName(),
 							persistentClass.getClassName(),
 							jpaEntityName
@@ -478,7 +478,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		final IdentifierGeneratorDefinition old = idGeneratorDefinitionMap.put( generator.getName(), generator );
 		if ( old != null && !old.equals( generator ) ) {
 			if ( bootstrapContext.getJpaCompliance().isGlobalGeneratorScopeEnabled() ) {
-				throw new IllegalArgumentException( "Duplicate generator name " + old.getName() + " you will likely want to set the property " + AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE + " to false " );
+				throw new IllegalArgumentException( "Duplicate generator name found: " + old.getName() + "; you will likely want to set the property " + AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE + " to false " );
 			}
 			else {
 				log.duplicateGeneratorName( old.getName() );
@@ -999,7 +999,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 
 		if ( physicalName == null ) {
 			throw new MappingException(
-					"Unable to find column with logical name " + logicalName.render() + " in table " + table.getName()
+					"Unable to find column with logical name [" + logicalName.render() + "] in table [" + table.getName() + "]"
 			);
 		}
 		return physicalName;
@@ -1037,7 +1037,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 
 		if ( logicalName == null ) {
 			throw new MappingException(
-					"Unable to find column with physical name " + physicalNameString + " in table " + table.getName()
+					"Unable to find column with physical name [" + physicalNameString + "] in table [" + table.getName() + "]"
 			);
 		}
 		return logicalName.render();
@@ -1846,9 +1846,9 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				final String referencedEntityName = fk.getReferencedEntityName();
 				if ( referencedEntityName == null ) {
 					throw new MappingException(
-							"An association from the table " +
+							"An association from the table [" +
 									fk.getTable().getName() +
-									" does not specify the referenced entity"
+									"] does not specify the referenced entity"
 					);
 				}
 
@@ -1856,9 +1856,9 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				final PersistentClass referencedClass = getEntityBinding( referencedEntityName );
 				if ( referencedClass == null ) {
 					throw new MappingException(
-							"An association from the table " +
+							"An association from the table [" +
 									fk.getTable().getName() +
-									" refers to an unmapped class: " +
+									"] refers to an unmapped class: " +
 									referencedEntityName
 					);
 				}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -97,7 +97,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		}
 		else if ( BootstrapServiceRegistry.class.isInstance( serviceRegistry ) ) {
 			log.debugf(
-					"ServiceRegistry passed to MetadataBuilder was a BootstrapServiceRegistry; this likely wont end well" +
+					"ServiceRegistry passed to MetadataBuilder was a BootstrapServiceRegistry; this likely won't end well " +
 							"if attempt is made to build SessionFactory"
 			);
 			return new StandardServiceRegistryBuilder( (BootstrapServiceRegistry) serviceRegistry ).build();

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
@@ -74,7 +74,7 @@ public abstract class AbstractBinder implements Binder {
 			return new BufferedXMLEventReader( staxReader, 100 );
 		}
 		catch ( XMLStreamException e ) {
-			throw new MappingException( "Unable to create stax reader", e, origin );
+			throw new MappingException( "Unable to create StAX reader", e, origin );
 		}
 	}
 
@@ -92,7 +92,7 @@ public abstract class AbstractBinder implements Binder {
 			return new BufferedXMLEventReader( staxReader, 100 );
 		}
 		catch ( XMLStreamException e ) {
-			throw new MappingException( "Unable to create stax reader", e, origin );
+			throw new MappingException( "Unable to create StAX reader", e, origin );
 		}
 	}
 
@@ -138,7 +138,7 @@ public abstract class AbstractBinder implements Binder {
 			}
 		}
 		catch ( Exception e ) {
-			throw new MappingException( "Error accessing stax stream", e, origin );
+			throw new MappingException( "Error accessing StAX stream", e, origin );
 		}
 
 		if ( rootElementStartEvent == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistry.java
@@ -92,7 +92,7 @@ public class TypeDefinitionRegistry {
 					throw new IllegalArgumentException(
 							String.format(
 									Locale.ROOT,
-									"Attempted to ovewrite registration [%s] for type definition.",
+									"Attempted to overwrite registration [%s] for type definition",
 									name
 							)
 					);

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ImplicitNamingStrategyJpaCompliantImpl.java
@@ -32,7 +32,7 @@ public class ImplicitNamingStrategyJpaCompliantImpl implements ImplicitNamingStr
 	public Identifier determinePrimaryTableName(ImplicitEntityNameSource source) {
 		if ( source == null ) {
 			// should never happen, but to be defensive...
-			throw new HibernateException( "Entity naming information was not provided." );
+			throw new HibernateException( "Entity naming information was not provided" );
 		}
 
 		String tableName = transformEntityName( source.getEntityNaming() );

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
@@ -103,7 +103,7 @@ final class BiDirectionalAssociationHandler implements Implementation {
 
 			if ( persistentField.getType().asErasure().isAssignableTo( Map.class ) || targetType.isAssignableTo( Map.class ) ) {
 				log.infof(
-						"Bi-directional association not managed for field [%s#%s]: @ManyToMany in java.util.Map attribute not supported ",
+						"Bi-directional association not managed for field [%s#%s]: @ManyToMany in java.util.Map attribute not supported",
 						managedCtClass.getName(),
 						persistentField.getName()
 				);

--- a/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
@@ -17,8 +17,8 @@ import org.hibernate.cfg.Environment;
 public class NoCacheRegionFactoryAvailableException extends CacheException {
 	private static final String MSG = String.format(
 			"Second-level cache is used in the application, but property %s is not given; " +
-					"please either disable second level cache or set correct region factory using the %s setting " +
-					"and make sure the second level cache provider (hibernate-infinispan, e.g.) is available on the " +
+					"please either disable second-level cache or set correct region factory using the %s setting " +
+					"and make sure the second-level cache provider (hibernate-infinispan, e.g.) is available on the " +
 					"classpath.",
 			Environment.CACHE_REGION_FACTORY,
 			Environment.CACHE_REGION_FACTORY

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
@@ -117,7 +117,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 				throw new HibernateException(
 						String.format(
 								Locale.ROOT,
-								"Region [%s] returned from RegionFactory [%s] was named differently than requested name.  Expecting `%s`, but found `%s`",
+								"Region [%s] returned from RegionFactory [%s] was named differently than requested name. Expecting `%s`, but found `%s`",
 								region,
 								getRegionFactory().getClass().getName(),
 								regionConfig.getRegionName(),
@@ -451,7 +451,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	@Override
 	public void evictQueryRegions() {
 		if ( LOG.isDebugEnabled() ) {
-			LOG.debug( "Evicting cache of all query regions." );
+			LOG.debug( "Evicting cache of all query regions" );
 		}
 
 		evictQueryResultRegion( defaultQueryResultsCache );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -317,7 +317,7 @@ public abstract class CollectionBinder {
 		}
 		else {
 			throw new AnnotationException(
-					"Illegal attempt to map a non collection as a @OneToMany, @ManyToMany or @CollectionOfElements: "
+					"Illegal attempt to map a non collection as a @OneToMany, @ManyToMany or @ElementCollection: "
 							+ StringHelper.qualify( entityName, property.getName() )
 			);
 		}
@@ -347,28 +347,28 @@ public abstract class CollectionBinder {
 			String entityName, boolean isIndexed) {
 		if ( java.util.Set.class.equals( clazz) ) {
 			if ( property.isAnnotationPresent( CollectionId.class) ) {
-				throw new AnnotationException("Set do not support @CollectionId: "
+				throw new AnnotationException("Set does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new SetBinder( false );
 		}
 		else if ( java.util.SortedSet.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Set do not support @CollectionId: "
+				throw new AnnotationException( "Set does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new SetBinder( true );
 		}
 		else if ( java.util.Map.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Map do not support @CollectionId: "
+				throw new AnnotationException( "Map does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new MapBinder( false );
 		}
 		else if ( java.util.SortedMap.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Map do not support @CollectionId: "
+				throw new AnnotationException( "Map does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new MapBinder( true );
@@ -385,7 +385,7 @@ public abstract class CollectionBinder {
 			if ( isIndexed ) {
 				if ( property.isAnnotationPresent( CollectionId.class ) ) {
 					throw new AnnotationException(
-							"List do not support @CollectionId and @OrderColumn (or @IndexColumn) at the same time: "
+							"List does not support @CollectionId and @OrderColumn (or @IndexColumn) at the same time: "
 									+ StringHelper.qualify( entityName, property.getName() ) );
 				}
 				return new ListBinder();
@@ -535,7 +535,7 @@ public abstract class CollectionBinder {
 				&& (property.isAnnotationPresent( JoinColumn.class )
 					|| property.isAnnotationPresent( JoinColumns.class )
 					|| propertyHolder.getJoinTable( property ) != null ) ) {
-			String message = "Associations marked as mappedBy must not define database mappings like @JoinTable or @JoinColumn: ";
+			String message = "Associations marked as @mappedBy must not define database mappings like @JoinTable or @JoinColumn: ";
 			message += StringHelper.qualify( propertyHolder.getPath(), propertyName );
 			throw new AnnotationException( message );
 		}
@@ -666,7 +666,7 @@ public abstract class CollectionBinder {
 		if ( isSortedCollection ) {
 			if ( ! hadExplicitSort && !hadOrderBy ) {
 				throw new AnnotationException(
-						"A sorted collection must define and ordering or sorting : " + safeCollectionRole()
+						"A sorted collection must define an ordering or sorting : " + safeCollectionRole()
 				);
 			}
 		}
@@ -692,7 +692,7 @@ public abstract class CollectionBinder {
 	private AnnotationException buildIllegalSortCombination() {
 		return new AnnotationException(
 				String.format(
-						"Illegal combination of annotations on %s.  Only one of @%s, @%s and @%s can be used",
+						"Illegal combination of annotations on %s. Only one of @%s, @%s and @%s can be used",
 						safeCollectionRole(),
 						Sort.class.getName(),
 						SortNatural.class.getName(),
@@ -723,7 +723,7 @@ public abstract class CollectionBinder {
 		}
 		else {
 			throw new AssertionFailure(
-					"Define fetch strategy on a property not annotated with @ManyToOne nor @OneToMany nor @CollectionOfElements"
+					"Define fetch strategy on a property not annotated with @ManyToOne nor @OneToMany nor @ElementCollection"
 			);
 		}
 		if ( lazy != null ) {
@@ -762,7 +762,7 @@ public abstract class CollectionBinder {
 				return collectionType;
 			}
 			else {
-				String errorMsg = "Collection has neither generic type or OneToMany.targetEntity() defined: "
+				String errorMsg = "Collection has neither generic type nor OneToMany.targetEntity() defined: "
 						+ safeCollectionRole();
 				throw new AnnotationException( errorMsg );
 			}
@@ -989,7 +989,7 @@ public abstract class CollectionBinder {
 					}
 			else {
 				throw new AnnotationException(
-						"Illegal use of @FilterJoinTable on an association without join table:"
+						"Illegal use of @FilterJoinTable on an association without join table: "
 								+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 				);
 			}
@@ -1004,7 +1004,7 @@ public abstract class CollectionBinder {
 				}
 				else {
 					throw new AnnotationException(
-							"Illegal use of @FilterJoinTable on an association without join table:"
+							"Illegal use of @FilterJoinTable on an association without join table: "
 									+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 					);
 				}
@@ -1067,7 +1067,7 @@ public abstract class CollectionBinder {
 			}
 			else {
 				throw new AnnotationException(
-						"Illegal use of @WhereJoinTable on an association without join table:"
+						"Illegal use of @WhereJoinTable on an association without join table: "
 								+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 				);
 			}
@@ -1095,7 +1095,7 @@ public abstract class CollectionBinder {
 			cond = buildingContext.getMetadataCollector().getFilterDefinition( name ).getDefaultFilterCondition();
 			if ( StringHelper.isEmpty( cond ) ) {
 				throw new AnnotationException(
-						"no filter condition found for filter " + name + " in "
+						"no filter condition found for filter [" + name + "] in "
 								+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 				);
 			}
@@ -1313,7 +1313,7 @@ public abstract class CollectionBinder {
 				LOG.debugf("Binding a OneToMany: %s through an association table", path);
 			}
 			else if (isCollectionOfEntities) {
-				LOG.debugf("Binding as ManyToMany: %s", path);
+				LOG.debugf("Binding a ManyToMany: %s", path);
 			}
 			else if (anyAnn != null) {
 				LOG.debugf("Binding a ManyToAny: %s", path);
@@ -1365,7 +1365,7 @@ public abstract class CollectionBinder {
 			}
 			catch (MappingException e) {
 				throw new AnnotationException(
-						"mappedBy reference an unknown target entity property: "
+						"mappedBy references an unknown target entity property: "
 								+ collType + "." + joinColumns[0].getMappedBy() + " in "
 								+ collValue.getOwnerEntityName() + "." + joinColumns[0].getPropertyName()
 				);
@@ -1671,7 +1671,7 @@ public abstract class CollectionBinder {
 				!( collValue.getElement() instanceof SimpleValue ) && //SimpleValue (CollectionOfElements) are always SELECT but it does not matter
 				collValue.getElement().getFetchMode() != FetchMode.JOIN ) {
 			throw new MappingException(
-					"@ManyToMany or @CollectionOfElements defining filter or where without join fetching "
+					"@ManyToMany or @ElementCollection defining filter or where without join fetching "
 							+ "not valid within collection using join fetching[" + collValue.getRole() + "]"
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -420,14 +420,14 @@ public class EntityBinder {
 				cond = definition == null ? null : definition.getDefaultFilterCondition();
 				if ( StringHelper.isEmpty( cond ) ) {
 					throw new AnnotationException(
-							"no filter condition found for filter " + filterName + " in " + this.name
+							"no filter condition found for filter [" + filterName + "] in " + this.name
 					);
 				}
 			}
 			persistentClass.addFilter(filterName, cond, filter.deduceAliasInjectionPoints(),
 					toAliasTableMap(filter.aliases()), toAliasEntityMap(filter.aliases()));
 		}
-		LOG.debugf( "Import with entity name %s", name );
+		LOG.debugf( "Import with entity name [%s]", name );
 		try {
 			context.getMetadataCollector().addImport( name, persistentClass.getEntityName() );
 			String entityName = persistentClass.getEntityName();
@@ -870,7 +870,7 @@ public class EntityBinder {
 		);
 
 		if ( persistentClass instanceof TableOwner ) {
-			LOG.debugf( "Bind entity %s on table %s", persistentClass.getEntityName(), table.getName() );
+			LOG.debugf( "Bind entity [%s] on table [%s]", persistentClass.getEntityName(), table.getName() );
 			( (TableOwner) persistentClass ).setTable( table );
 		}
 		else {
@@ -1313,7 +1313,7 @@ public class EntityBinder {
 
 		if ( hibernateAccessType != null && jpaAccessType != null && hibernateAccessType != jpaAccessType ) {
 			throw new MappingException(
-					"Found @Access and @AccessType with conflicting values on a property in class " + annotatedClass.toString()
+					"Found @Access and @AccessType with conflicting values on a property in class [" + annotatedClass.toString() + "]"
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -532,7 +532,7 @@ public class MapBinder extends CollectionBinder {
 			return targetValue;
 		}
 		else {
-			throw new AssertionFailure( "Unknown type encounters for map key: " + value.getClass() );
+			throw new AssertionFailure( "Unknown type encountered for map key: " + value.getClass() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -362,7 +362,7 @@ public class PropertyBinder {
 			if ( candidate != null ) {
 				if ( valueGeneration != null ) {
 					throw new AnnotationException(
-							"Only one generator annotation is allowed:" + StringHelper.qualify(
+							"Only one generator annotation is allowed: " + StringHelper.qualify(
 									holder.getPath(),
 									name
 							)
@@ -436,7 +436,7 @@ public class PropertyBinder {
 		}
 		catch (Exception e) {
 			throw new AnnotationException(
-					"Exception occurred during processing of generator annotation:" + StringHelper.qualify(
+					"Exception occurred during processing of generator annotation: " + StringHelper.qualify(
 							holder.getPath(),
 							name
 					), e

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
@@ -234,7 +234,7 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 				}
 				catch (ClassCastException e) {
 					throw new MappingException(
-							"dotted notation reference neither a component nor a many/one to one", e
+							"dotted notation references neither a component nor a many/one to one", e
 					);
 				}
 			}
@@ -250,13 +250,13 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 				}
 				catch (ClassCastException e) {
 					throw new MappingException(
-							"dotted notation reference neither a component nor a many/one to one", e
+							"dotted notation references neither a component nor a many/one to one", e
 					);
 				}
 			}
 		}
 		else {
-			throw new MappingException( "dotted notation reference neither a component nor a many/one to one" );
+			throw new MappingException( "dotted notation references neither a component nor a many/one to one" );
 		}
 		return parentPropIter;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
@@ -210,7 +210,7 @@ public class SimpleValueBinder {
 					}
 					case TIME: {
 						throw new NotYetImplementedException(
-								"Calendar cannot persist TIME only" + StringHelper.qualify( persistentClassName, propertyName )
+								"Calendar cannot persist TIME only: " + StringHelper.qualify( persistentClassName, propertyName )
 						);
 					}
 					default: {
@@ -492,7 +492,7 @@ public class SimpleValueBinder {
 			if ( ! BinderHelper.isEmptyAnnotationValue( explicitType ) ) {
 				throw new AnnotationException(
 						String.format(
-								"AttributeConverter and explicit Type cannot be applied to same attribute [%s.%s];" +
+								"AttributeConverter and explicit type cannot be applied to same attribute [%s.%s]; " +
 										"remove @Type or specify @Convert(disableConversion = true)",
 								persistentClassName,
 								propertyName

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
@@ -551,7 +551,7 @@ public class TableBinder {
 			 * Get the columns of the mapped-by property
 			 * copy them and link the copy to the actual value
 			 */
-			LOG.debugf( "Retrieving property %s.%s", associatedClass.getEntityName(), mappedByProperty );
+			LOG.debugf( "Retrieving property: %s.%s", associatedClass.getEntityName(), mappedByProperty );
 
 			final Property property = associatedClass.getRecursiveProperty( columns[0].getMappedBy() );
 			Iterator mappedByColumns;
@@ -615,13 +615,13 @@ public class TableBinder {
 				}
 				else {
 					throw new AssertionFailure(
-							"Do a property ref on an unexpected Value type: "
+							"Property ref on an unexpected Value type: "
 									+ value.getClass().getName()
 					);
 				}
 				if ( referencedPropertyName == null ) {
 					throw new AssertionFailure(
-							"No property ref found while expected"
+							"No property ref found as expected"
 					);
 				}
 				Property synthProp = referencedEntity.getReferencedProperty( referencedPropertyName );
@@ -640,7 +640,7 @@ public class TableBinder {
 					//implicit case, we hope PK and FK columns are in the same order
 					if ( columns.length != referencedEntity.getIdentifier().getColumnSpan() ) {
 						throw new AnnotationException(
-								"A Foreign key refering " + referencedEntity.getEntityName()
+								"A Foreign key referring " + referencedEntity.getEntityName()
 										+ " from " + associatedClass.getEntityName()
 										+ " has the wrong number of column. should be " + referencedEntity.getIdentifier()
 										.getColumnSpan()

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -1675,7 +1675,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( access + " is not a valid access type. Check you xml confguration." );
+				throw new AnnotationException( access + " is not a valid access type. Check you xml configuration." );
 			}
 
 			if ( ( AccessType.PROPERTY.equals( type ) && this.element instanceof Method ) ||
@@ -1850,7 +1850,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		else {
 			if ( isMandatory ) {
-				throw new AnnotationException( current.getPath() + ".column is mandatory. " + SCHEMA_VALIDATION );
+				throw new AnnotationException( current.getPath() + " column is mandatory. " + SCHEMA_VALIDATION );
 			}
 			return null;
 		}
@@ -1881,7 +1881,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( access + " is not a valid access type. Check you xml confguration." );
+				throw new AnnotationException( access + " is not a valid access type. Check you xml configuration." );
 			}
 			ad.setValue( "value", type );
 			return AnnotationFactory.create( ad );
@@ -2481,7 +2481,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			copyStringAttribute( ann, subelement, "name", false );
 			Element queryElt = subelement.element( "query" );
 			if ( queryElt == null ) {
-				throw new AnnotationException( "No <query> element found." + SCHEMA_VALIDATION );
+				throw new AnnotationException( "No <query> element found" + SCHEMA_VALIDATION );
 			}
 			copyStringElement( queryElt, ann, "query" );
 			List<Element> elements = subelement.elements( "hint" );
@@ -2614,7 +2614,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				}
 				else {
 					throw new AnnotationException(
-							"Unknown DiscrimiatorType in XML: " + value + " (" + SCHEMA_VALIDATION + ")"
+							"Unknown DiscriminatorType in XML: " + value + " (" + SCHEMA_VALIDATION + ")"
 					);
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -136,7 +136,7 @@ public class XMLContext implements Serializable {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( "Invalid access type " + access + " (check your xml configuration)" );
+				throw new AnnotationException( "Invalid access type: " + access + " (check your xml configuration)" );
 			}
 			defaultType.setAccess( type );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -612,7 +612,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		throw new LazyInitializationException(
 				"failed to lazily initialize a collection" +
 						(role == null ? "" : " of role: " + role) +
-						", " + message
+						": " + message
 		);
 	}
 
@@ -698,7 +698,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			final String msg = generateUnexpectedSessionStateMessage( session );
 			if ( isConnectedToSession() ) {
 				throw new HibernateException(
-						"Illegal attempt to associate a collection with two open sessions. " + msg
+						"Illegal attempt to associate a collection with two open sessions: " + msg
 				);
 			}
 			else {
@@ -783,7 +783,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	public final void forceInitialization() throws HibernateException {
 		if ( !initialized ) {
 			if ( initializing ) {
-				throw new AssertionFailure( "force initialize loading collection" );
+				throw new AssertionFailure( "force initializing loading collection" );
 			}
 			initialize( false );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
@@ -103,7 +103,7 @@ public class JTASessionContext extends AbstractCurrentSessionContext {
 					currentSession.close();
 				}
 				catch ( Throwable ignore ) {
-					LOG.debug( "Unable to release generated current-session on failed synch registration", ignore );
+					LOG.debug( "Unable to release generated current-session on failed synchronization registration", ignore );
 				}
 				throw new HibernateException( "Unable to register cleanup Synchronization with TransactionManager" );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
@@ -44,7 +44,7 @@ public class OptimisticForceIncrementLockingStrategy implements LockingStrategy 
 	@Override
 	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
-			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
+			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entity [" + lockable.getEntityName() + "]" );
 		}
 		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		// Register the EntityIncrementVersionProcess action to run just prior to transaction commit.

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
@@ -44,7 +44,7 @@ public class OptimisticLockingStrategy implements LockingStrategy {
 	@Override
 	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
-			throw new OptimisticLockException( object, "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
+			throw new OptimisticLockException( object, "[" + lockMode + "] not supported for non-versioned entity [" + lockable.getEntityName() + "]" );
 		}
 		// Register the EntityVerifyVersionProcess action to run just prior to transaction commit.
 		( (EventSource) session ).getActionQueue().registerProcess( new EntityVerifyVersionProcess( object ) );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
@@ -43,7 +43,7 @@ public class PessimisticForceIncrementLockingStrategy implements LockingStrategy
 	@Override
 	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
-			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
+			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entity [" + lockable.getEntityName() + "]" );
 		}
 		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		final EntityPersister persister = entry.getPersister();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -69,7 +69,7 @@ public class PessimisticWriteUpdateLockingStrategy implements LockingStrategy {
 	@Override
 	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
-			throw new HibernateException( "write locks via update not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
+			throw new HibernateException( "write locks via update not supported for non-versioned entity [" + lockable.getEntityName() + "]" );
 		}
 
 		final SessionFactoryImplementor factory = session.getFactory();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -75,7 +75,7 @@ public class UpdateLockingStrategy implements LockingStrategy {
 			SharedSessionContractImplementor session) throws StaleObjectStateException, JDBCException {
 		final String lockableEntityName = lockable.getEntityName();
 		if ( !lockable.isVersioned() ) {
-			throw new HibernateException( "write locks via update not supported for non-versioned entities [" + lockableEntityName + "]" );
+			throw new HibernateException( "write locks via update not supported for non-versioned entity [" + lockableEntityName + "]" );
 		}
 
 		// todo : should we additionally check the current isolation mode explicitly?

--- a/hibernate-core/src/main/java/org/hibernate/engine/OptimisticLockStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/OptimisticLockStyle.java
@@ -63,7 +63,7 @@ public enum OptimisticLockStyle {
 				return ALL;
 			}
 			default: {
-				throw new IllegalArgumentException( "Illegal legacy optimistic lock style code :" + oldCode );
+				throw new IllegalArgumentException( "Illegal legacy optimistic lock style code : " + oldCode );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
@@ -94,7 +94,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 				target = serviceRegistry.getService( ClassLoaderService.class ).classForName( candidate.toString() );
 			}
 			catch ( ClassLoadingException e ) {
-				LOG.debugf( "Unable to locate %s implementation class %s", expected.getName(), candidate.toString() );
+				LOG.debugf( "Unable to locate %s implementation class: %s", expected.getName(), candidate.toString() );
 				target = null;
 			}
 		}
@@ -104,7 +104,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 			}
 			catch ( Exception e ) {
 				LOG.debugf(
-						"Unable to instantiate %s class %s", expected.getName(),
+						"Unable to instantiate %s class: %s", expected.getName(),
 						target.getName()
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -526,7 +526,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 			// In case any of the enums cannot be stored in 4 bits anymore, we'd have to re-structure the compressed
 			// state int
 			if ( enumConstants.length > 15 ) {
-				throw new AssertionFailure( "Cannot store enum type " + enumType.getName() + " in compressed state as"
+				throw new AssertionFailure( "Cannot store enum type [" + enumType.getName() + "] in compressed state as"
 						+ " it has too many values." );
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -192,7 +192,7 @@ public class EntityEntryContext {
 			// NOTE: otherPersistenceContext may be operating on the entityEntry in a different thread.
 			//       it is not safe to associate entityEntry with this EntityEntryContext.
 			throw new HibernateException(
-					"Illegal attempt to associate a ManagedEntity with two open persistence contexts. " + entityEntry
+					"Illegal attempt to associate a ManagedEntity with two open persistence contexts: " + entityEntry
 			);
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
@@ -162,10 +162,10 @@ public class NaturalIdXrefDelegate {
 	 */
 	protected void validateNaturalId(EntityPersister persister, Object[] naturalIdValues) {
 		if ( !persister.hasNaturalIdentifier() ) {
-			throw new IllegalArgumentException( "Entity did not define a natrual-id" );
+			throw new IllegalArgumentException( "Entity did not define a natural-id" );
 		}
 		if ( persister.getNaturalIdentifierProperties().length != naturalIdValues.length ) {
-			throw new IllegalArgumentException( "Mismatch between expected number of natural-id values and found." );
+			throw new IllegalArgumentException( "Mismatch between expected number of natural-id values and found ones." );
 		}
 	}
 
@@ -334,7 +334,7 @@ public class NaturalIdXrefDelegate {
 
 		final NaturalIdResolutionCache entityNaturalIdResolutionCache = naturalIdResolutionCacheMap.get( persister );
 		if ( entityNaturalIdResolutionCache == null ) {
-			throw new AssertionFailure( "Expecting NaturalIdResolutionCache to exist already for entity " + persister.getEntityName() );
+			throw new AssertionFailure( "Expecting NaturalIdResolutionCache to exist already for entity: " + persister.getEntityName() );
 		}
 
 		entityNaturalIdResolutionCache.stashInvalidNaturalIdReference( invalidNaturalIdValues );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
@@ -106,7 +106,7 @@ public final class Nullability {
 					if ( !nullability[i] && value == null ) {
 						//check basic level one nullablilty
 						throw new PropertyValueException(
-								"not-null property references a null or transient value",
+								"non-null property references a null or transient value",
 								persister.getEntityName(),
 								persister.getPropertyNames()[i]
 							);
@@ -117,7 +117,7 @@ public final class Nullability {
 						final String breakProperties = checkSubElementsNullability( propertyTypes[i], value );
 						if ( breakProperties != null ) {
 							throw new PropertyValueException(
-								"not-null property references a null or transient value",
+								"non-null property references a null or transient value",
 								persister.getEntityName(),
 								buildPropertyPath( persister.getPropertyNames()[i], breakProperties )
 							);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -346,7 +346,7 @@ public final class TwoPhaseLoad {
 
 		if ( debugEnabled ) {
 			LOG.debugf(
-					"Done materializing entity %s",
+					"Done materializing entity: %s",
 					MessageHelper.infoString( persister, id, session.getFactory() )
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ResultSetWrapperProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ResultSetWrapperProxy.java
@@ -97,7 +97,7 @@ public class ResultSetWrapperProxy implements InvocationHandler {
 					return invokeMethod( columnIndexMethod, buildColumnIndexMethodArgs( args, columnIndex ) );
 				}
 				catch ( SQLException ex ) {
-					final String msg = "Exception getting column index for column: [" + args[0] +
+					final String msg = "Exception thrown when getting column index for column: [" + args[0] +
 							"].\nReverting to using: [" + args[0] +
 							"] as first argument for method: [" + method + "]";
 					SQL_EXCEPTION_HELPER.logExceptions( ex, msg );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/BasicConnectionCreator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/BasicConnectionCreator.java
@@ -67,7 +67,7 @@ public abstract class BasicConnectionCreator implements ConnectionCreator {
 			}
 		}
 		catch (SQLException e) {
-			throw convertSqlException( "Unable to set transaction isolation (" + isolation + ")", e );
+			throw convertSqlException( "Unable to set transaction isolation [" + isolation + "]", e );
 		}
 
 		try {
@@ -76,7 +76,7 @@ public abstract class BasicConnectionCreator implements ConnectionCreator {
 			}
 		}
 		catch (SQLException e) {
-			throw convertSqlException( "Unable to set auto-commit (" + autoCommit + ")", e );
+			throw convertSqlException( "Unable to set auto-commit [" + autoCommit + "]", e );
 		}
 
 		return conn;

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverConnectionCreator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverConnectionCreator.java
@@ -38,7 +38,7 @@ public class DriverConnectionCreator extends BasicConnectionCreator {
 			return driver.connect( url, connectionProps );
 		}
 		catch (SQLException e) {
-			throw convertSqlException( "Error calling Driver#connect", e );
+			throw convertSqlException( "Error calling Driver#connect(String,Properties)", e );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/DefaultSchemaNameResolver.java
@@ -50,18 +50,18 @@ public class DefaultSchemaNameResolver implements SchemaNameResolver {
 					return new SchemaNameResolverJava17Delegate();
 				}
 				catch (java.lang.AbstractMethodError e) {
-					log.debugf( "Unable to use Java 1.7 Connection#getSchema" );
+					log.debugf( "Unable to use Java 1.7 Connection#getSchema()" );
 					return SchemaNameResolverFallbackDelegate.INSTANCE;
 				}
 			}
 			else {
-				log.debugf( "Unable to use Java 1.7 Connection#getSchema" );
+				log.debugf( "Unable to use Java 1.7 Connection#getSchema()" );
 				return SchemaNameResolverFallbackDelegate.INSTANCE;
 			}
 		}
 		catch (Exception ignore) {
 			log.debugf(
-					"Unable to use Java 1.7 Connection#getSchema : An error occurred trying to resolve the connection default schema resolver: "
+					"Unable to use Java 1.7 Connection#getSchema(); an error occurred trying to resolve the connection default schema resolver: "
 							+ ignore.getMessage() );
 			return SchemaNameResolverFallbackDelegate.INSTANCE;
 		}
@@ -98,7 +98,7 @@ public class DefaultSchemaNameResolver implements SchemaNameResolver {
 						"Use of DefaultSchemaNameResolver requires Dialect to provide the " +
 								"proper SQL statement/command but provided Dialect [" +
 								dialect.getClass().getName() + "] did not return anything " +
-								"from Dialect#getCurrentSchemaCommand"
+								"from Dialect#getCurrentSchemaCommand()"
 				);
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeNullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeNullability.java
@@ -50,7 +50,7 @@ public enum TypeNullability {
 				return UNKNOWN;
 			}
 			default: {
-				throw new IllegalArgumentException( "Unknown type nullability code [" + code + "] enountered" );
+				throw new IllegalArgumentException( "Unknown type nullability code [" + code + "] encountered" );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeSearchability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeSearchability.java
@@ -58,7 +58,7 @@ public enum TypeSearchability {
 				return CHAR;
 			}
 			default: {
-				throw new IllegalArgumentException( "Unknown type searchability code [" + code + "] enountered" );
+				throw new IllegalArgumentException( "Unknown type searchability code [" + code + "] encountered" );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
@@ -97,7 +97,7 @@ public class JndiServiceImpl implements JndiService {
 			return initialContext.lookup( name );
 		}
 		catch ( NamingException e ) {
-			throw new JndiException( "Unable to lookup JNDI name [" + jndiName + "]", e );
+			throw new JndiException( "Unable to look up JNDI name [" + jndiName + "]", e );
 		}
 		finally {
 			cleanUp( initialContext );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
@@ -342,8 +342,8 @@ public final class QueryParameters {
 		final int values = positionalParameterValues == null ? 0 : positionalParameterValues.length;
 		if ( types != values ) {
 			throw new QueryException(
-					"Number of positional parameter types:" + types +
-							" does not match number of positional parameters: " + values
+					"Number of positional parameter types [" + types +
+							"] does not match number of positional parameters [" + values + "]"
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractReassociateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractReassociateEventListener.java
@@ -47,7 +47,7 @@ public abstract class AbstractReassociateEventListener implements Serializable {
 
 		if ( log.isTraceEnabled() ) {
 			log.tracev(
-					"Reassociating transient instance: {0}",
+					"Re-associating transient instance: {0}",
 					MessageHelper.infoString( persister, id, event.getSession().getFactory() )
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -114,7 +114,7 @@ public abstract class AbstractSaveEventListener
 		EntityPersister persister = source.getEntityPersister( entityName, entity );
 		Object generatedId = persister.getIdentifierGenerator().generate( source, entity );
 		if ( generatedId == null ) {
-			throw new IdentifierGenerationException( "null id generated for:" + entity.getClass() );
+			throw new IdentifierGenerationException( "null id generated for: " + entity.getClass() );
 		}
 		else if ( generatedId == IdentifierGeneratorHelper.SHORT_CIRCUIT_INDICATOR ) {
 			return source.getIdentifier( entity );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
@@ -65,7 +65,7 @@ public class DefaultAutoFlushEventListener extends AbstractFlushingEventListener
 					}
 				}
 				else {
-					LOG.trace( "Don't need to execute flush" );
+					LOG.trace( "No need to execute flush" );
 					event.setFlushRequired( false );
 					actionQueue.clearFromFlushNeededCheck( oldSize );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -187,7 +187,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 		EntityPersister persister = source.getEntityPersister( entityName, event.getObject() );
 		Object id =  persister.getIdentifier( event.getObject(), source );
 		entityName = entityName == null ? source.guessEntityName( event.getObject() ) : entityName;
-		throw new IllegalArgumentException("Removing a detached instance "+ entityName + "#" + id);
+		throw new IllegalArgumentException("Removing a detached instance: "+ entityName + "#" + id);
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
@@ -89,7 +89,7 @@ public class DefaultEvictEventListener implements EvictEventListener {
 					}
 				}
 				if ( persister == null ) {
-					throw new IllegalArgumentException( "Non-entity object instance passed to evict : " + object );
+					throw new IllegalArgumentException( "Non-entity object instance passed to evict() : " + object );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -79,7 +79,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			if ( !persister.getIdentifierType().isEqual( id, oid, session.getFactory() ) ) {
 				throw new HibernateException(
 						"identifier of an instance of " + persister.getEntityName() + " was altered from "
-								+ id + " to " + oid
+								+ oid + " to " + id
 				);
 			}
 		}
@@ -128,7 +128,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 				if ( !propertyType.isEqual( current[naturalIdentifierPropertyIndex], snapshot[i] ) ) {
 					throw new HibernateException(
 							String.format(
-									"An immutable natural identifier of entity %s was altered from `%s` to `%s`",
+									"An immutable natural identifier of entity [%s] was altered from `%s` to `%s`",
 									persister.getEntityName(),
 									propertyTypes[naturalIdentifierPropertyIndex].toLoggableString(
 											snapshot[i],
@@ -283,7 +283,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 				}
 				else {
 					LOG.tracev(
-							"Updating deleted entity: ",
+							"Updating deleted entity: {0}",
 							MessageHelper.infoString( persister, entry.getId(), session.getFactory() )
 					);
 				}
@@ -701,7 +701,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 				dirtyPropertyNames[i] = allPropertyNames[dirtyProperties[i]];
 			}
 			LOG.tracev(
-					"Found dirty properties [{0}] : {1}",
+					"Found dirty properties in [{0}] : {1}",
 					MessageHelper.infoString( persister.getEntityName(), id ),
 					Arrays.toString( dirtyPropertyNames )
 			);

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -44,7 +44,7 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 			final CollectionPersister ceLoadedPersister = ce.getLoadedPersister();
 			if ( LOG.isTraceEnabled() ) {
 				LOG.tracev(
-						"Initializing collection {0}",
+						"Initializing collection: {0}",
 						MessageHelper.collectionInfoString(
 								ceLoadedPersister,
 								collection,

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -151,8 +151,8 @@ public class DefaultLoadEventListener implements LoadEventListener {
 		}
 
 		throw new TypeMismatchException(
-				"Provided id of the wrong type for class " + persister.getEntityName() + ". Expected: " + idClass
-						+ ", got " + event.getEntityId().getClass()
+				"Provided id of the wrong type for class: " + persister.getEntityName() + ". Expected: " + idClass
+						+ ", got: " + event.getEntityId().getClass()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLockEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLockEventListener.java
@@ -69,8 +69,7 @@ public class DefaultLockEventListener extends AbstractLockUpgradeEventListener i
 			final Object id = persister.getIdentifier( entity, source );
 			if ( !ForeignKeys.isNotTransient( event.getEntityName(), entity, Boolean.FALSE, source ) ) {
 				throw new TransientObjectException(
-						"cannot lock an unsaved transient instance: " +
-						persister.getEntityName()
+						"cannot lock an unsaved transient instance: " + persister.getEntityName() + "#" + id
 				);
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -61,7 +61,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 
 		// For an uninitialized proxy, noop, don't even need to return an id, since it is never a save()
 		if ( reassociateIfUninitializedProxy( object, source ) ) {
-			LOG.trace( "Reassociated uninitialized proxy" );
+			LOG.trace( "Re-associated uninitialized proxy" );
 		}
 		else {
 			//initialize properties of the event:

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
@@ -251,8 +251,8 @@ public class MergeContext implements Map {
 			}
 			if ( oldOperatedOn != null ) {
 				throw new IllegalStateException(
-						"MergeContext#mergeEntityToOperatedOnFlagMap contains a merge entity " + printEntity( mergeEntity )
-								+ ", but MergeContext#mergeToManagedEntityXref does not."
+						"MergeContext#mergeEntityToOperatedOnFlagMap contains a merge entity [" + printEntity( mergeEntity )
+								+ "], but MergeContext#mergeToManagedEntityXref does not."
 				);
 			}
 		}
@@ -260,15 +260,15 @@ public class MergeContext implements Map {
 			// mergeEntity was already mapped in mergeToManagedEntityXref
 			if ( oldManagedEntity != managedEntity ) {
 				throw new IllegalArgumentException(
-						"Error occurred while storing a merge Entity " + printEntity( mergeEntity )
-								+ ". It was previously associated with managed entity " + printEntity( oldManagedEntity )
-								+ ". Attempted to replace managed entity with " + printEntity( managedEntity )
+						"Error occurred while storing a merge Entity [" + printEntity( mergeEntity )
+								+ "]. It was previously associated with managed entity [" + printEntity( oldManagedEntity )
+								+ "]. Attempted to replace managed entity with " + printEntity( managedEntity )
 				);
 			}
 			if ( oldOperatedOn == null ) {
 				throw new IllegalStateException(
-						"MergeContext#mergeToManagedEntityXref contained a merge entity " + printEntity( mergeEntity )
-								+ ", but MergeContext#mergeEntityToOperatedOnFlagMap did not."
+						"MergeContext#mergeToManagedEntityXref contained a merge entity [" + printEntity( mergeEntity )
+								+ "], but MergeContext#mergeEntityToOperatedOnFlagMap did not."
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/OnLockVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/OnLockVisitor.java
@@ -43,26 +43,26 @@ public class OnLockVisitor extends ReattachVisitor {
 				if ( isOwnerUnchanged( persister, extractCollectionKeyFromOwner( persister ), persistentCollection ) ) {
 					// a "detached" collection that originally belonged to the same entity
 					if ( persistentCollection.isDirty() ) {
-						throw new HibernateException( "reassociated object has dirty collection" );
+						throw new HibernateException( "re-associated object has dirty collection" );
 					}
 					reattachCollection( persistentCollection, type );
 				}
 				else {
 					// a "detached" collection that belonged to a different entity
-					throw new HibernateException( "reassociated object has dirty collection reference" );
+					throw new HibernateException( "re-associated object has dirty collection reference" );
 				}
 			}
 			else {
 				// a collection loaded in the current session
 				// can not possibly be the collection belonging
 				// to the entity passed to update()
-				throw new HibernateException( "reassociated object has dirty collection reference" );
+				throw new HibernateException( "re-associated object has dirty collection reference" );
 			}
 		}
 		else {
 			// brand new collection
 			//TODO: or an array!! we can't lock objects with arrays now??
-			throw new HibernateException( "reassociated object has dirty collection reference (or an array)" );
+			throw new HibernateException( "re-associated object has dirty collection reference (or an array)" );
 		}
 
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/ProxyVisitor.java
@@ -68,7 +68,7 @@ public abstract class ProxyVisitor extends AbstractVisitor {
 		}
 		else {
 			if ( !isCollectionSnapshotValid( collection ) ) {
-				throw new HibernateException( "could not reassociate uninitialized transient collection" );
+				throw new HibernateException( "could not re-associate uninitialized transient collection" );
 			}
 			CollectionPersister collectionPersister = session.getFactory()
 					.getCollectionPersister( collection.getRole() );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/ReattachVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/ReattachVisitor.java
@@ -80,7 +80,7 @@ public abstract class ReattachVisitor extends ProxyVisitor {
 			throws HibernateException {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
-					"Collection dereferenced while transient {0}",
+					"Collection dereferenced while transient: {0}",
 					MessageHelper.collectionInfoString( role, ownerIdentifier, source.getFactory() )
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
@@ -240,7 +240,7 @@ class EventListenerGroupImpl<T> implements EventListenerGroup<T> {
 						}
 						case REPLACE_ORIGINAL: {
 							if ( debugEnabled ) {
-								log.debugf( "Replacing listener registration (%s) : `%s` -> %s", strategy.getAction(), existingListener, listener );
+								log.debugf( "Replacing listener registration (%s) : `%s` -> `%s`", strategy.getAction(), existingListener, listener );
 							}
 							prepareListener( listener );
 

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/ResolveNaturalIdEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/ResolveNaturalIdEvent.java
@@ -83,7 +83,7 @@ public class ResolveNaturalIdEvent extends AbstractEvent {
 			final String propertyName = entityPersister.getPropertyNames()[position];
 			if ( ! naturalIdValues.containsKey( propertyName ) ) {
 				throw new HibernateException(
-						String.format( "No value specified for natural-id property %s#%s", getEntityName(), propertyName )
+						String.format( "No value specified for natural-id property: %s#%s", getEntityName(), propertyName )
 				);
 			}
 			orderedNaturalIdValues[i++] = naturalIdValues.get( entityPersister.getPropertyNames()[position] );

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceIdentityGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceIdentityGenerator.java
@@ -74,7 +74,7 @@ public class SequenceIdentityGenerator
 			this.sequenceNextValFragment = dialect.getSelectSequenceNextValString( sequenceName );
 			this.keyColumns = getPersister().getRootTableKeyColumnNames();
 			if ( keyColumns.length > 1 ) {
-				throw new HibernateException( "sequence-identity generator cannot be used with with multi-column keys" );
+				throw new HibernateException( "sequence-identity generator cannot be used with multi-column keys" );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
@@ -78,7 +78,7 @@ public class Cloneable {
 					);
 				}
 				catch (Throwable t) {
-					throw new HibernateException( "Unable copy copy listener [" + pd.getName() + "]" );
+					throw new HibernateException( "Unable to copy listener [" + pd.getName() + "]" );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
@@ -145,7 +145,7 @@ public class JmxServiceImpl implements JmxService, Stoppable {
 			registerMBean( objectName, service.getManagementBean() );
 		}
 		catch ( MalformedObjectNameException e ) {
-			throw new HibernateException( "Unable to generate service IbjectName", e );
+			throw new HibernateException( "Unable to generate service ObjectName", e );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -185,7 +185,7 @@ public class AttributeFactory {
 	public <X, Y> SingularAttributeImpl<X, Y> buildVersionAttribute(
 			IdentifiableDomainType<X> ownerType,
 			Property property) {
-		LOG.trace( "Building version attribute [ownerType.getTypeName()" + "." + "property.getName()]" );
+		LOG.trace( "Building version attribute [" + ownerType.getTypeName() + "." + property.getName() + "]" );
 
 		final SingularAttributeMetadata<X, Y> attributeMetadata = (SingularAttributeMetadata<X, Y>) determineAttributeMetadata(
 				wrap( ownerType, property ),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/BaseAttributeMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/BaseAttributeMetadata.java
@@ -52,7 +52,7 @@ public abstract class BaseAttributeMetadata<X, Y> implements AttributeMetadata<X
 			declaredType = ( (MapMember) member ).getType();
 		}
 		else {
-			throw new IllegalArgumentException( "Cannot determine java-type from given member [" + member + "]" );
+			throw new IllegalArgumentException( "Cannot determine java type from given member [" + member + "]" );
 		}
 		//noinspection unchecked
 		this.javaType = AttributeFactory.accountForPrimitiveTypes( declaredType, metadataContext );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
@@ -163,7 +163,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 		else {
 			throw new AssertionFailure(
 					"Fail to process type argument in a generic declaration. Member : " + getMemberDescription()
-							+ " Type: " + type.getClass()
+							+ "; Type : " + type.getClass()
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/ElementPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/ElementPropertyMapping.java
@@ -47,7 +47,7 @@ public class ElementPropertyMapping implements PropertyMapping {
 	 * Given a property path, return the corresponding column name(s).
 	 */
 	public String[] toColumns(String propertyName) throws QueryException, UnsupportedOperationException {
-		throw new UnsupportedOperationException( "References to collections must be define a SQL alias" );
+		throw new UnsupportedOperationException( "References to collections must define an SQL alias" );
 	}
 
 	public Type getType() {

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -674,7 +674,7 @@ public class ProcedureCallImpl<R>
 		try {
 			final Output rtn = outputs().getCurrent();
 			if ( ! ResultSetOutput.class.isInstance( rtn ) ) {
-				throw new IllegalStateException( "Current CallableStatement ou was not a ResultSet, but getResultList was called" );
+				throw new IllegalStateException( "Current CallableStatement output was not a ResultSet, but getResultList was called" );
 			}
 
 			return ( (ResultSetOutput) rtn ).getResultList();
@@ -708,7 +708,7 @@ public class ProcedureCallImpl<R>
 		try {
 			final Output rtn = outputs().getCurrent();
 			if ( !(rtn instanceof ResultSetOutput) ) {
-				throw new IllegalStateException( "Current CallableStatement ou was not a ResultSet, but getResultList was called" );
+				throw new IllegalStateException( "Current CallableStatement output was not a ResultSet, but getResultList was called" );
 			}
 
 			return ( (ResultSetOutput) rtn ).getResultList();

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -236,7 +236,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			checkTargetState(session);
 		}
 		else {
-			throw new LazyInitializationException( "could not initialize proxy [" + entityName + "#" + id + "] - Session was closed or disced" );
+			throw new LazyInitializationException( "could not initialize proxy [" + entityName + "#" + id + "] - Session was closed or disconnected" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/ImmutableEntityUpdateQueryHandlingMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/ImmutableEntityUpdateQueryHandlingMode.java
@@ -51,7 +51,7 @@ public enum ImmutableEntityUpdateQueryHandlingMode {
 		}
 		throw new HibernateException(
 				"Unrecognized immutable_entity_update_query_handling_mode value : " + mode
-						+ ".  Supported values include 'warning' and 'exception''."
+						+ ".  Supported values include 'warning' and 'exception'."
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
@@ -96,7 +96,7 @@ public class ContainerManagedLifecycleStrategy implements BeanLifecycleStrategy 
 				throw e;
 			}
 			catch (Exception e) {
-				log.debugf( "Error resolving CDI bean [%s] - using fallback" );
+				log.debugf( "Error resolving CDI bean [%s] - using fallback", this.beanInstance );
 				this.beanInstance = produceFallbackInstance();
 				this.instance = null;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
@@ -167,7 +167,7 @@ public class OutputsImpl implements Outputs {
 		protected Output buildOutput() {
 			if ( log.isDebugEnabled() ) {
 				log.debugf(
-						"Building Return [isResultSet=%s, updateCount=%s, extendedReturn=%s",
+						"Building Return [isResultSet=%s, updateCount=%s, extendedReturn=%s]",
 						isResultSet(),
 						getUpdateCount(),
 						hasExtendedReturns()

--- a/hibernate-core/src/main/java/org/hibernate/transform/AliasToBeanResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/AliasToBeanResultTransformer.java
@@ -80,10 +80,10 @@ public class AliasToBeanResultTransformer extends AliasedTupleSubsetResultTransf
 			}
 		}
 		catch ( InstantiationException e ) {
-			throw new HibernateException( "Could not instantiate resultclass: " + resultClass.getName() );
+			throw new HibernateException( "Could not instantiate result class: " + resultClass.getName() );
 		}
 		catch ( IllegalAccessException e ) {
-			throw new HibernateException( "Could not instantiate resultclass: " + resultClass.getName() );
+			throw new HibernateException( "Could not instantiate result class: " + resultClass.getName() );
 		}
 
 		return result;

--- a/hibernate-core/src/main/java/org/hibernate/transform/AliasedTupleSubsetResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/AliasedTupleSubsetResultTransformer.java
@@ -24,7 +24,7 @@ public abstract class AliasedTupleSubsetResultTransformer
 		if ( aliases.length != tupleLength ) {
 			throw new IllegalArgumentException(
 					"aliases and tupleLength must have the same length; " +
-							"aliases.length=" + aliases.length + "tupleLength=" + tupleLength
+							"aliases.length=" + aliases.length + ";tupleLength=" + tupleLength
 			);
 		}
 		boolean[] includeInTransform = new boolean[tupleLength];

--- a/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
@@ -97,8 +97,8 @@ public class CacheableResultTransformer implements ResultTransformer {
 		int tupleLength = ArrayHelper.countTrue( includeInTuple );
 		if ( aliases != null && aliases.length != tupleLength ) {
 			throw new IllegalArgumentException(
-					"if aliases is not null, then the length of aliases[] must equal the number of true elements in includeInTuple; " +
-							"aliases.length=" + aliases.length + "tupleLength=" + tupleLength
+					"if aliases are not null, then the length of aliases must equal the number of true elements in includeInTuple; " +
+							"aliases.length=" + aliases.length + "; tupleLength=" + tupleLength
 			);
 		}
 		return new CacheableResultTransformer(

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/emops/MergeMultipleEntityCopiesDisallowedByDefaultTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/emops/MergeMultipleEntityCopiesDisallowedByDefaultTest.java
@@ -61,7 +61,7 @@ public class MergeMultipleEntityCopiesDisallowedByDefaultTest extends BaseEntity
 		em.getTransaction().begin();
 		try {
 			em.merge( hoarder );
-			fail( "should have failed due IllegalStateException");
+			fail( "should have failed due to IllegalStateException");
 		}
 		catch (IllegalStateException ex) {
 			//expected
@@ -106,7 +106,7 @@ public class MergeMultipleEntityCopiesDisallowedByDefaultTest extends BaseEntity
 		// now item1Merged is managed and it has a nested detached item
 		try {
 			em.merge( item1Merged );
-			fail( "should have failed due IllegalStateException");
+			fail( "should have failed due to IllegalStateException");
 		}
 		catch (IllegalStateException ex) {
 			//expected

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
@@ -77,7 +77,7 @@ public final class ClassWriter {
 		catch ( IOException ioEx ) {
 			context.logMessage(
 					Diagnostic.Kind.ERROR,
-					"Problem opening file to write MetaModel for " + entity.getSimpleName() + ioEx.getMessage()
+					"Problem opening file to write MetaModel for " + entity.getSimpleName() + ": " + ioEx.getMessage()
 			);
 		}
 	}


### PR DESCRIPTION
There are various verbiage issues in log messages for the natural reason of rare exposure, including

- typo
- grammatical error
- unintended concatenation due to code sloppiness
- misaligned String.format usage
- wrong content
- confusing references
- various improvements
- many others

This PR is another ambitious endeavour to improve non-coding quality (I've improved Javadoc and user guide previously).