### PR TITLE
HHH-13884 Order.reverse() contract

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/OrderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/OrderImpl.java
@@ -5,6 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.query.criteria.internal;
+
 import java.io.Serializable;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Order;
@@ -15,8 +16,9 @@ import javax.persistence.criteria.Order;
  * @author Steve Ebersole
  */
 public class OrderImpl implements Order, Serializable {
+
 	private final Expression<?> expression;
-	private boolean ascending;
+	private final boolean ascending;
 
 	public OrderImpl(Expression<?> expression) {
 		this( expression, true );
@@ -28,8 +30,7 @@ public class OrderImpl implements Order, Serializable {
 	}
 
 	public Order reverse() {
-		ascending = !ascending;
-		return this;
+		return new OrderImpl( expression, !ascending );
 	}
 
 	public boolean isAscending() {

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/HHH13884Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/HHH13884Test.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query.criteria.internal;
+
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Order;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author seregamorph
+ */
+@TestForIssue(jiraKey = "HHH-13884")
+public class HHH13884Test {
+
+	@Test
+	public void testDefaultReversedOrderImpl() {
+		Expression<?> expression = mock( Expression.class );
+
+		OrderImpl order = new OrderImpl( expression );
+
+		assertEquals( expression, order.getExpression() );
+		assertTrue( "Order should be ascending by default", order.isAscending() );
+
+		Order reversed = order.reverse();
+
+		assertEquals( expression, reversed.getExpression() );
+		assertFalse( "Reversed Order should be descending", reversed.isAscending() );
+
+		assertNotSame( "Order.reverse() should create new instance by the contract", order, reversed );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13884

backport for #3272

[javax.persistence.criteria.Order.reverse()](https://docs.jboss.org/hibernate/jpa/2.2/api/javax/persistence/criteria/Order.html#reverse--) method javadoc explicitly declares that `reverse()` should return new instance.