### PR TITLE
HHH-13058 Fix issue left join root cannot be replaced by correlated parent in subquery

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/FromImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/FromImplementor.java
@@ -22,4 +22,7 @@ public interface FromImplementor<Z,X> extends PathImplementor<X>, From<Z,X> {
 	FromImplementor<Z,X> correlateTo(CriteriaSubqueryImpl subquery);
 	void prepareCorrelationDelegate(FromImplementor<Z,X> parent);
 	FromImplementor<Z, X> getCorrelationParent();
+	default boolean canBeReplacedByCorrelatedParentInSubQuery() {
+		return isCorrelated();
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/HHH13058Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/HHH13058Test.java
@@ -1,0 +1,133 @@
+package org.hibernate.query.criteria.internal.hhh13058;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Archie Cobbs
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-13058" )
+public class HHH13058Test extends BaseEntityManagerFunctionalTestCase {
+
+	private Set<Site> validSites;
+
+	private Task taskWithoutPatient;
+	private Task taskWithPatientWithoutSite;
+	private Task taskWithPatient1WithValidSite1;
+	private Task taskWithPatient2WithValidSite1;
+	private Task taskWithPatient3WithValidSite2;
+	private Task taskWithPatientWithInvalidSite;
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Task.class,
+				Patient.class,
+				Site.class
+		};
+	}
+
+	@Before
+	public void setUp() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final Site validSite1 = new Site();
+			final Site validSite2 = new Site();
+			final Site invalidSite = new Site();
+
+			entityManager.persist( validSite1 );
+			entityManager.persist( validSite2 );
+			entityManager.persist( invalidSite );
+
+			validSites = new HashSet<>( Arrays.asList( validSite1, validSite2 ) );
+
+			final Patient patientWithoutSite = new Patient();
+			final Patient patient1WithValidSite1 = new Patient( validSite1 );
+			final Patient patient2WithValidSite1 = new Patient( validSite1 );
+			final Patient patient3WithValidSite2 = new Patient( validSite2 );
+			final Patient patientWithInvalidSite = new Patient( invalidSite );
+
+			entityManager.persist( patientWithoutSite );
+			entityManager.persist( patient1WithValidSite1 );
+			entityManager.persist( patient2WithValidSite1 );
+			entityManager.persist( patient3WithValidSite2 );
+			entityManager.persist( patientWithInvalidSite );
+
+			taskWithoutPatient = new Task();
+			taskWithoutPatient.description = "taskWithoutPatient";
+
+			taskWithPatientWithoutSite = new Task( patientWithoutSite );
+			taskWithPatientWithoutSite.description = "taskWithPatientWithoutSite";
+
+			taskWithPatient1WithValidSite1 = new Task( patient1WithValidSite1 );
+			taskWithPatient1WithValidSite1.description = "taskWithPatient1WithValidSite1";
+
+			taskWithPatient2WithValidSite1 = new Task( patient2WithValidSite1 );
+			taskWithPatient2WithValidSite1.description = "taskWithPatient2WithValidSite1";
+
+			taskWithPatient3WithValidSite2 = new Task( patient3WithValidSite2 );
+			taskWithPatient3WithValidSite2.description = "taskWithPatient3WithValidSite2";
+
+			taskWithPatientWithInvalidSite = new Task( patientWithInvalidSite );
+			taskWithPatientWithInvalidSite.description = "taskWithPatientWithInvalidSite";
+
+			entityManager.persist( taskWithoutPatient );
+			entityManager.persist( taskWithPatientWithoutSite );
+			entityManager.persist( taskWithPatient1WithValidSite1 );
+			entityManager.persist( taskWithPatient2WithValidSite1 );
+			entityManager.persist( taskWithPatient3WithValidSite2 );
+			entityManager.persist( taskWithPatientWithInvalidSite );
+		} );
+	}
+
+	@Test
+	public void testCorrelateSubQueryLeftJoin() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<Task> outerQuery = builder.createQuery( Task.class );
+			final Root<Task> outerTask = outerQuery.from( Task.class );
+
+			final Subquery<Task> subquery = outerQuery.subquery( Task.class );
+			final Root<Task> subtask = subquery.correlate( outerTask );
+			final From<Task, Patient> patient = subtask.join( Task_.patient, JoinType.LEFT );
+			final From<Patient, Site> site = patient.join( Patient_.site, JoinType.LEFT );
+			outerQuery.where(
+					builder.exists(
+							subquery.select( subtask )
+									.where(
+											builder.or(
+												   patient.isNull(),
+												   site.in( validSites )
+											)
+									)
+					)
+			);
+			final List<Task> tasks = entityManager.createQuery( outerQuery ).getResultList();
+			assertThat( new HashSet<>( tasks ), is( new HashSet<>( Arrays.asList(
+					taskWithoutPatient,
+					taskWithPatient1WithValidSite1,
+					taskWithPatient2WithValidSite1,
+					taskWithPatient3WithValidSite2
+			) ) ) );
+
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Patient.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Patient.java
@@ -1,0 +1,32 @@
+package org.hibernate.query.criteria.internal.hhh13058;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * @author Archie Cobbs
+ * @author Nathan Xu
+ */
+@Entity(name = "Patient")
+@Table(name = "Patient")
+public class Patient {
+
+	@Id
+	@GeneratedValue
+	Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	Site site;
+
+	public Patient() {
+	}
+
+	public Patient(Site site) {
+		this.site = site;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Site.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Site.java
@@ -1,0 +1,20 @@
+package org.hibernate.query.criteria.internal.hhh13058;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author Archie Cobbs
+ * @author Nathan Xu
+ */
+@Entity(name = "Site")
+@Table(name = "Site")
+public class Site {
+
+	@Id
+	@GeneratedValue
+	Long id;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Task.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/criteria/internal/hhh13058/Task.java
@@ -1,0 +1,56 @@
+package org.hibernate.query.criteria.internal.hhh13058;
+
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+/**
+ * @author Archie Cobbs
+ * @author Nathan Xu
+ */
+@Entity(name = "Task")
+@Table(name = "Task")
+public class Task {
+
+	@Id
+	@GeneratedValue
+	Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	Patient patient;
+
+	String description;
+
+	public Task() {
+	}
+
+	public Task(Patient patient) {
+		this.patient = patient;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Task task = (Task) o;
+		return id.equals( task.id );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( id );
+	}
+
+	@Override
+	public String toString() {
+		return String.format( "Task(id: %d; description: %s)", id, description == null ? "null" : description );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13058

The current correlated subquery ignores the first left join and ends up with 'inner join' instead invariably. So suppose for the below entities:
```
@Entity(name = "Task")
public class Task {
    @Id
    Long id;

    @ManyToOne
    Patient patient;
}

@Entity(name = "Patient")
public class Patient {
    @Id
    Long id;

    @ManyToOne
    Site site;
}

@Entity(name = "Site")
public class Site {
    @Id
    Long id;
}
```
Note that `@ManyToOne`'s `optional` is `true` by default.

the following Criteria would skip the `Task` without `Patient`:
```
final Subquery<Task> subquery = outerQuery.subquery( Task.class );
final Root<Task> subtask = subquery.correlate( outerTask );
final From<Task, Patient> patient = subtask.join( Task_.patient, JoinType.LEFT );
final From<Patient, Site> site = patient.join( Patient_.site, JoinType.LEFT );
outerQuery.where(
    builder.exists(
        subquery.select( subtask )
            .where(
                builder.or(
                    patient.isNull(),
                    site.in( validSites )
                )
        )
    )
);
```
because internally the jpasql generated is:
```
select generatedAlias0 from Task as generatedAlias0 
where exists (
    select generatedAlias0 
    from generatedAlias0.patient as generatedAlias1 
        left join generatedAlias1.site as generatedAlias2 
    where ( generatedAlias1 is null ) or ( generatedAlias2 in (:param0, :param1) 
))
```
Note that `generatedAlias1 is null` can never be true for the left join from Task to Patient has been skipped by correlate parent's alias substitution; but given that Task's Patient is optional we should reserve the `left join` from `Task` to `Patient`. 
The fix in this PR is to create the following jpasql instead:
```
select generatedAlias0 from Task as generatedAlias0 
where exists (
    select generatedAlias0 
    from Task as generatedAlias1 
        left join generatedAlias1.patient as generatedAlias1 
        left join generatedAlias1.site as generatedAlias2 
    where 
        generatedAlias1 = generatedAlias0 and (( generatedAlias1 is null ) or ( generatedAlias2 in (:param0, :param1))
))
```
The basic idea is to generate new alias for correlated root and add `newAlias = oldAlias` to the `WHERE` jpasql clause, thus reserving the `LEFT JOIN` semantic of the correlated root in subquery.
However, the old pattern still remains for performance reason and the above changes only apply when `LEFT JOIN` is involved.