### PR TITLE
wip/6.0 Reuse ArrayHelper's empty array constants to avoid unnecessary array creation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/AbstractPluralAttributeSourceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/AbstractPluralAttributeSourceImpl.java
@@ -34,6 +34,7 @@ import org.hibernate.boot.model.source.spi.PluralAttributeSource;
 import org.hibernate.boot.model.source.spi.TableSpecificationSource;
 import org.hibernate.boot.model.source.spi.ToolingHintContext;
 import org.hibernate.cfg.NotYetImplementedException;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 /**
  * @author Steve Ebersole
@@ -169,7 +170,7 @@ public abstract class AbstractPluralAttributeSourceImpl
 
 	private static String[] extractSynchronizedTableNames(PluralAttributeInfo pluralAttributeElement) {
 		if ( pluralAttributeElement.getSynchronize().isEmpty() ) {
-			return new String[0];
+			return ArrayHelper.EMPTY_STRING_ARRAY;
 		}
 
 		final String[] names = new String[pluralAttributeElement.getSynchronize().size()];

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.spi.CompositeOwner;
 import org.hibernate.engine.spi.CompositeTracker;
 import org.hibernate.engine.spi.ExtendedSelfDirtinessTracker;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.field.FieldDescription;
@@ -82,7 +83,7 @@ class CodeTemplates {
 				@Advice.FieldValue(value = EnhancerConstants.TRACKER_FIELD_NAME, readOnly = false) DirtyTracker $$_hibernate_tracker,
 				@Advice.FieldValue(value = EnhancerConstants.TRACKER_COLLECTION_NAME, readOnly = false) CollectionTracker $$_hibernate_collectionTracker) {
 			if ( $$_hibernate_collectionTracker == null ) {
-				returned = ( $$_hibernate_tracker == null ) ? new String[0] : $$_hibernate_tracker.get();
+				returned = ( $$_hibernate_tracker == null ) ? ArrayHelper.EMPTY_STRING_ARRAY : $$_hibernate_tracker.get();
 			}
 			else {
 				if ( $$_hibernate_tracker == null ) {
@@ -99,7 +100,7 @@ class CodeTemplates {
 		static void $$_hibernate_getDirtyAttributes(
 				@Advice.Return(readOnly = false) String[] returned,
 				@Advice.FieldValue(value = EnhancerConstants.TRACKER_FIELD_NAME) DirtyTracker $$_hibernate_tracker) {
-			returned = $$_hibernate_tracker == null ? new String[0] : $$_hibernate_tracker.get();
+			returned = $$_hibernate_tracker == null ? ArrayHelper.EMPTY_STRING_ARRAY : $$_hibernate_tracker.get();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleCollectionTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleCollectionTracker.java
@@ -9,6 +9,7 @@ package org.hibernate.bytecode.enhance.internal.tracker;
 import java.util.Arrays;
 
 import org.hibernate.bytecode.enhance.spi.CollectionTracker;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 /**
  * small low memory class to keep track of the number of elements in a collection
@@ -21,8 +22,8 @@ public final class SimpleCollectionTracker implements CollectionTracker {
 	private int[] sizes;
 
 	public SimpleCollectionTracker() {
-		names = new String[0];
-		sizes = new int[0];
+		names = ArrayHelper.EMPTY_STRING_ARRAY;
+		sizes = ArrayHelper.EMPTY_INT_ARRAY;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SimpleFieldTracker.java
@@ -8,6 +8,8 @@ package org.hibernate.bytecode.enhance.internal.tracker;
 
 import java.util.Arrays;
 
+import org.hibernate.internal.util.collections.ArrayHelper;
+
 /**
  * small low memory class to keep track of changed fields
  * <p/>
@@ -22,7 +24,7 @@ public final class SimpleFieldTracker implements DirtyTracker {
 	private boolean suspended;
 
 	public SimpleFieldTracker() {
-		names = new String[0];
+		names = ArrayHelper.EMPTY_STRING_ARRAY;
 	}
 
 	@Override
@@ -49,7 +51,7 @@ public final class SimpleFieldTracker implements DirtyTracker {
 	@Override
 	public void clear() {
 		if ( !isEmpty() ) {
-			names = new String[0];
+			names = ArrayHelper.EMPTY_STRING_ARRAY;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/tracker/SortedFieldTracker.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.bytecode.enhance.internal.tracker;
 
+import org.hibernate.internal.util.collections.ArrayHelper;
+
 /**
  * small low memory class to keep track of changed fields
  *
@@ -19,7 +21,7 @@ public final class SortedFieldTracker implements DirtyTracker {
 	private boolean suspended;
 
 	public SortedFieldTracker() {
-		names = new String[0];
+		names = ArrayHelper.EMPTY_STRING_ARRAY;
 	}
 
 	@Override
@@ -75,7 +77,7 @@ public final class SortedFieldTracker implements DirtyTracker {
 	@Override
 	public void clear() {
 		if ( !isEmpty() ) {
-			names = new String[0];
+			names = ArrayHelper.EMPTY_STRING_ARRAY;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.bytecode.spi.BasicProxyFactory;
 import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.proxy.ProxyConfiguration;
 
 import net.bytebuddy.NamingStrategy;
@@ -23,7 +24,7 @@ import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
 
 public class BasicProxyFactoryImpl implements BasicProxyFactory {
 
-	private static final Class[] NO_INTERFACES = new Class[0];
+	private static final Class[] NO_INTERFACES = ArrayHelper.EMPTY_CLASS_ARRAY;
 	private static final String PROXY_NAMING_SUFFIX = Environment.useLegacyProxyClassnames() ? "HibernateBasicProxy$" : "HibernateBasicProxy";
 
 	private final Class proxyClass;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ByteCodeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ByteCodeHelper.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
+import org.hibernate.internal.util.collections.ArrayHelper;
+
 /**
  * A helper for reading byte code from various input sources.
  *
@@ -43,7 +45,7 @@ public class ByteCodeHelper {
 		}
 
 		final byte[] buffer = new byte[409600];
-		byte[] classBytes = new byte[0];
+		byte[] classBytes = ArrayHelper.EMPTY_BYTE_ARRAY;
 
 		try {
 			int r = inputStream.read( buffer );

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
@@ -20,6 +20,7 @@ import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 
 /**
@@ -179,7 +180,7 @@ public class DisabledCaching implements CacheImplementor {
 
 	@Override
 	public String[] getSecondLevelCacheRegionNames() {
-		return new String[0];
+		return ArrayHelper.EMPTY_STRING_ARRAY;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -20,6 +20,7 @@ import org.hibernate.dialect.pagination.LimitOffsetLimitHandler;
 import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.env.spi.SchemaNameResolver;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.ForeignKey;
@@ -788,12 +789,12 @@ public class SpannerDialect extends Dialect {
 
 		@Override
 		public String[] getSqlCreateStrings(T exportable, Metadata metadata) {
-			return new String[0];
+			return ArrayHelper.EMPTY_STRING_ARRAY;
 		}
 
 		@Override
 		public String[] getSqlDropStrings(T exportable, Metadata metadata) {
-			return new String[0];
+			return ArrayHelper.EMPTY_STRING_ARRAY;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/LobCreatorBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/LobCreatorBuilderImpl.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.NonContextualLobCreator;
 import org.hibernate.engine.jdbc.env.spi.LobCreatorBuilder;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
 import org.jboss.logging.Logger;
@@ -66,8 +67,8 @@ public class LobCreatorBuilderImpl implements LobCreatorBuilder {
 		return new LobCreatorBuilderImpl( false );
 	}
 
-	private static final Class[] NO_ARG_SIG = new Class[0];
-	private static final Object[] NO_ARGS = new Object[0];
+	private static final Class[] NO_ARG_SIG = ArrayHelper.EMPTY_CLASS_ARRAY;
+	private static final Object[] NO_ARGS = ArrayHelper.EMPTY_OBJECT_ARRAY;
 
 	/**
 	 * Basically here we are simply checking whether we can call the {@link java.sql.Connection} methods for

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/LobCreatorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/LobCreatorBuilder.java
@@ -18,6 +18,7 @@ import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.NonContextualLobCreator;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
 import org.jboss.logging.Logger;
@@ -46,8 +47,8 @@ public class LobCreatorBuilder {
 		this.useContextualLobCreation = useContextualLobCreation( configValues, jdbcConnection );
 	}
 
-	private static final Class[] NO_ARG_SIG = new Class[0];
-	private static final Object[] NO_ARGS = new Object[0];
+	private static final Class[] NO_ARG_SIG = ArrayHelper.EMPTY_CLASS_ARRAY;
+	private static final Object[] NO_ARGS = ArrayHelper.EMPTY_OBJECT_ARRAY;
 
 	/**
 	 * Basically here we are simply checking whether we can call the {@link Connection} methods for

--- a/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
@@ -13,6 +13,7 @@ import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.spi.Mapping;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
@@ -103,7 +104,7 @@ public class ExportableColumn extends Column {
 
 		@Override
 		public boolean[] getColumnInsertability() {
-			return new boolean[] { true };
+			return ArrayHelper.TRUE;
 		}
 
 		@Override
@@ -113,7 +114,7 @@ public class ExportableColumn extends Column {
 
 		@Override
 		public boolean[] getColumnUpdateability() {
-			return new boolean[] { true };
+			return ArrayHelper.TRUE;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/EmptyScrollableResults.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/EmptyScrollableResults.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal;
 
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 
 /**
@@ -92,7 +93,7 @@ public class EmptyScrollableResults implements ScrollableResultsImplementor {
 
 	@Override
 	public Object[] get() {
-		return new Object[0];
+		return ArrayHelper.EMPTY_OBJECT_ARRAY;
 	}
 
 //	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/Cloneable.java
@@ -14,6 +14,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import org.hibernate.HibernateException;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 /**
  * An object that is shallow-cloneable
@@ -22,7 +23,7 @@ import org.hibernate.HibernateException;
  */
 public class Cloneable {
 
-	private static final Object[] READER_METHOD_ARGS = new Object[0];
+	private static final Object[] READER_METHOD_ARGS = ArrayHelper.EMPTY_OBJECT_ARRAY;
 
 	/**
 	 * Essentially performs a shallow copy of this SessionEventListenerConfig

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -23,6 +23,7 @@ import org.hibernate.PropertyNotFoundException;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.property.access.internal.PropertyAccessStrategyMixedImpl;
 import org.hibernate.property.access.spi.Getter;
 import org.hibernate.type.PrimitiveType;
@@ -41,8 +42,8 @@ public final class ReflectHelper {
 	private static final Pattern JAVA_CONSTANT_PATTERN = Pattern.compile(
 			"[a-z\\d]+\\.([A-Z]+[a-z\\d]+)+\\$?([A-Z]{1}[a-z\\d]+)*\\.[A-Z_\\$]+", Pattern.UNICODE_CHARACTER_CLASS);
 
-	public static final Class[] NO_PARAM_SIGNATURE = new Class[0];
-	public static final Object[] NO_PARAMS = new Object[0];
+	public static final Class[] NO_PARAM_SIGNATURE = ArrayHelper.EMPTY_CLASS_ARRAY;
+	public static final Object[] NO_PARAMS = ArrayHelper.EMPTY_OBJECT_ARRAY;
 
 	public static final Class[] SINGLE_OBJECT_PARAM_SIGNATURE = new Class[] { Object.class };
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -16,13 +16,14 @@ import java.util.StringTokenizer;
 
 import org.hibernate.boot.model.source.internal.hbm.CommaSeparatedStringHelper;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.loader.internal.AliasConstantsHelper;
 
 public final class StringHelper {
 
 	private static final int ALIAS_TRUNCATE_LENGTH = 10;
 	public static final String WHITESPACE = " \n\r\f\t";
-	public static final String[] EMPTY_STRINGS = new String[0];
+	public static final String[] EMPTY_STRINGS = ArrayHelper.EMPTY_STRING_ARRAY;
 
 	private StringHelper() { /* static methods only - hide constructor */
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.loader.ast.internal;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.loader.ast.spi.SingleIdEntityLoader;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.query.named.NamedQueryMemento;
@@ -84,6 +85,6 @@ public class SingleIdEntityLoaderProvidedQueryImpl<T> implements SingleIdEntityL
 
 	@Override
 	public Object[] loadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
-		return new Object[0];
+		return ArrayHelper.EMPTY_OBJECT_ARRAY;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -84,7 +84,7 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 	private static final EntityManagerMessageLogger log = HEMLogging.messageLogger( MappingMetamodelImpl.class );
 
 	private static final String INVALID_IMPORT = "";
-	private static final String[] EMPTY_IMPLEMENTORS = new String[0];
+	private static final String[] EMPTY_IMPLEMENTORS = ArrayHelper.EMPTY_STRING_ARRAY;
 
 	private final SessionFactoryImplementor sessionFactory;
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2416,7 +2416,7 @@ public abstract class AbstractEntityPersister
 	@Override
 	public int[] resolveAttributeIndexes(String[] attributeNames) {
 		if ( attributeNames == null || attributeNames.length == 0 ) {
-			return new int[0];
+			return ArrayHelper.EMPTY_INT_ARRAY;
 		}
 		int[] fields = new int[attributeNames.length];
 		int counter = 0;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -223,7 +223,7 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 						typesByPropertyPath.remove( path );
 						// Set everything to empty to signal action has to be taken!
 						// org.hibernate.hql.internal.ast.tree.DotNode#dereferenceEntityJoin() is reacting to this
-						String[] empty = new String[0];
+						String[] empty = ArrayHelper.EMPTY_STRING_ARRAY;
 						columnsByPropertyPath.put( path, empty );
 						columnReadersByPropertyPath.put( path, empty );
 						columnReaderTemplatesByPropertyPath.put( path, empty );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -417,7 +417,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	protected boolean[] getTableHasColumns() {
-		return new boolean[] {true};
+		return ArrayHelper.TRUE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
@@ -9,6 +9,7 @@ package org.hibernate.sql.results.internal;
 import java.util.List;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.query.named.RowReaderMemento;
 import org.hibernate.sql.exec.spi.Callback;
 import org.hibernate.sql.results.LoadingLogger;
@@ -190,12 +191,12 @@ public class StandardRowReader<T> implements RowReader<T> {
 		return new RowReaderMemento() {
 			@Override
 			public Class<?>[] getResultClasses() {
-				return new Class[0];
+				return ArrayHelper.EMPTY_CLASS_ARRAY;
 			}
 
 			@Override
 			public String[] getResultMappingNames() {
-				return new String[0];
+				return ArrayHelper.EMPTY_STRING_ARRAY;
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
@@ -9,6 +9,7 @@ package org.hibernate.tool.schema.spi;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.Exportable;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 /**
  * Defines a contract for exporting of database objects (tables, sequences, etc) for use in SQL {@code CREATE} and
@@ -19,7 +20,7 @@ import org.hibernate.boot.model.relational.Exportable;
  * @author Steve Ebersole
  */
 public interface Exporter<T extends Exportable> {
-	String[] NO_COMMANDS = new String[0];
+	String[] NO_COMMANDS = ArrayHelper.EMPTY_STRING_ARRAY;
 
 	/**
 	 * Get the commands needed for creation.

--- a/hibernate-core/src/main/java/org/hibernate/type/MetaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/MetaType.java
@@ -18,12 +18,13 @@ import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 
 /**
  * @author Gavin King
  */
 public class MetaType extends AbstractType {
-	public static final String[] REGISTRATION_KEYS = new String[0];
+	public static final String[] REGISTRATION_KEYS = ArrayHelper.EMPTY_STRING_ARRAY;
 
 	private final Type baseType;
 	private final Map<Object,String> discriminatorValuesToEntityNameMap;

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/StandardBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/StandardBasicTypeImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.internal;
 
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.SqlTypeDescriptorIndicatorCapable;
@@ -20,7 +21,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
 public class StandardBasicTypeImpl<J>
 		extends AbstractSingleColumnStandardBasicType
 		implements SqlTypeDescriptorIndicatorCapable {
-	public static final String[] NO_REG_KEYS = new String[0];
+	public static final String[] NO_REG_KEYS = ArrayHelper.EMPTY_STRING_ARRAY;
 
 	public StandardBasicTypeImpl(JavaTypeDescriptor<J> jtd, SqlTypeDescriptor std) {
 		//noinspection unchecked


### PR DESCRIPTION
We have the following empty array constants in `org.hibernate.internal.util.collections.ArrayHelper`:
```
        public static final String[] EMPTY_STRING_ARRAY = {};
	public static final int[] EMPTY_INT_ARRAY = {};
	public static final boolean[] EMPTY_BOOLEAN_ARRAY = {};
	public static final Class[] EMPTY_CLASS_ARRAY = {};
	public static final Object[] EMPTY_OBJECT_ARRAY = {};
	public static final Type[] EMPTY_TYPE_ARRAY = {};
	public static final byte[] EMPTY_BYTE_ARRAY = {};
```

This PR aims to reuse these constant in lieu of empty array creation to both boost performance and decrease memory footprint. Given the array is empty, it seems the replacement is hassle-free (unlike `Collections.emptyList()` which is immutable and adding element triggers exception).

As per https://stackoverflow.com/questions/30132902/how-is-the-zero-length-array-represented-in-memory, 32 bytes will be allocated for an empty array.