### PR TITLE
Wip/6.0 Make List.toArray() usage consistent

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
@@ -91,7 +91,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 			}
 		}
 
-		this.affectedTableSpaces = spacesList.toArray( new String[ spacesList.size() ] );
+		this.affectedTableSpaces = spacesList.toArray( new String[ 0 ] );
 	}
 
 	/**
@@ -138,7 +138,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 			}
 		}
 
-		this.affectedTableSpaces = spacesList.toArray( new String[ spacesList.size() ] );
+		this.affectedTableSpaces = spacesList.toArray( new String[ 0 ] );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -889,7 +889,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	@Override
 	public SessionFactoryObserver[] getSessionFactoryObservers() {
-		return sessionFactoryObserverList.toArray( new SessionFactoryObserver[ sessionFactoryObserverList.size() ] );
+		return sessionFactoryObserverList.toArray( new SessionFactoryObserver[ 0 ] );
 	}
 
 	@Override
@@ -1109,7 +1109,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	@Override
 	public EntityNameResolver[] getEntityNameResolvers() {
-		return entityNameResolvers.toArray( new EntityNameResolver[ entityNameResolvers.size() ] );
+		return entityNameResolvers.toArray( new EntityNameResolver[ 0 ] );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -54,7 +54,7 @@ public class NamingHelper {
 			columnNamesArray = new Identifier[0];
 		}
 		else {
-			columnNamesArray = columnNames.toArray( new Identifier[ columnNames.size() ] );
+			columnNamesArray = columnNames.toArray( new Identifier[ 0 ] );
 		}
 
 		return generateHashedFkName(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ResultSetMappingBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ResultSetMappingBinder.java
@@ -402,7 +402,7 @@ public abstract class ResultSetMappingBinder {
 			Map.Entry entry = (Map.Entry) o;
 			if ( entry.getValue() instanceof ArrayList ) {
 				ArrayList list = (ArrayList) entry.getValue();
-				entry.setValue( list.toArray( new String[list.size()] ) );
+				entry.setValue( list.toArray( new String[ 0 ] ) );
 			}
 		}
 		return results.isEmpty() ? Collections.EMPTY_MAP : results;

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedClassLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/classloading/internal/AggregatedClassLoader.java
@@ -18,7 +18,7 @@ public class AggregatedClassLoader extends ClassLoader {
 
 	public AggregatedClassLoader(final LinkedHashSet<ClassLoader> orderedClassLoaderSet, TcclLookupPrecedence precedence) {
 		super( null );
-		individualClassLoaders = orderedClassLoaderSet.toArray( new ClassLoader[orderedClassLoaderSet.size()] );
+		individualClassLoaders = orderedClassLoaderSet.toArray( new ClassLoader[ 0 ] );
 		tcclLookupPrecedence = precedence;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCollectionCacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCollectionCacheEntry.java
@@ -32,7 +32,7 @@ public class StructuredCollectionCacheEntry implements CacheEntryStructure {
 	@Override
 	public Object destructure(Object structured, SessionFactoryImplementor factory) {
 		final List list = (List) structured;
-		return new CollectionCacheEntry( list.toArray( new Serializable[list.size()] ) );
+		return new CollectionCacheEntry( list.toArray( new Serializable[ 0 ] ) );
 	}
 
 	private StructuredCollectionCacheEntry() {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
@@ -434,7 +434,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 				for (Map.Entry<String, List<Column>> entry : columnOverrideList.entrySet()) {
 					columnOverride.put(
 						entry.getKey(),
-						entry.getValue().toArray( new Column[entry.getValue().size()] )
+						entry.getValue().toArray( new Column[ 0 ] )
 					);
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -381,7 +381,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				addIfNotNull( annotationList, getEntityListeners( tree, defaults ) );
 				addIfNotNull( annotationList, getConverts( tree, defaults ) );
 
-				this.annotations = annotationList.toArray( new Annotation[annotationList.size()] );
+				this.annotations = annotationList.toArray( new Annotation[ 0 ] );
 				for ( Annotation ann : this.annotations ) {
 					annotationsMap.put( ann.annotationType(), ann );
 				}
@@ -426,7 +426,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				}
 				processEventAnnotations( annotationList, defaults );
 				//FIXME use annotationsMap rather than annotationList this will be faster since the annotation type is usually known at put() time
-				this.annotations = annotationList.toArray( new Annotation[annotationList.size()] );
+				this.annotations = annotationList.toArray( new Annotation[ 0 ] );
 				for ( Annotation ann : this.annotations ) {
 					annotationsMap.put( ann.annotationType(), ann );
 				}
@@ -474,7 +474,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 
 		if ( !convertAnnotationsMap.isEmpty() ) {
 			final AnnotationDescriptor groupingDescriptor = new AnnotationDescriptor( Converts.class );
-			groupingDescriptor.setValue( "value", convertAnnotationsMap.values().toArray( new Convert[convertAnnotationsMap.size()]) );
+			groupingDescriptor.setValue( "value", convertAnnotationsMap.values().toArray( new Convert[ 0 ]) );
 			return AnnotationFactory.create( groupingDescriptor );
 		}
 
@@ -499,7 +499,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 
 		if ( !convertAnnotationsMap.isEmpty() ) {
 			final AnnotationDescriptor groupingDescriptor = new AnnotationDescriptor( Converts.class );
-			groupingDescriptor.setValue( "value", convertAnnotationsMap.values().toArray( new Convert[convertAnnotationsMap.size()]) );
+			groupingDescriptor.setValue( "value", convertAnnotationsMap.values().toArray( new Convert[ 0 ]) );
 			return AnnotationFactory.create( groupingDescriptor );
 		}
 
@@ -739,7 +739,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				}
 			}
 			AnnotationDescriptor ad = new AnnotationDescriptor( EntityListeners.class );
-			ad.setValue( "value", entityListenerClasses.toArray( new Class[entityListenerClasses.size()] ) );
+			ad.setValue( "value", entityListenerClasses.toArray( new Class[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else if ( defaults.canUseJavaAnnotations() ) {
@@ -1038,7 +1038,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				joinColumns.add( AnnotationFactory.create( column ) );
 			}
 		}
-		return joinColumns.toArray( new MapKeyJoinColumn[joinColumns.size()] );
+		return joinColumns.toArray( new MapKeyJoinColumn[ 0 ] );
 	}
 
 	private AttributeOverrides getMapKeyAttributeOverrides(Element tree, XMLContext.Default defaults) {
@@ -1318,7 +1318,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			cascades.add( CascadeType.PERSIST );
 		}
 		if ( cascades.size() > 0 ) {
-			ad.setValue( "cascade", cascades.toArray( new CascadeType[cascades.size()] ) );
+			ad.setValue( "cascade", cascades.toArray( new CascadeType[ 0 ] ) );
 		}
 	}
 
@@ -1606,7 +1606,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( columns.size() > 0 ) {
 			AnnotationDescriptor columnsDescr = new AnnotationDescriptor( Columns.class );
-			columnsDescr.setValue( "columns", columns.toArray( new Column[columns.size()] ) );
+			columnsDescr.setValue( "columns", columns.toArray( new Column[ 0 ] ) );
 			return AnnotationFactory.create( columnsDescr );
 		}
 		else {
@@ -1708,7 +1708,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( attributes.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( AssociationOverrides.class );
-			ad.setValue( "value", attributes.toArray( new AssociationOverride[attributes.size()] ) );
+			ad.setValue( "value", attributes.toArray( new AssociationOverride[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -1753,7 +1753,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				joinColumns.add( AnnotationFactory.create( column ) );
 			}
 		}
-		return joinColumns.toArray( new JoinColumn[joinColumns.size()] );
+		return joinColumns.toArray( new JoinColumn[ 0 ] );
 	}
 
 	private void addAssociationOverrideIfNeeded(AssociationOverride annotation, List<AssociationOverride> overrides) {
@@ -1802,7 +1802,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( attributes.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( AttributeOverrides.class );
-			ad.setValue( "value", attributes.toArray( new AttributeOverride[attributes.size()] ) );
+			ad.setValue( "value", attributes.toArray( new AttributeOverride[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -1937,7 +1937,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( results.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( SqlResultSetMappings.class );
-			ad.setValue( "value", results.toArray( new SqlResultSetMapping[results.size()] ) );
+			ad.setValue( "value", results.toArray( new SqlResultSetMapping[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -1996,7 +1996,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			annSubgraphNodes.add( AnnotationFactory.create( annSubgraphNode ) );
 		}
 
-		ann.setValue( "subgraphs", annSubgraphNodes.toArray( new NamedSubgraph[annSubgraphNodes.size()] ) );
+		ann.setValue( "subgraphs", annSubgraphNodes.toArray( new NamedSubgraph[ 0 ] ) );
 	}
 
 	private static void bindNamedAttributeNodes(Element subElement, AnnotationDescriptor ann) {
@@ -2009,7 +2009,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			copyStringAttribute( annNamedAttributeNode, namedAttributeNode, "key-subgraph", false );
 			annNamedAttributeNodes.add( AnnotationFactory.create( annNamedAttributeNode ) );
 		}
-		ann.setValue( "attributeNodes", annNamedAttributeNodes.toArray( new NamedAttributeNode[annNamedAttributeNodes.size()] ) );
+		ann.setValue( "attributeNodes", annNamedAttributeNodes.toArray( new NamedAttributeNode[ 0 ] ) );
 	}
 
 	public static List<NamedStoredProcedureQuery> buildNamedStoreProcedureQueries(
@@ -2056,7 +2056,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 
 			ann.setValue(
 					"parameters",
-					storedProcedureParameters.toArray( new StoredProcedureParameter[storedProcedureParameters.size()] )
+					storedProcedureParameters.toArray( new StoredProcedureParameter[ 0 ] )
 			);
 
 			elements = subElement.elements( "result-class" );
@@ -2074,7 +2074,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				}
 				returnClasses.add( clazz );
 			}
-			ann.setValue( "resultClasses", returnClasses.toArray( new Class[returnClasses.size()] ) );
+			ann.setValue( "resultClasses", returnClasses.toArray( new Class[ 0 ] ) );
 
 
 			elements = subElement.elements( "result-set-mapping" );
@@ -2082,7 +2082,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			for ( Element resultSetMappingElement : elements ) {
 				resultSetMappings.add( resultSetMappingElement.getTextTrim() );
 			}
-			ann.setValue( "resultSetMappings", resultSetMappings.toArray( new String[resultSetMappings.size()] ) );
+			ann.setValue( "resultSetMappings", resultSetMappings.toArray( new String[ 0 ] ) );
 			elements = subElement.elements( "hint" );
 			buildQueryHints( elements, ann );
 			namedStoredProcedureQueries.add( AnnotationFactory.create( ann ) );
@@ -2163,19 +2163,19 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			if ( entityResultAnnotations != null && !entityResultAnnotations.isEmpty() ) {
 				resultSetMappingAnnotation.setValue(
 						"entities",
-						entityResultAnnotations.toArray( new EntityResult[entityResultAnnotations.size()] )
+						entityResultAnnotations.toArray( new EntityResult[ 0 ] )
 				);
 			}
 			if ( columnResultAnnotations != null && !columnResultAnnotations.isEmpty() ) {
 				resultSetMappingAnnotation.setValue(
 						"columns",
-						columnResultAnnotations.toArray( new ColumnResult[columnResultAnnotations.size()] )
+						columnResultAnnotations.toArray( new ColumnResult[ 0 ] )
 				);
 			}
 			if ( constructorResultAnnotations != null && !constructorResultAnnotations.isEmpty() ) {
 				resultSetMappingAnnotation.setValue(
 						"classes",
-						constructorResultAnnotations.toArray( new ConstructorResult[constructorResultAnnotations.size()] )
+						constructorResultAnnotations.toArray( new ConstructorResult[ 0 ] )
 				);
 			}
 
@@ -2209,7 +2209,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			fieldResultAnnotations.add( AnnotationFactory.create( fieldResultDescriptor ) );
 		}
 		entityResultDescriptor.setValue(
-				"fields", fieldResultAnnotations.toArray( new FieldResult[fieldResultAnnotations.size()] )
+				"fields", fieldResultAnnotations.toArray( new FieldResult[ 0 ] )
 		);
 		return AnnotationFactory.create( entityResultDescriptor );
 	}
@@ -2263,7 +2263,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		constructorResultDescriptor.setValue(
 				"columns",
-				columnResultAnnotations.toArray( new ColumnResult[ columnResultAnnotations.size() ] )
+				columnResultAnnotations.toArray( new ColumnResult[ 0 ] )
 		);
 
 		return AnnotationFactory.create( constructorResultDescriptor );
@@ -2300,7 +2300,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( queries.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( NamedQueries.class );
-			ad.setValue( "value", queries.toArray( new NamedQuery[queries.size()] ) );
+			ad.setValue( "value", queries.toArray( new NamedQuery[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -2338,7 +2338,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( queries.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( NamedEntityGraphs.class );
-			ad.setValue( "value", queries.toArray( new NamedEntityGraph[queries.size()] ) );
+			ad.setValue( "value", queries.toArray( new NamedEntityGraph[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -2377,7 +2377,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( queries.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( NamedStoredProcedureQueries.class );
-			ad.setValue( "value", queries.toArray( new NamedStoredProcedureQuery[queries.size()] ) );
+			ad.setValue( "value", queries.toArray( new NamedStoredProcedureQuery[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -2418,7 +2418,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( queries.size() > 0 ) {
 			AnnotationDescriptor ad = new AnnotationDescriptor( NamedNativeQueries.class );
-			ad.setValue( "value", queries.toArray( new NamedNativeQuery[queries.size()] ) );
+			ad.setValue( "value", queries.toArray( new NamedNativeQuery[ 0 ] ) );
 			return AnnotationFactory.create( ad );
 		}
 		else {
@@ -2458,7 +2458,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			hintDescriptor.setValue( "value", value );
 			queryHints.add( AnnotationFactory.create( hintDescriptor ) );
 		}
-		ann.setValue( "hints", queryHints.toArray( new QueryHint[queryHints.size()] ) );
+		ann.setValue( "hints", queryHints.toArray( new QueryHint[ 0 ] ) );
 	}
 
 	public static List buildNamedQueries(
@@ -2884,7 +2884,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 		}
 		if ( secondaryTables.size() > 0 ) {
 			AnnotationDescriptor descriptor = new AnnotationDescriptor( SecondaryTables.class );
-			descriptor.setValue( "value", secondaryTables.toArray( new SecondaryTable[secondaryTables.size()] ) );
+			descriptor.setValue( "value", secondaryTables.toArray( new SecondaryTable[ 0 ] ) );
 			return AnnotationFactory.create( descriptor );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/GroupsPerOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/GroupsPerOperation.java
@@ -83,7 +83,7 @@ public class GroupsPerOperation {
 					}
 				}
 			}
-			return groupsList.toArray( new Class<?>[groupsList.size()] );
+			return groupsList.toArray( new Class<?>[ 0 ] );
 		}
 
 		//null is bad and excluded by instanceof => exception is raised

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/sql/NativeSQLQueryConstructorReturn.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/sql/NativeSQLQueryConstructorReturn.java
@@ -19,7 +19,7 @@ public class NativeSQLQueryConstructorReturn implements NativeSQLQueryReturn {
 
 	public NativeSQLQueryConstructorReturn(Class targetClass, List<NativeSQLQueryScalarReturn> columnReturns) {
 		this.targetClass = targetClass;
-		this.columnReturns = columnReturns.toArray( new NativeSQLQueryScalarReturn[ columnReturns.size() ] );
+		this.columnReturns = columnReturns.toArray( new NativeSQLQueryScalarReturn[ 0 ] );
 	}
 
 	public Class getTargetClass() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -634,7 +634,7 @@ public class ActionQueue {
 	}
 
 	private static String[] convertTimestampSpaces(Set spaces) {
-		return (String[]) spaces.toArray( new String[ spaces.size() ] );
+		return (String[]) spaces.toArray( new String[ 0 ] );
 	}
 
 	/**
@@ -993,7 +993,7 @@ public class ActionQueue {
 
 			if ( session.getFactory().getSessionFactoryOptions().isQueryCacheEnabled() ) {
 				session.getFactory().getCache().getTimestampsCache().invalidate(
-						querySpacesToInvalidate.toArray( new String[querySpacesToInvalidate.size()] ),
+						querySpacesToInvalidate.toArray( new String[ 0 ] ),
 						session
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -75,7 +75,7 @@ public final class ArrayHelper {
 	}
 
 	public static String[] toStringArray(Collection coll) {
-		return (String[]) coll.toArray( new String[coll.size()] );
+		return (String[]) coll.toArray( new String[ 0 ] );
 	}
 
 	public static String[][] to2DStringArray(Collection coll) {
@@ -87,7 +87,7 @@ public final class ArrayHelper {
 	}
 
 	public static Type[] toTypeArray(Collection coll) {
-		return (Type[]) coll.toArray( new Type[coll.size()] );
+		return (Type[]) coll.toArray( new Type[ 0 ] );
 	}
 
 	public static int[] toIntArray(Collection coll) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
@@ -27,7 +27,7 @@ public class JoinedIterator<T> implements Iterator<T> {
 
 	@SuppressWarnings("unchecked")
 	public JoinedIterator(List<Iterator<T>> wrappedIterators) {
-		this( wrappedIterators.toArray( new Iterator[ wrappedIterators.size() ]) );
+		this( wrappedIterators.toArray( new Iterator[ 0 ]) );
 	}
 
 	public JoinedIterator(Iterator<T>... iteratorsToWrap) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/streams/StreamUtils.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/streams/StreamUtils.java
@@ -10,8 +10,8 @@ package org.hibernate.internal.util.streams;
  * @author Steve Ebersole
  */
 public class StreamUtils {
-	public static StingArrayCollector toStringArray() {
-		return StingArrayCollector.INSTANCE;
+	public static StringArrayCollector toStringArray() {
+		return StringArrayCollector.INSTANCE;
 	}
 
 	public static <T> GenericArrayCollector<T> toArray(Class<T> collectedType) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/streams/StringArrayCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/streams/StringArrayCollector.java
@@ -21,11 +21,11 @@ import java.util.stream.Collector;
  *
  * @author Steve Ebersole
  */
-public class StingArrayCollector implements Collector<String, List<String>, String[]> {
+public class StringArrayCollector implements Collector<String, List<String>, String[]> {
 	/**
 	 * Singleton access
 	 */
-	public static final StingArrayCollector INSTANCE = new StingArrayCollector();
+	public static final StringArrayCollector INSTANCE = new StringArrayCollector();
 
 	@Override
 	public Supplier<List<String>> supplier() {
@@ -47,7 +47,7 @@ public class StingArrayCollector implements Collector<String, List<String>, Stri
 
 	@Override
 	public Function<List<String>, String[]> finisher() {
-		return strings -> strings.toArray( new String[strings.size()] );
+		return strings -> strings.toArray( new String[ 0 ] );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackBuilderLegacyImpl.java
@@ -234,7 +234,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 				}
 			}
 		}
-		return callbacks.toArray( new Callback[callbacks.size()] );
+		return callbacks.toArray( new Callback[ 0 ] );
 	}
 
 	@SuppressWarnings({"unchecked", "WeakerAccess"})
@@ -294,7 +294,7 @@ final class CallbackBuilderLegacyImpl implements CallbackBuilder {
 		}
 		while ( currentClazz != null );
 
-		return callbacks.toArray( new Callback[callbacks.size()] );
+		return callbacks.toArray( new Callback[ 0 ] );
 	}
 
 	private static boolean useAnnotationAnnotatedByListener;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -689,7 +689,7 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 			}
 		}
 
