### PR TITLE
HHH-14021 - Add Java Type byte to JDBC Type TINYINT mapping

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/JdbcTypeJavaClassMappings.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/JdbcTypeJavaClassMappings.java
@@ -103,6 +103,7 @@ public class JdbcTypeJavaClassMappings {
 		workMap.put( BigDecimal.class, Types.NUMERIC );
 		workMap.put( BigInteger.class, Types.NUMERIC );
 		workMap.put( Boolean.class, Types.BIT );
+		workMap.put( Byte.class, Types.TINYINT );
 		workMap.put( Short.class, Types.SMALLINT );
 		workMap.put( Integer.class, Types.INTEGER );
 		workMap.put( Long.class, Types.BIGINT );

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/AttributeConverterTest.java
@@ -308,6 +308,52 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-14021")
+	public void testBasicByteUsage() {
+		Configuration cfg = new Configuration();
+		cfg.addAttributeConverter( EnumToByteConverter.class, false );
+		cfg.addAnnotatedClass( Tester4.class );
+		cfg.setProperty( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+		cfg.setProperty( AvailableSettings.GENERATE_STATISTICS, "true" );
+
+		SessionFactory sf = cfg.buildSessionFactory();
+
+		try {
+			Session session = sf.openSession();
+			session.beginTransaction();
+			session.save( new Tester4( 1L, "George", 150, ConvertibleEnum.DEFAULT ) );
+			session.getTransaction().commit();
+			session.close();
+
+			sf.getStatistics().clear();
+			session = sf.openSession();
+			session.beginTransaction();
+			session.get( Tester4.class, 1L );
+			session.getTransaction().commit();
+			session.close();
+			assertEquals( 0, sf.getStatistics().getEntityUpdateCount() );
+
+			session = sf.openSession();
+			session.beginTransaction();
+			Tester4 t4 = (Tester4) session.get( Tester4.class, 1L );
+			t4.convertibleEnum = ConvertibleEnum.VALUE;
+			session.getTransaction().commit();
+			session.close();
+
+			session = sf.openSession();
+			session.beginTransaction();
+			t4 = (Tester4) session.get( Tester4.class, 1L );
+			assertEquals( ConvertibleEnum.VALUE, t4.convertibleEnum );
+			session.delete( t4 );
+			session.getTransaction().commit();
+			session.close();
+		}
+		finally {
+			sf.close();
+		}
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HHH-8866")
 	public void testEnumConverter() {
 		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
@@ -392,8 +438,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			StandardServiceRegistryBuilder.destroy( ssr );
 		}
 	}
-	
-	
+
+
 
 	// Entity declarations used in the test ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -440,6 +486,8 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 		private String name;
 		@Convert( converter = IntegerToVarcharConverter.class )
 		private Integer code;
+		@Convert( converter = EnumToByteConverter.class )
+		private ConvertibleEnum convertibleEnum;
 
 		public Tester4() {
 		}
@@ -448,6 +496,13 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 			this.id = id;
 			this.name = name;
 			this.code = code;
+		}
+
+		public Tester4(Long id, String name, Integer code, ConvertibleEnum convertibleEnum) {
+			this.id = id;
+			this.name = name;
+			this.code = code;
+			this.convertibleEnum = convertibleEnum;
 		}
 	}
 
@@ -607,6 +662,19 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 		@Override
 		public Instant convertToEntityAttribute(Timestamp dbData) {
 			return Instant.fromJavaMillis( dbData.getTime() );
+		}
+	}
+
+	@Converter( autoApply = true )
+	public static class EnumToByteConverter implements AttributeConverter<ConvertibleEnum, Byte> {
+		@Override
+		public Byte convertToDatabaseColumn(ConvertibleEnum attribute) {
+			return attribute == null ? null : (byte) attribute.ordinal();
+		}
+
+		@Override
+		public ConvertibleEnum convertToEntityAttribute(Byte dbData) {
+			return dbData == null ? null : ConvertibleEnum.values()[dbData];
 		}
 	}
 }


### PR DESCRIPTION
According to JDBC API Specification (TABLE B-2), the Java type Byte is mapped to JDBC type TINYINT.