### PR TITLE
HHH-13085 : Use FetchMode.JOIN to load OneToOne associations that hav…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractLoadPlanBuildingAssociationVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/plan/build/internal/AbstractLoadPlanBuildingAssociationVisitationStrategy.java
@@ -44,6 +44,7 @@ import org.hibernate.persister.walking.internal.FetchStrategyHelper;
 import org.hibernate.persister.walking.spi.AnyMappingDefinition;
 import org.hibernate.persister.walking.spi.AssociationAttributeDefinition;
 import org.hibernate.persister.walking.spi.AssociationKey;
+import org.hibernate.persister.walking.spi.AssociationVisitationStrategy;
 import org.hibernate.persister.walking.spi.AttributeDefinition;
 import org.hibernate.persister.walking.spi.CollectionDefinition;
 import org.hibernate.persister.walking.spi.CollectionElementDefinition;
@@ -647,8 +648,11 @@ public abstract class AbstractLoadPlanBuildingAssociationVisitationStrategy
 			return false;  // EARLY EXIT
 		}
 
-		final Joinable currentEntityPersister = (Joinable) currentSource().resolveEntityReference()
-				.getEntityPersister();
+		final EntityReference currentEntityReference = currentSource().resolveEntityReference();
+		if ( currentEntityReference == null ) {
+			return LoadPlanBuildingAssociationVisitationStrategy.super.isDuplicateAssociatedEntity( attributeDefinition );
+		}
+		final Joinable currentEntityPersister = (Joinable) currentEntityReference.getEntityPersister();
 		final AssociationKey currentEntityReferenceAssociationKey =
 				new AssociationKey( currentEntityPersister.getTableName(), currentEntityPersister.getKeyColumnNames() );
 		final AssociationKey associationKey = attributeDefinition.getAssociationKey();

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/AssociationVisitationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/AssociationVisitationStrategy.java
@@ -155,4 +155,8 @@ public interface AssociationVisitationStrategy {
 	public void foundCircularAssociation(AssociationAttributeDefinition attributeDefinition);
 	public boolean isDuplicateAssociationKey(AssociationKey associationKey);
 
+	default boolean isDuplicateAssociatedEntity(AssociationAttributeDefinition attributeDefinition) {
+		return isDuplicateAssociationKey( attributeDefinition.getAssociationKey() );
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/MetamodelGraphWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/walking/spi/MetamodelGraphWalker.java
@@ -150,7 +150,7 @@ public class MetamodelGraphWalker {
 			final AssociationAttributeDefinition associationAttributeDefinition =
 					(AssociationAttributeDefinition) attributeDefinition;
 			final AssociationKey associationKey = associationAttributeDefinition.getAssociationKey();
-			if ( isDuplicateAssociationKey( associationKey ) ) {
+			if ( isDuplicateAttributeDefinition( associationAttributeDefinition ) ) {
 				log.debug( "Property path deemed to be circular : " + subPath.getFullPath() );
 				strategy.foundCircularAssociation( associationAttributeDefinition );
 				// EARLY EXIT!!!
@@ -325,5 +325,17 @@ public class MetamodelGraphWalker {
 	 */
 	protected boolean isDuplicateAssociationKey(AssociationKey associationKey) {
 		return visitedAssociationKeys.contains( associationKey ) || strategy.isDuplicateAssociationKey( associationKey );
+	}
+
+	protected boolean isDuplicateAttributeDefinition(AssociationAttributeDefinition attributeDefinition) {
+		if ( isDuplicateAssociationKey( attributeDefinition.getAssociationKey() ) ) {
+			if ( attributeDefinition.getAssociationNature() == AssociationAttributeDefinition.AssociationNature.ENTITY ) {
+				return strategy.isDuplicateAssociatedEntity( attributeDefinition );
+			}
+			else {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mappedbyid/LoadGraphFindByIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/mappedbyid/LoadGraphFindByIdTest.java
@@ -23,7 +23,6 @@ import javax.persistence.criteria.Root;
 
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
@@ -60,7 +59,6 @@ public class LoadGraphFindByIdTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-10842")
-	@FailureExpected( jiraKey = "HHH-10842" )
 	public void findByPrimaryKeyWithId() {
 		doInJPA( this::entityManagerFactory, em -> {
 			User result = em.find( User.class, 1L, createProperties( em ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/BasicWalkingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/BasicWalkingTest.java
@@ -13,6 +13,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import java.util.List;
 
+import org.hibernate.LockMode;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.walking.spi.MetamodelGraphWalker;
 
@@ -32,7 +34,13 @@ public class BasicWalkingTest extends BaseCoreFunctionalTestCase {
 	@Test
 	public void testIt() {
 		EntityPersister ep = (EntityPersister) sessionFactory().getClassMetadata(Message.class);
-		MetamodelGraphWalker.visitEntity( new LoggingAssociationVisitationStrategy(), ep );
+		MetamodelGraphWalker.visitEntity(
+				new LoggingAssociationVisitationStrategy(
+						sessionFactory(),
+						new LoadQueryInfluencers(),
+						LockMode.NONE
+				),
+				ep );
 	}
 
 	@Entity( name = "Message" )

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/CompositesWalkingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/CompositesWalkingTest.java
@@ -6,8 +6,11 @@
  */
 package org.hibernate.test.loadplans.walking;
 
+import org.hibernate.LockMode;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.walking.spi.MetamodelGraphWalker;
 
@@ -30,7 +33,14 @@ public class CompositesWalkingTest extends BaseUnitTestCase {
 				.buildSessionFactory();
 		try {
 			final EntityPersister ep = (EntityPersister) sf.getClassMetadata( TestCourse.class );
-			MetamodelGraphWalker.visitEntity( new LoggingAssociationVisitationStrategy(), ep );
+			MetamodelGraphWalker.visitEntity(
+					new LoggingAssociationVisitationStrategy(
+							(SessionFactoryImplementor) sf,
+							new LoadQueryInfluencers(),
+							LockMode.NONE
+					),
+					ep
+			);
 		}
 		finally {
 			sf.close();

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/KeyManyToOneWalkingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/KeyManyToOneWalkingTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.test.loadplans.walking;
 
+import org.hibernate.LockMode;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.walking.spi.MetamodelGraphWalker;
 
@@ -28,6 +30,13 @@ public class KeyManyToOneWalkingTest extends BaseCoreFunctionalTestCase {
 		// Address has a composite id with a bi-directional key-many to Person
 		final EntityPersister ep = (EntityPersister) sessionFactory().getClassMetadata( Address.class );
 
-		MetamodelGraphWalker.visitEntity( new LoggingAssociationVisitationStrategy(), ep );
+		MetamodelGraphWalker.visitEntity(
+				new LoggingAssociationVisitationStrategy(
+						sessionFactory(),
+						new LoadQueryInfluencers(),
+						LockMode.NONE
+				),
+				ep
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/LoggingAssociationVisitationStrategy.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/LoggingAssociationVisitationStrategy.java
@@ -6,12 +6,16 @@
  */
 package org.hibernate.test.loadplans.walking;
 
-import org.hibernate.internal.util.StringHelper;
+import org.hibernate.LockMode;
+import org.hibernate.annotations.common.util.StringHelper;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.loader.plan.build.internal.FetchStyleLoadPlanBuildingAssociationVisitationStrategy;
 import org.hibernate.loader.plan.spi.FetchSource;
+import org.hibernate.loader.plan.spi.LoadPlan;
 import org.hibernate.persister.walking.spi.AnyMappingDefinition;
 import org.hibernate.persister.walking.spi.AssociationAttributeDefinition;
 import org.hibernate.persister.walking.spi.AssociationKey;
-import org.hibernate.persister.walking.spi.AssociationVisitationStrategy;
 import org.hibernate.persister.walking.spi.AttributeDefinition;
 import org.hibernate.persister.walking.spi.CollectionDefinition;
 import org.hibernate.persister.walking.spi.CollectionElementDefinition;
@@ -23,17 +27,32 @@ import org.hibernate.persister.walking.spi.EntityIdentifierDefinition;
 /**
  * @author Steve Ebersole
  */
-public class LoggingAssociationVisitationStrategy implements AssociationVisitationStrategy {
+public class LoggingAssociationVisitationStrategy extends FetchStyleLoadPlanBuildingAssociationVisitationStrategy {
 	private int depth = 1;
+
+	/**
+	 * Constructs a FetchStyleLoadPlanBuildingAssociationVisitationStrategy.
+	 *
+	 * @param sessionFactory       The session factory
+	 * @param loadQueryInfluencers The options which can influence the SQL query needed to perform the load.
+	 * @param lockMode             The lock mode.
+	 */
+	public LoggingAssociationVisitationStrategy(
+			SessionFactoryImplementor sessionFactory,
+			LoadQueryInfluencers loadQueryInfluencers, LockMode lockMode) {
+		super( sessionFactory, loadQueryInfluencers, lockMode );
+	}
 
 	@Override
 	public void start() {
 		System.out.println( ">> Start" );
+		super.start();
 	}
 
 	@Override
 	public void finish() {
 		System.out.println( "<< Finish" );
+		super.finish();
 	}
 
 	@Override
@@ -45,6 +64,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						entityDefinition.getEntityPersister().getEntityName()
 				)
 		);
+		super.startingEntity( entityDefinition );
 	}
 
 	@Override
@@ -56,6 +76,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						entityDefinition.getEntityPersister().getEntityName()
 				)
 		);
+		super.finishingEntity( entityDefinition );
 	}
 
 	@Override
@@ -68,6 +89,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						entityIdentifierDefinition.getEntityDefinition().getEntityPersister().getEntityName()
 				)
 		);
+		super.startingEntityIdentifier( entityIdentifierDefinition );
 	}
 
 	@Override
@@ -79,6 +101,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						entityIdentifierDefinition.getEntityDefinition().getEntityPersister().getEntityName()
 				)
 		);
+		super.finishingEntityIdentifier( entityIdentifierDefinition );
 	}
 
 	@Override
@@ -90,12 +113,12 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						attributeDefinition.getName()
 				)
 		);
-		return true;
+		return super.startingAttribute( attributeDefinition );
 	}
 
 	@Override
 	public void finishingAttribute(AttributeDefinition attributeDefinition) {
-		// nothing to do
+		super.finishingAttribute( attributeDefinition );
 	}
 
 	@Override
@@ -107,6 +130,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						compositionDefinition.getName()
 				)
 		);
+		super.startingComposite( compositionDefinition );
 	}
 
 	@Override
@@ -118,6 +142,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						compositionDefinition.getName()
 				)
 		);
+		super.finishingComposite( compositionDefinition );
 	}
 
 	@Override
