### PR TITLE
HHH-13682 Follow-up: restore the "net.bytebuddy.experimental" system property for JDK15+

### DIFF
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -208,6 +208,15 @@ processTestResources {
 	}
 }
 
+// Enable the experimental features of ByteBuddy with JDK 15+
+test {
+	if ( Integer.valueOf( gradle.ext.testedJavaVersionAsEnum.getMajorVersion() ) >= 15 ) {
+		logger.warn( "The version of java that will be tested is not supported by Bytebuddy by default. " +
+				 " Setting 'net.bytebuddy.experimental=true'." )
+		systemProperty 'net.bytebuddy.experimental', true
+	}
+}
+
 test {
 	if ( project.findProperty( 'log-test-progress' )?.toString()?.toBoolean() ) {
 		// Log a statement for each test.


### PR DESCRIPTION
Follow-up on #3329 ([HHH-13682](https://hibernate.atlassian.net/browse/HHH-13682))

Couldn't test for now,  because Gradle 6.3 doesn't work with JDK15+ (a problem with Groovy reflection, apparently). But @Sanne suggested this, and I think he's right: we will need to set the system property.
