### PR TITLE
HHH-13975 : geolatte-geom support for SpatialPredicates

### DIFF
--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteFilterPredicate.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteFilterPredicate.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.spatial.predicate;
+
+import java.io.Serializable;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.query.criteria.internal.CriteriaBuilderImpl;
+import org.hibernate.query.criteria.internal.ParameterRegistry;
+import org.hibernate.query.criteria.internal.Renderable;
+import org.hibernate.query.criteria.internal.compile.RenderingContext;
+import org.hibernate.query.criteria.internal.predicate.AbstractSimplePredicate;
+import org.hibernate.spatial.SpatialDialect;
+import org.hibernate.spatial.SpatialFunction;
+import org.hibernate.spatial.dialect.WithCustomJPAFilter;
+
+import org.geolatte.geom.Envelope;
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.Polygon;
+import org.geolatte.geom.Position;
+import org.geolatte.geom.PositionSequence;
+import org.geolatte.geom.PositionSequenceBuilders;
+import org.geolatte.geom.crs.CoordinateReferenceSystem;
+
+/**
+ * {@link JTSFilterPredicate}, but for geolatte-geom.
+ */
+public class GeolatteFilterPredicate extends AbstractSimplePredicate implements Serializable {
+
+	private final Expression<? extends Geometry> geometry;
+	private final Expression<? extends Geometry> filter;
+
+	public GeolatteFilterPredicate(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			Expression<? extends Geometry> filter) {
+		super( (CriteriaBuilderImpl) criteriaBuilder );
+		this.geometry = geometry;
+		this.filter = filter;
+	}
+
+	public GeolatteFilterPredicate(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			Geometry filter) {
+		this( criteriaBuilder, geometry, criteriaBuilder.literal( filter )
+		);
+	}
+
+	public GeolatteFilterPredicate(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			Envelope envelope) {
+		this( criteriaBuilder, geometry, fromEnvelope( envelope )
+		);
+	}
+
+	@Override
+	public void registerParameters(ParameterRegistry registry) {
+		Helper.possibleParameter( geometry, registry );
+		Helper.possibleParameter( filter, registry );
+	}
+
+	@Override
+	public String render(boolean isNegated, RenderingContext renderingContext) {
+		String geometryParameter = ( (Renderable) geometry ).render( renderingContext );
+		String filterParameter = ( (Renderable) filter ).render( renderingContext );
+		Dialect dialect = renderingContext.getDialect();
+		if ( !( dialect instanceof SpatialDialect ) ) {
+			throw new IllegalStateException( "Dialect must be spatially enabled dialect" );
+		}
+		if ( dialect instanceof WithCustomJPAFilter ) {
+			return ( (WithCustomJPAFilter) dialect ).filterExpression( geometryParameter, filterParameter );
+		}
+		else {
+			return SpatialFunction.filter.name() + "(" + geometryParameter + ", " + filterParameter + ") = true";
+		}
+	}
+
+	private static <P extends Position> Polygon<P> fromEnvelope(Envelope<P> envelope) {
+		CoordinateReferenceSystem<P> crs = envelope.getCoordinateReferenceSystem();
+
+		P lowerLeft = envelope.lowerLeft();
+		P upperLeft = envelope.upperLeft();
+		P upperRight = envelope.upperRight();
+		P lowerRight = envelope.lowerRight();
+
+		PositionSequence<P> positionSequence = PositionSequenceBuilders.fixedSized(
+				5,
+				crs.getPositionClass()
+		)
+				.add( lowerLeft )
+				.add( upperLeft )
+				.add( upperRight )
+				.add( lowerRight )
+				.add( lowerLeft )
+				.toPositionSequence();
+
+		return new Polygon<>( positionSequence, crs );
+	}
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
@@ -20,9 +20,9 @@ import org.geolatte.geom.Geometry;
  *
  * @author Daniel Shuy
  */
-public final class GeolatteSpatialPredicates {
+public class GeolatteSpatialPredicates {
 
-	private GeolatteSpatialPredicates() {
+	protected GeolatteSpatialPredicates() {
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
@@ -1,0 +1,571 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.spatial.predicate;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+
+import org.hibernate.spatial.SpatialFunction;
+
+import org.geolatte.geom.Envelope;
+import org.geolatte.geom.Geometry;
+
+/**
+ * {@link JTSSpatialPredicates}, but for geolatte-geom.
+ *
+ * @author Daniel Shuy
+ */
+public final class GeolatteSpatialPredicates {
+
+	private GeolatteSpatialPredicates() {
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially equal" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially equal" predicate
+	 *
+	 * @see JTSSpatialPredicates#eq(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate eq(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.equals.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially equal" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially equal" predicate
+	 *
+	 * @see #eq(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate eq(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return eq( criteriaBuilder, geometry1,
+				   criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially within" predicate
+	 *
+	 * @see JTSSpatialPredicates#within(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate within(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.within.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially within" predicate
+	 *
+	 * @see #within(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate within(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return within( criteriaBuilder, geometry1,
+					   criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially contains" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially contains" predicate
+	 *
+	 * @see JTSSpatialPredicates#contains(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate contains(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.contains.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially contains" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially contains" predicate
+	 *
+	 * @see #contains(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate contains(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return contains( criteriaBuilder, geometry1,
+						 criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially crosses" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially crosses" predicate
+	 *
+	 * @see JTSSpatialPredicates#crosses(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate crosses(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.crosses.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially crosses" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially crosses" predicate
+	 *
+	 * @see #crosses(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate crosses(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return crosses( criteriaBuilder, geometry1,
+						criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially disjoint" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially disjoint" predicate
+	 *
+	 * @see JTSSpatialPredicates#disjoint(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate disjoint(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.disjoint.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially disjoint" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially disjoint" predicate
+	 *
+	 * @see #disjoint(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate disjoint(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return disjoint( criteriaBuilder, geometry1,
+						 criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially intersects" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially intersects" predicate
+	 *
+	 * @see JTSSpatialPredicates#intersects(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate intersects(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.intersects.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially intersects" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially intersects" predicate
+	 *
+	 * @see #intersects(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate intersects(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return intersects( criteriaBuilder, geometry1,
+						   criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially overlaps" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially overlaps" predicate
+	 *
+	 * @see JTSSpatialPredicates#overlaps(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate overlaps(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.overlaps.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially overlaps" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially overlaps" predicate
+	 *
+	 * @see #overlaps(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate overlaps(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return overlaps( criteriaBuilder, geometry1,
+						 criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially touches" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 *
+	 * @return "spatially touches" predicate
+	 *
+	 * @see JTSSpatialPredicates#touches(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate touches(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.touches.toString(), boolean.class,
+										  geometry1, geometry2
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "spatially touches" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 *
+	 * @return "spatially touches" predicate
+	 *
+	 * @see #touches(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate touches(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return touches( criteriaBuilder, geometry1,
+						criteriaBuilder.literal( geometry2 )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for bounding box overlap constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression whose bounding box to use in the comparison
+	 *
+	 * @return bounding box overlap predicate
+	 *
+	 * @see GeolatteFilterPredicate
+	 * @see JTSSpatialPredicates#filter(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate filter(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2) {
+		return new GeolatteFilterPredicate( criteriaBuilder, geometry1, geometry2 );
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for bounding box overlap constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value whose bounding box to use in the comparison
+	 *
+	 * @return bounding box overlap predicate
+	 *
+	 * @see GeolatteFilterPredicate
+	 * @see JTSSpatialPredicates#filter(CriteriaBuilder, Expression, org.locationtech.jts.geom.Geometry)
+	 */
+	public static Predicate filter(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2) {
+		return new GeolatteFilterPredicate( criteriaBuilder, geometry1, geometry2 );
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for bounding box overlap constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry geometry expression
+	 * @param envelope envelope or bounding box to use in the comparison
+	 *
+	 * @return bounding box overlap predicate
+	 *
+	 * @see GeolatteFilterPredicate
+	 * @see JTSSpatialPredicates#filterByPolygon(CriteriaBuilder, Expression, org.locationtech.jts.geom.Envelope, int)
+	 */
+	public static Predicate filterByPolygon(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			Envelope envelope) {
+		return new GeolatteFilterPredicate( criteriaBuilder, geometry, envelope );
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "distance within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 * @param distance distance expression
+	 *
+	 * @return "distance within" predicate
+	 *
+	 * @see JTSSpatialPredicates#distanceWithin(CriteriaBuilder, Expression, Expression, Expression)
+	 */
+	public static Predicate distanceWithin(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2, Expression<Double> distance) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.dwithin.toString(), boolean.class,
+										  geometry1, geometry2, distance
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "distance within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 * @param distance distance expression
+	 *
+	 * @return "distance within" predicate
+	 *
+	 * @see #distanceWithin(CriteriaBuilder, Expression, Expression, Expression)
+	 */
+	public static Predicate distanceWithin(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2, Expression<Double> distance) {
+		return distanceWithin( criteriaBuilder, geometry1,
+							   criteriaBuilder.literal( geometry2 ), distance
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "distance within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry value
+	 * @param distance distance value
+	 *
+	 * @return "distance within" predicate
+	 *
+	 * @see #distanceWithin(CriteriaBuilder, Expression, Expression, Expression)
+	 */
+	public static Predicate distanceWithin(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Geometry geometry2, double distance) {
+		return distanceWithin( criteriaBuilder, geometry1,
+							   criteriaBuilder.literal( geometry2 ), criteriaBuilder.literal( distance )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "distance within" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry1 geometry expression
+	 * @param geometry2 geometry expression
+	 * @param distance distance value
+	 *
+	 * @return "distance within" predicate
+	 *
+	 * @see #distanceWithin(CriteriaBuilder, Expression, Expression, Expression)
+	 */
+	public static Predicate distanceWithin(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
+			Expression<? extends Geometry> geometry2, double distance) {
+		return distanceWithin( criteriaBuilder, geometry1, geometry2,
+							   criteriaBuilder.literal( distance )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "having srid" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry geometry expression
+	 * @param srid SRID expression
+	 *
+	 * @return "having srid" predicate
+	 *
+	 * @see JTSSpatialPredicates#havingSRID(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate havingSRID(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			Expression<Integer> srid) {
+		return criteriaBuilder.equal(
+				criteriaBuilder.function( SpatialFunction.srid.toString(), int.class, geometry ),
+				srid
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "having srid" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry geometry expression
+	 * @param srid SRID expression
+	 *
+	 * @return "having srid" predicate
+	 *
+	 * @see #havingSRID(CriteriaBuilder, Expression, Expression)
+	 */
+	public static Predicate havingSRID(
+			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
+			int srid) {
+		return havingSRID( criteriaBuilder, geometry,
+						   criteriaBuilder.literal( srid )
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "is empty" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry geometry expression
+	 *
+	 * @return "is empty" predicate
+	 *
+	 * @see JTSSpatialPredicates#isEmpty(CriteriaBuilder, Expression)
+	 */
+	public static Predicate isEmpty(CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry) {
+		return booleanExpressionToPredicate(
+				criteriaBuilder,
+				criteriaBuilder.function( SpatialFunction.isempty.toString(), boolean.class,
+										  geometry
+				)
+		);
+	}
+
+	/**
+	 * Create a predicate for testing the arguments for "is not empty" constraint.
+	 *
+	 * @param criteriaBuilder CriteriaBuilder
+	 * @param geometry geometry expression
+	 *
+	 * @return "is not empty" predicate
+	 *
+	 * @see JTSSpatialPredicates#isNotEmpty(CriteriaBuilder, Expression)
+	 */
+	public static Predicate isNotEmpty(CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry) {
+		return isEmpty( criteriaBuilder, geometry )
+				.not();
+	}
+
+	private static Predicate booleanExpressionToPredicate(
+			CriteriaBuilder criteriaBuilder,
+			Expression<Boolean> expression) {
+		return criteriaBuilder.equal( expression, true );
+	}
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/GeolatteSpatialPredicates.java
@@ -42,7 +42,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.equals.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -62,7 +62,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return eq( criteriaBuilder, geometry1,
-				   criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -83,7 +83,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.within.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -103,7 +103,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return within( criteriaBuilder, geometry1,
-					   criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -124,7 +124,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.contains.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -144,7 +144,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return contains( criteriaBuilder, geometry1,
-						 criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -165,7 +165,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.crosses.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -185,7 +185,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return crosses( criteriaBuilder, geometry1,
-						criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -206,7 +206,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.disjoint.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -226,7 +226,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return disjoint( criteriaBuilder, geometry1,
-						 criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -247,7 +247,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.intersects.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -267,7 +267,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return intersects( criteriaBuilder, geometry1,
-						   criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -288,7 +288,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.overlaps.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -308,7 +308,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return overlaps( criteriaBuilder, geometry1,
-						 criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -329,7 +329,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.touches.toString(), boolean.class,
-										  geometry1, geometry2
+						geometry1, geometry2
 				)
 		);
 	}
@@ -349,7 +349,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
 		return touches( criteriaBuilder, geometry1,
-						criteriaBuilder.literal( geometry2 )
+				criteriaBuilder.literal( geometry2 )
 		);
 	}
 
@@ -425,7 +425,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.dwithin.toString(), boolean.class,
-										  geometry1, geometry2, distance
+						geometry1, geometry2, distance
 				)
 		);
 	}
@@ -446,7 +446,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2, Expression<Double> distance) {
 		return distanceWithin( criteriaBuilder, geometry1,
-							   criteriaBuilder.literal( geometry2 ), distance
+				criteriaBuilder.literal( geometry2 ), distance
 		);
 	}
 
@@ -466,7 +466,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2, double distance) {
 		return distanceWithin( criteriaBuilder, geometry1,
-							   criteriaBuilder.literal( geometry2 ), criteriaBuilder.literal( distance )
+				criteriaBuilder.literal( geometry2 ), criteriaBuilder.literal( distance )
 		);
 	}
 
@@ -486,7 +486,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Expression<? extends Geometry> geometry2, double distance) {
 		return distanceWithin( criteriaBuilder, geometry1, geometry2,
-							   criteriaBuilder.literal( distance )
+				criteriaBuilder.literal( distance )
 		);
 	}
 
@@ -525,7 +525,7 @@ public final class GeolatteSpatialPredicates {
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
 			int srid) {
 		return havingSRID( criteriaBuilder, geometry,
-						   criteriaBuilder.literal( srid )
+				criteriaBuilder.literal( srid )
 		);
 	}
 
@@ -543,7 +543,7 @@ public final class GeolatteSpatialPredicates {
 		return booleanExpressionToPredicate(
 				criteriaBuilder,
 				criteriaBuilder.function( SpatialFunction.isempty.toString(), boolean.class,
-										  geometry
+						geometry
 				)
 		);
 	}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSFilterPredicate.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSFilterPredicate.java
@@ -29,12 +29,12 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * JPA Criteria API {@link Predicate} equivalent of {@link SpatialFilter}.
  */
-public class FilterPredicate extends AbstractSimplePredicate implements Serializable {
+public class JTSFilterPredicate extends AbstractSimplePredicate implements Serializable {
 
 	private final Expression<? extends Geometry> geometry;
 	private final Expression<? extends Geometry> filter;
 
-	public FilterPredicate(
+	public JTSFilterPredicate(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
 			Expression<? extends Geometry> filter) {
 		super( (CriteriaBuilderImpl) criteriaBuilder );
@@ -42,14 +42,14 @@ public class FilterPredicate extends AbstractSimplePredicate implements Serializ
 		this.filter = filter;
 	}
 
-	public FilterPredicate(
+	public JTSFilterPredicate(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
 			Geometry filter) {
 		this( criteriaBuilder, geometry, criteriaBuilder.literal( filter )
 		);
 	}
 
-	public FilterPredicate(
+	public JTSFilterPredicate(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
 			Envelope envelope, int srid) {
 		this( criteriaBuilder, geometry, EnvelopeAdapter.toPolygon( envelope, srid )

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSSpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSSpatialPredicates.java
@@ -15,7 +15,6 @@ import org.hibernate.spatial.criterion.SpatialRestrictions;
 
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Polygon;
 
 /**
  * A factory for spatial JPA Criteria API {@link Predicate}s.
@@ -23,9 +22,9 @@ import org.locationtech.jts.geom.Polygon;
  * @author Daniel Shuy
  * @see SpatialRestrictions
  */
-public final class SpatialPredicates {
+public final class JTSSpatialPredicates {
 
-	private SpatialPredicates() {
+	private JTSSpatialPredicates() {
 	}
 
 	/**
@@ -365,13 +364,13 @@ public final class SpatialPredicates {
 	 *
 	 * @return bounding box overlap predicate
 	 *
-	 * @see FilterPredicate
+	 * @see JTSFilterPredicate
 	 * @see SpatialRestrictions#filter(String, Geometry)
 	 */
 	public static Predicate filter(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Expression<? extends Geometry> geometry2) {
-		return new FilterPredicate( criteriaBuilder, geometry1, geometry2 );
+		return new JTSFilterPredicate( criteriaBuilder, geometry1, geometry2 );
 	}
 
 	/**
@@ -383,13 +382,13 @@ public final class SpatialPredicates {
 	 *
 	 * @return bounding box overlap predicate
 	 *
-	 * @see FilterPredicate
+	 * @see JTSFilterPredicate
 	 * @see SpatialRestrictions#filter(String, Geometry)
 	 */
 	public static Predicate filter(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry1,
 			Geometry geometry2) {
-		return new FilterPredicate( criteriaBuilder, geometry1, geometry2 );
+		return new JTSFilterPredicate( criteriaBuilder, geometry1, geometry2 );
 	}
 
 	/**
@@ -402,13 +401,13 @@ public final class SpatialPredicates {
 	 *
 	 * @return bounding box overlap predicate
 	 *
-	 * @see FilterPredicate
+	 * @see JTSFilterPredicate
 	 * @see SpatialRestrictions#filter(String, Envelope, int)
 	 */
 	public static Predicate filterByPolygon(
 			CriteriaBuilder criteriaBuilder, Expression<? extends Geometry> geometry,
 			Envelope envelope, int srid) {
-		return new FilterPredicate( criteriaBuilder, geometry, envelope, srid );
+		return new JTSFilterPredicate( criteriaBuilder, geometry, envelope, srid );
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSSpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/JTSSpatialPredicates.java
@@ -22,9 +22,9 @@ import org.locationtech.jts.geom.Geometry;
  * @author Daniel Shuy
  * @see SpatialRestrictions
  */
-public final class JTSSpatialPredicates {
+public class JTSSpatialPredicates {
 
-	private JTSSpatialPredicates() {
+	protected JTSSpatialPredicates() {
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/SpatialPredicates.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/predicate/SpatialPredicates.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.spatial.predicate;
+
+/**
+ * @deprecated Use {@link JTSSpatialPredicates} instead.
+ */
+@Deprecated
+public class SpatialPredicates extends JTSSpatialPredicates {
+
+	protected SpatialPredicates() {
+	}
+}

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/TestGeolatteSpatialPredicates.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/TestGeolatteSpatialPredicates.java
@@ -1,0 +1,284 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.spatial.integration;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.spatial.HSMessageLogger;
+import org.hibernate.spatial.SpatialFunction;
+import org.hibernate.spatial.dialect.hana.HANASpatialDialect;
+import org.hibernate.spatial.integration.geolatte.GeomEntity;
+import org.hibernate.spatial.predicate.GeolatteSpatialPredicates;
+import org.hibernate.spatial.testing.SpatialDialectMatcher;
+import org.hibernate.spatial.testing.SpatialFunctionalTestCase;
+
+import org.hibernate.testing.Skip;
+import org.hibernate.testing.SkipForDialect;
+import org.junit.Test;
+
+import org.jboss.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @see TestJTSSpatialPredicates
+ */
+@Skip(condition = SpatialDialectMatcher.class, message = "No Spatial Dialect")
+@SkipForDialect(value = HANASpatialDialect.class, comment = "The HANA dialect is tested via org.hibernate.spatial.dialect.hana.TestHANASpatialFunctions", jiraKey = "HHH-12426")
+public class TestGeolatteSpatialPredicates extends SpatialFunctionalTestCase {
+
+	private static HSMessageLogger LOG = Logger.getMessageLogger(
+			HSMessageLogger.class,
+			TestGeolatteSpatialPredicates.class.getName()
+	);
+
+	protected HSMessageLogger getLogger() {
+		return LOG;
+	}
+
+	@Test
+	public void within() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.within ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getWithin( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.within(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void filter() throws SQLException {
+		if ( !dialectSupportsFiltering() ) {
+			LOG.info( "Filtering is not supported by Dialect" );
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getFilter( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.filter(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void contains() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.contains ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getContains( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.contains(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void crosses() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.crosses ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getCrosses( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.crosses(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void touches() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.touches ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getTouches( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.touches(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void disjoint() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.disjoint ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getDisjoint( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.disjoint(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void eq() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.equals ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getEquals( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.eq(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void intersects() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.intersects ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getIntersects( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.intersects(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void overlaps() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.overlaps ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getOverlaps( expectationsFactory.getTestPolygon() );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.overlaps(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPolygon() )
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void dwithin() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.dwithin ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getDwithin( expectationsFactory.getTestPoint(), 30.0 );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.distanceWithin(
+						criteriaBuilder,
+						root.get( "geom" ),
+						org.geolatte.geom.jts.JTS.from( expectationsFactory.getTestPoint() ),
+						30.0
+				);
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void isEmpty() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.isempty ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getIsEmpty();
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.isEmpty( criteriaBuilder, root.get( "geom" ) );
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void isNotEmpty() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.isempty ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.getIsNotEmpty();
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.isNotEmpty( criteriaBuilder, root.get( "geom" ) );
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	@Test
+	public void havingSRID() throws SQLException {
+		if ( !isSupportedByDialect( SpatialFunction.srid ) ) {
+			return;
+		}
+		Map<Integer, Boolean> dbexpected = expectationsFactory.havingSRID( 4326 );
+		BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 4326 );
+		retrieveAndCompare( dbexpected, predicateFactory );
+		dbexpected = expectationsFactory.havingSRID( 31370 );
+		predicateFactory = (criteriaBuilder, root) ->
+				GeolatteSpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 31370 );
+		retrieveAndCompare( dbexpected, predicateFactory );
+	}
+
+	private void retrieveAndCompare(
+			Map<Integer, Boolean> dbexpected,
+			BiFunction<CriteriaBuilder, Root<GeomEntity>, Predicate> predicateFactory) {
+		try (Session session = openSession()) {
+			Transaction tx = null;
+			try {
+				tx = session.beginTransaction();
+				CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+				CriteriaQuery<GeomEntity> criteriaQuery = criteriaBuilder.createQuery( GeomEntity.class );
+				Root<GeomEntity> root = criteriaQuery.from( GeomEntity.class );
+				criteriaQuery.select( root )
+						.where( predicateFactory.apply( criteriaBuilder, root ) );
+				List<GeomEntity> list = session.createQuery( criteriaQuery )
+						.getResultList();
+				compare( dbexpected, list );
+			}
+			finally {
+				if ( tx != null ) {
+					tx.rollback();
+				}
+			}
+		}
+	}
+
+	private void compare(Map<Integer, Boolean> dbexpected, List<GeomEntity> list) {
+		int cnt = dbexpected.entrySet()
+				.stream()
+				.filter( Map.Entry::getValue )
+				.reduce( 0, (accumulator, entry) -> {
+					if ( !findInList( entry.getKey(), list ) ) {
+						fail( String.format( "Expected object with id= %d, but not found in result", entry.getKey() ) );
+					}
+					return accumulator + 1;
+				}, Integer::sum );
+		assertEquals( cnt, list.size() );
+		LOG.infof( "Found %d objects within testsuite-suite polygon.", cnt );
+	}
+
+	private boolean findInList(Integer id, List<GeomEntity> list) {
+		return list.stream()
+				.anyMatch( entity -> entity.getId().equals( id ) );
+	}
+}

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/TestJTSSpatialPredicates.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/TestJTSSpatialPredicates.java
@@ -21,7 +21,7 @@ import org.hibernate.spatial.HSMessageLogger;
 import org.hibernate.spatial.SpatialFunction;
 import org.hibernate.spatial.dialect.hana.HANASpatialDialect;
 import org.hibernate.spatial.integration.jts.JtsGeomEntity;
-import org.hibernate.spatial.predicate.SpatialPredicates;
+import org.hibernate.spatial.predicate.JTSSpatialPredicates;
 import org.hibernate.spatial.testing.SpatialDialectMatcher;
 import org.hibernate.spatial.testing.SpatialFunctionalTestCase;
 
@@ -39,11 +39,11 @@ import static org.junit.Assert.fail;
  */
 @Skip(condition = SpatialDialectMatcher.class, message = "No Spatial Dialect")
 @SkipForDialect(value = HANASpatialDialect.class, comment = "The HANA dialect is tested via org.hibernate.spatial.dialect.hana.TestHANASpatialFunctions", jiraKey = "HHH-12426")
-public class TestSpatialPredicates extends SpatialFunctionalTestCase {
+public class TestJTSSpatialPredicates extends SpatialFunctionalTestCase {
 
 	private static HSMessageLogger LOG = Logger.getMessageLogger(
 			HSMessageLogger.class,
-			TestSpatialPredicates.class.getName()
+			TestJTSSpatialPredicates.class.getName()
 	);
 
 	protected HSMessageLogger getLogger() {
@@ -57,7 +57,11 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getWithin( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.within( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
+				JTSSpatialPredicates.within(
+						criteriaBuilder,
+						root.get( "geom" ),
+						expectationsFactory.getTestPolygon()
+				);
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -69,7 +73,11 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getFilter( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.filter( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
+				JTSSpatialPredicates.filter(
+						criteriaBuilder,
+						root.get( "geom" ),
+						expectationsFactory.getTestPolygon()
+				);
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -80,7 +88,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getContains( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.contains(
+				JTSSpatialPredicates.contains(
 						criteriaBuilder,
 						root.get( "geom" ),
 						expectationsFactory.getTestPolygon()
@@ -95,7 +103,11 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getCrosses( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.crosses( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
+				JTSSpatialPredicates.crosses(
+						criteriaBuilder,
+						root.get( "geom" ),
+						expectationsFactory.getTestPolygon()
+				);
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -106,7 +118,11 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getTouches( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.touches( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
+				JTSSpatialPredicates.touches(
+						criteriaBuilder,
+						root.get( "geom" ),
+						expectationsFactory.getTestPolygon()
+				);
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -117,7 +133,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getDisjoint( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.disjoint(
+				JTSSpatialPredicates.disjoint(
 						criteriaBuilder,
 						root.get( "geom" ),
 						expectationsFactory.getTestPolygon()
@@ -132,7 +148,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getEquals( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.eq( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
+				JTSSpatialPredicates.eq( criteriaBuilder, root.get( "geom" ), expectationsFactory.getTestPolygon() );
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -143,7 +159,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getIntersects( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.intersects(
+				JTSSpatialPredicates.intersects(
 						criteriaBuilder,
 						root.get( "geom" ),
 						expectationsFactory.getTestPolygon()
@@ -158,7 +174,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getOverlaps( expectationsFactory.getTestPolygon() );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.overlaps(
+				JTSSpatialPredicates.overlaps(
 						criteriaBuilder,
 						root.get( "geom" ),
 						expectationsFactory.getTestPolygon()
@@ -173,7 +189,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getDwithin( expectationsFactory.getTestPoint(), 30.0 );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.distanceWithin(
+				JTSSpatialPredicates.distanceWithin(
 						criteriaBuilder,
 						root.get( "geom" ),
 						expectationsFactory.getTestPoint(),
@@ -189,7 +205,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getIsEmpty();
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.isEmpty( criteriaBuilder, root.get( "geom" ) );
+				JTSSpatialPredicates.isEmpty( criteriaBuilder, root.get( "geom" ) );
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -200,7 +216,7 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.getIsNotEmpty();
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.isNotEmpty( criteriaBuilder, root.get( "geom" ) );
+				JTSSpatialPredicates.isNotEmpty( criteriaBuilder, root.get( "geom" ) );
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 
@@ -211,11 +227,11 @@ public class TestSpatialPredicates extends SpatialFunctionalTestCase {
 		}
 		Map<Integer, Boolean> dbexpected = expectationsFactory.havingSRID( 4326 );
 		BiFunction<CriteriaBuilder, Root<JtsGeomEntity>, Predicate> predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 4326 );
+				JTSSpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 4326 );
 		retrieveAndCompare( dbexpected, predicateFactory );
 		dbexpected = expectationsFactory.havingSRID( 31370 );
 		predicateFactory = (criteriaBuilder, root) ->
-				SpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 31370 );
+				JTSSpatialPredicates.havingSRID( criteriaBuilder, root.get( "geom" ), 31370 );
 		retrieveAndCompare( dbexpected, predicateFactory );
 	}
 

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/dialects/postgis/PostgisTestSupport.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/dialects/postgis/PostgisTestSupport.java
@@ -9,7 +9,7 @@ package org.hibernate.spatial.testing.dialects.postgis;
 
 
 import org.hibernate.spatial.integration.TestSpatialFunctions;
-import org.hibernate.spatial.integration.TestSpatialPredicates;
+import org.hibernate.spatial.integration.TestJTSSpatialPredicates;
 import org.hibernate.spatial.integration.TestSpatialRestrictions;
 import org.hibernate.spatial.testing.AbstractExpectationsFactory;
 import org.hibernate.spatial.testing.DataSourceUtils;
@@ -30,7 +30,7 @@ public class PostgisTestSupport extends TestSupport {
 		Class<? extends BaseCoreFunctionalTestCase> testcaseClass = testcase.getClass();
 		if ( testcaseClass == TestSpatialFunctions.class ||
 				testcaseClass == TestSpatialRestrictions.class ||
-				testcaseClass == TestSpatialPredicates.class ) {
+				testcaseClass == TestJTSSpatialPredicates.class ) {
 			return TestData.fromFile( "postgis-functions-test.xml" );
 		}
 		return TestData.fromFile( "test-data-set.xml" );

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/dialects/postgis/PostgisTestSupport.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/dialects/postgis/PostgisTestSupport.java
@@ -8,6 +8,7 @@
 package org.hibernate.spatial.testing.dialects.postgis;
 
 
+import org.hibernate.spatial.integration.TestGeolatteSpatialPredicates;
 import org.hibernate.spatial.integration.TestSpatialFunctions;
 import org.hibernate.spatial.integration.TestJTSSpatialPredicates;
 import org.hibernate.spatial.integration.TestSpatialRestrictions;
@@ -30,7 +31,8 @@ public class PostgisTestSupport extends TestSupport {
 		Class<? extends BaseCoreFunctionalTestCase> testcaseClass = testcase.getClass();
 		if ( testcaseClass == TestSpatialFunctions.class ||
 				testcaseClass == TestSpatialRestrictions.class ||
-				testcaseClass == TestJTSSpatialPredicates.class ) {
+				testcaseClass == TestJTSSpatialPredicates.class ||
+				testcaseClass == TestGeolatteSpatialPredicates.class ) {
 			return TestData.fromFile( "postgis-functions-test.xml" );
 		}
 		return TestData.fromFile( "test-data-set.xml" );


### PR DESCRIPTION
This enhances `SpatialPredicates` (added in version `5.4.13`, see #3159 for the original PR) to support `geolatte-geom` (in addition to `JTS`).

To clearly distinguish the classes, I've renamed `SpatialPredicates` to `JTSSpatialPredicates`, and added a new class `GeolatteSpatialPredicates` for `geolatte-geom`. ~~This unfortunately, is a minor breaking change~~.

Please review by commit, else the file renaming will mess with the Diffs.