### PR TITLE
wip/6.0 Get rid of check warnings of the builders in SessionFactoryImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -18,7 +18,7 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * @author Steve Ebersole
  */
 @SuppressWarnings("UnusedReturnValue")
-public interface SessionBuilder<T extends SessionBuilder> {
+public interface SessionBuilder<T extends SessionBuilder<T>> {
 	/**
 	 * Opens a session with the specified options.
 	 *
@@ -145,10 +145,8 @@ public interface SessionBuilder<T extends SessionBuilder> {
 	 * @return {@code this}, for method chaining
 	 */
 	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
+		return self();
 	}
-
-
 
 	/**
 	 * Should the session be automatically closed after transaction completion?
@@ -187,7 +185,6 @@ public interface SessionBuilder<T extends SessionBuilder> {
 	 * @deprecated (since 5.2) use {@link #flushMode(FlushMode)} instead.
 	 */
 	@Deprecated
-	@SuppressWarnings("unchecked")
 	default T flushBeforeCompletion(boolean flushBeforeCompletion) {
 		if ( flushBeforeCompletion ) {
 			flushMode( FlushMode.ALWAYS );
@@ -195,6 +192,8 @@ public interface SessionBuilder<T extends SessionBuilder> {
 		else {
 			flushMode( FlushMode.MANUAL );
 		}
-		return (T) this;
+		return self();
 	}
+
+	T self();
 }

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -13,7 +13,7 @@ import java.sql.Connection;
  *
  * @author Steve Ebersole
  */
-public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
+public interface StatelessSessionBuilder<T extends StatelessSessionBuilder<T>> {
 	/**
 	 * Opens a session with the specified options.
 	 *
@@ -50,6 +50,8 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 * @return {@code this}, for method chaining
 	 */
 	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
+		return self();
 	}
+
+	T self();
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionBuilderImplementor.java
@@ -16,7 +16,7 @@ import org.hibernate.SessionBuilder;
  *
  * @author Gail Badner
  */
-public interface SessionBuilderImplementor<T extends SessionBuilder> extends SessionBuilder<T> {
+public interface SessionBuilderImplementor<T extends SessionBuilderImplementor<T>> extends SessionBuilder<T> {
 	/**
 	 * Adds the session owner to the session options
 	 *
@@ -29,4 +29,5 @@ public interface SessionBuilderImplementor<T extends SessionBuilder> extends Ses
 	 */
 	@Deprecated
 	T owner(SessionOwner sessionOwner);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1079,7 +1079,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		return null;
 	}
 
-	public static class SessionBuilderImpl<T extends SessionBuilder> implements SessionBuilderImplementor<T>, SessionCreationOptions {
+	public static class SessionBuilderImpl implements SessionBuilderImplementor<SessionBuilderImpl>, SessionCreationOptions {
 		private static final Logger log = CoreLogging.logger( SessionBuilderImpl.class );
 
 		private final SessionFactoryImpl sessionFactory;
@@ -1223,42 +1223,36 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T owner(SessionOwner sessionOwner) {
+		public SessionBuilderImpl owner(SessionOwner sessionOwner) {
 			throw new UnsupportedOperationException( "SessionOwner was long deprecated and this method should no longer be invoked" );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T interceptor(Interceptor interceptor) {
+		public SessionBuilderImpl interceptor(Interceptor interceptor) {
 			this.interceptor = interceptor;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T noInterceptor() {
+		public SessionBuilderImpl noInterceptor() {
 			this.interceptor = EmptyInterceptor.INSTANCE;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T statementInspector(StatementInspector statementInspector) {
+		public SessionBuilderImpl statementInspector(StatementInspector statementInspector) {
 			this.statementInspector = statementInspector;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T connection(Connection connection) {
+		public SessionBuilderImpl connection(Connection connection) {
 			this.connection = connection;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T connectionReleaseMode(ConnectionReleaseMode connectionReleaseMode) {
+		public SessionBuilderImpl connectionReleaseMode(ConnectionReleaseMode connectionReleaseMode) {
 			// NOTE : Legacy behavior (when only ConnectionReleaseMode was exposed) was to always acquire a
 			// Connection using ConnectionAcquisitionMode.AS_NEEDED..
 
@@ -1267,66 +1261,58 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 					connectionReleaseMode
 			);
 			connectionHandlingMode( handlingMode );
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T connectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
+		public SessionBuilderImpl connectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
 			this.connectionHandlingMode = connectionHandlingMode;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T autoJoinTransactions(boolean autoJoinTransactions) {
+		public SessionBuilderImpl autoJoinTransactions(boolean autoJoinTransactions) {
 			this.autoJoinTransactions = autoJoinTransactions;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T autoClose(boolean autoClose) {
+		public SessionBuilderImpl autoClose(boolean autoClose) {
 			this.autoClose = autoClose;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T autoClear(boolean autoClear) {
+		public SessionBuilderImpl autoClear(boolean autoClear) {
 			this.autoClear = autoClear;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T flushMode(FlushMode flushMode) {
+		public SessionBuilderImpl flushMode(FlushMode flushMode) {
 			this.flushMode = flushMode;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T tenantIdentifier(String tenantIdentifier) {
+		public SessionBuilderImpl tenantIdentifier(String tenantIdentifier) {
 			this.tenantIdentifier = tenantIdentifier;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T eventListeners(SessionEventListener... listeners) {
+		public SessionBuilderImpl eventListeners(SessionEventListener... listeners) {
 			if ( this.listeners == null ) {
 				this.listeners = sessionFactory.getSessionFactoryOptions()
 						.getBaselineSessionEventsListenerBuilder()
 						.buildBaselineList();
 			}
 			Collections.addAll( this.listeners, listeners );
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T clearEventListeners() {
+		public SessionBuilderImpl clearEventListeners() {
 			if ( listeners == null ) {
 				//Needs to initialize explicitly to an empty list as otherwise "null" immplies the default listeners will be applied
 				this.listeners = new ArrayList<>( 3 );
@@ -1334,23 +1320,28 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			else {
 				listeners.clear();
 			}
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		public T jdbcTimeZone(TimeZone timeZone) {
+		public SessionBuilderImpl jdbcTimeZone(TimeZone timeZone) {
 			jdbcTimeZone = timeZone;
-			return (T) this;
+			return this;
 		}
 
 		@Override
-		public T setQueryParameterValidation(boolean enabled) {
+		public SessionBuilderImpl setQueryParameterValidation(boolean enabled) {
 			queryParametersValidationEnabled = enabled;
-			return (T) this;
+			return this;
+		}
+
+		@Override
+		public SessionBuilderImpl self() {
+			return this;
 		}
 	}
 
-	public static class StatelessSessionBuilderImpl implements StatelessSessionBuilder, SessionCreationOptions {
+	public static class StatelessSessionBuilderImpl implements StatelessSessionBuilder<StatelessSessionBuilderImpl>, SessionCreationOptions {
 		private final SessionFactoryImpl sessionFactory;
 		private Connection connection;
 		private String tenantIdentifier;
@@ -1372,13 +1363,13 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public StatelessSessionBuilder connection(Connection connection) {
+		public StatelessSessionBuilderImpl connection(Connection connection) {
 			this.connection = connection;
 			return this;
 		}
 
 		@Override
-		public StatelessSessionBuilder tenantIdentifier(String tenantIdentifier) {
+		public StatelessSessionBuilderImpl tenantIdentifier(String tenantIdentifier) {
 			this.tenantIdentifier = tenantIdentifier;
 			return this;
 		}
@@ -1411,7 +1402,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		@Override
 		public Interceptor getInterceptor() {
 			return configuredInterceptor( EmptyInterceptor.INSTANCE, sessionFactory.getSessionFactoryOptions() );
-
 		}
 
 		@Override
@@ -1465,8 +1455,13 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public StatelessSessionBuilder setQueryParameterValidation(boolean enabled) {
+		public StatelessSessionBuilderImpl setQueryParameterValidation(boolean enabled) {
 			queryParametersValidationEnabled = enabled;
+			return self();
+		}
+
+		@Override
+		public StatelessSessionBuilderImpl self() {
 			return this;
 		}
 	}


### PR DESCRIPTION
Utilized builder hierarchy trick borrowed from `Effective Java` Item 2.