@@ -129,6 +154,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						collectionDefinition.getCollectionPersister().getRole()
 				)
 		);
+		super.startingCollection( collectionDefinition );
 	}
 
 	@Override
@@ -140,6 +166,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						collectionDefinition.getCollectionPersister().getRole()
 				)
 		);
+		super.finishingCollection( collectionDefinition );
 	}
 
 
@@ -152,6 +179,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						collectionIndexDefinition.getCollectionDefinition().getCollectionPersister().getRole()
 				)
 		);
+		super.startingCollectionIndex( collectionIndexDefinition );
 	}
 
 	@Override
@@ -163,6 +191,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						collectionIndexDefinition.getCollectionDefinition().getCollectionPersister().getRole()
 				)
 		);
+		super.finishingCollectionIndex( collectionIndexDefinition );
 	}
 
 	@Override
@@ -174,6 +203,7 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						elementDefinition.getCollectionDefinition().getCollectionPersister().getRole()
 				)
 		);
+		super.startingCollectionElements( elementDefinition );
 	}
 
 	@Override
@@ -185,11 +215,12 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						elementDefinition.getCollectionDefinition().getCollectionPersister().getRole()
 				)
 		);
+		super.finishingCollectionElements( elementDefinition );
 	}
 
 	@Override
 	public void foundAny(AnyMappingDefinition anyDefinition) {
-		// nothing to do
+		super.foundAny( anyDefinition );
 	}
 
 	@Override
