### PR TITLE
make constructor of StatelessSessionImpl public

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -72,7 +72,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	private final boolean connectionProvided;
 	private final boolean allowBytecodeProxy;
 
-	StatelessSessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
+	public StatelessSessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
 		connectionProvided = options.getConnection() != null;
 		allowBytecodeProxy = getFactory().getSessionFactoryOptions().isEnhancementAsProxyEnabled();


### PR DESCRIPTION
needed by Hibernate Reactive, see:

<https://github.com/hibernate/hibernate-reactive/pull/310>
<https://hibernate.atlassian.net/browse/HHH-14142>