### PR TITLE
Avoid logging parameters when logging statements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
@@ -15,6 +15,7 @@ import org.hibernate.engine.jdbc.batch.spi.BatchKey;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.internal.CoreMessageLogger;
 
+import org.hibernate.resource.jdbc.spi.JdbcObserver;
 import org.jboss.logging.Logger;
 
 /**
@@ -108,6 +109,7 @@ public class BatchingBatch extends AbstractBatchImpl {
 
 	private void performExecution() {
 		LOG.debugf( "Executing batch size: %s", batchPosition );
+		final JdbcObserver observer = getJdbcCoordinator().getJdbcSessionOwner().getJdbcSessionContext().getObserver();
 		try {
 			for ( Map.Entry<String,PreparedStatement> entry : getStatements().entrySet() ) {
 				String sql = entry.getKey();
@@ -115,11 +117,11 @@ public class BatchingBatch extends AbstractBatchImpl {
 					final PreparedStatement statement = entry.getValue();
 					final int[] rowCounts;
 					try {
-						getJdbcCoordinator().getJdbcSessionOwner().getJdbcSessionContext().getObserver().jdbcExecuteBatchStart();
+						observer.jdbcExecuteBatchStart();
 						rowCounts = statement.executeBatch();
 					}
 					finally {
-						getJdbcCoordinator().getJdbcSessionOwner().getJdbcSessionContext().getObserver().jdbcExecuteBatchEnd();
+						observer.jdbcExecuteBatchEnd();
 					}
 					checkRowCounts( rowCounts, statement );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchingBatch.java
@@ -112,7 +112,7 @@ public class BatchingBatch extends AbstractBatchImpl {
 		final JdbcObserver observer = getJdbcCoordinator().getJdbcSessionOwner().getJdbcSessionContext().getObserver();
 		try {
 			for ( Map.Entry<String,PreparedStatement> entry : getStatements().entrySet() ) {
-				String sql = entry.getKey();
+				final String sql = entry.getKey();
 				try {
 					final PreparedStatement statement = entry.getValue();
 					final int[] rowCounts;
@@ -123,7 +123,7 @@ public class BatchingBatch extends AbstractBatchImpl {
 					finally {
 						observer.jdbcExecuteBatchEnd();
 					}
-					checkRowCounts( rowCounts, statement );
+					checkRowCounts( rowCounts, statement, sql );
 				}
 				catch ( SQLException e ) {
 					abortBatch();
@@ -142,13 +142,13 @@ public class BatchingBatch extends AbstractBatchImpl {
 		}
 	}
 
-	private void checkRowCounts(int[] rowCounts, PreparedStatement ps) throws SQLException, HibernateException {
+	private void checkRowCounts(int[] rowCounts, PreparedStatement ps, String statementSQL) throws SQLException, HibernateException {
 		final int numberOfRowCounts = rowCounts.length;
 		if ( batchPosition != 0 && numberOfRowCounts != batchPosition / getStatements().size() ) {
 			LOG.unexpectedRowCounts();
 		}
 		for ( int i = 0; i < numberOfRowCounts; i++ ) {
-			getKey().getExpectation().verifyOutcome( rowCounts[i], ps, i );
+			getKey().getExpectation().verifyOutcome( rowCounts[i], ps, i, statementSQL );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/NonBatchingBatch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/NonBatchingBatch.java
@@ -40,16 +40,17 @@ public class NonBatchingBatch extends AbstractBatchImpl {
 	public void addToBatch() {
 		notifyObserversImplicitExecution();
 		for ( Map.Entry<String,PreparedStatement> entry : getStatements().entrySet() ) {
+			final String statementSQL = entry.getKey();
 			try {
 				final PreparedStatement statement = entry.getValue();
 				final int rowCount = jdbcCoordinator.getResultSetReturn().executeUpdate( statement );
-				getKey().getExpectation().verifyOutcome( rowCount, statement, 0 );
+				getKey().getExpectation().verifyOutcome( rowCount, statement, 0, statementSQL );
 				jdbcCoordinator.getResourceRegistry().release( statement );
 				jdbcCoordinator.afterStatementExecution();
 			}
 			catch ( SQLException e ) {
 				abortBatch();
-				throw sqlExceptionHelper().convert( e, "could not execute non-batched batch statement", entry.getKey() );
+				throw sqlExceptionHelper().convert( e, "could not execute non-batched batch statement", statementSQL );
 			}
 			catch (JDBCException e) {
 				abortBatch();

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
@@ -23,10 +23,11 @@ public interface Expectation {
 	 * @param rowCount The RDBMS reported "number of rows affected".
 	 * @param statement The statement representing the operation
 	 * @param batchPosition The position in the batch (if batching)
+	 * @param statementSQL The SQL backing the prepared statement, for logging purposes
 	 * @throws SQLException Exception from the JDBC driver
 	 * @throws HibernateException Problem processing the outcome.
 	 */
