### PR TITLE
HHH-14124 Entity graph (fetch graph) is incorrectly applied to query results beyond the first one

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -441,8 +441,10 @@ public abstract class Loader {
 						loadedKeys,
 						returnProxies
 				);
-				// Signal that a new row starts. Used in initializeEntitiesAndCollections
-				nullSeparatedHydratedObjects.add( null );
+				if ( nullSeparatedHydratedObjects != null ) {
+					// Signal that a new row starts. Used in initializeEntitiesAndCollections
+					nullSeparatedHydratedObjects.add( null );
+				}
 				if ( !keyToRead.equals( loadedKeys[0] ) ) {
 					throw new AssertionFailure(
 							String.format(
@@ -1051,8 +1053,10 @@ public abstract class Loader {
 					forcedResultTransformer
 			);
 			results.add( result );
-			// Signal that a new row starts. Used in initializeEntitiesAndCollections
-			nullSeparatedHydratedObjects.add( null );
+			if ( nullSeparatedHydratedObjects != null ) {
+				// Signal that a new row starts. Used in initializeEntitiesAndCollections
+				nullSeparatedHydratedObjects.add( null );
+			}
 			if ( createSubselects ) {
 				subselectResultKeys.add( keys );
 				keys = new EntityKey[entitySpan]; //can't reuse in this case

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -406,7 +406,7 @@ public abstract class Loader {
 		}
 
 		initializeEntitiesAndCollections(
-				hydratedObjects == null ? null : Collections.singletonList( hydratedObjects ),
+				hydratedObjects,
 				resultSet,
 				session,
 				queryParameters.isReadOnly( session )
@@ -423,7 +423,7 @@ public abstract class Loader {
 			final EntityKey keyToRead) throws HibernateException {
 
 		final int entitySpan = getEntityPersisters().length;
-		final List<List<Object>> hydratedObjectsPerRow = entitySpan == 0 ?
+		final List<Object> nullSeparatedHydratedObjects = entitySpan == 0 ?
 				null : new ArrayList<>( entitySpan );
 
 		Object result = null;
@@ -431,26 +431,18 @@ public abstract class Loader {
 
 		try {
 			do {
-				List<Object> hydratedObjects;
-				if ( hydratedObjectsPerRow == null ) {
-					hydratedObjects = null;
-				}
-				else {
-					hydratedObjects = new ArrayList<>( entitySpan );
-				}
 				Object loaded = getRowFromResultSet(
 						resultSet,
 						session,
 						queryParameters,
 						getLockModes( queryParameters.getLockOptions() ),
 						null,
-						hydratedObjects,
+						nullSeparatedHydratedObjects,
 						loadedKeys,
 						returnProxies
 				);
-				if ( hydratedObjects != null && !hydratedObjects.isEmpty() ) {
-					hydratedObjectsPerRow.add( hydratedObjects );
-				}
+				// Signal that a new row starts. Used in initializeEntitiesAndCollections
+				nullSeparatedHydratedObjects.add( null );
 				if ( !keyToRead.equals( loadedKeys[0] ) ) {
 					throw new AssertionFailure(
 							String.format(
@@ -476,7 +468,7 @@ public abstract class Loader {
 		}
 
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				nullSeparatedHydratedObjects,
 				resultSet,
 				session,
 				queryParameters.isReadOnly( session )
@@ -996,7 +988,7 @@ public abstract class Loader {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
 		final List<EntityKey[]> subselectResultKeys = createSubselects ? new ArrayList<>() : null;
-		final List<List<Object>> hydratedObjectsPerRow = entitySpan == 0 ? null : new ArrayList<>();
+		final List<Object> nullSeparatedHydratedObjectsPerRow = entitySpan == 0 ? null : new ArrayList<>();
 
 		final List results = getRowsFromResultSet(
 				rs,
@@ -1005,12 +997,12 @@ public abstract class Loader {
 				returnProxies,
 				forcedResultTransformer,
 				maxRows,
-				hydratedObjectsPerRow,
+				nullSeparatedHydratedObjectsPerRow,
 				subselectResultKeys
 		);
 
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				nullSeparatedHydratedObjectsPerRow,
 				rs,
 				session,
 				queryParameters.isReadOnly( session ),
@@ -1029,7 +1021,7 @@ public abstract class Loader {
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer,
 			int maxRows,
-			List<List<Object>> hydratedObjectsPerRow,
+			List<Object> nullSeparatedHydratedObjects,
 			List<EntityKey[]> subselectResultKeys) throws SQLException {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
@@ -1047,28 +1039,20 @@ public abstract class Loader {
 			if ( debugEnabled ) {
 				LOG.debugf( "Result set row: %s", count );
 			}
-			List<Object> hydratedObjects;
-			if ( hydratedObjectsPerRow == null ) {
-				hydratedObjects = null;
-			}
-			else {
-				hydratedObjects = new ArrayList<>( entitySpan );
-			}
 			Object result = getRowFromResultSet(
 					rs,
 					session,
 					queryParameters,
 					lockModesArray,
 					optionalObjectKey,
-					hydratedObjects,
+					nullSeparatedHydratedObjects,
 					keys,
 					returnProxies,
 					forcedResultTransformer
 			);
 			results.add( result );
-			if ( hydratedObjects != null && !hydratedObjects.isEmpty() ) {
-				hydratedObjectsPerRow.add( hydratedObjects );
-			}
+			// Signal that a new row starts. Used in initializeEntitiesAndCollections
+			nullSeparatedHydratedObjects.add( null );
 			if ( createSubselects ) {
 				subselectResultKeys.add( keys );
 				keys = new EntityKey[entitySpan]; //can't reuse in this case
@@ -1159,12 +1143,12 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<List<Object>> hydratedObjectsPerRow,
+			final List<Object> nullSeparatedHydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly) throws HibernateException {
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				nullSeparatedHydratedObjects,
 				resultSetId,
 				session,
 				readOnly,
@@ -1173,7 +1157,7 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<List<Object>> hydratedObjectsPerRow,
+			final List<Object> nullSeparatedHydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly,
@@ -1205,11 +1189,13 @@ public abstract class Loader {
 			post = null;
 		}
 
-		if ( hydratedObjectsPerRow != null && !hydratedObjectsPerRow.isEmpty() ) {
+		if ( nullSeparatedHydratedObjects != null && !nullSeparatedHydratedObjects.isEmpty() ) {
 			if ( LOG.isTraceEnabled() ) {
 				int hydratedObjectsSize = 0;
-				for ( List<Object> hydratedObjects : hydratedObjectsPerRow ) {
-					hydratedObjectsSize += hydratedObjects.size();
+				for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
+					if ( hydratedObject != null ) {
+						++hydratedObjectsSize;
+					}
 				}
 				LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
 			}
@@ -1222,17 +1208,21 @@ public abstract class Loader {
 				.listeners();
 
 			GraphImplementor<?> fetchGraphLoadContextToRestore = session.getFetchGraphLoadContext();
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
-					TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
+			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
+				if ( hydratedObject == null ) {
+					// This is a hack to signal that we're starting to process a new row
+
+					// HHH-14124: TwoPhaseLoad has nasty side-effects in order to handle sub-graphs.
+					// That's very fragile, but someone would need to spend much more time on this
+					// in order to implement it correctly, and apparently that's already been done in ORM 6.0.
+					// So for now, we'll just ensure side-effects (and whatever bugs they lead to)
+					// are limited to each row.
+					session.setFetchGraphLoadContext( fetchGraphLoadContextToRestore );
+
+					continue;
 				}
 
-				// HHH-14124: TwoPhaseLoad has nasty side-effects in order to handle sub-graphs.
-				// That's very fragile, but someone would need to spend much more time on this
-				// in order to implement it correctly, and apparently that's already been done in ORM 6.0.
-				// So for now, we'll just ensure side-effects (and whatever bugs they lead to)
-				// are limited to each row.
-				session.setFetchGraphLoadContext( fetchGraphLoadContextToRestore );
+				TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
 			}
 		}
 
@@ -1248,11 +1238,14 @@ public abstract class Loader {
 			}
 		}
 
-		if ( hydratedObjectsPerRow != null ) {
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
-					TwoPhaseLoad.afterInitialize( hydratedObject, session );
+		if ( nullSeparatedHydratedObjects != null ) {
+			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
+				if ( hydratedObject == null ) {
+					// This is a hack to signal that we're starting to process a new row
+					// Ignore
+					continue;
 				}
+				TwoPhaseLoad.afterInitialize( hydratedObject, session );
 			}
 		}
 
@@ -1261,21 +1254,24 @@ public abstract class Loader {
 		// endCollectionLoad to ensure the collection is in the
 		// persistence context.
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-		if ( hydratedObjectsPerRow != null && !hydratedObjectsPerRow.isEmpty() ) {
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
-					TwoPhaseLoad.postLoad( hydratedObject, session, post );
-					if ( afterLoadActions != null ) {
-						for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
-							final EntityEntry entityEntry = persistenceContext.getEntry( hydratedObject );
-							if ( entityEntry == null ) {
-								// big problem
-								throw new HibernateException(
-										"Could not locate EntityEntry immediately after two-phase load"
-								);
-							}
-							afterLoadAction.afterLoad( session, hydratedObject, (Loadable) entityEntry.getPersister() );
+		if ( nullSeparatedHydratedObjects != null && !nullSeparatedHydratedObjects.isEmpty() ) {
+			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
+				if ( hydratedObject == null ) {
+					// This is a hack to signal that we're starting to process a new row
+					// Ignore
+					continue;
+				}
+				TwoPhaseLoad.postLoad( hydratedObject, session, post );
+				if ( afterLoadActions != null ) {
+					for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
+						final EntityEntry entityEntry = persistenceContext.getEntry( hydratedObject );
+						if ( entityEntry == null ) {
+							// big problem
+							throw new HibernateException(
+									"Could not locate EntityEntry immediately after two-phase load"
+							);
 						}
+						afterLoadAction.afterLoad( session, hydratedObject, (Loadable) entityEntry.getPersister() );
 					}
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
@@ -186,7 +186,10 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 					assertFalse( Hibernate.isInitialized( cEntity.getC() ) );
 					assertFalse( Hibernate.isInitialized( cEntity.getdList() ) );
 
-					assertEquals( 1L, statistics.getPrepareStatementCount() );
+					assertTrue( Hibernate.isInitialized( cEntity.getEagerC() ) );
+
+					// 1 + 1 for the eager C
+					assertEquals( 2L, statistics.getPrepareStatementCount() );
 				} );
 	}
 
@@ -217,7 +220,12 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 						assertTrue( Hibernate.isInitialized( dEntity.getE() ) );
 					} );
 
-					assertEquals( 1L, statistics.getPrepareStatementCount() );
+					// With LOAD semantic, attributes that are not mentioned in the graph are LAZY or EAGER,
+					// depending on the mapping.
+					assertTrue( Hibernate.isInitialized( cEntity.getEagerC() ) );
+
+					// 1 + 1 for the eager C
+					assertEquals( 2L, statistics.getPrepareStatementCount() );
 				} );
 	}
 
@@ -246,6 +254,10 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 					cEntity.getdList().forEach( dEntity -> {
 						assertTrue( Hibernate.isInitialized( dEntity.getE() ) );
 					} );
+
+					// With FETCH semantic, attributes that are not mentioned in the graph are LAZY,
+					// even if they were EAGER in the mapping.
+					assertFalse( Hibernate.isInitialized( cEntity.getEagerC() ) );
 
 					assertEquals( 1L, statistics.getPrepareStatementCount() );
 				} );
@@ -366,6 +378,9 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 		@ManyToOne(fetch = FetchType.LAZY)
 		private CEntity c;
 
+		@OneToOne(fetch = FetchType.EAGER)
+		private CEntity eagerC;
+
 		@OneToMany(
 				fetch = FetchType.LAZY,
 				mappedBy = "c",
@@ -417,6 +432,14 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 
 		public void setC(CEntity c) {
 			this.c = c;
+		}
+
+		public CEntity getEagerC() {
+			return eagerC;
+		}
+
+		public void setEagerC(CEntity eagerC) {
+			this.eagerC = eagerC;
 		}
 
 		public List<DEntity> getdList() {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.jpa.test.graphs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.persistence.CascadeType;
@@ -17,6 +18,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.TypedQuery;
 
@@ -62,110 +64,119 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Before
 	public void setUp() {
-		doInJPA(
-				this::entityManagerFactory, entityManager -> {
-					AEntity a1 = new AEntity();
-					a1.setId( 1 );
-					a1.setLabel( "A1" );
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			// Create the model twice, with different IDs,
+			// because we also need to test what happens when multiple results are loaded by a query.
+			for ( int offset : new int[]{ 0, 10000 } ) {
+				AEntity a1 = new AEntity();
+				a1.setId( offset + 1 );
+				a1.setLabel( "A1" );
 
-					AEntity a2 = new AEntity();
-					a2.setId( 2 );
-					a2.setLabel( "A2" );
+				AEntity a2 = new AEntity();
+				a2.setId( offset + 2 );
+				a2.setLabel( "A2" );
 
-					entityManager.persist( a1 );
-					entityManager.persist( a2 );
+				entityManager.persist( a1 );
+				entityManager.persist( a2 );
 
-					BEntity b1 = new BEntity();
-					b1.setId( 1 );
-					b1.setLabel( "B1" );
+				BEntity b1 = new BEntity();
+				b1.setId( offset + 1 );
+				b1.setLabel( "B1" );
 
-					BEntity b2 = new BEntity();
-					b2.setId( 2 );
-					b2.setLabel( "B2" );
+				BEntity b2 = new BEntity();
+				b2.setId( offset + 2 );
+				b2.setLabel( "B2" );
 
-					entityManager.persist( b1 );
-					entityManager.persist( b2 );
+				entityManager.persist( b1 );
+				entityManager.persist( b2 );
 
-					EEntity e1 = new EEntity();
-					e1.setId( 1 );
-					e1.setLabel( "E1" );
+				EEntity e1 = new EEntity();
+				e1.setId( offset + 1 );
+				e1.setLabel( "E1" );
 
-					EEntity e2 = new EEntity();
-					e2.setId( 2 );
-					e2.setLabel( "E2" );
+				EEntity e2 = new EEntity();
+				e2.setId( offset + 2 );
+				e2.setLabel( "E2" );
 
-					EEntity e3 = new EEntity();
-					e3.setId( 3 );
-					e3.setLabel( "E3" );
+				EEntity e3 = new EEntity();
+				e3.setId( offset + 3 );
+				e3.setLabel( "E3" );
 
-					EEntity e4 = new EEntity();
-					e4.setId( 4 );
-					e4.setLabel( "E4" );
+				EEntity e4 = new EEntity();
+				e4.setId( offset + 4 );
+				e4.setLabel( "E4" );
 
-					entityManager.persist( e1 );
-					entityManager.persist( e2 );
-					entityManager.persist( e3 );
-					entityManager.persist( e4 );
+				entityManager.persist( e1 );
+				entityManager.persist( e2 );
+				entityManager.persist( e3 );
+				entityManager.persist( e4 );
 
-					DEntity d1 = new DEntity();
-					d1.setId( 1 );
-					d1.setLabel( "D1" );
-					d1.setE( e1 );
+				DEntity d1 = new DEntity();
+				d1.setId( offset + 1 );
+				d1.setLabel( "D1" );
+				d1.setE( e1 );
 
-					DEntity d2 = new DEntity();
-					d2.setId( 2 );
-					d2.setLabel( "D2" );
-					d2.setE( e2 );
+				DEntity d2 = new DEntity();
+				d2.setId( offset + 2 );
+				d2.setLabel( "D2" );
+				d2.setE( e2 );
 
-					CEntity c1 = new CEntity();
-					c1.setId( 1 );
-					c1.setLabel( "C1" );
-					c1.setA( a1 );
-					c1.setB( b1 );
-					c1.addD( d1 );
-					c1.addD( d2 );
+				CEntity c1 = new CEntity();
+				c1.setId( offset + 1 );
+				c1.setLabel( "C1" );
+				c1.setA( a1 );
+				c1.setB( b1 );
+				c1.addD( d1 );
+				c1.addD( d2 );
 
-					entityManager.persist( c1 );
+				entityManager.persist( c1 );
 
-					DEntity d3 = new DEntity();
-					d3.setId( 3 );
-					d3.setLabel( "D3" );
-					d3.setE( e3 );
+				DEntity d3 = new DEntity();
+				d3.setId( offset + 3 );
+				d3.setLabel( "D3" );
+				d3.setE( e3 );
 
-					DEntity d4 = new DEntity();
-					d4.setId( 4 );
-					d4.setLabel( "D4" );
-					d4.setE( e4 );
+				DEntity d4 = new DEntity();
+				d4.setId( offset + 4 );
+				d4.setLabel( "D4" );
+				d4.setE( e4 );
 
-					CEntity c2 = new CEntity();
-					c2.setId( 2 );
-					c2.setLabel( "C2" );
-					c2.setA( a2 );
-					c2.setB( b2 );
-					c2.addD( d3 );
-					c2.addD( d4 );
+				CEntity c2 = new CEntity();
+				c2.setId( offset + 2 );
+				c2.setLabel( "C2" );
+				c2.setA( a2 );
+				c2.setB( b2 );
+				c2.addD( d3 );
+				c2.addD( d4 );
 
-					entityManager.persist( c2 );
+				entityManager.persist( c2 );
 
-					CEntity c3 = new CEntity();
-					c3.setId( 3 );
-					c3.setLabel( "C3" );
+				CEntity c3 = new CEntity();
+				c3.setId( offset + 3 );
+				c3.setLabel( "C3" );
 
-					entityManager.persist( c3 );
+				entityManager.persist( c3 );
 
-					c1.setC( c2 );
-					c2.setC( c3 );
+				CEntity c4 = new CEntity();
+				c4.setId( offset + 4 );
+				c4.setLabel( "C4" );
 
-					int id = 5;
-					for ( int i = 0; i < 10; i++ ) {
-						DEntity dn = new DEntity();
-						dn.setId( id++ );
-						dn.setLabel( "label" );
-						dn.setE( e3 );
-						entityManager.persist( dn );
-					}
+				entityManager.persist( c4 );
 
-				} );
+				c1.setC( c2 );
+				c2.setC( c3 );
+				c1.setEagerC( c4 );
+
+				int id = 5;
+				for ( int i = 0; i < 10; i++ ) {
+					DEntity dn = new DEntity();
+					dn.setId( offset + id++ );
+					dn.setLabel( "label" );
+					dn.setE( e3 );
+					entityManager.persist( dn );
+				}
+			}
+		} );
 	}
 
 	@Test
@@ -284,8 +295,89 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 					assertTrue( Hibernate.isInitialized( cEntity.getC().getA() ) );
 					assertFalse( Hibernate.isInitialized( cEntity.getC().getC() ) );
 
+					// With FETCH semantic, attributes that are not mentioned in the graph are LAZY,
+					// even if they were EAGER in the mapping.
+					assertFalse( Hibernate.isInitialized( cEntity.getEagerC() ) );
+
 					assertEquals( 1L, statistics.getPrepareStatementCount() );
 				} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14124")
+	public void testQueryByIdWithLoadGraphMultipleResults() {
+		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
+		statistics.clear();
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			EntityGraph<CEntity> entityGraph = entityManager.createEntityGraph( CEntity.class );
+			entityGraph.addAttributeNodes( "a", "b" );
+			entityGraph.addSubgraph( "dList" ).addAttributeNodes( "e" );
+
+			TypedQuery<CEntity> query = entityManager.createQuery(
+					"select c from CEntity as c where c.id in :cid ",
+					CEntity.class
+			);
+			query.setHint( GraphSemantic.LOAD.getJpaHintName(), entityGraph );
+			query.setParameter( "cid", Arrays.asList( 1, 10001 ) );
+
+			List<CEntity> cEntityList = query.getResultList();
+			assertEquals( 2, cEntityList.size() );
+
+			for ( CEntity cEntity : cEntityList ) {
+				assertTrue( Hibernate.isInitialized( cEntity.getA() ) );
+				assertTrue( Hibernate.isInitialized( cEntity.getB() ) );
+				assertFalse( Hibernate.isInitialized( cEntity.getC() ) );
+				assertTrue( Hibernate.isInitialized( cEntity.getdList() ) );
+				cEntity.getdList().forEach( dEntity -> {
+					assertTrue( Hibernate.isInitialized( dEntity.getE() ) );
+				} );
+
+				// With LOAD semantic, attributes that are not mentioned in the graph are LAZY or EAGER,
+				// depending on the mapping.
+				assertTrue( Hibernate.isInitialized( cEntity.getEagerC() ) );
+			}
+
+			// 1 + 2 for the eager C
+			assertEquals( 3L, statistics.getPrepareStatementCount() );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14124")
+	public void testQueryByIdWithFetchGraphMultipleResults() {
+		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
+		statistics.clear();
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			EntityGraph<CEntity> entityGraph = entityManager.createEntityGraph( CEntity.class );
+			entityGraph.addAttributeNodes( "a", "b" );
+			entityGraph.addSubgraph( "dList" ).addAttributeNodes( "e" );
+
+			TypedQuery<CEntity> query = entityManager.createQuery(
+					"select c from CEntity as c where c.id in :cid ",
+					CEntity.class
+			);
+			query.setHint( GraphSemantic.FETCH.getJpaHintName(), entityGraph );
+			query.setParameter( "cid", Arrays.asList( 1, 10001 ) );
+
+			List<CEntity> cEntityList = query.getResultList();
+			assertEquals( 2, cEntityList.size() );
+
+			for ( CEntity cEntity : cEntityList ) {
+				assertTrue( Hibernate.isInitialized( cEntity.getA() ) );
+				assertTrue( Hibernate.isInitialized( cEntity.getB() ) );
+				assertFalse( Hibernate.isInitialized( cEntity.getC() ) );
+				assertTrue( Hibernate.isInitialized( cEntity.getdList() ) );
+				cEntity.getdList().forEach( dEntity -> {
+					assertTrue( Hibernate.isInitialized( dEntity.getE() ) );
+				} );
+
+				// With FETCH semantic, attributes that are not mentioned in the graph are LAZY,
+				// even if they were EAGER in the mapping.
+				assertFalse( Hibernate.isInitialized( cEntity.getEagerC() ) );
+			}
+
+			assertEquals( 1L, statistics.getPrepareStatementCount() );
+		} );
 	}
 
 	@Entity(name = "AEntity")


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14124

Essentially, the current implementation of sub-graph handling relies on side-effects in the session: when it loads an entity with an entity graph, it will replace the entity graph in the session with the subgraph, and hope that the next loaded entity needs this subgraph.

This will sort of work, though it's probably riddled with bugs (what if there are multiple subgraphs? what if entities are not processed in the expected order?). These bugs are not what HHH-14124 is about, however, so I won't try to address them.

The real problem that caused HHH-14124 is that this implementation of sub-graph handling doesn't take care of restoring the "root" entity graph after we're done processing one row in the result set. It may leave an incorrect graph, or even set the graph to null. As a result, in many cases only the very first entity in the result set will be loaded correctly. The next ones won't have the correct entity graph in the session, and thus won't be loaded correctly.

This PR tries to solve the problem with a workaround: by storing the entities to load in a structure that lets us know when we're moving from one row to the next, we're able to "restore" the original entity graph before we load the entities of each row. That way, the bugs of the sub-graph handling implementation won't affect the next row, and simple graphs without a sub-graph will work correctly (like they used to). Sub-graphs will still be buggy, but that's been the case for a long time, and as I wrote above, solving this is not the goal of this PR.

You'll notice there are two commits. 

The first one uses a naive approach of storing the entities to load in a `List<List<Object>>`, each sub-list containing all the objects to load for a given row. That's a very straightforward approach, but it requires to allocate one list per result row, which I think is something we want to avoid. Thus I added a second commit which stores entities to load in a `List<Object>`, but inserts a `null` element to signal that the next elements were extracted from a different row.

Either solution is fine to me, but I think the second one, while quite ugly, is less likely to lead to performance regressions (since it'll allocate memory very similarly to the current code). It might be a good-enough compromise until we rewrite it all in Hibernate ORM 6.0?