### PR TITLE
wip/6.0 Refactor Dialect to include version field

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -35,9 +35,9 @@ import java.util.Map;
  * @author Gavin King
  */
 abstract class AbstractTransactSQLDialect extends Dialect {
-	public AbstractTransactSQLDialect() {
-		super();
 
+	public AbstractTransactSQLDialect(Integer version) {
+		super( version );
 		registerColumnType( Types.BOOLEAN, "bit" );
 
 		//SQL Server/Sybase 'bit' type is always exactly one bit

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2390Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2390Dialect.java
@@ -24,10 +24,8 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
  */
 public class DB2390Dialect extends DB2Dialect {
 
-	private final int version;
-
 	int get390Version() {
-		return version;
+		return getVersion();
 	}
 
 	public DB2390Dialect(DialectResolutionInfo info) {
@@ -39,8 +37,7 @@ public class DB2390Dialect extends DB2Dialect {
 	}
 
 	public DB2390Dialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB297Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB297Dialect.java
@@ -17,7 +17,7 @@ package org.hibernate.dialect;
 public class DB297Dialect extends DB2Dialect {
 
 	@Override
-	int getVersion() {
+	public Integer getVersion() {
 		return 970;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -58,13 +58,7 @@ public class DB2Dialect extends Dialect {
 	// * can't select a parameter unless wrapped
 	//   in a cast or function call
 
-	private final int version;
-
 	private LimitHandler limitHandler;
-
-	int getVersion() {
-		return version;
-	}
 
 	private final UniqueDelegate uniqueDelegate;
 
@@ -77,8 +71,7 @@ public class DB2Dialect extends Dialect {
 	}
 
 	public DB2Dialect(int version) {
-		super();
-		this.version = version;
+		super(version);
 
 		registerColumnType( Types.BIT, 1, "boolean" ); //no bit
 		registerColumnType( Types.BIT, "smallint" ); //no bit

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -69,12 +69,6 @@ public class DerbyDialect extends Dialect {
 	// * can't select a parameter unless wrapped
 	//   in a cast or function call
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	private final LimitHandler limitHandler;
 
 	public DerbyDialect(DialectResolutionInfo info) {
@@ -86,8 +80,7 @@ public class DerbyDialect extends Dialect {
 	}
 
 	public DerbyDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		registerColumnType( Types.BIT, 1, "boolean" ); //no bit
 		registerColumnType( Types.BIT, "smallint" ); //no bit

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -23,6 +23,7 @@ import org.hibernate.dialect.unique.DefaultUniqueDelegate;
 import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.internal.DefaultSchemaNameResolver;
 import org.hibernate.engine.jdbc.env.spi.*;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -135,10 +136,12 @@ public abstract class Dialect implements ConversionContext {
 
 	private DefaultSizeStrategy defaultSizeStrategy;
 
+	private final Integer version;
+
 
 	// constructors and factory methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-	protected Dialect() {
+	protected Dialect(Integer version) {
 
 		registerColumnType( Types.BIT, 1, "bit" );
 		registerColumnType( Types.BIT, "bit($l)" );
@@ -225,6 +228,19 @@ public abstract class Dialect implements ConversionContext {
 
 		uniqueDelegate = new DefaultUniqueDelegate( this );
 		defaultSizeStrategy = new DefaultSizeStrategyImpl();
+		this.version = version;
+	}
+
+	protected Dialect() {
+		this( null );
+	}
+
+	protected Dialect(int majorVersion, int minorVersion) {
+		this( majorVersion * 100 + minorVersion * 10 );
+	}
+
+	public Integer getVersion() {
+		return version;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
@@ -65,12 +65,6 @@ import static org.hibernate.type.descriptor.DateTimeUtils.formatAsTimestampWithM
  */
 public class FirebirdDialect extends Dialect {
 
-	private final int version;
-
-	public int getVersion() {
-		return version;
-	}
-
 	public FirebirdDialect() {
 		this(250);
 	}
@@ -88,8 +82,7 @@ public class FirebirdDialect extends Dialect {
 	//   cast (not even when wrapped in a function call)
 
 	public FirebirdDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		registerColumnType( Types.BIT, 1, "smallint" );
 		registerColumnType( Types.BIT, "smallint" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixDialect.java
@@ -45,12 +45,6 @@ import java.sql.Types;
  */
 public class InformixDialect extends Dialect {
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public InformixDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() );
 	}
@@ -67,8 +61,7 @@ public class InformixDialect extends Dialect {
 	 * Informix type mappings.
 	 */
 	public InformixDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		// Informix doesn't have a bit type
 		registerColumnType( Types.BIT, 1, "boolean" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -60,13 +60,7 @@ public class IngresDialect extends Dialect {
 
 	private final LimitHandler limitHandler;
 
-	private final int version;
-
 	private final SequenceSupport sequenceSupport;
-
-	int getVersion() {
-		return version;
-	}
 
 	public IngresDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() * 100 + info.getDatabaseMinorVersion() * 10 );
@@ -80,8 +74,7 @@ public class IngresDialect extends Dialect {
 	 * Constructs a IngresDialect
 	 */
 	public IngresDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		if ( getVersion() < 1000 ) {
 			registerColumnType( Types.BIT, 1, "tinyint" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -57,12 +57,6 @@ public class MySQLDialect extends Dialect {
 
 	private final UniqueDelegate uniqueDelegate;
 	private MySQLStorageEngine storageEngine;
-	private int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public MySQLDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() * 100 + info.getDatabaseMinorVersion() * 10 );
 	}
@@ -72,8 +66,7 @@ public class MySQLDialect extends Dialect {
 	}
 
 	public MySQLDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		String storageEngine = Environment.getProperties().getProperty( Environment.STORAGE_ENGINE );
 		if (storageEngine == null) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -66,12 +66,6 @@ import static org.hibernate.query.TemporalUnit.*;
  */
 public class OracleDialect extends Dialect {
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public OracleDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() );
 	}
@@ -97,8 +91,7 @@ public class OracleDialect extends Dialect {
 	}
 
 	public OracleDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		registerCharacterTypeMappings();
 		registerNumericTypeMappings();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -71,12 +71,6 @@ import static org.hibernate.type.descriptor.DateTimeUtils.wrapAsAnsiTimeLiteral;
  */
 public class PostgreSQLDialect extends Dialect {
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public PostgreSQLDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() * 100 + info.getDatabaseMinorVersion() * 10 );
 	}
@@ -86,8 +80,7 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	public PostgreSQLDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		registerColumnType( Types.TINYINT, "smallint" ); //no tinyint, not even in Postgres 11
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -42,12 +42,6 @@ import static org.hibernate.query.TemporalUnit.NANOSECOND;
 public class SQLServerDialect extends AbstractTransactSQLDialect {
 	private static final int PARAM_LIST_SIZE_LIMIT = 2100;
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public SQLServerDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() );
 	}
@@ -57,8 +51,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 	}
 
 	public SQLServerDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		//there is no 'double' type in SQL server
 		//but 'float' is double precision by default

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
@@ -32,12 +32,6 @@ import java.util.Map;
  */
 public class SybaseASEDialect extends SybaseDialect {
 
-	private final int version;
-
-	int getVersion() {
-		return version;
-	}
-
 	public SybaseASEDialect(DialectResolutionInfo info) {
 		this( info.getDatabaseMajorVersion() * 100 + info.getDatabaseMinorVersion() * 10 );
 	}
@@ -47,8 +41,7 @@ public class SybaseASEDialect extends SybaseDialect {
 	}
 
 	public SybaseASEDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		//On Sybase ASE, the 'bit' type cannot be null,
 		//and cannot have indexes (while we don't use

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -27,7 +27,11 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 	private static final int PARAM_LIST_SIZE_LIMIT = 250000;
 
 	public SybaseDialect() {
-		super();
+		this( null );
+	}
+
+	public SybaseDialect(Integer version) {
+		super( version );
 
 		//Sybase ASE didn't introduce bigint until version 15.0
 		registerColumnType( Types.BIGINT, "numeric(19,0)" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TeradataDialect.java
@@ -53,12 +53,6 @@ import java.util.Map;
  */
 public class TeradataDialect extends Dialect {
 
-	private int version;
-
-	int getVersion() {
-		return version;
-	}
-	
 	private static final int PARAM_LIST_SIZE_LIMIT = 1024;
 
 	public TeradataDialect(DialectResolutionInfo info) {
@@ -70,8 +64,7 @@ public class TeradataDialect extends Dialect {
 	}
 
 	public TeradataDialect(int version) {
-		super();
-		this.version = version;
+		super( version );
 
 		registerColumnType( Types.BOOLEAN, "byteint" );
 		registerColumnType( Types.BIT, 1, "byteint" );


### PR DESCRIPTION
Hibernate is an ORM library and should be a role model of OO design. 
Seems the Dialect hierarchy can benefit a lot from moving the common 'version' field to the topmost class, i.e. Dialect.

Feel free to postpone merging it if it conflicts with other PRs. Just another cosmetic improvement but I think it is worthwhile.