### PR TITLE
HHH-13882 Fix bug in EntityGraphQueryHint

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/EntityGraphQueryHint.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/EntityGraphQueryHint.java
@@ -18,7 +18,6 @@ import javax.persistence.Subgraph;
 import org.hibernate.QueryException;
 import org.hibernate.engine.internal.JoinSequence;
 import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.hql.internal.ast.HqlSqlWalker;

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/EntityGraphQueryHint.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/EntityGraphQueryHint.java
@@ -102,7 +102,6 @@ public class EntityGraphQueryHint implements AppliedGraph {
 			// TODO: This is ignored by collection types and probably wrong for entity types.  Presumably it screws
 			// with inheritance.
 			final String role = className + "." + attributeName;
-			final String classAlias = origin.getClassAlias();
 			final String originTableAlias = origin.getTableAlias();
 			final Type propertyType = origin.getPropertyType( attributeName, attributeName );
 
@@ -120,7 +119,7 @@ public class EntityGraphQueryHint implements AppliedGraph {
 
 						final FromElementFactory fromElementFactory = new FromElementFactory(
 								fromClause, origin,
-								attributeName, classAlias, columns, false
+								attributeName, null, columns, false
 						);
 						final JoinSequence joinSequence = walker.getSessionFactoryHelper().createJoinSequence(
 								false, entityType, tableAlias, JoinType.LEFT_OUTER_JOIN, columns
@@ -142,7 +141,7 @@ public class EntityGraphQueryHint implements AppliedGraph {
 
 						final FromElementFactory fromElementFactory = new FromElementFactory(
 								fromClause, origin,
-								attributeName, classAlias, columns, false
+								attributeName, null, columns, false
 						);
 						final QueryableCollection queryableCollection = walker.getSessionFactoryHelper()
 								.requireQueryableCollection( collectionType.getRole() );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryWithEntityGraphOnCollectionAndLockmodeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/QueryWithEntityGraphOnCollectionAndLockmodeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.query;
+
+import java.util.Set;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.LockModeType;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
+import javax.persistence.TypedQuery;
+
+import org.hibernate.graph.GraphSemantic;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-13882" )
+public class QueryWithEntityGraphOnCollectionAndLockmodeTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Person.class };
+	}
+
+	@Test
+	public void test() {
+		inTransaction( session -> {
+			TypedQuery<Person> query = session.createQuery( "select p from Person p", Person.class );
+			query.setLockMode( LockModeType.READ );
+			query.setHint( GraphSemantic.FETCH.getJpaHintName(), session.createEntityGraph( "withNicknames" ) );
+			query.getResultList(); // NPE thrown here in HHH-13882
+		} );
+	}
+
+	@Entity( name = "Person" )
+	@NamedEntityGraph( name = "withNicknames", attributeNodes = @NamedAttributeNode( "nicknames" ) )
+	public static class Person {
+		@Id
+		private long id;
+
+		@ElementCollection
+		private Set<String> nicknames;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13882

The bug manifests itself with the following preconditions:

1. entity graph is used on collection
2. LockMode is specified for query

The root cause is we set 'classAlias' of LHS to RHS in EntityGraphQueryHint. Luckily EntityGraphQueryHint will be refactored in v6 so this PR only applies for v5.
