### PR TITLE
Wip/6.0 Entity Graph implementation followup

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/fetching/Fetching.adoc
@@ -45,6 +45,12 @@ _dynamic_ (sometimes referred to as runtime)::
     HQL / JPQL::: both Hibernate and JPA Criteria queries have the ability to specify fetching, specific to said query.
     entity graphs::: starting in Hibernate 4.2 (JPA 2.1), this is also an option.
 
+[NOTE]
+====
+`fetch profile` and `entity graph` are mutually exclusive. When both are present, `entity graph` would take effect
+and `fetch profile` would be ignored.
+====
+
 [[fetching-direct-vs-query]]
 === Direct fetching vs. entity queries
 
@@ -77,7 +83,7 @@ include::{extrasdir}/fetching-direct-vs-query-direct-fetching-example.sql[]
 ----
 ====
 
-The `LEFT JOIN` clause is added to the generated SQL query because this association is required to be fetched eagerly.
+The `LEFT OUTER JOIN` clause is added to the generated SQL query because this association is required to be fetched eagerly.
 
 On the other hand, if you are using an entity query that does not contain a `JOIN FETCH` directive to the `Department` association:
 
@@ -101,7 +107,7 @@ so Hibernate requires a secondary select to ensure that the EAGER association is
 [IMPORTANT]
 ====
 If you forget to JOIN FETCH all EAGER associations, Hibernate is going to issue a secondary select for each and every one of those
-which, in turn, can lead to N+1 query issues.
+which, in turn, can lead to N + 1 query issue.
 
 For this reason, you should prefer LAZY associations.
 ====
@@ -109,7 +115,7 @@ For this reason, you should prefer LAZY associations.
 [[fetching-strategies]]
 === Applying fetch strategies
 
-Let's consider these topics as it relates to a simple domain model and a few use cases.
+Let's consider these topics as it relates to a sample domain model and a few use cases.
 
 [[fetching-strategies-domain-model-example]]
 .Sample domain model
@@ -188,8 +194,15 @@ In both cases, this resolves to exactly one database query to get all that infor
 [[fetching-strategies-dynamic-fetching-entity-graph]]
 === Dynamic fetching via JPA entity graph
 
-JPA 2.1 introduced entity graphs so the application developer has more control over fetch plans.
+JPA 2.1 introduced ``entity graph`` so the application developer has more control over fetch plans. It has two modes to choose from:
 
+fetch graph:::
+In this case, all attributes specified in the entity graph will be treated as FetchType.EAGER, and all attributes not specified will *ALWAYS* be treated as FetchType.LAZY.
+
+load graph:::
+In this case, all attributes specified in the entity graph will be treated as FetchType.EAGER, but attributes not specified use their static mapping specification.
+
+Below is an `fetch graph` dynamic fetching example:
 [[fetching-strategies-dynamic-fetching-entity-graph-example]]
 .Fetch graph example
 ====
@@ -202,14 +215,6 @@ include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fet
 ----
 include::{sourcedir}/GraphFetchingTest.java[tags=fetching-strategies-dynamic-fetching-entity-graph-example]
 ----
-====
-
-[NOTE]
-====
-When executing a JPQL query, if an EAGER association is omitted, Hibernate will issue a secondary select for every association needed to be fetched eagerly,
-which can lead to N+1 query issues.
-
-For this reason, it's better to use LAZY associations, and only fetch them eagerly on a per-query basis.
 ====
 
 An EntityGraph is the root of a "load plan" and must correspond to an EntityType.
@@ -432,10 +437,10 @@ As you can see in the example above, there are only two SQL statements used to f
 
 [TIP]
 ====
-Without `@BatchSize`, you'd run into a N+1 query issue, so,
+Without `@BatchSize`, you'd run into a N + 1 query issue, so,
 instead of 2 SQL statements, there would be 10 queries needed for fetching the `Employee` child entities.
 
