### PR TITLE
Wip/6.0 SelectEagerCollectionInitializer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractBagSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractBagSemantics.java
@@ -73,12 +73,8 @@ public abstract class AbstractBagSemantics<B extends Collection<?>> implements C
 			String resultVariable,
 			LockMode lockMode,
 			DomainResultCreationState creationState) {
-		final TableGroup tableGroup = creationState.getSqlAstCreationState()
-				.getFromClauseAccess()
-				.getTableGroup( navigablePath );
 		return new BagInitializerProducer(
 				attributeMapping,
-				selected,
 				attributeMapping.getIdentifierDescriptor() == null ? null : attributeMapping.getIdentifierDescriptor().generateFetch(
 						fetchParent,
 						navigablePath.append( CollectionPart.Nature.ID.getName() ),

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractMapSemantics.java
@@ -86,12 +86,8 @@ public abstract class AbstractMapSemantics<M extends Map<?,?>> implements MapSem
 			String resultVariable,
 			LockMode lockMode,
 			DomainResultCreationState creationState) {
-		final TableGroup tableGroup = creationState.getSqlAstCreationState()
-				.getFromClauseAccess()
-				.getTableGroup( navigablePath );
 		return new MapInitializerProducer(
 				attributeMapping,
-				selected,
 				attributeMapping.getIndexDescriptor().generateFetch(
 						fetchParent,
 						navigablePath.append( CollectionPart.Nature.INDEX.getName() ),

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractSetSemantics.java
@@ -58,7 +58,6 @@ public abstract class AbstractSetSemantics<S extends Set<?>> implements Collecti
 			DomainResultCreationState creationState) {
 		return new SetInitializerProducer(
 				attributeMapping,
-				selected,
 				attributeMapping.getElementDescriptor().generateFetch(
 						fetchParent,
 						navigablePath.append( CollectionPart.Nature.ELEMENT.getName() ),

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentArrayHolder.java
@@ -133,6 +133,7 @@ public class PersistentArrayHolder extends AbstractPersistentCollection {
 	public void initializeEmptyCollection(CollectionPersister persister) {
 		assert array == null;
 		array = Array.newInstance( persister.getElementClass(), 0 );
+		persister.getAttributeMapping().getPropertyAccess().getSetter().set( getOwner(), array, getSession().getFactory() );
 		endRead();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
@@ -104,12 +104,8 @@ public class StandardArraySemantics implements CollectionSemantics<Object[]> {
 			String resultVariable,
 			LockMode lockMode,
 			DomainResultCreationState creationState) {
-		final TableGroup tableGroup = creationState.getSqlAstCreationState()
-				.getFromClauseAccess()
-				.getTableGroup( navigablePath );
 		return new ArrayInitializerProducer(
 				attributeMapping,
-				selected,
 				attributeMapping.getIndexDescriptor().generateFetch(
 						fetchParent,
 						navigablePath.append( CollectionPart.Nature.INDEX.getName() ),

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
@@ -78,12 +78,8 @@ public class StandardListSemantics implements CollectionSemantics<List> {
 			String resultVariable,
 			LockMode lockMode,
 			DomainResultCreationState creationState) {
-		final TableGroup tableGroup = creationState.getSqlAstCreationState()
-				.getFromClauseAccess()
-				.getTableGroup( navigablePath );
 		return new ListInitializerProducer(
 				attributeMapping,
-				selected,
 				attributeMapping.getIndexDescriptor().generateFetch(
 						fetchParent,
 						navigablePath.append( CollectionPart.Nature.INDEX.getName() ),

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -90,7 +90,8 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 	private void handlePotentiallyEmptyCollection(
 			PersistentCollection collection,
 			SessionImplementor source,
-			CollectionEntry ce, CollectionPersister ceLoadedPersister) {
+			CollectionEntry ce,
+			CollectionPersister ceLoadedPersister) {
 		if ( !collection.wasInitialized() ) {
 			collection.initializeEmptyCollection( ceLoadedPersister );
 			org.hibernate.sql.results.internal.Helper.finalizeCollectionLoading(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/Fetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/Fetch.java
@@ -57,11 +57,6 @@ public interface Fetch extends DomainResultGraphNode {
 	boolean hasTableGroup();
 
 	/**
-	 * Is this fetch nullable?  Meaning is it mapped as being optional?
-	 */
-	boolean isNullable();
-
-	/**
 	 * Create the assembler for this fetch
 	 */
 	DomainResultAssembler createAssembler(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicFetch.java
@@ -93,11 +93,6 @@ public class BasicFetch<T> implements Fetch, BasicResultGraphNode<T> {
 	}
 
 	@Override
-	public boolean isNullable() {
-		return nullable;
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionAssembler.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.results.graph.collection.internal;
+
+import org.hibernate.collection.internal.PersistentArrayHolder;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
+import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
+/**
+ * @author Andrea Boriero
+ */
+public abstract class AbstractCollectionAssembler implements DomainResultAssembler {
+	private final PluralAttributeMapping fetchedMapping;
+
+	protected final CollectionInitializer initializer;
+
+	public AbstractCollectionAssembler(
+			PluralAttributeMapping fetchedMapping,
+			CollectionInitializer initializer) {
+		this.fetchedMapping = fetchedMapping;
+		this.initializer = initializer;
+	}
+
+	@Override
+	public Object assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
+		PersistentCollection collectionInstance = initializer.getCollectionInstance();
+		if ( collectionInstance instanceof PersistentArrayHolder ) {
+			return collectionInstance.getValue();
+		}
+		return collectionInstance;
+	}
+
+	@Override
+	public JavaTypeDescriptor getAssembledJavaTypeDescriptor() {
+		return fetchedMapping.getJavaTypeDescriptor();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -67,10 +67,24 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			return;
 		}
 
+		final PluralAttributeMapping collectionAttributeMapping = getCollectionAttributeMapping();
+		final CollectionPersister collectionDescriptor = collectionAttributeMapping.getCollectionDescriptor();
+		final CollectionSemantics collectionSemantics = collectionDescriptor.getCollectionSemantics();
+
 		final SharedSessionContractImplementor session = rowProcessingState.getSession();
 		final PersistenceContext persistenceContext = session.getPersistenceContext();
 
 		final CollectionKey collectionKey = resolveCollectionKey( rowProcessingState );
+
+		if ( collectionKey == null ) {
+			collectionInstance = collectionSemantics.instantiateWrapper(
+					null,
+					collectionDescriptor,
+					session
+			);
+			collectionInstance.initializeEmptyCollection( collectionDescriptor );
+			persistenceContext.addNonLazyCollection( collectionInstance );
+		}
 
 		if ( CollectionLoadingLogger.TRACE_ENABLED ) {
 			CollectionLoadingLogger.INSTANCE.tracef(
@@ -91,10 +105,6 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 				.findLoadingCollectionEntry( collectionKey );
 //		final LoadingCollectionEntry existingLoadingEntry = rowProcessingState.getJdbcValuesSourceProcessingState()
 //				.findLoadingCollectionLocally( getCollectionDescriptor(), collectionKey.getKey() );
-
-		final PluralAttributeMapping collectionAttributeMapping = getCollectionAttributeMapping();
-		final CollectionPersister collectionDescriptor = collectionAttributeMapping.getCollectionDescriptor();
-		final CollectionSemantics collectionSemantics = collectionDescriptor.getCollectionSemantics();
 
 		if ( existingLoadingEntry != null ) {
 			collectionInstance = existingLoadingEntry.getCollectionInstance();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -31,7 +31,6 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer {
 			NavigablePath navigablePath,
 			PluralAttributeMapping arrayDescriptor,
 			FetchParentAccess parentAccess,
-			boolean selected,
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
@@ -41,7 +40,6 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer {
 				navigablePath,
 				arrayDescriptor,
 				parentAccess,
-				selected,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -24,17 +24,14 @@ import org.hibernate.sql.results.graph.Initializer;
  */
 public class ArrayInitializerProducer implements CollectionInitializerProducer {
 	private final PluralAttributeMapping arrayDescriptor;
-	private final boolean joined;
 	private final Fetch listIndexFetch;
 	private final Fetch elementFetch;
 
 	public ArrayInitializerProducer(
 			PluralAttributeMapping arrayDescriptor,
-			boolean joined,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
 		this.arrayDescriptor = arrayDescriptor;
-		this.joined = joined;
 		this.listIndexFetch = listIndexFetch;
 		this.elementFetch = elementFetch;
 	}
@@ -53,7 +50,6 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				navigablePath,
 				arrayDescriptor,
 				parentAccess,
-				joined,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -33,13 +33,12 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer {
 			PluralAttributeMapping bagDescriptor,
 			FetchParentAccess parentAccess,
 			NavigablePath navigablePath,
-			boolean selected,
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
 			DomainResultAssembler elementAssembler,
 			DomainResultAssembler collectionIdAssembler) {
-		super( navigablePath, bagDescriptor, parentAccess, selected, lockMode, keyContainerAssembler, keyCollectionAssembler );
+		super( navigablePath, bagDescriptor, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.elementAssembler = elementAssembler;
 		this.collectionIdAssembler = collectionIdAssembler;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -25,17 +25,14 @@ import org.hibernate.sql.results.graph.Initializer;
  */
 public class BagInitializerProducer implements CollectionInitializerProducer {
 	private final PluralAttributeMapping bagDescriptor;
-	private final boolean selected;
 	private final Fetch collectionIdFetch;
 	private final Fetch elementFetch;
 
 	public BagInitializerProducer(
 			PluralAttributeMapping bagDescriptor,
-			boolean selected,
 			Fetch collectionIdFetch,
 			Fetch elementFetch) {
 		this.bagDescriptor = bagDescriptor;
-		this.selected = selected;
 
 		if ( bagDescriptor.getIdentifierDescriptor() != null ) {
 			assert collectionIdFetch != null;
@@ -82,7 +79,6 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 				bagDescriptor,
 				parentAccess,
 				navigablePath,
-				selected,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionFetch.java
@@ -18,19 +18,15 @@ public abstract class CollectionFetch implements Fetch {
 	private final NavigablePath fetchedPath;
 	private final PluralAttributeMapping fetchedAttribute;
 
-	private final boolean nullable;
-
 	private final FetchParent fetchParent;
 
 	public CollectionFetch(
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
-			boolean nullable,
 			FetchParent fetchParent) {
 		this.fetchedPath = fetchedPath;
 		this.fetchedAttribute = fetchedAttribute;
 		this.fetchParent = fetchParent;
-		this.nullable = nullable;
 	}
 
 	@Override
@@ -46,10 +42,5 @@ public abstract class CollectionFetch implements Fetch {
 	@Override
 	public NavigablePath getNavigablePath() {
 		return fetchedPath;
-	}
-
-	@Override
-	public boolean isNullable() {
-		return nullable;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
@@ -6,41 +6,17 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import org.hibernate.collection.internal.PersistentArrayHolder;
-import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.sql.results.graph.collection.CollectionInitializer;
-import org.hibernate.sql.results.graph.DomainResultAssembler;
-import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
-import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * @author Steve Ebersole
  */
-public class EagerCollectionAssembler implements DomainResultAssembler {
-	private final PluralAttributeMapping fetchedMapping;
-	private final CollectionInitializer initializer;
+public class EagerCollectionAssembler extends AbstractCollectionAssembler {
 
 	public EagerCollectionAssembler(
 			PluralAttributeMapping fetchedMapping,
 			CollectionInitializer initializer) {
-		this.fetchedMapping = fetchedMapping;
-		this.initializer = initializer;
+		super( fetchedMapping, initializer );
 	}
-
-	@Override
-	public Object assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
-		PersistentCollection collectionInstance = initializer.getCollectionInstance();
-		if ( collectionInstance instanceof PersistentArrayHolder ) {
-			return collectionInstance.getValue();
-		}
-		return collectionInstance;
-	}
-
-	@Override
-	public JavaTypeDescriptor getAssembledJavaTypeDescriptor() {
-		return fetchedMapping.getJavaTypeDescriptor();
-	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionFetch.java
@@ -49,10 +49,9 @@ public class EagerCollectionFetch extends CollectionFetch implements FetchParent
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
 			TableGroup collectionTableGroup,
-			boolean nullable,
 			FetchParent fetchParent,
 			DomainResultCreationState creationState) {
-		super( fetchedPath, fetchedAttribute, nullable, fetchParent );
+		super( fetchedPath, fetchedAttribute, fetchParent );
 
 		final FromClauseAccess fromClauseAccess = creationState.getSqlAstCreationState().getFromClauseAccess();
 		final NavigablePath parentPath = fetchedPath.getParent();
@@ -91,7 +90,7 @@ public class EagerCollectionFetch extends CollectionFetch implements FetchParent
 				fetchedPath,
 				fetchedAttribute,
 				fetchParent,
-				nullable,
+				true,
 				null,
 				// todo (6.0) : we need to propagate these lock modes
 				LockMode.READ,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -33,13 +33,12 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer {
 			NavigablePath navigablePath,
 			PluralAttributeMapping attributeMapping,
 			FetchParentAccess parentAccess,
-			boolean selected,
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
 			DomainResultAssembler listIndexAssembler,
 			DomainResultAssembler elementAssembler) {
-		super( navigablePath, attributeMapping, parentAccess, selected, lockMode, keyContainerAssembler, keyCollectionAssembler );
+		super( navigablePath, attributeMapping, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.listIndexAssembler = listIndexAssembler;
 		this.elementAssembler = elementAssembler;
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -24,17 +24,14 @@ import org.hibernate.sql.results.graph.Initializer;
  */
 public class ListInitializerProducer implements CollectionInitializerProducer {
 	private final PluralAttributeMapping attributeMapping;
-	private final boolean joined;
 	private final Fetch listIndexFetch;
 	private final Fetch elementFetch;
 
 	public ListInitializerProducer(
 			PluralAttributeMapping attributeMapping,
-			boolean joined,
 			Fetch listIndexFetch,
 			Fetch elementFetch) {
 		this.attributeMapping = attributeMapping;
-		this.joined = joined;
 		this.listIndexFetch = listIndexFetch;
 		this.elementFetch = elementFetch;
 	}
@@ -53,7 +50,6 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				navigablePath,
 				attributeMapping,
 				parentAccess,
-				joined,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -34,13 +34,12 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer {
 			NavigablePath navigablePath,
 			PluralAttributeMapping attributeMapping,
 			FetchParentAccess parentAccess,
-			boolean selected,
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
 			DomainResultAssembler mapKeyAssembler,
 			DomainResultAssembler mapValueAssembler) {
-		super( navigablePath, attributeMapping, parentAccess, selected, lockMode, keyContainerAssembler, keyCollectionAssembler );
+		super( navigablePath, attributeMapping, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.mapKeyAssembler = mapKeyAssembler;
 		this.mapValueAssembler = mapValueAssembler;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -24,17 +24,14 @@ import org.hibernate.sql.results.graph.Initializer;
  */
 public class MapInitializerProducer implements CollectionInitializerProducer {
 	private final PluralAttributeMapping mapDescriptor;
-	private final boolean isJoined;
 	private final Fetch mapKeyFetch;
 	private final Fetch mapValueFetch;
 
 	public MapInitializerProducer(
 			PluralAttributeMapping mapDescriptor,
-			boolean isJoined,
 			Fetch mapKeyFetch,
 			Fetch mapValueFetch) {
 		this.mapDescriptor = mapDescriptor;
-		this.isJoined = isJoined;
 		this.mapKeyFetch = mapKeyFetch;
 		this.mapValueFetch = mapValueFetch;
 	}
@@ -65,7 +62,6 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 				navigablePath,
 				mapDescriptor,
 				parentAccess,
-				isJoined,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionAssembler.java
@@ -15,16 +15,17 @@ import org.hibernate.sql.results.graph.FetchParentAccess;
 import org.hibernate.sql.results.graph.Initializer;
 
 /**
- * @author Steve Ebersole
+ * @author Andrea Boriero
  */
-public class DelayedCollectionAssembler extends AbstractCollectionAssembler {
-	public DelayedCollectionAssembler(
+public class SelectEagerCollectionAssembler extends AbstractCollectionAssembler {
+
+	public SelectEagerCollectionAssembler(
 			NavigablePath fetchPath,
 			PluralAttributeMapping fetchedMapping,
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		super( fetchedMapping, new DelayedCollectionInitializer( fetchPath, fetchedMapping, parentAccess ) );
+		super( fetchedMapping, new SelectEagerCollectionInitializer( fetchPath, fetchedMapping, parentAccess ) );
 		collector.accept( initializer );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -19,28 +19,14 @@ import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
- * @author Steve Ebersole
+ * @author Andrea Boriero
  */
-public class DelayedCollectionFetch extends CollectionFetch {
-	public DelayedCollectionFetch(
+public class SelectEagerCollectionFetch extends CollectionFetch {
+	public SelectEagerCollectionFetch(
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedAttribute,
 			FetchParent fetchParent) {
 		super( fetchedPath, fetchedAttribute, fetchParent );
-	}
-
-	@Override
-	public DomainResultAssembler createAssembler(
-			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
-			AssemblerCreationState creationState) {
-		return new DelayedCollectionAssembler(
-				getNavigablePath(),
-				getFetchedMapping(),
-				parentAccess,
-				collector,
-				creationState
-		);
 	}
 
 	@Override
@@ -51,6 +37,18 @@ public class DelayedCollectionFetch extends CollectionFetch {
 	@Override
 	public boolean hasTableGroup() {
 		return false;
+	}
+
+	@Override
+	public DomainResultAssembler createAssembler(
+			FetchParentAccess parentAccess, Consumer<Initializer> collector, AssemblerCreationState creationState) {
+		return new SelectEagerCollectionAssembler(
+				getNavigablePath(),
+				getFetchedMapping(),
+				parentAccess,
+				collector,
+				creationState
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -20,11 +20,11 @@ import org.hibernate.sql.results.graph.collection.LoadingCollectionEntry;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 
 /**
- * @author Steve Ebersole
+ * @author Andrea Boriero
  */
-public class DelayedCollectionInitializer extends AbstractCollectionInitializer {
+public class SelectEagerCollectionInitializer extends AbstractCollectionInitializer {
 
-	public DelayedCollectionInitializer(
+	public SelectEagerCollectionInitializer(
 			NavigablePath fetchedPath,
 			PluralAttributeMapping fetchedMapping,
 			FetchParentAccess parentAccess) {
@@ -74,6 +74,8 @@ public class DelayedCollectionInitializer extends AbstractCollectionInitializer 
 					key
 			);
 
+			persistenceContext.addNonLazyCollection( collectionInstance );
+
 			if ( collectionSemantics.getCollectionClassification() == CollectionClassification.ARRAY ) {
 				session.getPersistenceContext().addCollectionHolder( collectionInstance );
 			}
@@ -86,7 +88,7 @@ public class DelayedCollectionInitializer extends AbstractCollectionInitializer 
 
 	@Override
 	public String toString() {
-		return "DelayedCollectionInitializer(" + LoggingHelper.toLoggableString( getNavigablePath() ) + ")";
+		return "SelectEagerCollectionInitializer(" + LoggingHelper.toLoggableString( getNavigablePath() ) + ")";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -28,12 +28,11 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer {
 			NavigablePath navigablePath,
 			PluralAttributeMapping setDescriptor,
 			FetchParentAccess parentAccess,
-			boolean selected,
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
 			DomainResultAssembler elementAssembler) {
-		super( navigablePath, setDescriptor, parentAccess, selected, lockMode, keyContainerAssembler, keyCollectionAssembler );
+		super( navigablePath, setDescriptor, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.elementAssembler = elementAssembler;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -24,16 +24,13 @@ import org.hibernate.sql.results.graph.Initializer;
  */
 public class SetInitializerProducer implements CollectionInitializerProducer {
 	private final PluralAttributeMapping setDescriptor;
-	private final boolean isSelected;
 	private final Fetch elementFetch;
 
 	public SetInitializerProducer(
 			PluralAttributeMapping setDescriptor,
-			boolean isSelected,
 			Fetch elementFetch) {
 		this.setDescriptor = setDescriptor;
 		this.elementFetch = elementFetch;
-		this.isSelected = isSelected;
 	}
 
 	@Override
@@ -56,7 +53,6 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 				navigablePath,
 				setDescriptor,
 				parentAccess,
-				isSelected,
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
@@ -111,11 +111,6 @@ public class EmbeddableFetchImpl extends AbstractFetchParent implements Embeddab
 	}
 
 	@Override
-	public boolean isNullable() {
-		return nullable;
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
@@ -62,11 +62,6 @@ public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent imp
 	}
 
 	@Override
-	public boolean isNullable() {
-		return nullable;
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchDelayedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchDelayedImpl.java
@@ -55,11 +55,6 @@ public class EntityFetchDelayedImpl extends AbstractNonJoinedEntityFetch {
 	}
 
 	@Override
-	public boolean isNullable() {
-		return nullable;
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -53,11 +53,6 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 	}
 
 	@Override
-	public boolean isNullable() {
-		return nullable;
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/BiDirectionalFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/BiDirectionalFetchImpl.java
@@ -89,11 +89,6 @@ public class BiDirectionalFetchImpl implements BiDirectionalFetch, Association {
 	}
 
 	@Override
-	public boolean isNullable() {
-		throw new NotYetImplementedFor6Exception( getClass() );
-	}
-
-	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
 			Consumer<Initializer> collector,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.sql.results.jdbc.spi.JdbcValues;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
@@ -47,7 +48,8 @@ public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 			RowProcessingStateStandardImpl rowProcessingState,
 			RowReader<R> rowReader) {
 		try {
-			session.getPersistenceContext().getLoadContexts().register( jdbcValuesSourceProcessingState );
+			final PersistenceContext persistenceContext = session.getPersistenceContext();
+			persistenceContext.getLoadContexts().register( jdbcValuesSourceProcessingState );
 
 			boolean uniqueRows = false;
 			final Class<R> resultJavaType = rowReader.getResultJavaType();
@@ -76,6 +78,7 @@ public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 
 				rowProcessingState.finishRowProcessing();
 			}
+			persistenceContext.initializeNonLazyCollections();
 			return results;
 		}
 		catch (SQLException e) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/array/ArrayTests.java
@@ -8,6 +8,7 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.hibernate.query.spi.QueryImplementor;
+import org.hibernate.stat.spi.StatisticsImplementor;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -25,11 +26,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 		annotatedClasses = { ArrayTests.Employee.class }
 )
 @ServiceRegistry
-@SessionFactory
+@SessionFactory(generateStatistics = true)
 public class ArrayTests {
 
 	@Test
 	public void basicTest(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
 		scope.inTransaction(
 				session -> {
 					final QueryImplementor<Employee> query = session.createQuery(
@@ -37,6 +40,7 @@ public class ArrayTests {
 							Employee.class
 					);
 					final Employee result = query.uniqueResult();
+					assertThat( statistics.getPrepareStatementCount(), is(2L) );
 					assertThat( result, notNullValue() );
 					assertThat( result.getName(), is( "Koen" ) );
 					String[] todo = result.getToDoList();
@@ -57,6 +61,8 @@ public class ArrayTests {
 				}
 		);
 
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
 		scope.inTransaction(
 				session -> {
 					final QueryImplementor<Employee> query = session.createQuery(
@@ -64,6 +70,7 @@ public class ArrayTests {
 							Employee.class
 					);
 					final Employee result = query.setParameter( "id", 2 ).uniqueResult();
+					assertThat( statistics.getPrepareStatementCount(), is(2L) );
 
 					assertThat( result, notNullValue() );
 					assertThat( result.getName(), is( "Andrea" ) );
@@ -72,6 +79,7 @@ public class ArrayTests {
 				}
 		);
 
+		statistics.clear();
 		scope.inTransaction(
 				session -> {
 					final QueryImplementor<Employee> query = session.createQuery(
@@ -79,6 +87,7 @@ public class ArrayTests {
 							Employee.class
 					);
 					final List<Employee> results = query.list();
+					assertThat( statistics.getPrepareStatementCount(), is(3L) );
 
 					assertThat( results.size(), is( 2 ) );
 					results.forEach( employee -> {


### PR DESCRIPTION
Given an `Order` with a eager collection of `Item`s
the `session.createQuery( "from Order", Order.class ).uniqueResult();`
should not create one Sql query with a join but 2 different queries.