### PR TITLE
HHH-14041 - H2Dialect: fix referential integrity constraint constraint name extraction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -327,6 +327,9 @@ public class H2Dialect extends Dialect {
 				if ( idx > 0 ) {
 					constraintName = message.substring( idx + "violation: ".length() );
 				}
+				if ( sqle.getSQLState().equals("23506") ) {
+					constraintName  = constraintName.substring( 1, constraintName.indexOf(":") );
+				}
 			}
 			return constraintName;
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14041

The problem is that h2 does not directly substitute the constraint name but wraps it in a description: https://github.com/h2database/h2database/blob/9e2e212cf806fa75cd42437a13a33cb3185f5fb1/h2/src/main/org/h2/constraint/ConstraintReferential.java#L312