### PR TITLE
Added test case for HHH-14125 'Selecting EntityCollection fails 

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/collectionelement/QueryTest.java
@@ -15,6 +15,7 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 /**
  * @author Steve Ebersole
+ * @author Benjamin Maurer
  */
 public class QueryTest extends BaseCoreFunctionalTestCase {
 	@Override
@@ -28,6 +29,15 @@ public class QueryTest extends BaseCoreFunctionalTestCase {
 		// performs syntax checking of the MEMBER OF predicate against a basic collection
 		Session s = openSession();
 		s.createQuery( "from EntityWithAnElementCollection e where 'abc' member of e.someStrings" ).list();
+		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-14125" )
+	public void testSelectElementCollectionProperty() {
+		// Selecting property directly works for basic types and associated entities, should also work for ElementCollection
+		Session s = openSession();
+		s.createQuery( "select e.someStrings from EntityWithAnElementCollection e" ).list();
 		s.close();
 	}
 }


### PR DESCRIPTION
Added test case for HHH-14125 'Selecting EntityCollection fails ("not an entity")'

`select e.someStrings from EntityWithAnElementCollection e`

fails with the Exception "not an entity". Fetching any property of basic type or entity association works. With ElementCollection, only works with explicit join.

I looked at org.hibernate.hql.internal.ast.tree.SelectClause#initializeExplicitSelectClause - `selectExpression.isScalar()`is `false` because CollectionType.isAssociation() returns `true`. I've tried to change that, but this doesn't work and is clearly not the whole story. Unfortunately, I'm new to the code base and couldn't quite figure it out.