### PR TITLE
HHH-14023: Adjust H2Dialect for 1.4.201: sequence handling, DECIMAL, NUMERIC and VARBINARY

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -118,8 +118,8 @@ public class H2Dialect extends Dialect {
 		registerColumnType( Types.BIT, "boolean" );
 		registerColumnType( Types.CHAR, "char($l)" );
 		registerColumnType( Types.DATE, "date" );
-		registerColumnType( Types.DECIMAL, "decimal($p,$s)" );
-		registerColumnType( Types.NUMERIC, "decimal($p,$s)" );
+		registerColumnType( Types.DECIMAL, buildId >= 201 ? "numeric($p,$s)" : "decimal($p,$s)" );
+		registerColumnType( Types.NUMERIC, buildId >= 201 ? "numeric($p,$s)" : "decimal($p,$s)" );
 		registerColumnType( Types.DOUBLE, "double" );
 		registerColumnType( Types.FLOAT, "float" );
 		registerColumnType( Types.INTEGER, "integer" );
@@ -132,7 +132,7 @@ public class H2Dialect extends Dialect {
 		registerColumnType( Types.TIME, "time" );
 		registerColumnType( Types.TIMESTAMP, "timestamp" );
 		registerColumnType( Types.VARCHAR, "varchar($l)" );
-		registerColumnType( Types.VARBINARY, "binary($l)" );
+		registerColumnType( Types.VARBINARY, buildId >= 201 ? "varbinary($l)" : "binary($l)" );
 		registerColumnType( Types.BLOB, "blob" );
 		registerColumnType( Types.CLOB, "clob" );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -37,6 +37,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorH2DatabaseImpl;
+import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.type.StandardBasicTypes;
@@ -101,7 +102,9 @@ public class H2Dialect extends Dialect {
 		}
 
 		if ( buildId >= 32 ) {
-			this.sequenceInformationExtractor = SequenceInformationExtractorH2DatabaseImpl.INSTANCE;
+			this.sequenceInformationExtractor = buildId >= 201
+					? SequenceInformationExtractorLegacyImpl.INSTANCE
+					: SequenceInformationExtractorH2DatabaseImpl.INSTANCE;
 			this.querySequenceString = "select * from INFORMATION_SCHEMA.SEQUENCES";
 		}
 		else {
@@ -423,12 +426,12 @@ public class H2Dialect extends Dialect {
 		// see http://groups.google.com/group/h2-database/browse_thread/thread/562d8a49e2dabe99?hl=en
 		return true;
 	}
-	
+
 	@Override
 	public boolean supportsTuplesInSubqueries() {
 		return false;
 	}
-	
+
 	// Do not drop constraints explicitly, just do this by cascading instead.
 	@Override
 	public boolean dropConstraints() {


### PR DESCRIPTION
See also:
- https://github.com/h2database/h2database/issues/2625
- https://hibernate.zulipchat.com/#narrow/stream/132096-hibernate-user/topic/Locale.20problem.20when.20building.20hibernate-orm

cc @Sanne

To test this, you will need a current h2 SNAPSHOT (build it yourself from `master`) _with adjusted `org.h2.engine.Constants.BUILD_ID`_ (which is still on 200 until the release of 201).
I was able to get my local SNAPSHOT in to Gradle via:
```diff
diff --git a/gradle/java-module.gradle b/gradle/java-module.gradle
index 1928f00d42..8d2ea3dbbc 100644
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -5,6 +5,11 @@
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */

+repositories {
+       mavenLocal()
+       mavenCentral()
+}
+
 buildscript {
        repositories {
                mavenCentral()
@@ -81,7 +86,7 @@ dependencies {
        testRuntime( libraries.byteBuddy )

        //Databases
-       testRuntime( libraries.h2 )
+       testRuntime( libraries.h2 ) { changing = true }
        testRuntime( libraries.hsqldb )
        testRuntime( libraries.postgresql )
        testRuntime( libraries.mysql )
diff --git a/gradle/libraries.gradle b/gradle/libraries.gradle
index cc53eb9448..8481c51267 100644
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -10,7 +10,7 @@
 ext {

     junitVersion = '4.12'
-    h2Version = '1.4.196'
+    h2Version = '1.4.201-SNAPSHOT'
     bytemanVersion = '4.0.8' //Compatible with JDK14
     jnpVersion = '5.0.6.CR1'

@@ -177,6 +177,9 @@ ext {
 }

 configurations.all {
+    resolutionStrategy {
+      cacheChangingModulesFor 0, 'seconds'
+    }
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         //Force the "byte buddy agent" version to match the Byte Buddy version we use, as Mockito might p
         if (details.requested.group + ":" + details.requested.name == 'net.bytebuddy:byte-buddy-agent') {
```
⚠️ You will see _many_ failures with this but _without_ this PR you would see even more errors.