### PR TITLE
wip/6.0 Enable entity graph parser test cases

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/fetching/GraphParsingTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/fetching/GraphParsingTest.java
@@ -16,7 +16,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.TypedQuery;
 
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.graph.AbstractEntityGraphTest;
+import org.hibernate.orm.test.loading.entitygraph.parser.AbstractEntityGraphTest;
 import org.hibernate.graph.GraphParser;
 import org.hibernate.graph.EntityGraphs;
 import org.hibernate.graph.GraphSemantic;

--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageLexer.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageLexer.g4
@@ -39,17 +39,30 @@ RPAREN: ')';
 /**
  * In this grammar, basically any string since we (atm) have no keywords
  */
-NAME : NAME_START ( NAME_CONTINUATION )*;
+ATTR_NAME : ATTR_NAME_START NAME_CONTINUATION*;
 
-fragment NAME_START
-    :    '_'
+TYPE_NAME : TYPE_NAME_START NAME_CONTINUATION*;
+
+fragment NON_ALPHANUM_EXTENTION
+	:    '_'
     |    '$'
-    |    'a'..'z'
     // HHH-558 : Allow unicode chars in identifiers
     //|    '\u0080'..'\ufffe'
     ;
 
+fragment ATTR_NAME_START
+    :    NON_ALPHANUM_EXTENTION
+    |    'a'..'z'
+    ;
+
+fragment TYPE_NAME_START
+    :    NON_ALPHANUM_EXTENTION
+    |    'A'..'Z'
+    ;
+
 fragment NAME_CONTINUATION
-    :    NAME_START
+    :    NON_ALPHANUM_EXTENTION
+    |    'a'..'z'
+    |    'A'..'Z'
     |    '0'..'9'
     ;

--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageParser.g4
@@ -33,15 +33,15 @@ attributeList
     ;
 
 attributeNode
-	: attributePath (subGraph)?
+	: attributePath subGraph?
 	;
 
 attributePath
-	: NAME attributeQualifier?
+	: ATTR_NAME attributeQualifier?
 	;
 
 attributeQualifier
-	: DOT NAME
+	: DOT ATTR_NAME
 	;
 
 subGraph
@@ -49,5 +49,5 @@ subGraph
 	;
 
 subType
