### PR TITLE
Wip/6.0 Fix a double-checked locking implementation imperfection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -753,7 +753,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	// lazily initialize instance field via 'double-checked locking'
-	// see https://en.wikipedia.org/wiki/Double-checked_locking
+	// see https://en.wikipedia.org/wiki/Double-checked_locking on why 'volatile' and local copy is used
 	protected CollectionLoader getStandardCollectionLoader() {
 		CollectionLoader localCopy = standardCollectionLoader;
 		if ( localCopy == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -744,7 +744,7 @@ public abstract class AbstractCollectionPersister
 		}
 	}
 
-	private CollectionLoader standardCollectionLoader;
+	private volatile CollectionLoader standardCollectionLoader;
 
 	@Override
 	public void initialize(Object key, SharedSessionContractImplementor session) throws HibernateException {
@@ -752,10 +752,13 @@ public abstract class AbstractCollectionPersister
 		determineLoaderToUse( key, session ).load( key, session );
 	}
 
+	// lazily initialize instance field via 'double-checked locking'
+	// see https://en.wikipedia.org/wiki/Double-checked_locking
 	protected CollectionLoader getStandardCollectionLoader() {
 		CollectionLoader localCopy = standardCollectionLoader;
 		if ( localCopy == null ) {
 			synchronized (this) {
+				localCopy = standardCollectionLoader;
 				if ( localCopy == null ) {
 					localCopy = createCollectionLoader( LoadQueryInfluencers.NONE );
 					standardCollectionLoader  = localCopy;


### PR DESCRIPTION
Double checked locking is subtle and error-prone. There is some imperfection as per https://en.wikipedia.org/wiki/Double-checked_locking. See code review self-comment for details.