### PR TITLE
HHH-13954 - An SQL Dialect for PostgreSQL 10 and later. Adds support for Partition table.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL10Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQL10Dialect.java
@@ -18,4 +18,14 @@ public class PostgreSQL10Dialect extends PostgreSQL95Dialect {
 	public IdentityColumnSupport getIdentityColumnSupport() {
 		return new PostgreSQL10IdentityColumnSupport();
 	}
+
+	/**
+	 * An SQL Dialect for PostgreSQL 10 and later. Adds support for Partition table.
+	 * @author huazhang.jiang
+	 */
+	@Override
+	public void augmentRecognizedTableTypes(List<String> tableTypesList) {
+		super.augmentRecognizedTableTypes( tableTypesList );
+		tableTypesList.add( "PARTITIONED TABLE" );
+	}
 }


### PR DESCRIPTION
PostgreSQL starts at 10.pg_class.relkind has p = partitioned table
Driving embodied PgDatabaseMetaData.tableTypeClauses.put ( "PARTITIONED TABLE", ht);
https://www.postgresql.org/docs/10/catalog-pg-class.html