### PR TITLE
fix an obvious mistake in LocalTimeJavaDescriptor (H5)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaDescriptor.java
@@ -54,7 +54,7 @@ public class LocalTimeJavaDescriptor extends AbstractTypeDescriptor<LocalTime> {
 			return null;
 		}
 
-		if ( LocalDate.class.isAssignableFrom( type ) ) {
+		if ( LocalTime.class.isAssignableFrom( type ) ) {
 			return (X) value;
 		}
 


### PR DESCRIPTION
This code is obviously wrong, though perhaps it doesn't actually produce any real bug.