### PR TITLE
wip/6.0 Implement filter for HQL/Criteria

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/pc/FilterJoinTableTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/pc/FilterJoinTableTest.java
@@ -18,15 +18,12 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 
 import org.hibernate.Session;
-import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.FilterJoinTable;
 import org.hibernate.annotations.ParamDef;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.junit.Test;
-
-import org.jboss.logging.Logger;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
@@ -117,10 +114,6 @@ public class FilterJoinTableTest extends BaseEntityManagerFunctionalTestCase {
             name="maxOrderId",
             type="int"
         )
-    )
-    @Filter(
-        name="firstAccounts",
-        condition="order_id <= :maxOrderId"
     )
     public static class Client {
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterJdbcParameter.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal;
+
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.exec.internal.JdbcParameterImpl;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.hibernate.sql.exec.spi.JdbcParameterBinding;
+
+/**
+ * @author Nathan Xu
+ */
+public class FilterJdbcParameter {
+	private final JdbcParameter parameter;
+	private final JdbcMapping jdbcMapping;
+	private final Object jdbcParameterValue;
+
+	public FilterJdbcParameter(JdbcMapping jdbcMapping, Object jdbcParameterValue) {
+		this.parameter = new JdbcParameterImpl( jdbcMapping );
+		this.jdbcMapping = jdbcMapping;
+		this.jdbcParameterValue = jdbcParameterValue;
+	}
+
+	public JdbcParameter getParameter() {
+		return parameter;
+	}
+
+	public JdbcParameterBinder getBinder() {
+		return parameter.getParameterBinder();
+	}
+
+	public JdbcParameterBinding getBinding() {
+		return new JdbcParameterBinding() {
+			@Override
+			public JdbcMapping getBindType() {
+				return jdbcMapping;
+			}
+
+			@Override
+			public Object getBindValue() {
+				return jdbcParameterValue;
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderBatchKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderBatchKey.java
@@ -163,8 +163,7 @@ public class CollectionLoaderBatchKey implements CollectionLoader {
 			final JdbcSelect jdbcSelect = sqlAstTranslatorFactory.buildSelectTranslator( sessionFactory ).translate( sqlAst );
 
 			final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( keyJdbcCount * smallBatchLength );
-
-			sqlAst.getQuerySpec().bindFilterPredicateParameters( jdbcParameterBindings );
+			jdbcSelect.registerFilterJdbcParameterBindings( jdbcParameterBindings );
 
 			final Iterator<JdbcParameter> paramItr = jdbcParameters.iterator();
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderSingleKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderSingleKey.java
@@ -99,6 +99,7 @@ public class CollectionLoaderSingleKey implements CollectionLoader {
 		final JdbcSelect jdbcSelect = sqlAstTranslatorFactory.buildSelectTranslator( sessionFactory ).translate( sqlAst );
 
 		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( keyJdbcCount );
+		jdbcSelect.registerFilterJdbcParameterBindings( jdbcParameterBindings );
 
 		final Iterator<JdbcParameter> paramItr = jdbcParameters.iterator();
 
@@ -126,8 +127,6 @@ public class CollectionLoaderSingleKey implements CollectionLoader {
 				session
 		);
 		assert !paramItr.hasNext();
-
-		sqlAst.getQuerySpec().bindFilterPredicateParameters( jdbcParameterBindings );
 
 		jdbcServices.getJdbcSelectExecutor().list(
 				jdbcSelect,

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -93,6 +93,7 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 		assert jdbcParameters.size() % jdbcTypeCount == 0;
 
 		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( jdbcTypeCount );
+		jdbcSelect.registerFilterJdbcParameterBindings( jdbcParameterBindings );
 
 		final Iterator<JdbcParameter> paramItr = jdbcParameters.iterator();
 
@@ -121,8 +122,6 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 					session
 			);
 		}
-
-		sqlAst.getQuerySpec().bindFilterPredicateParameters( jdbcParameterBindings );
 
 		final List list = JdbcSelectExecutorStandardImpl.INSTANCE.list(
 				jdbcSelect,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -160,6 +160,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 				sqmInterpretation.getTableGroupAccess()::findTableGroup,
 				session
 		);
+		sqmInterpretation.getJdbcSelect().registerFilterJdbcParameterBindings( jdbcParameterBindings );
 
 		try {
 			return session.getFactory().getJdbcServices().getJdbcSelectExecutor().list(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
@@ -45,6 +45,11 @@ public class SqmInterpretationsKey implements QueryInterpretationCache.Key {
 	private static boolean isCacheable(QuerySqmImpl<?> query) {
 		assert query.getQueryOptions().getAppliedGraph() != null;
 
+		if ( query.getSession().getLoadQueryInfluencers().hasEnabledFilters() ) {
+			// At the moment we cannot cache query plan if there is filter enabled.
+			return false;
+		}
+
 		if ( query.getQueryOptions().getAppliedGraph().getSemantic() != null ) {
 			// At the moment we cannot cache query plan if there is an
 			// EntityGraph enabled.

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/StandardSqlAstSelectTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/StandardSqlAstSelectTranslator.java
@@ -74,7 +74,8 @@ public class StandardSqlAstSelectTranslator
 						querySpec.getSelectClause().getSqlSelections(),
 						Collections.emptyList()
 				),
-				getAffectedTableNames()
+				getAffectedTableNames(),
+				filterJdbcParameters
 		);
 	}
 
@@ -93,7 +94,8 @@ public class StandardSqlAstSelectTranslator
 						sqlAstSelect.getQuerySpec().getSelectClause().getSqlSelections(),
 						sqlAstSelect.getDomainResultDescriptors()
 				),
-				getAffectedTableNames()
+				getAffectedTableNames(),
+				filterJdbcParameters
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/FilterPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/FilterPredicate.java
@@ -6,13 +6,10 @@
  */
 package org.hibernate.sql.ast.tree.predicate;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.internal.FilterHelper;
+import org.hibernate.internal.FilterJdbcParameter;
 import org.hibernate.sql.ast.SqlAstWalker;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
-import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 
 /**
  * Represents a filter applied to an entity/collection.
@@ -20,19 +17,15 @@ import org.hibernate.sql.exec.internal.JdbcParameterImpl;
  * Note, we do not attempt to parse the filter
  *
  * @author Steve Ebersole
+ * @author Nathan Xu
  */
 public class FilterPredicate implements Predicate {
 	private final String filterFragment;
-	private final List<JdbcParameter> jdbcParameters;
-	private final List<FilterHelper.TypedValue> jdbcParameterTypedValues;
+	private final List<FilterJdbcParameter> filterJdbcParameters;
 
-	public FilterPredicate(String filterFragment, List<FilterHelper.TypedValue> jdbcParameterTypedValues) {
+	public FilterPredicate(String filterFragment, List<FilterJdbcParameter> filterJdbcParameters) {
 		this.filterFragment = filterFragment;
-		jdbcParameters = new ArrayList<>( jdbcParameterTypedValues.size() );
-		this.jdbcParameterTypedValues = jdbcParameterTypedValues;
-		for (int i = 0; i < jdbcParameterTypedValues.size(); i++) {
-			jdbcParameters.add( new JdbcParameterImpl( null ) );
-		}
+		this.filterJdbcParameters = filterJdbcParameters;
 	}
 
 	@Override
@@ -49,11 +42,7 @@ public class FilterPredicate implements Predicate {
 		return filterFragment;
 	}
 
-	public List<JdbcParameter> getJdbcParameters() {
-		return jdbcParameters;
-	}
-
-	public List<FilterHelper.TypedValue> getJdbcParameterTypedValues() {
-		return jdbcParameterTypedValues;
+	public List<FilterJdbcParameter> getFilterJdbcParameters() {
+		return filterJdbcParameters;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcSelect.java
@@ -9,6 +9,8 @@ package org.hibernate.sql.exec.spi;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.internal.FilterJdbcParameter;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducer;
 
 /**
@@ -21,16 +23,19 @@ public class JdbcSelect implements JdbcOperation {
 	private final List<JdbcParameterBinder> parameterBinders;
 	private final JdbcValuesMappingProducer jdbcValuesMappingProducer;
 	private final Set<String> affectedTableNames;
+	private final List<FilterJdbcParameter> filterJdbcParameters;
 
 	public JdbcSelect(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
 			JdbcValuesMappingProducer jdbcValuesMappingProducer,
-			Set<String> affectedTableNames) {
+			Set<String> affectedTableNames,
+			List<FilterJdbcParameter> filterJdbcParameters) {
 		this.sql = sql;
 		this.parameterBinders = parameterBinders;
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.affectedTableNames = affectedTableNames;
+		this.filterJdbcParameters = filterJdbcParameters;
 	}
 
 	@Override
@@ -50,5 +55,13 @@ public class JdbcSelect implements JdbcOperation {
 
 	public JdbcValuesMappingProducer getJdbcValuesMappingProducer() {
 		return jdbcValuesMappingProducer;
+	}
+
+	public void registerFilterJdbcParameterBindings(JdbcParameterBindings jdbcParameterBindings) {
+		if ( CollectionHelper.isNotEmpty( filterJdbcParameters ) ) {
+			for ( FilterJdbcParameter filterJdbcParameter : filterJdbcParameters ) {
+				jdbcParameterBindings.addBinding( filterJdbcParameter.getParameter(), filterJdbcParameter.getBinding() );
+			}
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterBasicsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterBasicsTests.java
@@ -1,0 +1,300 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.criteria.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterBasicsTests.Client.class,
+				FilterBasicsTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterBasicsTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnEntity(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
+
+			final CriteriaQuery<Account> criteriaQuery1 = createCriteriaQuery( criteriaBuilder, Account.class, "id", 1L );
+			Account account1 = session.createQuery( criteriaQuery1 ).uniqueResult();
+			assertThat( account1, notNullValue() );
+
+			final CriteriaQuery<Account> criteriaQuery2 = createCriteriaQuery( criteriaBuilder, Account.class, "id", 2L );
+			Account account2 = session.createQuery( criteriaQuery2 ).uniqueResult();
+			assertThat( account2, enableFilter ? nullValue() : notNullValue() );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnCollectionField(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+
+			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
+			final CriteriaQuery<Client> criteriaQuery = createCriteriaQuery( criteriaBuilder, Client.class, "id", 1L );
+			final Client client = session.createQuery(criteriaQuery).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="active_status = :active"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	@Filter(
+			name="activeAccount",
+			condition="active_status = :active"
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+
+	private static <T> CriteriaQuery<T> createCriteriaQuery(CriteriaBuilder criteriaBuilder, Class<T> entityClass, String idFieldName, Object idValue) {
+		final CriteriaQuery<T> criteria = criteriaBuilder.createQuery( entityClass );
+		Root<T> root = criteria.from( entityClass );
+		criteria.select( root );
+		criteria.where( criteriaBuilder.equal( root.get( idFieldName ), criteriaBuilder.literal( idValue ) ) );
+		return criteria;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterJoinTableTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterJoinTableTests.java
@@ -1,0 +1,218 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.criteria.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.FilterJoinTable;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterJoinTableTests.Client.class,
+				FilterJoinTableTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterJoinTableTests {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+			);
+
+			session.persist( client );
+		} );
+	}
+
+	@Test
+	void testLoadFilterOnCollectionField(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.enableFilter( "firstAccounts" ).setParameter( "maxOrderId", 1);
+
+			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
+			final CriteriaQuery<Client> criteriaQuery = createCriteriaQuery( criteriaBuilder, Client.class, "id", 1L );
+			final Client client = session.createQuery( criteriaQuery ).uniqueResult();
+			assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+						equalTo( new HashSet<>( Arrays.asList( 1L, 2L ) ) ) );
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	@FilterDef(
+			name="firstAccounts",
+			parameters=@ParamDef(
+					name="maxOrderId",
+					type="int"
+			)
+	)
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@ManyToMany(cascade = CascadeType.ALL)
+		@JoinTable
+		@OrderColumn(name = "order_id")
+		@FilterJoinTable(
+				name="firstAccounts",
+				condition="order_id <= :maxOrderId"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+	}
+
+	private static <T> CriteriaQuery<T> createCriteriaQuery(CriteriaBuilder criteriaBuilder, Class<T> entityClass, String idFieldName, Object idValue) {
+		final CriteriaQuery<T> criteria = criteriaBuilder.createQuery( entityClass );
+		Root<T> root = criteria.from( entityClass );
+		criteria.select( root );
+		criteria.where( criteriaBuilder.equal( root.get( idFieldName ), criteriaBuilder.literal( idValue ) ) );
+		return criteria;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterOnJoinFetchedCollectionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterOnJoinFetchedCollectionTests.java
@@ -1,0 +1,278 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.criteria.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterOnJoinFetchedCollectionTests.Client.class,
+				FilterOnJoinFetchedCollectionTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterOnJoinFetchedCollectionTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testJoinFetchedCollectionField(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
+			final CriteriaQuery<Client> criteriaQuery = createCriteriaQuery( criteriaBuilder, Client.class, "id", 1L );
+			final Client client = session.createQuery( criteriaQuery ).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+					equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="active_status = :active"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	@Filter(
+			name="activeAccount",
+			condition="active_status = :active"
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+
+	private static <T> CriteriaQuery<T> createCriteriaQuery(CriteriaBuilder criteriaBuilder, Class<T> entityClass, String idFieldName, Object idValue) {
+		final CriteriaQuery<T> criteria = criteriaBuilder.createQuery( entityClass );
+		Root<T> root = criteria.from( entityClass );
+		criteria.select( root );
+		criteria.where( criteriaBuilder.equal( root.get( idFieldName ), criteriaBuilder.literal( idValue ) ) );
+		return criteria;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterWithSqlFragmentAliasTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/filter/FilterWithSqlFragmentAliasTests.java
@@ -1,0 +1,291 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.criteria.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SqlFragmentAlias;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterWithSqlFragmentAliasTests.Client.class,
+				FilterWithSqlFragmentAliasTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterWithSqlFragmentAliasTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnCollectionField(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+
+			final CriteriaBuilder criteriaBuilder = scope.getSessionFactory().getCriteriaBuilder();
+			final CriteriaQuery<Client> criteriaQuery = createCriteriaQuery( criteriaBuilder, Client.class, "id", 1L );
+			final Client client = session.createQuery( criteriaQuery ).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	@Table(name = "client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		private AccountType type;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="{a}.active_status = :active",
+				aliases = {
+						@SqlFragmentAlias( alias = "a", table= "account")
+				}
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public void setType(AccountType type) {
+			this.type = type;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@Table(name = "account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+
+	private static <T> CriteriaQuery<T> createCriteriaQuery(CriteriaBuilder criteriaBuilder, Class<T> entityClass, String idFieldName, Object idValue) {
+		final CriteriaQuery<T> criteria = criteriaBuilder.createQuery( entityClass );
+		Root<T> root = criteria.from( entityClass );
+		criteria.select( root );
+		criteria.where( criteriaBuilder.equal( root.get( idFieldName ), criteriaBuilder.literal( idValue ) ) );
+		return criteria;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterBasicsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterBasicsTests.java
@@ -1,0 +1,284 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterBasicsTests.Client.class,
+				FilterBasicsTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterBasicsTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnEntity(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			final String hqlString = "select a from Account a where a.id = :id";
+			final Account account1 = session.createQuery( hqlString, Account.class )
+					.setParameter( "id", 1L ).uniqueResult();
+			final Account account2 = session.createQuery( hqlString, Account.class )
+					.setParameter( "id", 2L ).uniqueResult();
+			assertThat( account1, notNullValue() );
+			assertThat( account2, enableFilter ? nullValue() : notNullValue() );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnCollectionField(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			Client client = session.createQuery( "select c from Client c where c.id = :id", Client.class )
+					.setParameter( "id", 1L ).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map(Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map(Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="active_status = :active"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	@Filter(
+			name="activeAccount",
+			condition="active_status = :active"
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterJoinTableTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterJoinTableTests.java
@@ -1,0 +1,202 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.OrderColumn;
+
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.FilterJoinTable;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterJoinTableTests.Client.class,
+				FilterJoinTableTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterJoinTableTests {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+			);
+
+			session.persist( client );
+		} );
+	}
+
+	@Test
+	void testFilterJoinableOnCollectionField(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.enableFilter( "firstAccounts" ).setParameter( "maxOrderId", 1 );
+			final Client client = session.createQuery( "select c from Client c where c.id = :id", Client.class )
+					.setParameter( "id", 1L ).uniqueResult();
+			assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+						equalTo( new HashSet<>( Arrays.asList( 1L, 2L ) ) ) );
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	@FilterDef(
+			name="firstAccounts",
+			parameters=@ParamDef(
+					name="maxOrderId",
+					type="int"
+			)
+	)
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@ManyToMany(cascade = CascadeType.ALL)
+		@JoinTable
+		@OrderColumn(name = "order_id")
+		@FilterJoinTable(
+				name="firstAccounts",
+				condition="order_id <= :maxOrderId"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterOnJoinFetchedCollectionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterOnJoinFetchedCollectionTests.java
@@ -1,0 +1,262 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterOnJoinFetchedCollectionTests.Client.class,
+				FilterOnJoinFetchedCollectionTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterOnJoinFetchedCollectionTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testLoadFilterOnCollectionField(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			final Client client = session.createQuery( "select c from Client c join fetch c.accounts where c.id = :id", Client.class )
+					.setParameter( "id", 1L ).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="active_status = :active"
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	@Filter(
+			name="activeAccount",
+			condition="active_status = :active"
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterWithSqlFragmentAliasTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/filter/FilterWithSqlFragmentAliasTests.java
@@ -1,0 +1,279 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SqlFragmentAlias;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(
+		annotatedClasses = {
+				FilterWithSqlFragmentAliasTests.Client.class,
+				FilterWithSqlFragmentAliasTests.Account.class
+		}
+)
+@SessionFactory
+public class FilterWithSqlFragmentAliasTests implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			// ensure query plan cache won't interfere
+			scope.getSessionFactory().getQueryEngine().getInterpretationCache().close();
+
+			Client client = new Client()
+					.setId( 1L )
+					.setName( "John Doe" )
+					.setType( AccountType.DEBIT );
+
+			client.addAccount(
+					new Account()
+							.setId( 1L )
+							.setType( AccountType.CREDIT )
+							.setAmount( 5000d )
+							.setRate( 1.25 / 100 )
+							.setActive( true )
+			);
+
+			client.addAccount(
+					new Account()
+							.setId( 2L )
+							.setType( AccountType.DEBIT )
+							.setAmount( 0d )
+							.setRate( 1.05 / 100 )
+							.setActive( false )
+			);
+
+			client.addAccount(
+					new Account()
+							.setType( AccountType.DEBIT )
+							.setId( 3L )
+							.setAmount( 250d )
+							.setRate( 1.05 / 100 )
+							.setActive( true )
+			);
+			session.persist( client );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	void testSqlFragmentAlias(boolean enableFilter) {
+		scope.inTransaction( session -> {
+			if ( enableFilter ) {
+				session.enableFilter( "activeAccount" ).setParameter( "active", true );
+			}
+			Client client = session.createQuery( "select c from Client c where c.id = :id", Client.class )
+					.setParameter( "id", 1L ).uniqueResult();
+
+			if ( enableFilter ) {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 3L ) ) ) );
+			}
+			else {
+				assertThat( client.getAccounts().stream().map( Account::getId ).collect( Collectors.toSet() ),
+							equalTo( new HashSet<>( Arrays.asList( 1L, 2L, 3L ) ) ) );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Account" ).executeUpdate();
+			session.createQuery( "delete from Client" ).executeUpdate();
+		} );
+	}
+
+	public enum AccountType {
+		DEBIT,
+		CREDIT
+	}
+
+	@Entity(name = "Client")
+	@Table(name = "client")
+	public static class Client {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		private AccountType type;
+
+		@OneToMany(
+				mappedBy = "client",
+				cascade = CascadeType.ALL
+		)
+		@Filter(
+				name="activeAccount",
+				condition="{a}.active_status = :active",
+				aliases = {
+						@SqlFragmentAlias( alias = "a", table= "account")
+				}
+		)
+		private List<Account> accounts = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public Client setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Client setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Client setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public List<Account> getAccounts() {
+			return accounts;
+		}
+
+		public void addAccount(Account account) {
+			account.setClient( this );
+			this.accounts.add( account );
+		}
+	}
+
+	@Entity(name = "Account")
+	@Table(name = "account")
+	@FilterDef(
+			name="activeAccount",
+			parameters = @ParamDef(
+					name="active",
+					type="boolean"
+			)
+	)
+	public static class Account {
+
+		@Id
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Client client;
+
+		@Column(name = "account_type")
+		@Enumerated(EnumType.STRING)
+		private AccountType type;
+
+		private Double amount;
+
+		private Double rate;
+
+		@Column(name = "active_status")
+		private boolean active;
+
+		public Long getId() {
+			return id;
+		}
+
+		public Account setId(Long id) {
+			this.id = id;
+			return this;
+		}
+
+		public Client getClient() {
+			return client;
+		}
+
+		public Account setClient(Client client) {
+			this.client = client;
+			return this;
+		}
+
+		public AccountType getType() {
+			return type;
+		}
+
+		public Account setType(AccountType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Double getAmount() {
+			return amount;
+		}
+
+		public Account setAmount(Double amount) {
+			this.amount = amount;
+			return this;
+		}
+
+		public Double getRate() {
+			return rate;
+		}
+
+		public Account setRate(Double rate) {
+			this.rate = rate;
+			return this;
+		}
+
+		public boolean isActive() {
+			return active;
+		}
+
+		public Account setActive(boolean active) {
+			this.active = active;
+			return this;
+		}
+	}
+}


### PR DESCRIPTION
https://trello.com/c/KLZjWiX0/118-filter-support-for-hql-criteria

Also a followup for https://trello.com/c/RQxAqQaT/104-loaderselectbuilder-implement-use-of-loadqueryinfluencer, which was mainly focused on `loader` filter implementation.
 
The idiosyncrasy of `@Filter` and `@FilterJointable` feature is that they bring about additional JDBC parameter bindings. In last PR I registered these filter parameter bindings via `QuerySpec` which is tightly coupled with `loader` and not workable for `HQL/Criteria`. To support both `loader` and `HQL/Criteria`, this PR refactored previous implementation to store filter parameter to `JdbcSelect` instead, which accommodates both scenarios well. However, better idea is more than welcome!

As in last PR, extensive testing cases were added. 