### PR TITLE
HHH-14148 fix issue mapping-based order fragment might lead to incorrect SQL

### DIFF
--- a/hibernate-core/src/main/antlr/sql-gen.g
+++ b/hibernate-core/src/main/antlr/sql-gen.g
@@ -146,7 +146,7 @@ selectStatement
 		from
 		( #(WHERE { out(" where "); } whereExpr ) )?
 		( #(GROUP { out(" group by "); } groupExprs ( #(HAVING { out(" having "); } booleanExpr[false]) )? ) )?
-		( #(ORDER { out(" order by "); } orderExprs ) )?
+		( #(ORDER { out(" order by "); } orderBySqlFragmentOrExprs ) )?
 	)
 	;
 
@@ -189,6 +189,11 @@ whereClause
 whereClauseExpr
 	: (SQL_TOKEN) => conditionList
 	| booleanExpr[ false ]
+	;
+
+orderBySqlFragmentOrExprs
+	: sqlToken // for the purpose of mapping-defined orderBy SQL fragment
+	| orderExprs
 	;
 
 orderExprs { String ordExp = null; String ordDir = null; String ordNul = null; }
@@ -277,7 +282,7 @@ distinctOrAll
 	;
 
 countExpr
-	// Syntacitic predicate resolves star all by itself, avoiding a conflict with STAR in expr.
+	// Syntactic predicate resolves star all by itself, avoiding a conflict with STAR in expr.
 	: ROW_STAR { out("*"); }
 	| simpleExpr
 	;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OrderByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/onetomany/OrderByTest.java
@@ -24,15 +24,17 @@ import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.NullPrecedence;
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.dialect.SQLServer2008Dialect;
-import org.hibernate.dialect.SQLServer2012Dialect;
-import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.graph.RootGraph;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.collection.QueryableCollection;
+import org.hibernate.query.Query;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
@@ -513,6 +515,28 @@ public class OrderByTest extends BaseCoreFunctionalTestCase {
 
 		s.getTransaction().commit();
 		s.close();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-14148" )
+	@RequiresDialect(value = { H2Dialect.class, MySQLDialect.class, SQLServer2008Dialect.class },
+			comment = "By default H2 places NULL values first, so testing 'NULLS LAST' expression. " +
+					"For MySQL and SQL Server 2008 testing overridden Dialect#renderOrderByElement(String, String, String, NullPrecedence) method. " +
+					"MySQL and SQL Server 2008 does not support NULLS FIRST / LAST syntax at the moment, so transforming the expression to 'CASE WHEN ...'.")
+	public void testNullPrecedenceWithOrderBySqlFragment() {
+		inTransaction( session -> {
+			final RootGraph<Order> graph = session.createEntityGraph( Order.class );
+			graph.addAttributeNodes( "itemList" );
+
+			Query<Order> query = session.createQuery( "from Order", Order.class );
+			query.applyFetchGraph( graph );
+			query.getResultList(); // before HHH-14148 is fixed, incorrect SQL would be generated ending with " nulls last nulls last"
+		} );
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.DEFAULT_NULL_ORDERING, "last" );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14148

The issue is invalid SQL like `... order by ... nulls last nulls last` would be generated for the combination of `@OrderBy on collection field` + `entity graph dictating the collection field to be fetched eagerly`.

So it turns out that the root cause is the following ANTLR2 snippet in sql-gen.g:

```
orderExprs { String ordExp = null; String ordDir = null; String ordNul = null; }
	// TODO: remove goofy space before the comma when we don't have to regression test anymore.
	// Dialect is provided a hook to render each ORDER BY element, so the expression is being captured instead of
	// printing to the SQL output directly. See Dialect#renderOrderByElement(String, String, String, NullPrecedence).
	: { captureExpressionStart(); } ( expr ) { captureExpressionFinish(); ordExp = resetCapture(); }
	    (dir:orderDirection { ordDir = #dir.getText(); })? (ordNul=nullOrdering)?
	        { out( renderOrderByElement( ordExp, ordDir, ordNul ) ); }
	    ( {out(", "); } orderExprs )?
	;
```

The above case only applies for explicit HQL order by processing. There is another implicit mapping-based order by SQL fragment to go through this matching rule (e.g. the order by fragment added by @OrderBy). In that case, the SQL order by fragment has been complete (including the potential null precedence like `nulls last`). Going through the above processing would add another null precedence fragment again, thus ending up with incorrect SQL.

The solution in this PR is simply to add another rule for such complete SQL order fragment case to have it printed intact.