-However, although `@BatchSize` is better than running into an N+1 query issue,
+However, although `@BatchSize` is better than running into an N + 1 query issue,
 most of the time, a DTO projection or a `JOIN FETCH` is a much better alternative since
 it allows you to fetch all the required data with a single query.
 ====
@@ -447,12 +452,11 @@ Besides the `FetchType.LAZY` or `FetchType.EAGER` JPA annotations,
 you can also use the Hibernate-specific `@Fetch` annotation that accepts one of the following ``FetchMode``s:
 
 SELECT::
-	The association is going to be fetched lazily using a secondary select for each individual entity,
-	collection, or join load.
-	It's equivalent to JPA `FetchType.LAZY` fetching strategy.
+	The association is going to be fetched using a secondary select for each individual entity,
+	collection, or join load. This mode can be used for either `FetchType.EAGER` or `FetchType.LAZY`.
 JOIN::
-	Use an outer join to load the related entities, collections or joins when using direct fetching.
-	It's equivalent to JPA `FetchType.EAGER` fetching strategy.
+	Use an outer join to load the related entities, collections or joins when using direct fetching. This mode
+	can only be used for `FetchType.EAGER`.
 SUBSELECT::
 	Available for collections only. When accessing a non-initialized collection,
 	this fetch mode will trigger loading all elements of all collections of the same role for all owners associated
@@ -491,7 +495,7 @@ include::{extrasdir}/fetching-strategies-fetch-mode-select-example.sql[]
 ====
 
 The more `Department` entities are fetched by the first query, the more secondary `SELECT` statements are executed to initialize the `employees` collections.
-Therefore, `FetchMode.SELECT` can lead to N+1 query issues.
+Therefore, `FetchMode.SELECT` can lead to N + 1 query issue.
 
 [[fetching-fetchmode-subselect]]
 === `FetchMode.SUBSELECT`
