### PR TITLE
HHH-13682 Generate Java 11/13/14 bytecode for tests when building with JDK11/13/14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ task release {
 	// Force to release with JDK 8. Releasing with JDK 11 is not supported yet:
 	// - the hibernate-orm-modules tests do not run due to an issue with the ASM version currently used by Gradle
 	doFirst {
-		if ( !JavaVersion.current().isJava8() ) {
+		if ( !JavaVersion.current().isJava8() || !gradle.ext.testedJavaVersionAsEnum.isJava8() ) {
 			throw new IllegalStateException( "Please use JDK 8 to perform the release." )
 		}
 	}

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -140,9 +140,7 @@ task aggregateJavadocs(type: Javadoc) {
 			options.source = project.baselineJavaVersion
 		}
 
-		if ( JavaVersion.current().isJava8Compatible() ) {
-			options.addStringOption( 'Xdoclint:none', '-quiet' )
-		}
+		options.addStringOption( 'Xdoclint:none', '-quiet' )
 	}
 
     // process each project, building up:

--- a/gradle/base-information.gradle
+++ b/gradle/base-information.gradle
@@ -13,6 +13,21 @@ ext {
 	jpaVersion = new JpaVersion('2.2')
 }
 
+if ( JavaVersion.current() == JavaVersion.VERSION_HIGHER ) {
+	// This JDK is not supported by Gradle.
+	// Use a hack to retrieve the major as a string.
+
+	// This only works for Java 9+ (we're at least on Java 13 here).
+	def major = System.getProperty( 'java.specification.version' )
+	logger.warn( "[WARN] The Java version '$major' is not supported by gradle." )
+
+	ext.testedJavaVersion = major
+}
+else {
+	// This JDK is supported by Gradle.
+	ext.testedJavaVersion = JavaVersion.current()
+}
+
 group = 'org.hibernate'
 version = project.ormVersion.fullName
 

--- a/gradle/base-information.gradle
+++ b/gradle/base-information.gradle
@@ -13,21 +13,6 @@ ext {
 	jpaVersion = new JpaVersion('2.2')
 }
 
-if ( JavaVersion.current() == JavaVersion.VERSION_HIGHER ) {
-	// This JDK is not supported by Gradle.
-	// Use a hack to retrieve the major as a string.
-
-	// This only works for Java 9+ (we're at least on Java 13 here).
-	def major = System.getProperty( 'java.specification.version' )
-	logger.warn( "[WARN] The Java version '$major' is not supported by gradle." )
-
-	ext.testedJavaVersion = major
-}
-else {
-	// This JDK is supported by Gradle.
-	ext.testedJavaVersion = JavaVersion.current()
-}
-
 group = 'org.hibernate'
 version = project.ormVersion.fullName
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -208,18 +208,6 @@ processTestResources {
 	}
 }
 
