### PR TITLE
HHH-13765 - Missing Hierarchy subclass in query clause when using treat

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -622,8 +622,8 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			if ( !queryable.isAbstract() ) {
 				values.add( queryable.getDiscriminatorSQLValue() );
 			}
-			else if ( queryable.hasSubclasses() ) {
-				// if the treat is an abstract class, add the concrete implementations to values if any
+			if ( queryable.hasSubclasses() ) {
+				// add the concrete implementations to values if any
 				Set<String> actualSubClasses = queryable.getEntityMetamodel().getSubclassEntityNames();
 
 				for ( String actualSubClass : actualSubClasses ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -632,9 +632,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 					}
 
 					Queryable actualQueryable = (Queryable) getFactory().getEntityPersister( actualSubClass );
-					if ( !actualQueryable.hasSubclasses() ) {
-						values.add( actualQueryable.getDiscriminatorSQLValue() );
-					}
+					values.add( actualQueryable.getDiscriminatorSQLValue() );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Boat.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Boat.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.criteria;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Michele Preti
+ */
+@Entity
+public class Boat extends Veicle {
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Car.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Car.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.criteria;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Michele Preti
+ */
+@Entity
+public class Car extends Veicle {
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/SUV.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/SUV.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.criteria;
+
+import javax.persistence.Entity;
+
+/**
+ * @author Michele Preti
+ */
+@Entity
+public class SUV extends Car {
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/TreatKeywordTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/TreatKeywordTest.java
@@ -38,7 +38,7 @@ public class TreatKeywordTest extends BaseEntityManagerFunctionalTestCase {
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class[] {
 				Animal.class, Elephant.class, Human.class, Thing.class, ThingWithQuantity.class,
-				TreatAnimal.class, Dog.class, Dachshund.class, Greyhound.class
+				TreatAnimal.class, Dog.class, Dachshund.class, Greyhound.class, Veicle.class, Car.class, Boat.class, SUV.class
 		};
 	}
 
@@ -175,6 +175,39 @@ public class TreatKeywordTest extends BaseEntityManagerFunctionalTestCase {
 		criteria.select( builder.treat( root, Human.class ) );
 		List<Human> humans = em.createQuery( criteria ).getResultList();
 		Assert.assertEquals( 1, humans.size() );
+
+		em.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-13765" )
+	public void treatRootSingleTableInheritance() {
+		EntityManager em = getOrCreateEntityManager();
+
+		em.getTransaction().begin();
+		Veicle veicle = new Veicle();
+		veicle.setId(100L);
+		veicle.setName("Veicle");
+		em.persist(veicle);
+		Car car = new Car();
+		car.setId(200L);
+		car.setName("Car");
+		em.persist(car);
+		SUV suv = new SUV();
+		suv.setId(300L);
+		suv.setName("SUV");
+		em.persist(suv);
+		em.getTransaction().commit();
+
+		CriteriaBuilder builder = em.getCriteriaBuilder();
+		CriteriaQuery<Veicle> criteria = builder.createQuery( Veicle.class );
+		Root<Veicle> root = criteria.from( Veicle.class );
+		criteria.select( root );
+		criteria.where( builder.isNotNull( builder.treat( root, Car.class ).get( "name" ) ) );
+		
+		List<Veicle> veicles = em.createQuery( criteria ).getResultList();
+		Assert.assertEquals( 2, veicles.size() );
+
 
 		em.close();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Veicle.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/Veicle.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.criteria;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+/**
+ * @author Michele Preti
+ */
+@Entity
+@Table( name = "VEICLE" )
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public class Veicle {
+	private Long id;
+	private String name;
+
+	@Id
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}


### PR DESCRIPTION
With an entity hierarchy as such:

**A**  
  **B** extends **A**    
    **C1** extendes **B**    
    **C2** extends **B**     
      **D** extends **C1**

creating a query using treat:

`select a from A where treat(a as B).property = 'something';`

the generated sql will be:

```
select ... 
from A
where DTYPE in ('C2', 'D') and ...
```

**C1** and **B** are missing, but should be there, since they are not Abstract.
The subclass should be excluded from the query only if the entity is Abstract

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-13765
<!-- Hibernate GitHub Bot issue links end -->