@@ -201,11 +232,12 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						associationKey.toString()
 				)
 		);
+		super.associationKeyRegistered( associationKey );
 	}
 
 	@Override
 	public FetchSource registeredFetchSource(AssociationKey associationKey) {
-		return null;
+		return super.registeredFetchSource( associationKey );
 	}
 
 	@Override
@@ -219,11 +251,21 @@ public class LoggingAssociationVisitationStrategy implements AssociationVisitati
 						attributeDefinition.getAssociationKey().toString()
 				)
 		);
+		super.foundCircularAssociation( attributeDefinition );
 	}
 
 	@Override
 	public boolean isDuplicateAssociationKey(AssociationKey associationKey) {
-		return false;  //To change body of implemented methods use File | Settings | File Templates.
+		return super.isDuplicateAssociationKey( associationKey );
 	}
 
+	@Override
+	public boolean isDuplicateAssociatedEntity(AssociationAttributeDefinition attributeDefinition) {
+		return super.isDuplicateAssociatedEntity( attributeDefinition );
+	}
+
+	@Override
+	public LoadPlan buildLoadPlan() {
+		return null;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/NestedCompositeElementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/loadplans/walking/NestedCompositeElementTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.test.loadplans.walking;
 
+import org.hibernate.LockMode;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.walking.spi.MetamodelGraphWalker;
 
@@ -27,6 +29,13 @@ public class NestedCompositeElementTest extends BaseCoreFunctionalTestCase {
 	@Test
 	public void testWalkingKeyManyToOneGraphs() {
 		final EntityPersister ep = (EntityPersister) sessionFactory().getClassMetadata( Customer.class );
-		MetamodelGraphWalker.visitEntity( new LoggingAssociationVisitationStrategy(), ep );
+		MetamodelGraphWalker.visitEntity(
+				new LoggingAssociationVisitationStrategy(
+						sessionFactory(),
+						new LoadQueryInfluencers(),
+						LockMode.NONE
+				),
+				ep
+		);
 	}
 }


### PR DESCRIPTION
…e the same AssociationKey as the entity owner

https://hibernate.atlassian.net/browse/HHH-13085

SQL generated for the following tests show that one-to-one associations are being joined:
rg.hibernate.test.annotations.derivedidentities.bidirectional.OneToOneWithDerivedIdentityTest
org.hibernate.test.annotations.derivedidentities.e4.a.DerivedIdentitySimpleParentSimpleDepTest
org.hibernate.test.annotations.derivedidentities.e4.b.DerivedIdentitySimpleParentSimpleDepMapsIdTest
org.hibernate.test.annotations.derivedidentities.e5.a.DerivedIdentityIdClassParentSameIdTypeIdClassDepTest
org.hibernate.test.annotations.derivedidentities.e5.b.DerivedIdentityIdClassParentSameIdTypeEmbeddedIdDepTest
org.hibernate.test.annotations.derivedidentities.e5.c.ForeignGeneratorViaMapsIdTest
org.hibernate.test.annotations.derivedidentities.e6.a.DerivedIdentityEmbeddedIdParentSameIdTypeIdClassDepTest
org.hibernate.test.annotations.derivedidentities.e6.b.DerivedIdentityEmbeddedIdParentSameIdTypeEmbeddedIdDepTest
org.hibernate.test.annotations.manytoone.ManyToOneMapsIdFlushModeTest
org.hibernate.test.annotations.notfound.NotFoundOneToOneNonInsertableNonUpdateableTest
org.hibernate.test.annotations.onetoone.OneToOneTest
org.hibernate.test.annotations.onetoone.OptionalOneToOneMappedByTest
org.hibernate.test.annotations.onetoone.OptionalOneToOneMapsIdQueryTest
org.hibernate.test.annotations.onetoone.OptionalOneToOnePKJCQueryTest
org.hibernate.test.annotations.onetoone.OptionalOneToOnePKJCTest
org.hibernate.test.criteria.mapsid.MapsIdOneToOneSelectTest
