### PR TITLE
Wip/6.0 Fix some log or exception messages

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/UnknownProfileException.java
+++ b/hibernate-core/src/main/java/org/hibernate/UnknownProfileException.java
@@ -20,7 +20,7 @@ public class UnknownProfileException extends HibernateException {
 	 * @param name The profile name that was unknown.
 	 */
 	public UnknownProfileException(String name) {
-		super( "Unknow fetch profile [" + name + "]" );
+		super( "Unknown fetch profile [" + name + "]" );
 		this.name = name;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -128,7 +128,7 @@ public class EntityDeleteAction extends EntityAction {
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityEntry entry = persistenceContext.removeEntry( instance );
 		if ( entry == null ) {
-			throw new AssertionFailure( "possible nonthreadsafe access to session" );
+			throw new AssertionFailure( "possible non-threadsafe access to session" );
 		}
 		entry.postDelete();
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -211,7 +211,7 @@ public class EntityUpdateAction extends EntityAction {
 
 		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( instance );
 		if ( entry == null ) {
-			throw new AssertionFailure( "possible nonthreadsafe access to session" );
+			throw new AssertionFailure( "possible non-threadsafe access to session" );
 		}
 
 		if ( entry.getStatus()==Status.MANAGED || persister.isVersionPropertyGenerated() ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/ArchiveHelper.java
@@ -118,7 +118,7 @@ public class ArchiveHelper {
 				jarUrl = new URL( "file:" + jarPath );
 			}
 			catch (MalformedURLException ee) {
-				throw new IllegalArgumentException( "Unable to find jar:" + jarPath, ee );
+				throw new IllegalArgumentException( "Unable to find jar: " + jarPath, ee );
 			}
 		}
 		return jarUrl;

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarProtocolArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarProtocolArchiveDescriptor.java
@@ -39,7 +39,7 @@ public class JarProtocolArchiveDescriptor implements ArchiveDescriptor {
 		final String urlFile = url.getFile();
 		final int subEntryIndex = urlFile.lastIndexOf( '!' );
 		if ( subEntryIndex == -1 ) {
-			throw new AssertionFailure( "JAR URL does not contain '!/' :" + url );
+			throw new AssertionFailure( "JAR URL does not contain '!/' : " + url );
 		}
 
 		final String subEntry;

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/ConfigLoader.java
@@ -168,7 +168,7 @@ public class ConfigLoader {
 		}
 		catch (FileNotFoundException e) {
 			throw new ConfigurationException(
-					"Unable locate specified properties file [" + file.getAbsolutePath() + "]",
+					"Unable to locate specified properties file [" + file.getAbsolutePath() + "]",
 					e
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
@@ -73,7 +73,7 @@ public class JaxbCfgProcessor {
 			}
 		}
 		catch ( XMLStreamException e ) {
-			throw new HibernateException( "Unable to create stax reader", e );
+			throw new HibernateException( "Unable to create StAX reader", e );
 		}
 	}
 
@@ -104,7 +104,7 @@ public class JaxbCfgProcessor {
 			}
 		}
 		catch ( Exception e ) {
-			throw new HibernateException( "Error accessing stax stream", e );
+			throw new HibernateException( "Error accessing StAX stream", e );
 		}
 
 		if ( event == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -298,7 +298,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		if ( matchingPersistentClass != null ) {
 			throw new DuplicateMappingException(
 					String.format(
-							"The [%s] and [%s] entities share the same JPA entity name: [%s] which is not allowed!",
+							"The [%s] and [%s] entities share the same JPA entity name: [%s], which is not allowed!",
 							matchingPersistentClass.getClassName(),
 							persistentClass.getClassName(),
 							jpaEntityName
@@ -478,7 +478,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		final IdentifierGeneratorDefinition old = idGeneratorDefinitionMap.put( generator.getName(), generator );
 		if ( old != null && !old.equals( generator ) ) {
 			if ( bootstrapContext.getJpaCompliance().isGlobalGeneratorScopeEnabled() ) {
-				throw new IllegalArgumentException( "Duplicate generator name " + old.getName() + " you will likely want to set the property " + AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE + " to false " );
+				throw new IllegalArgumentException( "Duplicate generator name " + old.getName() + "; you will likely want to set the property " + AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE + " to false " );
 			}
 			else {
 				log.duplicateGeneratorName( old.getName() );

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -97,7 +97,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		}
 		else if ( BootstrapServiceRegistry.class.isInstance( serviceRegistry ) ) {
 			log.debugf(
-					"ServiceRegistry passed to MetadataBuilder was a BootstrapServiceRegistry; this likely wont end well" +
+					"ServiceRegistry passed to MetadataBuilder was a BootstrapServiceRegistry; this likely won't end well " +
 							"if attempt is made to build SessionFactory"
 			);
 			return new StandardServiceRegistryBuilder( (BootstrapServiceRegistry) serviceRegistry ).build();

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/AbstractBinder.java
@@ -74,7 +74,7 @@ public abstract class AbstractBinder implements Binder {
 			return new BufferedXMLEventReader( staxReader, 100 );
 		}
 		catch ( XMLStreamException e ) {
-			throw new MappingException( "Unable to create stax reader", e, origin );
+			throw new MappingException( "Unable to create StAX reader", e, origin );
 		}
 	}
 
@@ -92,7 +92,7 @@ public abstract class AbstractBinder implements Binder {
 			return new BufferedXMLEventReader( staxReader, 100 );
 		}
 		catch ( XMLStreamException e ) {
-			throw new MappingException( "Unable to create stax reader", e, origin );
+			throw new MappingException( "Unable to create StAX reader", e, origin );
 		}
 	}
 
@@ -138,7 +138,7 @@ public abstract class AbstractBinder implements Binder {
 			}
 		}
 		catch ( Exception e ) {
-			throw new MappingException( "Error accessing stax stream", e, origin );
+			throw new MappingException( "Error accessing StAX stream", e, origin );
 		}
 
 		if ( rootElementStartEvent == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistry.java
@@ -92,7 +92,7 @@ public class TypeDefinitionRegistry {
 					throw new IllegalArgumentException(
 							String.format(
 									Locale.ROOT,
-									"Attempted to ovewrite registration [%s] for type definition.",
+									"Attempted to overwrite registration [%s] for type definition.",
 									name
 							)
 					);

--- a/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/NoCacheRegionFactoryAvailableException.java
@@ -17,8 +17,8 @@ import org.hibernate.cfg.Environment;
 public class NoCacheRegionFactoryAvailableException extends CacheException {
 	private static final String MSG = String.format(
 			"Second-level cache is used in the application, but property %s is not given; " +
-					"please either disable second level cache or set correct region factory using the %s setting " +
-					"and make sure the second level cache provider (hibernate-infinispan, e.g.) is available on the " +
+					"please either disable second-level cache or set correct region factory using the %s setting " +
+					"and make sure the second-level cache provider (hibernate-infinispan, e.g.) is available on the " +
 					"classpath.",
 			Environment.CACHE_REGION_FACTORY,
 			Environment.CACHE_REGION_FACTORY

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -317,7 +317,7 @@ public abstract class CollectionBinder {
 		}
 		else {
 			throw new AnnotationException(
-					"Illegal attempt to map a non collection as a @OneToMany, @ManyToMany or @CollectionOfElements: "
+					"Illegal attempt to map a non collection as a @OneToMany, @ManyToMany or @ElementCollection: "
 							+ StringHelper.qualify( entityName, property.getName() )
 			);
 		}
@@ -347,28 +347,28 @@ public abstract class CollectionBinder {
 			String entityName, boolean isIndexed) {
 		if ( java.util.Set.class.equals( clazz) ) {
 			if ( property.isAnnotationPresent( CollectionId.class) ) {
-				throw new AnnotationException("Set do not support @CollectionId: "
+				throw new AnnotationException("Set does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new SetBinder( false );
 		}
 		else if ( java.util.SortedSet.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Set do not support @CollectionId: "
+				throw new AnnotationException( "SortedSet does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new SetBinder( true );
 		}
 		else if ( java.util.Map.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Map do not support @CollectionId: "
+				throw new AnnotationException( "Map does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new MapBinder( false );
 		}
 		else if ( java.util.SortedMap.class.equals( clazz ) ) {
 			if ( property.isAnnotationPresent( CollectionId.class ) ) {
-				throw new AnnotationException( "Map do not support @CollectionId: "
+				throw new AnnotationException( "SortedMap does not support @CollectionId: "
 						+ StringHelper.qualify( entityName, property.getName() ) );
 			}
 			return new MapBinder( true );
@@ -385,7 +385,7 @@ public abstract class CollectionBinder {
 			if ( isIndexed ) {
 				if ( property.isAnnotationPresent( CollectionId.class ) ) {
 					throw new AnnotationException(
-							"List do not support @CollectionId and @OrderColumn (or @IndexColumn) at the same time: "
+							"List does not support @CollectionId and @OrderColumn (or @IndexColumn) at the same time: "
 									+ StringHelper.qualify( entityName, property.getName() ) );
 				}
 				return new ListBinder();
@@ -666,7 +666,7 @@ public abstract class CollectionBinder {
 		if ( isSortedCollection ) {
 			if ( ! hadExplicitSort && !hadOrderBy ) {
 				throw new AnnotationException(
-						"A sorted collection must define and ordering or sorting : " + safeCollectionRole()
+						"A sorted collection must define an ordering or sorting : " + safeCollectionRole()
 				);
 			}
 		}
@@ -723,7 +723,7 @@ public abstract class CollectionBinder {
 		}
 		else {
 			throw new AssertionFailure(
-					"Define fetch strategy on a property not annotated with @ManyToOne nor @OneToMany nor @CollectionOfElements"
+					"Define fetch strategy on a property not annotated with @ManyToOne nor @OneToMany nor @ElementCollection"
 			);
 		}
 		if ( lazy != null ) {
@@ -989,7 +989,7 @@ public abstract class CollectionBinder {
 					}
 			else {
 				throw new AnnotationException(
-						"Illegal use of @FilterJoinTable on an association without join table:"
+						"Illegal use of @FilterJoinTable on an association without join table: "
 								+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 				);
 			}
@@ -1004,7 +1004,7 @@ public abstract class CollectionBinder {
 				}
 				else {
 					throw new AnnotationException(
-							"Illegal use of @FilterJoinTable on an association without join table:"
+							"Illegal use of @FilterJoinTable on an association without join table: "
 									+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 					);
 				}
@@ -1067,7 +1067,7 @@ public abstract class CollectionBinder {
 			}
 			else {
 				throw new AnnotationException(
-						"Illegal use of @WhereJoinTable on an association without join table:"
+						"Illegal use of @WhereJoinTable on an association without join table: "
 								+ StringHelper.qualify( propertyHolder.getPath(), propertyName )
 				);
 			}
@@ -1313,7 +1313,7 @@ public abstract class CollectionBinder {
 				LOG.debugf("Binding a OneToMany: %s through an association table", path);
 			}
 			else if (isCollectionOfEntities) {
-				LOG.debugf("Binding as ManyToMany: %s", path);
+				LOG.debugf("Binding a ManyToMany: %s", path);
 			}
 			else if (anyAnn != null) {
 				LOG.debugf("Binding a ManyToAny: %s", path);
@@ -1365,7 +1365,7 @@ public abstract class CollectionBinder {
 			}
 			catch (MappingException e) {
 				throw new AnnotationException(
-						"mappedBy reference an unknown target entity property: "
+						"mappedBy references an unknown target entity property: "
 								+ collType + "." + joinColumns[0].getMappedBy() + " in "
 								+ collValue.getOwnerEntityName() + "." + joinColumns[0].getPropertyName()
 				);
@@ -1671,7 +1671,7 @@ public abstract class CollectionBinder {
 				!( collValue.getElement() instanceof SimpleValue ) && //SimpleValue (CollectionOfElements) are always SELECT but it does not matter
 				collValue.getElement().getFetchMode() != FetchMode.JOIN ) {
 			throw new MappingException(
-					"@ManyToMany or @CollectionOfElements defining filter or where without join fetching "
+					"@ManyToMany or @ElementCollection defining filter or where without join fetching "
 							+ "not valid within collection using join fetching[" + collValue.getRole() + "]"
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -532,7 +532,7 @@ public class MapBinder extends CollectionBinder {
 			return targetValue;
 		}
 		else {
-			throw new AssertionFailure( "Unknown type encounters for map key: " + value.getClass() );
+			throw new AssertionFailure( "Unknown type encountered for map key: " + value.getClass() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -362,7 +362,7 @@ public class PropertyBinder {
 			if ( candidate != null ) {
 				if ( valueGeneration != null ) {
 					throw new AnnotationException(
-							"Only one generator annotation is allowed:" + StringHelper.qualify(
+							"Only one generator annotation is allowed: " + StringHelper.qualify(
 									holder.getPath(),
 									name
 							)
@@ -436,7 +436,7 @@ public class PropertyBinder {
 		}
 		catch (Exception e) {
 			throw new AnnotationException(
-					"Exception occurred during processing of generator annotation:" + StringHelper.qualify(
+					"Exception occurred during processing of generator annotation: " + StringHelper.qualify(
 							holder.getPath(),
 							name
 					), e

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
@@ -234,7 +234,7 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 				}
 				catch (ClassCastException e) {
 					throw new MappingException(
-							"dotted notation reference neither a component nor a many/one to one", e
+							"dotted notation references neither a component nor a many/one to one", e
 					);
 				}
 			}
@@ -250,13 +250,13 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 				}
 				catch (ClassCastException e) {
 					throw new MappingException(
-							"dotted notation reference neither a component nor a many/one to one", e
+							"dotted notation references neither a component nor a many/one to one", e
 					);
 				}
 			}
 		}
 		else {
-			throw new MappingException( "dotted notation reference neither a component nor a many/one to one" );
+			throw new MappingException( "dotted notation references neither a component nor a many/one to one" );
 		}
 		return parentPropIter;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SimpleValueBinder.java
@@ -210,7 +210,7 @@ public class SimpleValueBinder {
 					}
 					case TIME: {
 						throw new NotYetImplementedException(
-								"Calendar cannot persist TIME only" + StringHelper.qualify( persistentClassName, propertyName )
+								"Calendar cannot persist TIME only: " + StringHelper.qualify( persistentClassName, propertyName )
 						);
 					}
 					default: {
@@ -492,7 +492,7 @@ public class SimpleValueBinder {
 			if ( ! BinderHelper.isEmptyAnnotationValue( explicitType ) ) {
 				throw new AnnotationException(
 						String.format(
-								"AttributeConverter and explicit Type cannot be applied to same attribute [%s.%s];" +
+								"AttributeConverter and explicit Type cannot be applied to same attribute [%s.%s]; " +
 										"remove @Type or specify @Convert(disableConversion = true)",
 								persistentClassName,
 								propertyName

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
@@ -640,7 +640,7 @@ public class TableBinder {
 					//implicit case, we hope PK and FK columns are in the same order
 					if ( columns.length != referencedEntity.getIdentifier().getColumnSpan() ) {
 						throw new AnnotationException(
-								"A Foreign key refering " + referencedEntity.getEntityName()
+								"A Foreign key referring " + referencedEntity.getEntityName()
 										+ " from " + associatedClass.getEntityName()
 										+ " has the wrong number of column. should be " + referencedEntity.getIdentifier()
 										.getColumnSpan()

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -1675,7 +1675,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( access + " is not a valid access type. Check you xml confguration." );
+				throw new AnnotationException( access + " is not a valid access type. Check you xml configuration." );
 			}
 
 			if ( ( AccessType.PROPERTY.equals( type ) && this.element instanceof Method ) ||
@@ -1881,7 +1881,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( access + " is not a valid access type. Check you xml confguration." );
+				throw new AnnotationException( access + " is not a valid access type. Check you xml configuration." );
 			}
 			ad.setValue( "value", type );
 			return AnnotationFactory.create( ad );
@@ -2481,7 +2481,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			copyStringAttribute( ann, subelement, "name", false );
 			Element queryElt = subelement.element( "query" );
 			if ( queryElt == null ) {
-				throw new AnnotationException( "No <query> element found." + SCHEMA_VALIDATION );
+				throw new AnnotationException( "No <query> element found. " + SCHEMA_VALIDATION );
 			}
 			copyStringElement( queryElt, ann, "query" );
 			List<Element> elements = subelement.elements( "hint" );
@@ -2614,7 +2614,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				}
 				else {
 					throw new AnnotationException(
-							"Unknown DiscrimiatorType in XML: " + value + " (" + SCHEMA_VALIDATION + ")"
+							"Unknown DiscriminatorType in XML: " + value + " (" + SCHEMA_VALIDATION + ")"
 					);
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -136,7 +136,7 @@ public class XMLContext implements Serializable {
 				type = AccessType.valueOf( access );
 			}
 			catch ( IllegalArgumentException e ) {
-				throw new AnnotationException( "Invalid access type " + access + " (check your xml configuration)" );
+				throw new AnnotationException( "Invalid access type: " + access + " (check your xml configuration)" );
 			}
 			defaultType.setAccess( type );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -612,7 +612,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		throw new LazyInitializationException(
 				"failed to lazily initialize a collection" +
 						(role == null ? "" : " of role: " + role) +
-						", " + message
+						": " + message
 		);
 	}
 
@@ -698,7 +698,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			final String msg = generateUnexpectedSessionStateMessage( session );
 			if ( isConnectedToSession() ) {
 				throw new HibernateException(
-						"Illegal attempt to associate a collection with two open sessions. " + msg
+						"Illegal attempt to associate a collection with two open sessions: " + msg
 				);
 			}
 			else {
@@ -783,7 +783,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	public final void forceInitialization() throws HibernateException {
 		if ( !initialized ) {
 			if ( initializing ) {
-				throw new AssertionFailure( "force initialize loading collection" );
+				throw new AssertionFailure( "force initializing collection loading" );
 			}
 			initialize( false );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
@@ -103,7 +103,7 @@ public class JTASessionContext extends AbstractCurrentSessionContext {
 					currentSession.close();
 				}
 				catch ( Throwable ignore ) {
-					LOG.debug( "Unable to release generated current-session on failed synch registration", ignore );
+					LOG.debug( "Unable to release generated current-session on failed synchronization registration", ignore );
 				}
 				throw new HibernateException( "Unable to register cleanup Synchronization with TransactionManager" );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/engine/OptimisticLockStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/OptimisticLockStyle.java
@@ -63,7 +63,7 @@ public enum OptimisticLockStyle {
 				return ALL;
 			}
 			default: {
-				throw new IllegalArgumentException( "Illegal legacy optimistic lock style code :" + oldCode );
+				throw new IllegalArgumentException( "Illegal legacy optimistic lock style code : " + oldCode );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -192,7 +192,7 @@ public class EntityEntryContext {
 			// NOTE: otherPersistenceContext may be operating on the entityEntry in a different thread.
 			//       it is not safe to associate entityEntry with this EntityEntryContext.
 			throw new HibernateException(
-					"Illegal attempt to associate a ManagedEntity with two open persistence contexts. " + entityEntry
+					"Illegal attempt to associate a ManagedEntity with two open persistence contexts: " + entityEntry
 			);
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdXrefDelegate.java
@@ -162,7 +162,7 @@ public class NaturalIdXrefDelegate {
 	 */
 	protected void validateNaturalId(EntityPersister persister, Object[] naturalIdValues) {
 		if ( !persister.hasNaturalIdentifier() ) {
-			throw new IllegalArgumentException( "Entity did not define a natrual-id" );
+			throw new IllegalArgumentException( "Entity did not define a natural-id" );
 		}
 		if ( persister.getNaturalIdentifierProperties().length != naturalIdValues.length ) {
 			throw new IllegalArgumentException( "Mismatch between expected number of natural-id values and found." );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeNullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeNullability.java
@@ -50,7 +50,7 @@ public enum TypeNullability {
 				return UNKNOWN;
 			}
 			default: {
-				throw new IllegalArgumentException( "Unknown type nullability code [" + code + "] enountered" );
+				throw new IllegalArgumentException( "Unknown type nullability code [" + code + "] encountered" );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeSearchability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeSearchability.java
@@ -58,7 +58,7 @@ public enum TypeSearchability {
 				return CHAR;
 			}
 			default: {
-				throw new IllegalArgumentException( "Unknown type searchability code [" + code + "] enountered" );
+				throw new IllegalArgumentException( "Unknown type searchability code [" + code + "] encountered" );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/QueryParameters.java
@@ -342,8 +342,8 @@ public final class QueryParameters {
 		final int values = positionalParameterValues == null ? 0 : positionalParameterValues.length;
 		if ( types != values ) {
 			throw new QueryException(
-					"Number of positional parameter types:" + types +
-							" does not match number of positional parameters: " + values
+					"Number of positional parameter types [" + types +
+							"] does not match number of positional parameters [" + values + "]"
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -114,7 +114,7 @@ public abstract class AbstractSaveEventListener
 		EntityPersister persister = source.getEntityPersister( entityName, entity );
 		Object generatedId = persister.getIdentifierGenerator().generate( source, entity );
 		if ( generatedId == null ) {
-			throw new IdentifierGenerationException( "null id generated for:" + entity.getClass() );
+			throw new IdentifierGenerationException( "null id generated for: " + entity.getClass() );
 		}
 		else if ( generatedId == IdentifierGeneratorHelper.SHORT_CIRCUIT_INDICATOR ) {
 			return source.getIdentifier( entity );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
@@ -65,7 +65,7 @@ public class DefaultAutoFlushEventListener extends AbstractFlushingEventListener
 					}
 				}
 				else {
-					LOG.trace( "Don't need to execute flush" );
+					LOG.trace( "No need to execute flush" );
 					event.setFlushRequired( false );
 					actionQueue.clearFromFlushNeededCheck( oldSize );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -79,7 +79,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			if ( !persister.getIdentifierType().isEqual( id, oid, session.getFactory() ) ) {
 				throw new HibernateException(
 						"identifier of an instance of " + persister.getEntityName() + " was altered from "
-								+ id + " to " + oid
+								+ oid + " to " + id
 				);
 			}
 		}
@@ -283,7 +283,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 				}
 				else {
 					LOG.tracev(
-							"Updating deleted entity: ",
+							"Updating deleted entity: {0}",
 							MessageHelper.infoString( persister, entry.getId(), session.getFactory() )
 					);
 				}

--- a/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
@@ -240,7 +240,7 @@ class EventListenerGroupImpl<T> implements EventListenerGroup<T> {
 						}
 						case REPLACE_ORIGINAL: {
 							if ( debugEnabled ) {
-								log.debugf( "Replacing listener registration (%s) : `%s` -> %s", strategy.getAction(), existingListener, listener );
+								log.debugf( "Replacing listener registration (%s) : `%s` -> `%s`", strategy.getAction(), existingListener, listener );
 							}
 							prepareListener( listener );
 

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceIdentityGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceIdentityGenerator.java
@@ -74,7 +74,7 @@ public class SequenceIdentityGenerator
 			this.sequenceNextValFragment = dialect.getSelectSequenceNextValString( sequenceName );
 			this.keyColumns = getPersister().getRootTableKeyColumnNames();
 			if ( keyColumns.length > 1 ) {
-				throw new HibernateException( "sequence-identity generator cannot be used with with multi-column keys" );
+				throw new HibernateException( "sequence-identity generator cannot be used with multi-column keys" );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -195,7 +195,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			}
 			if ( sharedOptions.getPhysicalConnectionHandlingMode() != this.jdbcCoordinator.getLogicalConnection().getConnectionHandlingMode() ) {
 				log.debug(
-						"Session creation specified 'PhysicalConnectionHandlingMode which is invalid in conjunction " +
+						"Session creation specified 'PhysicalConnectionHandlingMode' which is invalid in conjunction " +
 								"with sharing JDBC connection between sessions; ignoring"
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -665,7 +665,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		//		2) an explicit SynchronizationType is specified
 		if ( !getServiceRegistry().getService( TransactionCoordinatorBuilder.class ).isJta() ) {
 			throw new IllegalStateException(
-					"Illegal attempt to specify a SynchronizationType when building an EntityManager from a " +
+					"Illegal attempt to specify a SynchronizationType when building an EntityManager from an " +
 							"EntityManagerFactory defined as RESOURCE_LOCAL (as opposed to JTA)"
 			);
 		}
@@ -879,7 +879,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		// if we get here, we are unsure how to properly unwrap the incoming query to extract the needed information
 		throw new PersistenceException(
 				String.format(
-						"Unsure how to how to properly unwrap given Query [%s] as basis for named query",
+						"Unsure how to properly unwrap given Query [%s] as basis for named query",
 						query
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
@@ -78,7 +78,7 @@ public class Cloneable {
 					);
 				}
 				catch (Throwable t) {
-					throw new HibernateException( "Unable copy copy listener [" + pd.getName() + "]" );
+					throw new HibernateException( "Unable to copy listener [" + pd.getName() + "]" );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/xml/DTDEntityResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/xml/DTDEntityResolver.java
@@ -71,7 +71,7 @@ public class DTDEntityResolver implements EntityResolver, Serializable {
 					LOG.debugf( "Unable to locate [%s] on classpath", systemId );
 				}
 				else {
-					LOG.debugf( "Located [%s] in classpath", systemId );
+					LOG.debugf( "Located [%s] on classpath", systemId );
 					source = new InputSource( stream );
 					source.setPublicId( publicId );
 					source.setSystemId( systemId );
@@ -92,7 +92,7 @@ public class DTDEntityResolver implements EntityResolver, Serializable {
 			}
 		}
 		else {
-			LOG.debugf( "Located [%s] in classpath", systemId );
+			LOG.debugf( "Located [%s] on classpath", systemId );
 			source = new InputSource( dtdStream );
 			source.setPublicId( publicId );
 			source.setSystemId( systemId );

--- a/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
@@ -145,7 +145,7 @@ public class JmxServiceImpl implements JmxService, Stoppable {
 			registerMBean( objectName, service.getManagementBean() );
 		}
 		catch ( MalformedObjectNameException e ) {
-			throw new HibernateException( "Unable to generate service IbjectName", e );
+			throw new HibernateException( "Unable to generate service ObjectName", e );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/CacheEntityLoaderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/CacheEntityLoaderHelper.java
@@ -160,7 +160,7 @@ public class CacheEntityLoaderHelper extends AbstractLockUpgradeEventListener {
 		if ( entry.isReferenceEntry() ) {
 			if ( event.getInstanceToLoad() != null ) {
 				throw new HibernateException(
-						"Attempt to load entity [%s] from cache using provided object instance, but cache " +
+						"Attempt to load entity from cache using provided object instance, but cache " +
 								"is storing references: " + event.getEntityId() );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -182,7 +182,7 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 				throw new MappingException(
 						"Circular inheritance mapping detected: " +
 								subclass.getEntityName() +
-								" will have it self as superclass when extending " +
+								" will have itself as superclass when extending " +
 								getEntityName()
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -185,7 +185,7 @@ public class AttributeFactory {
 	public <X, Y> SingularAttributeImpl<X, Y> buildVersionAttribute(
 			IdentifiableDomainType<X> ownerType,
 			Property property) {
-		LOG.trace( "Building version attribute [ownerType.getTypeName()" + "." + "property.getName()]" );
+		LOG.trace( "Building version attribute [" + ownerType.getTypeName() + "." + property.getName() + "]" );
 
 		final SingularAttributeMetadata<X, Y> attributeMetadata = (SingularAttributeMetadata<X, Y>) determineAttributeMetadata(
 				wrap( ownerType, property ),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -309,7 +309,7 @@ public class JpaMetamodelImpl implements JpaMetamodel {
 	private void applyNamedEntityGraphs(java.util.Collection<NamedEntityGraphDefinition> namedEntityGraphs) {
 		for ( NamedEntityGraphDefinition definition : namedEntityGraphs ) {
 			log.debugf(
-					"Applying named entity graph [name=%s, entity-name=%s, jpa-entity-name=%s",
+					"Applying named entity graph [name=%s, entity-name=%s, jpa-entity-name=%s]",
 					definition.getRegisteredName(),
 					definition.getEntityName(),
 					definition.getJpaEntityName()

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/ElementPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/ElementPropertyMapping.java
@@ -47,7 +47,7 @@ public class ElementPropertyMapping implements PropertyMapping {
 	 * Given a property path, return the corresponding column name(s).
 	 */
 	public String[] toColumns(String propertyName) throws QueryException, UnsupportedOperationException {
-		throw new UnsupportedOperationException( "References to collections must be define a SQL alias" );
+		throw new UnsupportedOperationException( "References to collections must define an SQL alias" );
 	}
 
 	public Type getType() {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -236,7 +236,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			checkTargetState(session);
 		}
 		else {
-			throw new LazyInitializationException( "could not initialize proxy [" + entityName + "#" + id + "] - Session was closed or disced" );
+			throw new LazyInitializationException( "could not initialize proxy [" + entityName + "#" + id + "] - Session was closed or disconnected" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/ImmutableEntityUpdateQueryHandlingMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/ImmutableEntityUpdateQueryHandlingMode.java
@@ -51,7 +51,7 @@ public enum ImmutableEntityUpdateQueryHandlingMode {
 		}
 		throw new HibernateException(
 				"Unrecognized immutable_entity_update_query_handling_mode value : " + mode
-						+ ".  Supported values include 'warning' and 'exception''."
+						+ ".  Supported values include 'warning' and 'exception'."
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
@@ -96,7 +96,7 @@ public class ContainerManagedLifecycleStrategy implements BeanLifecycleStrategy 
 				throw e;
 			}
 			catch (Exception e) {
-				log.debugf( "Error resolving CDI bean [%s] - using fallback" );
+				log.debugf( "Error resolving CDI bean - using fallback" );
 				this.beanInstance = produceFallbackInstance();
 				this.instance = null;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
@@ -167,7 +167,7 @@ public class OutputsImpl implements Outputs {
 		protected Output buildOutput() {
 			if ( log.isDebugEnabled() ) {
 				log.debugf(
-						"Building Return [isResultSet=%s, updateCount=%s, extendedReturn=%s",
+						"Building Return [isResultSet=%s, updateCount=%s, extendedReturn=%s]",
 						isResultSet(),
 						getUpdateCount(),
 						hasExtendedReturns()

--- a/hibernate-core/src/main/java/org/hibernate/transform/AliasedTupleSubsetResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/AliasedTupleSubsetResultTransformer.java
@@ -24,7 +24,7 @@ public abstract class AliasedTupleSubsetResultTransformer
 		if ( aliases.length != tupleLength ) {
 			throw new IllegalArgumentException(
 					"aliases and tupleLength must have the same length; " +
-							"aliases.length=" + aliases.length + "tupleLength=" + tupleLength
+							"aliases.length=" + aliases.length + "; tupleLength=" + tupleLength
 			);
 		}
 		boolean[] includeInTransform = new boolean[tupleLength];

--- a/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/CacheableResultTransformer.java
@@ -97,8 +97,8 @@ public class CacheableResultTransformer implements ResultTransformer {
 		int tupleLength = ArrayHelper.countTrue( includeInTuple );
 		if ( aliases != null && aliases.length != tupleLength ) {
 			throw new IllegalArgumentException(
-					"if aliases is not null, then the length of aliases[] must equal the number of true elements in includeInTuple; " +
-							"aliases.length=" + aliases.length + "tupleLength=" + tupleLength
+					"if aliases are not null, then the length of aliases must equal the number of true elements in includeInTuple; " +
+							"aliases.length=" + aliases.length + "; tupleLength=" + tupleLength
 			);
 		}
 		return new CacheableResultTransformer(

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/emops/MergeMultipleEntityCopiesDisallowedByDefaultTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/emops/MergeMultipleEntityCopiesDisallowedByDefaultTest.java
@@ -61,7 +61,7 @@ public class MergeMultipleEntityCopiesDisallowedByDefaultTest extends BaseEntity
 		em.getTransaction().begin();
 		try {
 			em.merge( hoarder );
-			fail( "should have failed due IllegalStateException");
+			fail( "should have failed due to IllegalStateException");
 		}
 		catch (IllegalStateException ex) {
 			//expected
@@ -106,7 +106,7 @@ public class MergeMultipleEntityCopiesDisallowedByDefaultTest extends BaseEntity
 		// now item1Merged is managed and it has a nested detached item
 		try {
 			em.merge( item1Merged );
-			fail( "should have failed due IllegalStateException");
+			fail( "should have failed due to IllegalStateException");
 		}
 		catch (IllegalStateException ex) {
 			//expected

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
@@ -77,7 +77,7 @@ public final class ClassWriter {
 		catch ( IOException ioEx ) {
 			context.logMessage(
 					Diagnostic.Kind.ERROR,
-					"Problem opening file to write MetaModel for " + entity.getSimpleName() + ioEx.getMessage()
+					"Problem opening file to write MetaModel for " + entity.getSimpleName() + ": " + ioEx.getMessage()
 			);
 		}
 	}


### PR DESCRIPTION
There are various verbiage issues in log messages for the natural reason of rare exposure, including

- typo
- grammatical error
- unintended concatenation without whitespace delimiter
- misaligned String.format usage (format placeholder has different number than provided)
- wrong content
- confusing references
- various improvements

This is the part 1 of such efforts. I didn't include everything for that would make review too demanding and time consuming. Might consider followup later.