### PR TITLE
on H2 prior to 2.0 map NUMERIC to DECIMAL (H6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -101,6 +101,12 @@ public class H2Dialect extends Dialect {
 			this.sequenceInformationExtractor = SequenceInformationExtractorNoOpImpl.INSTANCE;
 			this.querySequenceString = null;
 		}
+
+		if ( version < 200 ) {
+			// prior to version 2.0, H2 reported NUMERIC columns as DECIMAL,
+			// which caused problems for schema update tool
+			registerColumnType( Types.NUMERIC, "decimal($p,$s)" );
+		}
 	}
 
 	private static int parseBuildId(DialectResolutionInfo info) {


### PR DESCRIPTION
This is helpful to the schema update tool.

This workaround was lost during my work on `Dialect`s.
