### PR TITLE
HHH-14031 Update h2 to 1.4.197

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -10,7 +10,7 @@
 ext {
 
     junitVersion = '4.12'
-    h2Version = '1.4.196'
+    h2Version = '1.4.197'
     bytemanVersion = '4.0.13' //Compatible with JDK16
     jnpVersion = '5.0.6.CR1'
 

--- a/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
@@ -10,7 +10,6 @@ import java.sql.Time;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -41,6 +40,9 @@ public class TimePropertyTest extends BaseCoreFunctionalTestCase {
 		// See javadoc for java.sql.Time: 'The date components should be set to the "zero epoch" value of January 1, 1970 and should not be accessed'
 		// Other dates can potentially lead to errors in JDBC drivers, in particular MySQL ConnectorJ 8.x.
 		calendar.set( 1970, Calendar.JANUARY, 1 );
+		// H2Dialect uses TIME (without fractional seconds precision) so H2 would round half up if milliseconds were set
+		// See also: http://h2database.com/html/datatypes.html#time_type
+		calendar.set( Calendar.MILLISECOND, 0 );
 		eOrig.tAsDate = new Time( calendar.getTimeInMillis() );
 
 		Session s = openSession();

--- a/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/AbstractJavaTimeTypeTest.java
@@ -20,16 +20,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.MariaDB10Dialect;
-import org.hibernate.dialect.Oracle8iDialect;
-import org.hibernate.dialect.PostgreSQL81Dialect;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
 import org.hibernate.testing.TestForIssue;
@@ -304,8 +298,9 @@ abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalTestCase
 		}
 
 		protected final boolean isNanosecondPrecisionSupported() {
-			// Most databases apparently don't support nanosecond precision correctly
-			return dialect instanceof H2Dialect;
+			// This used to return true for H2Dialect, but as of 1.4.197 h2 does not use ns precision by default anymore.
+			// Bringing back ns precision would require timestamp(9) in the dialect class.
+			return false;
 		}
 
 		protected final S add(ZoneId defaultJvmTimeZone, Object ... subClassParameters) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -35,6 +35,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.build.AllowSysOut;
+import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jdbc.AbstractReturningWork;
@@ -350,6 +351,11 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 
 	@After
 	public final void afterTest() throws Exception {
+		// see https://github.com/hibernate/hibernate-orm/pull/3412#issuecomment-678338398
+		if ( getDialect() instanceof H2Dialect ) {
+			ReflectHelper.getMethod( Class.forName( "org.h2.util.DateTimeUtils" ), "resetCalendar" ).invoke( null );
+		}
+
 		completeStrayTransaction();
 
 		if ( isCleanupTestDataRequired() ) {
@@ -425,6 +431,8 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 	}
 
 	public static class RollbackWork implements Work {
+
+		@Override
 		public void execute(Connection connection) throws SQLException {
 			connection.rollback();
 		}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
@@ -40,6 +40,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.build.AllowPrintStacktrace;
 import org.hibernate.internal.build.AllowSysOut;
+import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.jdbc.Work;
 import org.hibernate.mapping.Collection;
@@ -450,6 +451,11 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 
 	@After
 	public final void afterTest() throws Exception {
+		// see https://github.com/hibernate/hibernate-orm/pull/3412#issuecomment-678338398
+		if ( getDialect() instanceof H2Dialect ) {
+			ReflectHelper.getMethod( Class.forName( "org.h2.util.DateTimeUtils" ), "resetCalendar" ).invoke( null );
+		}
+
 		completeStrayTransaction();
 
 		if ( isCleanupTestDataRequired() ) {
@@ -505,6 +511,8 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 	}
 
 	public class RollbackWork implements Work {
+
+		@Override
 		public void execute(Connection connection) throws SQLException {
 			connection.rollback();
 		}


### PR DESCRIPTION
Resolves https://hibernate.atlassian.net/browse/HHH-14031

Notes:
- h2 1.4.197+ does not support ns precision by default anymore
- h2 DateTimeUtils.resetCalendar() is required for many tests to avoid failures due to h2 internal caching

This was separated from #3412 which originally aimed at updating to 1.4.200+ but that path seems blocked for now: https://github.com/hibernate/hibernate-orm/pull/3412#issuecomment-678813877 (and subsequent comments).