### PR TITLE
HHH-13900: added keepReference option to SQLDelete

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
@@ -36,4 +36,9 @@ public @interface SQLDelete {
 	 * For persistence operation what style of determining results (success/failure) is to be used.
 	 */
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
+
+	/**
+	 * Use for soft delete operations if you want to keep the references to entities marked as deleted.
+	 */
+	boolean keepReference() default false;
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -364,7 +364,7 @@ public class EntityBinder {
 			);
 		}
 		if ( sqlDelete != null ) {
-			persistentClass.setCustomSQLDelete( sqlDelete.sql(), sqlDelete.callable(),
+			persistentClass.setCustomSQLDelete( sqlDelete.sql(), sqlDelete.callable(), sqlDelete.keepReference(),
 					ExecuteUpdateResultCheckStyle.fromExternalName( sqlDelete.check().toString().toLowerCase(Locale.ROOT) )
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -281,7 +281,9 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 
 		new ForeignKeys.Nullifier(  entity, true, false, session, persister ).nullifyTransientReferences( entityEntry.getDeletedState() );
 		new Nullability( session ).checkNullability( entityEntry.getDeletedState(), persister, Nullability.NullabilityCheckType.DELETE );
-		persistenceContext.registerNullifiableEntityKey( key );
+		if( persister.getClassMetadata() != null && !persister.getClassMetadata().keepReference() ) {
+			persistenceContext.registerNullifiableEntityKey(key);
+		}
 
 		if ( isOrphanRemovalBeforeUpdates ) {
 			// TODO: The removeOrphan concept is a temporary "hack" for HHH-6484.  This should be removed once action/task

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -281,8 +281,8 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 
 		new ForeignKeys.Nullifier(  entity, true, false, session, persister ).nullifyTransientReferences( entityEntry.getDeletedState() );
 		new Nullability( session ).checkNullability( entityEntry.getDeletedState(), persister, Nullability.NullabilityCheckType.DELETE );
-		if( persister.getClassMetadata() != null && !persister.getClassMetadata().keepReference() ) {
-			persistenceContext.registerNullifiableEntityKey(key);
+		if ( persister.getClassMetadata() != null && !persister.getClassMetadata().keepReference() ) {
+			persistenceContext.registerNullifiableEntityKey( key );
 		}
 
 		if ( isOrphanRemovalBeforeUpdates ) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -81,6 +81,7 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 	private boolean customUpdateCallable;
 	private ExecuteUpdateResultCheckStyle updateCheckStyle;
 	private String customSQLDelete;
+	private boolean customSQLDeleteNullifiable;
 	private boolean customDeleteCallable;
 	private ExecuteUpdateResultCheckStyle deleteCheckStyle;
 
@@ -786,12 +787,23 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		this.deleteCheckStyle = checkStyle;
 	}
 
+	public void setCustomSQLDelete(String customSQLDelete, boolean callable, boolean nullifiable, ExecuteUpdateResultCheckStyle checkStyle) {
+		this.customSQLDelete = customSQLDelete;
+		this.customDeleteCallable = callable;
+		this.deleteCheckStyle = checkStyle;
+		this.customSQLDeleteNullifiable = nullifiable;
+	}
+
 	public String getCustomSQLDelete() {
 		return customSQLDelete;
 	}
 
 	public boolean isCustomDeleteCallable() {
 		return customDeleteCallable;
+	}
+
+	public boolean isCustomSQLDeleteNullifiable() {
+		return customSQLDeleteNullifiable;
 	}
 
 	public ExecuteUpdateResultCheckStyle getCustomSQLDeleteCheckStyle() {

--- a/hibernate-core/src/main/java/org/hibernate/metadata/ClassMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/metadata/ClassMetadata.java
@@ -73,6 +73,11 @@ public interface ClassMetadata {
 	boolean isVersioned();
 
 	/**
+	 * Should references to this class be kept after entity is marked for deletion?
+	 */
+	boolean keepReference();
+
+	/**
 	 * Get the index of the version property
 	 */
 	int getVersionProperty();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -4740,6 +4740,10 @@ public abstract class AbstractEntityPersister
 		return entityMetamodel.isVersioned();
 	}
 
+	public boolean keepReference(){
+		return entityMetamodel.keepReference();
+	}
+
 	public boolean isIdentifierAssignedByInsert() {
 		return entityMetamodel.getIdentifierProperty().isIdentifierAssignedByInsert();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -66,6 +66,7 @@ public class EntityMetamodel implements Serializable {
 
 	private final IdentifierProperty identifierAttribute;
 	private final boolean versioned;
+	private final boolean keepReference;
 
 	private final int propertySpan;
 	private final int versionPropertyIndex;
@@ -139,6 +140,7 @@ public class EntityMetamodel implements Serializable {
 		);
 
 		versioned = persistentClass.isVersioned();
+		keepReference = persistentClass.isCustomSQLDeleteNullifiable();
 
 		if ( persistentClass.hasPojoRepresentation() ) {
 			final Component identifierMapperComponent = persistentClass.getIdentifierMapper();
@@ -945,6 +947,10 @@ public class EntityMetamodel implements Serializable {
 
 	public boolean isVersioned() {
 		return versioned;
+	}
+
+	public boolean keepReference() {
+		return keepReference;
 	}
 
 	public boolean isAbstract() {

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/BaseEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/BaseEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.delete.keepreference;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+/**
+ * @author Richard Bizik
+ */
+@MappedSuperclass
+public class BaseEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+	private boolean deleted;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public boolean isDeleted() {
+		return deleted;
+	}
+
+	public void setDeleted(boolean deleted) {
+		this.deleted = deleted;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/DeathStar.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/DeathStar.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.delete.keepreference;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * @author Richard Bizik
+ */
+@Entity
+@SQLDelete(sql = "UPDATE deathstar SET deleted = true WHERE id = ?", keepReference = true)
+@Where(clause = "deleted = false")
+public class DeathStar extends BaseEntity {
+
+    @NotNull
+	@OneToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	private Vader vader;
+	@OneToMany(cascade = CascadeType.MERGE, orphanRemoval = true, mappedBy = "deathStar",fetch = FetchType.EAGER)
+	private Set<Trooper> troppers;
+    @NotNull
+    @OneToOne(optional = false, fetch = FetchType.EAGER)
+	private Universe universe;
+
+	public Vader getVader() {
+		return vader;
+	}
+
+	public void setVader(Vader vader) {
+		this.vader = vader;
+	}
+
+	public Set<Trooper> getTroppers() {
+		return troppers;
+	}
+
+	public void setTroppers(Set<Trooper> troppers) {
+		this.troppers = troppers;
+	}
+
+    public Universe getUniverse() {
+        return universe;
+    }
+
+    public void setUniverse(Universe universe) {
+        this.universe = universe;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/DeathStar.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/DeathStar.java
@@ -21,13 +21,13 @@ import java.util.Set;
 @Where(clause = "deleted = false")
 public class DeathStar extends BaseEntity {
 
-    @NotNull
+	@NotNull
 	@OneToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private Vader vader;
 	@OneToMany(cascade = CascadeType.MERGE, orphanRemoval = true, mappedBy = "deathStar",fetch = FetchType.EAGER)
 	private Set<Trooper> troppers;
-    @NotNull
-    @OneToOne(optional = false, fetch = FetchType.EAGER)
+	@NotNull
+	@OneToOne(optional = false, fetch = FetchType.EAGER)
 	private Universe universe;
 
 	public Vader getVader() {
@@ -46,11 +46,11 @@ public class DeathStar extends BaseEntity {
 		this.troppers = troppers;
 	}
 
-    public Universe getUniverse() {
-        return universe;
-    }
+	public Universe getUniverse() {
+		return universe;
+	}
 
-    public void setUniverse(Universe universe) {
-        this.universe = universe;
-    }
+	public void setUniverse(Universe universe) {
+		this.universe = universe;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/KeepReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/KeepReferenceTest.java
@@ -25,95 +25,95 @@ public class KeepReferenceTest extends BaseCoreFunctionalTestCase {
 
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-XXXXX")//TODO: assign jira key
+	@TestForIssue( jiraKey = "HHH-13900")
 	public void keepReferenceShouldKeepReference(){
-        Transaction transaction;
+		Transaction transaction;
 		Session session = openSession();
-        transaction = session.beginTransaction();
+		transaction = session.beginTransaction();
 
-        Universe universe = new Universe();
-        session.save(universe);
+		Universe universe = new Universe();
+		session.save(universe);
 
-        DeathStar deathStar = new DeathStar();
-        deathStar.setUniverse(universe);
-        universe.setDeathStar(deathStar);
+		DeathStar deathStar = new DeathStar();
+		deathStar.setUniverse(universe);
+		universe.setDeathStar(deathStar);
 
-        Vader vader = new Vader();
-        vader.setDeathStar(deathStar);
+		Vader vader = new Vader();
+		vader.setDeathStar(deathStar);
 
-        deathStar.setVader(vader);
-        session.save(deathStar);
+		deathStar.setVader(vader);
+		session.save(deathStar);
 
-        Trooper trooper = new Trooper();
-        trooper.setCode("TK-421");
-        trooper.setDeathStar(deathStar);
-        deathStar.setTroppers(Sets.newLinkedHashSet(trooper));
+		Trooper trooper = new Trooper();
+		trooper.setCode("TK-421");
+		trooper.setDeathStar(deathStar);
+		deathStar.setTroppers(Sets.newLinkedHashSet(trooper));
 
-        session.save(trooper);
+		session.save(trooper);
 
-        transaction.commit();
-        session.clear();
+		transaction.commit();
+		session.clear();
 
-        transaction = session.beginTransaction();
-        deathStar = session.get(DeathStar.class, deathStar.getId());
-        assertEquals(1, deathStar.getTroppers().size());
-        assertNotNull(deathStar.getVader());
-        transaction.commit();
-        session.clear();
+		transaction = session.beginTransaction();
+		deathStar = session.get(DeathStar.class, deathStar.getId());
+		assertEquals(1, deathStar.getTroppers().size());
+		assertNotNull(deathStar.getVader());
+		transaction.commit();
+		session.clear();
 
-        transaction = session.beginTransaction();
-        session.delete(deathStar);
-        transaction.commit();
-        session.clear();
+		transaction = session.beginTransaction();
+		session.delete(deathStar);
+		transaction.commit();
+		session.clear();
 
-        transaction = session.beginTransaction();
+		transaction = session.beginTransaction();
 
-        //universe should not be deleted
-        universe = session.get(Universe.class, universe.getId());
-        assertNotNull(universe);
-        //deathStar should be deleted
-        deathStar = session.get(DeathStar.class, deathStar.getId());
-        assertNull(deathStar);
-        List universes = session.createSQLQuery("SELECT * from universe").list();
-        List deathStars = session.createSQLQuery("SELECT * from deathstar").list();
-        List troopers = session.createSQLQuery("SELECT * from trooper").list();
-        List vaders = session.createSQLQuery("SELECT * from vader").list();
+		//universe should not be deleted
+		universe = session.get(Universe.class, universe.getId());
+		assertNotNull(universe);
+		//deathStar should be deleted
+		deathStar = session.get(DeathStar.class, deathStar.getId());
+		assertNull(deathStar);
+		List universes = session.createSQLQuery("SELECT * from universe").list();
+		List deathStars = session.createSQLQuery("SELECT * from deathstar").list();
+		List troopers = session.createSQLQuery("SELECT * from trooper").list();
+		List vaders = session.createSQLQuery("SELECT * from vader").list();
 
-        assertEquals(1, universes.size());
-        assertEquals(1, deathStars.size());
-        assertEquals(1, troopers.size());
-        assertEquals(1, vaders.size());
+		assertEquals(1, universes.size());
+		assertEquals(1, deathStars.size());
+		assertEquals(1, troopers.size());
+		assertEquals(1, vaders.size());
 
-        //check if deleted is set
-        assertTrue((Boolean)((Object[])deathStars.get(0))[1]);
-        assertTrue((Boolean)((Object[])troopers.get(0))[1]);
-        assertTrue((Boolean)((Object[])vaders.get(0))[1]);
-        //universe should not be delted
-        assertFalse((Boolean)((Object[])universes.get(0))[1]);
+		//check if deleted is set
+		assertTrue((Boolean)((Object[])deathStars.get(0))[1]);
+		assertTrue((Boolean)((Object[])troopers.get(0))[1]);
+		assertTrue((Boolean)((Object[])vaders.get(0))[1]);
+		//universe should not be delted
+		assertFalse((Boolean)((Object[])universes.get(0))[1]);
 
-        //check if references are kept
-        assertNotNull(((Object[])deathStars.get(0))[2]);
-        assertNotNull(((Object[])troopers.get(0))[3]);
+		//check if references are kept
+		assertNotNull(((Object[])deathStars.get(0))[2]);
+		assertNotNull(((Object[])troopers.get(0))[3]);
 
-        session.close();
+		session.close();
 
-        cleanupData();
+		cleanupData();
 	}
 
-    private void cleanupData() {
-        doInHibernate( this::sessionFactory, s -> {
-            s.createSQLQuery("delete from trooper").executeUpdate();
-            s.createSQLQuery("delete from deathstar").executeUpdate();
-            s.createSQLQuery("delete from vader").executeUpdate();
-            s.createSQLQuery("delete from universe").executeUpdate();
-        });
-    }
+	private void cleanupData() {
+		doInHibernate( this::sessionFactory, s -> {
+			s.createSQLQuery("delete from trooper").executeUpdate();
+			s.createSQLQuery("delete from deathstar").executeUpdate();
+			s.createSQLQuery("delete from vader").executeUpdate();
+			s.createSQLQuery("delete from universe").executeUpdate();
+		});
+	}
 
-    @Override
+	@Override
 	protected Class[] getAnnotatedClasses() {
 		return new Class[] {
 				BaseEntity.class,
-                Universe.class,
+				Universe.class,
 				DeathStar.class,
 				Vader.class,
 				Trooper.class

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/KeepReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/KeepReferenceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.delete.keepreference;
+
+import org.assertj.core.util.Sets;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.*;
+
+/**
+ * @author Richard Bizik
+ */
+public class KeepReferenceTest extends BaseCoreFunctionalTestCase {
+
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-XXXXX")//TODO: assign jira key
+	public void keepReferenceShouldKeepReference(){
+        Transaction transaction;
+		Session session = openSession();
+        transaction = session.beginTransaction();
+
+        Universe universe = new Universe();
+        session.save(universe);
+
+        DeathStar deathStar = new DeathStar();
+        deathStar.setUniverse(universe);
+        universe.setDeathStar(deathStar);
+
+        Vader vader = new Vader();
+        vader.setDeathStar(deathStar);
+
+        deathStar.setVader(vader);
+        session.save(deathStar);
+
+        Trooper trooper = new Trooper();
+        trooper.setCode("TK-421");
+        trooper.setDeathStar(deathStar);
+        deathStar.setTroppers(Sets.newLinkedHashSet(trooper));
+
+        session.save(trooper);
+
+        transaction.commit();
+        session.clear();
+
+        transaction = session.beginTransaction();
+        deathStar = session.get(DeathStar.class, deathStar.getId());
+        assertEquals(1, deathStar.getTroppers().size());
+        assertNotNull(deathStar.getVader());
+        transaction.commit();
+        session.clear();
+
+        transaction = session.beginTransaction();
+        session.delete(deathStar);
+        transaction.commit();
+        session.clear();
+
+        transaction = session.beginTransaction();
+
+        //universe should not be deleted
+        universe = session.get(Universe.class, universe.getId());
+        assertNotNull(universe);
+        //deathStar should be deleted
+        deathStar = session.get(DeathStar.class, deathStar.getId());
+        assertNull(deathStar);
+        List universes = session.createSQLQuery("SELECT * from universe").list();
+        List deathStars = session.createSQLQuery("SELECT * from deathstar").list();
+        List troopers = session.createSQLQuery("SELECT * from trooper").list();
+        List vaders = session.createSQLQuery("SELECT * from vader").list();
+
+        assertEquals(1, universes.size());
+        assertEquals(1, deathStars.size());
+        assertEquals(1, troopers.size());
+        assertEquals(1, vaders.size());
+
+        //check if deleted is set
+        assertTrue((Boolean)((Object[])deathStars.get(0))[1]);
+        assertTrue((Boolean)((Object[])troopers.get(0))[1]);
+        assertTrue((Boolean)((Object[])vaders.get(0))[1]);
+        //universe should not be delted
+        assertFalse((Boolean)((Object[])universes.get(0))[1]);
+
+        //check if references are kept
+        assertNotNull(((Object[])deathStars.get(0))[2]);
+        assertNotNull(((Object[])troopers.get(0))[3]);
+
+        session.close();
+
+        cleanupData();
+	}
+
+    private void cleanupData() {
+        doInHibernate( this::sessionFactory, s -> {
+            s.createSQLQuery("delete from trooper").executeUpdate();
+            s.createSQLQuery("delete from deathstar").executeUpdate();
+            s.createSQLQuery("delete from vader").executeUpdate();
+            s.createSQLQuery("delete from universe").executeUpdate();
+        });
+    }
+
+    @Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				BaseEntity.class,
+                Universe.class,
+				DeathStar.class,
+				Vader.class,
+				Trooper.class
+		};
+	}
+
+	@Override
+	protected String[] getAnnotatedPackages() {
+		return new String[] {
+				"org.hibernate.test.annotations.query.keepReference"
+		};
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Trooper.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Trooper.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.delete.keepreference;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+
+/**
+ * @author Richard Bizik
+ */
+@Entity
+@SQLDelete(sql = "UPDATE trooper SET deleted = true WHERE id = ?", keepReference = true)
+@Where(clause = "deleted = false")
+public class Trooper extends BaseEntity{
+	private String code;
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
+	private DeathStar deathStar;
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public DeathStar getDeathStar() {
+		return deathStar;
+	}
+
+	public void setDeathStar(DeathStar deathStar) {
+		this.deathStar = deathStar;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Universe.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Universe.java
@@ -1,0 +1,25 @@
+package org.hibernate.test.annotations.delete.keepreference;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToOne;
+
+@Entity
+@SQLDelete(sql = "UPDATE universe SET deleted = true WHERE id = ?", keepReference = true)
+@Where(clause = "deleted = false")
+public class Universe extends BaseEntity {
+
+    @OneToOne(optional = true, fetch = FetchType.EAGER, mappedBy = "universe")
+    DeathStar deathStar;
+
+    public DeathStar getDeathStar() {
+        return deathStar;
+    }
+
+    public void setDeathStar(DeathStar deathStar) {
+        this.deathStar = deathStar;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Universe.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Universe.java
@@ -12,14 +12,14 @@ import javax.persistence.OneToOne;
 @Where(clause = "deleted = false")
 public class Universe extends BaseEntity {
 
-    @OneToOne(optional = true, fetch = FetchType.EAGER, mappedBy = "universe")
-    DeathStar deathStar;
+	@OneToOne(optional = true, fetch = FetchType.EAGER, mappedBy = "universe")
+	DeathStar deathStar;
 
-    public DeathStar getDeathStar() {
-        return deathStar;
-    }
+	public DeathStar getDeathStar() {
+		return deathStar;
+	}
 
-    public void setDeathStar(DeathStar deathStar) {
-        this.deathStar = deathStar;
-    }
+	public void setDeathStar(DeathStar deathStar) {
+		this.deathStar = deathStar;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Vader.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/delete/keepreference/Vader.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.test.annotations.delete.keepreference;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToOne;
+
+/**
+ * @author Richard Bizik
+ */
+@Entity
+@SQLDelete(sql = "UPDATE vader SET deleted = true WHERE id = ?", keepReference = true)
+@Where(clause = "deleted = false")
+public  class Vader extends BaseEntity{
+
+	private String name = "Darth Vader";
+	@OneToOne(optional = false, fetch = FetchType.LAZY, mappedBy = "vader")
+	private DeathStar deathStar;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public DeathStar getDeathStar() {
+		return deathStar;
+	}
+
+	public void setDeathStar(DeathStar deathStar) {
+		this.deathStar = deathStar;
+	}
+}


### PR DESCRIPTION
keepReference options allows hibernate to keep references for objects
that are being deleted. This behavior is wanted for soft delete
operations.