### PR TITLE
wip/6.0 AST tree logging line separator OS agnostic

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
@@ -125,7 +125,7 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 
 		final String title = header != null ? header : "SqmQuerySpec Tree";
 
-		LOGGER.debugf( "%s :\n%s", title, treePrinter.buffer.toString() );
+		LOGGER.debugf( "%s :%n%s", title, treePrinter.buffer.toString() );
 	}
 
 	public static void logTree(SqmStatement sqmStatement) {
@@ -148,7 +148,7 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 			printer.visitInsertSelectStatement( (SqmInsertSelectStatement) sqmStatement );
 		}
 
-		LOGGER.debugf( "SqmStatement Tree :\n%s", printer.buffer.toString() );
+		LOGGER.debugf( "SqmStatement Tree :%n%s", printer.buffer.toString() );
 	}
 
 	private final StringBuffer buffer = new StringBuffer();
@@ -217,7 +217,7 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 
 	private void logWithIndentation(Object line) {
 		pad( depth );
-		buffer.append( line ).append( '\n' );
+		buffer.append( line ).append( System.lineSeparator() );
 	}
 
 	private void pad(int depth) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
@@ -74,7 +74,7 @@ public class SqlTreePrinter implements SqlAstWalker {
 		final SqlTreePrinter printer = new SqlTreePrinter();
 		printer.visitStatement( sqlAstStatement );
 
-		SqlAstTreeLogger.INSTANCE.debugf( "SQL AST Tree:\n" + printer.buffer.toString() );
+		SqlAstTreeLogger.INSTANCE.debugf( "SQL AST Tree:%n" + printer.buffer.toString() );
 	}
 
 	private final StringBuffer buffer = new StringBuffer();
@@ -215,7 +215,7 @@ public class SqlTreePrinter implements SqlAstWalker {
 
 	private void logWithIndentation(Object line) {
 		pad( depth );
-		buffer.append( line ).append( '\n' );
+		buffer.append( line ).append( System.lineSeparator() );
 	}
 
 	private void logWithIndentation(String pattern, Object arg1) {


### PR DESCRIPTION
Given that Hibernate supports SqlServer on Windows OS, I assume it is desirable to ensure the logging statement should output lines in OS agnostic way. However, currently the two AST tree logger's output on Windows is screwed up because `\n` is hardcoded in code.

Not a big deal for sure. But imagine a new Java developer working on Windows OS to turn on the AST tree logging statements...