### PR TITLE
proposed change to SchemaManagementTool API for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -56,6 +56,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	private static final Logger log = Logger.getLogger( HibernateSchemaManagementTool.class );
 
 	private ServiceRegistry serviceRegistry;
+	private GenerationTarget customTarget;
 
 	@Override
 	public void injectServices(ServiceRegistryImplementor serviceRegistry) {
@@ -107,6 +108,15 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		return JdbcMetadaAccessStrategy.interpretSetting( options );
 	}
 
+	@Override
+	public void setCustomDatabaseGenerationTarget(GenerationTarget generationTarget) {
+		this.customTarget = generationTarget;
+	}
+
+	GenerationTarget getCustomDatabaseGenerationTarget() {
+		return customTarget;
+	}
+
 	GenerationTarget[] buildGenerationTargets(
 			TargetDescriptor targetDescriptor,
 			JdbcContext jdbcContext,
@@ -132,7 +142,10 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		}
 
 		if ( targetDescriptor.getTargetTypes().contains( TargetType.DATABASE ) ) {
-			targets[index] = new GenerationTargetToDatabase( getDdlTransactionIsolator( jdbcContext ), true );
+			targets[index] = customTarget == null
+					? new GenerationTargetToDatabase( getDdlTransactionIsolator( jdbcContext ), true )
+					: customTarget;
+			index++;
 		}
 
 		return targets;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -423,7 +423,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			SourceDescriptor sourceDescriptor) {
 		final JournalingGenerationTarget target = new JournalingGenerationTarget();
 		doDrop( metadata, options, tool.getServiceRegistry().getService( JdbcEnvironment.class ).getDialect(), sourceDescriptor, target );
-		return new DelayedDropActionImpl( target.commands );
+		return new DelayedDropActionImpl( target.commands, tool.getCustomDatabaseGenerationTarget() );
 	}
 
 	/**
@@ -514,9 +514,11 @@ public class SchemaDropperImpl implements SchemaDropper {
 		private static final CoreMessageLogger log = CoreLogging.messageLogger( DelayedDropActionImpl.class );
 
 		private final ArrayList<String> commands;
+		private GenerationTarget target;
 
-		public DelayedDropActionImpl(ArrayList<String> commands) {
+		public DelayedDropActionImpl(ArrayList<String> commands, GenerationTarget target) {
 			this.commands = commands;
+			this.target = target;
 		}
 
 		@Override
@@ -524,10 +526,14 @@ public class SchemaDropperImpl implements SchemaDropper {
 			log.startingDelayedSchemaDrop();
 
 			final JdbcContext jdbcContext = new JdbcContextDelayedDropImpl( serviceRegistry );
-			final GenerationTargetToDatabase target = new GenerationTargetToDatabase(
-					serviceRegistry.getService( TransactionCoordinatorBuilder.class ).buildDdlTransactionIsolator( jdbcContext ),
-					true
-			);
+
+			if ( target == null ) {
+				target = new GenerationTargetToDatabase(
+						serviceRegistry.getService( TransactionCoordinatorBuilder.class )
+								.buildDdlTransactionIsolator( jdbcContext ),
+						true
+				);
+			}
 
 			target.prepare();
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.hibernate.Incubating;
 import org.hibernate.service.Service;
+import org.hibernate.tool.schema.internal.exec.GenerationTarget;
 
 /**
  * Contract for schema management tool integration.
@@ -22,4 +23,5 @@ public interface SchemaManagementTool extends Service {
 	SchemaDropper getSchemaDropper(Map options);
 	SchemaMigrator getSchemaMigrator(Map options);
 	SchemaValidator getSchemaValidator(Map options);
+	void setCustomDatabaseGenerationTarget(GenerationTarget generationTarget);
 }


### PR DESCRIPTION
we've decided that HR should not use JDBC for schema exportHibernate Reactive needs a way to plug its own Vert.x-based database driver into the schema export tool.

Here's my not-very-deeply-thought-out proposal.

Hoping for feedback from @sebersole and @Sanne.