### PR TITLE
HHH-11877 Wrap CompoundPredicate's expression list

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/CompoundPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/predicate/CompoundPredicate.java
@@ -80,7 +80,10 @@ public class CompoundPredicate
 
 	private void applyExpressions(List<Expression<Boolean>> expressions) {
 		this.expressions.clear();
-		this.expressions.addAll( expressions );
+		final CriteriaBuilderImpl criteriaBuilder = criteriaBuilder();
+		for ( Expression<Boolean> expression : expressions ) {
+			this.expressions.add( criteriaBuilder.wrap( expression ) );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh11877/Foo.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh11877/Foo.java
@@ -1,0 +1,31 @@
+package org.hibernate.query.criteria.internal.hhh11877;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Foo {
+
+	private long id;
+	private boolean bar;
+
+	@Column(nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id
+	public long getId() {
+		return this.id;
+	}
+	public void setId(final long id) {
+		this.id = id;
+	}
+
+	public boolean isBar() {
+		return this.bar;
+	}
+	public void setBar(final boolean bar) {
+		this.bar = bar;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh11877/HHH111877Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh11877/HHH111877Test.java
@@ -1,0 +1,44 @@
+package org.hibernate.query.criteria.internal.hhh11877;
+
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+/**
+ * @author Archie Cobbs
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-11877" )
+public class HHH111877Test extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Foo.class };
+	}
+
+	@Test
+	public void testNoExceptionThrow() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+
+			final CriteriaQuery<Foo> cq = cb.createQuery( Foo.class );
+			final Root<Foo> foo = cq.from( Foo.class );
+
+			cq.select( foo ).where( cb.and( cb.and(), foo.get( Foo_.bar ) ) );
+
+			final TypedQuery<Foo> tq = entityManager.createQuery( cq );
+
+			// without fixing, the statement below will throw exception:
+			// java.lang.IllegalArgumentException: org.hibernate.hql.internal.ast.QuerySyntaxException: unexpected AST node: . near line 1, column 106 [select generatedAlias0 from org.hibernate.bugs.Foo as generatedAlias0 where ( 1=1 ) and ( generatedAlias0.bar )]
+			tq.getResultList();
+		} );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11877

The issue can be summarized as following:

Suppose we have an entity class `Foo` that contains a boolean field `bar`, the following criteria building will produce invalid SQL:
```
cq.select( foo ).where( cb.and( cb.and(), foo.get( Foo_.bar ) ) );
```
whereas the following is working fine:
```
cq.select( foo ).where( foo.get( Foo_.bar ) );
```

The root cause is internally in `CriteriaBuilderImpl#wrap()` method we fixed boolean type Path to ensure creating SQL snippet like `Foo_.bar = 1` rather than `Foo_.bar` (which will trigger invalid SQL). But we didn't go deeper than root level and this PR fixed the loophole to fix non-root level boolean type Path as well.