-	: NAME
+	: TYPE_NAME
 	;

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
@@ -77,7 +77,7 @@ public class GraphParser extends GraphLanguageParserBaseVisitor {
 
 	@Override
 	public AttributeNodeImplementor visitAttributeNode(GraphLanguageParser.AttributeNodeContext ctx) {
-		final String attributeName = ctx.attributePath().NAME().getText();
+		final String attributeName = ctx.attributePath().ATTR_NAME().getText();
 
 		final SubGraphGenerator subGraphCreator;
 
@@ -93,7 +93,7 @@ public class GraphParser extends GraphLanguageParserBaseVisitor {
 			subGraphCreator = PathQualifierType.VALUE.getSubGraphCreator();
 		}
 		else {
-			final String qualifierName = ctx.attributePath().attributeQualifier().NAME().getText();
+			final String qualifierName = ctx.attributePath().attributeQualifier().ATTR_NAME().getText();
 
 			if ( PARSING_LOGGER.isDebugEnabled() ) {
 				PARSING_LOGGER.debugf(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractManagedType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractManagedType.java
@@ -117,7 +117,7 @@ public abstract class AbstractManagedType<J>
 	@SuppressWarnings("unchecked")
 	public PersistentAttribute<? super J,?> getAttribute(String name) {
 		final PersistentAttribute attribute = findAttribute( name );
-		checkNotNull( "Attribute ", attribute, name );
+		checkNotNull( "Attribute", attribute, name );
 		return attribute;
 	}
 
@@ -164,7 +164,7 @@ public abstract class AbstractManagedType<J>
 	@SuppressWarnings("unchecked")
 	public PersistentAttribute<J,?> getDeclaredAttribute(String name) {
 		PersistentAttribute attr = findDeclaredAttribute( name );
-		checkNotNull( "Attribute ", attr, name );
+		checkNotNull( "Attribute", attr, name );
 		return attr;
 	}
 
@@ -209,7 +209,7 @@ public abstract class AbstractManagedType<J>
 	@SuppressWarnings("unchecked")
 	public SingularPersistentAttribute<? super J, ?> getSingularAttribute(String name) {
 		SingularPersistentAttribute attribute = findSingularAttribute( name );
-		checkNotNull( "SingularAttribute ", attribute, name );
+		checkNotNull( "SingularAttribute", attribute, name );
 		return attribute;
 	}
 
@@ -235,7 +235,7 @@ public abstract class AbstractManagedType<J>
 	@SuppressWarnings("unchecked")
 	public SingularAttribute<J, ?> getDeclaredSingularAttribute(String name) {
 		final SingularAttribute attr = findDeclaredSingularAttribute( name );
-		checkNotNull( "SingularAttribute ", attr, name );
+		checkNotNull( "SingularAttribute", attr, name );
 		return attr;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
@@ -29,7 +29,7 @@ public class DomainModelHelper {
 		}
 
 		// first, try to find it by name directly..
-		ManagedDomainType<S> subManagedType = jpaMetamodel.entity( subTypeName );
+		ManagedDomainType<S> subManagedType = jpaMetamodel.resolveHqlEntityReference( subTypeName );
 		if ( subManagedType != null ) {
 			return subManagedType;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/AbstractEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/AbstractEntityGraphTest.java
@@ -4,17 +4,17 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.graph;
+package org.hibernate.orm.test.loading.entitygraph.parser;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import javax.persistence.AttributeNode;
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.Subgraph;
 
+import org.hibernate.graph.GraphParser;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
@@ -28,7 +28,7 @@ public abstract class AbstractEntityGraphTest extends BaseEntityManagerFunctiona
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{ GraphParsingTestEntity.class, GraphParsingTestSubentity.class };
+		return new Class[]{ GraphParsingTestEntity.class, GraphParsingTestSubEntity.class };
 	}
 
 	protected <T> RootGraphImplementor<T> parseGraph(Class<T> entityType, String graphString) {
@@ -104,3 +104,4 @@ public abstract class AbstractEntityGraphTest extends BaseEntityManagerFunctiona
 	}
 
 }
+

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/EntityGraphParserTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/EntityGraphParserTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.graph;
+package org.hibernate.orm.test.loading.entitygraph.parser;
 
 import java.util.List;
 import java.util.Map;
@@ -15,6 +15,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.Subgraph;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.graph.GraphParser;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
@@ -191,7 +192,7 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 		//
 		// return type.isAssignableFrom( entityPersister.getMappedClass() );
 
-		RootGraphImplementor<GraphParsingTestEntity> graph = parseGraph( "linkToOne(name, description), linkToOne(GraphParsingTestSubentity: sub)" );
+		RootGraphImplementor<GraphParsingTestEntity> graph = parseGraph( "linkToOne(name, description), linkToOne(GraphParsingTestSubEntity: sub)" );
 		assertNotNull( graph );
 
 		List<AttributeNodeImplementor<?>> attrs = graph.getAttributeNodeImplementors();
@@ -204,7 +205,7 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 
 		assertNullOrEmpty( linkToOneNode.getKeySubgraphs() );
 
-		final SubGraphImplementor subGraph = linkToOneNode.getSubGraphMap().get( GraphParsingTestSubentity.class );
+		final SubGraphImplementor subGraph = linkToOneNode.getSubGraphMap().get( GraphParsingTestSubEntity.class );
 		assertNotNull( subGraph );
 
 		assertBasicAttributes( subGraph, "sub" );
@@ -215,12 +216,12 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 		EntityManager entityManager = getOrCreateEntityManager();
 		RootGraphImplementor<GraphParsingTestEntity> graph = ( (SessionImplementor) entityManager ).createEntityGraph(
 				GraphParsingTestEntity.class );
-		final SubGraphImplementor<GraphParsingTestSubentity> subGraph = graph.addSubGraph(
+		final SubGraphImplementor<GraphParsingTestSubEntity> subGraph = graph.addSubGraph(
 				"linkToOne",
-				GraphParsingTestSubentity.class
+				GraphParsingTestSubEntity.class
 		);
 
-		assertEquals( subGraph.getGraphedType().getJavaType(), GraphParsingTestSubentity.class );
+		assertEquals( subGraph.getGraphedType().getJavaType(), GraphParsingTestSubEntity.class );
 
 		final AttributeNodeImplementor<Object> subTypeAttrNode = subGraph.addAttributeNode( "sub" );
 		assert subTypeAttrNode != null;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/EntityGraphsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/EntityGraphsTest.java
@@ -4,10 +4,12 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.graph;
+package org.hibernate.orm.test.loading.entitygraph.parser;
 
 import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
+
+import org.hibernate.graph.EntityGraphs;
 
 import org.junit.Assert;
 import org.junit.Ignore;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/GraphParsingTestEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/GraphParsingTestEntity.java
@@ -1,7 +1,6 @@
-package org.hibernate.graph;
+package org.hibernate.orm.test.loading.entitygraph.parser;
 
 import java.util.Map;
-
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.ElementCollection;
@@ -11,7 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
-@Entity
+@Entity( name = "GraphParsingTestEntity" )
 public class GraphParsingTestEntity {
 
 	private String id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/GraphParsingTestSubEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/entitygraph/parser/GraphParsingTestSubEntity.java
@@ -1,10 +1,10 @@
-package org.hibernate.graph;
+package org.hibernate.orm.test.loading.entitygraph.parser;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 
-@Entity
-public class GraphParsingTestSubentity extends GraphParsingTestEntity {
+@Entity( name = "GraphParsingTestSubEntity" )
+public class GraphParsingTestSubEntity extends GraphParsingTestEntity {
 
 	private String sub;
 


### PR DESCRIPTION
The first step to entity graph verification. The following bugs were fixed:

1. ANTLR rule errors
2. entity graph subtype verification error