### PR TITLE
Fix: Use data from cached parentsByChild in StatefulPersistenceContext

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1361,7 +1361,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 	private Object getParentsByChild(Object childEntity) {
 		if ( parentsByChild != null ) {
-			parentsByChild.get( childEntity );
+			return parentsByChild.get( childEntity );
 		}
 		return null;
 	}


### PR DESCRIPTION
Fixed usage of cache in StatefulPersistenceContext.

In [5.3](https://github.com/hibernate/hibernate-orm/commit/0d10174c236d4d73d7f64893819687a663ce1be7) a change was made that can be quite harmful to performance.

Please consider integrating this change for 5.4.19.Final