@@ -511,7 +515,7 @@ include::{sourcedir}/FetchModeSubselectTest.java[tags=fetching-strategies-fetch-
 Now, we are going to fetch all `Department` entities that match a given filtering predicate
 and then navigate their `employees` collections.
 
-Hibernate is going to avoid the N+1 query issue by generating a single SQL statement to initialize all `employees` collections
+Hibernate is going to avoid the N + 1 query issue by generating a single SQL statement to initialize all `employees` collections
 for all `Department` entities that were previously fetched.
 Instead of using passing all entity identifiers, Hibernate simply reruns the previous query that fetched the `Department` entities.
 
@@ -643,5 +647,5 @@ include::{extrasdir}/fetching-LazyCollection-select-example.sql[]
 ====
 Therefore, the child entities were fetched one after the other without triggering a full collection initialization.
 
-For this reason, caution is advised since accessing all elements using `LazyCollectionOption.EXTRA` can lead to N+1 query issues.
+For this reason, caution is advised since accessing all elements using `LazyCollectionOption.EXTRA` can lead to N + 1 query issue.
 ====

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -30,8 +30,6 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
-import org.hibernate.graph.spi.AttributeNodeImplementor;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -183,9 +181,6 @@ public final class TwoPhaseLoad {
 		String entityName = persister.getEntityName();
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
-		
-		final GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
-		
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
 			if ( debugEnabled ) {
@@ -231,10 +226,6 @@ public final class TwoPhaseLoad {
 				if ( debugEnabled ) {
 					LOG.debugf( "Skipping <unknown> attribute : `%s`", propertyNames[i] );
 				}
-			}
-			
-			if ( session.getFetchGraphLoadContext() != fetchGraphContext ) {
-				session.setFetchGraphLoadContext( fetchGraphContext );
 			}
 		}
 
@@ -373,51 +364,27 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overridden (i.e. skipping metamodel strategy), including (order sensitive):
-	 * <ol>
-	 *     <li>fetch graph</li>
-	 *     <li>fetch profile</li>
-	 * </ol>
+	 * Check if eager of the association is overriden by anything.
 	 *
 	 * @param session session
 	 * @param entityName entity name
 	 * @param associationName association name
-	 * @param associationType association type
-	 * @param isDebugEnabled if debug log level enabled
+	 *
 	 * @return null if there is no overriding, true if it is overridden to eager and false if it is overridden to lazy
 	 */
 	private static Boolean getOverridingEager(
 			final SharedSessionContractImplementor session,
 			final String entityName,
 			final String associationName,
-			final Type associationType,
+			final Type type,
 			final boolean isDebugEnabled) {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
-		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
+		if ( type.isCollectionType() || type.isAssociationType()  ) {
+			final Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
 
-			// check 'fetch graph' first; skip 'fetch profile' if 'fetch graph' takes effect
-			Boolean overridingEager = isEagerFetchGraph( session, associationName, associationType );
-
-			if ( overridingEager != null ) {
-				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
-				if ( isDebugEnabled ) {
-					LOG.debugf(
-							"Overriding eager fetching using fetch graph. EntityName: %s, associationName: %s, eager fetching: %s",
-							entityName,
-							associationName,
-							overridingEager
-					);
-				}
-
-				return overridingEager;
-			}
-			
-			// check 'fetch profile' next; skip 'metamodel' if 'fetch profile' takes effect
-			overridingEager = isEagerFetchProfile( session, entityName, associationName );
-
-			if ( overridingEager != null ) {
-				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
-				if ( isDebugEnabled ) {
+			//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+			if ( isDebugEnabled ) {
+				if ( overridingEager != null ) {
 					LOG.debugf(
 							"Overriding eager fetching using active fetch profile. EntityName: %s, associationName: %s, eager fetching: %s",
 							entityName,
@@ -425,10 +392,10 @@ public final class TwoPhaseLoad {
 							overridingEager
 					);
 				}
-				return overridingEager;
 			}
+
+			return overridingEager;
 		}
-		// let 'metamodel' decide eagerness
 		return null;
 	}
 
@@ -446,39 +413,6 @@ public final class TwoPhaseLoad {
 				if ( fetch != null && Fetch.Style.JOIN == fetch.getStyle() ) {
 					return true;
 				}
-			}
-		}
-
-		return null;
-	}
-	
-	private static Boolean isEagerFetchGraph(SharedSessionContractImplementor session, String associationName, Type associationType) {
-		final GraphImplementor<?> context = session.getFetchGraphLoadContext();
-		
-		if ( context != null ) {
-			// 'fetch graph' is in effect, so null should not be returned
-			final AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
-			if ( attributeNode != null ) {
-				if ( associationType.isCollectionType() ) {
-					// to do: deal with Map's key and value
-					session.setFetchGraphLoadContext( null );
-				}
-				else {
-					// set 'fetchGraphContext' to sub-graph so graph is explored further (internal loading)
-					final GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
-					if ( subContext != null ) {
-						session.setFetchGraphLoadContext( subContext );
-					}
-					else {
-						session.setFetchGraphLoadContext( null );
-					}
-				}
-				// explicit 'fetch graph' applies, so fetch eagerly
-				return true;
-			}
-			else {
-				// implicit 'fetch graph' applies, so fetch lazily
-				return false;
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -458,31 +458,4 @@ public interface SharedSessionContractImplementor
 	 */
 	PersistenceContext getPersistenceContextInternal();
 
-	/**
-	 * Get the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}. 
-	 * Suppose fetch graph is "a(b(c))", then during {@link org.hibernate.engine.internal.TwoPhaseLoad}:
-	 * <ul>
-	 *     <li>when loading root</li>: {@link org.hibernate.graph.spi.RootGraphImplementor root} will be returned
-	 *     <li>when internally loading 'a'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a' will be returned
-	 *     <li>when internally loading 'b'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b)' will be returned
-	 *     <li>when internally loading 'c'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b(c))' will be returned
-	 * </ul>
-	 * 
-	 * @return current fetch graph context; can be null if fetch graph is not effective or the graph eager loading is done.
-	 * @see #setFetchGraphLoadContext(GraphImplementor) 
-	 * @see org.hibernate.engine.internal.TwoPhaseLoad
-	 */
-	default GraphImplementor getFetchGraphLoadContext() {
-		return null;
-	}
-
-	/**
-	 * Set the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}.
-	 * 
-	 * @param fetchGraphLoadContext new fetch graph context; can be null (this field will be set to null after root entity loading is done).
-	 * @see #getFetchGraphLoadContext()                                 
-	 */
-	default void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -185,8 +185,6 @@ public class SessionImpl
 	private transient LoadEvent loadEvent; //cached LoadEvent instance
 
 	private transient TransactionObserver transactionObserver;
-	
-	private transient GraphImplementor fetchGraphLoadContext;
 
 	public SessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
@@ -2748,10 +2746,6 @@ public class SessionImpl
 				lockOptions = buildLockOptions( lockModeType, properties );
 				loadAccess.with( lockOptions );
 			}
-			
-			if ( getLoadQueryInfluencers().getEffectiveEntityGraph().getSemantic() == GraphSemantic.FETCH ) {
-				setFetchGraphLoadContext( getLoadQueryInfluencers().getEffectiveEntityGraph().getGraph() );
-			}
 
 			return loadAccess.load( primaryKey );
 		}
@@ -2797,7 +2791,6 @@ public class SessionImpl
 		finally {
 			getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
 			getLoadQueryInfluencers().setReadOnly( null );
-			setFetchGraphLoadContext( null );
 		}
 	}
 
@@ -3160,16 +3153,6 @@ public class SessionImpl
 	public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
 		checkOpen();
 		return getEntityManagerFactory().findEntityGraphsByType( entityClass );
-	}
-	
-	@Override
-	public GraphImplementor getFetchGraphLoadContext() {
-		return this.fetchGraphLoadContext;
-	}
-	
-	@Override
-	public void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-		this.fetchGraphLoadContext = fetchGraphLoadContext;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -382,14 +382,6 @@ public class PluralAttributeMappingImpl extends AbstractAttributeMapping impleme
 									creationState.getSqlAstCreationState().getSqlExpressionResolver(),
 									creationState.getSqlAstCreationState().getCreationContext()
 							);
