### PR TITLE
HHH 14212 ultimate Fetch Graph fix

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -415,11 +415,7 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overridden (i.e. skipping metamodel strategy), including (order sensitive):
-	 * <ol>
-	 *     <li>fetch graph</li>
-	 *     <li>fetch profile</li>
-	 * </ol>
+	 * Check if eager of the association is overridden by anything.
 	 *
 	 * @param session session
 	 * @param entityName entity name
@@ -437,7 +433,6 @@ public final class TwoPhaseLoad {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
 		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
 
-			// check 'fetch graph' first; skip 'fetch profile' if 'fetch graph' takes effect
 			Boolean overridingEager = isEagerFetchGraph( session, associationName, associationType );
 
 			if ( overridingEager != null ) {
@@ -454,7 +449,6 @@ public final class TwoPhaseLoad {
 				return overridingEager;
 			}
 			
-			// check 'fetch profile' next; skip 'metamodel' if 'fetch profile' takes effect
 			overridingEager = isEagerFetchProfile( session, entityName, associationName );
 
 			if ( overridingEager != null ) {
@@ -470,7 +464,6 @@ public final class TwoPhaseLoad {
 				return overridingEager;
 			}
 		}
-		// let 'metamodel' decide eagerness
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -495,7 +495,6 @@ public final class TwoPhaseLoad {
 			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
 			if ( attributeNode != null ) {
 				if ( associationType.isCollectionType() ) {
-					// to do: deal with Map's key and value
 					session.setFetchGraphLoadContext( null );
 				}
 				else {
@@ -503,8 +502,7 @@ public final class TwoPhaseLoad {
 					GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
 					if ( subContext != null ) {
 						session.setFetchGraphLoadContext( subContext );
-					}
-					else {
+					} else {
 						session.setFetchGraphLoadContext( null );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -207,10 +207,11 @@ public final class TwoPhaseLoad {
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
 		
-		final GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
+		GraphImplementor<?> fetchGraphContext = session.getFetchGraphLoadContext();
 		
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
+			
 			if ( debugEnabled ) {
 				LOG.debugf(
 					"Processing attribute `%s` : value = %s",
@@ -494,11 +495,11 @@ public final class TwoPhaseLoad {
 	}
 	
 	private static Boolean isEagerFetchGraph(SharedSessionContractImplementor session, String associationName, Type associationType) {
-		final GraphImplementor<?> context = session.getFetchGraphLoadContext();
+		GraphImplementor<?> context = session.getFetchGraphLoadContext();
 		
 		if ( context != null ) {
 			// 'fetch graph' is in effect, so null should not be returned
-			final AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
+			AttributeNodeImplementor<Object> attributeNode = context.findAttributeNode( associationName );
 			if ( attributeNode != null ) {
 				if ( associationType.isCollectionType() ) {
 					// to do: deal with Map's key and value
@@ -506,7 +507,7 @@ public final class TwoPhaseLoad {
 				}
 				else {
 					// set 'fetchGraphContext' to sub-graph so graph is explored further (internal loading)
-					final GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
+					GraphImplementor<?> subContext = attributeNode.getSubGraphMap().get( associationType.getReturnedClass() );
 					if ( subContext != null ) {
 						session.setFetchGraphLoadContext( subContext );
 					}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -39,6 +39,7 @@ import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.internal.StatsHelper;
 import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
 import org.hibernate.type.TypeHelper;
 
@@ -118,18 +119,13 @@ public final class TwoPhaseLoad {
 			final boolean readOnly,
 			final SharedSessionContractImplementor session,
 			final PreLoadEvent preLoadEvent) {
-		final PersistenceContext persistenceContext = session.getPersistenceContext();
-		final EntityEntry entityEntry = persistenceContext.getEntry( entity );
-		if ( entityEntry == null ) {
-			throw new AssertionFailure( "possible non-threadsafe access to the session" );
-		}
 		final EventListenerGroup<PreLoadEventListener> listenerGroup = session
 			.getFactory()
 			.getServiceRegistry()
 			.getService( EventListenerRegistry.class )
 			.getEventListenerGroup( EventType.PRE_LOAD );
 		final Iterable<PreLoadEventListener> listeners = listenerGroup.listeners();
-		doInitializeEntity( entity, entityEntry, readOnly, session, preLoadEvent, listeners );
+		initializeEntity( entity, readOnly, session, preLoadEvent, listeners, EntityResolver.DEFAULT );
 	}
 
 	/**
@@ -152,22 +148,46 @@ public final class TwoPhaseLoad {
 		final SharedSessionContractImplementor session,
 		final PreLoadEvent preLoadEvent,
 		final Iterable<PreLoadEventListener> preLoadEventListeners) {
+		initializeEntity( entity, readOnly, session, preLoadEvent, preLoadEventListeners, EntityResolver.DEFAULT );
+	}
+
+	/**
+	 * Perform the second step of 2-phase load. Fully initialize the entity
+	 * instance.
+	 * <p/>
+	 * After processing a JDBC result set, we "resolve" all the associations
+	 * between the entities which were instantiated and had their state
+	 * "hydrated" into an array
+	 *
+	 * @param entity The entity being loaded
+	 * @param readOnly Is the entity being loaded as read-only
+	 * @param session The Session
+	 * @param preLoadEvent The (re-used) pre-load event
+	 * @param preLoadEventListeners the pre-load event listeners
+	 * @param entityResolver the resolver used for to-one entity associations
+	 *                       (not used when an entity is a bytecode-enhanced lazy entity)
+	 */
+	public static void initializeEntity(
+			final Object entity,
+			final boolean readOnly,
+			final SharedSessionContractImplementor session,
+			final PreLoadEvent preLoadEvent,
+			final Iterable<PreLoadEventListener> preLoadEventListeners,
+			final EntityResolver entityResolver) {
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityEntry entityEntry = persistenceContext.getEntry( entity );
 		if ( entityEntry == null ) {
 			throw new AssertionFailure( "possible non-threadsafe access to the session" );
 		}
-		doInitializeEntity( entity, entityEntry, readOnly, session, preLoadEvent, preLoadEventListeners );
+		initializeEntityEntryLoadedState( entity, entityEntry, session, entityResolver );
+		initializeEntityFromEntityEntryLoadedState( entity, entityEntry, readOnly, session, preLoadEvent, preLoadEventListeners );
 	}
 
-	private static void doInitializeEntity(
+	public static void initializeEntityEntryLoadedState(
 			final Object entity,
 			final EntityEntry entityEntry,
-			final boolean readOnly,
 			final SharedSessionContractImplementor session,
-			final PreLoadEvent preLoadEvent,
-			final Iterable<PreLoadEventListener> preLoadEventListeners) throws HibernateException {
-		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+			final EntityResolver entityResolver) throws HibernateException {
 		final EntityPersister persister = entityEntry.getPersister();
 		final Serializable id = entityEntry.getId();
 		final Object[] hydratedState = entityEntry.getLoadedState();
@@ -184,13 +204,16 @@ public final class TwoPhaseLoad {
 		String entityName = persister.getEntityName();
 		String[] propertyNames = persister.getPropertyNames();
 		final Type[] types = persister.getPropertyTypes();
+
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object value = hydratedState[i];
 			if ( debugEnabled ) {
 				LOG.debugf(
-					"Processing attribute `%s` : value = %s",
-					propertyNames[i],
-					value == LazyPropertyInitializer.UNFETCHED_PROPERTY ? "<un-fetched>" : value == PropertyAccessStrategyBackRefImpl.UNKNOWN ? "<unknown>" : value
+						"Processing attribute `%s` : value = %s",
+						propertyNames[i],
+						value == LazyPropertyInitializer.UNFETCHED_PROPERTY ?
+								"<un-fetched>" :
+								value == PropertyAccessStrategyBackRefImpl.UNKNOWN ? "<unknown>" : value
 				);
 			}
 
@@ -207,23 +230,41 @@ public final class TwoPhaseLoad {
 					// IMPLEMENTATION NOTE: this is a lazy collection property on a bytecode-enhanced entity.
 					// HHH-10989: We need to resolve the collection so that a CollectionReference is added to StatefulPersistentContext.
 					// As mentioned above, hydratedState[i] needs to remain LazyPropertyInitializer.UNFETCHED_PROPERTY
-					// so do not assign the resolved, unitialized PersistentCollection back to hydratedState[i].
-					Boolean overridingEager = getOverridingEager( session, entityName, propertyNames[i], types[i], debugEnabled );
+					// so do not assign the resolved, uninitialized PersistentCollection back to hydratedState[i].
+					Boolean overridingEager = getOverridingEager(
+							session,
+							entityName,
+							propertyNames[i],
+							types[i],
+							debugEnabled
+					);
 					types[i].resolve( value, session, entity, overridingEager );
 				}
 			}
 			else if ( value != PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				if ( debugEnabled ) {
 					final boolean isLazyEnhanced = persister.getBytecodeEnhancementMetadata()
-						.getLazyAttributesMetadata()
-						.getLazyAttributeNames()
-						.contains( propertyNames[i] );
-					LOG.debugf( "Attribute (`%s`)  - enhanced for lazy-loading? - %s", propertyNames[i], isLazyEnhanced );
+							.getLazyAttributesMetadata()
+							.getLazyAttributeNames()
+							.contains( propertyNames[i] );
+					LOG.debugf(
+							"Attribute (`%s`)  - enhanced for lazy-loading? - %s",
+							propertyNames[i],
+							isLazyEnhanced
+					);
 				}
 
 				// we know value != LazyPropertyInitializer.UNFETCHED_PROPERTY
-				Boolean overridingEager = getOverridingEager( session, entityName, propertyNames[i], types[i], debugEnabled );
-				hydratedState[i] = types[i].resolve( value, session, entity, overridingEager );
+				Boolean overridingEager = getOverridingEager(
+						session,
+						entityName,
+						propertyNames[i],
+						types[i],
+						debugEnabled
+				);
+				hydratedState[i] = types[i].isEntityType()
+						? entityResolver.resolve( (EntityType) types[i], value, session, entity, overridingEager )
+						: types[i].resolve( value, session, entity, overridingEager );
 			}
 			else {
 				if ( debugEnabled ) {
@@ -231,6 +272,22 @@ public final class TwoPhaseLoad {
 				}
 			}
 		}
+	}
+
+	public static void initializeEntityFromEntityEntryLoadedState(
+			final Object entity,
+			final EntityEntry entityEntry,
+			final boolean readOnly,
+			final SharedSessionContractImplementor session,
+			final PreLoadEvent preLoadEvent,
+			final Iterable<PreLoadEventListener> preLoadEventListeners) throws HibernateException {
+
+		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+		final EntityPersister persister = entityEntry.getPersister();
+		final Serializable id = entityEntry.getId();
+		final Object[] hydratedState = entityEntry.getLoadedState();
+
+		final boolean debugEnabled = LOG.isDebugEnabled();
 
 		//Must occur after resolving identifiers!
 		if ( session.isEventSource() ) {
@@ -367,27 +424,40 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
-	 * Check if eager of the association is overriden by anything.
+	 * Check if eager of the association is overridden (i.e. skipping metamodel strategy), including (order sensitive):
+	 * <ol>
+	 *     <li>fetch graph</li>
+	 *     <li>fetch profile</li>
+	 * </ol>
 	 *
 	 * @param session session
 	 * @param entityName entity name
 	 * @param associationName association name
-	 *
+	 * @param associationType association type
+	 * @param isDebugEnabled if debug log level enabled
 	 * @return null if there is no overriding, true if it is overridden to eager and false if it is overridden to lazy
 	 */
 	private static Boolean getOverridingEager(
 			final SharedSessionContractImplementor session,
 			final String entityName,
 			final String associationName,
-			final Type type,
+			final Type associationType,
 			final boolean isDebugEnabled) {
 		// Performance: check type.isCollectionType() first, as type.isAssociationType() is megamorphic
-		if ( type.isCollectionType() || type.isAssociationType()  ) {
-			final Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
+		if ( associationType.isCollectionType() || associationType.isAssociationType()  ) {
 
-			//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
-			if ( isDebugEnabled ) {
-				if ( overridingEager != null ) {
+			// we can return false invariably for if the entity has been covered by entity graph,
+			// its associated JOIN has been present in the SQL generated and hence it would be loaded anyway
+			if ( session.isEnforcingFetchGraph() ) {
+				return false;
+			}
+
+			// check 'fetch profile' next; skip 'metamodel' if 'fetch profile' takes effect
+			Boolean overridingEager = isEagerFetchProfile( session, entityName, associationName );
+
+			if ( overridingEager != null ) {
+				//This method is very hot, and private so let's piggy back on the fact that the caller already knows the debugging state.
+				if ( isDebugEnabled ) {
 					LOG.debugf(
 							"Overriding eager fetching using active fetch profile. EntityName: %s, associationName: %s, eager fetching: %s",
 							entityName,
@@ -395,10 +465,10 @@ public final class TwoPhaseLoad {
 							overridingEager
 					);
 				}
+				return overridingEager;
 			}
-
-			return overridingEager;
 		}
+		// let 'metamodel' decide eagerness
 		return null;
 	}
 
@@ -423,6 +493,20 @@ public final class TwoPhaseLoad {
 	}
 
 	/**
+	 * This method will be removed.
+	 * @deprecated Use {@link #postLoad(Object, SharedSessionContractImplementor, PostLoadEvent)}
+	 * instead.
+	 */
+	@Deprecated
+	public static void postLoad(
+			final Object entity,
+			final SharedSessionContractImplementor session,
+			final PostLoadEvent postLoadEvent,
+			final Iterable<PostLoadEventListener> postLoadEventListeners) {
+		postLoad( entity, session, postLoadEvent );
+	}
+
+	/**
 	 * PostLoad cannot occur during initializeEntity, as that call occurs *before*
 	 * the Set collections are added to the persistence context by Loader.
 	 * Without the split, LazyInitializationExceptions can occur in the Entity's
@@ -435,41 +519,16 @@ public final class TwoPhaseLoad {
 	 * @param postLoadEvent The (re-used) post-load event
 	 */
 	public static void postLoad(
-			final Object entity,
-			final SharedSessionContractImplementor session,
-			final PostLoadEvent postLoadEvent,
-			final Iterable<PostLoadEventListener> postLoadEventListeners) {
-
-		if ( session.isEventSource() ) {
-			final PersistenceContext persistenceContext
-					= session.getPersistenceContextInternal();
-			final EntityEntry entityEntry = persistenceContext.getEntry( entity );
-
-			postLoadEvent.setEntity( entity ).setId( entityEntry.getId() ).setPersister( entityEntry.getPersister() );
-
-			for ( PostLoadEventListener listener : postLoadEventListeners ) {
-				listener.onPostLoad( postLoadEvent );
-			}
-		}
-	}
-
-	/**
-	 * This method will be removed.
-	 * @deprecated Use {@link #postLoad(Object, SharedSessionContractImplementor, PostLoadEvent, Iterable)}
-	 * instead.
-	 */
-	@Deprecated
-	public static void postLoad(
 		final Object entity,
 		final SharedSessionContractImplementor session,
 		final PostLoadEvent postLoadEvent) {
+		if ( session.isEventSource() ) {
+			final EntityEntry entityEntry = session.getPersistenceContextInternal().getEntry( entity );
 
-		final EventListenerGroup<PostLoadEventListener> listenerGroup = session.getFactory()
-			.getServiceRegistry()
-			.getService( EventListenerRegistry.class )
-			.getEventListenerGroup( EventType.POST_LOAD );
+			postLoadEvent.setEntity( entity ).setId( entityEntry.getId() ).setPersister( entityEntry.getPersister() );
 
-		postLoad( entity, session, postLoadEvent, listenerGroup.listeners() );
+			session.getFactory().getFastSessionServices().firePostLoadEvent( postLoadEvent );
+		}
 	}
 
 	private static boolean useMinimalPuts(SharedSessionContractImplementor session, EntityEntry entityEntry) {
@@ -543,5 +602,24 @@ public final class TwoPhaseLoad {
 				persister,
 				false
 		);
+	}
+
+	/**
+	 * Implementations determine how a to-one associations is resolved.
+	 *
+	 * @see #initializeEntity(Object, boolean, SharedSessionContractImplementor, PreLoadEvent, Iterable, EntityResolver)
+	 */
+	public interface EntityResolver {
+
+		Object resolve(
+				EntityType entityType,
+				Object value,
+				SharedSessionContractImplementor session,
+				Object owner,
+				Boolean overridingEager
+		);
+
+		EntityResolver DEFAULT = (entityType, value, session, owner, overridingEager) ->
+				entityType.resolve( value, session, owner, overridingEager );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -522,4 +522,11 @@ public interface SharedSessionContractImplementor
 	 */
 	PersistenceContext getPersistenceContextInternal();
 
+	default boolean isEnforcingFetchGraph() {
+		return false;
+	}
+
+	default void setEnforcingFetchGraph(boolean enforcingFetchGraph) {
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -30,7 +30,6 @@ import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.custom.CustomQuery;
@@ -41,7 +40,6 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
-import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -523,32 +521,5 @@ public interface SharedSessionContractImplementor
 	 * @return the PersistenceContext associated to this session.
 	 */
 	PersistenceContext getPersistenceContextInternal();
-
-	/**
-	 * Get the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}. 
-	 * Suppose fetch graph is "a(b(c))", then during {@link org.hibernate.engine.internal.TwoPhaseLoad}:
-	 * <ul>
-	 *     <li>when loading root</li>: {@link org.hibernate.graph.spi.RootGraphImplementor root} will be returned
-	 *     <li>when internally loading 'a'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a' will be returned
-	 *     <li>when internally loading 'b'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b)' will be returned
-	 *     <li>when internally loading 'c'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b(c))' will be returned
-	 * </ul>
-	 * 
-	 * @return current fetch graph context; can be null if fetch graph is not effective or the graph eager loading is done.
-	 * @see #setFetchGraphLoadContext(GraphImplementor) 
-	 * @see org.hibernate.engine.internal.TwoPhaseLoad
-	 */
-	default GraphImplementor getFetchGraphLoadContext() {
-		return null;
-	}
-
-	/**
-	 * Set the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}.
-	 * 
-	 * @param fetchGraphLoadContext new fetch graph context; can be null (this field will be set to null after root entity loading is done).
-	 * @see #getFetchGraphLoadContext()                                 
-	 */
-	default void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -41,6 +41,7 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
+import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -215,6 +215,8 @@ public class SessionImpl
 
 	private transient TransactionObserver transactionObserver;
 
+	private transient boolean enforcingFetchGraph;
+
 	public SessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
 
@@ -3313,6 +3315,10 @@ public class SessionImpl
 				loadAccess.with( lockOptions );
 			}
 
+			if ( getLoadQueryInfluencers().getEffectiveEntityGraph().getSemantic() == GraphSemantic.FETCH ) {
+				setEnforcingFetchGraph( true );
+			}
+
 			return loadAccess.load( (Serializable) primaryKey );
 		}
 		catch ( EntityNotFoundException ignored ) {
@@ -3357,6 +3363,7 @@ public class SessionImpl
 		finally {
 			getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
 			getLoadQueryInfluencers().setReadOnly( null );
+			setEnforcingFetchGraph( false );
 		}
 	}
 
@@ -3728,6 +3735,16 @@ public class SessionImpl
 	public List getEntityGraphs(Class entityClass) {
 		checkOpen();
 		return getEntityManagerFactory().findEntityGraphsByType( entityClass );
+	}
+
+	@Override
+	public boolean isEnforcingFetchGraph() {
+		return this.enforcingFetchGraph;
+	}
+
+	@Override
+	public void setEnforcingFetchGraph(boolean enforcingFetchGraph) {
+		this.enforcingFetchGraph = enforcingFetchGraph;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -130,7 +130,6 @@ import org.hibernate.event.spi.SaveOrUpdateEventListener;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.internal.RootGraphImpl;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.hql.spi.QueryTranslator;
 import org.hibernate.internal.CriteriaImpl.CriterionEntry;
@@ -215,8 +214,6 @@ public class SessionImpl
 	private transient LoadEvent loadEvent; //cached LoadEvent instance
 
 	private transient TransactionObserver transactionObserver;
-	
-	private transient GraphImplementor fetchGraphLoadContext;
 
 	public SessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
@@ -3315,10 +3312,6 @@ public class SessionImpl
 				lockOptions = buildLockOptions( lockModeType, properties );
 				loadAccess.with( lockOptions );
 			}
-			
-			if ( getLoadQueryInfluencers().getEffectiveEntityGraph().getSemantic() == GraphSemantic.FETCH ) {
-				setFetchGraphLoadContext( getLoadQueryInfluencers().getEffectiveEntityGraph().getGraph() );
-			}
 
 			return loadAccess.load( (Serializable) primaryKey );
 		}
@@ -3364,7 +3357,6 @@ public class SessionImpl
 		finally {
 			getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
 			getLoadQueryInfluencers().setReadOnly( null );
-			setFetchGraphLoadContext( null );
 		}
 	}
 
@@ -3736,16 +3728,6 @@ public class SessionImpl
 	public List getEntityGraphs(Class entityClass) {
 		checkOpen();
 		return getEntityManagerFactory().findEntityGraphsByType( entityClass );
-	}
-	
-	@Override
-	public GraphImplementor getFetchGraphLoadContext() {
-		return this.fetchGraphLoadContext;
-	}
-	
-	@Override
-	public void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-		this.fetchGraphLoadContext = fetchGraphLoadContext;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -68,7 +68,6 @@ import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.hql.internal.HolderInstantiator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -381,8 +380,8 @@ public abstract class Loader {
 			final boolean returnProxies) throws HibernateException {
 
 		final int entitySpan = getEntityPersisters().length;
-		final List<Object> hydratedObjects = entitySpan == 0 ?
-				null : new ArrayList<>( entitySpan );
+		final List hydratedObjects = entitySpan == 0 ?
+				null : new ArrayList( entitySpan );
 
 		final Object result;
 		try {
@@ -406,7 +405,7 @@ public abstract class Loader {
 		}
 
 		initializeEntitiesAndCollections(
-				hydratedObjects == null ? null : Collections.singletonList( hydratedObjects ),
+				hydratedObjects,
 				resultSet,
 				session,
 				queryParameters.isReadOnly( session )
@@ -423,21 +422,14 @@ public abstract class Loader {
 			final EntityKey keyToRead) throws HibernateException {
 
 		final int entitySpan = getEntityPersisters().length;
-		final List<List<Object>> hydratedObjectsPerRow = entitySpan == 0 ?
-				null : new ArrayList<>( entitySpan );
+		final List hydratedObjects = entitySpan == 0 ?
+				null : new ArrayList( entitySpan );
 
 		Object result = null;
 		final EntityKey[] loadedKeys = new EntityKey[entitySpan];
 
 		try {
 			do {
-				List<Object> hydratedObjects;
-				if ( hydratedObjectsPerRow == null ) {
-					hydratedObjects = null;
-				}
-				else {
-					hydratedObjects = new ArrayList<>( entitySpan );
-				}
 				Object loaded = getRowFromResultSet(
 						resultSet,
 						session,
@@ -448,9 +440,6 @@ public abstract class Loader {
 						loadedKeys,
 						returnProxies
 				);
-				if ( hydratedObjects != null && !hydratedObjects.isEmpty() ) {
-					hydratedObjectsPerRow.add( hydratedObjects );
-				}
 				if ( !keyToRead.equals( loadedKeys[0] ) ) {
 					throw new AssertionFailure(
 							String.format(
@@ -476,7 +465,7 @@ public abstract class Loader {
 		}
 
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				hydratedObjects,
 				resultSet,
 				session,
 				queryParameters.isReadOnly( session )
@@ -707,7 +696,7 @@ public abstract class Loader {
 			final QueryParameters queryParameters,
 			final LockMode[] lockModesArray,
 			final EntityKey optionalObjectKey,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final EntityKey[] keys,
 			boolean returnProxies) throws SQLException, HibernateException {
 		return getRowFromResultSet(
@@ -729,7 +718,7 @@ public abstract class Loader {
 			final QueryParameters queryParameters,
 			final LockMode[] lockModesArray,
 			final EntityKey optionalObjectKey,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final EntityKey[] keys,
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer) throws SQLException, HibernateException {
@@ -793,7 +782,7 @@ public abstract class Loader {
 			SharedSessionContractImplementor session,
 			EntityKey[] keys,
 			LockMode[] lockModes,
-			List<Object> hydratedObjects) throws SQLException {
+			List hydratedObjects) throws SQLException {
 		final int entitySpan = persisters.length;
 
 		final int numberOfPersistersToProcess;
@@ -996,7 +985,7 @@ public abstract class Loader {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
 		final List<EntityKey[]> subselectResultKeys = createSubselects ? new ArrayList<>() : null;
-		final List<List<Object>> hydratedObjectsPerRow = entitySpan == 0 ? null : new ArrayList<>();
+		final List<Object> hydratedObjects = entitySpan == 0 ? null : new ArrayList<>( entitySpan * 10 );
 
 		final List results = getRowsFromResultSet(
 				rs,
@@ -1005,12 +994,12 @@ public abstract class Loader {
 				returnProxies,
 				forcedResultTransformer,
 				maxRows,
-				hydratedObjectsPerRow,
+				hydratedObjects,
 				subselectResultKeys
 		);
 
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				hydratedObjects,
 				rs,
 				session,
 				queryParameters.isReadOnly( session ),
@@ -1029,7 +1018,7 @@ public abstract class Loader {
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer,
 			int maxRows,
-			List<List<Object>> hydratedObjectsPerRow,
+			List<Object> hydratedObjects,
 			List<EntityKey[]> subselectResultKeys) throws SQLException {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
@@ -1047,13 +1036,6 @@ public abstract class Loader {
 			if ( debugEnabled ) {
 				LOG.debugf( "Result set row: %s", count );
 			}
-			List<Object> hydratedObjects;
-			if ( hydratedObjectsPerRow == null ) {
-				hydratedObjects = null;
-			}
-			else {
-				hydratedObjects = new ArrayList<>( entitySpan );
-			}
 			Object result = getRowFromResultSet(
 					rs,
 					session,
@@ -1066,9 +1048,6 @@ public abstract class Loader {
 					forcedResultTransformer
 			);
 			results.add( result );
-			if ( hydratedObjects != null && !hydratedObjects.isEmpty() ) {
-				hydratedObjectsPerRow.add( hydratedObjects );
-			}
 			if ( createSubselects ) {
 				subselectResultKeys.add( keys );
 				keys = new EntityKey[entitySpan]; //can't reuse in this case
@@ -1159,12 +1138,12 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<List<Object>> hydratedObjectsPerRow,
+			final List hydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly) throws HibernateException {
 		initializeEntitiesAndCollections(
-				hydratedObjectsPerRow,
+				hydratedObjects,
 				resultSetId,
 				session,
 				readOnly,
@@ -1173,7 +1152,7 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<List<Object>> hydratedObjectsPerRow,
+			final List hydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly,
@@ -1205,34 +1184,22 @@ public abstract class Loader {
 			post = null;
 		}
 
-		if ( hydratedObjectsPerRow != null && !hydratedObjectsPerRow.isEmpty() ) {
-			if ( LOG.isTraceEnabled() ) {
-				int hydratedObjectsSize = 0;
-				for ( List<Object> hydratedObjects : hydratedObjectsPerRow ) {
-					hydratedObjectsSize += hydratedObjects.size();
-				}
-				LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
-			}
+		if ( hydratedObjects != null ) {
+			int hydratedObjectsSize = hydratedObjects.size();
+			LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
 
-			final Iterable<PreLoadEventListener> listeners = session
-				.getFactory()
-				.getServiceRegistry()
-				.getService( EventListenerRegistry.class )
-				.getEventListenerGroup( EventType.PRE_LOAD )
-				.listeners();
+			if ( hydratedObjectsSize != 0 ) {
+				final Iterable<PreLoadEventListener> listeners = session
+					.getFactory()
+					.getServiceRegistry()
+					.getService( EventListenerRegistry.class )
+					.getEventListenerGroup( EventType.PRE_LOAD )
+					.listeners();
 
-			GraphImplementor<?> fetchGraphLoadContextToRestore = session.getFetchGraphLoadContext();
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
+				for ( Object hydratedObject : hydratedObjects ) {
 					TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
 				}
 
-				// HHH-14124: TwoPhaseLoad has nasty side-effects in order to handle sub-graphs.
-				// That's very fragile, but someone would need to spend much more time on this
-				// in order to implement it correctly, and apparently that's already been done in ORM 6.0.
-				// So for now, we'll just ensure side-effects (and whatever bugs they lead to)
-				// are limited to each row.
-				session.setFetchGraphLoadContext( fetchGraphLoadContextToRestore );
 			}
 		}
 
@@ -1248,11 +1215,9 @@ public abstract class Loader {
 			}
 		}
 
-		if ( hydratedObjectsPerRow != null ) {
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
-					TwoPhaseLoad.afterInitialize( hydratedObject, session );
-				}
+		if ( hydratedObjects != null ) {
+			for ( Object hydratedObject : hydratedObjects ) {
+				TwoPhaseLoad.afterInitialize( hydratedObject, session );
 			}
 		}
 
@@ -1261,21 +1226,19 @@ public abstract class Loader {
 		// endCollectionLoad to ensure the collection is in the
 		// persistence context.
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-		if ( hydratedObjectsPerRow != null && !hydratedObjectsPerRow.isEmpty() ) {
-			for ( List<?> hydratedObjectsForRow : hydratedObjectsPerRow ) {
-				for ( Object hydratedObject : hydratedObjectsForRow ) {
-					TwoPhaseLoad.postLoad( hydratedObject, session, post );
-					if ( afterLoadActions != null ) {
-						for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
-							final EntityEntry entityEntry = persistenceContext.getEntry( hydratedObject );
-							if ( entityEntry == null ) {
-								// big problem
-								throw new HibernateException(
-										"Could not locate EntityEntry immediately after two-phase load"
-								);
-							}
-							afterLoadAction.afterLoad( session, hydratedObject, (Loadable) entityEntry.getPersister() );
+		if ( hydratedObjects != null && hydratedObjects.size() > 0 ) {
+			for ( Object hydratedObject : hydratedObjects ) {
+				TwoPhaseLoad.postLoad( hydratedObject, session, post );
+				if ( afterLoadActions != null ) {
+					for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
+						final EntityEntry entityEntry = persistenceContext.getEntry( hydratedObject );
+						if ( entityEntry == null ) {
+							// big problem
+							throw new HibernateException(
+									"Could not locate EntityEntry immediately after two-phase load"
+							);
 						}
+						afterLoadAction.afterLoad( session, hydratedObject, (Loadable) entityEntry.getPersister() );
 					}
 				}
 			}
@@ -1622,7 +1585,7 @@ public abstract class Loader {
 			final Object optionalObject,
 			final EntityKey optionalObjectKey,
 			final LockMode[] lockModes,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final SharedSessionContractImplementor session) throws HibernateException, SQLException {
 		final int cols = persisters.length;
 		final EntityAliases[] entityAliases = getEntityAliases();
@@ -1689,7 +1652,7 @@ public abstract class Loader {
 			final EntityKey key,
 			final Object object,
 			final LockMode requestedLockMode,
-			List<Object> hydratedObjects,
+			List hydratedObjects,
 			final SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {
 		if ( !persister.isInstance( object ) ) {
@@ -1757,7 +1720,7 @@ public abstract class Loader {
 			final LockMode lockMode,
 			final EntityKey optionalObjectKey,
 			final Object optionalObject,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {
 		final String instanceClass = getInstanceClass(

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -441,10 +441,8 @@ public abstract class Loader {
 						loadedKeys,
 						returnProxies
 				);
-				if ( nullSeparatedHydratedObjects != null ) {
-					// Signal that a new row starts. Used in initializeEntitiesAndCollections
-					nullSeparatedHydratedObjects.add( null );
-				}
+				// Signal that a new row starts. Used in initializeEntitiesAndCollections
+				nullSeparatedHydratedObjects.add( null );
 				if ( !keyToRead.equals( loadedKeys[0] ) ) {
 					throw new AssertionFailure(
 							String.format(
@@ -1053,10 +1051,8 @@ public abstract class Loader {
 					forcedResultTransformer
 			);
 			results.add( result );
-			if ( nullSeparatedHydratedObjects != null ) {
-				// Signal that a new row starts. Used in initializeEntitiesAndCollections
-				nullSeparatedHydratedObjects.add( null );
-			}
+			// Signal that a new row starts. Used in initializeEntitiesAndCollections
+			nullSeparatedHydratedObjects.add( null );
 			if ( createSubselects ) {
 				subselectResultKeys.add( keys );
 				keys = new EntityKey[entitySpan]; //can't reuse in this case

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1437,6 +1437,9 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
+		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
+			getProducer().setEnforcingFetchGraph( true );
+		}
 	}
 
 	protected void afterQuery() {
@@ -1448,6 +1451,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
+		getProducer().setEnforcingFetchGraph( false );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1437,9 +1437,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
-		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
-			getProducer().setFetchGraphLoadContext( entityGraphQueryHint.getGraph() );
-		}
 	}
 
 	protected void afterQuery() {
@@ -1451,7 +1448,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
-		getProducer().setFetchGraphLoadContext( null );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/FetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/FetchGraphTest.java
@@ -1,0 +1,175 @@
+package org.hibernate.jpa.test.graphs;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EntityGraph;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.graph.GraphParser;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Yaroslav Prokipchyn
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14212" )
+public class FetchGraphTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				LedgerRecord.class,
+				LedgerRecordItem.class,
+				BudgetRecord.class,
+				Trigger.class,
+				FinanceEntity.class
+		};
+	}
+
+	@Before
+	public void setUp() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Trigger trigger = new Trigger();
+			entityManager.persist( trigger );
+
+			BudgetRecord budgetRecord = new BudgetRecord();
+			budgetRecord.amount = 100;
+			budgetRecord.trigger = trigger;
+			entityManager.persist( budgetRecord );
+
+			FinanceEntity client = new FinanceEntity();
+			client.name = "client";
+			FinanceEntity vendor = new FinanceEntity();
+			vendor.name = "vendor";
+			entityManager.persist( client );
+			entityManager.persist( vendor );
+
+			LedgerRecordItem item1 = new LedgerRecordItem();
+			item1.financeEntity = client;
+			LedgerRecordItem item2 = new LedgerRecordItem();
+			item2.financeEntity = vendor;
+			entityManager.persist( item1 );
+			entityManager.persist( item2 );
+
+			LedgerRecord ledgerRecord = new LedgerRecord();
+			ledgerRecord.budgetRecord = budgetRecord;
+			ledgerRecord.trigger = trigger;
+			ledgerRecord.ledgerRecordItems= Arrays.asList( item1, item2 );
+
+			item1.ledgerRecord = ledgerRecord;
+			item2.ledgerRecord = ledgerRecord;
+
+			entityManager.persist( ledgerRecord );
+		} );
+	}
+
+	@Test
+	public void testCollectionEntityGraph() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final EntityGraph<LedgerRecord> entityGraph = GraphParser.parse( LedgerRecord.class, "budgetRecord, ledgerRecordItems.value(financeEntity)", entityManager );
+			final List<LedgerRecord> records = entityManager.createQuery( "from LedgerRecord", LedgerRecord.class )
+					.setHint( GraphSemantic.FETCH.getJpaHintName(), entityGraph )
+					.getResultList();
+			assertThat( records.size(), is( 1 ) );
+			records.forEach( record -> {
+				assertFalse( Hibernate.isInitialized( record.trigger ) );
+				assertTrue( Hibernate.isInitialized( record.budgetRecord ) );
+				assertFalse( Hibernate.isInitialized( record.budgetRecord.trigger ) );
+				assertTrue( Hibernate.isInitialized( record.ledgerRecordItems) );
+				assertThat( record.ledgerRecordItems.size(), is( 2 ) );
+				record.ledgerRecordItems.forEach( item -> {
+					assertSame( record, item.ledgerRecord );
+					assertTrue( Hibernate.isInitialized( item.financeEntity ) );
+				} );
+			} );
+		} );
+	}
+
+	@Entity(name = "LedgerRecord")
+	@Table(name = "LedgerRecord")
+	static class LedgerRecord {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		@ManyToOne
+		BudgetRecord budgetRecord;
+
+		@OneToMany(mappedBy = "ledgerRecord", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		@Fetch(FetchMode.SUBSELECT)
+		List<LedgerRecordItem> ledgerRecordItems;
+
+		@ManyToOne
+		Trigger trigger;
+	}
+
+	@Entity(name = "LedgerRecordItem")
+	@Table(name = "LedgerRecordItem")
+	static class LedgerRecordItem {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		@ManyToOne
+		LedgerRecord ledgerRecord;
+
+		@ManyToOne
+		FinanceEntity financeEntity;
+	}
+
+	@Entity(name = "BudgetRecord")
+	@Table(name = "BudgetRecord")
+	static class BudgetRecord {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		int amount;
+
+		@ManyToOne
+		Trigger trigger;
+	}
+
+	@Entity(name = "Trigger")
+	@Table(name = "Trigger")
+	static class Trigger {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		String name;
+	}
+
+	@Entity(name = "FinanceEntity")
+	@Table(name = "FinanceEntity")
+	static class FinanceEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		String name;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14212

This ticket exposes another regression issue and it forced me to re-consider the previous Fetch Graph implementation I initiated previously. It is becoming more and more difficult to maintain and obviously it is full of bugs and terribly fragile.

Finally I figured out we have a much simpler way to implement Fetch Graph we overlooked previously:

- revert back all the previous PRs related to Fetch Graph implementation and bug fixing (HHH-8776, HHH-14097, HHH-14124);
- simply add a logic in `TwoPhaseLoad` class to check whether Fetch Graph is in effective for now; return false if so in the internal `getOverridingEager()` method in `TwoPhaseLoad` class.

The reason is our HQL to SQL step has added all the JOINs already and we simply keep from loading any other entities during hydrating phase. We don't need to duplicate Fetch Graph enforcement for another time!  Boom, all of sudden, we solve the Fetch Graph issue in a simple and elegant way. My previous initial implementation is purely misled.

I intentionally organized the commit list to streamline code review. All the commits except the last one are reverting back previous PR commits. You can go to the last commit directly to understand the new implementation.