### PR TITLE
Wip/6.0 Fix HashMap constructor with expected size usage error

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -43,6 +43,7 @@ import org.hibernate.event.service.spi.EventListenerGroup;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.id.factory.spi.MutableIdentifierGeneratorFactory;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.FetchProfile;
 import org.hibernate.mapping.MappedSuperclass;
@@ -315,10 +316,10 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 	@Override
 	public NamedQueryRepository buildNamedQueryRepository(SessionFactoryImplementor sessionFactory) {
 		return new NamedQueryRepositoryImpl(
-				new HashMap<>( namedQueryMap.size() ),
-				new HashMap<>( namedNativeQueryMap.size() ),
-				new HashMap<>( namedProcedureCallMap.size() ),
-				new HashMap<>( sqlResultSetMappingMap.size() )
+				CollectionHelper.mapOfSize( namedQueryMap.size() ),
+				CollectionHelper.mapOfSize( namedNativeQueryMap.size() ),
+				CollectionHelper.mapOfSize( namedProcedureCallMap.size() ),
+				CollectionHelper.mapOfSize( sqlResultSetMappingMap.size() )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredMapCacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredMapCacheEntry.java
@@ -7,10 +7,10 @@
 package org.hibernate.cache.spi.entry;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 /**
  * Structured CacheEntry format for persistent Maps.
@@ -28,7 +28,7 @@ public class StructuredMapCacheEntry implements CacheEntryStructure {
 	public Object structure(Object item) {
 		final CollectionCacheEntry entry = (CollectionCacheEntry) item;
 		final Serializable[] state = entry.getState();
-		final Map map = new HashMap( state.length );
+		final Map map = CollectionHelper.mapOfSize( state.length );
 		int i = 0;
 		while ( i < state.length ) {
 			map.put( state[i++], state[i++] );

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractDomainDataRegion.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractDomainDataRegion.java
@@ -25,6 +25,7 @@ import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 
 import org.jboss.logging.Logger;
@@ -127,7 +128,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 			return Collections.emptyMap();
 		}
 
-		final Map<NavigableRole, EntityDataAccess> accessMap = new HashMap<>( entityCaching.size() );
+		final Map<NavigableRole, EntityDataAccess> accessMap = CollectionHelper.mapOfSize( entityCaching.size() );
 		for ( EntityDataCachingConfig entityAccessConfig : entityCaching ) {
 			accessMap.put(
 					entityAccessConfig.getNavigableRole(),
@@ -144,7 +145,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 			return Collections.emptyMap();
 		}
 
-		final Map<NavigableRole, NaturalIdDataAccess> accessMap = new HashMap<>( naturalIdCaching.size() );
+		final Map<NavigableRole, NaturalIdDataAccess> accessMap = CollectionHelper.mapOfSize( naturalIdCaching.size() );
 		for ( NaturalIdDataCachingConfig naturalIdAccessConfig : naturalIdCaching ) {
 			accessMap.put(
 					naturalIdAccessConfig.getNavigableRole(),
@@ -162,7 +163,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 			return Collections.emptyMap();
 		}
 
-		final Map<NavigableRole, CollectionDataAccess> accessMap = new HashMap<>( collectionCaching.size() );
+		final Map<NavigableRole, CollectionDataAccess> accessMap = CollectionHelper.mapOfSize( collectionCaching.size() );
 		for ( CollectionDataCachingConfig cachingConfig : collectionCaching ) {
 			accessMap.put(
 					cachingConfig.getNavigableRole(),

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ClassPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ClassPropertyHolder.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.annotations.EntityBinder;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Join;
 import org.hibernate.mapping.KeyValue;
@@ -263,7 +264,7 @@ public class ClassPropertyHolder extends AbstractPropertyHolder {
 	 */
 	private Map<String, Join> getJoinsPerRealTableName() {
 		if ( joinsPerRealTableName == null ) {
-			joinsPerRealTableName = new HashMap<>( joins.size() );
+			joinsPerRealTableName = CollectionHelper.mapOfSize( joins.size() );
 			for (Join join : joins.values()) {
 				joinsPerRealTableName.put( join.getTable().getName(), join );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -16,6 +16,7 @@ import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
@@ -67,7 +68,7 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 
 		//prepare column name structure
 		boolean isExplicitReference = true;
-		Map<String, Ejb3JoinColumn> columnByReferencedName = new HashMap<>(joinColumns.length);
+		Map<String, Ejb3JoinColumn> columnByReferencedName = CollectionHelper.mapOfSize( joinColumns.length);
 		for (Ejb3JoinColumn joinColumn : joinColumns) {
 			final String referencedColumnName = joinColumn.getReferencedColumn();
 			if ( referencedColumnName == null || BinderHelper.isEmptyAnnotationValue( referencedColumnName ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
@@ -30,6 +30,7 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.ClassLoaderAccessDelegateImpl;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 import org.dom4j.Element;
 
@@ -53,7 +54,7 @@ public class JPAMetadataProvider implements MetadataProvider {
 	private final boolean xmlMappingEnabled;
 
 	private Map<Object, Object> defaults;
-	private Map<AnnotatedElement, AnnotationReader> cache = new HashMap<>(100);
+	private Map<AnnotatedElement, AnnotationReader> cache = CollectionHelper.mapOfSize( 100 );
 
 	/**
 	 * @deprecated Use {@link JPAMetadataProvider#JPAMetadataProvider(BootstrapContext)} instead.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAOverriddenAnnotationReader.java
@@ -129,6 +129,7 @@ import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 import org.dom4j.Attribute;
 import org.dom4j.Element;
@@ -348,7 +349,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				Element tree = xmlContext.getXMLTree( className );
 				Annotation[] annotations = getPhysicalAnnotations();
 				List<Annotation> annotationList = new ArrayList<>( annotations.length + 5 );
-				annotationsMap = new HashMap<>( annotations.length + 5 );
+				annotationsMap = CollectionHelper.mapOfSize( annotations.length + 5 );
 				for ( Annotation annotation : annotations ) {
 					if ( !annotationToXml.containsKey( annotation.annotationType() ) ) {
 						//unknown annotations are left over
@@ -391,7 +392,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 				Element tree = xmlContext.getXMLTree( className );
 				Annotation[] annotations = getPhysicalAnnotations();
 				List<Annotation> annotationList = new ArrayList<>( annotations.length + 5 );
-				annotationsMap = new HashMap<>( annotations.length + 5 );
+				annotationsMap = CollectionHelper.mapOfSize( annotations.length + 5 );
 				for ( Annotation annotation : annotations ) {
 					if ( !annotationToXml.containsKey( annotation.annotationType() ) ) {
 						//unknown annotations are left over
@@ -433,7 +434,7 @@ public class JPAOverriddenAnnotationReader implements AnnotationReader {
 			}
 			else {
 				this.annotations = getPhysicalAnnotations();
-				annotationsMap = new HashMap<>( annotations.length + 5 );
+				annotationsMap = CollectionHelper.mapOfSize( annotations.length + 5 );
 				for ( Annotation ann : this.annotations ) {
 					annotationsMap.put( ann.annotationType(), ann );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/BeanValidationEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/BeanValidationEventListener.java
@@ -28,6 +28,7 @@ import org.hibernate.event.spi.PreInsertEventListener;
 import org.hibernate.event.spi.PreUpdateEvent;
 import org.hibernate.event.spi.PreUpdateEventListener;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.persister.entity.EntityPersister;
 
 import org.jboss.logging.Logger;
@@ -114,7 +115,7 @@ public class BeanValidationEventListener
 		if ( groups.length > 0 ) {
 			final Set<ConstraintViolation<T>> constraintViolations = validator.validate( object, groups );
 			if ( constraintViolations.size() > 0 ) {
-				Set<ConstraintViolation<?>> propagatedViolations = new HashSet<>( constraintViolations.size() );
+				Set<ConstraintViolation<?>> propagatedViolations = CollectionHelper.setOfSize( constraintViolations.size() );
 				Set<String> classNames = new HashSet<>();
 				for ( ConstraintViolation<?> violation : constraintViolations ) {
 					LOG.trace( violation );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/GroupsPerOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/GroupsPerOperation.java
@@ -15,6 +15,7 @@ import javax.validation.groups.Default;
 import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.ClassLoaderAccess;
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 /**
  * @author Emmanuel Bernard
@@ -26,7 +27,7 @@ public class GroupsPerOperation {
 	private static final Class<?>[] DEFAULT_GROUPS = new Class<?>[] { Default.class };
 	private static final Class<?>[] EMPTY_GROUPS = new Class<?>[] { };
 
-	private Map<Operation, Class<?>[]> groupsPerOperation = new HashMap<>(4);
+	private Map<Operation, Class<?>[]> groupsPerOperation = CollectionHelper.mapOfSize( 4 );
 
 	private GroupsPerOperation() {
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/ValidationMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/ValidationMode.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 /**
  * Duplicates the javax.validation enum (because javax validation might not be on the runtime classpath)
@@ -30,7 +31,7 @@ public enum ValidationMode {
 	}
 
 	public static Set<ValidationMode> getModes(Object modeProperty) {
-		Set<ValidationMode> modes = new HashSet<>(3);
+		Set<ValidationMode> modes = CollectionHelper.setOfSize( 3);
 		if (modeProperty == null) {
 			modes.add( ValidationMode.AUTO );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentIdentifierBag.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.type.Type;
@@ -353,7 +354,7 @@ public class PersistentIdentifierBag extends AbstractPersistentCollection implem
 	@Override
 	@SuppressWarnings("unchecked")
 	public Serializable getSnapshot(CollectionPersister persister) throws HibernateException {
-		final HashMap map = new HashMap( values.size() );
+		final HashMap map = CollectionHelper.mapOfSize( values.size() );
 		final Iterator iter = values.iterator();
 		int i=0;
 		while ( iter.hasNext() ) {

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentMap.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.type.Type;
@@ -94,7 +95,7 @@ public class PersistentMap extends AbstractPersistentCollection implements Map {
 	@Override
 	@SuppressWarnings( {"unchecked"})
 	public Serializable getSnapshot(CollectionPersister persister) throws HibernateException {
-		final HashMap clonedMap = new HashMap( map.size() );
+		final HashMap clonedMap = CollectionHelper.mapOfSize( map.size() );
 		for ( Object o : map.entrySet() ) {
 			final Entry e = (Entry) o;
 			final Object copy = persister.getElementType().deepCopy( e.getValue(), persister.getFactory() );

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSet.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
@@ -99,7 +100,7 @@ public class PersistentSet extends AbstractPersistentCollection implements java.
 	@Override
 	@SuppressWarnings( {"unchecked"})
 	public Serializable getSnapshot(CollectionPersister persister) throws HibernateException {
-		final HashMap clonedSet = new HashMap( set.size() );
+		final HashMap clonedSet = CollectionHelper.mapOfSize( set.size() );
 		for ( Object aSet : set ) {
 			final Object copied = persister.getElementType().deepCopy( aSet, persister.getFactory() );
 			clonedSet.put( copied, copied );

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.persister.collection.CollectionPersister;
 
@@ -34,7 +35,7 @@ public class StandardSetSemantics extends AbstractSetSemantics<Set<?>> {
 	public Set<?> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return anticipatedSize < 1 ? new HashSet<>() : new HashSet<>( anticipatedSize );
+		return anticipatedSize < 1 ? new HashSet<>() : CollectionHelper.setOfSize( anticipatedSize );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -58,6 +58,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.internal.util.collections.ConcurrentReferenceHashMap;
 import org.hibernate.internal.util.collections.IdentityMap;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
@@ -204,7 +205,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void addUnownedCollection(CollectionKey key, PersistentCollection collection) {
 		if ( unownedCollections == null ) {
-			unownedCollections = new HashMap<>( INIT_COLL_SIZE );
+			unownedCollections = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 		}
 		unownedCollections.put( key, collection );
 	}
@@ -319,7 +320,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		else {
 			final Object[] snapshot = persister.getDatabaseSnapshot( id, session );
 			if ( entitySnapshotsByKey == null ) {
-				entitySnapshotsByKey = new HashMap<>( INIT_COLL_SIZE );
+				entitySnapshotsByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 			}
 			entitySnapshotsByKey.put( key, snapshot == null ? NO_ROW : snapshot );
 			return snapshot;
@@ -392,7 +393,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void addEntity(EntityKey key, Object entity) {
 		if ( entitiesByKey == null ) {
-			entitiesByKey = new HashMap<>( INIT_COLL_SIZE );
+			entitiesByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 		}
 		entitiesByKey.put( key, entity );
 		final BatchFetchQueue fetchQueue = this.batchFetchQueue;
@@ -453,7 +454,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void addEntity(EntityUniqueKey euk, Object entity) {
 		if ( entitiesByUniqueKey == null ) {
-			entitiesByUniqueKey = new HashMap<>( INIT_COLL_SIZE );
+			entitiesByUniqueKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 		}
 		entitiesByUniqueKey.put( euk, entity );
 	}
@@ -775,7 +776,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void addEnhancedProxy(EntityKey key, PersistentAttributeInterceptable entity) {
 		if ( entitiesByKey == null ) {
-			entitiesByKey = new HashMap<>( INIT_COLL_SIZE );
+			entitiesByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 		}
 		entitiesByKey.put( key, entity );
 	}
@@ -1449,7 +1450,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public void addNullProperty(EntityKey ownerKey, String propertyName) {
 		if ( nullAssociations == null ) {
-			nullAssociations = new HashSet<>( INIT_COLL_SIZE );
+			nullAssociations = CollectionHelper.setOfSize( INIT_COLL_SIZE );
 		}
 		nullAssociations.add( new AssociationKey( ownerKey, propertyName ) );
 	}
@@ -1711,7 +1712,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] entitiesByKey entries" );
 			}
-			rtn.entitiesByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
+			rtn.entitiesByKey = CollectionHelper.mapOfSize( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
 			for ( int i = 0; i < count; i++ ) {
 				rtn.entitiesByKey.put( EntityKey.deserialize( ois, sfi ), ois.readObject() );
 			}
@@ -1721,7 +1722,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 				LOG.trace( "Starting deserialization of [" + count + "] entitiesByUniqueKey entries" );
 			}
 			if ( count != 0 ) {
-				rtn.entitiesByUniqueKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
+				rtn.entitiesByUniqueKey = CollectionHelper.mapOfSize( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
 				for ( int i = 0; i < count; i++ ) {
 					rtn.entitiesByUniqueKey.put( EntityUniqueKey.deserialize( ois, session ), ois.readObject() );
 				}
@@ -1750,7 +1751,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] entitySnapshotsByKey entries" );
 			}
-			rtn.entitySnapshotsByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
+			rtn.entitySnapshotsByKey = CollectionHelper.mapOfSize( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
 			for ( int i = 0; i < count; i++ ) {
 				rtn.entitySnapshotsByKey.put( EntityKey.deserialize( ois, sfi ), ois.readObject() );
 			}
@@ -1761,7 +1762,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			if ( LOG.isTraceEnabled() ) {
 				LOG.trace( "Starting deserialization of [" + count + "] collectionsByKey entries" );
 			}
-			rtn.collectionsByKey = new HashMap<>( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
+			rtn.collectionsByKey = CollectionHelper.mapOfSize( count < INIT_COLL_SIZE ? INIT_COLL_SIZE : count );
 			for ( int i = 0; i < count; i++ ) {
 				rtn.collectionsByKey.put( CollectionKey.deserialize( ois, session ), (PersistentCollection) ois.readObject() );
 			}
@@ -1907,7 +1908,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public PersistentCollection addCollectionByKey(CollectionKey collectionKey, PersistentCollection persistentCollection) {
 		if ( collectionsByKey == null ) {
-			collectionsByKey = new HashMap<>( INIT_COLL_SIZE );
+			collectionsByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
 		}
 		final PersistentCollection old = collectionsByKey.put( collectionKey, persistentCollection );
 		return old;

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
@@ -29,6 +29,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.beans.BeanInfoHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 /**
@@ -81,7 +82,7 @@ public class ConnectionProviderInitiator implements StandardServiceInitiator<Con
 	private static final Map<String,String> LEGACY_CONNECTION_PROVIDER_MAPPING;
 
 	static {
-		LEGACY_CONNECTION_PROVIDER_MAPPING = new HashMap<>( 5 );
+		LEGACY_CONNECTION_PROVIDER_MAPPING = CollectionHelper.mapOfSize( 5 );
 
 		LEGACY_CONNECTION_PROVIDER_MAPPING.put(
 				"org.hibernate.connection.DatasourceConnectionProvider",

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -18,6 +18,7 @@ import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.CacheHelper;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
@@ -104,7 +105,7 @@ public class BatchFetchQueue {
 	 */
 	public void addSubselect(EntityKey key, SubselectFetch subquery) {
 		if ( subselectsByEntityKey == null ) {
-			subselectsByEntityKey = new HashMap<>( 12 );
+			subselectsByEntityKey = CollectionHelper.mapOfSize( 12 );
 		}
 		subselectsByEntityKey.put( key, subquery );
 	}
@@ -136,7 +137,7 @@ public class BatchFetchQueue {
 	public void addBatchLoadableEntityKey(EntityKey key) {
 		if ( key.isBatchLoadable() ) {
 			if ( batchLoadableEntityKeys == null ) {
-				batchLoadableEntityKeys = new HashMap<>( 12 );
+				batchLoadableEntityKeys = CollectionHelper.mapOfSize( 12 );
 			}
 			final LinkedHashSet<EntityKey> keysForEntity = batchLoadableEntityKeys.computeIfAbsent(
 					key.getEntityName(),
@@ -255,7 +256,7 @@ public class BatchFetchQueue {
 		final CollectionPersister persister = ce.getLoadedPersister();
 
 		if ( batchLoadableCollections == null ) {
-			batchLoadableCollections = new HashMap<>( 12 );
+			batchLoadableCollections = CollectionHelper.mapOfSize( 12 );
 		}
 
 		final LinkedHashMap<CollectionEntry, PersistentCollection> map =  batchLoadableCollections.computeIfAbsent(

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecutableList.java
@@ -334,7 +334,7 @@ public class ExecutableList<E extends Executable & Comparable & Serializable> im
 			this.querySpaces = null;
 		}
 		else {
-			querySpaces = new HashSet<>( CollectionHelper.determineProperSizing( numberOfQuerySpaces ) );
+			querySpaces = CollectionHelper.setOfSize( numberOfQuerySpaces );
 			for ( int i = 0; i < numberOfQuerySpaces; i++ ) {
 				querySpaces.add( in.readUTF() );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.graph.AttributeNode;
 import org.hibernate.graph.CannotBecomeEntityGraphException;
@@ -48,7 +49,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	protected AbstractGraph(boolean mutable, GraphImplementor<J> original) {
 		this( original.getGraphedType(), mutable, original.jpaMetamodel() );
 
-		this.attrNodeMap = CollectionHelper.concurrentMap( original.getAttributeNodeList().size() );
+		this.attrNodeMap = new ConcurrentHashMap<>( original.getAttributeNodeList().size() );
 		original.visitAttributeNodes(
 				node -> attrNodeMap.put(
 						node.getAttributeDescriptor(),

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/BoundedConcurrentHashMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/BoundedConcurrentHashMap.java
@@ -1605,7 +1605,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
 					evictedCopy = singletonMap( evictedEntry.key, evictedEntry.value );
 				}
 				else {
-					evictedCopy = new HashMap<>( evicted.size() );
+					evictedCopy = CollectionHelper.mapOfSize( evicted.size() );
 					for ( HashEntry<K, V> he : evicted ) {
 						evictedCopy.put( he.key, he.value );
 					}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
@@ -57,8 +57,21 @@ public final class CollectionHelper {
 	 *
 	 * @return The sized map.
 	 */
-	public static <K, V> Map<K, V> mapOfSize(int size) {
+	public static <K, V> HashMap<K, V> mapOfSize(int size) {
 		return new HashMap<>( determineProperSizing( size ), LOAD_FACTOR );
+	}
+
+	/**
+	 * Build a properly sized set, especially handling load size and load factor to prevent immediate resizing.
+	 * <p/>
+	 * Especially helpful for copy set contents.
+	 *
+	 * @param size The size to make the set.
+	 *
+	 * @return The sized set.
+	 */
+	public static <K> HashSet<K> setOfSize(int size) {
+		return new HashSet<>( determineProperSizing( size ), LOAD_FACTOR );
 	}
 
 	/**
@@ -175,8 +188,7 @@ public final class CollectionHelper {
 	 * @return The created map.
 	 */
 	public static <K, V> ConcurrentHashMap<K, V> concurrentMap(int expectedNumberOfElements, float loadFactor) {
-		final int size = expectedNumberOfElements + 1 + (int) ( expectedNumberOfElements * loadFactor );
-		return new ConcurrentHashMap<>( size, loadFactor );
+		return new ConcurrentHashMap<>( expectedNumberOfElements, loadFactor );
 	}
 
 	public static <T> ArrayList<T> arrayList(int expectedNumberOfElements) {
@@ -189,7 +201,7 @@ public final class CollectionHelper {
 		}
 
 		final int size = source.size();
-		final Set<T> copy = new HashSet<>( size + 1 );
+		final Set<T> copy = CollectionHelper.setOfSize( size + 1 );
 		copy.addAll( source );
 		return copy;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/IdentityMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/IdentityMap.java
@@ -144,7 +144,7 @@ public final class IdentityMap<K,V> implements Map<K,V> {
 
 	@Override
 	public Set<Entry<K,V>> entrySet() {
-		Set<Entry<K,V>> set = new HashSet<>( map.size() );
+		Set<Entry<K,V>> set = CollectionHelper.setOfSize( map.size() );
 		for ( Entry<IdentityKey<K>, V> entry : map.entrySet() ) {
 			set.add( new IdentityMapEntry<>( entry.getKey().key, entry.getValue() ) );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEmbeddableRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEmbeddableRepresentationStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.metamodel.internal;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Component;
@@ -37,7 +38,7 @@ public abstract class AbstractEmbeddableRepresentationStrategy implements Embedd
 		this.embeddableJavaTypeDescriptor = embeddableJavaTypeDescriptor;
 
 		this.propertyAccesses = new PropertyAccess[ propertySpan ];
-		this.attributeNameToPositionMap = CollectionHelper.concurrentMap( propertySpan );
+		this.attributeNameToPositionMap = new ConcurrentHashMap<>( propertySpan );
 
 		boolean foundCustomAccessor = false;
 		Iterator itr = bootDescriptor.getPropertyIterator();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -209,7 +209,7 @@ public class JpaMetamodelImpl implements JpaMetamodel {
 		final int setSize = CollectionHelper.determineProperSizing(
 				jpaEntityTypeMap.size() + jpaMappedSuperclassTypeMap.size() + jpaEmbeddableDescriptorMap.size()
 		);
-		final Set<ManagedType<?>> managedTypes = new HashSet<>( setSize );
+		final Set<ManagedType<?>> managedTypes = CollectionHelper.setOfSize( setSize );
 		managedTypes.addAll( jpaEntityTypeMap.values() );
 		managedTypes.addAll( jpaMappedSuperclassTypeMap.values() );
 		managedTypes.addAll( jpaEmbeddableDescriptorMap.values() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -37,6 +37,7 @@ import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.util.MarkerObject;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Formula;
 import org.hibernate.mapping.Join;
@@ -528,7 +529,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			subclassesByDiscriminatorValue.put( discriminatorValue, getEntityName() );
 
 			discriminatorValuesByTableName = new LinkedHashMap<>( subclassSpan + 1 );
-			subclassNameByTableName = new HashMap<>( subclassSpan + 1);
+			subclassNameByTableName = CollectionHelper.mapOfSize( subclassSpan + 1);
 			// We need to convert the `discriminatorSQLString` (which is a String read from boot-mapping) into
 			// 	the type indicated by `#discriminatorType` (String -> Integer, e.g.).
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.query.internal;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import org.hibernate.Incubating;
@@ -79,7 +80,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 		this.parameterMetadata = parameterMetadata;
 		this.queryParametersValidationEnabled = queryParametersValidationEnabled;
 
-		this.parameterBindingMap = CollectionHelper.concurrentMap( parameterMetadata.getParameterCount() );
+		this.parameterBindingMap = new ConcurrentHashMap<>( parameterMetadata.getParameterCount() );
 	}
 
 	@SuppressWarnings({"WeakerAccess", "unchecked"})

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/TableBasedUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/TableBasedUpdateHandler.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.persister.entity.EntityPersister;
@@ -142,7 +143,7 @@ public class TableBasedUpdateHandler
 		// cross-reference the TableReference by alias.  The TableGroup already
 		// cross-references it by name, bu the ColumnReference only has the alias
 
-		final Map<String, TableReference> tableReferenceByAlias = new HashMap<>( updatingTableGroup.getTableReferenceJoins().size() + 1 );
+		final Map<String, TableReference> tableReferenceByAlias = CollectionHelper.mapOfSize( updatingTableGroup.getTableReferenceJoins().size() + 1 );
 		collectTableReference( updatingTableGroup.getPrimaryTableReference(), tableReferenceByAlias::put );
 		for ( int i = 0; i < updatingTableGroup.getTableReferenceJoins().size(); i++ ) {
 			collectTableReference( updatingTableGroup.getTableReferenceJoins().get( i ), tableReferenceByAlias::put );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/UpdateExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/UpdateExecutionDelegate.java
@@ -18,6 +18,7 @@ import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.ColumnConsumer;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPartContainer;
@@ -99,7 +100,7 @@ public class UpdateExecutionDelegate implements TableBasedUpdateHandler.Executio
 
 		this.entityDescriptor = (EntityMappingType) updatingModelPart;
 
-		this.assignmentsByTable = new HashMap<>( updatingTableGroup.getTableReferenceJoins().size() + 1 );
+		this.assignmentsByTable = CollectionHelper.mapOfSize( updatingTableGroup.getTableReferenceJoins().size() + 1 );
 
 		jdbcParameterBindings = SqmUtil.createJdbcParameterBindings(
 				executionContext.getQueryParameterBindings(),

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -29,6 +29,7 @@ import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Index;
@@ -160,7 +161,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 		final boolean format = Helper.interpretFormattingEnabled( options.getConfigurationValues() );
 		final Formatter formatter = format ? FormatStyle.DDL.getFormatter() : FormatStyle.NONE.getFormatter();
 
-		final Set<String> exportIdentifiers = new HashSet<>( 50 );
+		final Set<String> exportIdentifiers = CollectionHelper.setOfSize( 50 );
 
 		final Database database = metadata.getDatabase();
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -34,6 +34,7 @@ import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Index;
@@ -216,7 +217,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 
 		final Database database = metadata.getDatabase();
 
-		final Set<String> exportIdentifiers = new HashSet<>( 50 );
+		final Set<String> exportIdentifiers = CollectionHelper.setOfSize( 50 );
 
 		// first, create each catalog/schema
 		if ( tryToCreateCatalogs || tryToCreateSchemas ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
@@ -200,7 +201,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			}
 		}
 
-		final Set<String> exportIdentifiers = new HashSet<>( 50 );
+		final Set<String> exportIdentifiers = CollectionHelper.setOfSize( 50 );
 
 		// NOTE : init commands are irrelevant for dropping...
 

--- a/hibernate-core/src/main/java/org/hibernate/transform/AliasToEntityMapResultTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/transform/AliasToEntityMapResultTransformer.java
@@ -5,8 +5,9 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.transform;
-import java.util.HashMap;
 import java.util.Map;
+
+import org.hibernate.internal.util.collections.CollectionHelper;
 
 /**
  * {@link ResultTransformer} implementation which builds a map for each "row",
@@ -30,7 +31,7 @@ public class AliasToEntityMapResultTransformer extends AliasedTupleSubsetResultT
 
 	@Override
 	public Object transformTuple(Object[] tuple, String[] aliases) {
-		Map result = new HashMap(tuple.length);
+		Map result = CollectionHelper.mapOfSize( tuple.length );
 		for ( int i=0; i<tuple.length; i++ ) {
 			String alias = aliases[i];
 			if ( alias!=null ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/SetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SetType.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import org.hibernate.collection.internal.PersistentSet;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -39,7 +40,7 @@ public class SetType extends CollectionType {
 	public Object instantiate(int anticipatedSize) {
 		return anticipatedSize <= 0
 				? new HashSet()
-				: new HashSet( anticipatedSize + (int)( anticipatedSize * .75f ), .75f );
+				: CollectionHelper.setOfSize( anticipatedSize );
 	}
 
 }


### PR DESCRIPTION
There are quite some coding statements with incorrect usage of `new HashMap<>(n)` in our codebase. When we aim to build a map with expected size, we should use another util class in our code base (i.e. `CollectionHelper.mapOfSize( n )`). Using `new HashMap<>(n)` takes no consideration of `load factor`  and we often end up with rehashing unless there are many hashing conflicts.

Also enrich `CollectionHelper`by providing a new `setOfSize()` method and fixed a bug in `concurrentMap()` util method (thus making it not useful any more).