### PR TITLE
wip/6.0 Fix an obvious bug in SqmSelectClause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -109,14 +109,15 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 		final List<SqmSelectableNode<?>> subSelections = new ArrayList<>();
 
 		//TODO: this has gotta be wrong!!
-		if ( this.selections != null || this.selections.size() != 1 ) {
-			this.selections.get( 0 ).getSelectableNode().visitSubSelectableNodes( subSelections::add );
-		}
-		else {
-			for ( SqmSelection<?> selection : this.selections ) {
-				selection.getSelectableNode().visitSubSelectableNodes( subSelections::add );
+		if ( this.selections != null ) {
+			if ( this.selections.size() == 1 ) {
+				this.selections.get( 0 ).getSelectableNode().visitSubSelectableNodes( subSelections::add );
 			}
-
+			else {
+				for ( SqmSelection<?> selection : this.selections ) {
+					selection.getSelectableNode().visitSubSelectableNodes( subSelections::add );
+				}
+			}
 		}
 		return subSelections;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -108,7 +108,6 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 	public List<SqmSelectableNode<?>> getSelectionItems() {
 		final List<SqmSelectableNode<?>> subSelections = new ArrayList<>();
 
-		//TODO: this has gotta be wrong!!
 		if ( this.selections != null ) {
 			if ( this.selections.size() == 1 ) {
 				this.selections.get( 0 ).getSelectableNode().visitSubSelectableNodes( subSelections::add );


### PR DESCRIPTION
Just encountered the obvious bug. Guess the original intention is to go about optimization when the collection is singleton.

Did some jmh experimenting as following:
```
    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void iterateSingletonList() {
        List<String> list = Arrays.asList("xxx");
        for (String val : list) {
        }
    }

    @Benchmark
    @BenchmarkMode(Mode.AverageTime)
    @OutputTimeUnit(TimeUnit.NANOSECONDS)
    public void getByIndexSingletonList() {
        List<String> list = Arrays.asList("xxx");
        list.get( 0 );
    }
```

The jmh result goes as below:
```
Benchmark                   Mode  Cnt   Score   Error  Units
getByIndexSingletonList  avgt    5   5.200 ± 2.040  ns/op
iterateSingletonList    avgt    5  10.598 ± 1.498  ns/op
```

Not sure it is worthwhile, though. Now let us fix the bug first.