### PR TITLE
HHH-13920 Make JarFileBasedArchiveDescriptor ignore module-info.class…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/internal/JarFileBasedArchiveDescriptor.java
@@ -65,7 +65,9 @@ public class JarFileBasedArchiveDescriptor extends AbstractArchiveDescriptor {
 				if ( zipEntry.isDirectory() ) {
 					continue;
 				}
-
+				if ( entryName.equals( "module-info.class" ) ) {
+					continue;
+				}
 				if ( entryName.equals( getEntryBasePrefix() ) ) {
 					// exact match, might be a nested jar entry (ie from jar:file:..../foo.ear!/bar.jar)
 					//


### PR DESCRIPTION
When `persistence.xml` is located in JPMS module then Hibernate throws NullPointerException when it scans jar archive and finds `module-info.class` as I noted in the [issue](https://hibernate.atlassian.net/browse/HHH-13920). 

So, in this PR I check if the entry is a `module-info.class` and if it is this entry is ignored.