### PR TITLE
prefer localtime, localtimestamp on H2, HSQL, and Postgres (H6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -488,26 +488,76 @@ public abstract class Dialect implements ConversionContext {
 		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "current_instant", "instant" ); //deprecated legacy!
 	}
 
+	/**
+	 * Translation of the HQL/JPQL {@code current_date} function, which
+	 * maps to the Java type {@code java.sql.Date}, and of the HQL
+	 * {@code local_date} function which maps to the Java type
+	 * {@code java.sql.LocalDate}.
+	 */
 	public String currentDate() {
 		return "current_date";
 	}
 
+	/**
+	 * Translation of the HQL/JPQL {@code current_time} function, which
+	 * maps to the Java type {@code java.sql.Time} which is a time with
+	 * no time zone. This contradicts ANSI SQL where {@code current_time}
+	 * has the type {@code TIME WITH TIME ZONE}.
+	 * <p>
+	 * It is recommended to override this in dialects for databases which
+	 * support {@code localtime} or {@code time at local}.
+	 */
 	public String currentTime() {
 		return "current_time";
 	}
 
+	/**
+	 * Translation of the HQL/JPQL {@code current_timestamp} function,
+	 * which maps to the Java type {@code java.sql.Timestamp} which is
+	 * a datetime with no time zone. This contradicts ANSI SQL where
+	 * {@code current_timestamp} has the type
+	 * {@code TIMESTAMP WITH TIME ZONE}.
+	 * <p>
+	 * It is recommended to override this in dialects for databases which
+	 * support {@code localtimestamp} or {@code timestamp at local}.
+	 */
 	public String currentTimestamp() {
 		return "current_timestamp";
 	}
 
+	/**
+	 * Translation of the HQL {@code local_time} function, which maps to
+	 * the Java type {@code java.time.LocalTime} which is a time with no
+	 * time zone. It should usually be the same SQL function as for
+	 * {@link #currentTime()}.
+	 * <p>
+	 * It is recommended to override this in dialects for databases which
+	 * support {@code localtime} or {@code current_time at local}.
+	 */
 	public String currentLocalTime() {
 		return currentTime();
 	}
 
+	/**
+	 * Translation of the HQL {@code local_datetime} function, which maps
+	 * to the Java type {@code java.time.LocalDateTime} which is a datetime
+	 * with no time zone. It should usually be the same SQL function as for
+	 * {@link #currentTimestamp()}.
+	 * <p>
+	 * It is recommended to override this in dialects for databases which
+	 * support {@code localtimestamp} or {@code current_timestamp at local}.
+	 */
 	public String currentLocalTimestamp() {
 		return currentTimestamp();
 	}
 
+	/**
+	 * Translation of the HQL {@code offset_datetime} function, which maps
+	 * to the Java type {@code java.time.OffsetDateTime} which is a datetime
+	 * with a time zone. This in principle correctly maps to the ANSI SQL
+	 * {@code current_timestamp} which has the type
+	 * {@code TIMESTAMP WITH TIME ZONE}.
+	 */
 	public String currentTimestampWithTimeZone() {
 		return currentTimestamp();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -87,7 +87,7 @@ public class H2Dialect extends Dialect {
 		// Prior to 1.4.200 the 'cascade' in 'drop table' was implicit
 		cascadeConstraints = version > 140 || version == 140 && buildId >= 200;
 		// 1.4.200 introduced changes in current_time and current_timestamp
-		useLocalTime = version > 140 || version == 140 && buildId >= 200;
+		useLocalTime = version > 140 || version == 140 && buildId >= 199;
 
 		getDefaultProperties().setProperty( AvailableSettings.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
 		// http://code.google.com/p/h2database/issues/detail?id=235

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -58,6 +58,7 @@ public class H2Dialect extends Dialect {
 	private final LimitHandler limitHandler;
 
 	private final boolean cascadeConstraints;
+	private final boolean useLocalTime;
 
 	private final int version;
 
@@ -85,6 +86,8 @@ public class H2Dialect extends Dialect {
 
 		// Prior to 1.4.200 the 'cascade' in 'drop table' was implicit
 		cascadeConstraints = version > 140 || version == 140 && buildId >= 200;
+		// 1.4.200 introduced changes in current_time and current_timestamp
+		useLocalTime = version > 140 || version == 140 && buildId >= 200;
 
 		getDefaultProperties().setProperty( AvailableSettings.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
 		// http://code.google.com/p/h2database/issues/detail?id=235
@@ -167,6 +170,21 @@ public class H2Dialect extends Dialect {
 		CommonFunctionFactory.varPopSamp( queryEngine );
 		CommonFunctionFactory.format_formatdatetime( queryEngine );
 		CommonFunctionFactory.rownum( queryEngine );
+	}
+
+	@Override
+	public String currentTime() {
+		return useLocalTime ? "localtime" : super.currentTime();
+	}
+
+	@Override
+	public String currentTimestamp() {
+		return useLocalTime ? "localtimestamp" : super.currentTimestamp();
+	}
+
+	@Override
+	public String currentTimestampWithTimeZone() {
+		return "current_timestamp";
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -204,6 +204,21 @@ public class HSQLDialect extends Dialect {
 	}
 
 	@Override
+	public String currentTime() {
+		return "localtime";
+	}
+
+	@Override
+	public String currentTimestamp() {
+		return "localtimestamp";
+	}
+
+	@Override
+	public String currentTimestampWithTimeZone() {
+		return "current_timestamp";
+	}
+
+	@Override
 	public String castPattern(CastType from, CastType to) {
 		if ( from== BOOLEAN
 				&& (to== INTEGER || to== LONG)) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -118,6 +118,21 @@ public class PostgreSQLDialect extends Dialect {
 		return version;
 	}
 
+	@Override
+	public String currentTime() {
+		return "localtime";
+	}
+
+	@Override
+	public String currentTimestamp() {
+		return "localtimestamp";
+	}
+
+	@Override
+	public String currentTimestampWithTimeZone() {
+		return "current_timestamp";
+	}
+
 	/**
 	 * The {@code extract()} function returns {@link TemporalUnit#DAY_OF_WEEK}
 	 * numbered from 0 to 6. This isn't consistent with what most other


### PR DESCRIPTION
- As suggested by @famod we need to use `localtime` instead of `current_time` because of changes in H2.
- However, it actually makes sense to use `localtime` and `localtimestamp` on other databases too, starting with HSQLDB and Postgres.
- Also much more clearly document this stuff in the Javadoc for `Dialect`.

See https://github.com/hibernate/hibernate-orm/pull/3412