-	public void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition) throws SQLException, HibernateException;
+	public void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String statementSQL) throws SQLException, HibernateException;
 
 	/**
 	 * Perform any special statement preparation.

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
@@ -45,17 +45,17 @@ public class Expectations {
 			}
 		}
 
-		public final void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition) {
+		public final void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String statementSQL) {
 			rowCount = determineRowCount( rowCount, statement );
 			if ( batchPosition < 0 ) {
-				checkNonBatched( rowCount, statement );
+				checkNonBatched( rowCount, statement, statementSQL );
 			}
 			else {
-				checkBatched( rowCount, batchPosition, statement );
+				checkBatched( rowCount, batchPosition, statement, statementSQL );
 			}
 		}
 
-		private void checkBatched(int rowCount, int batchPosition, PreparedStatement statement) {
+		private void checkBatched(int rowCount, int batchPosition, PreparedStatement statement, String statementSQL) {
 			if ( rowCount == -2 ) {
 				LOG.debugf( "Success of batch update unknown: %s", batchPosition );
 			}
@@ -68,7 +68,7 @@ public class Expectations {
 							"Batch update returned unexpected row count from update ["
 									+ batchPosition + "]; actual row count: " + rowCount
 									+ "; expected: " + expectedRowCount + "; statement executed: "
-									+ statement
+									+ statementSQL
 					);
 				}
 				if ( expectedRowCount < rowCount ) {
@@ -80,11 +80,11 @@ public class Expectations {
 			}
 		}
 
-		private void checkNonBatched(int rowCount, PreparedStatement statement) {
+		private void checkNonBatched(int rowCount, PreparedStatement statement, String statementSQL) {
 			if ( expectedRowCount > rowCount ) {
 				throw new StaleStateException(
 						"Unexpected row count: " + rowCount + "; expected: " + expectedRowCount
-						+ "; statement executed: " + statement
+						+ "; statement executed: " + statementSQL
 				);
 			}
 			if ( expectedRowCount < rowCount ) {
@@ -150,7 +150,7 @@ public class Expectations {
 	// Various Expectation instances ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	public static final Expectation NONE = new Expectation() {
-		public void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition) {
+		public void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String statementSQL) {
 			// explicitly doAfterTransactionCompletion no checking...
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectations.java
@@ -48,14 +48,14 @@ public class Expectations {
 		public final void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String statementSQL) {
 			rowCount = determineRowCount( rowCount, statement );
 			if ( batchPosition < 0 ) {
-				checkNonBatched( rowCount, statement, statementSQL );
+				checkNonBatched( rowCount, statementSQL );
 			}
 			else {
-				checkBatched( rowCount, batchPosition, statement, statementSQL );
+				checkBatched( rowCount, batchPosition, statementSQL );
 			}
 		}
 
-		private void checkBatched(int rowCount, int batchPosition, PreparedStatement statement, String statementSQL) {
+		private void checkBatched(int rowCount, int batchPosition, String statementSQL) {
 			if ( rowCount == -2 ) {
 				LOG.debugf( "Success of batch update unknown: %s", batchPosition );
 			}
@@ -80,7 +80,7 @@ public class Expectations {
 			}
 		}
 
-		private void checkNonBatched(int rowCount, PreparedStatement statement, String statementSQL) {
+		private void checkNonBatched(int rowCount, String statementSQL) {
 			if ( expectedRowCount > rowCount ) {
 				throw new StaleStateException(
 						"Unexpected row count: " + rowCount + "; expected: " + expectedRowCount

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -1218,7 +1218,7 @@ public abstract class AbstractCollectionPersister
 				Expectation expectation = Expectations.appropriateExpectation( getDeleteAllCheckStyle() );
 				boolean callable = isDeleteAllCallable();
 				boolean useBatch = expectation.canBeBatched();
-				String sql = getSQLDeleteString();
+				final String sql = getSQLDeleteString();
 				if ( useBatch ) {
 					if ( removeBatchKey == null ) {
 						removeBatchKey = new BasicBatchKey(
@@ -1249,7 +1249,7 @@ public abstract class AbstractCollectionPersister
 								.addToBatch();
 					}
 					else {
-						expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1 );
+						expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1, sql );
 					}
 				}
 				catch ( SQLException sqle ) {
@@ -1319,7 +1319,7 @@ public abstract class AbstractCollectionPersister
 						final PreparedStatement st;
 						boolean callable = isInsertCallable();
 						boolean useBatch = expectation.canBeBatched();
-						String sql = getSQLInsertRowString();
+						final String sql = getSQLInsertRowString();
 
 						if ( useBatch ) {
 							if ( recreateBatchKey == null ) {
@@ -1358,7 +1358,7 @@ public abstract class AbstractCollectionPersister
 							}
 							else {
 								expectation.verifyOutcome( jdbcCoordinator
-																.getResultSetReturn().executeUpdate( st ), st, -1 );
+																.getResultSetReturn().executeUpdate( st ), st, -1, sql );
 							}
 
 							collection.afterRowInsert( this, entry, i );
@@ -1435,7 +1435,7 @@ public abstract class AbstractCollectionPersister
 					final PreparedStatement st;
 					boolean callable = isDeleteCallable();
 					boolean useBatch = expectation.canBeBatched();
-					String sql = getSQLDeleteRowString();
+					final String sql = getSQLDeleteRowString();
 
 					if ( useBatch ) {
 						if ( deleteBatchKey == null ) {
@@ -1481,7 +1481,7 @@ public abstract class AbstractCollectionPersister
 									.addToBatch();
 						}
 						else {
-							expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1 );
+							expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1, sql );
 						}
 						count++;
 					}
@@ -1593,7 +1593,7 @@ public abstract class AbstractCollectionPersister
 							session.getJdbcCoordinator().getBatch( insertBatchKey ).addToBatch();
 						}
 						else {
-							expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1 );
+							expectation.verifyOutcome( session.getJdbcCoordinator().getResultSetReturn().executeUpdate( st ), st, -1, sql );
 						}
 						collection.afterRowInsert( this, entry, i );
 						count++;

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -309,7 +309,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 					expectation.verifyOutcome(
 							session.getJdbcCoordinator().getResultSetReturn().executeUpdate(
 									st
-							), st, -1
+							), st, -1, sql
 					);
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
@@ -269,7 +269,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 									expectation.verifyOutcome(
 											session.getJdbcCoordinator()
 													.getResultSetReturn()
-													.executeUpdate( st ), st, -1
+													.executeUpdate( st ), st, -1, sql
 									);
 								}
 							}
@@ -378,7 +378,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 								deleteExpectation.verifyOutcome(
 										session.getJdbcCoordinator()
 												.getResultSetReturn()
-												.executeUpdate( st ), st, -1
+												.executeUpdate( st ), st, -1, sql
 								);
 							}
 							count++;
@@ -450,7 +450,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 								insertExpectation.verifyOutcome(
 										session.getJdbcCoordinator()
 												.getResultSetReturn()
-												.executeUpdate( st ), st, -1
+												.executeUpdate( st ), st, -1, sql
 								);
 							}
 							count++;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2591,9 +2591,10 @@ public abstract class AbstractEntityPersister
 			Serializable id,
 			int tableNumber,
 			Expectation expectation,
-			PreparedStatement statement) throws HibernateException {
+			PreparedStatement statement,
+			String statementSQL) throws HibernateException {
 		try {
-			expectation.verifyOutcome( rows, statement, -1 );
+			expectation.verifyOutcome( rows, statement, -1, statementSQL );
 		}
 		catch (StaleStateException e) {
 			if ( !isNullableTable( tableNumber ) ) {
@@ -3251,7 +3252,7 @@ public abstract class AbstractEntityPersister
 					expectation.verifyOutcome(
 							session.getJdbcCoordinator()
 									.getResultSetReturn()
-									.executeUpdate( insert ), insert, -1
+									.executeUpdate( insert ), insert, -1, sql
 					);
 				}
 			}
@@ -3450,7 +3451,8 @@ public abstract class AbstractEntityPersister
 							id,
 							j,
 							expectation,
-							update
+							update,
+							sql
 					);
 				}
 
@@ -3575,7 +3577,8 @@ public abstract class AbstractEntityPersister
 							id,
 							j,
 							expectation,
-							delete
+							delete,
+							sql
 					);
 				}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/batch/BatchOptimisticLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/batch/BatchOptimisticLockingTest.java
@@ -92,6 +92,7 @@ public class BatchOptimisticLockingTest extends
 		}
 		catch (Exception expected) {
 			assertEquals( OptimisticLockException.class, expected.getClass());
+			assertEquals( "Batch update returned unexpected row count from update [1]; actual row count: 0; expected: 1; statement executed: update Person set name=?, version=? where id=? and version=?", expected.getMessage() );
 		}
 	}
 


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HHH-11082

I've been wondering if we should still give an option to log the parameters, but considering that this log message was just recently introduced: seems users have been happy enough without any log at all for many years. So I'm proposing to keep it simple.