### PR TITLE
HHH-13932: Check for non existing query parameter in CriteriaQueryTypeQueryAdapter and throw an exception with the corresponding message

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaQueryTypeQueryAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/compile/CriteriaQueryTypeQueryAdapter.java
@@ -370,7 +370,10 @@ public class CriteriaQueryTypeQueryAdapter<X> implements QueryImplementor<X> {
 			return (ExplicitParameterInfo<?>) param;
 		}
 		else if ( ParameterExpression.class.isInstance( param ) ) {
-			return explicitParameterInfoMap.get( param );
+			ExplicitParameterInfo<?> parameterInfo = explicitParameterInfoMap.get( param );
+			if ( parameterInfo != null ) {
+				return parameterInfo;
+			}
 		}
 		else {
 			for ( ExplicitParameterInfo<?> parameterInfo : explicitParameterInfoMap.values() ) {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/CriteriaQueryTypeQueryAdapterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/criteria/CriteriaQueryTypeQueryAdapterTest.java
@@ -113,6 +113,22 @@ public class CriteriaQueryTypeQueryAdapterTest extends BaseEntityManagerFunction
 		} );
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	@TestForIssue(jiraKey = "HHH-13932")
+	public void testCriteriaQuerySetNonExistingParameter() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+			CriteriaQuery<Item> query = builder.createQuery( Item.class );
+			Root<Item> root = query.from( Item.class );
+			ParameterExpression<String> parameter = builder.parameter( String.class, "name" );
+			Predicate predicate = builder.equal( root.get( "name" ), parameter );
+			query.where( predicate );
+			TypedQuery<Item> criteriaQuery = entityManager.createQuery( query );
+			ParameterExpression<String> nonExistingParam = builder.parameter( String.class, "nonExistingParam" );
+			criteriaQuery.setParameter( nonExistingParam, "George" );
+		} );
+	}
+
 	@Test
 	public void testSetParameterPassingTypeNotFails() {
 		doInJPA( this::entityManagerFactory, entityManager -> {


### PR DESCRIPTION
Jira ticket: [HHH-13932](https://hibernate.atlassian.net/browse/HHH-13932)

**Issue:** 
When the user attempts to set non existing query parameter using` Query::setParameter` a `NullPointerException` is thrown. This is due to `CriteriaQueryTypeQueryAdapter.explicitParameterInfoMap` not having a key for the parameter, as it was never used in the query.  

**Solution:**
Check for non existing query parameter and throw an `IllegalArgumentException` with the corresponding message.