### PR TITLE
HHH-13724 Add testing configs and dialect for CockroachDB

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -63,6 +63,7 @@ dependencies {
 	testRuntime( libraries.mariadb )
 	testRuntime( libraries.mssql )
 	testRuntime( libraries.hana )
+	testRuntime( libraries.cockroachdb )
 
 	testCompile( project( ':hibernate-jcache' ) )
 	testRuntime( libraries.ehcache3 )

--- a/documentation/src/test/java/org/hibernate/userguide/hql/HQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/hql/HQLTest.java
@@ -24,6 +24,7 @@ import javax.persistence.TypedQuery;
 import org.hibernate.CacheMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
@@ -1296,6 +1297,7 @@ public class HQLTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/26710")
 	public void test_hql_sqrt_function_example() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			//tag::hql-sqrt-function-example[]

--- a/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockTest.java
@@ -9,15 +9,12 @@ package org.hibernate.userguide.locking;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
 import javax.persistence.Version;
-
 import org.hibernate.annotations.OptimisticLock;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
@@ -34,6 +31,7 @@ public class OptimisticLockTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails at SERIALIZABLE isolation")
 	public void test() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			Phone phone = new Phone();

--- a/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockingTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockingTest.java
@@ -13,9 +13,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Version;
-import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
@@ -34,7 +32,6 @@ public class OptimisticLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails at SERIALIZABLE isolation")
 	public void test() {
 		Phone _phone = doInJPA( this::entityManagerFactory, entityManager -> {
 			Person person = new Person(  );

--- a/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockingTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/locking/OptimisticLockingTest.java
@@ -13,12 +13,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Version;
-
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
@@ -36,6 +34,7 @@ public class OptimisticLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails at SERIALIZABLE isolation")
 	public void test() {
 		Phone _phone = doInJPA( this::entityManagerFactory, entityManager -> {
 			Person person = new Person(  );

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/NClobTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/NClobTest.java
@@ -18,6 +18,7 @@ import javax.persistence.Lob;
 import org.hibernate.Session;
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.MySQL5Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.engine.jdbc.NClobProxy;
@@ -37,7 +38,8 @@ import static org.junit.Assert.fail;
         value = {
                 PostgreSQL81Dialect.class,
                 MySQL5Dialect.class,
-                AbstractHANADialect.class
+                AbstractHANADialect.class,
+                CockroachDB192Dialect.class
         },
         comment = "@see https://hibernate.atlassian.net/browse/HHH-10693 and https://hibernate.atlassian.net/browse/HHH-10695"
 )

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -120,6 +120,14 @@ ext {
                         'jdbc.user'  : 'VLAD',
                         'jdbc.pass'  : 'V1ad_test',
                         'jdbc.url'   : 'jdbc:sap://localhost:39015/'
-                ]
+                ],
+                cockroachdb : [
+                        'db.dialect' : 'org.hibernate.dialect.CockroachDB192Dialect',
+                        // CockroachDB uses the same pgwire protocol as PostgreSQL, so the driver is the same.
+                        'jdbc.driver': 'org.postgresql.Driver',
+                        'jdbc.user'  : 'root',
+                        'jdbc.pass'  : '',
+                        'jdbc.url'   : 'jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable'
+                ],
         ]
 }

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -85,6 +85,7 @@ dependencies {
 	testRuntime( libraries.mssql )
 	testRuntime( libraries.informix )
 	testRuntime( libraries.hana )
+	testRuntime( libraries.cockroachdb )
 
 	asciidoclet 'org.asciidoctor:asciidoclet:1.+'
 

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -114,6 +114,7 @@ ext {
             postgresql:      'org.postgresql:postgresql:42.2.2',
             mysql:           'mysql:mysql-connector-java:8.0.17',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
+            cockroachdb:     'org.postgresql:postgresql:42.2.8',
 
             oracle:          'com.oracle.jdbc:ojdbc8:12.2.0.1',
             mssql:           'com.microsoft.sqlserver:mssql-jdbc:7.2.1.jre8',

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB192Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB192Dialect.java
@@ -635,17 +635,7 @@ public class CockroachDB192Dialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsMixedTypeArithmetic() {
-		return false;
-	}
-
-	@Override
 	public boolean canCreateSchema() {
-		return false;
-	}
-
-	@Override
-	public boolean supportsLoFunctions() {
 		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB192Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB192Dialect.java
@@ -1,3 +1,9 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
 package org.hibernate.dialect;
 
 import java.sql.DatabaseMetaData;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
@@ -1,3 +1,9 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
 package org.hibernate.dialect;
 
 import org.hibernate.dialect.function.NoArgSQLFunction;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
@@ -6,7 +6,7 @@ import org.hibernate.type.StandardBasicTypes;
 /**
  * An SQL dialect for CockroachDB 20.1 and later. Adds support for a few date/time functions.
  */
-public class CockroachDB201Dialect extends CockroachDBNewDialect {
+public class CockroachDB201Dialect extends CockroachDB192Dialect {
 	public CockroachDB201Dialect() {
 		super();
 		registerFunction( "current_time", new NoArgSQLFunction("current_time", StandardBasicTypes.TIME, false) );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDB201Dialect.java
@@ -1,0 +1,17 @@
+package org.hibernate.dialect;
+
+import org.hibernate.dialect.function.NoArgSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * An SQL dialect for CockroachDB 20.1 and later. Adds support for a few date/time functions.
+ */
+public class CockroachDB201Dialect extends CockroachDBNewDialect {
+	public CockroachDB201Dialect() {
+		super();
+		registerFunction( "current_time", new NoArgSQLFunction("current_time", StandardBasicTypes.TIME, false) );
+		registerFunction( "localtime", new NoArgSQLFunction("localtime", StandardBasicTypes.TIME, false) );
+		registerFunction( "localtimestamp", new NoArgSQLFunction("localtimestamp", StandardBasicTypes.TIMESTAMP, false) );
+		registerFunction( "timeofday", new NoArgSQLFunction("timeofday", StandardBasicTypes.STRING) );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -85,7 +84,6 @@ import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ReflectHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.io.StreamCopier;
 import org.hibernate.loader.BatchLoadSizingStrategy;
@@ -2976,6 +2974,24 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
+	/**
+	 * Does this dialect/database support LO_CREATE and related functions.
+	 *
+	 * @return {@code true} if LO_CREATE and related functions are supported
+	 */
+	public boolean supportsLoFunctions() {
+		return false;
+	}
+
+	/**
+	 * Does this dialect/database support mixed type arithmetic (e.g. int + float).
+	 *
+	 * @return {@code true} if mixed type arithmetic is supported
+	 */
+	public boolean supportsMixedTypeArithmetic() {
+		return true;
+	}
+
 	public boolean isLegacyLimitHandlerBehaviorEnabled() {
 		return legacyLimitHandlerBehavior;
 	}
@@ -3052,5 +3068,4 @@ public abstract class Dialect implements ConversionContext {
 	public boolean supportsSelectAliasInGroupByClause() {
 		return false;
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2974,24 +2974,6 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
-	/**
-	 * Does this dialect/database support LO_CREATE and related functions.
-	 *
-	 * @return {@code true} if LO_CREATE and related functions are supported
-	 */
-	public boolean supportsLoFunctions() {
-		return false;
-	}
-
-	/**
-	 * Does this dialect/database support mixed type arithmetic (e.g. int + float).
-	 *
-	 * @return {@code true} if mixed type arithmetic is supported
-	 */
-	public boolean supportsMixedTypeArithmetic() {
-		return true;
-	}
-
 	public boolean isLegacyLimitHandlerBehaviorEnabled() {
 		return legacyLimitHandlerBehavior;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL81Dialect.java
@@ -648,9 +648,4 @@ public class PostgreSQL81Dialect extends Dialect {
 	public boolean supportsSelectAliasInGroupByClause() {
 		return true;
 	}
-
-	@Override
-	public boolean supportsLoFunctions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/CockroachDB1920IdentityColumnSupport.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect.identity;
+
+import java.sql.Types;
+
+public class CockroachDB1920IdentityColumnSupport extends IdentityColumnSupportImpl {
+	@Override
+	public boolean supportsIdentityColumns() {
+		// Full support requires setting the sql.defaults.serial_normalization=sql_sequence in CockroachDB.
+		return false;
+	}
+
+	@Override
+	// CockroachDB does not create a sequence for id columns
+	public String getIdentitySelectString(String table, String column, int type) {
+		return "select 1";
+	}
+
+	@Override
+	public String getIdentityColumnString(int type) {
+		return type == Types.SMALLINT ?
+				"serial4 not null" :
+				"serial8 not null";
+	}
+
+	@Override
+	public boolean hasDataTypeInIdentityColumn() {
+		return false;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
@@ -107,6 +107,16 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 						: value;
 				return (X) clob;
 			}
+			else if ( String.class.isAssignableFrom( type ) ) {
+				if ( ClobImplementer.class.isInstance( value ) ) {
+					// if the incoming Clob is a wrapper, just get the underlying String.
+					return (X) ( (ClobImplementer) value ).getUnderlyingStream().asString();
+				}
+				else {
+					// otherwise we need to extract the String.
+					return (X) DataHelper.extractString( value.getCharacterStream() );
+				}
+			}
 		}
 		catch ( SQLException e ) {
 			throw new HibernateException( "Unable to access clob stream", e );
@@ -128,6 +138,9 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 		else if ( Reader.class.isAssignableFrom( value.getClass() ) ) {
 			Reader reader = (Reader) value;
 			return options.getLobCreator().createClob( DataHelper.extractString( reader ) );
+		}
+		else if ( String.class.isAssignableFrom( value.getClass() ) ) {
+			return options.getLobCreator().createClob( (String) value );
 		}
 
 		throw unknownWrap( value.getClass() );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
@@ -92,7 +92,7 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 
 		try {
 			if ( CharacterStream.class.isAssignableFrom( type ) ) {
-				if ( ClobImplementer.class.isInstance( value ) ) {
+				if (value instanceof ClobImplementer) {
 					// if the incoming Clob is a wrapper, just pass along its CharacterStream
 					return (X) ( (ClobImplementer) value ).getUnderlyingStream();
 				}
@@ -102,13 +102,13 @@ public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
 				}
 			}
 			else if (Clob.class.isAssignableFrom( type )) {
-				final Clob clob =  WrappedClob.class.isInstance( value )
+				final Clob clob =  value instanceof WrappedClob
 						? ( (WrappedClob) value ).getWrappedClob()
 						: value;
 				return (X) clob;
 			}
 			else if ( String.class.isAssignableFrom( type ) ) {
-				if ( ClobImplementer.class.isInstance( value ) ) {
+				if (value instanceof ClobImplementer) {
 					// if the incoming Clob is a wrapper, just get the underlying String.
 					return (X) ( (ClobImplementer) value ).getUnderlyingStream().asString();
 				}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
@@ -126,7 +126,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( index, characterStream.asReader() );
+					st.setCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
 				}
 
 				@Override
@@ -137,7 +137,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( name, characterStream.asReader() );
+					st.setCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
 				}
 			};
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ClobTypeDescriptor.java
@@ -126,7 +126,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
+					st.setCharacterStream( index, characterStream.asReader() );
 				}
 
 				@Override
@@ -137,7 +137,7 @@ public abstract class ClobTypeDescriptor implements SqlTypeDescriptor {
 							CharacterStream.class,
 							options
 					);
-					st.setCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
+					st.setCharacterStream( name, characterStream.asReader() );
 				}
 			};
 		}

--- a/hibernate-core/src/test/java/org/hibernate/cache/spi/ReadWriteCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cache/spi/ReadWriteCacheTest.java
@@ -19,6 +19,8 @@ import org.hibernate.Transaction;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.cfg.Configuration;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Before;
@@ -60,6 +62,7 @@ public class ReadWriteCacheTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "CockroachDB uses SERIALIZABLE isolation, and does not support this")
 	public void testDelete() throws InterruptedException {
 		bookId = 1L;
 
@@ -136,6 +139,7 @@ public class ReadWriteCacheTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "CockroachDB uses SERIALIZABLE isolation, and does not support this")
 	public void testUpdate() throws InterruptedException {
 		bookId = 4L;
 

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
@@ -15,7 +15,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -27,15 +26,13 @@ import org.hibernate.id.SequenceMismatchStrategy;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.logger.LoggerInspectionRule;
 import org.hibernate.testing.logger.Triggerable;
+import org.jboss.logging.Logger;
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -18,9 +18,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
 import javax.persistence.metamodel.EntityType;
-
 import org.hibernate.dialect.CockroachDB192Dialect;
-import org.hibernate.dialect.CockroachDB201Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.jpa.test.metamodel.Address;
@@ -39,7 +37,6 @@ import org.hibernate.jpa.test.metamodel.Spouse;
 import org.hibernate.metamodel.internal.MetamodelImpl;
 import org.hibernate.query.criteria.internal.CriteriaBuilderImpl;
 import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate;
-
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.SkipForDialect;
@@ -235,8 +232,7 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(CockroachDB192Dialect.class)
-	@RequiresDialect(CockroachDB201Dialect.class)
+	@SkipForDialect(value = CockroachDB192Dialect.class, strictMatching = true)
 	public void testDateTimeFunctions() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/QueryBuilderTest.java
@@ -19,6 +19,8 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
 import javax.persistence.metamodel.EntityType;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
+import org.hibernate.dialect.CockroachDB201Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.jpa.test.metamodel.Address;
@@ -40,6 +42,7 @@ import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate;
 
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
 
@@ -232,6 +235,8 @@ public class QueryBuilderTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(CockroachDB192Dialect.class)
+	@RequiresDialect(CockroachDB201Dialect.class)
 	public void testDateTimeFunctions() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
@@ -13,6 +13,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Oracle12cDialect;
 import org.hibernate.jpa.test.metamodel.AbstractMetamodelSpecificTest;
 import org.hibernate.jpa.test.metamodel.CreditCard;
@@ -247,7 +248,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5803" )
-	@RequiresDialectFeature( DialectChecks.SupportsMixedTypeArithmetic.class )
+	@SkipForDialect( value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/41943")
 	public void testQuotientConversion() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/basic/PredicateTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.jpa.test.criteria.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -28,6 +26,9 @@ import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the various predicates.
@@ -246,6 +247,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-5803" )
+	@RequiresDialectFeature( DialectChecks.SupportsMixedTypeArithmetic.class )
 	public void testQuotientConversion() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -61,6 +61,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	private static final Logger log = Logger.getLogger( LockTest.class );
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testFindWithTimeoutHint() {
 		final Lock lock = new Lock();
 		lock.setName( "name" );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -21,21 +21,18 @@ import javax.persistence.PersistenceException;
 import javax.persistence.PessimisticLockException;
 import javax.persistence.Query;
 import javax.persistence.QueryTimeoutException;
-
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.TransactionException;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.Oracle10gDialect;
-import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.RequiresDialectFeature;
@@ -43,9 +40,8 @@ import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.hibernate.testing.util.ExceptionUtil;
-import org.junit.Test;
-
 import org.jboss.logging.Logger;
+import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
@@ -61,7 +57,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	private static final Logger log = Logger.getLogger( LockTest.class );
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testFindWithTimeoutHint() {
 		final Lock lock = new Lock();
 		lock.setName( "name" );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
@@ -6,15 +6,14 @@
  */
 package org.hibernate.jpa.test.lock;
 
-import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-import org.hibernate.query.NativeQuery;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.util.ExceptionUtil;
-import org.hibernate.type.IntegerType;
 import org.junit.Test;
 
 import java.util.Map;
@@ -27,6 +26,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
+@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/41335")
 @TestForIssue( jiraKey = "HHH-13493")
 public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
@@ -46,6 +46,7 @@ public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCa
 
 				fail("Should have thrown lock timeout exception!");
 			} catch (Exception expected) {
+				expected.printStackTrace();
 				assertTrue(
 					ExceptionUtil.rootCause(expected)
 						.getMessage().contains("canceling statement due to user request")

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/NativeSQLQueryTimeoutTest.java
@@ -46,7 +46,6 @@ public class NativeSQLQueryTimeoutTest extends BaseEntityManagerFunctionalTestCa
 
 				fail("Should have thrown lock timeout exception!");
 			} catch (Exception expected) {
-				expected.printStackTrace();
 				assertTrue(
 					ExceptionUtil.rootCause(expected)
 						.getMessage().contains("canceling statement due to user request")

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -28,10 +28,7 @@ import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
 
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.*;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.junit.Test;
 
@@ -145,6 +142,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testPessimisticForcedIncrementOverall() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();
@@ -170,6 +168,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testPessimisticForcedIncrementSpecific() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -28,7 +28,10 @@ import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
 
-import org.hibernate.testing.*;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.junit.Test;
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/QueryLockingTest.java
@@ -19,18 +19,18 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Root;
-
 import org.hibernate.LockMode;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.junit.Test;
@@ -145,7 +145,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testPessimisticForcedIncrementOverall() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();
@@ -171,7 +171,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testPessimisticForcedIncrementSpecific() {
 		EntityManager em = getOrCreateEntityManager();
 		em.getTransaction().begin();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -67,6 +67,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 
 	@Test(timeout = 1000 * 30) //30 seconds
 	@TestForIssue(jiraKey = "HHH-11617")
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testStatementIsClosed() {
 
 		TransactionUtil.doInJPA( this::entityManagerFactory, em1 -> {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -11,14 +11,14 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.LockModeType;
-
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
-
+import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.hibernate.testing.util.ExceptionUtil;
 import org.junit.Before;
@@ -67,7 +67,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 
 	@Test(timeout = 1000 * 30) //30 seconds
 	@TestForIssue(jiraKey = "HHH-11617")
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testStatementIsClosed() {
 
 		TransactionUtil.doInJPA( this::entityManagerFactory, em1 -> {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
@@ -117,8 +117,7 @@ public class NativeQueryOrdinalParametersTest extends BaseEntityManagerFunctiona
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-12532")
-	@RequiresDialect(PostgreSQL82Dialect.class)
-	@RequiresDialect(CockroachDB201Dialect.class)
+	@RequiresDialect({ PostgreSQL82Dialect.class, CockroachDB201Dialect.class })
 	public void testCteNativeQueryOrdinalParameter() {
 
 		Node root1 = new Node();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NativeQueryOrdinalParametersTest.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB201Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.NativeQuery;
@@ -117,6 +118,7 @@ public class NativeQueryOrdinalParametersTest extends BaseEntityManagerFunctiona
 	@Test
 	@TestForIssue(jiraKey = "HHH-12532")
 	@RequiresDialect(PostgreSQL82Dialect.class)
+	@RequiresDialect(CockroachDB201Dialect.class)
 	public void testCteNativeQueryOrdinalParameter() {
 
 		Node root1 = new Node();

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryTest.java
@@ -25,6 +25,7 @@ import javax.persistence.Tuple;
 import org.hibernate.Hibernate;
 import org.hibernate.QueryException;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.dialect.PostgresPlusDialect;
@@ -383,6 +384,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 	@SkipForDialect(value = Oracle8iDialect.class, jiraKey = "HHH-10161", comment = "Cannot convert untyped null (assumed to be BINARY type) to NUMBER")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testNativeQueryNullPositionalParameter() throws Exception {
 		EntityManager em = getOrCreateEntityManager();
@@ -418,6 +420,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 	@TestForIssue(jiraKey = "HHH-10161")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = Oracle8iDialect.class, comment = "ORA-00932: inconsistent datatypes: expected NUMBER got BINARY")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testNativeQueryNullPositionalParameterParameter() throws Exception {
@@ -471,6 +474,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 	@SkipForDialect(value = Oracle8iDialect.class, jiraKey = "HHH-10161", comment = "Cannot convert untyped null (assumed to be BINARY type) to NUMBER")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testNativeQueryNullNamedParameter() throws Exception {
 		EntityManager em = getOrCreateEntityManager();
@@ -506,6 +510,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 	@TestForIssue(jiraKey = "HHH-10161")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = Oracle8iDialect.class, comment = "ORA-00932: inconsistent datatypes: expected NUMBER got BINARY")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testNativeQueryNullNamedParameterParameter() throws Exception {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/query/QueryAndSQLTest.java
@@ -23,6 +23,7 @@ import org.hibernate.Transaction;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQL9Dialect;
@@ -118,6 +119,7 @@ public class QueryAndSQLTest extends BaseCoreFunctionalTestCase {
 	@SkipForDialect(value = Oracle8iDialect.class, jiraKey = "HHH-10161", comment = "Cannot convert untyped null (assumed to be BINARY type) to NUMBER")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testQueryWithNullParameter(){
 		Chaos c0 = new Chaos();
@@ -203,6 +205,7 @@ public class QueryAndSQLTest extends BaseCoreFunctionalTestCase {
 	@SkipForDialect(value = Oracle8iDialect.class, jiraKey = "HHH-10161", comment = "Cannot convert untyped null (assumed to be BINARY type) to NUMBER")
 	@SkipForDialect(value = PostgreSQL9Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = PostgresPlusDialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
+	@SkipForDialect(value = CockroachDB192Dialect.class, jiraKey = "HHH-10312", comment = "Cannot convert untyped null (assumed to be bytea type) to bigint")
 	@SkipForDialect(value = SybaseDialect.class, comment = "Null == null on Sybase")
 	public void testNativeQueryWithNullParameter(){
 		Chaos c0 = new Chaos();

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.TeradataDialect;
@@ -29,7 +30,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class Ejb3XmlTest extends BaseCoreFunctionalTestCase {
 	@Test
-	@SkipForDialect(value = {PostgreSQL81Dialect.class, PostgreSQLDialect.class},
+	@SkipForDialect(value = {PostgreSQL81Dialect.class, PostgreSQLDialect.class, CockroachDB192Dialect.class},
 			comment = "postgresql jdbc driver does not implement the setQueryTimeout method")
 	@SkipForDialect(value = TeradataDialect.class,
 			jiraKey = "HHH-8190",

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
@@ -1,18 +1,18 @@
 package org.hibernate.test.bulkid;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
 import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
-import org.hibernate.hql.spi.id.inline.InlineIdsInClauseBulkIdStrategy;
 
-import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL82Dialect.class)
+@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/5807")
 public class GlobalTemporaryTableBulkCompositeIdTest extends AbstractBulkCompositeIdTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AndLobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AndLobTest.java
@@ -18,10 +18,13 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.converter.AttributeConverterTypeAdapter;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +62,8 @@ public class AndLobTest extends BaseUnitTestCase {
 
 		final Type type = metadata.getEntityBinding( EntityImpl.class.getName() ).getProperty( "status" ).getType();
 		final AttributeConverterTypeAdapter concreteType = assertTyping( AttributeConverterTypeAdapter.class, type );
-		assertEquals( Types.BLOB, concreteType.getSqlTypeDescriptor().getSqlType() );
+		SqlTypeDescriptor sqlTypeDescriptor = concreteType.getSqlTypeDescriptor();
+		assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(BlobTypeDescriptor.BLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 	}
 
 	@Converter

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AndNationalizedTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AndNationalizedTests.java
@@ -12,18 +12,16 @@ import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.internal.MetadataImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.mapping.PersistentClass;
-
-import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
@@ -47,8 +45,9 @@ public class AndNationalizedTests extends BaseUnitTestCase {
 
 			final PersistentClass entityBinding = metadata.getEntityBinding( TestEntity.class.getName() );
 			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect
-					|| metadata.getDatabase().getDialect() instanceof DB2Dialect){
-				// See issue HHH-10693 for PostgreSQL, HHH-12753 for DB2
+					|| metadata.getDatabase().getDialect() instanceof DB2Dialect
+					|| metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect){
+				// See issue HHH-10693 for PostgreSQL and CockroachDB, HHH-12753 for DB2
 				assertEquals(
 						Types.VARCHAR,
 						entityBinding.getProperty( "name" ).getType().sqlTypes( metadata )[0]

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
@@ -30,6 +30,7 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.HANACloudColumnStoreDialect;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.hql.internal.ast.tree.JavaConstantNode;
 import org.hibernate.internal.util.ConfigHelper;
@@ -47,6 +48,9 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.boot.MetadataBuildingContextTestingImpl;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.hibernate.testing.util.ExceptionUtil;
+import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.ClobTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.junit.Test;
 
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
@@ -111,7 +115,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 		}
 		AbstractStandardBasicType basicType = assertTyping( AbstractStandardBasicType.class, type );
 		assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-		assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+		SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+		assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 	}
 
 	@Test
@@ -162,7 +167,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			}
 			AbstractStandardBasicType basicType = assertTyping( AbstractStandardBasicType.class, type );
 			assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-			assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+			SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+			assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( ssr );
@@ -191,7 +197,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			}
 			AttributeConverterTypeAdapter basicType = assertTyping( AttributeConverterTypeAdapter.class, type );
 			assertSame( StringTypeDescriptor.INSTANCE, basicType.getJavaTypeDescriptor() );
-			assertEquals( Types.CLOB, basicType.getSqlTypeDescriptor().getSqlType() );
+			SqlTypeDescriptor sqlTypeDescriptor = basicType.getSqlTypeDescriptor();
+			assertEquals( Dialect.getDialect().remapSqlTypeDescriptor(ClobTypeDescriptor.CLOB_BINDING).getSqlType(), sqlTypeDescriptor.getSqlType() );
 		}
 		finally {
 			StandardServiceRegistryBuilder.destroy( ssr );

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -16,24 +16,7 @@ import org.hibernate.Transaction;
 import org.hibernate.TypeMismatchException;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.CUBRIDDialect;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.IngresDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SQLServer2008Dialect;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.Sybase11Dialect;
-import org.hibernate.dialect.SybaseASE15Dialect;
-import org.hibernate.dialect.SybaseAnywhereDialect;
-import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.dialect.TeradataDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.hql.internal.ast.ASTQueryTranslatorFactory;
 import org.hibernate.hql.internal.ast.QuerySyntaxException;
@@ -3285,6 +3268,8 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(CockroachDB192Dialect.class)
+	@RequiresDialect(CockroachDB201Dialect.class)
 	public void testStandardFunctions() throws Exception {
 		Session session = openSession();
 		Transaction t = session.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -3268,8 +3268,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@SkipForDialect(CockroachDB192Dialect.class)
-	@RequiresDialect(CockroachDB201Dialect.class)
+	@SkipForDialect(value = CockroachDB192Dialect.class, strictMatching = true)
 	public void testStandardFunctions() throws Exception {
 		Session session = openSession();
 		Transaction t = session.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -6,30 +6,6 @@
  */
 package org.hibernate.test.hql;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
@@ -87,6 +63,32 @@ import org.hibernate.type.ComponentType;
 import org.hibernate.type.ManyToOneType;
 import org.hibernate.type.Type;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertClassAssignability;
+import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests the integration of the new AST parser into the loading of query results using
@@ -976,6 +978,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
 	public void testExpressionWithParamInFunction() {
 		Session s = openSession();
 		s.beginTransaction();
@@ -2948,6 +2951,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
 	@SuppressWarnings( {"UnusedAssignment", "UnusedDeclaration"})
 	public void testSelectExpressions() {
 		createTestBaseData();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -961,7 +961,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/41943")
 	public void testExpressionWithParamInFunction() {
 		Session s = openSession();
 		s.beginTransaction();
@@ -2934,7 +2934,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportsMixedTypeArithmetic.class)
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/41943")
 	@SuppressWarnings( {"UnusedAssignment", "UnusedDeclaration"})
 	public void testSelectExpressions() {
 		createTestBaseData();
@@ -3829,7 +3829,8 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		 * <link>http://www.postgresql.org/docs/current/static/release-8-3.html</link>
 		 */
 		if ( getDialect() instanceof PostgreSQLDialect || getDialect() instanceof PostgreSQL81Dialect
-				|| getDialect() instanceof HSQLDialect ) {
+				|| getDialect() instanceof HSQLDialect
+				|| getDialect() instanceof CockroachDB192Dialect ) {
 			hql = "from Animal a where bit_length(str(a.bodyWeight)) = 24";
 		}
 		else {
@@ -3838,7 +3839,8 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 
 		session.createQuery(hql).list();
 		if ( getDialect() instanceof PostgreSQLDialect || getDialect() instanceof PostgreSQL81Dialect
-				|| getDialect() instanceof HSQLDialect ) {
+				|| getDialect() instanceof HSQLDialect
+				|| getDialect() instanceof CockroachDB192Dialect ) {
 			hql = "select bit_length(str(a.bodyWeight)) from Animal a";
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/HQLTest.java
@@ -18,6 +18,7 @@ import org.hibernate.QueryException;
 import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.HSQLDialect;
@@ -169,7 +170,8 @@ public class HQLTest extends QueryTranslatorTestCase {
 		Oracle8iDialect.class,
 		AbstractHANADialect.class,
 		PostgreSQL81Dialect.class,
-		MySQLDialect.class
+		MySQLDialect.class,
+		CockroachDB192Dialect.class
 	} )
 
     public void testRowValueConstructorSyntaxInInListBeingTranslated() {
@@ -404,6 +406,10 @@ public class HQLTest extends QueryTranslatorTestCase {
 			// MySQL dialects are smarter now wrt cast targets.  For example, float (as a db type) is not
 			// valid as a cast target for MySQL.  The new parser uses the dialect handling for casts, the old
 			// parser does not; so the outputs do not match here...
+			return;
+		}
+		if ( getDialect() instanceof CockroachDB192Dialect ) {
+			// CockroachDB turns "float" into "float4" so the outputs won't match.
 			return;
 		}
 		assertTranslation( "from Animal where abs(cast(1 as float) - cast(:param as float)) = 1.0" );
@@ -890,6 +896,7 @@ public class HQLTest extends QueryTranslatorTestCase {
 
 		if ( getDialect() instanceof Oracle8iDialect ) return; // the new hiearchy...
 		if ( getDialect() instanceof PostgreSQLDialect || getDialect() instanceof PostgreSQL81Dialect ) return;
+		if ( getDialect() instanceof CockroachDB192Dialect ) return;
 		if ( getDialect() instanceof TeradataDialect) return;
 		if ( ! H2Dialect.class.isInstance( getDialect() ) ) {
 			// H2 has no year function
@@ -1070,6 +1077,7 @@ public class HQLTest extends QueryTranslatorTestCase {
 	}
 
 	@Test
+	@SkipForDialect(CockroachDB192Dialect.class)
 	public void testSelectStandardFunctionsNoParens() throws Exception {
 		assertTranslation( "select current_date, current_time, current_timestamp from Animal" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/id/NonUniqueIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/id/NonUniqueIdTest.java
@@ -32,15 +32,19 @@ public class NonUniqueIdTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Before
 	public void setup() {
+		// Drop and recreate table so it has no primary key. The drop is done in a separate transaction because
+		// some databases do not support dropping and recreating in the same transaction.
 		doInHibernate(
 				this::sessionFactory,
 				session -> {
-					// drop and recreate table so it has no primary key
-
 					session.createNativeQuery(
 							"DROP TABLE CATEGORY"
 					).executeUpdate();
-
+				}
+		);
+		doInHibernate(
+				this::sessionFactory,
+				session -> {
 					session.createNativeQuery(
 							"create table CATEGORY( id integer not null, name varchar(255) )"
 					).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomSQLTest.java
@@ -11,14 +11,12 @@ package org.hibernate.test.legacy;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.id.PostInsertIdentifierGenerator;
-
 import org.hibernate.testing.DialectCheck;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
@@ -47,7 +45,7 @@ public class CustomSQLTest extends LegacyTestCase {
 
 	@Test
     @RequiresDialectFeature( NonIdentityGeneratorChecker.class )
-    @SkipForDialect( value = {PostgreSQL81Dialect.class, PostgreSQLDialect.class}, jiraKey = "HHH-6704")
+    @SkipForDialect( value = {PostgreSQL81Dialect.class, PostgreSQLDialect.class, CockroachDB192Dialect.class}, jiraKey = "HHH-6704")
 	public void testInsert() throws HibernateException, SQLException {
 		Session s = openSession();
 		s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
@@ -2275,6 +2275,7 @@ public class FooBarTest extends LegacyTestCase {
 					!( SybaseDialect.class.isAssignableFrom( getDialect().getClass() ) ) &&
 					!( SQLServerDialect.class.isAssignableFrom( getDialect().getClass() ) ) &&
 					!( getDialect() instanceof PostgreSQLDialect ) && !(getDialect() instanceof PostgreSQL81Dialect ) &&
+					!(getDialect() instanceof CockroachDB192Dialect ) &&
 					!( getDialect() instanceof AbstractHANADialect) ) {
 				// SybaseAnywhereDialect supports implicit conversions from strings to ints
 				s.createQuery(
@@ -2350,7 +2351,10 @@ public class FooBarTest extends LegacyTestCase {
 
 		s.delete(bar);
 
-		if ( getDialect() instanceof DB2Dialect || getDialect() instanceof PostgreSQLDialect || getDialect() instanceof PostgreSQL81Dialect ) {
+		if ( getDialect() instanceof DB2Dialect ||
+				getDialect() instanceof PostgreSQLDialect ||
+				getDialect() instanceof PostgreSQL81Dialect ||
+		        getDialect() instanceof CockroachDB192Dialect) {
 			s.createQuery( "select one from One one join one.manies many group by one order by count(many)" ).iterate();
 			s.createQuery( "select one from One one join one.manies many group by one having count(many) < 5" )
 					.iterate();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/FooBarTest.java
@@ -45,24 +45,7 @@ import org.hibernate.criterion.Example;
 import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.InterbaseDialect;
-import org.hibernate.dialect.MckoiDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.Oracle12cDialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PointbaseDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SAPDBDialect;
-import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.dialect.TeradataDialect;
-import org.hibernate.dialect.TimesTenDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
@@ -80,8 +63,6 @@ import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.env.ConnectionProviderBuilder;
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -391,6 +372,7 @@ public class FooBarTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/43007")
 	public void testQuery() throws Exception {
 		Session s = openSession();
 		Transaction txn = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/LegacyTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/LegacyTestCase.java
@@ -13,6 +13,7 @@ import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
@@ -38,8 +39,11 @@ public abstract class LegacyTestCase extends BaseCoreFunctionalTestCase {
 	}
 
 	protected boolean supportsLockingNullableSideOfJoin(Dialect dialect) {
-		// db2 and pgsql do *NOT*
-		return ! ( DB2Dialect.class.isInstance( dialect ) || PostgreSQL81Dialect.class.isInstance( dialect ) || PostgreSQLDialect.class.isInstance( dialect ));
+		// db2. pgsql, and cockroachdb do *NOT*
+		return ! ( DB2Dialect.class.isInstance( dialect ) ||
+				PostgreSQL81Dialect.class.isInstance( dialect ) ||
+				PostgreSQLDialect.class.isInstance( dialect ) ||
+				CockroachDB192Dialect.class.isInstance( dialect ));
 	}
 
 	protected static String extractFromSystem(String systemPropertyName) {

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/MasterDetailTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/MasterDetailTest.java
@@ -21,11 +21,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.criterion.Example;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.MckoiDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SAPDBDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.jdbc.AbstractWork;
@@ -196,6 +192,7 @@ public class MasterDetailTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testSelfManyToOne() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -220,6 +217,7 @@ public class MasterDetailTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testExample() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
@@ -30,10 +30,13 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.jdbc.Work;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
@@ -249,6 +252,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testMultiTable() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -392,6 +396,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testMultiTableGeneratedId() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -515,6 +520,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testMultiTableCollections() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -587,6 +593,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/27871")
 	public void testMultiTableManyToOne() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/MultiTableTest.java
@@ -8,10 +8,6 @@
 //$Id: MultiTableTest.java 10977 2006-12-12 23:28:04Z steve.ebersole@jboss.com $
 package org.hibernate.test.legacy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -22,7 +18,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
 import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.LockMode;
@@ -35,10 +30,12 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.jdbc.Work;
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 public class MultiTableTest extends LegacyTestCase {
@@ -252,7 +249,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testMultiTable() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -396,7 +393,7 @@ public class MultiTableTest extends LegacyTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testMultiTableGeneratedId() throws Exception {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.dialect.*;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
@@ -33,12 +34,6 @@ import org.hibernate.ReplicationMode;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.dialect.IngresDialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.TeradataDialect;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.jdbc.AbstractWork;
@@ -1095,6 +1090,7 @@ public class ParentChildTest extends LegacyTestCase {
 	}
 
 	@Test
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testLocking() throws Exception {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();
@@ -1209,7 +1205,8 @@ public class ParentChildTest extends LegacyTestCase {
 		s.close();
 	}
 
-	 @Test
+	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Uses READ_COMMITTED isolation")
 	public void testLoadAfterNonExists() throws HibernateException, SQLException {
 		Session session = openSession();
 		if ( ( getDialect() instanceof MySQLDialect ) || ( getDialect() instanceof IngresDialect ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/ParentChildTest.java
@@ -1090,7 +1090,7 @@ public class ParentChildTest extends LegacyTestCase {
 	}
 
 	@Test
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testLocking() throws Exception {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
@@ -17,7 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
-import org.hibernate.dialect.CockroachDBNewDialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
  * @author Andrea Boriero
  */
 @TestForIssue(jiraKey = "HHH-11477")
-@RequiresDialect({ PostgreSQL81Dialect.class, CockroachDBNewDialect.class })
+@RequiresDialect({ PostgreSQL81Dialect.class, CockroachDB192Dialect.class })
 public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	private static final int LONG_STRING_SIZE = 3999;

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
@@ -16,14 +16,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
-
 import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
-
-import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -93,7 +89,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
-	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
+	@RequiresDialect(PostgreSQL81Dialect.class)
 	public void testUsingStringLobAnnotatedPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<TestEntity> results = session.createNativeQuery(
@@ -120,7 +116,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
-	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
+	@RequiresDialect(PostgreSQL81Dialect.class)
 	public void testSelectStringLobAnnotatedInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -138,7 +134,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
-	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
+	@RequiresDialect(PostgreSQL81Dialect.class)
 	public void testUsingLobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -156,7 +152,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
-	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
+	@RequiresDialect(PostgreSQL81Dialect.class)
 	public void testSelectClobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<byte[]> results = session.createNativeQuery(

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/LobStringTest.java
@@ -17,10 +17,13 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
+import org.hibernate.dialect.CockroachDBNewDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -34,7 +37,7 @@ import static org.junit.Assert.fail;
  * @author Andrea Boriero
  */
 @TestForIssue(jiraKey = "HHH-11477")
-@RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialect({ PostgreSQL81Dialect.class, CockroachDBNewDialect.class })
 public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	private static final int LONG_STRING_SIZE = 3999;
@@ -90,6 +93,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testUsingStringLobAnnotatedPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<TestEntity> results = session.createNativeQuery(
@@ -116,6 +120,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testSelectStringLobAnnotatedInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -133,6 +138,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testUsingLobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<String> results = session.createNativeQuery(
@@ -150,6 +156,7 @@ public class LobStringTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-11477")
+	@RequiresDialectFeature(DialectChecks.SupportsLoFunctions.class)
 	public void testSelectClobPropertyInNativeQuery() {
 		doInHibernate( this::sessionFactory, session -> {
 						   final List<byte[]> results = session.createNativeQuery(

--- a/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/lob/PostgreSqlLobStringTest.java
@@ -21,8 +21,7 @@ import javax.persistence.Table;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.query.Query;
 
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.*;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.util.ExceptionUtil;
 import org.junit.Test;

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
@@ -5,17 +5,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
-import org.hibernate.dialect.*;
+import org.hibernate.dialect.MySQL8Dialect;
+import org.hibernate.dialect.Oracle8iDialect;
+import org.hibernate.dialect.PostgreSQL95Dialect;
+import org.hibernate.dialect.SQLServer2005Dialect;
 import org.hibernate.query.Query;
-
-import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
 
@@ -70,7 +68,6 @@ public abstract class AbstractSkipLockedTest
 
 	@Test
 	@RequiresDialect({ PostgreSQL95Dialect.class })
-	@RequiresDialectFeature(DialectChecks.SupportSkipLocked.class)
 	public void testPostgreSQLSkipLocked() {
 
 		doInHibernate( this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/AbstractSkipLockedTest.java
@@ -9,14 +9,13 @@ import javax.persistence.Id;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
-import org.hibernate.dialect.MySQL57Dialect;
-import org.hibernate.dialect.MySQL8Dialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PostgreSQL95Dialect;
-import org.hibernate.dialect.SQLServer2005Dialect;
+import org.hibernate.dialect.*;
 import org.hibernate.query.Query;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
 
@@ -71,6 +70,7 @@ public abstract class AbstractSkipLockedTest
 
 	@Test
 	@RequiresDialect({ PostgreSQL95Dialect.class })
+	@RequiresDialectFeature(DialectChecks.SupportSkipLocked.class)
 	public void testPostgreSQLSkipLocked() {
 
 		doInHibernate( this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
@@ -201,6 +201,7 @@ public class LockModeTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-12257")
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testRefreshWithExplicitHigherLevelLockMode() {
 		doInHibernate( this::sessionFactory, session -> {
 						   A a = session.get( A.class, id );

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
@@ -14,6 +14,7 @@ import javax.persistence.LockModeType;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.dialect.SybaseDialect;
@@ -201,7 +202,7 @@ public class LockModeTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-12257")
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
+	@SkipForDialect( value = CockroachDB192Dialect.class )
 	public void testRefreshWithExplicitHigherLevelLockMode() {
 		doInHibernate( this::sessionFactory, session -> {
 						   A a = session.get( A.class, id );

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
@@ -8,12 +8,9 @@ import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQL95Dialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
-
-import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,7 +53,6 @@ public class PessimisticWriteLockTimeoutTest
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL81Dialect.class,
 			SQLServer2005Dialect.class } )
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testNoWait()
 			throws NoSuchFieldException, IllegalAccessException {
 
@@ -82,7 +78,6 @@ public class PessimisticWriteLockTimeoutTest
 
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL95Dialect.class })
-	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testSkipLocked()
 			throws NoSuchFieldException, IllegalAccessException {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/PessimisticWriteLockTimeoutTest.java
@@ -9,7 +9,9 @@ import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.dialect.PostgreSQL95Dialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.junit.Before;
@@ -54,6 +56,7 @@ public class PessimisticWriteLockTimeoutTest
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL81Dialect.class,
 			SQLServer2005Dialect.class } )
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testNoWait()
 			throws NoSuchFieldException, IllegalAccessException {
 
@@ -79,6 +82,7 @@ public class PessimisticWriteLockTimeoutTest
 
 	@Test
 	@RequiresDialect({ Oracle8iDialect.class, PostgreSQL95Dialect.class })
+	@RequiresDialectFeature(DialectChecks.SupportNoWait.class)
 	public void testSkipLocked()
 			throws NoSuchFieldException, IllegalAccessException {
 

--- a/hibernate-core/src/test/java/org/hibernate/test/nationalized/SimpleNationalizedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/nationalized/SimpleNationalizedTest.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -81,7 +82,8 @@ public class SimpleNationalizedTest extends BaseUnitTestCase {
 			assertNotNull( pc );
 
 			Property prop = pc.getProperty( "nvarcharAtt" );
-			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ){
+			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect ){
 				// See issue HHH-10693
 				assertSame( StringType.INSTANCE, prop.getType() );
 			}else{
@@ -89,7 +91,8 @@ public class SimpleNationalizedTest extends BaseUnitTestCase {
 			}
 
 			prop = pc.getProperty( "materializedNclobAtt" );
-			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ){
+			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect ){
 				// See issue HHH-10693
 				assertSame( MaterializedClobType.INSTANCE, prop.getType() );
 			}else {
@@ -102,7 +105,8 @@ public class SimpleNationalizedTest extends BaseUnitTestCase {
 			assertSame( NTextType.INSTANCE, prop.getType() );
 
 			prop = pc.getProperty( "ncharArrAtt" );
-			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ){
+			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect ){
 				// See issue HHH-10693
 				assertSame( CharacterArrayType.INSTANCE, prop.getType() );
 			}else {
@@ -110,7 +114,8 @@ public class SimpleNationalizedTest extends BaseUnitTestCase {
 			}
 
 			prop = pc.getProperty( "ncharacterAtt" );
-			if ( metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ) {
+			if ( metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect ) {
 				// See issue HHH-10693
 				assertSame( CharacterType.INSTANCE, prop.getType() );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/test/nationalized/UseNationalizedCharDataSettingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/nationalized/UseNationalizedCharDataSettingTest.java
@@ -16,6 +16,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -51,7 +52,8 @@ public class UseNationalizedCharDataSettingTest extends BaseUnitTestCase {
 			final Metadata metadata = ms.buildMetadata();
 			final PersistentClass pc = metadata.getEntityBinding( NationalizedBySettingEntity.class.getName() );
 			final Property nameAttribute = pc.getProperty( "name" );
-			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ){
+			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect){
 				// See issue HHH-10693
 				assertSame( StringType.INSTANCE, nameAttribute.getType() );
 			}else {
@@ -78,7 +80,8 @@ public class UseNationalizedCharDataSettingTest extends BaseUnitTestCase {
 			final Metadata metadata = ms.buildMetadata();
 			final PersistentClass pc = metadata.getEntityBinding( NationalizedBySettingEntity.class.getName() );
 			final Property nameAttribute = pc.getProperty( "flag" );
-			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ){
+			if(metadata.getDatabase().getDialect() instanceof PostgreSQL81Dialect ||
+					metadata.getDatabase().getDialect() instanceof CockroachDB192Dialect ){
 				assertSame( CharacterType.INSTANCE, nameAttribute.getType() );
 			}else {
 				assertSame( CharacterNCharType.INSTANCE, nameAttribute.getType() );

--- a/hibernate-core/src/test/java/org/hibernate/test/optlock/OptimisticLockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/optlock/OptimisticLockTest.java
@@ -8,19 +8,17 @@ package org.hibernate.test.optlock;
 
 
 import javax.persistence.PersistenceException;
-
 import org.hibernate.JDBCException;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.StaleStateException;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.SQLServerDialect;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
 import static org.junit.Assert.fail;
 
 /**
@@ -161,20 +159,23 @@ public class OptimisticLockTest extends BaseCoreFunctionalTestCase {
 	private void checkException(Session mainSession, PersistenceException e) {
 		final Throwable cause = e.getCause();
 		if ( cause instanceof JDBCException ) {
-			// SQLServer will report this condition via a SQLException
-			// when using its SNAPSHOT transaction isolation...
-
-			if ( !(getDialect() instanceof SQLServerDialect && ((JDBCException) cause).getErrorCode() == 3960) ) {
-				throw e;
-			}
-			else {
+			if ( getDialect() instanceof SQLServerDialect && ((JDBCException) cause).getErrorCode() == 3960 ) {
+				// SQLServer will report this condition via a SQLException
+				// when using its SNAPSHOT transaction isolation.
 				// it seems to "lose track" of the transaction as well...
 				mainSession.getTransaction().rollback();
 				mainSession.beginTransaction();
 			}
+			else if ( getDialect() instanceof CockroachDB192Dialect && ((JDBCException) cause).getSQLState().equals("40001")) {
+				// CockroachDB always runs in SERIALIZABLE isolation, and uses SQL state 40001 to indicate
+				// serialization failure.
+			}
+			else {
+				throw e;
+			}
 		}
 		else if ( !(cause instanceof StaleObjectStateException) && !(cause instanceof StaleStateException) ) {
-			fail( "expectd StaleObjectStateException or StaleStateException exception but is" + cause );
+			fail( "expected StaleObjectStateException or StaleStateException exception but is " + cause );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
@@ -16,19 +16,15 @@ import java.sql.Types;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Properties;
 import javax.persistence.ParameterMode;
 import javax.persistence.StoredProcedureQuery;
-
 import org.hibernate.Session;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.procedure.ProcedureCall;
-import org.hibernate.type.StringType;
-
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
+import org.hibernate.type.StringType;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteDefaultSchemaTest.java
@@ -26,6 +26,8 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 
@@ -47,6 +49,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteDefaultSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/AlterTableQuoteSpecifiedSchemaTest.java
@@ -24,6 +24,8 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
 
@@ -45,6 +47,7 @@ import static org.junit.Assert.fail;
 		PostgreSQL82Dialect.class,
 		SQLServer2012Dialect.class,
 })
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class AlterTableQuoteSpecifiedSchemaTest extends AbstractAlterTableQuoteSchemaTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/PostgreSQLMultipleSchemaSequenceTest.java
@@ -31,6 +31,8 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 
@@ -48,6 +50,7 @@ import static org.junit.Assert.fail;
  * @author Vlad Mihalcea
  */
 @RequiresDialect(PostgreSQL81Dialect.class)
+@RequiresDialectFeature(DialectChecks.SupportSchemaCreation.class)
 public class PostgreSQLMultipleSchemaSequenceTest extends BaseUnitTestCase {
 
 	private File output;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithFunctionIndexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithFunctionIndexTest.java
@@ -12,7 +12,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
-
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -22,13 +21,12 @@ import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.tool.hbm2ddl.SchemaExport;
-import org.hibernate.tool.hbm2ddl.SchemaUpdate;
-import org.hibernate.tool.schema.TargetType;
-
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateWithViewsTest.java
@@ -20,8 +20,10 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
@@ -38,6 +40,7 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HHH-1872")
 @RequiresDialect(PostgreSQL81Dialect.class)
+@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/24897")
 public class SchemaUpdateWithViewsTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	protected ServiceRegistry serviceRegistry;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/inheritance/tableperclass/SchemaCreationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/inheritance/tableperclass/SchemaCreationTest.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
@@ -87,7 +88,7 @@ public class SchemaCreationTest {
 					isUniqueConstraintCreated = true;
 				}
 			}
-			else if ( dialect instanceof PostgreSQL81Dialect) {
+			else if ( dialect instanceof PostgreSQL81Dialect || dialect instanceof CockroachDB192Dialect) {
 				if (statement.toLowerCase().startsWith("alter table if exists category add constraint")
 						&& statement.toLowerCase().contains("unique (code)")) {
 					isUniqueConstraintCreated = true;

--- a/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemavalidation/ViewValidationTest.java
@@ -16,8 +16,10 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.tool.hbm2ddl.SchemaValidator;
 import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
 
@@ -36,6 +38,7 @@ import org.junit.Test;
 		@RequiresDialect(PostgreSQL81Dialect.class),
 		@RequiresDialect(H2Dialect.class)
 })
+@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/10028")
 public class ViewValidationTest extends BaseCoreFunctionalTestCase {
 	private StandardServiceRegistry ssr;
 

--- a/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/timestamp/JdbcTimestampWithoutUTCTimeZoneTest.java
@@ -16,9 +16,11 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 
 import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.test.util.jdbc.TimeZoneConnectionProvider;
 import org.junit.Test;
@@ -58,6 +60,7 @@ public class JdbcTimestampWithoutUTCTimeZoneTest
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "https://github.com/cockroachdb/cockroach/issues/3781")
 	public void testTimeZone() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person person = new Person();

--- a/hibernate-core/src/test/java/org/hibernate/test/typeoverride/TypeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/typeoverride/TypeOverrideTest.java
@@ -13,18 +13,10 @@ import static org.junit.Assert.assertSame;
 
 import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.AbstractHANADialect;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SybaseASE15Dialect;
-import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.dialect.*;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.type.descriptor.sql.BlobTypeDescriptor;
-import org.hibernate.type.descriptor.sql.IntegerTypeDescriptor;
-import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
-import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
+import org.hibernate.type.descriptor.sql.*;
 import org.junit.Test;
 
 /**
@@ -47,7 +39,13 @@ public class TypeOverrideTest extends BaseCoreFunctionalTestCase {
 		assertSame( IntegerTypeDescriptor.INSTANCE, remapSqlTypeDescriptor( IntegerTypeDescriptor.INSTANCE ) );
 
 		// A few dialects explicitly override BlobTypeDescriptor.DEFAULT
-		if ( PostgreSQL81Dialect.class.isInstance( getDialect() ) || PostgreSQLDialect.class.isInstance( getDialect() ) )  {
+		if ( CockroachDB192Dialect.class.isInstance( getDialect() ))  {
+			assertSame(
+					VarbinaryTypeDescriptor.INSTANCE,
+					getDialect().remapSqlTypeDescriptor( BlobTypeDescriptor.DEFAULT )
+			);
+		}
+		else if ( PostgreSQL81Dialect.class.isInstance( getDialect() ) || PostgreSQLDialect.class.isInstance( getDialect() ) )  {
 			assertSame(
 					BlobTypeDescriptor.BLOB_BINDING,
 					getDialect().remapSqlTypeDescriptor( BlobTypeDescriptor.DEFAULT )

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
@@ -53,10 +53,15 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyManyToManyNonUniqueIdWhereTest.java
@@ -53,10 +53,10 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "BUILDING_RATINGS" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "ASSOCIATION_TABLE" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" )).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
@@ -50,7 +50,7 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery("DROP TABLE if exists MAIN_TABLE cascade").executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" )).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/annotations/LazyOneToManyNonUniqueIdWhereTest.java
@@ -50,7 +50,12 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery("DROP TABLE if exists MAIN_TABLE cascade").executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -35,10 +35,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "BUILDING_RATINGS" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "ASSOCIATION_TABLE" )).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" )).executeUpdate();
 				}
 		);
 
@@ -150,10 +150,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	public void cleanup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "drop table MATERIAL_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "BUILDING_RATINGS" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "ASSOCIATION_TABLE" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" ) ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -150,10 +150,10 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	public void cleanup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" ) ).executeUpdate();
-					session.createSQLQuery( getDialect().getDropTableString( "BUILDING_RATINGS" ) ).executeUpdate();
-					session.createSQLQuery( getDialect().getDropTableString( "ASSOCIATION_TABLE" ) ).executeUpdate();
-					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" ) ).executeUpdate();
+					session.createSQLQuery( "delete from MATERIAL_RATINGS" ).executeUpdate();
+					session.createSQLQuery( "delete from BUILDING_RATINGS" ).executeUpdate();
+					session.createSQLQuery( "delete from ASSOCIATION_TABLE" ).executeUpdate();
+					session.createSQLQuery( "delete from MAIN_TABLE" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdNotFoundWhereTest.java
@@ -8,9 +8,7 @@ package org.hibernate.test.where.hbm;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import org.hibernate.Hibernate;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.After;
@@ -37,10 +35,15 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 		doInHibernate(
 				this::sessionFactory, session -> {
 
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+				}
+		);
+
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +
@@ -147,16 +150,16 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	public void cleanup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "delete from MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "delete from BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "delete from ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "delete from MAIN_TABLE" ).executeUpdate();
+					session.createSQLQuery( "drop table MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table MAIN_TABLE cascade" ).executeUpdate();
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-12875")
+	@TestForIssue( jiraKey = "HHH-12875" )
 	public void testInitializeFromUniqueAssociationTable() {
 		doInHibernate(
 				this::sessionFactory, session -> {
@@ -185,7 +188,7 @@ public class LazyManyToManyNonUniqueIdNotFoundWhereTest extends BaseCoreFunction
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-12875")
+	@TestForIssue( jiraKey = "HHH-12875" )
 	public void testInitializeFromNonUniqueAssociationTable() {
 		doInHibernate(
 				this::sessionFactory, session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
@@ -41,10 +41,10 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
-					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MATERIAL_RATINGS" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "BUILDING_RATINGS" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "ASSOCIATION_TABLE" ) ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" ) ).executeUpdate();
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyManyToManyNonUniqueIdWhereTest.java
@@ -41,11 +41,15 @@ public class LazyManyToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCa
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
+					session.createSQLQuery( "drop table if exists MATERIAL_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists BUILDING_RATINGS cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists ASSOCIATION_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( "drop table if exists MAIN_TABLE cascade" ).executeUpdate();
+				}
+		);
 
-					session.createSQLQuery( "drop table MATERIAL_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table BUILDING_RATINGS" ).executeUpdate();
-					session.createSQLQuery( "drop table ASSOCIATION_TABLE" ).executeUpdate();
-					session.createSQLQuery( "drop table MAIN_TABLE" ).executeUpdate();
+		doInHibernate(
+				this::sessionFactory, session -> {
 
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
@@ -41,9 +41,12 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
+					session.createSQLQuery( "DROP TABLE IF EXISTS MAIN_TABLE cascade" ).executeUpdate();
+				}
+		);
 
-					session.createSQLQuery( "DROP TABLE MAIN_TABLE" ).executeUpdate();
-
+		doInHibernate(
+				this::sessionFactory, session -> {
 					session.createSQLQuery(
 							"create table MAIN_TABLE( " +
 									"ID integer not null, NAME varchar(255) not null, CODE varchar(10) not null, " +

--- a/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/where/hbm/LazyOneToManyNonUniqueIdWhereTest.java
@@ -41,7 +41,7 @@ public class LazyOneToManyNonUniqueIdWhereTest extends BaseCoreFunctionalTestCas
 	public void setup() {
 		doInHibernate(
 				this::sessionFactory, session -> {
-					session.createSQLQuery( "DROP TABLE IF EXISTS MAIN_TABLE cascade" ).executeUpdate();
+					session.createSQLQuery( getDialect().getDropTableString( "MAIN_TABLE" ) ).executeUpdate();
 				}
 		);
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
@@ -25,6 +25,7 @@ import org.hibernate.envers.test.entities.collection.MultipleCollectionEntity;
 import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity1;
 import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity2;
 import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.SkipForDialects;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jta.TestingJtaBootstrap;
 import org.hibernate.testing.jta.TestingJtaPlatformImpl;
@@ -226,7 +227,12 @@ public class DetachedMultipleCollectionChangeTest extends BaseEnversJPAFunctiona
 	}
 
 	@Test
-	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "requires serial_normalization=sql_sequence setting")
+	@SkipForDialects( value = {
+			@SkipForDialect(value = CockroachDB192Dialect.class,
+					comment = "requires serial_normalization=sql_sequence setting"),
+			@SkipForDialect(value = Oracle8iDialect.class,
+					comment = "Oracle does not support identity key generation")
+	})
 	public void testAuditJoinTable() throws Exception {
 		List<AuditJoinTableInfo> mceRe1AuditJoinTableInfos = getAuditJoinTableRows(
 				"MCE_RE1_AUD", "MCE_ID",

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/DetachedMultipleCollectionChangeTest.java
@@ -14,8 +14,8 @@ import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
-
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
@@ -24,7 +24,6 @@ import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.collection.MultipleCollectionEntity;
 import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity1;
 import org.hibernate.envers.test.entities.collection.MultipleCollectionRefEntity2;
-
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jta.TestingJtaBootstrap;
@@ -227,6 +226,7 @@ public class DetachedMultipleCollectionChangeTest extends BaseEnversJPAFunctiona
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "requires serial_normalization=sql_sequence setting")
 	public void testAuditJoinTable() throws Exception {
 		List<AuditJoinTableInfo> mceRe1AuditJoinTableInfos = getAuditJoinTableRows(
 				"MCE_RE1_AUD", "MCE_ID",

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/jta/IdentifierProxyJtaSessionClosedBeforeCommitTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/jta/IdentifierProxyJtaSessionClosedBeforeCommitTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  * @author Chris Cranford
  */
 @TestForIssue(jiraKey="HHH-13191")
-@RequiresDialectFeature(DialectChecks.SupportsNoColumnInsert.class)
+@RequiresDialectFeature({ DialectChecks.SupportsNoColumnInsert.class, DialectChecks.SupportsIdentityColumns.class })
 public class IdentifierProxyJtaSessionClosedBeforeCommitTest extends BaseEnversJPAFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytomany/sametable/BasicSametable.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytomany/sametable/BasicSametable.java
@@ -44,17 +44,22 @@ public class BasicSametable extends BaseEnversJPAFunctionalTestCase {
 	public void initData() {
 		EntityManager em = getEntityManager();
 
-		// We need first to modify the columns in the middle (join table) to allow null values. Hbm2ddl doesn't seem
-		// to allow this.
 		em.getTransaction().begin();
 		Session session = (Session) em.getDelegate();
 		session.createSQLQuery( "DROP TABLE children" ).executeUpdate();
+		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
+		em.getTransaction().commit();
+		em.clear();
+
+		// We need first to modify the columns in the middle (join table) to allow null values. Hbm2ddl doesn't seem
+		// to allow this.
+		em.getTransaction().begin();
+		session = (Session) em.getDelegate();
 		session.createSQLQuery(
 				"CREATE TABLE children ( parent_id " + getDialect().getTypeName( Types.INTEGER ) +
 						", child1_id " + getDialect().getTypeName( Types.INTEGER ) + getDialect().getNullColumnString() +
 						", child2_id " + getDialect().getTypeName( Types.INTEGER ) + getDialect().getNullColumnString() + " )"
 		).executeUpdate();
-		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
 		session.createSQLQuery(
 				"CREATE TABLE children_AUD ( REV " + getDialect().getTypeName( Types.INTEGER ) + " NOT NULL" +
 						", REVEND " + getDialect().getTypeName( Types.INTEGER ) +

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/CustomDate.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/CustomDate.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Date;
 import javax.persistence.EntityManager;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.exception.RevisionDoesNotExistException;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
@@ -17,6 +18,7 @@ import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.StrTestEntity;
 import org.hibernate.envers.test.entities.reventity.CustomDateRevEntity;
 
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 /**
@@ -69,6 +71,7 @@ public class CustomDate extends BaseEnversJPAFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testTimestamps() {
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp2 ) ).intValue() == 1;
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp3 ) ).intValue() == 2;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/CustomPropertyAccess.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/CustomPropertyAccess.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Date;
 import javax.persistence.EntityManager;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.exception.RevisionDoesNotExistException;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
@@ -17,6 +18,7 @@ import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.StrTestEntity;
 import org.hibernate.envers.test.entities.reventity.CustomPropertyAccessRevEntity;
 
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 /**
@@ -66,6 +68,7 @@ public class CustomPropertyAccess extends BaseEnversJPAFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testTimestamps() {
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp2 ) ).intValue() == 1;
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp3 ) ).intValue() == 2;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/Inherited.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/Inherited.java
@@ -13,12 +13,14 @@ import java.util.Map;
 import java.util.Set;
 import javax.persistence.EntityManager;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.exception.RevisionDoesNotExistException;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.StrTestEntity;
 
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 /**
@@ -68,6 +70,7 @@ public class Inherited extends BaseEnversJPAFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testTimestamps() {
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp2 ) ).intValue() == 1;
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp3 ) ).intValue() == 2;

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/revfordate/RevisionForDate.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/revfordate/RevisionForDate.java
@@ -9,12 +9,14 @@ package org.hibernate.envers.test.integration.revfordate;
 import java.util.Date;
 import javax.persistence.EntityManager;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.exception.RevisionDoesNotExistException;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.envers.test.entities.StrTestEntity;
 
+import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 /**
@@ -81,6 +83,7 @@ public class RevisionForDate extends BaseEnversJPAFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testTimestamps() {
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp2 ) ).intValue() == 1;
 		assert getAuditReader().getRevisionNumberForDate( new Date( timestamp3 ) ).intValue() == 2;
@@ -88,6 +91,7 @@ public class RevisionForDate extends BaseEnversJPAFunctionalTestCase {
 	}
 	
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testEntitiesForTimestamps() {
 		assert "x".equals( getAuditReader().find( StrTestEntity.class, id, new Date( timestamp2 ) ).getStr() );
 		assert "y".equals( getAuditReader().find( StrTestEntity.class, id, new Date( timestamp3 ) ).getStr() );
@@ -103,6 +107,7 @@ public class RevisionForDate extends BaseEnversJPAFunctionalTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "Fails because of int size")
 	public void testRevisionsForDates() {
 		AuditReader vr = getAuditReader();
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/strategy/ValidityAuditStrategyRevEndTestCustomRevEnt.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/strategy/ValidityAuditStrategyRevEndTestCustomRevEnt.java
@@ -75,6 +75,12 @@ public class ValidityAuditStrategyRevEndTestCustomRevEnt extends BaseEnversJPAFu
 		em.getTransaction().begin();
 		Session session = (Session) em.getDelegate();
 		session.createSQLQuery( "DROP TABLE children" ).executeUpdate();
+		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
+		em.getTransaction().commit();
+		em.clear();
+
+		em.getTransaction().begin();
+		session = (Session) em.getDelegate();
 		session
 				.createSQLQuery(
 						"CREATE TABLE children ( parent_id " + getDialect().getTypeName( Types.INTEGER ) +
@@ -82,7 +88,6 @@ public class ValidityAuditStrategyRevEndTestCustomRevEnt extends BaseEnversJPAFu
 								", child2_id " + getDialect().getTypeName( Types.INTEGER ) + getDialect().getNullColumnString() + " )"
 				)
 				.executeUpdate();
-		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
 		session
 				.createSQLQuery(
 						"CREATE TABLE children_AUD ( REV " + getDialect().getTypeName( Types.INTEGER ) + " NOT NULL" +

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/strategy/ValidityAuditStrategyRevEndTsTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/strategy/ValidityAuditStrategyRevEndTsTest.java
@@ -75,6 +75,12 @@ public class ValidityAuditStrategyRevEndTsTest extends BaseEnversJPAFunctionalTe
 		em.getTransaction().begin();
 		Session session = (Session) em.getDelegate();
 		session.createSQLQuery( "DROP TABLE children" ).executeUpdate();
+		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
+		em.getTransaction().commit();
+		em.clear();
+
+		em.getTransaction().begin();
+		session = (Session) em.getDelegate();
 		session
 				.createSQLQuery(
 						"CREATE TABLE children ( parent_id " + getDialect().getTypeName( Types.INTEGER ) +
@@ -82,7 +88,6 @@ public class ValidityAuditStrategyRevEndTsTest extends BaseEnversJPAFunctionalTe
 								", child2_id " + getDialect().getTypeName( Types.INTEGER ) + getDialect().getNullColumnString() + " )"
 				)
 				.executeUpdate();
-		session.createSQLQuery( "DROP TABLE children_AUD" ).executeUpdate();
 		session
 				.createSQLQuery(
 						"CREATE TABLE children_AUD ( REV " + getDialect().getTypeName( Types.INTEGER ) + " NOT NULL" +

--- a/hibernate-jcache/src/test/java/org/hibernate/jcache/test/RefreshUpdatedDataTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/jcache/test/RefreshUpdatedDataTest.java
@@ -14,23 +14,21 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Version;
-
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.jcache.test.TestHelper;
-import org.hibernate.mapping.Collection;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.tool.schema.Action;
-
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.tool.schema.Action;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +86,7 @@ public class RefreshUpdatedDataTest extends BaseUnitTestCase {
 	}
 
 	@Test
+	@SkipForDialect(value = CockroachDB192Dialect.class, comment = "does not support nested transactions")
 	public void testUpdateAndFlushThenRefresh() {
 		final String BEFORE = "before";
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -280,11 +280,15 @@ abstract public class DialectChecks {
 	}
 
 	public static class SupportsMixedTypeArithmetic implements DialectCheck {
-		public boolean isMatch(Dialect dialect) { return dialect.supportsMixedTypeArithmetic(); }
+		public boolean isMatch(Dialect dialect) {
+			return dialect.supportsMixedTypeArithmetic();
+		}
 	}
 
 	public static class SupportsLoFunctions implements DialectCheck {
-		public boolean isMatch(Dialect dialect) { return  dialect.supportsLoFunctions(); }
+		public boolean isMatch(Dialect dialect) {
+			return dialect.supportsLoFunctions();
+		}
 	}
 
 	public static class SupportsNClob implements DialectCheck {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.testing;
 
-import org.hibernate.dialect.CockroachDBNewDialect;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -295,7 +295,7 @@ abstract public class DialectChecks {
 				dialect instanceof PostgreSQL81Dialect ||
 				dialect instanceof SybaseDialect ||
 				dialect instanceof MySQLDialect ||
-				dialect instanceof CockroachDBNewDialect
+				dialect instanceof CockroachDB192Dialect
 			);
 		}
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -279,18 +279,6 @@ abstract public class DialectChecks {
 		}
 	}
 
-	public static class SupportsMixedTypeArithmetic implements DialectCheck {
-		public boolean isMatch(Dialect dialect) {
-			return dialect.supportsMixedTypeArithmetic();
-		}
-	}
-
-	public static class SupportsLoFunctions implements DialectCheck {
-		public boolean isMatch(Dialect dialect) {
-			return dialect.supportsLoFunctions();
-		}
-	}
-
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.testing;
 
+import org.hibernate.dialect.CockroachDBNewDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -278,6 +279,14 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class SupportsMixedTypeArithmetic implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return dialect.supportsMixedTypeArithmetic(); }
+	}
+
+	public static class SupportsLoFunctions implements DialectCheck {
+		public boolean isMatch(Dialect dialect) { return  dialect.supportsLoFunctions(); }
+	}
+
 	public static class SupportsNClob implements DialectCheck {
 		@Override
 		public boolean isMatch(Dialect dialect) {
@@ -285,7 +294,8 @@ abstract public class DialectChecks {
 				dialect instanceof DB2Dialect ||
 				dialect instanceof PostgreSQL81Dialect ||
 				dialect instanceof SybaseDialect ||
-				dialect instanceof MySQLDialect
+				dialect instanceof MySQLDialect ||
+				dialect instanceof CockroachDBNewDialect
 			);
 		}
 	}


### PR DESCRIPTION
This adds a CockroachDB dialect and build configuration for testing with CockroachDB.

Tests that use features that CockroachDB does not support yet are annotated with SkipForDialect.