### PR TITLE
HHH-14133 fix obvious example caching code error in user guide

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/caching/SecondLevelCacheTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/caching/SecondLevelCacheTest.java
@@ -206,7 +206,7 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			//tag::caching-management-cache-mode-entity-jpa-example[]
 			Map<String, Object> hints = new HashMap<>(  );
-			hints.put( "javax.persistence.cache.retrieveMode " , CacheRetrieveMode.USE );
+			hints.put( "javax.persistence.cache.retrieveMode" , CacheRetrieveMode.USE );
 			hints.put( "javax.persistence.cache.storeMode" , CacheStoreMode.REFRESH );
 			Person person = entityManager.find( Person.class, 1L , hints);
 			//end::caching-management-cache-mode-entity-jpa-example[]
@@ -225,7 +225,7 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 			List<Person> persons = entityManager.createQuery(
 				"select p from Person p", Person.class)
 			.setHint( QueryHints.HINT_CACHEABLE, "true")
-			.setHint( "javax.persistence.cache.retrieveMode " , CacheRetrieveMode.USE )
+			.setHint( "javax.persistence.cache.retrieveMode" , CacheRetrieveMode.USE )
 			.setHint( "javax.persistence.cache.storeMode" , CacheStoreMode.REFRESH )
 			.getResultList();
 			//end::caching-management-cache-mode-query-jpa-example[]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14133

Simple error of including empty char at the end of hint property key. Should be intolerable for example code in user guide.