### PR TITLE
HHH-14083  Add gradle task to automate the CI release

### DIFF
--- a/gradle/base-information.gradle
+++ b/gradle/base-information.gradle
@@ -7,8 +7,20 @@
 
 apply plugin: 'base'
 
+File versionFile = file( "${rootProject.projectDir}/gradle/version.properties" )
+
+if ( project.hasProperty( 'releaseVersion' ) ) {
+	if ( !project.hasProperty( 'developmentVersion' ) ) {
+		throw new GradleException(
+				"When the releaseVersion parameter is specified, the parameter developmentVersion is required as well."
+		)
+	}
+	versionFile.text = "hibernateVersion=${project.property( 'releaseVersion' )}"
+}
+
 ext {
-	ormVersion = new HibernateVersion( '5.5.0-SNAPSHOT', project )
+	ormVersionFile = versionFile
+	ormVersion = HibernateVersion.fromFile( versionFile, project )
 	baselineJavaVersion = '1.8'
 	jpaVersion = new JpaVersion('2.2')
 }
@@ -52,6 +64,22 @@ class HibernateVersion {
 		this.isSnapshot = fullName.endsWith( '-SNAPSHOT' )
 
 		this.osgiVersion = isSnapshot ? family + '.' + hibernateVersionComponents[2] + '.SNAPSHOT' : fullName
+	}
+
+	static HibernateVersion fromFile(File file, Project project){
+		def fullName = readVersionProperties(file)
+		return new HibernateVersion(fullName, project)
+	}
+
+	private static String readVersionProperties(File file) {
+		if ( !file.exists() ) {
+			throw new GradleException( "Version file $file.canonicalPath does not exists" )
+		}
+		Properties versionProperties = new Properties()
+		file.withInputStream {
+			stream -> versionProperties.load( stream )
+		}
+		return versionProperties.hibernateVersion
 	}
 
 	@Override

--- a/gradle/base-information.gradle
+++ b/gradle/base-information.gradle
@@ -9,18 +9,13 @@ apply plugin: 'base'
 
 File versionFile = file( "${rootProject.projectDir}/gradle/version.properties" )
 
-if ( project.hasProperty( 'releaseVersion' ) ) {
-	if ( !project.hasProperty( 'developmentVersion' ) ) {
-		throw new GradleException(
-				"When the releaseVersion parameter is specified, the parameter developmentVersion is required as well."
-		)
-	}
-	versionFile.text = "hibernateVersion=${project.property( 'releaseVersion' )}"
-}
-
 ext {
 	ormVersionFile = versionFile
 	ormVersion = HibernateVersion.fromFile( versionFile, project )
+	// Override during releases
+	if ( project.hasProperty( 'releaseVersion' ) ) {
+		ormVersion = new HibernateVersion( project.releaseVersion, project )
+	}
 	baselineJavaVersion = '1.8'
 	jpaVersion = new JpaVersion('2.2')
 }