-		return results.toArray( new String[results.size()] );
+		return results.toArray( new String[ 0 ] );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -773,7 +773,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 							)
 					);
 				}
-				mapping[index] = classNames.toArray( new String[ classNames.size() ] );
+				mapping[index] = classNames.toArray( new String[ 0 ] );
 				break;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -653,7 +653,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 				}
 			}
 		}
-		return values.toArray( new String[values.size()] );
+		return values.toArray( new String[ 0 ] );
 	}
 
 	private String[] fullDiscriminatorValues;
@@ -668,7 +668,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 					values.add( queryable.getDiscriminatorSQLValue() );
 				}
 			}
-			fullDiscriminatorValues = values.toArray( new String[values.size()] );
+			fullDiscriminatorValues = values.toArray( new String[ 0 ] );
 		}
 
 		return fullDiscriminatorValues;

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
@@ -66,7 +66,7 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 			return ArrayHelper.EMPTY_CLASS_ARRAY;
 		}
 
-		return interfaces.toArray( new Class[interfaces.size()] );
+		return interfaces.toArray( new Class[ 0 ] );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/javassist/JavassistProxyFactory.java
@@ -80,7 +80,7 @@ public class JavassistProxyFactory implements ProxyFactory, Serializable {
 			return ArrayHelper.EMPTY_CLASS_ARRAY;
 		}
 
