### PR TITLE
wip/6.0 Fix bug in EmbeddedCollectionPart#createTableGroupJoin

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedCollectionPart.java
@@ -207,12 +207,14 @@ public class EmbeddedCollectionPart implements CollectionPart, EmbeddableValuedF
 
 		final TableGroup tableGroup = new CompositeTableGroup( navigablePath, this, lhs );
 
-		return new TableGroupJoin(
+		final TableGroupJoin tableGroupJoin = new TableGroupJoin(
 				navigablePath,
 				sqlAstJoinType,
 				tableGroup,
 				null
 		);
+		lhs.addTableGroupJoin( tableGroupJoin );
+		return tableGroupJoin;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/graph/embeddable/internal/EmbeddableFetchImplTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/graph/embeddable/internal/EmbeddableFetchImplTests.java
@@ -1,0 +1,63 @@
+package org.hibernate.orm.test.sql.results.graph.embeddable.internal;
+
+import java.util.Set;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				EmbeddableFetchImplTests.ExpressCompany.class,
+				EmbeddableFetchImplTests.Address.class,
+				EmbeddableFetchImplTests.Country.class
+		}
+)
+@SessionFactory
+public class EmbeddableFetchImplTests {
+
+	@Test
+	void testTableGroupJoin(SessionFactoryScope scope) {
+		scope.inTransaction(
+				// will throw exception if the patch accompanying this test is not applied
+				// for 'country' alias shows up in 'select', but not in 'from' clause
+				session -> session.get( ExpressCompany.class, "nonexistent" )
+		);
+	}
+
+	@Entity(name = "ExpressCompany")
+	public static class ExpressCompany {
+		@Id
+		String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		Set<Address> shipAddresses;
+	}
+
+	@Embeddable
+	public static class Address {
+		@ManyToOne
+		@Fetch(FetchMode.JOIN)
+		Country country;
+	}
+
+	@Entity(name = "Country")
+	public static class Country {
+		@Id
+		String name;
+	}
+
+}


### PR DESCRIPTION
Seems an overlooking. In all other cases the created 'tableJoinFetch' is added to 'lhsTableGroup', except this one.