### PR TITLE
Oracle schema validation fails due to missing sequences

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -490,7 +490,7 @@ public class Oracle8iDialect extends Dialect {
 
 	@Override
 	public String getQuerySequencesString() {
-		return "select * from user_sequences";
+		return "select * from all_sequences";
 	}
 
 	public SequenceInformationExtractor getSequenceInformationExtractor() {


### PR DESCRIPTION
Fetching only user_sequences instead of all_sequences is a breaking change for many applications.

Hibernate-core is updated with spring-boot-dependencies update from 2.2.6 to 2.2.7.

Usually, user creating DB resources (sequences) is admin even if flyway/liquibase is used then user creating the DB resources is different from the DB user running the application.

With Spring config spring.jpa.hibernate.ddl-auto=validate the startup of application fails as it cannot find the user_sequences.