### PR TITLE
HHH-14210 locking and DB2 (H6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -329,6 +329,15 @@ public class DB2Dialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsSkipLocked() {
+		return true;
+	}
+
+	@Override
+	public String getForUpdateSkipLockedString() {
+		return getForUpdateString() + " skip locked data";
+	}
+	@Override
 	public boolean supportsOuterJoinForUpdate() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1396,10 +1396,11 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Is <tt>FOR UPDATE OF</tt> syntax supported?
+	 * Does the <tt>FOR UPDATE OF</tt> clause accept a list of columns
+	 * instead of a list of table aliases?
 	 *
-	 * @return True if the database supports <tt>FOR UPDATE OF</tt> syntax;
-	 * false otherwise.
+	 * @return True if the database <tt>FOR UPDATE OF</tt> clause takes
+	 * a column list; false otherwise.
 	 */
 	public boolean forUpdateOfColumns() {
 		// by default we report no support

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1054,7 +1054,7 @@ public abstract class Dialect implements ConversionContext {
 	 * @return The Hibernate {@link Type} name.
 	 * @throws HibernateException If no mapping was specified for that type.
 	 */
-	@SuppressWarnings( {"UnusedDeclaration"})
+	@SuppressWarnings("UnusedDeclaration")
 	public String getHibernateTypeName(int code) throws HibernateException {
 		final String result = hibernateTypeNames.get( code );
 		if ( result == null ) {
@@ -1299,7 +1299,7 @@ public abstract class Dialect implements ConversionContext {
 		return getForUpdateString( lockOptions.getLockMode(), lockOptions.getTimeOut() );
 	}
 
-	@SuppressWarnings( {"deprecation"})
+	@SuppressWarnings("deprecation")
 	private String getForUpdateString(LockMode lockMode, int timeout){
 		switch ( lockMode ) {
 			case UPGRADE:
@@ -1536,7 +1536,6 @@ public abstract class Dialect implements ConversionContext {
 	 * @param keyColumnNames a map of key columns indexed by aliased table names.
 	 * @return the modified SQL string.
 	 */
-	@SuppressWarnings("deprecation")
 	public String applyLocksToSql(String sql, LockOptions aliasedLockOptions, Map<String, String[]> keyColumnNames) {
 		return sql + new ForUpdateFragment( this, aliasedLockOptions, keyColumnNames ).toFragmentString();
 	}
@@ -2791,7 +2790,7 @@ public abstract class Dialect implements ConversionContext {
 	 * @return Returns {@code true} if the database supports accepting bind params as args, {@code false} otherwise. The
 	 * default is {@code true}.
 	 */
-	@SuppressWarnings( {"UnusedDeclaration"})
+	@SuppressWarnings("UnusedDeclaration")
 	public boolean supportsBindAsCallableArgument() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresDialect.java
@@ -293,15 +293,16 @@ public class IngresDialect extends Dialect {
 
 	// lock acquisition support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+	/**
+	 * <TT>FOR UPDATE</TT> only supported for cursors
+	 *
+	 * @return the empty string
+	 */
 	@Override
-	public boolean supportsOuterJoinForUpdate() {
-		return getVersion() >= 930;
+	public String getForUpdateString() {
+		return "";
 	}
 
-	@Override
-	public boolean forUpdateOfColumns() {
-		return getVersion() >= 930;
-	}
 
 	// current timestamp support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/RDMSOS2200Dialect.java
@@ -222,25 +222,9 @@ public class RDMSOS2200Dialect extends Dialect {
 	}
 
 	/**
-	 * The RDMS DB supports the 'FOR UPDATE OF' clause. However, the RDMS-JDBC
-	 * driver does not support this feature, so a false is return.
-	 * The base dialect also returns a false, but we will leave this over-ride
-	 * in to make sure it stays false.
-	 * <p/>
-	 * {@inheritDoc}
-	 */
-	@Override
-	public boolean forUpdateOfColumns() {
-		return false;
-	}
-
-	/**
-	 * Since the RDMS-JDBC driver does not support for updates, this string is
-	 * set to an empty string. Whenever, the driver does support this feature,
-	 * the returned string should be " FOR UPDATE OF". Note that RDMS does not
-	 * support the string 'FOR UPDATE' string.
-	 * <p/>
-	 * {@inheritDoc}
+	 * <TT>FOR UPDATE</TT> only supported for cursors
+	 *
+	 * @return the empty string
 	 */
 	@Override
 	public String getForUpdateString() {

--- a/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/locktimeout/DB2LockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/dialect/unit/locktimeout/DB2LockTimeoutTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.dialect.unit.locktimeout;
+
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gavin King
+ */
+public class DB2LockTimeoutTest extends BaseUnitTestCase {
+
+	private final Dialect dialect = new DB2Dialect();
+
+	@Test
+	public void testLockTimeoutNoAliasNoTimeout() {
+		assertEquals(
+				" for read only with rs use and keep share locks",
+				dialect.getForUpdateString( new LockOptions( LockMode.PESSIMISTIC_READ ) )
+		);
+		assertEquals(
+				" for read only with rs use and keep update locks",
+				dialect.getForUpdateString( new LockOptions( LockMode.PESSIMISTIC_WRITE ) )
+		);
+	}
+
+	@Test
+	public void testLockTimeoutNoAliasSkipLocked() {
+		assertEquals(
+				" for read only with rs use and keep share locks skip locked data",
+				dialect.getForUpdateString( new LockOptions( LockMode.PESSIMISTIC_READ )
+													.setTimeOut( LockOptions.SKIP_LOCKED ) )
+		);
+		assertEquals(
+				" for read only with rs use and keep update locks skip locked data",
+				dialect.getForUpdateString( new LockOptions( LockMode.PESSIMISTIC_WRITE )
+													.setTimeOut( LockOptions.SKIP_LOCKED ) )
+		);
+	}
+}


### PR DESCRIPTION
Contains the following changes:

- support for `skip locked data` on DB2
- support for `use and keep share locks` on DB2
- removal of support for `for update` in `IngresDialect` and RDMS, since those databases only support `for update` in cursors, AFAICS
- fixed documentation of `Dialect.forUpdateOfColumns()`, which was completely wrong about its semantics

Fixes HHH-14210