### PR TITLE
Added Initializer de-duplication handling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionInitializerProducer.java
@@ -34,6 +34,5 @@ public interface CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultInitializeCollectionEventListener.java
@@ -21,6 +21,7 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.pretty.MessageHelper;
+import org.hibernate.sql.results.internal.ResultsHelper;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
@@ -94,7 +95,7 @@ public class DefaultInitializeCollectionEventListener implements InitializeColle
 			CollectionPersister ceLoadedPersister) {
 		if ( !collection.wasInitialized() ) {
 			collection.initializeEmptyCollection( ceLoadedPersister );
-			org.hibernate.sql.results.internal.Helper.finalizeCollectionLoading(
+			ResultsHelper.finalizeCollectionLoading(
 					source.getPersistenceContext(),
 					ceLoadedPersister,
 					collection,

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/LoggingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/LoggingHelper.java
@@ -20,8 +20,8 @@ import org.hibernate.query.NavigablePath;
  * @author Steve Ebersole
  */
 public class LoggingHelper {
-	private static final String NULL = "<null>";
-	private static final String UNREFERENCED = "<unreferenced>";
+	public static final String NULL = "<null>";
+	public static final String UNREFERENCED = "<unreferenced>";
 
 	public static String toLoggableString(NavigableRole role) {
 		if ( role == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.hibernate.LockMode;
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.FetchStrategy;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -44,7 +43,6 @@ import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableValuedFetchable;
 import org.hibernate.sql.results.graph.embeddable.internal.EmbeddableFetchImpl;
 import org.hibernate.sql.results.graph.embeddable.internal.EmbeddableResultImpl;
-import org.hibernate.type.CompositeType;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -402,9 +402,7 @@ public class PluralAttributeMappingImpl extends AbstractAttributeMapping impleme
 									null,
 									SqlAstJoinType.LEFT,
 									lockMode,
-									creationState.getSqlAliasBaseManager(),
-									creationState.getSqlAstCreationState().getSqlExpressionResolver(),
-									creationState.getSqlAstCreationState().getCreationContext()
+									creationState.getSqlAstCreationState()
 							);
 							return tableGroupJoin.getJoinedGroup();
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/NavigablePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NavigablePath.java
@@ -125,7 +125,7 @@ public class NavigablePath implements DotIdentifierSequence {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + "[" + fullPath + "]";
+		return fullPath;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -610,8 +610,7 @@ public abstract class BaseSqmToSqlAstConverter
 					sqmJoin.getExplicitAlias(),
 					sqmJoin.getSqmJoinType().getCorrespondingSqlJoinType(),
 					determineLockMode( sqmJoin.getExplicitAlias() ),
-					sqlAliasBaseManager, getSqlExpressionResolver(),
-					creationContext
+					this
 			);
 			joinedTableGroup = joinedTableGroupJoin.getJoinedGroup();
 
@@ -642,8 +641,7 @@ public abstract class BaseSqmToSqlAstConverter
 					sqmJoin.getExplicitAlias(),
 					sqmJoin.getSqmJoinType().getCorrespondingSqlJoinType(),
 					determineLockMode( sqmJoin.getExplicitAlias() ),
-					sqlAliasBaseManager, getSqlExpressionResolver(),
-					creationContext
+					this
 			);
 
 			joinedTableGroup = joinedTableGroupJoin.getJoinedGroup();
@@ -684,9 +682,7 @@ public abstract class BaseSqmToSqlAstConverter
 						sqmJoin.getExplicitAlias(),
 						sqmJoin.getSqmJoinType().getCorrespondingSqlJoinType(),
 						determineLockMode( sqmJoin.getExplicitAlias() ),
-						sqlAliasBaseManager,
-						getSqlExpressionResolver(),
-						creationContext
+						this
 				);
 
 				joinedTableGroup = joinedTableGroupJoin.getJoinedGroup();
@@ -802,9 +798,7 @@ public abstract class BaseSqmToSqlAstConverter
 							null,
 							tableGroup.isInnerJoinPossible() ? SqlAstJoinType.INNER : SqlAstJoinType.LEFT,
 							null,
-							sqlAliasBaseManager,
-							getSqlExpressionResolver(),
-							creationContext
+							this
 					);
 
 					fromClauseIndex.register( joinedPath, tableGroupJoin.getJoinedGroup() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/StandardSqmSelectTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/StandardSqmSelectTranslator.java
@@ -388,9 +388,7 @@ public class StandardSqmSelectTranslator
 									alias,
 									SqlAstJoinType.LEFT,
 									LockMode.NONE,
-									getSqlAliasBaseManager(),
-									getSqlExpressionResolver(),
-									getCreationContext()
+									this
 							);
 							return tableGroupJoin.getJoinedGroup();
 						}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
@@ -6,67 +6,29 @@
  */
 package org.hibernate.sql.ast;
 
-import java.util.Locale;
+import java.util.List;
+import java.util.Set;
 
-import org.hibernate.NotYetImplementedFor6Exception;
-import org.hibernate.SortOrder;
-import org.hibernate.query.sqm.tree.expression.Conversion;
-import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.SqlAstTreeLogger;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
-import org.hibernate.sql.ast.tree.expression.Any;
-import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
-import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
-import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
-import org.hibernate.sql.ast.tree.expression.CastTarget;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.expression.Distinct;
-import org.hibernate.sql.ast.tree.expression.Duration;
-import org.hibernate.sql.ast.tree.expression.DurationUnit;
-import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
-import org.hibernate.sql.ast.tree.expression.Every;
-import org.hibernate.sql.ast.tree.expression.ExtractUnit;
-import org.hibernate.sql.ast.tree.expression.Format;
-import org.hibernate.sql.ast.tree.expression.JdbcLiteral;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
-import org.hibernate.sql.ast.tree.expression.QueryLiteral;
-import org.hibernate.sql.ast.tree.expression.SelfRenderingExpression;
-import org.hibernate.sql.ast.tree.expression.SqlSelectionExpression;
-import org.hibernate.sql.ast.tree.expression.SqlTuple;
-import org.hibernate.sql.ast.tree.expression.Star;
-import org.hibernate.sql.ast.tree.expression.TrimSpecification;
-import org.hibernate.sql.ast.tree.expression.UnaryOperation;
 import org.hibernate.sql.ast.tree.from.FromClause;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
-import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
-import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
-import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
-import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
-import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
-import org.hibernate.sql.ast.tree.predicate.InListPredicate;
-import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
-import org.hibernate.sql.ast.tree.predicate.Junction;
-import org.hibernate.sql.ast.tree.predicate.LikePredicate;
-import org.hibernate.sql.ast.tree.predicate.NegatedPredicate;
-import org.hibernate.sql.ast.tree.predicate.NullnessPredicate;
-import org.hibernate.sql.ast.tree.predicate.SelfRenderingPredicate;
-import org.hibernate.sql.ast.tree.select.QuerySpec;
-import org.hibernate.sql.ast.tree.select.SelectClause;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
-import org.hibernate.sql.ast.tree.select.SortSpecification;
-import org.hibernate.sql.ast.tree.update.Assignment;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
 
 /**
+ * Logs a debug representation of the SQL AST.
+ *
+ * NOTE : at the moment, we only render the from-elements
+ *
  * @author Steve Ebersole
  */
-public class SqlTreePrinter implements SqlAstWalker {
-	public static void print(Statement sqlAstStatement) {
+public class SqlTreePrinter {
+	public static void logSqlAst(Statement sqlAstStatement) {
 		if ( ! SqlAstTreeLogger.DEBUG_ENABLED ) {
 			return;
 		}
@@ -85,88 +47,37 @@ public class SqlTreePrinter implements SqlAstWalker {
 
 	private void visitStatement(Statement sqlAstStatement) {
 		if ( sqlAstStatement instanceof SelectStatement ) {
+			final SelectStatement selectStatement = (SelectStatement) sqlAstStatement;
 			logNode(
-					"select-statement",
-					() -> visitQuerySpec( ( (SelectStatement) sqlAstStatement ).getQuerySpec() )
+					"SelectStatement",
+					() -> visitFromClause( selectStatement.getQuerySpec().getFromClause() )
 			);
 		}
 		else if ( sqlAstStatement instanceof DeleteStatement ) {
 			final DeleteStatement deleteStatement = (DeleteStatement) sqlAstStatement;
 			logNode(
-					"delete-statement",
-					() -> {
-						logNode(
-								"target",
-								() -> logNode( deleteStatement.getTargetTable().toString() )
-						);
-						logNode(
-								"where",
-								() -> {
-									if ( deleteStatement.getRestriction() != null ) {
-										deleteStatement.getRestriction().accept( this );
-									}
-								}
-						);
-					}
+					"DeleteStatement",
+					() -> logWithIndentation(
+							"target : " + deleteStatement.getTargetTable().getTableExpression()
+					)
 			);
 		}
 		else if ( sqlAstStatement instanceof UpdateStatement ) {
 			final UpdateStatement updateStatement = (UpdateStatement) sqlAstStatement;
 			logNode(
-					"update-statement",
-					() -> {
-						logNode(
-								"target",
-								() -> logNode( updateStatement.getTargetTable().toString() )
-						);
-						logNode(
-								"set",
-								() -> {
-									for ( Assignment assignment : updateStatement.getAssignments() ) {
-										logNode(
-												"assignment",
-												() -> assignment.accept( this ),
-												true
-										);
-									}
-								}
-						);
-						logNode(
-								"where",
-								() -> {
-									if ( updateStatement.getRestriction() != null ) {
-										updateStatement.getRestriction().accept( this );
-									}
-								}
-						);
-					}
+					"UpdateStatement",
+					() -> logWithIndentation(
+							"target : " + updateStatement.getTargetTable().getTableExpression()
+					)
 			);
 		}
 		else if ( sqlAstStatement instanceof InsertStatement) {
 			final InsertStatement insertStatement = (InsertStatement) sqlAstStatement;
 			logNode(
-					"insert-select-statement",
-					() -> {
-						logNode(
-								"target",
-								() -> logNode( insertStatement.getTargetTable().toString() )
-						);
-						logNode(
-								"into",
-								() -> {
-									for ( ColumnReference spec : insertStatement.getTargetColumnReferences() ) {
-										logNode(
-												"target-column",
-												() -> spec.accept( this )
-										);
-									}
-								}
-						);
-						logNode(
-								"select",
-								() -> visitQuerySpec( insertStatement.getSourceSelectStatement() )
-						);
-					}
+					"InsertStatement",
+					() -> logWithIndentation(
+							"target : " + insertStatement.getTargetTable().getTableExpression()
+					)
 			);
 		}
 		else {
@@ -174,16 +85,69 @@ public class SqlTreePrinter implements SqlAstWalker {
 		}
 	}
 
+	private void visitFromClause(FromClause fromClause) {
+		logNode(
+				"FromClause",
+				() -> fromClause.visitRoots( this::visitTableGroup )
+		);
+	}
+
+	private void visitTableGroup(TableGroup tableGroup) {
+		logNode(
+				toDisplayText( tableGroup ),
+				() -> logTableGroupDetails( tableGroup )
+		);
+	}
+
+	private String toDisplayText(TableGroup tableGroup) {
+		return tableGroup.getClass().getSimpleName() + " ("
+					+ tableGroup.getGroupAlias() + " : "
+					+ tableGroup.getNavigablePath()
+					+ ")";
+	}
+
+	private void logTableGroupDetails(TableGroup tableGroup) {
+		logWithIndentation(
+				"primaryTableReference : %s as %s",
+				tableGroup.getPrimaryTableReference().getTableExpression(),
+				tableGroup.getPrimaryTableReference().getIdentificationVariable()
+		);
+
+		final List<TableReferenceJoin> tableReferenceJoins = tableGroup.getTableReferenceJoins();
+		if ( ! tableReferenceJoins.isEmpty() ) {
+			logNode(
+					"TableReferenceJoins",
+					() -> {
+						for ( TableReferenceJoin join : tableReferenceJoins ) {
+							logWithIndentation(
+									"%s join %s as %s",
+									join.getJoinType().getText(),
+									join.getJoinedTableReference().getTableExpression(),
+									join.getJoinedTableReference().getIdentificationVariable()
+							);
+						}
+					}
+			);
+		}
+
+		final Set<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
+		if ( ! tableGroupJoins.isEmpty() ) {
+			logNode(
+					"TableGroupJoins",
+					() -> tableGroup.visitTableGroupJoins( this::visitTableGroupJoin )
+			);
+		}
+	}
+
+	private void visitTableGroupJoin(TableGroupJoin tableGroupJoin) {
+		logNode(
+				tableGroupJoin.getJoinType().getText() + " join " + toDisplayText( tableGroupJoin.getJoinedGroup() ),
+				() -> logTableGroupDetails( tableGroupJoin.getJoinedGroup() )
+		);
+	}
+
 	private void logNode(String text) {
-		logWithIndentation( "-> [%s]", text );
-	}
-
-	private void logNode(String pattern, Object arg) {
-		logWithIndentation( "-> [" + String.format( pattern, arg ) + ']');
-	}
-
-	private void logNode(String pattern, Object arg, Object arg2) {
-		logWithIndentation( "-> [" + String.format( pattern, arg, arg2 ) + ']');
+		logWithIndentation( "%s", text );
 	}
 
 	private void logNode(String text, Runnable subTreeHandler) {
@@ -191,7 +155,7 @@ public class SqlTreePrinter implements SqlAstWalker {
 	}
 
 	private void logNode(String text, Runnable subTreeHandler, boolean indentContinuation) {
-		logWithIndentation( "-> [%s]", text );
+		logWithIndentation( "%s {", text );
 		depth++;
 
 		try {
@@ -210,7 +174,7 @@ public class SqlTreePrinter implements SqlAstWalker {
 		}
 
 		depth--;
-		logWithIndentation( "<- [%s]", text );
+		logWithIndentation( "}", text );
 	}
 
 	private void logWithIndentation(Object line) {
@@ -226,8 +190,8 @@ public class SqlTreePrinter implements SqlAstWalker {
 		logWithIndentation( String.format( pattern, arg1, arg2 ) );
 	}
 
-	private void logWithIndentation(String pattern, Object... args) {
-		logWithIndentation(  String.format( pattern, args ) );
+	private void logWithIndentation(String pattern, Object arg1, Object arg2, Object arg3) {
+		logWithIndentation( String.format( pattern, arg1, arg2, arg3 ) );
 	}
 
 	private void pad(int depth) {
@@ -235,533 +199,5 @@ public class SqlTreePrinter implements SqlAstWalker {
 			buffer.append( "  " );
 		}
 	}
-
-	@Override
-	public void visitAssignment(Assignment assignment) {
-
-	}
-
-	@Override
-	public void visitQuerySpec(QuerySpec querySpec) {
-		logNode(
-				"query-spec",
-				() -> {
-					visitSelectClause( querySpec.getSelectClause() );
-					visitFromClause( querySpec.getFromClause() );
-
-					if ( querySpec.getWhereClauseRestrictions() != null && ! querySpec.getWhereClauseRestrictions().isEmpty() ) {
-						logNode(
-								"where",
-								() -> querySpec.getWhereClauseRestrictions().accept( this )
-						);
-					}
-
-					// todo (6.0) : group-by
-					// todo (6.0) : having
-
-					if ( ! querySpec.getSortSpecifications().isEmpty() ) {
-						logNode(
-								"order-by",
-								() -> {
-									for ( SortSpecification sortSpecification : querySpec.getSortSpecifications() ) {
-										visitSortSpecification( sortSpecification );
-									}
-								}
-						);
-					}
-
-					if ( querySpec.getLimitClauseExpression() != null ) {
-						logNode(
-								"limit",
-								() -> querySpec.getLimitClauseExpression().accept( this )
-						);
-					}
-
-					if ( querySpec.getOffsetClauseExpression() != null ) {
-						logNode(
-								"offset",
-								() -> querySpec.getOffsetClauseExpression().accept( this )
-
-						);
-					}
-				}
-		);
-	}
-
-	@Override
-	public void visitSortSpecification(SortSpecification sortSpecification) {
-		logNode(
-				"sort",
-				() -> {
-					sortSpecification.getSortExpression().accept( this );
-					logNode(
-							sortSpecification.getSortOrder() == null
-									? SortOrder.ASCENDING.name()
-									: sortSpecification.getSortOrder().name()
-					);
-				}
-		);
-	}
-
-	@Override
-	public void visitLimitOffsetClause(QuerySpec querySpec) {
-		throw new UnsupportedOperationException( "Unexpected call to #visitLimitOffsetClause" );
-	}
-
-	@Override
-	public void visitSelectClause(SelectClause selectClause) {
-		logNode(
-				"select",
-				() -> {
-					for ( SqlSelection sqlSelection : selectClause.getSqlSelections() ) {
-						visitSqlSelection( sqlSelection );
-					}
-				}
-		);
-	}
-
-	@Override
-	public void visitSqlSelection(SqlSelection sqlSelection) {
-		logWithIndentation( "selection - " + sqlSelection );
-	}
-
-	@Override
-	public void visitFromClause(FromClause fromClause) {
-		logNode(
-				"from",
-				() -> fromClause.visitRoots( this::visitTableGroup )
-		);
-	}
-
-	@Override
-	public void visitTableGroup(TableGroup tableGroup) {
-		logNode(
-				"table-group",
-				() -> {
-					visitTableReference( tableGroup.getPrimaryTableReference() );
-
-					for ( TableReferenceJoin join : tableGroup.getTableReferenceJoins() ) {
-						visitTableReferenceJoin( join );
-					}
-
-					tableGroup.visitTableGroupJoins( this::visitTableGroupJoin );
-				}
-		);
-	}
-
-	@Override
-	public void visitTableGroupJoin(TableGroupJoin tableGroupJoin) {
-		logNode(
-				"table-group-join",
-				() -> {
-					visitTableGroup( tableGroupJoin.getJoinedGroup() );
-					logNode( tableGroupJoin.getJoinType().getText() );
-					logNode(
-							"on",
-							() -> tableGroupJoin.getPredicate().accept( this )
-					);
-				}
-		);
-	}
-
-	@Override
-	public void visitTableReference(TableReference tableReference) {
-		logNode( tableReference.getTableExpression() + " as " + tableReference.getIdentificationVariable() );
-	}
-
-	@Override
-	public void visitTableReferenceJoin(TableReferenceJoin tableReferenceJoin) {
-		logNode(
-				"join",
-				() -> {
-					visitTableReference( tableReferenceJoin.getJoinedTableReference() );
-					logNode( tableReferenceJoin.getJoinType().getText() );
-					logNode(
-							"on",
-							() -> tableReferenceJoin.getJoinPredicate().accept( this )
-					);
-				}
-		);
-	}
-
-	@Override
-	public void visitColumnReference(ColumnReference columnReference) {
-		logNode( "{%s}.{%s}", columnReference.getQualifier(), columnReference.getColumnExpression() );
-	}
-
-	@Override
-	public void visitExtractUnit(ExtractUnit extractUnit) {
-		logNode( extractUnit.getUnit().toString() );
-	}
-
-	@Override
-	public void visitFormat(Format format) {
-		logNode( format.getFormat() );
-	}
-
-	@Override
-	public void visitDistinct(Distinct distinct) {
-		logNode( "{distinct}" );
-	}
-
-	@Override
-	public void visitStar(Star star) {
-		logNode( "{*}" );
-	}
-
-	@Override
-	public void visitTrimSpecification(TrimSpecification trimSpecification) {
-		logNode( "{" + trimSpecification.getSpecification().toSqlText() + "}" );
-	}
-
-	@Override
-	public void visitCastTarget(CastTarget castTarget) {
-		logNode( "`" + castTarget.getExpressionType().getJdbcMapping().getSqlTypeDescriptor() + "`" );
-	}
-
-	@Override
-	public void visitBinaryArithmeticExpression(BinaryArithmeticExpression expression) {
-		logNode(
-				expression.getOperator().getOperatorSqlTextString(),
-				() -> {
-					expression.getLeftHandOperand().accept( this );
-					expression.getRightHandOperand().accept( this );
-				}
-		);
-	}
-
-	@Override
-	public void visitSqlSelectionExpression(SqlSelectionExpression expression) {
-		logNode( "selection-reference (%s)", expression.getSelection().getJdbcResultSetIndex() );
-	}
-
-	@Override
-	public void visitEntityTypeLiteral(EntityTypeLiteral expression) {
-
-	}
-
-	@Override
-	public void visitTuple(SqlTuple tuple) {
-		logNode(
-				"tuple",
-				() -> tuple.getExpressions().forEach( expr -> expr.accept( this ) )
-		);
-	}
-
-	@Override
-	public void visitParameter(JdbcParameter jdbcParameter) {
-		logNode( "parameter" );
-	}
-
-	@Override
-	public void visitCaseSearchedExpression(CaseSearchedExpression caseSearchedExpression) {
-		throw new NotYetImplementedFor6Exception();
-	}
-
-	@Override
-	public void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression) {
-		throw new NotYetImplementedFor6Exception();
-	}
-
-	@Override
-	public void visitAny(Any any) {
-
-	}
-
-	@Override
-	public void visitEvery(Every every) {
-
-	}
-
-	//	@Override
-//	public void visitCoalesceFunction(CoalesceFunction coalesceExpression) {
-//		throw new NotYetImplementedFor6Exception();
-//	}
-//
-//	@Override
-//	public void visitNamedParameter(NamedParameter namedParameter) {
-//		logNode( "named-param (%s)", namedParameter.getName() );
-//	}
-//
-//	@Override
-//	public void visitGenericParameter(GenericParameter parameter) {
-//		logNode( "generic-param" );
-//	}
-//
-//	@Override
-//	public void visitPositionalParameter(PositionalParameter parameter) {
-//		logNode( "positional-param (%s)", parameter.getPosition() );
-//	}
-
-
-	@Override
-	public void visitJdbcLiteral(JdbcLiteral jdbcLiteral) {
-		logNode( "literal (" + jdbcLiteral.getLiteralValue() + ')' );
-	}
-
-	@Override
-	public void visitQueryLiteral(QueryLiteral queryLiteral) {
-		logNode( "literal (" + queryLiteral.getLiteralValue() + ')' );
-	}
-
-	@Override
-	public void visitUnaryOperationExpression(UnaryOperation operation) {
-		logNode(
-				operation.getOperator().name().toLowerCase( Locale.ROOT ),
-				() -> operation.getOperand().accept( this )
-		);
-	}
-
-	@Override
-	public void visitBetweenPredicate(BetweenPredicate betweenPredicate) {
-		logNode(
-				"between",
-				() -> {
-					betweenPredicate.getExpression().accept( this );
-					betweenPredicate.getLowerBound().accept( this );
-					betweenPredicate.getUpperBound().accept( this );
-				}
-		);
-	}
-
-	@Override
-	public void visitFilterPredicate(FilterPredicate filterPredicate) {
-		logNode(
-				"filter-predicate",
-				() -> {
-					logNode( filterPredicate.getFilterFragment() );
-				}
-		);
-	}
-
-	@Override
-	public void visitGroupedPredicate(GroupedPredicate groupedPredicate) {
-		logNode(
-				"grouped-predicate",
-				() -> groupedPredicate.getSubPredicate().accept( this )
-		);
-	}
-
-	@Override
-	public void visitInListPredicate(InListPredicate inListPredicate) {
-		logNode(
-				"in",
-				() -> {
-					inListPredicate.getTestExpression().accept( this );
-					logNode(
-							"list",
-							() -> inListPredicate.getListExpressions().forEach( expr -> expr.accept( this ) )
-					);
-				}
-		);
-	}
-
-	@Override
-	public void visitInSubQueryPredicate(InSubQueryPredicate inSubQueryPredicate) {
-		logNode(
-				"in",
-				() -> {
-					inSubQueryPredicate.getTestExpression().accept( this );
-					visitQuerySpec( inSubQueryPredicate.getSubQuery() );
-				}
-		);
-	}
-
-	@Override
-	public void visitExistsPredicate(ExistsPredicate existsPredicate) {
-
-	}
-
-	@Override
-	public void visitJunction(Junction junction) {
-		logNode(
-				junction.getNature().name().toLowerCase(),
-				() -> junction.getPredicates().forEach( predicate -> predicate.accept( this ) )
-		);
-	}
-
-	@Override
-	public void visitLikePredicate(LikePredicate likePredicate) {
-		logNode(
-				"like",
-				() -> {
-					likePredicate.getMatchExpression().accept( this );
-					likePredicate.getPattern().accept( this );
-					if ( likePredicate.getEscapeCharacter() != null ) {
-						likePredicate.getEscapeCharacter().accept( this );
-					}
-				}
-		);
-	}
-
-	@Override
-	public void visitNegatedPredicate(NegatedPredicate negatedPredicate) {
-		logNode(
-				"not",
-				() -> negatedPredicate.getPredicate().accept( this )
-		);
-	}
-
-	@Override
-	public void visitNullnessPredicate(NullnessPredicate nullnessPredicate) {
-	}
-
-	@Override
-	public void visitRelationalPredicate(ComparisonPredicate comparisonPredicate) {
-		logNode(
-				comparisonPredicate.getOperator().name().toLowerCase( Locale.ROOT ),
-				() -> {
-					comparisonPredicate.getLeftHandExpression().accept( this );
-					comparisonPredicate.getRightHandExpression().accept( this );
-				}
-		);
-	}
-
-	@Override
-	public void visitSelfRenderingPredicate(SelfRenderingPredicate selfRenderingPredicate) {
-	}
-
-	@Override
-	public void visitSelfRenderingExpression(SelfRenderingExpression expression) {
-
-	}
-
-	@Override
-	public void visitDurationUnit(DurationUnit durationUnit) {
-
-	}
-
-	@Override
-	public void visitDuration(Duration duration) {
-
-	}
-
-	@Override
-	public void visitConversion(Conversion conversion) {
-
-	}
-
-	//	@Override
-//	public void visitNonStandardFunctionExpression(NonStandardFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitAbsFunction(AbsFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitAvgFunction(AvgFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitBitLengthFunction(BitLengthFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitCastFunction(CastFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitConcatFunction(ConcatFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitSubstrFunction(SubstrFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitCountFunction(CountFunction function) {
-//		logNode(
-//				"count",
-//				() -> function.getArgument().accept( this )
-//		);
-//	}
-//
-//	@Override
-//	public void visitCountStarFunction(CountStarFunction function) {
-//		logNode( "count(*)" );
-//	}
-//
-//	@Override
-//	public void visitCurrentDateFunction(CurrentDateFunction function) {
-//		logNode( "current_date" );
-//	}
-//
-//	@Override
-//	public void visitCurrentTimeFunction(CurrentTimeFunction function) {
-//		logNode( "current_time" );
-//	}
-//
-//	@Override
-//	public void visitCurrentTimestampFunction(CurrentTimestampFunction function) {
-//		logNode( "current_timestamp" );
-//	}
-
-//	@Override
-//	public void visitExtractFunction(ExtractFunction extractFunction) {
-//
-//	}
-//
-//	@Override
-//	public void visitLengthFunction(LengthFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitLocateFunction(LocateFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitLowerFunction(LowerFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitMaxFunction(MaxFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitMinFunction(MinFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitModFunction(ModFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitNullifFunction(NullifFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitSqrtFunction(SqrtFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitSumFunction(SumFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitTrimFunction(TrimFunction function) {
-//
-//	}
-//
-//	@Override
-//	public void visitUpperFunction(UpperFunction function) {
-//
-//	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/StandardSqlAstSelectTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/StandardSqlAstSelectTranslator.java
@@ -20,6 +20,9 @@ import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.JdbcSelect;
 import org.hibernate.sql.results.jdbc.internal.JdbcValuesMappingProducerStandard;
 
+import static org.hibernate.sql.ast.SqlTreePrinter.logSqlAst;
+import static org.hibernate.sql.results.graph.DomainResultGraphPrinter.logDomainResultGraph;
+
 /**
  * The final phase of query translation.  Here we take the SQL-AST an
  * "interpretation".  For a select query, that means an instance of
@@ -81,9 +84,8 @@ public class StandardSqlAstSelectTranslator
 
 	@Override
 	public JdbcSelect translate(SelectStatement sqlAstSelect) {
-		if ( SqlAstTreeLogger.DEBUG_ENABLED ) {
-			SqlTreePrinter.print( sqlAstSelect );
-		}
+		logDomainResultGraph( sqlAstSelect.getDomainResultDescriptors() );
+		logSqlAst( sqlAstSelect );
 
 		visitQuerySpec( sqlAstSelect.getQuerySpec() );
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoinProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoinProducer.java
@@ -11,12 +11,35 @@ import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.ast.SqlAstJoinType;
 import org.hibernate.sql.ast.spi.SqlAliasBaseGenerator;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
+import org.hibernate.sql.ast.spi.SqlAstCreationState;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 
 /**
  * @author Steve Ebersole
  */
 public interface TableGroupJoinProducer extends TableGroupProducer {
+	/**
+	 * Create a TableGroupJoin as defined for this producer
+	 */
+	default TableGroupJoin createTableGroupJoin(
+			NavigablePath navigablePath,
+			TableGroup lhs,
+			String explicitSourceAlias,
+			SqlAstJoinType sqlAstJoinType,
+			LockMode lockMode,
+			SqlAstCreationState creationState) {
+		return createTableGroupJoin(
+				navigablePath, 
+				lhs,
+				explicitSourceAlias,
+				sqlAstJoinType,
+				lockMode,
+				creationState.getSqlAliasBaseGenerator(),
+				creationState.getSqlExpressionResolver(),
+				creationState.getCreationContext()
+		);
+	}
+
 	/**
 	 * Create a TableGroupJoin as defined for this producer
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -28,7 +28,7 @@ import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcSelect;
 import org.hibernate.sql.exec.spi.JdbcSelectExecutor;
-import org.hibernate.sql.results.internal.Helper;
+import org.hibernate.sql.results.internal.ResultsHelper;
 import org.hibernate.sql.results.internal.RowProcessingStateStandardImpl;
 import org.hibernate.sql.results.jdbc.internal.DeferredResultSetAccess;
 import org.hibernate.sql.results.jdbc.internal.JdbcValuesCacheHit;
@@ -204,7 +204,7 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 
 		final List<AfterLoadAction> afterLoadActions = new ArrayList<>();
 
-		final RowReader<R> rowReader = Helper.createRowReader(
+		final RowReader<R> rowReader = ResultsHelper.createRowReader(
 				executionContext.getSession().getFactory(),
 				afterLoadActions::add,
 				rowTransformer,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/AssemblerCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/AssemblerCreationState.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.sql.results.graph;
 
+import java.util.function.Supplier;
+
+import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 
 /**
  * @author Steve Ebersole
  */
 public interface AssemblerCreationState {
+	Initializer resolveInitializer(NavigablePath navigablePath, Supplier<Initializer> producer);
 	SqlAstCreationContext getSqlAstCreationContext();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/AssemblerLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/AssemblerLogger.java
@@ -4,23 +4,18 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */
-package org.hibernate.sql.results.graph.entity;
+package org.hibernate.sql.results.graph;
 
-import org.hibernate.sql.results.LoadingLogger;
+import org.hibernate.sql.results.ResultsLogger;
 
 import org.jboss.logging.Logger;
 
 /**
  * @author Steve Ebersole
  */
-public interface EntityLoadingLogger {
-	String LOGGER_NAME = LoadingLogger.subLoggerName( "entity" );
+public interface AssemblerLogger {
+	Logger LOGGER = ResultsLogger.subLogger( "assembler" );
 
-	/**
-	 * Static access to the logging instance
-	 */
-	Logger LOGGER = LoadingLogger.subLogger( "entity" );
-
-	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
 	boolean DEBUG_ENABLED = LOGGER.isDebugEnabled();
+	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResult.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph;
 
-import java.util.function.Consumer;
-
 /**
  * Represents a result value in the domain query results.  Acts as the producer for the
  * {@link DomainResultAssembler} for this result as well as any {@link Initializer} instances needed
@@ -30,7 +28,5 @@ public interface DomainResult<J> extends DomainResultGraphNode {
 	/**
 	 * Create an assembler (and any initializers) for this result.
 	 */
-	DomainResultAssembler<J> createResultAssembler(
-			Consumer<Initializer> initializerCollector,
-			AssemblerCreationState creationState);
+	DomainResultAssembler<J> createResultAssembler(AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/Fetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/Fetch.java
@@ -59,8 +59,5 @@ public interface Fetch extends DomainResultGraphNode {
 	/**
 	 * Create the assembler for this fetch
 	 */
-	DomainResultAssembler createAssembler(
-			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
-			AssemblerCreationState creationState);
+	DomainResultAssembler createAssembler(FetchParentAccess parentAccess, AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/ResultGraphLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/ResultGraphLogger.java
@@ -4,23 +4,18 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
  */
-package org.hibernate.sql.results.graph.entity;
+package org.hibernate.sql.results.graph;
 
-import org.hibernate.sql.results.LoadingLogger;
+import org.hibernate.sql.results.ResultsLogger;
 
 import org.jboss.logging.Logger;
 
 /**
  * @author Steve Ebersole
  */
-public interface EntityLoadingLogger {
-	String LOGGER_NAME = LoadingLogger.subLoggerName( "entity" );
+public interface ResultGraphLogger {
+	Logger LOGGER = ResultsLogger.subLogger( "graph" );
 
-	/**
-	 * Static access to the logging instance
-	 */
-	Logger LOGGER = LoadingLogger.subLogger( "entity" );
-
-	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
 	boolean DEBUG_ENABLED = LOGGER.isDebugEnabled();
+	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicFetch.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.basic;
 
-import java.util.function.Consumer;
-
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
@@ -19,7 +17,6 @@ import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
 import org.hibernate.sql.results.graph.Fetchable;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
@@ -95,15 +92,12 @@ public class BasicFetch<T> implements Fetch, BasicResultGraphNode<T> {
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
 		return assembler;
 	}
 
 	@Override
-	public DomainResultAssembler<T> createResultAssembler(
-			Consumer<Initializer> initializerCollector,
-			AssemblerCreationState creationState) {
+	public DomainResultAssembler<T> createResultAssembler(AssemblerCreationState creationState) {
 		return assembler;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResult.java
@@ -6,15 +6,12 @@
  */
 package org.hibernate.sql.results.graph.basic;
 
-import java.util.function.Consumer;
-
 import org.hibernate.Internal;
-import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
+import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
@@ -93,9 +90,7 @@ public class BasicResult<T> implements DomainResult<T>, BasicResultGraphNode<T> 
 	}
 
 	@Override
-	public DomainResultAssembler<T> createResultAssembler(
-			Consumer<Initializer> initializerCollector,
-			AssemblerCreationState creationState) {
+	public DomainResultAssembler<T> createResultAssembler(AssemblerCreationState creationState) {
 		return assembler;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionLoadingLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/CollectionLoadingLogger.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.sql.results.graph.collection;
 
-import org.hibernate.sql.results.ResultsLogger;
+import org.hibernate.sql.results.LoadingLogger;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -15,12 +15,14 @@ import org.jboss.logging.Logger;
  * @author Steve Ebersole
  */
 public interface CollectionLoadingLogger extends BasicLogger {
-	String LOGGER_NAME = ResultsLogger.LOGGER_NAME + "loading.collection";
+	String LOCAL_NAME = "collection";
+
+	String LOGGER_NAME = LoadingLogger.subLoggerName( LOCAL_NAME );
 
 	/**
 	 * Static access to the logging instance
 	 */
-	Logger INSTANCE = Logger.getLogger( LOGGER_NAME );
+	Logger INSTANCE = LoadingLogger.subLogger( LOCAL_NAME );
 
 	boolean TRACE_ENABLED = INSTANCE.isTraceEnabled();
 	boolean DEBUG_ENABLED = INSTANCE.isDebugEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionAssembler.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
+import java.util.function.Supplier;
+
 import org.hibernate.collection.internal.PersistentArrayHolder;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -25,9 +27,9 @@ public abstract class AbstractCollectionAssembler implements DomainResultAssembl
 
 	public AbstractCollectionAssembler(
 			PluralAttributeMapping fetchedMapping,
-			CollectionInitializer initializer) {
+			Supplier<CollectionInitializer> initializerProducer) {
 		this.fetchedMapping = fetchedMapping;
-		this.initializer = initializer;
+		this.initializer = initializerProducer.get();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractImmediateCollectionInitializer.java
@@ -15,7 +15,6 @@ import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.log.LoggingHelper;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.query.NavigablePath;
@@ -71,6 +70,8 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 		this.lockMode = lockMode;
 	}
 
+	protected abstract String getSimpleConcreteImplName();
+
 	@Override
 	public void resolveInstance(RowProcessingState rowProcessingState) {
 		if ( collectionInstance != null ) {
@@ -80,7 +81,7 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 		if ( CollectionLoadingLogger.TRACE_ENABLED ) {
 			CollectionLoadingLogger.INSTANCE.tracef(
 					"(%s) Beginning Initializer#resolveInstance for collection : %s",
-					StringHelper.collapse( this.getClass().getName() ),
+					getSimpleConcreteImplName(),
 					LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() )
 			);
 		}
@@ -105,9 +106,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Found existing loading collection entry [%s]; using loading collection instance - %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-						LoggingHelper.toLoggableString( collectionInstance )
+						toLoggableString( collectionInstance )
 				);
 			}
 
@@ -120,7 +121,7 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 				if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 					CollectionLoadingLogger.INSTANCE.debugf(
 							"(%s) Collection [%s] being loaded by another initializer [%s] - skipping processing",
-							StringHelper.collapse( this.getClass().getName() ),
+							getSimpleConcreteImplName(),
 							LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
 							existingLoadingEntry.getInitializer()
 					);
@@ -142,9 +143,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 					if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 						CollectionLoadingLogger.INSTANCE.debugf(
 								"(%s) Found existing collection instance [%s] in Session; skipping processing - [%s]",
-								StringHelper.collapse( this.getClass().getName() ),
+								getSimpleConcreteImplName(),
 								LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-								LoggingHelper.toLoggableString( collectionInstance )
+								toLoggableString( collectionInstance )
 						);
 					}
 
@@ -167,9 +168,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 						if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 							CollectionLoadingLogger.INSTANCE.debugf(
 									"(%s) Found existing unowned collection instance [%s] in Session; skipping processing - [%s]",
-									StringHelper.collapse( this.getClass().getName() ),
+									getSimpleConcreteImplName(),
 									LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-									LoggingHelper.toLoggableString( collectionInstance )
+									toLoggableString( collectionInstance )
 							);
 						}
 
@@ -197,9 +198,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Created new collection wrapper [%s] : %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-						LoggingHelper.toLoggableString( collectionInstance )
+						toLoggableString( collectionInstance )
 				);
 			}
 
@@ -212,9 +213,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Responsible for loading collection [%s] : %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-						LoggingHelper.toLoggableString( collectionInstance )
+						toLoggableString( collectionInstance )
 				);
 			}
 
@@ -224,6 +225,16 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 				);
 			}
 		}
+	}
+
+	/**
+	 * Specialized toString handling for PersistentCollection.  All `PersistentCollection#toString`
+	 * implementations are crazy expensive as they trigger a load
+	 */
+	private String toLoggableString(PersistentCollection collectionInstance) {
+		return collectionInstance == null
+				? LoggingHelper.NULL
+				: collectionInstance.getClass().getName() + "@" + System.identityHashCode( collectionInstance );
 	}
 
 	protected void takeResponsibility(RowProcessingState rowProcessingState, CollectionKey collectionKey) {
@@ -280,7 +291,7 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Current row collection key : %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), this.collectionKey.getKey() )
 				);
 			}
@@ -294,7 +305,7 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Current row collection key : %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), this.collectionKey.getKey() )
 				);
 			}
@@ -343,9 +354,9 @@ public abstract class AbstractImmediateCollectionInitializer extends AbstractCol
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.INSTANCE.debugf(
 						"(%s) Reading element from row for collection [%s] -> %s",
-						StringHelper.collapse( this.getClass().getName() ),
+						getSimpleConcreteImplName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), collectionKey.getKey() ),
-						LoggingHelper.toLoggableString( collectionInstance )
+						toLoggableString( collectionInstance )
 				);
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -22,6 +22,8 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
  * @author Chris Cranford
  */
 public class ArrayInitializer extends AbstractImmediateCollectionInitializer {
+	private static final String CONCRETE_NAME = ArrayInitializer.class.getSimpleName();
+
 	private final DomainResultAssembler listIndexAssembler;
 	private final DomainResultAssembler elementAssembler;
 
@@ -48,6 +50,11 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer {
 		this.elementAssembler = elementAssembler;
 
 		this.indexBase = getCollectionAttributeMapping().getIndexMetadata().getListIndexBase();
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializerProducer.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Chris Cranford
@@ -44,7 +41,6 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		return new ArrayInitializer(
 				navigablePath,
@@ -53,16 +49,8 @@ public class ArrayInitializerProducer implements CollectionInitializerProducer {
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,
-				listIndexFetch.createAssembler(
-						parentAccess,
-						initializerConsumer,
-						creationState
-				),
-				elementFetch.createAssembler(
-						parentAccess,
-						initializerConsumer,
-						creationState
-				)
+				listIndexFetch.createAssembler( parentAccess, creationState ),
+				elementFetch.createAssembler( parentAccess, creationState )
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializer.java
@@ -26,6 +26,8 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
  * @author Steve Ebersole
  */
 public class BagInitializer extends AbstractImmediateCollectionInitializer {
+	private static final String CONCRETE_NAME = BagInitializer.class.getSimpleName();
+
 	private final DomainResultAssembler elementAssembler;
 	private final DomainResultAssembler collectionIdAssembler;
 
@@ -41,6 +43,11 @@ public class BagInitializer extends AbstractImmediateCollectionInitializer {
 		super( navigablePath, bagDescriptor, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.elementAssembler = elementAssembler;
 		this.collectionIdAssembler = collectionIdAssembler;
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/BagInitializerProducer.java
@@ -6,19 +6,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
-
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Steve Ebersole
@@ -55,11 +51,9 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		final DomainResultAssembler elementAssembler = elementFetch.createAssembler(
 				parentAccess,
-				initializerConsumer,
 				creationState
 		);
 
@@ -70,7 +64,6 @@ public class BagInitializerProducer implements CollectionInitializerProducer {
 		else {
 			collectionIdAssembler = collectionIdFetch.createAssembler(
 					parentAccess,
-					initializerConsumer,
 					creationState
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/CollectionDomainResult.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
@@ -79,27 +78,23 @@ public class CollectionDomainResult implements DomainResult, CollectionResultGra
 	}
 
 	@Override
-	public DomainResultAssembler createResultAssembler(
-			Consumer initializerCollector,
-			AssemblerCreationState creationState) {
+	public DomainResultAssembler createResultAssembler(AssemblerCreationState creationState) {
+		final CollectionInitializer initializer = (CollectionInitializer) creationState.resolveInitializer(
+				getNavigablePath(),
+				() -> {
+					final DomainResultAssembler fkAssembler = fkResult.createResultAssembler( creationState );
 
-		final DomainResultAssembler fkAssembler = fkResult.createResultAssembler(
-				initializerCollector,
-				creationState
+					return initializerProducer.produceInitializer(
+							loadingPath,
+							loadingAttribute,
+							null,
+							LockMode.READ,
+							fkAssembler,
+							fkAssembler,
+							creationState
+					);
+				}
 		);
-
-		final CollectionInitializer initializer = initializerProducer.produceInitializer(
-				loadingPath,
-				loadingAttribute,
-				null,
-				LockMode.READ,
-				fkAssembler,
-				fkAssembler,
-				initializerCollector,
-				creationState
-		);
-
-		initializerCollector.accept( initializer );
 
 		return new EagerCollectionAssembler( loadingAttribute, initializer );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionAssembler.java
@@ -13,6 +13,7 @@ import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.FetchParentAccess;
 import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Steve Ebersole
@@ -22,9 +23,14 @@ public class DelayedCollectionAssembler extends AbstractCollectionAssembler {
 			NavigablePath fetchPath,
 			PluralAttributeMapping fetchedMapping,
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		super( fetchedMapping, new DelayedCollectionInitializer( fetchPath, fetchedMapping, parentAccess ) );
-		collector.accept( initializer );
+		super(
+				fetchedMapping,
+				() -> (CollectionInitializer) creationState.resolveInitializer(
+						fetchPath,
+						() -> new DelayedCollectionInitializer( fetchPath, fetchedMapping, parentAccess )
+				)
+
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionFetch.java
@@ -32,13 +32,11 @@ public class DelayedCollectionFetch extends CollectionFetch {
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
 		return new DelayedCollectionAssembler(
 				getNavigablePath(),
 				getFetchedMapping(),
 				parentAccess,
-				collector,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EagerCollectionAssembler.java
@@ -17,6 +17,6 @@ public class EagerCollectionAssembler extends AbstractCollectionAssembler {
 	public EagerCollectionAssembler(
 			PluralAttributeMapping fetchedMapping,
 			CollectionInitializer initializer) {
-		super( fetchedMapping, initializer );
+		super( fetchedMapping, () -> initializer );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -24,6 +24,8 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
  * @author Steve Ebersole
  */
 public class ListInitializer extends AbstractImmediateCollectionInitializer {
+	private static final String CONCRETE_NAME = ListInitializer.class.getSimpleName();
+
 	private final DomainResultAssembler listIndexAssembler;
 	private final DomainResultAssembler elementAssembler;
 
@@ -43,6 +45,11 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer {
 		this.elementAssembler = elementAssembler;
 
 		listIndexBase = attributeMapping.getIndexMetadata().getListIndexBase();
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializerProducer.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Steve Ebersole
@@ -44,7 +41,6 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		return new ListInitializer(
 				navigablePath,
@@ -53,16 +49,8 @@ public class ListInitializerProducer implements CollectionInitializerProducer {
 				lockMode,
 				keyContainerAssembler,
 				keyCollectionAssembler,
-				listIndexFetch.createAssembler(
-						parentAccess,
-						initializerConsumer,
-						creationState
-				),
-				elementFetch.createAssembler(
-						parentAccess,
-						initializerConsumer,
-						creationState
-				)
+				listIndexFetch.createAssembler( parentAccess, creationState ),
+				elementFetch.createAssembler( parentAccess, creationState )
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializer.java
@@ -27,6 +27,8 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
  * @author Steve Ebersole
  */
 public class MapInitializer extends AbstractImmediateCollectionInitializer {
+	private static final String CONCRETE_NAME = MapInitializer.class.getSimpleName();
+
 	private final DomainResultAssembler mapKeyAssembler;
 	private final DomainResultAssembler mapValueAssembler;
 
@@ -42,6 +44,11 @@ public class MapInitializer extends AbstractImmediateCollectionInitializer {
 		super( navigablePath, attributeMapping, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.mapKeyAssembler = mapKeyAssembler;
 		this.mapValueAssembler = mapValueAssembler;
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/MapInitializerProducer.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Steve Ebersole
@@ -44,17 +41,14 @@ public class MapInitializerProducer implements CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		final DomainResultAssembler mapKeyAssembler = mapKeyFetch.createAssembler(
 				parentAccess,
-				initializerConsumer,
 				creationState
 		);
 
 		final DomainResultAssembler mapValueAssembler = mapValueFetch.createAssembler(
 				parentAccess,
-				initializerConsumer,
 				creationState
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionAssembler.java
@@ -6,13 +6,11 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Andrea Boriero
@@ -23,9 +21,13 @@ public class SelectEagerCollectionAssembler extends AbstractCollectionAssembler 
 			NavigablePath fetchPath,
 			PluralAttributeMapping fetchedMapping,
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		super( fetchedMapping, new SelectEagerCollectionInitializer( fetchPath, fetchedMapping, parentAccess ) );
-		collector.accept( initializer );
+		super(
+				fetchedMapping,
+				() -> (CollectionInitializer) creationState.resolveInitializer(
+						fetchPath,
+						() -> new SelectEagerCollectionInitializer( fetchPath, fetchedMapping, parentAccess )
+				)
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionFetch.java
@@ -41,12 +41,12 @@ public class SelectEagerCollectionFetch extends CollectionFetch {
 
 	@Override
 	public DomainResultAssembler createAssembler(
-			FetchParentAccess parentAccess, Consumer<Initializer> collector, AssemblerCreationState creationState) {
+			FetchParentAccess parentAccess,
+			AssemblerCreationState creationState) {
 		return new SelectEagerCollectionAssembler(
 				getNavigablePath(),
 				getFetchedMapping(),
 				parentAccess,
-				collector,
 				creationState
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializer.java
@@ -22,6 +22,8 @@ import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
  * @author Steve Ebersole
  */
 public class SetInitializer extends AbstractImmediateCollectionInitializer {
+	private static final String CONCRETE_NAME = SetInitializer.class.getSimpleName();
+
 	private final DomainResultAssembler elementAssembler;
 
 	public SetInitializer(
@@ -34,6 +36,11 @@ public class SetInitializer extends AbstractImmediateCollectionInitializer {
 			DomainResultAssembler elementAssembler) {
 		super( navigablePath, setDescriptor, parentAccess, lockMode, keyContainerAssembler, keyCollectionAssembler );
 		this.elementAssembler = elementAssembler;
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SetInitializerProducer.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.collection.spi.CollectionInitializerProducer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.collection.CollectionInitializer;
 
 /**
  * @author Steve Ebersole
@@ -41,13 +38,8 @@ public class SetInitializerProducer implements CollectionInitializerProducer {
 			LockMode lockMode,
 			DomainResultAssembler keyContainerAssembler,
 			DomainResultAssembler keyCollectionAssembler,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
-		final DomainResultAssembler elementAssembler = elementFetch.createAssembler(
-				parentAccess,
-				initializerConsumer,
-				creationState
-		);
+		final DomainResultAssembler elementAssembler = elementFetch.createAssembler( parentAccess, creationState );
 
 		return new SetInitializer(
 				navigablePath,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
@@ -8,10 +8,10 @@ package org.hibernate.sql.results.graph.embeddable;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
+import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.metamodel.mapping.StateArrayContributorMapping;
 import org.hibernate.query.NavigablePath;
@@ -20,7 +20,6 @@ import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.internal.NullValueAssembler;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 
@@ -44,7 +43,6 @@ public abstract class AbstractEmbeddableInitializer extends AbstractFetchParentA
 	public AbstractEmbeddableInitializer(
 			EmbeddableResultGraphNode resultDescriptor,
 			FetchParentAccess fetchParentAccess,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		this.navigablePath = resultDescriptor.getNavigablePath();
 		this.embeddedModelPartDescriptor = resultDescriptor.getReferencedMappingContainer();
@@ -61,7 +59,7 @@ public abstract class AbstractEmbeddableInitializer extends AbstractFetchParentA
 
 					final DomainResultAssembler stateAssembler = fetch == null
 							? new NullValueAssembler( stateArrayContributor.getJavaTypeDescriptor() )
-							: fetch.createAssembler( this, initializerConsumer, creationState );
+							: fetch.createAssembler( this, creationState );
 
 					assemblerMap.put( stateArrayContributor, stateAssembler );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/EmbeddableLoadingLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/EmbeddableLoadingLogger.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.sql.results.graph.embeddable;
 
-import org.hibernate.sql.results.ResultsLogger;
+import org.hibernate.sql.results.LoadingLogger;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -19,17 +19,16 @@ import org.jboss.logging.annotations.ValidIdRange;
 @MessageLogger( projectCode = "HHH" )
 @ValidIdRange( min = 90005301, max = 90005400 )
 public interface EmbeddableLoadingLogger extends BasicLogger {
-	String LOGGER_NAME = ResultsLogger.LOGGER_NAME + "loading.composite";
+	String LOCAL_NAME = "composite";
+
+	String LOGGER_NAME = LoadingLogger.subLoggerName( LOCAL_NAME );
 
 	/**
 	 * Static access to the logging instance
 	 */
-	EmbeddableLoadingLogger INSTANCE = Logger.getMessageLogger(
-			EmbeddableLoadingLogger.class,
-			LOGGER_NAME
-	);
+	Logger INSTANCE = LoadingLogger.subLogger( LOCAL_NAME );
+
 
 	boolean TRACE_ENABLED = INSTANCE.isTraceEnabled();
 	boolean DEBUG_ENABLED = INSTANCE.isDebugEnabled();
-	boolean INFO_ENABLED = INSTANCE.isInfoEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.embeddable.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
@@ -24,7 +22,7 @@ import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
 import org.hibernate.sql.results.graph.Fetchable;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableValuedFetchable;
 
@@ -64,9 +62,7 @@ public class EmbeddableFetchImpl extends AbstractFetchParent implements Embeddab
 							null,
 							nullable ? SqlAstJoinType.LEFT : SqlAstJoinType.INNER,
 							LockMode.NONE,
-							stem -> creationState.getSqlAliasBaseManager().createSqlAliasBase( stem ),
-							creationState.getSqlAstCreationState().getSqlExpressionResolver(),
-							creationState.getSqlAstCreationState().getCreationContext()
+							creationState.getSqlAstCreationState()
 					);
 					return tableGroupJoin.getJoinedGroup();
 				}
@@ -114,17 +110,15 @@ public class EmbeddableFetchImpl extends AbstractFetchParent implements Embeddab
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		final EmbeddableFetchInitializer initializer = new EmbeddableFetchInitializer(
-				parentAccess,
-				this,
-				collector,
-				creationState
+		final EmbeddableInitializer initializer = (EmbeddableInitializer) creationState.resolveInitializer(
+				getNavigablePath(),
+				() -> new EmbeddableFetchInitializer(
+						parentAccess,
+						this,
+						creationState
+				)
 		);
-
-
-		collector.accept( initializer );
 
 		return new EmbeddableAssembler( initializer );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchInitializer.java
@@ -6,14 +6,11 @@
  */
 package org.hibernate.sql.results.graph.embeddable.internal;
 
-import java.util.function.Consumer;
-
-import org.hibernate.sql.results.graph.embeddable.AbstractEmbeddableInitializer;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
+import org.hibernate.sql.results.graph.FetchParentAccess;
+import org.hibernate.sql.results.graph.embeddable.AbstractEmbeddableInitializer;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
-import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
 
 /**
  * @author Steve Ebersole
@@ -24,9 +21,8 @@ public class EmbeddableFetchInitializer
 	public EmbeddableFetchInitializer(
 			FetchParentAccess fetchParentAccess,
 			EmbeddableResultGraphNode resultDescriptor,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
-		super( resultDescriptor, fetchParentAccess, initializerConsumer, creationState );
+		super( resultDescriptor, fetchParentAccess, creationState );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.results.graph.embeddable.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.internal.util.MutableInteger;
@@ -26,9 +25,9 @@ import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.Fetchable;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.graph.basic.BasicResult;
+import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.sql.results.graph.entity.internal.EntityFetchDelayedImpl;
 import org.hibernate.sql.results.graph.entity.internal.EntityFetchSelectImpl;
@@ -36,7 +35,8 @@ import org.hibernate.sql.results.graph.entity.internal.EntityFetchSelectImpl;
 /**
  * @author Andrea Boriero
  */
-public class EmbeddableForeignKeyResultImpl<T> extends AbstractFetchParent
+public class EmbeddableForeignKeyResultImpl<T>
+		extends AbstractFetchParent
 		implements EmbeddableResultGraphNode, DomainResult<T> {
 
 	private final String resultVariable;
@@ -119,15 +119,11 @@ public class EmbeddableForeignKeyResultImpl<T> extends AbstractFetchParent
 	}
 
 	@Override
-	public DomainResultAssembler<T> createResultAssembler(
-			Consumer<Initializer> initializerCollector, AssemblerCreationState creationState) {
-		final EmbeddableResultInitializer initializer = new EmbeddableResultInitializer(
-				this,
-				initializerCollector,
-				creationState
+	public DomainResultAssembler<T> createResultAssembler(AssemblerCreationState creationState) {
+		final EmbeddableInitializer initializer = (EmbeddableInitializer) creationState.resolveInitializer(
+				getNavigablePath(),
+				() -> new EmbeddableResultInitializer(this, creationState )
 		);
-
-		initializerCollector.accept( initializer );
 
 		//noinspection unchecked
 		return new EmbeddableAssembler( initializer );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.embeddable.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
@@ -17,11 +15,11 @@ import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.results.graph.AbstractFetchParent;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
-import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.embeddable.EmbeddableInitializer;
+import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
@@ -50,9 +48,7 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 							resultVariable,
 							SqlAstJoinType.INNER,
 							LockMode.NONE,
-							creationState.getSqlAstCreationState().getSqlAliasBaseGenerator(),
-							creationState.getSqlAstCreationState().getSqlExpressionResolver(),
-							creationState.getSqlAstCreationState().getCreationContext()
+							creationState.getSqlAstCreationState()
 					);
 
 					return tableGroupJoin.getJoinedGroup();
@@ -88,16 +84,14 @@ public class EmbeddableResultImpl<T> extends AbstractFetchParent implements Embe
 	}
 
 	@Override
-	public DomainResultAssembler<T> createResultAssembler(
-			Consumer<Initializer> initializerCollector,
-			AssemblerCreationState creationState) {
-		final EmbeddableResultInitializer initializer = new EmbeddableResultInitializer(
-				this,
-				initializerCollector,
-				creationState
+	public DomainResultAssembler<T> createResultAssembler(AssemblerCreationState creationState) {
+		final EmbeddableInitializer initializer = (EmbeddableInitializer) creationState.resolveInitializer(
+				getNavigablePath(),
+				() -> new EmbeddableResultInitializer(
+						this,
+						creationState
+				)
 		);
-
-		initializerCollector.accept( initializer );
 
 		//noinspection unchecked
 		return new EmbeddableAssembler( initializer );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableResultInitializer.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.sql.results.graph.embeddable.internal;
 
-import java.util.function.Consumer;
-
-import org.hibernate.sql.results.graph.embeddable.AbstractEmbeddableInitializer;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
+import org.hibernate.sql.results.graph.embeddable.AbstractEmbeddableInitializer;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
-import org.hibernate.sql.results.graph.Initializer;
 
 /**
  * @author Steve Ebersole
@@ -19,13 +16,17 @@ import org.hibernate.sql.results.graph.Initializer;
 public class EmbeddableResultInitializer extends AbstractEmbeddableInitializer {
 	public EmbeddableResultInitializer(
 			EmbeddableResultGraphNode resultDescriptor,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
-		super( resultDescriptor, null, initializerConsumer, creationState );
+		super( resultDescriptor, null, creationState );
 	}
 
 	@Override
 	public Object getParentKey() {
 		return null;
+	}
+
+	@Override
+	public String toString() {
+		return "EmbeddableResultInitializer(" + getNavigablePath() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity;
 
-import java.util.function.Consumer;
-
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.EntityValuedModelPart;
 import org.hibernate.query.NavigablePath;
@@ -17,7 +15,6 @@ import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
 import org.hibernate.sql.results.graph.Fetchable;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.entity.internal.EntityAssembler;
 
 /**
@@ -64,19 +61,13 @@ public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent imp
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		final EntityInitializer entityInitializer = getEntityInitializer(
-				parentAccess,
-				collector,
-				creationState
-		);
+		final EntityInitializer entityInitializer = getEntityInitializer( parentAccess, creationState );
 		return new EntityAssembler( getFetchedMapping().getJavaTypeDescriptor(), entityInitializer );
 	}
 
 	protected abstract EntityInitializer getEntityInitializer(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityAssembler.java
@@ -18,6 +18,7 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 public class EntityAssembler implements DomainResultAssembler {
 	private final JavaTypeDescriptor javaTypeDescriptor;
 	private final EntityInitializer initializer;
+	private EntityInitializer replacedInitializer;
 
 	public EntityAssembler(
 			JavaTypeDescriptor javaTypeDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchDelayedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchDelayedImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.internal.SingularAssociationAttributeMapping;
@@ -17,7 +15,6 @@ import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.entity.EntityInitializer;
 
 /**
@@ -57,14 +54,16 @@ public class EntityFetchDelayedImpl extends AbstractNonJoinedEntityFetch {
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		final EntityInitializer entityInitializer = new EntityFetchDelayedInitializer(
+		final EntityInitializer entityInitializer = (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getEntityValuedModelPart().getEntityMappingType().getEntityPersister(),
-				keyResult.createResultAssembler( collector, creationState )
+				() -> new EntityFetchDelayedInitializer(
+						getNavigablePath(),
+						getEntityValuedModelPart().getEntityMappingType().getEntityPersister(),
+						keyResult.createResultAssembler( creationState )
+				)
 		);
-		collector.accept( entityInitializer );
+
 		return new EntityAssembler( getFetchedMapping().getJavaTypeDescriptor(), entityInitializer );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.query.NavigablePath;
@@ -15,7 +13,6 @@ import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.entity.AbstractNonLazyEntityFetch;
 import org.hibernate.sql.results.graph.entity.EntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityValuedFetchable;
@@ -49,17 +46,18 @@ public class EntityFetchJoinedImpl extends AbstractNonLazyEntityFetch {
 	@Override
 	protected EntityInitializer getEntityInitializer(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
-		return new EntityJoinedFetchInitializer(
-				entityResult,
+		return (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				lockMode,
-				entityResult.getIdentifierResult(),
-				entityResult.getDiscriminatorResult(),
-				entityResult.getVersionResult(),
-				collector,
-				creationState
+				() -> new EntityJoinedFetchInitializer(
+						entityResult,
+						getNavigablePath(),
+						lockMode,
+						entityResult.getIdentifierResult(),
+						entityResult.getDiscriminatorResult(),
+						entityResult.getVersionResult(),
+						creationState
+				)
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.internal.SingularAssociationAttributeMapping;
@@ -18,7 +16,7 @@ import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.entity.EntityInitializer;
 
 /**
  * An eager entity fetch performed as a subsequent (n+1) select
@@ -53,22 +51,17 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 	}
 
 	@Override
-	public DomainResultAssembler createAssembler(
-			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
-			AssemblerCreationState creationState) {
-		final EntitySelectFetchInitializer initializer = new EntitySelectFetchInitializer(
+	public DomainResultAssembler createAssembler(FetchParentAccess parentAccess, AssemblerCreationState creationState) {
+		final EntityInitializer initializer = (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getReferencedMappingContainer().getEntityPersister(),
-				result.createResultAssembler( collector, creationState ),
-				nullable
+				() -> new EntitySelectFetchInitializer(
+						getNavigablePath(),
+						getReferencedMappingContainer().getEntityPersister(),
+						result.createResultAssembler( creationState ),
+						nullable
+				)
 		);
 
-		collector.accept( initializer );
-
-		return new EntityAssembler(
-				getResultJavaTypeDescriptor(),
-				initializer
-		);
+		return new EntityAssembler( getResultJavaTypeDescriptor(), initializer );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityJoinedFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityJoinedFetchInitializer.java
@@ -6,21 +6,19 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
 import org.hibernate.internal.log.LoggingHelper;
-import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
-import org.hibernate.sql.results.graph.Initializer;
 
 /**
  * @author Andrea Boriero
  */
 public class EntityJoinedFetchInitializer extends AbstractEntityInitializer {
+	private static final String CONCRETE_NAME = EntityJoinedFetchInitializer.class.getSimpleName();
 
 	protected EntityJoinedFetchInitializer(
 			EntityResultGraphNode resultDescriptor,
@@ -29,7 +27,6 @@ public class EntityJoinedFetchInitializer extends AbstractEntityInitializer {
 			DomainResult<?> identifierResult,
 			DomainResult<?> discriminatorResult,
 			DomainResult<?> versionResult,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		super(
 				resultDescriptor,
@@ -38,9 +35,13 @@ public class EntityJoinedFetchInitializer extends AbstractEntityInitializer {
 				identifierResult,
 				discriminatorResult,
 				versionResult,
-				initializerConsumer,
 				creationState
 		);
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override
@@ -50,6 +51,6 @@ public class EntityJoinedFetchInitializer extends AbstractEntityInitializer {
 
 	@Override
 	public String toString() {
-		return "EntityFetchInitializer(" + LoggingHelper.toLoggableString( getNavigablePath() ) + ")";
+		return "EntityJoinedFetchInitializer(" + LoggingHelper.toLoggableString( getNavigablePath() ) + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.EntityValuedModelPart;
 import org.hibernate.query.NavigablePath;
@@ -16,6 +14,7 @@ import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchableContainer;
 import org.hibernate.sql.results.graph.entity.AbstractEntityResultGraphNode;
+import org.hibernate.sql.results.graph.entity.EntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 
 /**
@@ -68,20 +67,18 @@ public class EntityResultImpl extends AbstractEntityResultGraphNode implements E
 	}
 
 	@Override
-	public DomainResultAssembler createResultAssembler(
-			Consumer initializerCollector,
-			AssemblerCreationState creationState) {
-		// todo (6.0) : seems like here is where we ought to determine the SQL selection mappings
-
-		final EntityResultInitializer initializer = new EntityResultInitializer(
-				this,
+	public DomainResultAssembler createResultAssembler(AssemblerCreationState creationState) {
+		final EntityInitializer initializer = (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getLockMode(),
-				getIdentifierResult(),
-				getDiscriminatorResult(),
-				getVersionResult(),
-				initializerCollector,
-				creationState
+				() -> new EntityResultInitializer(
+						this,
+						getNavigablePath(),
+						getLockMode(),
+						getIdentifierResult(),
+						getDiscriminatorResult(),
+						getVersionResult(),
+						creationState
+				)
 		);
 
 		return new EntityAssembler( getResultJavaTypeDescriptor(), initializer );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultInitializer.java
@@ -6,15 +6,13 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
-import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.collection.internal.MapInitializer;
+import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
-import org.hibernate.sql.results.graph.Initializer;
 
 /**
  * Initializer for cases where the entity is a root domain selection
@@ -22,6 +20,8 @@ import org.hibernate.sql.results.graph.Initializer;
  * @author Steve Ebersole
  */
 public class EntityResultInitializer extends AbstractEntityInitializer {
+	private static final String CONCRETE_NAME = EntityResultInitializer.class.getSimpleName();
+
 	public EntityResultInitializer(
 			EntityResultGraphNode resultDescriptor,
 			NavigablePath navigablePath,
@@ -29,7 +29,6 @@ public class EntityResultInitializer extends AbstractEntityInitializer {
 			DomainResult identifierResult,
 			DomainResult discriminatorResult,
 			DomainResult versionResult,
-			Consumer<Initializer> initializerConsumer,
 			AssemblerCreationState creationState) {
 		super(
 				resultDescriptor,
@@ -38,9 +37,13 @@ public class EntityResultInitializer extends AbstractEntityInitializer {
 				identifierResult,
 				discriminatorResult,
 				versionResult,
-				initializerConsumer,
 				creationState
 		);
+	}
+
+	@Override
+	protected String getSimpleConcreteImplName() {
+		return CONCRETE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultJoinedSubclassImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityResultJoinedSubclassImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.results.graph.entity.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.EntityValuedModelPart;
@@ -17,6 +15,7 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.entity.EntityInitializer;
 
 /**
  * @author Andrea Boriero
@@ -31,20 +30,18 @@ public class EntityResultJoinedSubclassImpl extends EntityResultImpl {
 	}
 
 	@Override
-	public DomainResultAssembler createResultAssembler(
-			Consumer initializerCollector,
-			AssemblerCreationState creationState) {
-		// todo (6.0) : seems like here is where we ought to determine the SQL selection mappings
-
-		final EntityResultInitializer initializer = new EntityResultInitializer(
-				this,
+	public DomainResultAssembler createResultAssembler(AssemblerCreationState creationState) {
+		final EntityInitializer initializer = (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getLockMode(),
-				getIdentifierResult(),
-				getDiscriminatorResult(),
-				getVersionResult(),
-				initializerCollector,
-				creationState
+				() -> new EntityResultInitializer(
+						this,
+						getNavigablePath(),
+						getLockMode(),
+						getIdentifierResult(),
+						getDiscriminatorResult(),
+						getVersionResult(),
+						creationState
+				)
 		);
 
 		return new EntityAssembler( getResultJavaTypeDescriptor(), initializer );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/RootEntityResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/RootEntityResultImpl.java
@@ -26,6 +26,8 @@ import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchableContainer;
+import org.hibernate.sql.results.graph.Initializer;
+import org.hibernate.sql.results.graph.entity.EntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
@@ -186,20 +188,20 @@ public class RootEntityResultImpl extends AbstractFetchParent implements EntityR
 	}
 
 	@Override
-	public DomainResultAssembler createResultAssembler(
-			Consumer initializerCollector,
-			AssemblerCreationState creationState) {
+	public DomainResultAssembler createResultAssembler(AssemblerCreationState creationState) {
 		// todo (6.0) : seems like here is where we ought to determine the SQL selection mappings
 
-		final EntityResultInitializer initializer = new EntityResultInitializer(
-				this,
+		final EntityInitializer initializer = (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getLockMode(),
-				null,
-				getDiscriminatorResult(),
-				getVersionResult(),
-				initializerCollector,
-				creationState
+				() -> new EntityResultInitializer(
+						this,
+						getNavigablePath(),
+						getLockMode(),
+						null,
+						getDiscriminatorResult(),
+						getVersionResult(),
+						creationState
+				)
 		);
 
 		return new EntityAssembler( getResultJavaTypeDescriptor(), initializer );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/ArgumentDomainResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/ArgumentDomainResult.java
@@ -6,11 +6,8 @@
  */
 package org.hibernate.sql.results.graph.instantiation.internal;
 
-import java.util.function.Consumer;
-
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
@@ -35,11 +32,10 @@ public class ArgumentDomainResult<A> implements DomainResult<A> {
 
 	@Override
 	public ArgumentReader<A> createResultAssembler(
-			Consumer<Initializer> initializerCollector,
 			AssemblerCreationState creationState) {
 		//noinspection unchecked
 		return new ArgumentReader(
-				realDomainResult.createResultAssembler( initializerCollector, creationState ),
+				realDomainResult.createResultAssembler( creationState ),
 				getResultVariable()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.query.DynamicInstantiationNature;
@@ -19,7 +18,6 @@ import org.hibernate.query.sqm.tree.expression.Compatibility;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.instantiation.DynamicInstantiationResult;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 import org.jboss.logging.Logger;
@@ -58,9 +56,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 	}
 
 	@Override
-	public DomainResultAssembler<R> createResultAssembler(
-			Consumer<Initializer> initializerConsumer,
-			AssemblerCreationState creationState) {
+	public DomainResultAssembler<R> createResultAssembler(AssemblerCreationState creationState) {
 		boolean areAllArgumentsAliased = true;
 		boolean areAnyArgumentsAliased = false;
 		final Set<String> aliases = new HashSet<>();
@@ -84,7 +80,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 				}
 
 				argumentReaders.add(
-						argumentResult.createResultAssembler( initializerConsumer, creationState )
+						argumentResult.createResultAssembler( creationState )
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/LoadingCollectionEntryImpl.java
@@ -87,7 +87,7 @@ public class LoadingCollectionEntryImpl implements LoadingCollectionEntry {
 		final PersistenceContext persistenceContext = session.getPersistenceContext();
 		final CollectionPersister collectionDescriptor = getCollectionDescriptor();
 
-		Helper.finalizeCollectionLoading( persistenceContext, collectionDescriptor, collectionInstance, getKey() );
+		ResultsHelper.finalizeCollectionLoading( persistenceContext, collectionDescriptor, collectionInstance, getKey() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/BiDirectionalFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/BiDirectionalFetchImpl.java
@@ -6,10 +6,7 @@
  */
 package org.hibernate.sql.results.internal.domain;
 
-import java.util.function.Consumer;
-
 import org.hibernate.LockMode;
-import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.engine.FetchStrategy;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.spi.CollectionKey;
@@ -91,7 +88,6 @@ public class BiDirectionalFetchImpl implements BiDirectionalFetch, Association {
 	@Override
 	public DomainResultAssembler createAssembler(
 			FetchParentAccess parentAccess,
-			Consumer<Initializer> collector,
 			AssemblerCreationState creationState) {
 		return new CircularFetchAssembler(
 				fetchable,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/StandardJdbcValuesMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/StandardJdbcValuesMapping.java
@@ -7,14 +7,12 @@
 package org.hibernate.sql.results.jdbc.internal;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
 
 /**
@@ -42,17 +40,12 @@ public class StandardJdbcValuesMapping implements JdbcValuesMapping {
 	}
 
 	@Override
-	public List<DomainResultAssembler> resolveAssemblers(
-			Consumer<Initializer> initializerConsumer,
-			AssemblerCreationState creationState) {
+	public List<DomainResultAssembler> resolveAssemblers(AssemblerCreationState creationState) {
 		final List<DomainResultAssembler> assemblers = CollectionHelper.arrayList( domainResults.size() );
 
 		//noinspection ForLoopReplaceableByForEach
 		for ( int i = 0; i < domainResults.size(); i++ ) {
-			final DomainResultAssembler resultAssembler = domainResults.get( i ).createResultAssembler(
-					initializerConsumer,
-					creationState
-			);
+			final DomainResultAssembler resultAssembler = domainResults.get( i ).createResultAssembler( creationState );
 
 			assemblers.add( resultAssembler );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMapping.java
@@ -7,12 +7,10 @@
 package org.hibernate.sql.results.jdbc.spi;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
-import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.ast.spi.SqlSelection;
 
 /**
@@ -33,7 +31,5 @@ public interface JdbcValuesMapping {
 
 	List<DomainResult> getDomainResults();
 
-	List<DomainResultAssembler> resolveAssemblers(
-			Consumer<Initializer> initializerConsumer,
-			AssemblerCreationState creationState);
+	List<DomainResultAssembler> resolveAssemblers(AssemblerCreationState creationState);
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/plan/LoadPlanBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/plan/LoadPlanBuilderTest.java
@@ -123,7 +123,7 @@ public class LoadPlanBuilderTest {
 				.getDomainResultDescriptors()
 				.get( 0 );
 
-		DomainResultGraphPrinter.print( loader.getSqlAst().getDomainResultDescriptors() );
+		DomainResultGraphPrinter.logDomainResultGraph( loader.getSqlAst().getDomainResultDescriptors() );
 
 		assertThat( domainResult.getFetches(), isEmpty() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -200,10 +200,7 @@ public class SmokeTests {
 
 					// ScalarDomainResultImpl creates and caches the assembler at its creation.
 					// this just gets access to that cached one
-					final DomainResultAssembler resultAssembler = domainResult.createResultAssembler(
-							null,
-							null
-					);
+					final DomainResultAssembler resultAssembler = domainResult.createResultAssembler( null );
 
 					assertThat( resultAssembler, instanceOf( BasicResultAssembler.class ) );
 					final BasicValueConverter valueConverter = ( (BasicResultAssembler) resultAssembler ).getValueConverter();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/BasicResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/BasicResultTests.java
@@ -28,7 +28,7 @@ public class BasicResultTests extends AbstractResultTests {
 				"select s.id, s.someString, s.someLong from SimpleEntity s",
 				scope.getSessionFactory()
 		);
-		DomainResultGraphPrinter.print( sqlAst.getDomainResultDescriptors() );
+		DomainResultGraphPrinter.logDomainResultGraph( sqlAst.getDomainResultDescriptors() );
 
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/EmbeddableResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/EmbeddableResultTests.java
@@ -28,6 +28,6 @@ public class EmbeddableResultTests extends AbstractResultTests {
 				"select e from EntityOfComposites e join fetch e.component c join fetch c.nested",
 				scope.getSessionFactory()
 		);
-		DomainResultGraphPrinter.print( interpretation.getDomainResultDescriptors() );
+		DomainResultGraphPrinter.logDomainResultGraph( interpretation.getDomainResultDescriptors() );
 	}
 }

--- a/hibernate-core/src/test/resources/log4j.properties
+++ b/hibernate-core/src/test/resources/log4j.properties
@@ -9,6 +9,11 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
 
+log4j.appender.stdout2=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout2.Target=System.out
+log4j.appender.stdout2.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout2.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
+
 log4j.appender.unclosedSessionFactoryFile=org.apache.log4j.FileAppender
 log4j.appender.unclosedSessionFactoryFile.append=true
 log4j.appender.unclosedSessionFactoryFile.file=target/tmp/log/UnclosedSessionFactoryWarnings.log
@@ -16,6 +21,11 @@ log4j.appender.unclosedSessionFactoryFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.unclosedSessionFactoryFile.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L - %m%n
 
 log4j.rootLogger=info, stdout
+
+log4j.logger.org.hibernate.orm=debug, stdout2
+log4j.additivity.org.hibernate.orm=false
+
+log4j.logger.org.hibernate.orm.sql.results=debug
 
 log4j.logger.org.hibernate.orm.graph=debug
 log4j.logger.org.hibernate.orm.query.sqm=debug


### PR DESCRIPTION
The main gist is the addition of the following method:

```
public interface AssemblerCreationState {
	Initializer resolveInitializer(NavigablePath navigablePath, Supplier<Initializer> producer);
	...
}
```

as opposed to simply passing a "initializer collector" into the Assembler/Initializer creators