-// Enable the experimental features of ByteBuddy with JDK 12+
-test {
-	//Only safe to attempt to parse the version as an integer since JDK11
-	if ( JavaVersion.current().isJava11Compatible() ) {
-		int majorJVMVersionInt = Integer.valueOf(JavaVersion.current().toString());
-		//Set the -Dnet.bytebuddy.experimental=true property only when we need it:
-		if (majorJVMVersionInt >= 12) {
-			systemProperty 'net.bytebuddy.experimental', true
-		}
-	}
-}
-
 test {
 	if ( project.findProperty( 'log-test-progress' )?.toString()?.toBoolean() ) {
 		// Log a statement for each test.

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -10,7 +10,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'de.thetaphi:forbiddenapis:2.6'
+		classpath 'de.thetaphi:forbiddenapis:2.7'
 	}
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -38,10 +38,6 @@ ext {
 	forbiddenAPITargetJDKCompatibility = '11'
 }
 
-
-sourceCompatibility = project.baselineJavaVersion
-targetCompatibility = project.baselineJavaVersion
-
 if ( !project.description ) {
 	project.description = "The Hibernate ORM $project.name module"
 }
@@ -115,8 +111,20 @@ dependencies {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Compilation
 
-tasks.withType(JavaCompile) {
+tasks.withType( JavaCompile ) {
 	options.encoding = 'UTF-8'
+	sourceCompatibility = project.baselineJavaVersion
+	targetCompatibility = project.baselineJavaVersion
+}
+
+if ( project.baselineJavaVersion != project.testedJavaVersion ) {
+	logger.info( "Forcing the target bytecode version for test classes to '$project.testedJavaVersion'" )
+
+	tasks.compileTestJava {
+		// For *tests only*, generate bytecode matching the Java version currently in use.
+		// This allows testing bytecode enhancement on the latest Java versions (13, 14, ...).
+		targetCompatibility = project.testedJavaVersion
+	}
 }
 
 task compile(dependsOn: [compileJava, processResources, compileTestJava, processTestResources] )

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -117,13 +117,13 @@ tasks.withType( JavaCompile ) {
 	targetCompatibility = project.baselineJavaVersion
 }
 
-if ( project.baselineJavaVersion != project.testedJavaVersion ) {
-	logger.info( "Forcing the target bytecode version for test classes to '$project.testedJavaVersion'" )
+if ( project.baselineJavaVersion != gradle.ext.testedJavaVersion ) {
+	logger.info( "Forcing the target bytecode version for test classes to '$gradle.ext.testedJavaVersion'" )
 
 	tasks.compileTestJava {
 		// For *tests only*, generate bytecode matching the Java version currently in use.
 		// This allows testing bytecode enhancement on the latest Java versions (13, 14, ...).
-		targetCompatibility = project.testedJavaVersion
+		targetCompatibility = gradle.ext.testedJavaVersion
 	}
 }
 

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -131,9 +131,7 @@ javadoc {
 			options.source = project.baselineJavaVersion
 		}
 
-		if ( JavaVersion.current().isJava8Compatible() ) {
-			options.addStringOption( 'Xdoclint:none', '-quiet' )
-		}
+		options.addStringOption( 'Xdoclint:none', '-quiet' )
 
 		doFirst {
 			// ordering problems if we try to do this during config phase :(

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/NaturalIdInUninitializedAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/NaturalIdInUninitializedAssociationTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertFalse;
 @SuppressWarnings({"unused", "WeakerAccess","ResultOfMethodCallIgnored"})
 @TestForIssue( jiraKey = "HHH-13607" )
 @RunWith( BytecodeEnhancerRunner.class )
-@EnhancementOptions( lazyLoading = true )
+@EnhancementOptions( lazyLoading = true, extendedEnhancement = true )
 public class NaturalIdInUninitializedAssociationTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Test

--- a/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
+++ b/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
@@ -24,10 +24,12 @@ apply from: rootProject.file( 'gradle/java-module.gradle' )
 // so we have to use https://github.com/java9-modularity/gradle-modules-plugin
 apply plugin: "org.javamodularity.moduleplugin"
 
-// Override -source and -target
-ext.baselineJavaVersion = 11
-sourceCompatibility = project.baselineJavaVersion
-targetCompatibility = project.baselineJavaVersion
+// Override -source and -target to the version being tested (11+, since this module is enabled)
+ext.baselineJavaVersion = project.testedJavaVersion
+tasks.withType( JavaCompile ) {
+	sourceCompatibility = project.baselineJavaVersion
+	targetCompatibility = project.baselineJavaVersion
+}
 
 // Checkstyle fails for module-info
 checkstyleMain.exclude '**/module-info.java'

--- a/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
+++ b/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
@@ -25,7 +25,7 @@ apply from: rootProject.file( 'gradle/java-module.gradle' )
 apply plugin: "org.javamodularity.moduleplugin"
 
 // Override -source and -target to the version being tested (11+, since this module is enabled)
-ext.baselineJavaVersion = project.testedJavaVersion
+ext.baselineJavaVersion = gradle.ext.testedJavaVersion
 tasks.withType( JavaCompile ) {
 	sourceCompatibility = project.baselineJavaVersion
 	targetCompatibility = project.baselineJavaVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,36 @@ plugins {
 }
 
 if ( !JavaVersion.current().java8Compatible ) {
-    throw new GradleException( "Gradle must be run with Java 8" )
+    throw new GradleException( "Gradle must be run with Java 8 or later" )
+}
+
+// Consume the property 'testedJavaVersion' here and
+// set it on gradle.ext so that we can inspect the result in build.gradle.
+// We wouldn't be able to do that if we consumed
+// the property in base-information.gradle and set it on project.ext.
+
+if ( hasProperty( 'testedJavaVersion' ) ) {
+    logger.warn( "[WARN] Targeting Java version '$testedJavaVersion' in tests." )
+    gradle.ext.testedJavaVersion = testedJavaVersion
+    gradle.ext.testedJavaVersionAsEnum = JavaVersion.toVersion( testedJavaVersion )
+}
+else {
+    // We will simply use Gradle's JDK for compilation, tests and javadoc generation.
+    def major
+    if ( JavaVersion.current() == JavaVersion.VERSION_HIGHER) {
+        logger.warn( "Gradle does not support this JDK, because it is too recent; build is likely to fail." +
+                " To avoid failures, you should specify an older Java version in the 'testedJavaVersion' parameter." +
+                " Just append the following to your gradle command:" +
+                " '-PtestedJavaVersion=<major version of your newer JDK, e.g. 14>'" )
+        // Use a hack to retrieve the major as a string.
+        // This only works for Java 9+ (we're at least on Java 18 here).
+        gradle.ext.testedJavaVersion = System.getProperty( 'java.specification.version' )
+    }
+    else {
+        gradle.ext.testedJavaVersion = JavaVersion.current().getMajorVersion()
+    }
+
+    gradle.ext.testedJavaVersionAsEnum = JavaVersion.current()
 }
 
 include 'hibernate-core'


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13682

~This PR is based on #3328 (HHH-13925 - upgrade to Gradle 6.3) . #3328 should be merged first. This PR includes commits from #3328, so it should be rebased after #3328 has been merged.~ => Done

The goal here is simply to compile tests to Java 11/13/14 when we build with JDK 11/13/14. That way, not only do we check that Hibernate ORM can be run within JDK 11/13/14, but we also check that it will correctly interact with Java 11/13/14 bytecode, which is especially important for bytecode enhancement.

Hopefully this will allow us to avoid the kind of problems we've had before, where bytebuddy needed an update and we didn't notice it because we were only ever manipulating Java 8 bytecode in our tests.

Build against JDK13: https://ci.hibernate.org/view/Personal%20jobs/job/hibernate-orm-personal-yoann-jdk13/8/
Build against JDK14: https://ci.hibernate.org/view/Personal%20jobs/job/hibernate-orm-personal-yoann-jdk14/4/

How to test that Java 11/13/14 is actually generated for tests, and not for the main code:

```
# Build with JDK13
$ ...
# Check main code: bytecode version 52, i.e. Java 8
$ od -A d -t 'u2' -N 8 --endian big hibernate-core/target/classes/java/main/org/hibernate/Criteria.class
0000000 51966 47806     0    52
0000008
# Check test code: bytecode version 57, i.e. Java 13
$ od -A d -t 'u2' -N 8 --endian big hibernate-core/target/classes/java/test/org/hibernate/jpa/test/callbacks/PreUpdateBytecodeEnhancementTest.class
0000000 51966 47806     0    57
0000008
```