### PR TITLE
explicitly specify precision/scale for @Column in test

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mappedsuperclass/intermediate/SavingsAccountBase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mappedsuperclass/intermediate/SavingsAccountBase.java
@@ -17,7 +17,8 @@ import javax.persistence.MappedSuperclass;
  */
 @MappedSuperclass
 public abstract class SavingsAccountBase extends Account {
-	@Column(name = "SAVACC_WITHDRAWALLIMIT")
+	@Column(name = "SAVACC_WITHDRAWALLIMIT",
+			precision = 8, scale = 2)
 	private BigDecimal withdrawalLimit;
 
 	protected SavingsAccountBase() {


### PR DESCRIPTION
If you have a `@Column` annotation, then by default you will get `precision=0`, `scale=0`, resulting in a `numeric(0,0)`.

This caused a test failure on H2 1.4.200. Not sure why it wasn't causing problems earlier.