### PR TITLE
wip/6.0 Loader 'readOnly' support

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
@@ -57,7 +57,7 @@ public class SingleIdEntityLoaderProvidedQueryImpl<T> implements SingleIdEntityL
 	}
 
 	@Override
-	public T load(Object pkValue, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public T load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		//noinspection unchecked
 		final QueryImplementor<T> query = namedQueryMemento.toQuery(
 				session,
@@ -74,11 +74,12 @@ public class SingleIdEntityLoaderProvidedQueryImpl<T> implements SingleIdEntityL
 			Object pkValue,
 			Object entityInstance,
 			LockOptions lockOptions,
+			Boolean readOnly,
 			SharedSessionContractImplementor session) {
 		if ( entityInstance != null ) {
 			throw new UnsupportedOperationException(  );
 		}
-		return load( pkValue, lockOptions, session );
+		return load( pkValue, lockOptions, readOnly, session );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
@@ -52,14 +52,14 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 	}
 
 	@Override
-	public T load(Object key, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public T load(Object key, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		final SingleIdLoadPlan<T> loadPlan = resolveLoadPlan(
 				lockOptions,
 				session.getLoadQueryInfluencers(),
 				session.getFactory()
 		);
 
-		return loadPlan.load( key, lockOptions, null, session );
+		return loadPlan.load( key, lockOptions, readOnly, session );
 	}
 
 	@Override
@@ -67,6 +67,7 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 			Object key,
 			Object entityInstance,
 			LockOptions lockOptions,
+			Boolean readOnly,
 			SharedSessionContractImplementor session) {
 		final SingleIdLoadPlan<T> loadPlan = resolveLoadPlan(
 				lockOptions,
@@ -74,7 +75,7 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 				session.getFactory()
 		);
 
-		return loadPlan.load( key, lockOptions, entityInstance, session );
+		return loadPlan.load( key, lockOptions, entityInstance, readOnly, session );
 	}
 
 	@Internal

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -18,6 +18,7 @@ import org.hibernate.loader.ast.spi.Loadable;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.spi.QueryOptionsAdapter;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
@@ -73,14 +74,23 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 	T load(
 			Object restrictedValue,
 			LockOptions lockOptions,
+			Boolean readOnly,
 			SharedSessionContractImplementor session) {
-		return load( restrictedValue, lockOptions, null, session );
+		return load( restrictedValue, lockOptions, null, readOnly, session );
+	}
+
+	T load(
+			Object restrictedValue,
+			LockOptions lockOptions,
+			SharedSessionContractImplementor session) {
+		return load( restrictedValue, lockOptions, null, null, session );
 	}
 
 	T load(
 			Object restrictedValue,
 			LockOptions lockOptions,
 			Object entityInstance,
+			Boolean readOnly,
 			SharedSessionContractImplementor session) {
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
@@ -145,7 +155,12 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 
 					@Override
 					public QueryOptions getQueryOptions() {
-						return QueryOptions.NONE;
+						return new QueryOptionsAdapter() {
+							@Override
+							public Boolean isReadOnly() {
+								return readOnly;
+							}
+						};
 					}
 
 					@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
@@ -22,6 +22,7 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.spi.QueryOptionsAdapter;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
@@ -57,6 +58,7 @@ public class SingleUniqueKeyEntityLoaderStandard<T> implements SingleUniqueKeyEn
 	public T load(
 			Object ukValue,
 			LockOptions lockOptions,
+			Boolean readOnly,
 			SharedSessionContractImplementor session) {
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 
@@ -117,7 +119,12 @@ public class SingleUniqueKeyEntityLoaderStandard<T> implements SingleUniqueKeyEn
 
 					@Override
 					public QueryOptions getQueryOptions() {
-						return QueryOptions.NONE;
+						return new QueryOptionsAdapter() {
+							@Override
+							public Boolean isReadOnly() {
+								return readOnly;
+							}
+						};
 					}
 
 					@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/CollectionLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/CollectionLoader.java
@@ -23,4 +23,7 @@ public interface CollectionLoader extends Loader {
 	 * Load a collection by its key (not necessarily the same as its owner's PK).
 	 */
 	PersistentCollection load(Object key, SharedSessionContractImplementor session);
+
+	//TODO support 'readOnly' collection loading
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleEntityLoader.java
@@ -22,5 +22,9 @@ public interface SingleEntityLoader<T> extends Loader {
 	/**
 	 * Load an entity by a primary or unique key value.
 	 */
-	T load(Object key, LockOptions lockOptions, SharedSessionContractImplementor session);
+	T load(Object key, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session);
+
+	default T load(Object key, LockOptions lockOptions, SharedSessionContractImplementor session) {
+		return load( key, lockOptions, session );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleIdEntityLoader.java
@@ -19,14 +19,18 @@ public interface SingleIdEntityLoader<T> extends SingleEntityLoader<T> {
 	 * Load by primary key value
 	 */
 	@Override
-	T load(Object pkValue, LockOptions lockOptions, SharedSessionContractImplementor session);
+	T load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session);
 
 	/**
 	 * Load by primary key value, populating the passed entity instance.  Used to initialize an uninitialized
 	 * bytecode-proxy or {@link org.hibernate.event.spi.LoadEvent} handling.
 	 * The passed instance is the enhanced proxy or the entity to be loaded.
 	 */
-	T load(Object pkValue, Object entityInstance, LockOptions lockOptions, SharedSessionContractImplementor session);
+	T load(Object pkValue, Object entityInstance, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session);
+
+	default T load(Object pkValue, Object entityInstance, LockOptions lockOptions, SharedSessionContractImplementor session) {
+		return load( pkValue, entityInstance, lockOptions, null, session );
+	}
 
 	/**
 	 * Load database snapshot by primary key value

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleUniqueKeyEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/SingleUniqueKeyEntityLoader.java
@@ -19,7 +19,7 @@ public interface SingleUniqueKeyEntityLoader<T> extends SingleEntityLoader {
 	 * Load by unique key value
 	 */
 	@Override
-	T load(Object ukValue, LockOptions lockOptions, SharedSessionContractImplementor session);
+	T load(Object ukValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session);
 
 	/**
 	 * Resolve the matching id

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2617,7 +2617,15 @@ public abstract class AbstractEntityPersister
 			String propertyName,
 			Object uniqueKey,
 			SharedSessionContractImplementor session) throws HibernateException {
-		return getUniqueKeyLoader( propertyName ).load( uniqueKey, LockOptions.READ, session );
+		return loadByUniqueKey( propertyName, uniqueKey, null, session );
+	}
+
+	public Object loadByUniqueKey(
+			String propertyName,
+			Object uniqueKey,
+			Boolean readOnly,
+			SharedSessionContractImplementor session) throws HibernateException {
+		return getUniqueKeyLoader( propertyName ).load( uniqueKey, LockOptions.READ, readOnly, session );
 	}
 
 	private Map<SingularAttributeMapping, SingleUniqueKeyEntityLoader<?>> uniqueKeyLoadersNew;
@@ -4459,25 +4467,25 @@ public abstract class AbstractEntityPersister
 	 */
 	public Object load(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session)
 			throws HibernateException {
-		return doLoad( id, optionalObject, lockOptions, session, null );
+		return doLoad( id, optionalObject, lockOptions, null, session );
 	}
 
 	public Object load(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly)
 			throws HibernateException {
-		return doLoad( id, optionalObject, lockOptions, session, readOnly );
+		return doLoad( id, optionalObject, lockOptions, readOnly, session );
 	}
 
-	private Object doLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly)
+	private Object doLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session)
 			throws HibernateException {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev( "Fetching entity: {0}", MessageHelper.infoString( this, id, getFactory() ) );
 		}
 
 		if ( optionalObject == null ) {
-			return singleIdEntityLoader.load( id, lockOptions, session );
+			return singleIdEntityLoader.load( id, lockOptions, readOnly, session );
 		}
 		else {
-			return singleIdEntityLoader.load( id, optionalObject, lockOptions, session );
+			return singleIdEntityLoader.load( id, optionalObject, lockOptions, readOnly, session );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ScrollableResultsIterator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ScrollableResultsIterator.java
@@ -16,10 +16,10 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
  * @since 5.2
  */
 @Incubating
-public class ScrollableResultsIterator<T> implements CloseableIterator {
-	private final ScrollableResultsImplementor scrollableResults;
+public class ScrollableResultsIterator<T> implements CloseableIterator<T> {
+	private final ScrollableResultsImplementor<T> scrollableResults;
 
-	public ScrollableResultsIterator(ScrollableResultsImplementor scrollableResults) {
+	public ScrollableResultsIterator(ScrollableResultsImplementor<T> scrollableResults) {
 		this.scrollableResults = scrollableResults;
 	}
 
@@ -34,7 +34,6 @@ public class ScrollableResultsIterator<T> implements CloseableIterator {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public T next() {
 		return (T) scrollableResults.get();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
@@ -7,7 +7,6 @@
 package org.hibernate.query.spi;
 
 import java.sql.Statement;
-import java.util.Collections;
 import java.util.List;
 import javax.persistence.CacheRetrieveMode;
 import javax.persistence.CacheStoreMode;
@@ -184,85 +183,6 @@ public interface QueryOptions {
 	/**
 	 * Singleton access
 	 */
-	QueryOptions NONE = new QueryOptions() {
-		@Override
-		public Limit getLimit() {
-			return Limit.NONE;
-		}
-
-		@Override
-		public Integer getFetchSize() {
-			return null;
-		}
-
-		@Override
-		public String getComment() {
-			return null;
-		}
-
-		@Override
-		public LockOptions getLockOptions() {
-			return LockOptions.NONE;
-		}
-
-		@Override
-		public List<String> getDatabaseHints() {
-			return Collections.emptyList();
-		}
-
-		@Override
-		public Integer getTimeout() {
-			return null;
-		}
-
-		@Override
-		public FlushMode getFlushMode() {
-			return null;
-		}
-
-		@Override
-		public Boolean isReadOnly() {
-			return null;
-		}
-
-		@Override
-		public CacheRetrieveMode getCacheRetrieveMode() {
-			return CacheRetrieveMode.BYPASS;
-		}
-
-		@Override
-		public CacheStoreMode getCacheStoreMode() {
-			return CacheStoreMode.BYPASS;
-		}
-
-		@Override
-		public CacheMode getCacheMode() {
-			return CacheMode.IGNORE;
-		}
-
-		@Override
-		public Boolean isResultCachingEnabled() {
-			return null;
-		}
-
-		@Override
-		public String getResultCacheRegionName() {
-			return null;
-		}
-
-		@Override
-		public AppliedGraph getAppliedGraph() {
-			return null;
-		}
-
-		@Override
-		public TupleTransformer getTupleTransformer() {
-			return null;
-		}
-
-		@Override
-		public ResultListTransformer getResultListTransformer() {
-			return null;
-		}
+	QueryOptions NONE = new QueryOptionsAdapter() {
 	};
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.query.spi;
+
+import java.util.Collections;
+import java.util.List;
+import javax.persistence.CacheRetrieveMode;
+import javax.persistence.CacheStoreMode;
+
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.LockOptions;
+import org.hibernate.graph.spi.AppliedGraph;
+import org.hibernate.query.Limit;
+import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.TupleTransformer;
+
+public abstract class QueryOptionsAdapter implements QueryOptions {
+
+	@Override
+	public Limit getLimit() {
+		return Limit.NONE;
+	}
+
+	@Override
+	public Integer getFetchSize() {
+		return null;
+	}
+
+	@Override
+	public String getComment() {
+		return null;
+	}
+
+	@Override
+	public LockOptions getLockOptions() {
+		return LockOptions.NONE;
+	}
+
+	@Override
+	public List<String> getDatabaseHints() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Integer getTimeout() {
+		return null;
+	}
+
+	@Override
+	public FlushMode getFlushMode() {
+		return null;
+	}
+
+	@Override
+	public Boolean isReadOnly() {
+		return null;
+	}
+
+	@Override
+	public CacheRetrieveMode getCacheRetrieveMode() {
+		return CacheRetrieveMode.BYPASS;
+	}
+
+	@Override
+	public CacheStoreMode getCacheStoreMode() {
+		return CacheStoreMode.BYPASS;
+	}
+
+	@Override
+	public CacheMode getCacheMode() {
+		return CacheMode.IGNORE;
+	}
+
+	@Override
+	public Boolean isResultCachingEnabled() {
+		return null;
+	}
+
+	@Override
+	public String getResultCacheRegionName() {
+		return null;
+	}
+
+	@Override
+	public AppliedGraph getAppliedGraph() {
+		return null;
+	}
+
+	@Override
+	public TupleTransformer getTupleTransformer() {
+		return null;
+	}
+
+	@Override
+	public ResultListTransformer getResultListTransformer() {
+		return null;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ReadonlyHintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ReadonlyHintTest.java
@@ -1,0 +1,80 @@
+package org.hibernate.orm.test.loading;
+
+import java.util.Collections;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.jpa.QueryHints;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				ReadonlyHintTest.SimpleEntity.class
+		}
+)
+@SessionFactory
+@TestForIssue( jiraKey = "HHH-11958" )
+public class ReadonlyHintTest {
+
+	private static final String ORIGINAL_NAME = "original";
+	private static final String CHANGED_NAME = "changed";
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			SimpleEntity entity = new SimpleEntity();
+			entity.id = 1L;
+			entity.name = ORIGINAL_NAME;
+			session.persist( entity );
+		} );
+	}
+
+	@Test
+	void testWithReadOnlyHint(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			SimpleEntity fetchedEntity = session.find( SimpleEntity.class, 1L, Collections.singletonMap( QueryHints.HINT_READONLY, true ) );
+			fetchedEntity.name = CHANGED_NAME;
+		} );
+
+		scope.inTransaction( session -> {
+			SimpleEntity fetchedEntity = session.find( SimpleEntity.class, 1L );
+			assertThat(fetchedEntity.name, is( ORIGINAL_NAME ) );
+		} );
+	}
+
+	@Test
+	void testWithoutReadOnlyHint(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			SimpleEntity fetchedEntity = session.find( SimpleEntity.class, 1L );
+			fetchedEntity.name = CHANGED_NAME;
+		} );
+
+		scope.inTransaction( session -> {
+			SimpleEntity fetchedEntity = session.find( SimpleEntity.class, 1L );
+			assertThat(fetchedEntity.name, is( CHANGED_NAME ) );
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createQuery( "delete from SimpleEntity" ).executeUpdate() );
+	}
+
+	@Entity(name = "SimpleEntity")
+	public static class SimpleEntity {
+		@Id
+		private Long id;
+
+		private String name;
+	}
+}


### PR DESCRIPTION
The motivation of this PR is the fact that https://hibernate.atlassian.net/browse/HHH-11958 is not working in v6 because of code refactoring.
However, it is not difficult to fix it in v6. This PR doesn't include CollectionLoader into the scope, however.
A testing case is included.
