### PR TITLE
6.0 envers test enablement

### DIFF
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -210,7 +210,11 @@ tasks.withType( Test.class ).each { test ->
 	}
 
 	// todo (6.0) : temporarily include just the new tests so we can publish SNAPSHOTS for others to use
-	test.include 'org/hibernate/orm/test/**'
+	test.includes = [
+		'org/hibernate/orm/test/**',
+		'org/hibernate/envers/**',
+		'ee/estonia/entities/**'
+	]
 }
 
 sourceSets {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -220,8 +220,7 @@ public class AttributeFactory {
 				final Component component = (Component) typeContext.getHibernateValue();
 				final EmbeddableTypeImpl<Y> embeddableType;
 
-				if ( component.getComponentClass() != null
-						|| component.getComponentClassName() != null ) {
+				if ( component.getComponentClassName() != null ) {
 					// we should have a non-dynamic embeddable
 
 					final Class embeddableClass;
@@ -261,8 +260,16 @@ public class AttributeFactory {
 					return embeddableType;
 				}
 				else {
+
+					final ManagedTypeRepresentationStrategy representationStrategy = context.getTypeConfiguration()
+							.getMetadataBuildingContext()
+							.getBuildingOptions()
+							.getManagedTypeRepresentationResolver()
+							.resolveStrategy( component, context.getRuntimeModelCreationContext() );
+
 					embeddableType = new EmbeddableTypeImpl(
 							component.getRoleName(),
+							representationStrategy,
 							context.getJpaMetamodel()
 					);
 				}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardManagedTypeRepresentationResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardManagedTypeRepresentationResolver.java
@@ -62,7 +62,7 @@ public class StandardManagedTypeRepresentationResolver implements ManagedTypeRep
 //		RepresentationMode representation = bootDescriptor.getExplicitRepresentationMode();
 		RepresentationMode representation = null;
 		if ( representation == null ) {
-			if ( bootDescriptor.getComponentClass() == null ) {
+			if ( bootDescriptor.getComponentClassName() == null ) {
 				representation = RepresentationMode.MAP;
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
@@ -9,7 +9,6 @@ package org.hibernate.metamodel.model.domain.internal;
 import java.io.Serializable;
 import java.util.Map;
 
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.graph.internal.SubGraphImpl;
 import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.model.domain.AbstractManagedType;
@@ -41,6 +40,7 @@ public class EmbeddableTypeImpl<J>
 
 	public EmbeddableTypeImpl(
 			String name,
+			ManagedTypeRepresentationStrategy representationStrategy,
 			JpaMetamodel domainMetamodel) {
 		//noinspection unchecked
 		super(
@@ -52,8 +52,7 @@ public class EmbeddableTypeImpl<J>
 				domainMetamodel
 		);
 
-		// todo (6.0) : need ManagedTypeRepresentationStrategy impls
-		throw new NotYetImplementedFor6Exception( getClass() );
+		this.representationStrategy = representationStrategy;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -515,7 +515,7 @@ public class JpaMetamodelImpl implements JpaMetamodel {
 			PersistentClass persistentClass,
 			MetadataContext context,
 			TypeConfiguration typeConfiguration) {
-		final Class javaType = persistentClass.getMappedClass();
+		final Class javaType = persistentClass.getMappedClass() == null ? Map.class : persistentClass.getMappedClass();
 		context.pushEntityWorkedOn( persistentClass );
 		final MappedSuperclass superMappedSuperclass = persistentClass.getSuperMappedSuperclass();
 		IdentifiableDomainType<?> superType = superMappedSuperclass == null


### PR DESCRIPTION
Here's a quick pass to try and get Envers tests working.  

Run `org.hibernate.envers.test.integration.basic.Simple` test to observe the 
```
org.hibernate.sql.ast.SqlTreeCreationException: Could not locate TableGroup - NavigablePath[org.hibernate.envers.test.entities.IntTestEntity_AUD(e__).originalId.REV]
javax.persistence.PersistenceException: org.hibernate.sql.ast.SqlTreeCreationException: Could not locate TableGroup - NavigablePath[org.hibernate.envers.test.entities.IntTestEntity_AUD(e__).originalId.REV]
```