### PR TITLE
HHH-14152 reserve end-of-line chars in MultiLineImportExtractor

### DIFF
--- a/hibernate-core/src/main/antlr/sql-script.g
+++ b/hibernate-core/src/main/antlr/sql-script.g
@@ -56,7 +56,7 @@ script
     ;
 
 statement
-	: { statementStarted(); } (statementPart)*  DELIMITER { statementEnded(); }
+	: { statementStarted(); } (statementPart)* DELIMITER (WS_CHAR)* { statementEnded(); }
 	;
 
 statementPart
@@ -71,8 +71,11 @@ quotedString
 	;
 
 nonSkippedChar
-	: c:CHAR {
-   		out( c );
+	: w:WS_CHAR {
+   		out( w );
+   	}
+   	| o:OTHER_CHAR {
+   		out( o );
    	}
 	;
 
@@ -105,18 +108,13 @@ QUOTED_TEXT
 protected
 ESCqs :	'\'' '\'' ;
 
-CHAR
-	: ( ' ' | '\t' ) => ( ' ' | '\t' )
-    | ~( ';' | '\n' | '\r' )
+WS_CHAR
+	: ' '
+	| '\t'
+	| ( "\r\n" | '\r' | '\n' ) {newline();}
     ;
 
-NEWLINE
-	: ( '\r' | '\n' | '\r''\n' ) {
-		newline();
-		// skip the entire match from the lexer stream
-		$setType( Token.SKIP );
-	}
-	;
+OTHER_CHAR	: ~( ';' | ' ' | '\t' | '\n' | '\r' );
 
 LINE_COMMENT
 	// match `//` or `--` followed by anything other than \n or \r until NEWLINE

--- a/hibernate-core/src/test/java/org/hibernate/test/fileimport/MultiLineImportExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/fileimport/MultiLineImportExtractorTest.java
@@ -44,7 +44,7 @@ public class MultiLineImportExtractorTest {
 
 				assertThat( commands[1], is( "INSERT INTO test_data VALUES (1, 'sample')" ) );
 
-				assertThat( commands[2], is( "DELETE  FROM test_data" ) );
+				assertThat( commands[2], is( "DELETE\n  FROM test_data" ) );
 
 				assertThat( commands[3], startsWith( "INSERT INTO test_data VALUES (2," ) );
 				assertThat( commands[3], containsString( "-- line 2" ) );
@@ -52,7 +52,7 @@ public class MultiLineImportExtractorTest {
 				assertThat( commands[4], startsWith( "INSERT INTO test_data VALUES (3" ) );
 				assertThat( commands[4], not( containsString( "third record" ) ) );
 
-				assertThat( commands[5], containsString( "INSERT INTO test_data (id, text)" ) );
+				assertThat( commands[5], startsWith( "INSERT INTO test_data\nVALUES\n" ) );
 			}
 		}
 	}

--- a/hibernate-core/src/test/resources/org/hibernate/test/fileimport/multi-line-statements.sql
+++ b/hibernate-core/src/test/resources/org/hibernate/test/fileimport/multi-line-statements.sql
@@ -23,12 +23,14 @@ INSERT INTO test_data VALUES (2, 'Multi-line comment line 1
 -- INSERT INTO test_data VALUES (1, NULL);
 
 INSERT INTO test_data VALUES (3 /* 'third record' */, NULL /* value */); -- with NULL value
-INSERT INTO test_data (id, text)
-     VALUES
-          (
-            4 -- another record
-          , NULL
-          );
+INSERT INTO test_data
+VALUES
+	(
+    	4 -- another record
+     	, NULL
+    );
+-- comment;
+-- comment;
 
--- comment;
--- comment;
+
+


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14152

So the original implementation of `MultipleLinesSqlCommandExtractor` striped off end-of-line chars. However, end-of-line chars could be a meaningful delimiter as other white space chars. For instance, the following common SQL script
```
INSERT INTO ISSUERS
VALUES (1, 1, 'BIPlatform', NULL, NULL);
```
would be erroneously transformed to
```
INSERT INTO ISSUERSVALUES (1, 1, 'BIPlatform', NULL, NULL);
```

This PR tries to reserve such end-of-line chars.
Another strongly related minor issue is the trailing end-of-line chars given that they are reserved rather than skipped. I changed the parser rule to allow trailing white spaces to make the paring more robust (and less confusing. User would get misled and confused when they get `statement must end in ;` exception in face of trailing whitespaces).

The only testing script has been modified to make it more challenging. Without the code changes in this PR, both of the following testing cases would fail:

- org.hibernate.test.fileimport.MultiLineImportFileTest
- org.hibernate.test.fileimport.MultiLineImportExtractorTest