-		return interfaces.toArray( new Class[interfaces.size()] );
+		return interfaces.toArray( new Class[ 0 ] );
 	}
 
 	private javassist.util.proxy.ProxyFactory buildJavassistProxyFactory() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -18,7 +18,7 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.streams.StingArrayCollector;
+import org.hibernate.internal.util.streams.StringArrayCollector;
 import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
@@ -141,7 +141,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 				sqm.getQuerySpec().getSelectClause().getSelections()
 						.stream()
 						.map( SqmSelection::getAlias )
-						.collect( StingArrayCollector.INSTANCE ),
+						.collect( StringArrayCollector.INSTANCE ),
 				queryOptions.getTupleTransformer()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/PatternRenderer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/PatternRenderer.java
@@ -97,7 +97,7 @@ public class PatternRenderer {
 		varargParam = vararg;
 		maxParamIndex = max;
 
-		chunks = chunkList.toArray( new String[chunkList.size()] );
+		chunks = chunkList.toArray( new String[ 0 ] );
 		paramIndexes = new int[paramList.size()];
 		for ( i = 0; i < paramIndexes.length; ++i ) {
 			paramIndexes[i] = paramList.get( i );

--- a/hibernate-core/src/main/java/org/hibernate/secure/internal/StandardJaccServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/secure/internal/StandardJaccServiceImpl.java
@@ -162,7 +162,7 @@ public class StandardJaccServiceImpl implements JaccService, Configurable {
 		}
 
 		final Set<Principal> principalsSet = caller.getPrincipals();
-		return principalsSet.toArray( new Principal[ principalsSet.size()] );
+		return principalsSet.toArray( new Principal[ 0 ] );
 	}
 
 	private ContextSubjectAccess getContextSubjectAccess() {

--- a/hibernate-core/src/main/java/org/hibernate/tool/enhance/EnhancementTask.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/enhance/EnhancementTask.java
@@ -184,7 +184,7 @@ public class EnhancementTask extends Task {
 			}
 		}
 
-		return new URLClassLoader( urls.toArray( new URL[urls.size()] ), Enhancer.class.getClassLoader() );
+		return new URLClassLoader( urls.toArray( new URL[ 0 ] ), Enhancer.class.getClassLoader() );
 	}
 
 	private byte[] doEnhancement(File javaClassFile, Enhancer enhancer) throws BuildException {

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SingleLineSqlCommandExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/SingleLineSqlCommandExtractor.java
@@ -36,7 +36,7 @@ public class SingleLineSqlCommandExtractor implements ImportSqlCommandExtractor 
 				}
 				statementList.add( trimmedSql );
 			}
