### PR TITLE
Wip/6.0 array support 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentArrayHolder.java
@@ -143,6 +143,7 @@ public class PersistentArrayHolder extends AbstractPersistentCollection {
 		for ( int i = 0; i < loadingState.size(); i++ ) {
 			Array.set( array, i, loadingState.get( i ) );
 		}
+		attributeMapping.getPropertyAccess().getSetter().set( getOwner(), array, getSession().getFactory() );
 	}
 
 	@SuppressWarnings("UnusedDeclaration")

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -364,7 +364,7 @@ public class PluralAttributeMappingImpl extends AbstractAttributeMapping impleme
 			DomainResultCreationState creationState) {
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
 
-		if ( fetchTiming == FetchTiming.IMMEDIATE || selected ) {
+		if ( fetchTiming == FetchTiming.IMMEDIATE || selected || getCollectionDescriptor().getCollectionType().hasHolder() ) {
 			final TableGroup collectionTableGroup = sqlAstCreationState.getFromClauseAccess().resolveTableGroup(
 					fetchablePath,
 					p -> {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
@@ -134,7 +134,8 @@ public class PluralAttributeBuilder<D, C, E, K> {
 			return determineSimpleType( attributeMetadata.getMapKeyValueContext(), metadataContext );
 		}
 
-		if ( java.util.List.class.isAssignableFrom( attributeMetadata.getJavaType() ) ) {
+		if ( java.util.List.class.isAssignableFrom( attributeMetadata.getJavaType() )
+				|| attributeMetadata.getJavaType().isArray() ) {
 			return metadataContext.getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( Integer.class );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionAssembler.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.function.Consumer;
 
+import org.hibernate.collection.internal.PersistentArrayHolder;
 import org.hibernate.collection.spi.CollectionSemantics;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CollectionKey;
@@ -49,7 +50,11 @@ public class DelayedCollectionAssembler implements DomainResultAssembler {
 
 	@Override
 	public Object assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
-		return initializer.getCollectionInstance();
+		PersistentCollection collectionInstance = initializer.getCollectionInstance();
+		if ( collectionInstance instanceof PersistentArrayHolder ) {
+			return collectionInstance.getValue();
+		}
+		return collectionInstance;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import org.hibernate.collection.internal.PersistentArrayHolder;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
@@ -29,7 +31,11 @@ public class EagerCollectionAssembler implements DomainResultAssembler {
 
 	@Override
 	public Object assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
-		return initializer.getCollectionInstance();
+		PersistentCollection collectionInstance = initializer.getCollectionInstance();
+		if ( collectionInstance instanceof PersistentArrayHolder ) {
+			return collectionInstance.getValue();
+		}
+		return collectionInstance;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
@@ -1,0 +1,87 @@
+package org.hibernate.orm.test.metamodel.mapping.array;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OrderColumn;
+import javax.persistence.Table;
+
+import org.hibernate.query.spi.QueryImplementor;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@DomainModel(
+		annotatedClasses = { ArrayTests.Employee.class  }
+)
+@ServiceRegistry
+@SessionFactory
+public class ArrayTests {
+
+	@FailureExpected
+	@Test
+	public void basicTest(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final QueryImplementor<Employee> query = session.createQuery(
+							"select e from Employee e",
+							Employee.class
+					);
+					final Employee result = query.uniqueResult();
+					assertThat( result, notNullValue() );
+					assertThat( result.getName(), is( "Koen" ) );
+					String[] todo = result.getToDoList();
+					assertThat( todo.length, is( 3 ) );
+					assertThat( todo[0], is( "metro" ) );
+					assertThat( todo[1], is( "boulot" ) );
+					assertThat( todo[2], is( "dodo" ) );
+				}
+		);
+	}
+
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					ArrayTests.Employee employee = new ArrayTests.Employee();
+					employee.setId( 1 );
+					employee.setName( "Koen" );
+					employee.setToDoList( new String[]{ "metro", "boulot", "dodo"}  );
+					session.save( employee );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+	}
+
+	@Entity(name = "Employee")
+	@Table(name = "employee")
+	public static class Employee {
+		private Integer id;
+		private String name;
+		private String[] toDoList;
+		@Id public Integer getId() { return id; }
+		public void setId(Integer id) { this.id = id; }
+		public String getName() { return name; }
+		public void setName(String name) { this.name = name; }
+		@ElementCollection
+		@OrderColumn
+		public String[] getToDoList() {
+			return toDoList;
+		}
+		public void setToDoList(String[] toDoList) { this.toDoList = toDoList; }
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
@@ -9,7 +9,6 @@ import javax.persistence.Table;
 import org.hibernate.query.spi.QueryImplementor;
 
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -28,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SessionFactory
 public class ArrayTests {
 
-	@FailureExpected
 	@Test
 	public void basicTest(SessionFactoryScope scope) {
 		scope.inTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
@@ -21,7 +21,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @DomainModel(
-		annotatedClasses = { ArrayTests.Employee.class  }
+		annotatedClasses = { ArrayTests.Employee.class }
 )
 @ServiceRegistry
 @SessionFactory
@@ -55,7 +55,7 @@ public class ArrayTests {
 					ArrayTests.Employee employee = new ArrayTests.Employee();
 					employee.setId( 1 );
 					employee.setName( "Koen" );
-					employee.setToDoList( new String[]{ "metro", "boulot", "dodo"}  );
+					employee.setToDoList( new String[] { "metro", "boulot", "dodo" } );
 					session.save( employee );
 				}
 		);
@@ -63,6 +63,10 @@ public class ArrayTests {
 
 	@AfterEach
 	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session ->
+						session.createQuery( "delete from Employee" ).executeUpdate()
+		);
 	}
 
 	@Entity(name = "Employee")
@@ -71,15 +75,32 @@ public class ArrayTests {
 		private Integer id;
 		private String name;
 		private String[] toDoList;
-		@Id public Integer getId() { return id; }
-		public void setId(Integer id) { this.id = id; }
-		public String getName() { return name; }
-		public void setName(String name) { this.name = name; }
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
 		@ElementCollection
 		@OrderColumn
 		public String[] getToDoList() {
 			return toDoList;
 		}
-		public void setToDoList(String[] toDoList) { this.toDoList = toDoList; }
+
+		public void setToDoList(String[] toDoList) {
+			this.toDoList = toDoList;
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/collections/PluralAttributeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/collections/PluralAttributeMappingTests.java
@@ -12,6 +12,7 @@ import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.MappingMetamodel;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
+import org.hibernate.testing.orm.domain.gambit.EntityOfArrays;
 import org.hibernate.testing.orm.domain.gambit.EntityOfSets;
 import org.hibernate.testing.orm.domain.gambit.EntityOfMaps;
 import org.hibernate.testing.orm.domain.gambit.EntityOfLists;
@@ -34,6 +35,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SessionFactory
 @SuppressWarnings("WeakerAccess")
 public class PluralAttributeMappingTests {
+
+	@Test
+	public void testArrays(SessionFactoryScope scope) {
+		final MappingMetamodel domainModel = scope.getSessionFactory().getDomainModel();
+		final EntityMappingType containerEntityDescriptor = domainModel.getEntityDescriptor( EntityOfArrays.class );
+
+		assertThat( containerEntityDescriptor.getNumberOfAttributeMappings(), is( 2 ) );
+
+		final AttributeMapping arrayOfBasics = containerEntityDescriptor.findAttributeMapping( "arrayOfBasics" );
+		assertThat( arrayOfBasics, notNullValue() );
+	}
 
 	@Test
 	public void testLists(SessionFactoryScope scope) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/EntityOfArrays.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/EntityOfArrays.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.orm.domain.gambit;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OrderColumn;
+
+/**
+ * @author Koen Aers
+ */
+@SuppressWarnings("unused")
+@Entity
+public class EntityOfArrays {
+
+	private Integer id;
+	private String name;
+
+	private String[] arrayOfBasics;
+
+
+	public EntityOfArrays() {
+	}
+
+	public EntityOfArrays(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	@Id
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// arrayOfBasics
+
+	@ElementCollection
+	@OrderColumn
+	public String[] getArrayOfBasics() {
+		return arrayOfBasics;
+	}
+
+	public void setArrayOfBasics(String[] arrayOfBasics) {
+		this.arrayOfBasics = arrayOfBasics;
+	}
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/GambitDomainModel.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/GambitDomainModel.java
@@ -19,6 +19,7 @@ public class GambitDomainModel extends AbstractDomainModelDescriptor {
 				BasicEntity.class,
 				Component.class,
 				EmbeddedIdEntity.class,
+				EntityOfArrays.class,
 				EntityOfBasics.class,
 				EntityOfComposites.class,
 				EntityOfDynamicComponent.class,


### PR DESCRIPTION
Fix the error caused by trying to set a `PersisteArrayHolder` as the value of the Entity array filed when initializing the entity.