### PR TITLE
wip/6.0 add 'reverse' property to @RequiresDialectFeature annotation

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit5/DialectFilterExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit5/DialectFilterExtension.java
@@ -63,7 +63,7 @@ public class DialectFilterExtension implements ExecutionCondition {
 		if ( !effectiveRequiresDialects.isEmpty() ) {
 			StringBuilder requiredDialects = new StringBuilder(  );
 			for ( RequiresDialect requiresDialect : effectiveRequiresDialects ) {
-				requiredDialects.append(requiresDialect.value()  );
+				requiredDialects.append( requiresDialect.value()  );
 				requiredDialects.append( " " );
 				if ( requiresDialect.matchSubTypes() ) {
 					if ( requiresDialect.value().isInstance( dialect ) ) {
@@ -116,12 +116,15 @@ public class DialectFilterExtension implements ExecutionCondition {
 			try {
 				final DialectFeatureCheck dialectFeatureCheck = effectiveRequiresDialectFeature.feature()
 						.newInstance();
-				if ( !dialectFeatureCheck.apply( getDialect( context ) ) ) {
+				final boolean applicable = dialectFeatureCheck.apply( getDialect( context ) );
+				final boolean reverse = effectiveRequiresDialectFeature.reverse();
+				if ( applicable ^ reverse ) {
 					return ConditionEvaluationResult.disabled(
 							String.format(
 									Locale.ROOT,
-									"Failed @RequiresDialectFeature [%s]",
-									effectiveRequiresDialectFeature.feature()
+									"Failed @RequiresDialectFeature [feature: %s, reverse: %s]",
+									effectiveRequiresDialectFeature.feature(),
+									effectiveRequiresDialectFeature.reverse()
 							) );
 				}
 			}
@@ -130,7 +133,7 @@ public class DialectFilterExtension implements ExecutionCondition {
 			}
 		}
 
-		return ConditionEvaluationResult.enabled( "Passed all @SkipForDialects" );
+		return ConditionEvaluationResult.enabled( "Passed all @RequiresDialect(s), @SkipForDialect(s) and @RequiresDialectFeature(group)" );
 	}
 
 	private Dialect getDialect(ExtensionContext context) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -142,12 +142,6 @@ abstract public class DialectFeatureChecks {
 		}
 	}
 
-	public static class DoesRepeatableReadNotCauseReadersToBlockWritersCheck implements DialectFeatureCheck {
-		public boolean apply(Dialect dialect) {
-			return ! dialect.doesRepeatableReadCauseReadersToBlockWriters();
-		}
-	}
-
 	public static class SupportsExistsInSelectCheck implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			return dialect.supportsExistsInSelect();
@@ -182,12 +176,6 @@ abstract public class DialectFeatureChecks {
 	public static class SupportCatalogCreation implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			return dialect.canCreateCatalog();
-		}
-	}
-
-	public static class DoesNotSupportRowValueConstructorSyntax implements DialectFeatureCheck {
-		public boolean apply(Dialect dialect) {
-			return dialect.supportsRowValueConstructorSyntax() == false;
 		}
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeature.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeature.java
@@ -34,6 +34,11 @@ public @interface RequiresDialectFeature {
 	Class<? extends DialectFeatureCheck> feature();
 
 	/**
+	 * @return Whether the decision of {@link #feature()} is reversed
+	 */
+	boolean reverse() default false;
+
+	/**
 	 * Comment describing the reason why the feature is required.
 	 *
 	 * @return The comment


### PR DESCRIPTION
We all encounter such common scenario. There has been a `DialectFeatureCheck` implementation names `Supportsxxxx` in `DialectFeatureChecks` class. Then we need to cover the dialects which fail to be validated by it. Previously we have to create another one (`DoesNotSupportsxxxx`) manually which is tedious and not elegant.

This PR aims to streamline such common scenario by simply specifying a new `reverse` property of `@RequiresDialectFeature` to true.