### PR TITLE
generate sensibly-lengthed columns for UUIDs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/UUIDBinaryType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/UUIDBinaryType.java
@@ -8,6 +8,7 @@ package org.hibernate.type;
 
 import java.util.UUID;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.java.UUIDTypeDescriptor;
 import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
 
@@ -20,7 +21,12 @@ public class UUIDBinaryType extends AbstractSingleColumnStandardBasicType<UUID> 
 	public static final UUIDBinaryType INSTANCE = new UUIDBinaryType();
 
 	public UUIDBinaryType() {
-		super( BinaryTypeDescriptor.INSTANCE, UUIDTypeDescriptor.INSTANCE );
+		super( BinaryTypeDescriptor.INSTANCE, new UUIDTypeDescriptor() {
+			@Override
+			public long getDefaultSqlLength(Dialect dialect) {
+				return 16;
+			}
+		} );
 	}
 
 	public String getName() {

--- a/hibernate-core/src/main/java/org/hibernate/type/UUIDCharType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/UUIDCharType.java
@@ -21,7 +21,12 @@ public class UUIDCharType extends AbstractSingleColumnStandardBasicType<UUID> im
 	public static final UUIDCharType INSTANCE = new UUIDCharType();
 
 	public UUIDCharType() {
-		super( VarcharTypeDescriptor.INSTANCE, UUIDTypeDescriptor.INSTANCE );
+		super( VarcharTypeDescriptor.INSTANCE, new UUIDTypeDescriptor() {
+			@Override
+			public long getDefaultSqlLength(Dialect dialect) {
+				return 36;
+			}
+		} );
 	}
 
 	public String getName() {


### PR DESCRIPTION
Previously, Hibernate generated column definitions of length 255 for `BINARY`/`CHAR` columns that will have `UUID`s stored in them. It should be:

- length 16 for `BINARY`
- length 36 for `CHAR`