### PR TITLE
wip/6.0 Replace 'AtomicInteger' with 'MutableInteger' in single thread scenario

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/DelayedPostInsertIdentifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/DelayedPostInsertIdentifier.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author Sanne Grinovero
  */
 public class DelayedPostInsertIdentifier implements Serializable, Comparable<DelayedPostInsertIdentifier> {
-	private static final AtomicLong SEQUENCE = new AtomicLong( 0 );
+	private static final AtomicLong SEQUENCE = new AtomicLong();
 
 	private final long identifier;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AbstractAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AbstractAuxiliaryDatabaseObject.java
@@ -24,7 +24,7 @@ import org.hibernate.dialect.Dialect;
 public abstract class AbstractAuxiliaryDatabaseObject
 		implements AuxiliaryDatabaseObject, AuxiliaryDatabaseObject.Expandable {
 	private static final String EXPORT_IDENTIFIER_PREFIX = "auxiliary-object-";
-	private static final AtomicInteger counter = new AtomicInteger( 0 );
+	private static final AtomicInteger counter = new AtomicInteger();
 
 	private final String exportIdentifier;
 	private final boolean beforeTables;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -6,16 +6,15 @@
  */
 package org.hibernate.cfg;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
@@ -78,7 +77,7 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 			columnByReferencedName.put( referencedColumnName.toLowerCase(Locale.ROOT), joinColumn );
 		}
 		//try default column orientation
-		AtomicInteger index = new AtomicInteger( 0 );
+		MutableInteger index = new MutableInteger();
 		if ( columnByReferencedName.isEmpty() ) {
 			isExplicitReference = false;
 			for ( Ejb3JoinColumn joinColumn : joinColumns ) {
@@ -105,7 +104,7 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 			PersistentClass referencedPersistentClass,
 			boolean isExplicitReference,
 			Map<String, Ejb3JoinColumn> columnByReferencedName,
-			AtomicInteger index,
+			MutableInteger index,
 			Property referencedProperty ) {
 		Property property = new Property();
 		property.setName( referencedProperty.getName() );
@@ -144,7 +143,7 @@ public class CopyIdentifierComponentSecondPass implements SecondPass {
 			PersistentClass referencedPersistentClass,
 			boolean isExplicitReference,
 			Map<String, Ejb3JoinColumn> columnByReferencedName,
-			AtomicInteger index,
+			MutableInteger index,
 			Property referencedProperty ) {
 		Property property = new Property();
 		property.setName( referencedProperty.getName() );

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventType.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventType.java
@@ -26,7 +26,7 @@ public final class EventType<T> {
 	/**
 	 * Used to assign ordinals for the standard event-types
 	 */
-	private static AtomicInteger STANDARD_TYPE_COUNTER = new AtomicInteger( 0 );
+	private static AtomicInteger STANDARD_TYPE_COUNTER = new AtomicInteger();
 
 	public static final EventType<LoadEventListener> LOAD = create( "load", LoadEventListener.class );
 	public static final EventType<ResolveNaturalIdEventListener> RESOLVE_NATURAL_ID = create( "resolve-natural-id", ResolveNaturalIdEventListener.class );

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MutableLong.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MutableLong.java
@@ -6,33 +6,33 @@
  */
 package org.hibernate.internal.util;
 
-public class MutableInteger {
-	private int value;
+public class MutableLong {
+	private long value;
 
-	public MutableInteger() {
+	public MutableLong() {
 	}
 
-	public MutableInteger(int value) {
+	public MutableLong(long value) {
 		this.value = value;
 	}
 
-	public MutableInteger deepCopy() {
-		return new MutableInteger( value );
+	public MutableLong deepCopy() {
+		return new MutableLong( value );
 	}
 
-	public int getAndIncrement() {
+	public long getAndIncrement() {
 		return value++;
 	}
 
-	public int incrementAndGet() {
+	public long incrementAndGet() {
 		return ++value;
 	}
 
-	public int get() {
+	public long get() {
 		return value;
 	}
 
-	public void set(int value) {
+	public void set(long value) {
 		this.value = value;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -24,6 +23,7 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
 import org.hibernate.internal.FilterHelper;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.loader.ast.spi.Loadable;
 import org.hibernate.loader.ast.spi.Loader;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
@@ -711,7 +711,7 @@ public class LoaderSelectBuilder {
 
 		final SqlExpressionResolver sqlExpressionResolver = creationState.getSqlExpressionResolver();
 
-		final AtomicInteger count = new AtomicInteger();
+		final MutableInteger count = new MutableInteger();
 		fkDescriptor.visitTargetColumns(
 				(containingTableExpression, columnExpression, jdbcMapping) -> {
 					// for each column, resolve a SqlSelection and add it to the sub-query select-clause

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/Bindable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/Bindable.java
@@ -8,11 +8,11 @@ package org.hibernate.metamodel.mapping;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -44,7 +44,7 @@ public interface Bindable {
 	 */
 
 	default int getJdbcTypeCount(TypeConfiguration typeConfiguration) {
-		final AtomicInteger value = new AtomicInteger( 0 );
+		final MutableInteger value = new MutableInteger();
 		visitJdbcTypes(
 				sqlExpressableType -> value.incrementAndGet(),
 				Clause.IRRELEVANT,

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -35,6 +34,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.util.MarkerObject;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
@@ -1233,7 +1233,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	public void visitConstraintOrderedTables(ConstraintOrderedTableConsumer consumer) {
-		final AtomicInteger tablePositionWrapper = new AtomicInteger(  );
+		final MutableInteger tablePositionWrapper = new MutableInteger();
 
 		for ( String tableName : constraintOrderedTableNames ) {
 			final int tablePosition = tablePositionWrapper.getAndIncrement();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -8,14 +8,12 @@ package org.hibernate.persister.entity;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -31,6 +29,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.util.MarkerObject;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Formula;
@@ -942,7 +941,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	public void visitConstraintOrderedTables(ConstraintOrderedTableConsumer consumer) {
-		final AtomicInteger tablePositionWrapper = new AtomicInteger(  );
+		final MutableInteger tablePositionWrapper = new MutableInteger();
 
 		for ( String tableName : constraintOrderedTableNames ) {
 			final int tablePosition = tablePositionWrapper.getAndIncrement();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -34,6 +33,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.id.IdentityGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.StaticFilterAliasGenerator;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.internal.util.collections.SingletonIterator;
@@ -371,7 +371,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	public void visitConstraintOrderedTables(ConstraintOrderedTableConsumer consumer) {
-		final AtomicInteger tablePositionWrapper = new AtomicInteger(  );
+		final MutableInteger tablePositionWrapper = new MutableInteger();
 
 		for ( String tableName : constraintOrderedTableNames ) {
 			final int tablePosition = tablePositionWrapper.getAndIncrement();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MatchingIdSelectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MatchingIdSelectionHelper.java
@@ -11,10 +11,10 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
@@ -25,18 +25,18 @@ import org.hibernate.sql.ast.SqlAstSelectTranslator;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.ExecutionContext;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcSelect;
-import org.hibernate.sql.results.internal.SqlSelectionImpl;
-import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.basic.BasicResult;
+import org.hibernate.sql.results.internal.SqlSelectionImpl;
 
 import org.jboss.logging.Logger;
 
@@ -73,7 +73,7 @@ public class MatchingIdSelectionHelper {
 		idSelectionQuery.getFromClause().addRoot( mutatingTableGroup );
 
 		final List<DomainResult> domainResults = new ArrayList<>();
-		final AtomicInteger i = new AtomicInteger();
+		final MutableInteger i = new MutableInteger();
 		targetEntityDescriptor.getIdentifierMapping().visitColumns(
 				(containingTableExpression, columnExpression, jdbcMapping) -> {
 					final int position = i.getAndIncrement();
@@ -130,7 +130,7 @@ public class MatchingIdSelectionHelper {
 		final TableGroup mutatingTableGroup = sqmConverter.getMutatingTableGroup();
 		idSelectionQuery.getFromClause().addRoot( mutatingTableGroup );
 
-		final AtomicInteger i = new AtomicInteger();
+		final MutableInteger i = new MutableInteger();
 		targetEntityDescriptor.getIdentifierMapping().visitColumns(
 				(containingTableExpression, columnExpression, jdbcMapping) -> {
 					final int position = i.getAndIncrement();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/ExecuteWithIdTableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/ExecuteWithIdTableHelper.java
@@ -7,7 +7,6 @@
 package org.hibernate.query.sqm.mutation.internal.idtable;
 
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -16,9 +15,9 @@ import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.transaction.spi.IsolationDelegate;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.query.NavigablePath;
@@ -86,7 +85,7 @@ public final class ExecuteWithIdTableHelper {
 
 		matchingIdSelection.getFromClause().addRoot( mutatingTableGroup );
 
-		final AtomicInteger positionWrapper = new AtomicInteger();
+		final MutableInteger positionWrapper = new MutableInteger();
 
 		mutatingEntityDescriptor.getIdentifierMapping().visitColumns(
 				(containingTableExpression, columnExpression, jdbcMapping) -> {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/RestrictedDeleteExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/RestrictedDeleteExecutionDelegate.java
@@ -12,7 +12,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -21,6 +20,7 @@ import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.metamodel.mapping.ColumnConsumer;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
@@ -40,6 +40,7 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
@@ -48,7 +49,6 @@ import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcDelete;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 
 import org.jboss.logging.Logger;
@@ -178,7 +178,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 			rootEntityPersister = sessionFactory.getDomainModel().findEntityDescriptor( rootEntityName );
 		}
 
-		final AtomicInteger rows = new AtomicInteger();
+		final MutableInteger rows = new MutableInteger();
 
 		final String rootTableName = ( (Joinable) rootEntityPersister ).getTableName();
 		final TableReference rootTableReference = tableGroup.resolveTableReference( rootTableName );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/UnrestrictedDeleteExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/UnrestrictedDeleteExecutionDelegate.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.query.sqm.mutation.internal.idtable;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.MutableInteger;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.query.sqm.mutation.internal.SqmMutationStrategyHelper;
 import org.hibernate.sql.ast.SqlAstDeleteTranslator;
@@ -36,7 +35,7 @@ public class UnrestrictedDeleteExecutionDelegate implements TableBasedDeleteHand
 		// NOTE : we want the number of rows returned from this method to be the number of rows deleted
 		// 		from the root table of the entity hierarchy,  which happens to be the last table we
 		// 		will visit
-		final AtomicInteger result = new AtomicInteger();
+		final MutableInteger result = new MutableInteger();
 
 		SqmMutationStrategyHelper.cleanUpCollectionTables(
 				entityDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.results.graph.embeddable.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.hibernate.engine.FetchTiming;
@@ -65,13 +64,13 @@ public class EmbeddableForeignKeyResultImpl<T> extends AbstractFetchParent
 			List<SqlSelection> sqlSelections,
 			NavigablePath navigablePath,
 			DomainResultCreationState creationState,
-			MutableInteger atomicInteger,
+			MutableInteger mutableInteger,
 			Fetchable fetchable) {
 		if ( fetchable instanceof SingularAssociationAttributeMapping ) {
 			final SingularAssociationAttributeMapping singularAssociationAttributeMapping = (SingularAssociationAttributeMapping) fetchable;
 			EntityMappingType associatedEntityMappingType = singularAssociationAttributeMapping.getAssociatedEntityMappingType();
 			BasicResult domainResult = new BasicResult(
-					sqlSelections.get( atomicInteger.getAndIncrement() ).getValuesArrayPosition(),
+					sqlSelections.get( mutableInteger.getAndIncrement() ).getValuesArrayPosition(),
 					null,
 					associatedEntityMappingType.getIdentifierMapping().getJavaTypeDescriptor()
 			);
@@ -101,7 +100,7 @@ public class EmbeddableForeignKeyResultImpl<T> extends AbstractFetchParent
 		}
 		else {
 			final Fetch fetch = new BasicFetch(
-					sqlSelections.get( atomicInteger.getAndIncrement() ).getValuesArrayPosition(),
+					sqlSelections.get( mutableInteger.getAndIncrement() ).getValuesArrayPosition(),
 					null,
 					navigablePath.append( fetchable.getFetchableName() ),
 					(BasicValuedModelPart) fetchable,


### PR DESCRIPTION
There seems to be an established pattern to use `AtomicInteger` as a convenient class of `mutable integer container`, regardless of whether it is used in single thread scenario (e.g. within method as a temporary variable without being exposed externally) or not. That is a misuse or sloppiness for we have to pay the performance cost of concurrency safety unnecessarily.

Luckily, in some recent PR by Andrea, a more appropriate substitute has been committed: `MutableInteger`.
 
Below is the **jmh** benchmark result between `AtomicInteger` and `MutableInteger` when it comes to increasing by 1:
```
Benchmark                Mode  Cnt   Score     Error    Units
benchmarkAtomicInteger   avgt   5       13.143 ± 6.360  ns/op
benchmarkMutableInteger  avgt   5       0.399 ± 0.045   ns/op
```

It is a simple fact that `MutableInteger` is much much quicker!

This is the simple **jmh** benchmark methods:
```
    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void benchmarkAtomicInteger() {
        AtomicInteger counter = new AtomicInteger();
        int val = counter.incrementAndGet();
    }

    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void benchmarkMutableInteger() {
        MutableInteger counter = new MutableInteger();
        int val = counter.getAndIncrement();
    }
```

Another common performance optimization is we can use `new AtomicInteger()` in lieu of `new AtomicInteger( 0 )`. **Jmh** proves that the performance difference is significant:

```
Benchmark                                 Mode  Cnt   Score    Error  Units
benchmarkAtomicIntegerDefaultConstructor  avgt    5  15.199 ± 13.034  ns/op
benchmarkAtomicIntegerExplicitConstructor avgt    5  35.029 ± 88.696  ns/op
```

```
    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void benchmarkAtomicIntegerDefaultConstructor() {
        AtomicInteger counter = new AtomicInteger();
        int val = counter.incrementAndGet();
    }

    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void benchmarkAtomicIntegerExplicitConstructor() {
        AtomicInteger counter = new AtomicInteger( 0 );
        int val = counter.incrementAndGet();
    }
```
