### PR TITLE
fix an obvious mistake in LocalTimeJavaDescriptor (H6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
@@ -77,7 +77,7 @@ public class LocalTimeJavaDescriptor extends AbstractTemporalTypeDescriptor<Loca
 			return null;
 		}
 
-		if ( LocalDate.class.isAssignableFrom( type ) ) {
+		if ( LocalTime.class.isAssignableFrom( type ) ) {
 			return (X) value;
 		}
 


### PR DESCRIPTION
This code is obviously wrong, though perhaps it doesn't actually produce any real bug.