-
-							lhsTableGroup.addTableGroupJoin( tableGroupJoin );
-
-							sqlAstCreationState.getFromClauseAccess().registerTableGroup(
-									fetchablePath,
-									tableGroupJoin.getJoinedGroup()
-							);
-
 							return tableGroupJoin.getJoinedGroup();
 						}
 				);

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1372,9 +1372,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getSession().getCacheMode();
 			getSession().setCacheMode( effectiveCacheMode );
 		}
-		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
-			getSession().setFetchGraphLoadContext( entityGraphQueryHint.getGraph() );
-		}
 	}
 
 	protected void afterQuery() {
@@ -1386,7 +1383,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getSession().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
-		getSession().setFetchGraphLoadContext( null );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/EntityGraphTraversalState.java
@@ -12,23 +12,23 @@ import org.hibernate.graph.spi.GraphImplementor;
 /**
  * @author Nathan Xu
  */
-public interface EntityGraphSemanticTraverser {
+public interface EntityGraphTraversalState {
 
 	/**
 	 * POJO class to store the result of applied entity graph traversal, including
 	 * <ul>
-	 *     <li>previous entity graph node so later on traverser can backtrack to it</li>
+	 *     <li>previous entity graph node so later on {@link EntityGraphTraversalState} object can backtrack to it</li>
 	 *     <li>whether the new graph node should be eagerly loaded or not</li>
 	 *     <li>whether the new graph node fetching is joined</li>
 	 * </ul>
 	 */
-	class Result {
+	class TraversalResult {
 
 		private GraphImplementor previousContext;
 		private FetchTiming fetchTiming;
 		private boolean joined;
 
-		public Result(GraphImplementor previousContext, FetchTiming fetchTiming, boolean joined) {
+		public TraversalResult(GraphImplementor previousContext, FetchTiming fetchTiming, boolean joined) {
 			this.previousContext = previousContext;
 			this.fetchTiming = fetchTiming;
 			this.joined = joined;
@@ -64,5 +64,5 @@ public interface EntityGraphSemanticTraverser {
 	 * @param exploreKeySubgraph true if only key sub graph is explored; false if key sub graph is excluded
 	 * @return traversal result; never be null
 	 */
-	Result traverse(FetchParent parent, Fetchable fetchable, boolean exploreKeySubgraph);
+	TraversalResult traverse(FetchParent parent, Fetchable fetchable, boolean exploreKeySubgraph);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
@@ -68,7 +68,6 @@ public class EmbeddableFetchImpl extends AbstractFetchParent implements Embeddab
 							creationState.getSqlAstCreationState().getSqlExpressionResolver(),
 							creationState.getSqlAstCreationState().getCreationContext()
 					);
-					lhsTableGroup.addTableGroupJoin( tableGroupJoin );
 					return tableGroupJoin.getJoinedGroup();
 				}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -21,7 +21,7 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.sql.results.graph.EntityGraphSemanticTraverser;
+import org.hibernate.sql.results.graph.EntityGraphTraversalState;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
@@ -29,12 +29,12 @@ import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
 /**
  * @author Nathan Xu
  */
-public class StandardEntityGraphSemanticTraverserImpl implements EntityGraphSemanticTraverser {
+public class StandardEntityGraphTraversalStateImpl implements EntityGraphTraversalState {
 
 	private final GraphSemantic graphSemantic;
 	private GraphImplementor currentGraphContext;
 
-	public StandardEntityGraphSemanticTraverserImpl(EffectiveEntityGraph effectiveEntityGraph) {
+	public StandardEntityGraphTraversalStateImpl(EffectiveEntityGraph effectiveEntityGraph) {
 		assert effectiveEntityGraph != null;
 		if ( effectiveEntityGraph.getSemantic() == null ) {
 			throw new IllegalArgumentException( "The graph has not defined semantic: " + effectiveEntityGraph );
@@ -49,7 +49,7 @@ public class StandardEntityGraphSemanticTraverserImpl implements EntityGraphSema
 	}
 
 	@Override
-	public Result traverse(FetchParent fetchParent, Fetchable fetchable, boolean exploreKeySubgraph) {
+	public TraversalResult traverse(FetchParent fetchParent, Fetchable fetchable, boolean exploreKeySubgraph) {
 		final GraphImplementor previousContextRoot = currentGraphContext;
 		AttributeNodeImplementor attributeNode = null;
 		if ( appliesTo( fetchParent ) ) {
@@ -101,7 +101,7 @@ public class StandardEntityGraphSemanticTraverserImpl implements EntityGraphSema
 				joined = fetchable.getMappedFetchStrategy().getStyle() == FetchStyle.JOIN;
 			}
 		}
-		return new Result( previousContextRoot, fetchTiming, joined );
+		return new TraversalResult( previousContextRoot, fetchTiming, joined );
 	}
 
 	private Class<?> getEntityCollectionPartJavaClass(CollectionPart collectionPart) {


### PR DESCRIPTION
As Steve suggested, `EntityGraphSemanticsTraverser` is renamed to `EntityGraphTraversalState` (I think it is more in line with existing naming convention compared to `EntityGraphTraversalContext`).

Another improvement is to update user guide, including:

1. remove outdated content only applicable when `fetch graph` is not fully implemented;
2. add explanation about the difference between `fetch graph` and `load graph`;
3. correct an erroneous explanation of `SELECT` fetch mode;
4. revert back incompatible v5 fetch graph code changes;
4. minor verbiage tweaking.

Also, I cleaned up some duplicated code found during the testing.