### PR TITLE
HHH-13895 Upgrade the PostgreSQL JDBC driver used for testing to v. 42.2.11

### DIFF
--- a/databases/pgsql/matrix.gradle
+++ b/databases/pgsql/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency 'org.postgresql:postgresql:42.2.2'
+jdbcDependency 'org.postgresql:postgresql:42.2.11'

--- a/databases/pgsql/resources/hibernate.properties
+++ b/databases/pgsql/resources/hibernate.properties
@@ -5,7 +5,7 @@
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
 
-hibernate.dialect org.hibernate.dialect.PostgreSQL94Dialect
+hibernate.dialect org.hibernate.dialect.PostgreSQL95Dialect
 hibernate.connection.driver_class org.postgresql.Driver
 hibernate.connection.url jdbc:postgresql:hibernate_orm_test
 hibernate.connection.username hibernate_orm_test

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -115,7 +115,7 @@ ext {
             h2:              "com.h2database:h2:${h2Version}",
             hsqldb:          "org.hsqldb:hsqldb:2.3.2",
             derby:           "org.apache.derby:derby:10.11.1.1",
-            postgresql:      'org.postgresql:postgresql:42.2.2',
+            postgresql:      'org.postgresql:postgresql:42.2.11',
             mysql:           'mysql:mysql-connector-java:8.0.17',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
@@ -273,7 +273,13 @@ public class DriverManagerConnectionProviderImpl
 		}
 
 		public void add(Connection conn) throws SQLException {
-			conn.setAutoCommit( true );
+			try {
+				conn.setAutoCommit( true );
+			}
+			catch (Exception e) {
+				conn.rollback();
+				conn.setAutoCommit( true );
+			}
 			conn.clearWarnings();
 			availableConnections.offer( conn );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/connection/TestConnectionPool.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/connection/TestConnectionPool.java
@@ -18,6 +18,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.exception.GenericJDBCException;
 import org.hibernate.exception.SQLGrammarException;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -110,13 +110,16 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 					fail( "Exception should be thrown" );
 				}
 				catch (LockTimeoutException lte) {
+					entityManager.getTransaction().setRollbackOnly();
 					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
 					lte.getCause();
 				}
 				catch (PessimisticLockException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
 				}
 				catch (PersistenceException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					log.info(
 							"EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
 									"This is likely a consequence of " + getDialect().getClass()
@@ -157,13 +160,16 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 					fail( "Exception should be thrown" );
 				}
 				catch (LockTimeoutException lte) {
+					entityManager.getTransaction().setRollbackOnly();
 					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
 					lte.getCause();
 				}
 				catch (PessimisticLockException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
 				}
 				catch (PersistenceException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					log.info("EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
 									 "This is likely a consequence of " + getDialect().getClass().getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
 									 "See HHH-7251 for an example of one such situation.", pe);
@@ -201,13 +207,16 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 					fail( "Exception should be thrown" );
 				}
 				catch (LockTimeoutException lte) {
+					entityManager.getTransaction().setRollbackOnly();
 					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
 					lte.getCause();
 				}
 				catch (PessimisticLockException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
 				}
 				catch (PersistenceException pe) {
+					entityManager.getTransaction().setRollbackOnly();
 					log.info(
 						"EntityManager.find() for PESSIMISTIC_WRITE with timeout of 0 threw a PersistenceException.\n" +
 								"This is likely a consequence of " + getDialect().getClass()
@@ -247,9 +256,11 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 				catch (LockTimeoutException lte) {
 					// Proper exception thrown for dialect supporting lock timeouts when an immediate timeout is set.
 					lte.getCause();
+					entityManager.getTransaction().setRollbackOnly();
 				}
 				catch (PessimisticLockException pe) {
 					fail( "Find with immediate timeout should have thrown LockTimeoutException." );
+					entityManager.getTransaction().setRollbackOnly();
 				}
 				catch (PersistenceException pe) {
 					log.info(
@@ -258,6 +269,8 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 									.getName() + " not properly mapping SQL errors into the correct HibernateException subtypes.\n" +
 									"See HHH-7251 for an example of one such situation.", pe
 					);
+					entityManager.getTransaction().setRollbackOnly();
+
 					fail( "EntityManager should be throwing LockTimeoutException." );
 				}
 			} );
@@ -856,11 +869,15 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 								_entityManager.lock( lock2, LockModeType.PESSIMISTIC_WRITE, props );
 							}
 							catch ( LockTimeoutException e ) {
+								_entityManager.getTransaction().setRollbackOnly();
+
 								// success
 								log.info( "testContendedPessimisticWriteLockNoWait: (BG) got expected timeout exception" );
 								timedOut.set( true );
 							}
 							catch ( Throwable e ) {
+								_entityManager.getTransaction().setRollbackOnly();
+
 								log.info( "Expected LockTimeoutException but got unexpected exception", e );
 							}
 						} );
