### PR TITLE
HHH-13926 Only add statement to StaleStateException when hibernate.show_sql is true

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
@@ -67,8 +67,7 @@ public class Expectations {
 					throw new StaleStateException(
 							"Batch update returned unexpected row count from update ["
 									+ batchPosition + "]; actual row count: " + rowCount
-									+ "; expected: " + expectedRowCount + "; statement executed: "
-									+ statement
+									+ "; expected: " + expectedRowCount + statementMessage(statement)
 					);
 				}
 				if ( expectedRowCount < rowCount ) {
@@ -83,8 +82,7 @@ public class Expectations {
 		private void checkNonBatched(int rowCount, PreparedStatement statement) {
 			if ( expectedRowCount > rowCount ) {
 				throw new StaleStateException(
-						"Unexpected row count: " + rowCount + "; expected: " + expectedRowCount
-						+ "; statement executed: " + statement
+						"Unexpected row count: " + rowCount + "; expected: " + expectedRowCount + statementMessage(statement)
 				);
 			}
 			if ( expectedRowCount < rowCount ) {
@@ -103,6 +101,12 @@ public class Expectations {
 
 		protected int determineRowCount(int reportedRowCount, PreparedStatement statement) {
 			return reportedRowCount;
+		}
+
+		private static String statementMessage(PreparedStatement statement) {
+			return true // TODO How to get hibernate.show_sql value?
+					? "; statement executed: " + statement
+					: "";
 		}
 	}
 


### PR DESCRIPTION
Hello,

I would like to volunteer for [HHH-13926](https://hibernate.atlassian.net/browse/HHH-13926) (which I created 😌) but I could not figure out how I could [access a configuration property value (`hibernate.show_sql`) from `Expectations.java`](https://github.com/hibernate/hibernate-orm/pull/3455/files#diff-37035377848271db5df7e9bcbf1aba65R107).

Besides, I am not too familiar with Gradle and couldn't setup the project properly in IntelliJ IDEA so it might be hard to follow the guidelines…

```
➜  hibernate-orm git:(HHH-13926) ./gradlew idea

FAILURE: Build failed with an exception.

* Where:
Script '/Users/mickael/Workspace/hibernate-orm/gradle/publishing-repos.gradle' line: 12

* What went wrong:
A problem occurred evaluating script.
> Failed to apply plugin [id 'org.hibernate.build.maven-repo-auth']
   > Failed to parse template script (your template may contain an error or be trying to use expressions not currently supported): startup failed:
     GStringTemplateScript7.groovy: 2: illegal string body character after dollar sign;
        solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 2, column 42.
        plate() { return { out -> out << """Bios
                                      ^
     
     1 error


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 840ms
```

Any help would be appreciated!