--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -166,4 +166,5 @@ publishing {
 task ciBuild( dependsOn: [test, publish] )
 
 task release( dependsOn: [test, bintrayUpload] )
+bintrayUpload.mustRunAfter test
 

--- a/gradle/publishing-repos.gradle
+++ b/gradle/publishing-repos.gradle
@@ -14,8 +14,10 @@ apply plugin: 'com.jfrog.bintray'
 
 
 ext {
-	bintrayUser = project.hasProperty( 'PERSONAL_BINTRAY_USER' ) ? project.property( 'PERSONAL_BINTRAY_USER' ) : null
-	bintrayKey = project.hasProperty( 'PERSONAL_BINTRAY_API_KEY' ) ? project.property( 'PERSONAL_BINTRAY_API_KEY' ) : null
+	bintrayUser = project.findProperty( 'PERSONAL_BINTRAY_USER' )
+	bintrayKey = project.findProperty( 'PERSONAL_BINTRAY_API_KEY' )
+	sonatypeOssrhUser = project.findProperty( 'SONATYPE_OSSRH_USER' )
+	sonatypeOssrhPassword = project.findProperty( 'SONATYPE_OSSRH_PASSWORD' )
 }
 
 
@@ -58,6 +60,8 @@ bintray {
 			]
 			mavenCentralSync {
 				sync = true
+				user = project.sonatypeOssrhUser
+				password = project.sonatypeOssrhPassword
 			}
 		}
 	}

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,0 +1,1 @@
+hibernateVersion=5.5.0-SNAPSHOT

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -257,22 +257,13 @@ task updateChangeLogFile {
     group = "Release"
     description = "Updates the changelog.txt file and push the changes to github"
     doFirst{
+        logger.lifecycle( "Appending version '${project.releaseVersion}' to changelog..." )
         ChangeLogFile.update( ormVersion.fullName );
 
-        executeGitCommand(
-                "git add .",
-                "An error occurred during the execution of git add for the changelog.txt and the release version changes."
-        )
-
-        executeGitCommand(
-                "git commit -m \"${project.ormVersion.fullName}\"",
-                "An error occurred during the execution of git commit for the changelog.txt and the release version changes."
-        )
-
-        executeGitCommand(
-                "git push ${gitRemote}",
-                "An error occurred during the execution git push for the changelog.txt and the release version changes."
-        )
+        logger.lifecycle( "Adding commit to update version to '${project.releaseVersion}'..." )
+        executeGitCommand( 'add', '.' )
+        executeGitCommand( 'commit', '-m', project.ormVersion.fullName )
+        executeGitCommand( 'push', gitRemote )
     }
 }
 
@@ -291,31 +282,15 @@ task ciRelease() {
             if ( tag.endsWith( ".Final" ) ) {
                 tag = tag.replace( ".Final", "" )
             }
-            executeGitCommand(
-                    "git tag ${tag}",
-                    "An error occurred during the execution of git tag"
-            )
-            executeGitCommand(
-                    "git push ${gitRemote} ${tag}",
-                    "An error occurred during the execution of git push od the tag"
-            )
+            logger.lifecycle( "Tagging '${tag}'..." )
+            executeGitCommand( 'tag', tag )
+            executeGitCommand( 'push', gitRemote, tag )
 
-            // the hibernate version is changed to the development one and the changes are pushed to github
-            project.ormVersionFile.text = "hibernateVersion=${project.property( 'developmentVersion' )}"
-            executeGitCommand(
-                    "git add .",
-                    "An error occurred during the execution of git add for the development version change."
-            )
-
-            executeGitCommand(
-                    "git commit -m \"${project.property( 'developmentVersion' )}\"",
-                    "An error occurred during the execution of git commit for the development version change."
-            )
-
-            executeGitCommand(
-                    "git push ${gitRemote}",
-                    "An error occurred during the execution git push for the development version change."
-            )
+            logger.lifecycle( "Adding commit to update version to '${project.developmentVersion}'..." )
+            project.ormVersionFile.text = "hibernateVersion=${project.developmentVersion}"
+            executeGitCommand( 'add', '.')
+            executeGitCommand( 'commit', '-m', project.developmentVersion )
+            executeGitCommand( 'push', gitRemote )
         }
     }
 }
