### PR TITLE
HHH-13969 Fix handling of large varbinary in SybaseASE15Dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASE15Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASE15Dialect.java
@@ -30,6 +30,8 @@ public class SybaseASE15Dialect extends SybaseDialect {
 	public SybaseASE15Dialect() {
 		super();
 
+		registerColumnType( Types.VARBINARY, "image" );
+		registerColumnType( Types.VARBINARY, 8000, "varbinary($l)" );
 		registerColumnType( Types.LONGVARBINARY, "image" );
 		registerColumnType( Types.LONGVARCHAR, "text" );
 		registerColumnType( Types.BIGINT, "bigint" );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13969

Updates the handling of the VARBINARY type so when a using column size larger than what Sybase accepts, the `image` type is used instead.

This change mirrors the behaviour of other Transact-SQL dialects such as [SQLServerDialect](https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java#L42).


Document on `varbinary` - size only goes up to 16K:
https://wiki.ispirer.com/sqlways/sybase/data-types/varbinary

Document on the `image ` type:
https://wiki.ispirer.com/sqlways/sybase/data-types/image

