### PR TITLE
Return null early in the event of the CollectionEntry being null.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -846,7 +846,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public Object getLoadedCollectionOwnerOrNull(PersistentCollection collection) {
 		final CollectionEntry ce = getCollectionEntry( collection );
-		if ( ce.getLoadedPersister() == null ) {
+		if ( ce == null || ce.getLoadedPersister() == null ) {
 			return null;
 		}
 


### PR DESCRIPTION
Avoids NPE, as the collection entry could not exist.

We were hitting this NPE in production.
We're not doing anything fancy with our database management.

We do manually set the SharedSessionContractImplementor on collections and proxies, as we need to load them.

This NPE stops us from using the simple code path of set the session, and just load the thing.
Unfortunately, while the AbstractCollectionEvent is being built, it tries to fetch the owner id and friends from the context.
But seemingly, because we don't do the normal thing, it's not there.

I've already built quite a bit of code around it, to make sure the context is in the state that hibernate expects, but ideally, I'd just like to be able to set the session, and force load the collection/proxy.

Thanks!

PS, if we could also backport this to 5.4, and if possible 4.3 (Although, I think 4.3 is EOL.), that would be grand, thanks!