@@ -323,13 +298,15 @@ task ciRelease() {
 ciRelease.dependsOn updateChangeLogFile, release
 release.mustRunAfter updateChangeLogFile
 
-static void executeGitCommand(String command, String errorMessage){
+static void executeGitCommand(Object ... subcommand){
+    List<Object> command = ['git']
+    Collections.addAll( command, subcommand )
     def proc = command.execute()
     def code = proc.waitFor()
     def stdout = inputStreamToString( proc.getInputStream() )
     def stderr = inputStreamToString( proc.getErrorStream() )
     if ( code != 0 ) {
-        throw new GradleException( errorMessage + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
+        throw new GradleException( "An error occurred while executing " + command + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
     }
 }
 

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -302,7 +302,6 @@ task addVersionCommit( dependsOn: [releaseChecks] ) {
         logger.lifecycle( "Adding commit to update version to '${project.releaseVersion}'..." )
         executeGitCommand( 'add', '.' )
         executeGitCommand( 'commit', '-m', project.ormVersion.fullName )
-        executeGitCommand( 'push', project.gitRemote )
     }
 }
 release.mustRunAfter addVersionCommit
@@ -311,21 +310,29 @@ task ciRelease( dependsOn: [releaseChecks, addVersionCommit, release] ) {
     group = "Release"
     description = "Performs a release: the hibernate version is set and the changelog.txt file updated, the changes are pushed to github, then the release is performed, tagged and the hibernate version is set to the development one."
     doLast {
+        String tag = null
         if ( !project.hasProperty( 'noTag' ) ) {
-            String tag = project.ormVersion.fullName
+            tag = project.ormVersion.fullName
             // the release is tagged and the tag is pushed to github
             if ( tag.endsWith( ".Final" ) ) {
                 tag = tag.replace( ".Final", "" )
             }
             logger.lifecycle( "Tagging '${tag}'..." )
             executeGitCommand( 'tag', tag )
-            executeGitCommand( 'push', project.gitRemote, tag )
+        }
 
-            logger.lifecycle( "Adding commit to update version to '${project.developmentVersion}'..." )
-            project.ormVersionFile.text = "hibernateVersion=${project.developmentVersion}"
-            executeGitCommand( 'add', '.')
-            executeGitCommand( 'commit', '-m', project.developmentVersion )
-            executeGitCommand( 'push', project.gitRemote )
+        logger.lifecycle( "Adding commit to update version to '${project.developmentVersion}'..." )
+        project.ormVersionFile.text = "hibernateVersion=${project.developmentVersion}"
+        executeGitCommand( 'add', '.')
+        executeGitCommand( 'commit', '-m', project.developmentVersion )
+
+        if ( tag != null ) {
+            logger.lifecycle("Pushing branch and tag to remote '${project.gitRemote}'...")
+            executeGitCommand( 'push', '--atomic', project.gitRemote , project.gitBranch, tag )
+        }
+        else {
+            logger.lifecycle("Pushing branch to remote '${project.gitRemote}'...")
+            executeGitCommand( 'push', project.gitRemote , project.gitBranch )
         }
     }
 }

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -308,7 +308,7 @@ task ciRelease() {
             )
 
             executeGitCommand(
-                    "git commit -m \"${project.ormVersion.fullName}\"",
+                    "git commit -m \"${project.property( 'developmentVersion' )}\"",
                     "An error occurred during the execution of git commit for the development version change."
             )
 

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -45,7 +45,7 @@ task releaseChecks() {
         }
 
         logger.lifecycle( "Switching to branch '${project.gitBranch}'..." )
-        executeGitCommand( 'switch', project.gitBranch )
+        executeGitCommand( 'checkout', project.gitBranch )
 
         logger.lifecycle( "Checking that all commits are pushed..." )
         String diffWithUpstream = executeGitCommand( 'diff', '@{u}' )

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -13,10 +13,51 @@ apply from: rootProject.file( 'gradle/base-information.gradle' )
 apply plugin: 'idea'
 apply plugin: 'distribution'
 
+ext {
+    if ( !project.hasProperty( 'gitRemote' ) ) {
+        gitRemote = 'origin'
+    }
+}
+
 idea.module {
 }
 
 final File documentationDir = mkdir( "${project.buildDir}/documentation" );
+
+task releaseChecks() {
+    doFirst {
+        if ( !project.hasProperty('releaseVersion') || !project.hasProperty('developmentVersion')
+                || !project.hasProperty('gitRemote') ||!project.hasProperty('gitBranch') ) {
+            throw new GradleException(
+                    "Release tasks require all of the following properties to be set:"
+                            + "'releaseVersion', 'developmentVersion', 'gitRemote', 'gitBranch'."
+            )
+        }
+
+        logger.lifecycle( "Checking that the working tree is clean..." )
+        String uncommittedFiles = executeGitCommand( 'status', '--porcelain' )
+        if ( !uncommittedFiles.isEmpty() ) {
+            throw new GradleException(
+                    "Cannot release because there are uncommitted or untracked files in the working tree."
+                            + "\nCommit or stash your changes first."
+                            + "\nUncommitted files:\n" + uncommittedFiles
+            );
+        }
+
+        logger.lifecycle( "Switching to branch '${project.gitBranch}'..." )
+        executeGitCommand( 'switch', project.gitBranch )
+
+        logger.lifecycle( "Checking that all commits are pushed..." )
+        String diffWithUpstream = executeGitCommand( 'diff', '@{u}' )
+        if ( !diffWithUpstream.isEmpty() ) {
+            throw new GradleException(
+                    "Cannot release because there are commits on the branch to release that haven't been pushed yet."
+                            + "\nPush your commits to the branch to release first."
+            );
+        }
+
+    }
+}
 
 /**
  * Assembles all documentation into the {buildDir}/documentation directory.
@@ -246,23 +287,12 @@ artifacts {
     bundles distZip
 }
 
-task release( dependsOn: [uploadDocumentation, uploadBundlesSourceForge] )
+task release( dependsOn: [releaseChecks, uploadDocumentation, uploadBundlesSourceForge] )
 
-def gitRemote = 'origin'
-if ( project.hasProperty( 'gitRemote' ) ) {
-    gitRemote = project.property( 'gitRemote' )
-}
-
-task addVersionCommit {
+task addVersionCommit( dependsOn: [releaseChecks] ) {
     group = "Release"
     description = "Updates the changelog.txt file, adds a commit for the released version and push the changes to github"
     doFirst{
-        if ( !project.hasProperty( 'releaseVersion' ) ) {
-            throw new GradleException(
-                    "The releaseVersion parameter is necessary to create the version commit."
-            )
-        }
-
         logger.lifecycle( "Updating version to '${project.releaseVersion}'..." )
         project.ormVersionFile.text = "hibernateVersion=${project.releaseVersion}"
 
@@ -272,19 +302,15 @@ task addVersionCommit {
         logger.lifecycle( "Adding commit to update version to '${project.releaseVersion}'..." )
         executeGitCommand( 'add', '.' )
         executeGitCommand( 'commit', '-m', project.ormVersion.fullName )
-        executeGitCommand( 'push', gitRemote )
+        executeGitCommand( 'push', project.gitRemote )
     }
 }
+release.mustRunAfter addVersionCommit
 
-task ciRelease() {
+task ciRelease( dependsOn: [releaseChecks, addVersionCommit, release] ) {
     group = "Release"
     description = "Performs a release: the hibernate version is set and the changelog.txt file updated, the changes are pushed to github, then the release is performed, tagged and the hibernate version is set to the development one."
     doLast {
-        if ( !project.hasProperty( 'developmentVersion' ) ) {
-            throw new GradleException(
-                    "When the releaseVersion parameter is specified, the parameter developmentVersion is required as well."
-            )
-        }
         if ( !project.hasProperty( 'noTag' ) ) {
             String tag = project.ormVersion.fullName
             // the release is tagged and the tag is pushed to github
@@ -293,21 +319,18 @@ task ciRelease() {
             }
             logger.lifecycle( "Tagging '${tag}'..." )
             executeGitCommand( 'tag', tag )
-            executeGitCommand( 'push', gitRemote, tag )
+            executeGitCommand( 'push', project.gitRemote, tag )
 
             logger.lifecycle( "Adding commit to update version to '${project.developmentVersion}'..." )
             project.ormVersionFile.text = "hibernateVersion=${project.developmentVersion}"
             executeGitCommand( 'add', '.')
             executeGitCommand( 'commit', '-m', project.developmentVersion )
-            executeGitCommand( 'push', gitRemote )
+            executeGitCommand( 'push', project.gitRemote )
         }
     }
 }
 
-ciRelease.dependsOn addVersionCommit, release
-release.mustRunAfter addVersionCommit
-
-static void executeGitCommand(Object ... subcommand){
+static String executeGitCommand(Object ... subcommand){
     List<Object> command = ['git']
     Collections.addAll( command, subcommand )
     def proc = command.execute()
@@ -317,6 +340,7 @@ static void executeGitCommand(Object ... subcommand){
     if ( code != 0 ) {
         throw new GradleException( "An error occurred while executing " + command + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
     }
+    return stdout
 }
 
 static String inputStreamToString(InputStream inputStream) {

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
  *
@@ -243,4 +245,171 @@ artifacts {
 }
 
 task release( dependsOn: [uploadDocumentation, uploadBundlesSourceForge] )
+
+def gitRemote = 'origin'
+if ( project.hasProperty( 'gitRemote' ) ) {
+    gitRemote = project.property( 'gitRemote' )
+}
+
+task updateChangeLogFile {
+    group = "Release"
+    description = "Updates the changelog.txt file and push the changes to github"
+    doFirst{
+        ChangeLogFile.update( ormVersion.fullName );
+
+        executeGitCommand(
+                "git add .",
+                "An error occurred during the execution of git add for the changelog.txt and the release version changes."
+        )
+
+        executeGitCommand(
+                "git commit -m \"${project.ormVersion.fullName}\"",
+                "An error occurred during the execution of git commit for the changelog.txt and the release version changes."
+        )
+
+        executeGitCommand(
+                "git push ${gitRemote}",
+                "An error occurred during the execution git push for the changelog.txt and the release version changes."
+        )
+    }
+}
+
+task ciRelease() {
+    group = "Release"
+    description = "Performs a release: the hibernate version is set and the changelog.txt file updated, the changes are pushed to github, then the release is performed, tagged and the hibernate version is set to the development one."
+    doLast {
+        if ( !project.hasProperty( 'developmentVersion' ) ) {
+            throw new GradleException(
+                    "When the releaseVersion parameter is specified, the parameter developmentVersion is required as well."
+            )
+        }
+        if ( !project.hasProperty( 'noTag' ) ) {
+            String tag = project.ormVersion.fullName
+            // the release is tagged and the tag is pushed to github
+            if ( tag.endsWith( ".Final" ) ) {
+                tag = tag.replace( ".Final", "" )
+            }
+            executeGitCommand(
+                    "git tag ${tag}",
+                    "An error occurred during the execution of git tag"
+            )
+            executeGitCommand(
+                    "git push ${gitRemote} ${tag}",
+                    "An error occurred during the execution of git push od the tag"
+            )
+
+            // the hibernate version is changed to the development one and the changes are pushed to github
+            project.ormVersionFile.text = "hibernateVersion=${project.property( 'developmentVersion' )}"
+            executeGitCommand(
+                    "git add .",
+                    "An error occurred during the execution of git add for the development version change."
+            )
+
+            executeGitCommand(
+                    "git commit -m \"${project.ormVersion.fullName}\"",
+                    "An error occurred during the execution of git commit for the development version change."
+            )
+
+            executeGitCommand(
+                    "git push ${gitRemote}",
+                    "An error occurred during the execution git push for the development version change."
+            )
+        }
+    }
+}
+
+ciRelease.dependsOn updateChangeLogFile, release
+release.mustRunAfter updateChangeLogFile
+
+void executeGitCommand(String command, String errorMessage){
+    def proc = command.execute()
+    def errorsStringBuffer = new StringBuffer()
+    proc.waitFor()
+    proc.consumeProcessErrorStream( errorsStringBuffer )
+    if ( errorsStringBuffer.toString(  ) != "" ) {
+        throw new GradleException( errorMessage + " " + b );
+    }
+}
+
+class ChangeLogFile {
+
+    // Get the Release Notes from Jira and add them to the Hibernate changelog.txt file
+    static void update(String releaseVersion) {
+        def text = ""
+        File changelog = new File( "changelog.txt" )
+        def newReleaseNoteBlock = getNewReleaseNoteBlock(releaseVersion)
+        changelog.eachLine {
+            line ->
+                if ( line.startsWith( "Note:" ) ) {
+                    text += line + System.lineSeparator() + System.lineSeparator() + newReleaseNoteBlock
+                }
+                else {
+                    text += line + System.lineSeparator()
+                }
+        }
+        changelog.text = text
+    }
+
+    // Get the Release Notes from Jira
+    static String getNewReleaseNoteBlock(String releaseVersion) {
+        def restReleaseVersion;
+        if ( releaseVersion.endsWith( ".Final" ) ) {
+            restReleaseVersion = releaseVersion.replace( ".Final", "" )
+        }
+        else {
+            restReleaseVersion = releaseVersion
+        }
+        def apiString = "https://hibernate.atlassian.net/rest/api/2/search/?jql=project=HHH%20AND%20fixVersion=${restReleaseVersion}%20order%20by%20issuetype%20ASC"
+        def apiUrl = new URL( apiString )
+        def releseNotes = new JsonSlurper().parse( apiUrl )
+
+
+        def releaseDate = new Date().format( 'MMMM dd, YYYY' )
+        def versionId = releseNotes.issues.get( 0 ).fields.fixVersions.get( 0 ).id
+        ReleaseNote releaseNotes = new ReleaseNote( releaseVersion, releaseDate, versionId )
+
+        def issuetype
+        releseNotes.issues.each {
+            issue ->
+                if ( issuetype != issue.fields.issuetype.name ) {
+                    issuetype = issue.fields.issuetype.name
+                    releaseNotes.addEmptyLine();
+                    releaseNotes.addLine( "** ${issue.fields.issuetype.name}" )
+                }
+                releaseNotes.addLine( "    * [" + issue.key + "] - " + issue.fields.summary )
+        }
+        releaseNotes.addEmptyLine()
+        return releaseNotes.notes
+    }
+}
+
+class ReleaseNote {
+    String notes;
+    String notesHeaderSeparator = "------------------------------------------------------------------------------------------------------------------------"
+
+    ReleaseNote(String releaseVersion, String releaseDate, String versionId) {
+        notes = "Changes in ${releaseVersion} (${releaseDate})" + System.lineSeparator()
+        addHeaderSeparator()
+        addEmptyLine()
+        addLine( "https://hibernate.atlassian.net/projects/HHH/versions/${versionId}" )
+    }
+
+    void addLine(String text) {
+        notes += text + System.lineSeparator()
+    }
+
+    void addHeaderSeparator() {
+        addLine( notesHeaderSeparator )
+    }
+
+    void addEmptyLine() {
+        notes += System.lineSeparator()
+    }
+
+    void addEmptyLines(int numberOfLines) {
+        for ( i in 1..numberOfLines ) {
+            notes += System.lineSeparator()
+        }
+    }
+}
 

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -1,3 +1,5 @@
+import java.nio.charset.StandardCharsets
+
 import groovy.json.JsonSlurper
 
 /*
@@ -321,13 +323,28 @@ task ciRelease() {
 ciRelease.dependsOn updateChangeLogFile, release
 release.mustRunAfter updateChangeLogFile
 
-void executeGitCommand(String command, String errorMessage){
+static void executeGitCommand(String command, String errorMessage){
     def proc = command.execute()
-    def errorsStringBuffer = new StringBuffer()
-    proc.waitFor()
-    proc.consumeProcessErrorStream( errorsStringBuffer )
-    if ( errorsStringBuffer.toString(  ) != "" ) {
-        throw new GradleException( errorMessage + " " + b );
+    def code = proc.waitFor()
+    def stdout = inputStreamToString( proc.getInputStream() )
+    def stderr = inputStreamToString( proc.getErrorStream() )
+    if ( code != 0 ) {
+        throw new GradleException( errorMessage + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
+    }
+}
+
+static String inputStreamToString(InputStream inputStream) {
+    inputStream.withCloseable { ins ->
+        new BufferedInputStream(ins).withCloseable { bis ->
+            new ByteArrayOutputStream().withCloseable { buf ->
+                int result = bis.read();
+                while (result != -1) {
+                    buf.write((byte) result);
+                    result = bis.read();
+                }
+                return buf.toString( StandardCharsets.UTF_8.name());
+            }
+        }
     }
 }
 

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -289,15 +289,22 @@ artifacts {
 
 task release( dependsOn: [releaseChecks, uploadDocumentation, uploadBundlesSourceForge] )
 
-task addVersionCommit( dependsOn: [releaseChecks] ) {
+task changeLogFile( dependsOn: [releaseChecks] ) {
     group = "Release"
-    description = "Updates the changelog.txt file, adds a commit for the released version and push the changes to github"
+    description = "Updates the changelog.txt file"
+
+    doFirst {
+        logger.lifecycle( "Appending version '${project.releaseVersion}' to changelog..." )
+        ChangeLogFile.update( ormVersion.fullName );
+    }
+}
+
+task addVersionCommit( dependsOn: [changeLogFile] ) {
+    group = "Release"
+    description = "Adds a commit for the released version and push the changes to github"
     doFirst{
         logger.lifecycle( "Updating version to '${project.releaseVersion}'..." )
         project.ormVersionFile.text = "hibernateVersion=${project.releaseVersion}"
-
-        logger.lifecycle( "Appending version '${project.releaseVersion}' to changelog..." )
-        ChangeLogFile.update( ormVersion.fullName );
 
         logger.lifecycle( "Adding commit to update version to '${project.releaseVersion}'..." )
         executeGitCommand( 'add', '.' )

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -299,13 +299,7 @@ task changeLogFile( dependsOn: [releaseChecks] ) {
     }
 }
 
-rootProject.subprojects.each { Project subProject ->
-    if ( !this.name.equals( subProject.name ) ) {
-        if ( subProject.tasks.findByName( 'release' ) ) {
-            this.tasks.release.dependsOn( subProject.tasks.release )
-        }
-    }
-}
+
 
 task addVersionCommit( dependsOn: [changeLogFile] ) {
     group = "Release"
@@ -320,6 +314,15 @@ task addVersionCommit( dependsOn: [changeLogFile] ) {
     }
 }
 release.mustRunAfter addVersionCommit
+
+rootProject.subprojects.each { Project subProject ->
+    if ( !this.name.equals( subProject.name ) ) {
+        if ( subProject.tasks.findByName( 'release' ) ) {
+            this.tasks.release.dependsOn( subProject.tasks.release )
+            subProject.tasks.release.mustRunAfter( this.tasks.addVersionCommit )
+        }
+    }
+}
 
 task ciRelease( dependsOn: [releaseChecks, addVersionCommit, release] ) {
     group = "Release"

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -299,6 +299,14 @@ task changeLogFile( dependsOn: [releaseChecks] ) {
     }
 }
 
+rootProject.subprojects.each { Project subProject ->
+    if ( !this.name.equals( subProject.name ) ) {
+        if ( subProject.tasks.findByName( 'release' ) ) {
+            this.tasks.release.dependsOn( subProject.tasks.release )
+        }
+    }
+}
+
 task addVersionCommit( dependsOn: [changeLogFile] ) {
     group = "Release"
     description = "Adds a commit for the released version and push the changes to github"

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -253,10 +253,19 @@ if ( project.hasProperty( 'gitRemote' ) ) {
     gitRemote = project.property( 'gitRemote' )
 }
 
-task updateChangeLogFile {
+task addVersionCommit {
     group = "Release"
-    description = "Updates the changelog.txt file and push the changes to github"
+    description = "Updates the changelog.txt file, adds a commit for the released version and push the changes to github"
     doFirst{
+        if ( !project.hasProperty( 'releaseVersion' ) ) {
+            throw new GradleException(
+                    "The releaseVersion parameter is necessary to create the version commit."
+            )
+        }
+
+        logger.lifecycle( "Updating version to '${project.releaseVersion}'..." )
+        project.ormVersionFile.text = "hibernateVersion=${project.releaseVersion}"
+
         logger.lifecycle( "Appending version '${project.releaseVersion}' to changelog..." )
         ChangeLogFile.update( ormVersion.fullName );
 
@@ -295,8 +304,8 @@ task ciRelease() {
     }
 }
 
-ciRelease.dependsOn updateChangeLogFile, release
-release.mustRunAfter updateChangeLogFile
+ciRelease.dependsOn addVersionCommit, release
+release.mustRunAfter addVersionCommit
 
 static void executeGitCommand(Object ... subcommand){
     List<Object> command = ['git']


### PR DESCRIPTION
The PR add a new gradle task that automates the entire release process.
Running the command
`./gradlew clean ciRelease -PreleaseVersion=5.0.0.Final -PdevelopmentVersion=5.0.1-SNAPSHOT`
the following steps will be automatically executed :

1. the version is changed to `5.0.0.Final` (provided `releaseVersion`)
2.  the changelog.txt file is updated grabbing the Release Notes from Jira
3.  a git commit and push is executed
4.  the `relesase` task is kicked
5.  the release is tagged and the tag is pushed
6.  the version is changed to `5.0.1-SNAPSHOT` (provided `developmentVersion`)
7. a git commit and push is executed

the git remote used by default is `origin` the `gitRemote` property can be used to change the target remote.

the `noTag` parameter can be used to skip steps 5,6 and 7

Any suggestion is more than welcome :)