### PR TITLE
HHH-14159 Update 'hibernate.cache.query_cache_factory' config

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Annotations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Annotations.adoc
@@ -731,7 +731,7 @@ See the <<chapters/domain/basic_types.adoc#mapping-column-read-and-write-example
 [[annotations-hibernate-columntransformers]]
 ==== `@ColumnTransformers`
 
-The https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/annotations/ColumnTransformers.html[`@ColumnTransformers`] annotation iis used to group multiple <<annotations-hibernate-columntransformer>> annotations.
+The https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/annotations/ColumnTransformers.html[`@ColumnTransformers`] annotation is used to group multiple <<annotations-hibernate-columntransformer>> annotations.
 
 [[annotations-hibernate-creationtimestamp]]
 ==== `@CreationTimestamp`

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -657,7 +657,7 @@ Enables the query cache. You still need to set individual queries to be cachable
 Enable/disable the second-level cache, which is enabled by default, although the default `RegionFactor` is `NoCachingRegionFactory` (meaning there is no actual caching implementation).
 
 `*hibernate.cache.query_cache_factory*` (e.g. fully-qualified class name)::
-A custom https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/cache/spi/QueryCacheFactory.html[`QueryCacheFactory`] interface. The default is the built-in `StandardQueryCacheFactory`.
+A custom https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/cache/spi/TimestampsCacheFactory.html[`TimestampsCacheFactory`] interface. The default is the built-in `StandardTimestampsCacheFactory`.
 
 `*hibernate.cache.region_prefix*` (e.g. A string)::
 A prefix for second-level cache region names.

--- a/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
@@ -43,7 +43,7 @@ Besides provider specific configuration, there are a number of configurations op
 `hibernate.cache.query_cache_factory`::
 	Query result caching is handled by a special contract that deals with staleness-based invalidation of the results.
 	The default implementation does not allow stale results at all. Use this for applications that would like to relax that.
-	Names an implementation of `org.hibernate.cache.spi.QueryCacheFactory`.
+	Names an implementation of `org.hibernate.cache.spi.TimestampsCacheFactory`.
 `hibernate.cache.use_minimal_puts`::
 	Optimizes second-level cache operations to minimize writes, at the cost of more frequent reads. Providers typically set this appropriately.
 `hibernate.cache.region_prefix`::


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14159

Simply updating the 'hibernate.cache.query_cache_factory' related content to latest status quo. Seems the key name per se might be outdated as well, but it is not changed in this PR to maintain backward compatibility.