### PR TITLE
wip/6.0 Enrich CollectionHelper by adding LinkedHashMap and LinkedHashSet processing

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.persister.collection.CollectionPersister;
 
@@ -36,7 +37,7 @@ public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHash
 	public LinkedHashMap<?, ?> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return anticipatedSize < 1 ? new LinkedHashMap<>() : new LinkedHashMap<>( anticipatedSize );
+		return anticipatedSize < 1 ? CollectionHelper.linkedMap() : CollectionHelper.linkedMapOfSize( anticipatedSize );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.persister.collection.CollectionPersister;
 
@@ -36,7 +37,7 @@ public class StandardOrderedSetSemantics extends AbstractSetSemantics<LinkedHash
 	public LinkedHashSet<?> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return anticipatedSize < 1 ? new LinkedHashSet<>() : new LinkedHashSet<>( anticipatedSize );
+		return anticipatedSize < 1 ? CollectionHelper.linkedSet() : CollectionHelper.linkedSetOfSize( anticipatedSize );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -45,6 +45,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
@@ -105,7 +106,7 @@ public class ActionQueue {
 	 */
 	private static final LinkedHashMap<Class<? extends Executable>,ListProvider> EXECUTABLE_LISTS_MAP;
 	static {
-		EXECUTABLE_LISTS_MAP = new LinkedHashMap<>( 8 );
+		EXECUTABLE_LISTS_MAP = CollectionHelper.linkedMapOfSize( 8 );
 
 		EXECUTABLE_LISTS_MAP.put(
 				OrphanRemovalAction.class,

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.engine.spi;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -140,7 +139,7 @@ public class BatchFetchQueue {
 			}
 			final LinkedHashSet<EntityKey> keysForEntity = batchLoadableEntityKeys.computeIfAbsent(
 					key.getEntityName(),
-					k -> new LinkedHashSet<>( 8 )
+					k -> CollectionHelper.linkedSetOfSize( 8 )
 			);
 
 			keysForEntity.add( key );
@@ -260,7 +259,7 @@ public class BatchFetchQueue {
 
 		final LinkedHashMap<CollectionEntry, PersistentCollection> map =  batchLoadableCollections.computeIfAbsent(
 				persister.getRole(),
-				k -> new LinkedHashMap<>( 16 )
+				k -> CollectionHelper.linkedMapOfSize( 16 )
 		);
 
 		map.put( ce, collection );

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
@@ -11,7 +11,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -19,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
- * Various help for handling collections.
+ * Various helper util methods for handling collections.
  *
  * @author Gavin King
  * @author Steve Ebersole
@@ -28,22 +29,6 @@ public final class CollectionHelper {
 	public static final int DEFAULT_LIST_CAPACITY = 10;
 	public static final int MINIMUM_INITIAL_CAPACITY = 16;
 	public static final float LOAD_FACTOR = 0.75f;
-
-	/**
-	 * @deprecated use  {@link java.util.Collections#EMPTY_LIST} or {@link java.util.Collections#emptyList()}  instead
-	 */
-	@Deprecated
-	public static final List EMPTY_LIST = Collections.EMPTY_LIST;
-	/**
-	 * @deprecated use {@link java.util.Collections#EMPTY_LIST} or {@link java.util.Collections#emptyList()}  instead
-	 */
-	@Deprecated
-	public static final Collection EMPTY_COLLECTION = Collections.EMPTY_LIST;
-	/**
-	 * @deprecated use {@link java.util.Collections#EMPTY_MAP} or {@link java.util.Collections#emptyMap()}  instead
-	 */
-	@Deprecated
-	public static final Map EMPTY_MAP = Collections.EMPTY_MAP;
 
 	private CollectionHelper() {
 	}
@@ -62,6 +47,37 @@ public final class CollectionHelper {
 	}
 
 	/**
+	 * Build a properly sized linked map, especially handling load size and load factor to prevent immediate resizing.
+	 * <p/>
+	 * Especially helpful for copy map contents.
+	 *
+	 * @param size The size to make the map.
+	 *
+	 * @return The sized linked map.
+	 */
+	public static <K, V> LinkedHashMap<K, V> linkedMapOfSize(int size) {
+		return new LinkedHashMap<>( determineProperSizing( size ), LOAD_FACTOR );
+	}
+
+	/**
+	 * Build a map whose size is unknown.
+	 *
+	 * @return The map.
+	 */
+	public static <K, V> HashMap<K, V> map() {
+		return new HashMap<>();
+	}
+
+	/**
+	 * Build a linked map whose size is unknown.
+	 *
+	 * @return The linked map.
+	 */
+	public static <K, V> LinkedHashMap<K, V> linkedMap() {
+		return new LinkedHashMap<>();
+	}
+
+	/**
 	 * Build a properly sized set, especially handling load size and load factor to prevent immediate resizing.
 	 * <p/>
 	 * Especially helpful for copy set contents.
@@ -72,6 +88,37 @@ public final class CollectionHelper {
 	 */
 	public static <K> HashSet<K> setOfSize(int size) {
 		return new HashSet<>( determineProperSizing( size ), LOAD_FACTOR );
+	}
+
+	/**
+	 * Build a set whose size is unknown.
+	 *
+	 * @return The set.
+	 */
+	public static <K> HashSet<K> set() {
+		return new HashSet<>();
+	}
+
+	/**
+	 * Build a properly sized linked set, especially handling load size and load factor to prevent immediate resizing.
+	 * <p/>
+	 * Especially helpful for copy set contents.
+	 *
+	 * @param size The size to make the set.
+	 *
+	 * @return The sized linked set.
+	 */
+	public static <K> LinkedHashSet<K> linkedSetOfSize(int size) {
+		return new LinkedHashSet<>( determineProperSizing( size ), LOAD_FACTOR );
+	}
+
+	/**
+	 * Build a linked set whose size is unknown.
+	 *
+	 * @return The linked set.
+	 */
+	public static <K> LinkedHashSet<K> linkedSet() {
+		return new LinkedHashSet<>();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -530,10 +530,9 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		if ( persistentClass.isPolymorphic() ) {
 			subclassesByDiscriminatorValue.put( discriminatorValue, getEntityName() );
 
-			final int initialCapacity = CollectionHelper.determineProperSizing( subclassSpan + 1 );
-			discriminatorValuesByTableName = new LinkedHashMap<>( initialCapacity );
-			discriminatorColumnNameByTableName = new LinkedHashMap<>( initialCapacity );
-			subclassNameByTableName = new HashMap<>( initialCapacity );
+			discriminatorValuesByTableName = CollectionHelper.linkedMapOfSize( subclassSpan + 1 );
+			discriminatorColumnNameByTableName = CollectionHelper.linkedMapOfSize( subclassSpan + 1 );
+			subclassNameByTableName = CollectionHelper.mapOfSize( subclassSpan + 1 );
 			// We need to convert the `discriminatorSQLString` (which is a String read from boot-mapping) into
 			// 	the type indicated by `#discriminatorType` (String -> Integer, e.g.).
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/type/OrderedMapType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OrderedMapType.java
@@ -5,8 +5,8 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type;
-import java.util.LinkedHashMap;
 
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -21,8 +21,8 @@ public class OrderedMapType extends MapType {
 	@Override
 	public Object instantiate(int anticipatedSize) {
 		return anticipatedSize > 0
-				? new LinkedHashMap( anticipatedSize )
-				: new LinkedHashMap();
+				? CollectionHelper.linkedMap()
+				: CollectionHelper.linkedMapOfSize( anticipatedSize );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/OrderedSetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OrderedSetType.java
@@ -5,8 +5,8 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type;
-import java.util.LinkedHashSet;
 
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -21,8 +21,8 @@ public class OrderedSetType extends SetType {
 	@Override
 	public Object instantiate(int anticipatedSize) {
 		return anticipatedSize > 0
-				? new LinkedHashSet( anticipatedSize )
-				: new LinkedHashSet();
+				? CollectionHelper.linkedSetOfSize( anticipatedSize )
+				: CollectionHelper.linkedSet();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/SetType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SetType.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.type;
 
-import java.util.HashSet;
-
 import org.hibernate.collection.internal.PersistentSet;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -39,7 +37,7 @@ public class SetType extends CollectionType {
 	@Override
 	public Object instantiate(int anticipatedSize) {
 		return anticipatedSize <= 0
-				? new HashSet()
+				? CollectionHelper.set()
 				: CollectionHelper.setOfSize( anticipatedSize );
 	}
 


### PR DESCRIPTION
This is the follow up of https://github.com/hibernate/hibernate-orm/pull/3279. In recent code review, it seems we need to tackle the common confusion in case of `LinkedHashMap` and `LinkedHashSet` counterparts.