@@ -898,9 +915,11 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 					assertTrue( "background test thread timed out on lock attempt", bgTask.get() );
 				}
 				catch (InterruptedException e) {
+					em.getTransaction().setRollbackOnly();
 					Thread.interrupted();
 				}
 				catch (ExecutionException e) {
+					em.getTransaction().setRollbackOnly();
 					fail(e.getMessage());
 				}
 			} );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -87,6 +87,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 					fail( "Exception should be thrown" );
 				}
 				catch (Exception lte) {
+					em2.getTransaction().setRollbackOnly();
 					if( !ExceptionUtil.isSqlLockTimeout( lte )) {
 						fail("Should have thrown a Lock timeout exception");
 					}

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/GeneralWorkTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/GeneralWorkTest.java
@@ -98,7 +98,7 @@ public class GeneralWorkTest extends BaseCoreFunctionalTestCase {
 		catch ( JDBCException expected ) {
 			// expected outcome
 		}
-		session.getTransaction().commit();
+		session.getTransaction().rollback();
 		session.close();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/lock/LockExceptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/lock/LockExceptionTests.java
@@ -116,6 +116,7 @@ public class LockExceptionTests extends AbstractJPATest {
 										fail( "Expecting a failure" );
 									}
 									catch ( LockTimeoutException | PessimisticLockException expected ) {
+										secondSession.getTransaction().setRollbackOnly();
 										// expected outcome
 									}
 								}
@@ -157,6 +158,7 @@ public class LockExceptionTests extends AbstractJPATest {
 										fail( "Expecting a failure" );
 									}
 									catch ( LockTimeoutException | PessimisticLockException expected ) {
+										secondSession.getTransaction().setRollbackOnly();
 										// expected outcome
 									}
 								}

--- a/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/procedure/PostgreSQLStoredProcedureTest.java
@@ -29,6 +29,7 @@ import org.hibernate.type.StringType;
 
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,82 +55,6 @@ public class PostgreSQLStoredProcedureTest extends BaseEntityManagerFunctionalTe
 
 	@Before
 	public void init() {
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			Session session = entityManager.unwrap( Session.class );
-
-			session.doWork( connection -> {
-				Statement statement = null;
-				try {
-					statement = connection.createStatement();
-					statement.executeUpdate( "DROP FUNCTION sp_count_phones(bigint)" );
-				}
-				catch (SQLException ignore) {
-				}
-				finally {
-					if ( statement != null ) {
-						statement.close();
-					}
-				}
-			} );
-		} );
-
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			Session session = entityManager.unwrap( Session.class );
-
-			session.doWork( connection -> {
-				Statement statement = null;
-				try {
-					statement = connection.createStatement();
-					statement.executeUpdate( "DROP FUNCTION fn_phones(bigint)" );
-				}
-				catch (SQLException ignore) {
-				}
-				finally {
-					if ( statement != null ) {
-						statement.close();
-					}
-				}
-			} );
-		} );
-
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			Session session = entityManager.unwrap( Session.class );
-
-			session.doWork( connection -> {
-				Statement statement = null;
-				try {
-					statement = connection.createStatement();
-					statement.executeUpdate( "DROP FUNCTION singleRefCursor(bigint)" );
-				}
-				catch (SQLException ignore) {
-				}
-				finally {
-					if ( statement != null ) {
-						statement.close();
-					}
-				}
-			} );
-		} );
-
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			Session session = entityManager.unwrap( Session.class );
-
-			session.doWork( connection -> {
-				Statement statement = null;
-				try {
-					statement = connection.createStatement();
-					statement.executeUpdate( "DROP FUNCTION sp_is_null()" );
-				}
-				catch (SQLException ignore) {
-				}
-				finally {
-					if ( statement != null ) {
-						statement.close();
-					}
-				}
-			} );
-		} );
-
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			Session session = entityManager.unwrap( Session.class );
 
@@ -222,6 +147,85 @@ public class PostgreSQLStoredProcedureTest extends BaseEntityManagerFunctionalTe
 			phone2.setId( 2L );
 
 			person1.addPhone( phone2 );
+		} );
+	}
+
+	@After
+	public void tearDown(){
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Session session = entityManager.unwrap( Session.class );
+
+			session.doWork( connection -> {
+				Statement statement = null;
+				try {
+					statement = connection.createStatement();
+					statement.executeUpdate( "DROP FUNCTION sp_count_phones(bigint)" );
+				}
+				catch (SQLException ignore) {
+				}
+				finally {
+					if ( statement != null ) {
+						statement.close();
+					}
+				}
+			} );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Session session = entityManager.unwrap( Session.class );
+
+			session.doWork( connection -> {
+				Statement statement = null;
+				try {
+					statement = connection.createStatement();
+					statement.executeUpdate( "DROP FUNCTION fn_phones(bigint)" );
+				}
+				catch (SQLException ignore) {
+				}
+				finally {
+					if ( statement != null ) {
+						statement.close();
+					}
+				}
+			} );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Session session = entityManager.unwrap( Session.class );
+
+			session.doWork( connection -> {
+				Statement statement = null;
+				try {
+					statement = connection.createStatement();
+					statement.executeUpdate( "DROP FUNCTION singleRefCursor()" );
+				}
+				catch (SQLException ignore) {
+				}
+				finally {
+					if ( statement != null ) {
+						statement.close();
+					}
+				}
+			} );
+		} );
+
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Session session = entityManager.unwrap( Session.class );
+
+			session.doWork( connection -> {
+				Statement statement = null;
+				try {
+					statement = connection.createStatement();
+					statement.executeUpdate( "DROP FUNCTION sp_is_null(varchar)" );
+				}
+				catch (SQLException ignore) {
+				}
+				finally {
+					if ( statement != null ) {
+						statement.close();
+					}
+				}
+			} );
 		} );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13895

It seems the new PostgreSql driver has changed the behaviour if a commit is attempted after an error occurred, in such a case the `org.postgresql.util.PSQLException: The database returned ROLLBACK` exception is thrown.

This behaviour causes the failure of tests where we try to check failures, in such a case a call to `transaction.setRollbackOnly();` in the try/catch avoids the  to call a commit in the `TransactionUtil#doInJPA()` method.


For tests using the `Session#doWork` where we cause an exception on purpose the solution I found is to add the following try/catch block
```
try {
	conn.setAutoCommit( true );
}
catch (Exception e) {
	conn.rollback();
	conn.setAutoCommit( true );
}
```
in the `DriverManagerConnectionProviderImpl$PooledConnections#add()` methos