### PR TITLE
HHH-13619 - Support for JPA's `size` function as a select expression

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/CollectionSizeNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/CollectionSizeNode.java
@@ -74,7 +74,7 @@ public class CollectionSizeNode extends SqlNode implements SelectExpression {
 		final String sizeColumn = sizeColumns[0];
 
 		final StringBuilder buffer = new StringBuilder( "(select " ).append( sizeColumn );
-		buffer.append( " from " ).append( collectionDescriptor.getTableName() ).append( " as " ).append( collectionTableAlias );
+		buffer.append( " from " ).append( collectionDescriptor.getTableName() ).append( " " ).append( collectionTableAlias );
 		buffer.append( " where " );
 
 		boolean firstPass = true;


### PR DESCRIPTION
- Fix to work on Oracle by removing "as" between table name and alias

@sebersole or @dreab8, this works for Oracle. I thought there was some `Dialect` method that indicates if "as" is needed between table name and alias, but I don't see it.

Is there one that I missed?

Do you know if this will break for any dialects?