### PR TITLE
HHH-14062 bug fix about logic to determine remaining transaction timeout period

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -244,7 +244,7 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 			return -1;
 		}
 		final int secondsRemaining = (int) ((transactionTimeOutInstant - System.currentTimeMillis()) / 1000);
-		if ( secondsRemaining <= 0 ) {
+		if ( secondsRemaining < 0 ) {
 			throw new TransactionException( "transaction timeout expired" );
 		}
 		return secondsRemaining;


### PR DESCRIPTION
- bug was an issue that caused an exception unconditionally when the transaction timeout was set to 1