### PR TITLE
Wip/6.0 Implement ResourceRegistryStandardImpl#convert to avoid NPE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/ResourceRegistryStandardImpl.java
@@ -239,8 +239,7 @@ public final class ResourceRegistryStandardImpl implements ResourceRegistry {
 	}
 
 	private JDBCException convert(SQLException e, String s) {
-		// todo : implement
-		return null;
+		return new JDBCException( s, e );
 	}
 
 	@Override


### PR DESCRIPTION
A simple removal of 'todo'. Found during code review of Vlad's https://github.com/hibernate/hibernate-orm/pull/3292