### PR TITLE
wip/6.0 Get rid of session builder generics warnings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -18,7 +18,7 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * @author Steve Ebersole
  */
 @SuppressWarnings("UnusedReturnValue")
-public interface SessionBuilder<T extends SessionBuilder> {
+public interface SessionBuilder<T extends SessionBuilder<T>> {
 	/**
 	 * Opens a session with the specified options.
 	 *
@@ -145,10 +145,13 @@ public interface SessionBuilder<T extends SessionBuilder> {
 	 * @return {@code this}, for method chaining
 	 */
 	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
+		return getThis();
 	}
 
-
+	@SuppressWarnings("unchecked")
+	default T getThis() {
+		return (T) this;
+	}
 
 	/**
 	 * Should the session be automatically closed after transaction completion?
@@ -187,7 +190,6 @@ public interface SessionBuilder<T extends SessionBuilder> {
 	 * @deprecated (since 5.2) use {@link #flushMode(FlushMode)} instead.
 	 */
 	@Deprecated
-	@SuppressWarnings("unchecked")
 	default T flushBeforeCompletion(boolean flushBeforeCompletion) {
 		if ( flushBeforeCompletion ) {
 			flushMode( FlushMode.ALWAYS );
@@ -195,6 +197,6 @@ public interface SessionBuilder<T extends SessionBuilder> {
 		else {
 			flushMode( FlushMode.MANUAL );
 		}
-		return (T) this;
+		return getThis();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -13,7 +13,7 @@ import java.sql.Connection;
  *
  * @author Steve Ebersole
  */
-public interface SharedSessionBuilder<T extends SharedSessionBuilder> extends SessionBuilder<T> {
+public interface SharedSessionBuilder<T extends SharedSessionBuilder<T>> extends SessionBuilder<T> {
 
 	/**
 	 * Signifies that the transaction context from the original session should be used to create the new session.
@@ -87,10 +87,9 @@ public interface SharedSessionBuilder<T extends SharedSessionBuilder> extends Se
 	 * @deprecated (since 5.2) use {@link #flushMode()} instead.
 	 */
 	@Deprecated
-	@SuppressWarnings("unchecked")
 	default T flushBeforeCompletion() {
 		flushMode();
-		return (T) this;
+		return getThis();
 	}
 
 
@@ -123,6 +122,6 @@ public interface SharedSessionBuilder<T extends SharedSessionBuilder> extends Se
 		else {
 			flushMode( FlushMode.MANUAL );
 		}
-		return (T) this;
+		return getThis();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -13,7 +13,7 @@ import java.sql.Connection;
  *
  * @author Steve Ebersole
  */
-public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
+public interface StatelessSessionBuilder<T extends StatelessSessionBuilder<T>> {
 	/**
 	 * Opens a session with the specified options.
 	 *
@@ -39,6 +39,8 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 */
 	T tenantIdentifier(String tenantIdentifier);
 
+	T getThis();
+
 	/**
 	 * Should {@link org.hibernate.query.Query#setParameter} perform parameter validation
 	 * when the Session is bootstrapped via JPA {@link javax.persistence.EntityManagerFactory}
@@ -50,6 +52,6 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 * @return {@code this}, for method chaining
 	 */
 	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
+		return getThis();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -25,17 +25,12 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * @author Gunnar Morling
  * @author Guillaume Smet
  */
-public abstract class AbstractDelegatingSessionBuilder<T extends SessionBuilder> implements SessionBuilder<T> {
+public abstract class AbstractDelegatingSessionBuilder<T extends AbstractDelegatingSessionBuilder<T>> implements SessionBuilder<T> {
 
 	private final SessionBuilder delegate;
 
 	public AbstractDelegatingSessionBuilder(SessionBuilder delegate) {
 		this.delegate = delegate;
-	}
-
-	@SuppressWarnings("unchecked")
-	protected T getThis() {
-		return (T) this;
 	}
 
 	protected SessionBuilder delegate() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilderImplementor.java
@@ -12,7 +12,7 @@ package org.hibernate.engine.spi;
  *
  * @author Gunnar Morling
  */
-public abstract class AbstractDelegatingSessionBuilderImplementor<T extends SessionBuilderImplementor>
+public abstract class AbstractDelegatingSessionBuilderImplementor<T extends AbstractDelegatingSessionBuilderImplementor<T>>
 		extends AbstractDelegatingSessionBuilder<T>
 		implements SessionBuilderImplementor<T> {
 
@@ -24,10 +24,10 @@ public abstract class AbstractDelegatingSessionBuilderImplementor<T extends Sess
 		return (SessionBuilderImplementor) super.delegate();
 	}
 
-	@SuppressWarnings({ "unchecked", "deprecation" })
+	@SuppressWarnings("deprecation")
 	@Override
 	public T owner(SessionOwner sessionOwner) {
 		delegate().owner( sessionOwner );
-		return (T) this;
+		return getThis();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -26,17 +26,12 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * @author Guillaume Smet
  */
 @SuppressWarnings("unused")
-public abstract class AbstractDelegatingSharedSessionBuilder<T extends SharedSessionBuilder> implements SharedSessionBuilder<T> {
+public abstract class AbstractDelegatingSharedSessionBuilder<T extends AbstractDelegatingSharedSessionBuilder<T>> implements SharedSessionBuilder<T> {
 
 	private final SharedSessionBuilder delegate;
 
 	public AbstractDelegatingSharedSessionBuilder(SharedSessionBuilder delegate) {
 		this.delegate = delegate;
-	}
-
-	@SuppressWarnings("unchecked")
-	protected T getThis() {
-		return (T) this;
 	}
 
 	public SharedSessionBuilder delegate() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionBuilderImplementor.java
@@ -16,7 +16,7 @@ import org.hibernate.SessionBuilder;
  *
  * @author Gail Badner
  */
-public interface SessionBuilderImplementor<T extends SessionBuilder> extends SessionBuilder<T> {
+public interface SessionBuilderImplementor<T extends SessionBuilderImplementor<T>> extends SessionBuilder<T> {
 	/**
 	 * Adds the session owner to the session options
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1088,7 +1088,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		return null;
 	}
 
-	public static class SessionBuilderImpl<T extends SessionBuilder> implements SessionBuilderImplementor<T>, SessionCreationOptions {
+	public static class SessionBuilderImpl<T extends SessionBuilderImpl<T>> implements SessionBuilderImplementor<T>, SessionCreationOptions {
 		private static final Logger log = CoreLogging.logger( SessionBuilderImpl.class );
 
 		private final SessionFactoryImpl sessionFactory;
@@ -1232,41 +1232,35 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T owner(SessionOwner sessionOwner) {
 			throw new UnsupportedOperationException( "SessionOwner was long deprecated and this method should no longer be invoked" );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T interceptor(Interceptor interceptor) {
 			this.interceptor = interceptor;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T noInterceptor() {
 			this.interceptor = EmptyInterceptor.INSTANCE;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T statementInspector(StatementInspector statementInspector) {
 			this.statementInspector = statementInspector;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T connection(Connection connection) {
 			this.connection = connection;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T connectionReleaseMode(ConnectionReleaseMode connectionReleaseMode) {
 			// NOTE : Legacy behavior (when only ConnectionReleaseMode was exposed) was to always acquire a
 			// Connection using ConnectionAcquisitionMode.AS_NEEDED..
@@ -1276,53 +1270,46 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 					connectionReleaseMode
 			);
 			connectionHandlingMode( handlingMode );
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T connectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
 			this.connectionHandlingMode = connectionHandlingMode;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T autoJoinTransactions(boolean autoJoinTransactions) {
 			this.autoJoinTransactions = autoJoinTransactions;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T autoClose(boolean autoClose) {
 			this.autoClose = autoClose;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T autoClear(boolean autoClear) {
 			this.autoClear = autoClear;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T flushMode(FlushMode flushMode) {
 			this.flushMode = flushMode;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T tenantIdentifier(String tenantIdentifier) {
 			this.tenantIdentifier = tenantIdentifier;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T eventListeners(SessionEventListener... listeners) {
 			if ( this.listeners == null ) {
 				this.listeners = sessionFactory.getSessionFactoryOptions()
@@ -1330,11 +1317,10 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 						.buildBaselineList();
 			}
 			Collections.addAll( this.listeners, listeners );
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public T clearEventListeners() {
 			if ( listeners == null ) {
 				//Needs to initialize explicitly to an empty list as otherwise "null" immplies the default listeners will be applied
@@ -1343,23 +1329,23 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			else {
 				listeners.clear();
 			}
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
 		public T jdbcTimeZone(TimeZone timeZone) {
 			jdbcTimeZone = timeZone;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
 		public T setQueryParameterValidation(boolean enabled) {
 			queryParametersValidationEnabled = enabled;
-			return (T) this;
+			return getThis();
 		}
 	}
 
-	public static class StatelessSessionBuilderImpl implements StatelessSessionBuilder, SessionCreationOptions {
+	public static class StatelessSessionBuilderImpl implements StatelessSessionBuilder<StatelessSessionBuilderImpl>, SessionCreationOptions {
 		private final SessionFactoryImpl sessionFactory;
 		private Connection connection;
 		private String tenantIdentifier;
@@ -1381,14 +1367,19 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public StatelessSessionBuilder connection(Connection connection) {
+		public StatelessSessionBuilderImpl connection(Connection connection) {
 			this.connection = connection;
 			return this;
 		}
 
 		@Override
-		public StatelessSessionBuilder tenantIdentifier(String tenantIdentifier) {
+		public StatelessSessionBuilderImpl tenantIdentifier(String tenantIdentifier) {
 			this.tenantIdentifier = tenantIdentifier;
+			return this;
+		}
+
+		@Override
+		public StatelessSessionBuilderImpl getThis() {
 			return this;
 		}
 
@@ -1474,7 +1465,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public StatelessSessionBuilder setQueryParameterValidation(boolean enabled) {
+		public StatelessSessionBuilderImpl setQueryParameterValidation(boolean enabled) {
 			queryParametersValidationEnabled = enabled;
 			return this;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -113,7 +113,6 @@ import org.hibernate.event.spi.SaveOrUpdateEventListener;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.internal.RootGraphImpl;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.QueryHints;
@@ -1910,9 +1909,9 @@ public class SessionImpl
 		}
 	}
 
-	private static class SharedSessionBuilderImpl<T extends SharedSessionBuilder>
-			extends SessionFactoryImpl.SessionBuilderImpl<T>
-			implements SharedSessionBuilder<T>, SharedSessionCreationOptions {
+	private static class SharedSessionBuilderImpl
+			extends SessionFactoryImpl.SessionBuilderImpl<SharedSessionBuilderImpl>
+			implements SharedSessionBuilder<SharedSessionBuilderImpl>, SharedSessionCreationOptions {
 		private final SessionImpl session;
 		private boolean shareTransactionContext;
 
@@ -1927,45 +1926,44 @@ public class SessionImpl
 
 
 		@Override
-		public T tenantIdentifier(String tenantIdentifier) {
+		public SharedSessionBuilderImpl tenantIdentifier(String tenantIdentifier) {
 			// todo : is this always true?  Or just in the case of sharing JDBC resources?
 			throw new SessionException( "Cannot redefine tenant identifier on child session" );
 		}
 
 		@Override
-		public T interceptor() {
+		public SharedSessionBuilderImpl interceptor() {
 			return interceptor( session.getInterceptor() );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public T connection() {
+		public SharedSessionBuilderImpl connection() {
 			this.shareTransactionContext = true;
-			return (T) this;
+			return getThis();
 		}
 
 		@Override
-		public T connectionReleaseMode() {
+		public SharedSessionBuilderImpl connectionReleaseMode() {
 			return connectionReleaseMode( session.getJdbcCoordinator().getLogicalConnection().getConnectionHandlingMode().getReleaseMode() );
 		}
 
 		@Override
-		public T connectionHandlingMode() {
+		public SharedSessionBuilderImpl connectionHandlingMode() {
 			return connectionHandlingMode( session.getJdbcCoordinator().getLogicalConnection().getConnectionHandlingMode() );
 		}
 
 		@Override
-		public T autoJoinTransactions() {
+		public SharedSessionBuilderImpl autoJoinTransactions() {
 			return autoJoinTransactions( session.isAutoCloseSessionEnabled() );
 		}
 
 		@Override
-		public T flushMode() {
+		public SharedSessionBuilderImpl flushMode() {
 			return flushMode( session.getHibernateFlushMode() );
 		}
 
 		@Override
-		public T autoClose() {
+		public SharedSessionBuilderImpl autoClose() {
 			return autoClose( session.autoClose );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSessionBuilder.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSessionBuilder.java
@@ -22,8 +22,4 @@ public class TestDelegatingSessionBuilder extends AbstractDelegatingSessionBuild
 		super( delegate );
 	}
 
-	@Override
-	protected TestDelegatingSessionBuilder getThis() {
-		return this;
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSessionBuilderImplementor.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSessionBuilderImplementor.java
@@ -20,9 +20,4 @@ public class TestDelegatingSessionBuilderImplementor extends AbstractDelegatingS
 	public TestDelegatingSessionBuilderImplementor(SessionBuilderImplementor<TestDelegatingSessionBuilderImplementor> delegate) {
 		super( delegate );
 	}
-
-	@Override
-	protected TestDelegatingSessionBuilderImplementor getThis() {
-		return this;
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/spi/delegation/TestDelegatingSharedSessionBuilder.java
@@ -23,8 +23,4 @@ public class TestDelegatingSharedSessionBuilder extends AbstractDelegatingShared
 		super( delegate );
 	}
 
-	@Override
-	protected TestDelegatingSharedSessionBuilder getThis() {
-		return this;
-	}
 }


### PR DESCRIPTION
We made extensive usage of class hierarchy builder pattern (as explained in Effective Java v3, Item 2, e.g.), but there are many misuses and unnecessary generics warnings which could be eliminated by some standard generics programming tricks, e.g.:

- recursive generics specification
- `getThis()` refactoring instead of returning `this` directly

Some 30 generics warnings are eliminated in this PR and our codebase becomes a little bit more elegant and safer.

Two typical pattern misuse was explained in two self-comments in this PR.