### PR TITLE
the order of applying sql-processors of RowSelection and QueryHint ar…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -2026,10 +2026,12 @@ public abstract class Loader {
 		final LimitHandler limitHandler = getLimitHandler(
 				queryParameters.getRowSelection()
 		);
-		String sql = limitHandler.processSql( queryParameters.getFilteredSQL(), queryParameters.getRowSelection() );
+		String sql = queryParameters.getFilteredSQL();
 
 		// Adding locks and comments.
 		sql = preprocessSQL( sql, queryParameters, getFactory(), afterLoadActions );
+
+        sql = limitHandler.processSql( sql, queryParameters.getRowSelection() );
 
 		final PreparedStatement st = prepareQueryStatement( sql, queryParameters, limitHandler, scroll, session );
 


### PR DESCRIPTION
In case of row-selection, some dialect (such as Oracle) add a wrapper select around the core statement. If we introduce a query-hint to boost search step, it should be added to inner select not the outer one.

So, I suggest changing the order of these two processors.
