### PR TITLE
Wip/6.0 Fix HQL 'setClause' ANTLR grammar error

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -44,7 +44,7 @@ updateStatement
 	;
 
 setClause
-	: SET assignment+
+	: SET assignment (COMMA assignment)*
 	;
 
 assignment


### PR DESCRIPTION
Seems an obvious bug. I found this during the 'column quoting' verification developing.

The original grammar would be broken for the following HQL statements involving multiple set clauses:
```
update Product p set p.name = ?1, p.description = ?2 were p.id = 1
```
Obviously we need `COMMA` here.