### PR TITLE
wip/6.0 HHH-13937 Get rid of junit5 compile-time dependencies

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -88,10 +88,7 @@ dependencies {
     provided( libraries.ant )
 	provided( libraries.cdi )
 
-	runtime( libraries.junit5_vintage )
-	runtime( libraries.junit5_jupiter )
-
-    testCompile( project(':hibernate-testing') )
+	testCompile( project(':hibernate-testing') )
     testCompile( libraries.shrinkwrap_api )
     testCompile( libraries.shrinkwrap )
     testCompile( libraries.jacc )
@@ -124,7 +121,9 @@ dependencies {
     testRuntime( libraries.weld )
     testRuntime( libraries.atomikos )
     testRuntime( libraries.atomikos_jta )
-    testRuntime(libraries.wildfly_transaction_client)
+    testRuntime( libraries.wildfly_transaction_client )
+    testRuntime( libraries.junit5_vintage )
+    testRuntime( libraries.junit5_jupiter )
 
     testAnnotationProcessor( project( ':hibernate-jpamodelgen' ) )
 

--- a/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateEnversOnWildflyTest.java
+++ b/hibernate-orm-modules/src/test/java/org/hibernate/wildfly/integrationtest/HibernateEnversOnWildflyTest.java
@@ -28,7 +28,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence21.PersistenceDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.persistence21.PersistenceUnitTransactionType;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13937

The root cause that junit-jupiter and junit-vintage show up as compile time dependencies is they are specified as `runtime` dependency. They should be specified as `testRuntime` instead (see https://www.petrikainulainen.net/programming/testing/junit-5-tutorial-running-unit-tests-with-gradle/, e.g.).