-			return statementList.toArray( new String[statementList.size()] );
+			return statementList.toArray( new String[ 0 ] );
 		}
 		catch ( IOException e ) {
 			throw new ImportScriptException( "Error during import script parsing.", e );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -91,7 +91,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl implements Information
 		}
 		extractionContext.getJdbcEnvironment().getDialect().augmentRecognizedTableTypes( tableTypesList );
 
-		this.tableTypes = tableTypesList.toArray( new String[ tableTypesList.size() ] );
+		this.tableTypes = tableTypesList.toArray( new String[ 0 ] );
 	}
 
 	protected IdentifierHelper identifierHelper() {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -153,7 +153,7 @@ public class StandardTableExporter implements Exporter<Table> {
 
 		applyInitCommands( table, sqlStrings );
 
-		return sqlStrings.toArray( new String[ sqlStrings.size() ] );
+		return sqlStrings.toArray( new String[ 0 ] );
 	}
 
 	protected void applyComments(Table table, QualifiedName tableName, List<String> sqlStrings) {


### PR DESCRIPTION
It is counter-intuitive that the following typical pattern
```
list.toArray(new T[list.size()]);
```
is slower than
```
list.toArray(new T[0]);
```
see the good article of https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for details

A even better approach is to migrate away from Array usage in favour of Collection. Array puts performance cost at runtime whereas Collection moves that cost to compiling phase. See another good article on this: https://eclipsesource.com/blogs/2014/04/11/3-good-reasons-to-avoid-arrays-in-java-interfaces/. Array is the most ugly compromise during Java's evolution.

This PR tries to make the common coding pattern consistent (improving performance along the way).

This PR also fixes a naming error (from org.hibernate.internal.util.streams.**StingArrayCollector** -> org.hibernate.internal.util.streams.**StringArrayCollector**) 