### PR TITLE
HHH-14212 Ultimate Fetch Graph fix

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -522,4 +522,11 @@ public interface SharedSessionContractImplementor
 	 */
 	PersistenceContext getPersistenceContextInternal();
 
+	default boolean isEnforcingFetchGraph() {
+		return false;
+	}
+
+	default void setEnforcingFetchGraph(boolean enforcingFetchGraph) {
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -30,7 +30,6 @@ import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.spi.HibernateEntityManagerImplementor;
 import org.hibernate.loader.custom.CustomQuery;
@@ -522,32 +521,5 @@ public interface SharedSessionContractImplementor
 	 * @return the PersistenceContext associated to this session.
 	 */
 	PersistenceContext getPersistenceContextInternal();
-
-	/**
-	 * Get the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}. 
-	 * Suppose fetch graph is "a(b(c))", then during {@link org.hibernate.engine.internal.TwoPhaseLoad}:
-	 * <ul>
-	 *     <li>when loading root</li>: {@link org.hibernate.graph.spi.RootGraphImplementor root} will be returned
-	 *     <li>when internally loading 'a'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a' will be returned
-	 *     <li>when internally loading 'b'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b)' will be returned
-	 *     <li>when internally loading 'c'</li>: {@link org.hibernate.graph.spi.SubGraphImplementor subgraph} of 'a(b(c))' will be returned
-	 * </ul>
-	 * 
-	 * @return current fetch graph context; can be null if fetch graph is not effective or the graph eager loading is done.
-	 * @see #setFetchGraphLoadContext(GraphImplementor) 
-	 * @see org.hibernate.engine.internal.TwoPhaseLoad
-	 */
-	default GraphImplementor getFetchGraphLoadContext() {
-		return null;
-	}
-
-	/**
-	 * Set the current fetch graph context (either {@link org.hibernate.graph.spi.RootGraphImplementor} or {@link org.hibernate.graph.spi.SubGraphImplementor}.
-	 * 
-	 * @param fetchGraphLoadContext new fetch graph context; can be null (this field will be set to null after root entity loading is done).
-	 * @see #getFetchGraphLoadContext()                                 
-	 */
-	default void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -130,7 +130,6 @@ import org.hibernate.event.spi.SaveOrUpdateEventListener;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.internal.RootGraphImpl;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.hql.spi.QueryTranslator;
 import org.hibernate.internal.CriteriaImpl.CriterionEntry;
@@ -215,8 +214,6 @@ public class SessionImpl
 	private transient LoadEvent loadEvent; //cached LoadEvent instance
 
 	private transient TransactionObserver transactionObserver;
-	
-	private transient GraphImplementor fetchGraphLoadContext;
 
 	public SessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
@@ -3316,10 +3313,6 @@ public class SessionImpl
 				loadAccess.with( lockOptions );
 			}
 			
-			if ( getLoadQueryInfluencers().getEffectiveEntityGraph().getSemantic() == GraphSemantic.FETCH ) {
-				setFetchGraphLoadContext( getLoadQueryInfluencers().getEffectiveEntityGraph().getGraph() );
-			}
-
 			return loadAccess.load( (Serializable) primaryKey );
 		}
 		catch ( EntityNotFoundException ignored ) {
@@ -3364,7 +3357,6 @@ public class SessionImpl
 		finally {
 			getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
 			getLoadQueryInfluencers().setReadOnly( null );
-			setFetchGraphLoadContext( null );
 		}
 	}
 
@@ -3736,16 +3728,6 @@ public class SessionImpl
 	public List getEntityGraphs(Class entityClass) {
 		checkOpen();
 		return getEntityManagerFactory().findEntityGraphsByType( entityClass );
-	}
-	
-	@Override
-	public GraphImplementor getFetchGraphLoadContext() {
-		return this.fetchGraphLoadContext;
-	}
-	
-	@Override
-	public void setFetchGraphLoadContext(GraphImplementor fetchGraphLoadContext) {
-		this.fetchGraphLoadContext = fetchGraphLoadContext;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -215,6 +215,8 @@ public class SessionImpl
 
 	private transient TransactionObserver transactionObserver;
 
+	private transient boolean isEnforcingFetchGraph;
+
 	public SessionImpl(SessionFactoryImpl factory, SessionCreationOptions options) {
 		super( factory, options );
 
@@ -3312,6 +3314,10 @@ public class SessionImpl
 				lockOptions = buildLockOptions( lockModeType, properties );
 				loadAccess.with( lockOptions );
 			}
+
+			if ( getLoadQueryInfluencers().getEffectiveEntityGraph().getSemantic() == GraphSemantic.FETCH ) {
+				setEnforcingFetchGraph( true );
+			}
 			
 			return loadAccess.load( (Serializable) primaryKey );
 		}
@@ -3357,6 +3363,7 @@ public class SessionImpl
 		finally {
 			getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
 			getLoadQueryInfluencers().setReadOnly( null );
+			setEnforcingFetchGraph( false );
 		}
 	}
 
@@ -3785,4 +3792,15 @@ public class SessionImpl
 		}
 		return readOnly;
 	}
+
+	@Override
+	public boolean isEnforcingFetchGraph() {
+		return this.isEnforcingFetchGraph;
+	}
+
+	@Override
+	public void setEnforcingFetchGraph(boolean isEnforcingFetchGraph) {
+		this.isEnforcingFetchGraph = isEnforcingFetchGraph;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/Loader.java
@@ -68,7 +68,6 @@ import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
-import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.hql.internal.HolderInstantiator;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -381,8 +380,8 @@ public abstract class Loader {
 			final boolean returnProxies) throws HibernateException {
 
 		final int entitySpan = getEntityPersisters().length;
-		final List<Object> hydratedObjects = entitySpan == 0 ?
-				null : new ArrayList<>( entitySpan );
+		final List hydratedObjects = entitySpan == 0 ?
+				null : new ArrayList( entitySpan );
 
 		final Object result;
 		try {
@@ -423,8 +422,8 @@ public abstract class Loader {
 			final EntityKey keyToRead) throws HibernateException {
 
 		final int entitySpan = getEntityPersisters().length;
-		final List<Object> nullSeparatedHydratedObjects = entitySpan == 0 ?
-				null : new ArrayList<>( entitySpan );
+		final List hydratedObjects = entitySpan == 0 ?
+				null : new ArrayList( entitySpan );
 
 		Object result = null;
 		final EntityKey[] loadedKeys = new EntityKey[entitySpan];
@@ -437,14 +436,10 @@ public abstract class Loader {
 						queryParameters,
 						getLockModes( queryParameters.getLockOptions() ),
 						null,
-						nullSeparatedHydratedObjects,
+						hydratedObjects,
 						loadedKeys,
 						returnProxies
 				);
-				if ( nullSeparatedHydratedObjects != null ) {
-					// Signal that a new row starts. Used in initializeEntitiesAndCollections
-					nullSeparatedHydratedObjects.add( null );
-				}
 				if ( !keyToRead.equals( loadedKeys[0] ) ) {
 					throw new AssertionFailure(
 							String.format(
@@ -470,7 +465,7 @@ public abstract class Loader {
 		}
 
 		initializeEntitiesAndCollections(
-				nullSeparatedHydratedObjects,
+				hydratedObjects,
 				resultSet,
 				session,
 				queryParameters.isReadOnly( session )
@@ -701,7 +696,7 @@ public abstract class Loader {
 			final QueryParameters queryParameters,
 			final LockMode[] lockModesArray,
 			final EntityKey optionalObjectKey,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final EntityKey[] keys,
 			boolean returnProxies) throws SQLException, HibernateException {
 		return getRowFromResultSet(
@@ -723,7 +718,7 @@ public abstract class Loader {
 			final QueryParameters queryParameters,
 			final LockMode[] lockModesArray,
 			final EntityKey optionalObjectKey,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final EntityKey[] keys,
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer) throws SQLException, HibernateException {
@@ -787,7 +782,7 @@ public abstract class Loader {
 			SharedSessionContractImplementor session,
 			EntityKey[] keys,
 			LockMode[] lockModes,
-			List<Object> hydratedObjects) throws SQLException {
+			List hydratedObjects) throws SQLException {
 		final int entitySpan = persisters.length;
 
 		final int numberOfPersistersToProcess;
@@ -990,7 +985,7 @@ public abstract class Loader {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
 		final List<EntityKey[]> subselectResultKeys = createSubselects ? new ArrayList<>() : null;
-		final List<Object> nullSeparatedHydratedObjectsPerRow = entitySpan == 0 ? null : new ArrayList<>();
+		final List<Object> hydratedObjects = entitySpan == 0 ? null : new ArrayList<>( entitySpan * 10 );
 
 		final List results = getRowsFromResultSet(
 				rs,
@@ -999,12 +994,12 @@ public abstract class Loader {
 				returnProxies,
 				forcedResultTransformer,
 				maxRows,
-				nullSeparatedHydratedObjectsPerRow,
+				hydratedObjects,
 				subselectResultKeys
 		);
 
 		initializeEntitiesAndCollections(
-				nullSeparatedHydratedObjectsPerRow,
+				hydratedObjects,
 				rs,
 				session,
 				queryParameters.isReadOnly( session ),
@@ -1023,7 +1018,7 @@ public abstract class Loader {
 			boolean returnProxies,
 			ResultTransformer forcedResultTransformer,
 			int maxRows,
-			List<Object> nullSeparatedHydratedObjects,
+			List<Object> hydratedObjects,
 			List<EntityKey[]> subselectResultKeys) throws SQLException {
 		final int entitySpan = getEntityPersisters().length;
 		final boolean createSubselects = isSubselectLoadingEnabled();
@@ -1047,16 +1042,12 @@ public abstract class Loader {
 					queryParameters,
 					lockModesArray,
 					optionalObjectKey,
-					nullSeparatedHydratedObjects,
+					hydratedObjects,
 					keys,
 					returnProxies,
 					forcedResultTransformer
 			);
 			results.add( result );
-			if ( nullSeparatedHydratedObjects != null ) {
-				// Signal that a new row starts. Used in initializeEntitiesAndCollections
-				nullSeparatedHydratedObjects.add( null );
-			}
 			if ( createSubselects ) {
 				subselectResultKeys.add( keys );
 				keys = new EntityKey[entitySpan]; //can't reuse in this case
@@ -1147,12 +1138,12 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<Object> nullSeparatedHydratedObjects,
+			final List hydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly) throws HibernateException {
 		initializeEntitiesAndCollections(
-				nullSeparatedHydratedObjects,
+				hydratedObjects,
 				resultSetId,
 				session,
 				readOnly,
@@ -1161,7 +1152,7 @@ public abstract class Loader {
 	}
 
 	private void initializeEntitiesAndCollections(
-			final List<Object> nullSeparatedHydratedObjects,
+			final List hydratedObjects,
 			final Object resultSetId,
 			final SharedSessionContractImplementor session,
 			final boolean readOnly,
@@ -1193,40 +1184,22 @@ public abstract class Loader {
 			post = null;
 		}
 
-		if ( nullSeparatedHydratedObjects != null && !nullSeparatedHydratedObjects.isEmpty() ) {
-			if ( LOG.isTraceEnabled() ) {
-				int hydratedObjectsSize = 0;
-				for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
-					if ( hydratedObject != null ) {
-						++hydratedObjectsSize;
-					}
-				}
-				LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
-			}
+		if ( hydratedObjects != null ) {
+			int hydratedObjectsSize = hydratedObjects.size();
+			LOG.tracev( "Total objects hydrated: {0}", hydratedObjectsSize );
 
-			final Iterable<PreLoadEventListener> listeners = session
-				.getFactory()
-				.getServiceRegistry()
-				.getService( EventListenerRegistry.class )
-				.getEventListenerGroup( EventType.PRE_LOAD )
-				.listeners();
+			if ( hydratedObjectsSize != 0 ) {
+				final Iterable<PreLoadEventListener> listeners = session
+					.getFactory()
+					.getServiceRegistry()
+					.getService( EventListenerRegistry.class )
+					.getEventListenerGroup( EventType.PRE_LOAD )
+					.listeners();
 
-			GraphImplementor<?> fetchGraphLoadContextToRestore = session.getFetchGraphLoadContext();
-			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
-				if ( hydratedObject == null ) {
-					// This is a hack to signal that we're starting to process a new row
-
-					// HHH-14124: TwoPhaseLoad has nasty side-effects in order to handle sub-graphs.
-					// That's very fragile, but someone would need to spend much more time on this
-					// in order to implement it correctly, and apparently that's already been done in ORM 6.0.
-					// So for now, we'll just ensure side-effects (and whatever bugs they lead to)
-					// are limited to each row.
-					session.setFetchGraphLoadContext( fetchGraphLoadContextToRestore );
-
-					continue;
+				for ( Object hydratedObject : hydratedObjects ) {
+					TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
 				}
 
-				TwoPhaseLoad.initializeEntity( hydratedObject, readOnly, session, pre, listeners );
 			}
 		}
 
@@ -1242,13 +1215,8 @@ public abstract class Loader {
 			}
 		}
 
-		if ( nullSeparatedHydratedObjects != null ) {
-			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
-				if ( hydratedObject == null ) {
-					// This is a hack to signal that we're starting to process a new row
-					// Ignore
-					continue;
-				}
+		if ( hydratedObjects != null ) {
+			for ( Object hydratedObject : hydratedObjects ) {
 				TwoPhaseLoad.afterInitialize( hydratedObject, session );
 			}
 		}
@@ -1258,13 +1226,8 @@ public abstract class Loader {
 		// endCollectionLoad to ensure the collection is in the
 		// persistence context.
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-		if ( nullSeparatedHydratedObjects != null && !nullSeparatedHydratedObjects.isEmpty() ) {
-			for ( Object hydratedObject : nullSeparatedHydratedObjects ) {
-				if ( hydratedObject == null ) {
-					// This is a hack to signal that we're starting to process a new row
-					// Ignore
-					continue;
-				}
+		if ( hydratedObjects != null && hydratedObjects.size() > 0 ) {
+			for ( Object hydratedObject : hydratedObjects ) {
 				TwoPhaseLoad.postLoad( hydratedObject, session, post );
 				if ( afterLoadActions != null ) {
 					for ( AfterLoadAction afterLoadAction : afterLoadActions ) {
@@ -1622,7 +1585,7 @@ public abstract class Loader {
 			final Object optionalObject,
 			final EntityKey optionalObjectKey,
 			final LockMode[] lockModes,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final SharedSessionContractImplementor session) throws HibernateException, SQLException {
 		final int cols = persisters.length;
 		final EntityAliases[] entityAliases = getEntityAliases();
@@ -1689,7 +1652,7 @@ public abstract class Loader {
 			final EntityKey key,
 			final Object object,
 			final LockMode requestedLockMode,
-			List<Object> hydratedObjects,
+			List hydratedObjects,
 			final SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {
 		if ( !persister.isInstance( object ) ) {
@@ -1757,7 +1720,7 @@ public abstract class Loader {
 			final LockMode lockMode,
 			final EntityKey optionalObjectKey,
 			final Object optionalObject,
-			final List<Object> hydratedObjects,
+			final List hydratedObjects,
 			final SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {
 		final String instanceClass = getInstanceClass(

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1437,6 +1437,9 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
+		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
+			getProducer().setEnforcingFetchGraph( true );
+		}
 	}
 
 	protected void afterQuery() {
@@ -1448,6 +1451,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
+		getProducer().setEnforcingFetchGraph( false );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1437,9 +1437,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			sessionCacheMode = getProducer().getCacheMode();
 			getProducer().setCacheMode( effectiveCacheMode );
 		}
-		if ( entityGraphQueryHint != null && entityGraphQueryHint.getSemantic() == GraphSemantic.FETCH ) {
-			getProducer().setFetchGraphLoadContext( entityGraphQueryHint.getGraph() );
-		}
 	}
 
 	protected void afterQuery() {
@@ -1451,7 +1448,6 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			getProducer().setCacheMode( sessionCacheMode );
 			sessionCacheMode = null;
 		}
-		getProducer().setFetchGraphLoadContext( null );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/FetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/FetchGraphTest.java
@@ -1,0 +1,176 @@
+package org.hibernate.jpa.test.graphs;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.EntityGraph;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.graph.GraphParser;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Yaroslav Prokipchyn
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14212" )
+public class FetchGraphTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				LedgerRecord.class,
+				LedgerRecordItem.class,
+				BudgetRecord.class,
+				Trigger.class,
+				FinanceEntity.class
+		};
+	}
+
+	@Before
+	public void setUp() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Trigger trigger = new Trigger();
+			entityManager.persist( trigger );
+
+			BudgetRecord budgetRecord = new BudgetRecord();
+			budgetRecord.amount = 100;
+			budgetRecord.trigger = trigger;
+			entityManager.persist( budgetRecord );
+
+			FinanceEntity client = new FinanceEntity();
+			client.name = "client";
+			FinanceEntity vendor = new FinanceEntity();
+			vendor.name = "vendor";
+			entityManager.persist( client );
+			entityManager.persist( vendor );
+
+			LedgerRecordItem item1 = new LedgerRecordItem();
+			item1.financeEntity = client;
+			LedgerRecordItem item2 = new LedgerRecordItem();
+			item2.financeEntity = vendor;
+			entityManager.persist( item1 );
+			entityManager.persist( item2 );
+
+			LedgerRecord ledgerRecord = new LedgerRecord();
+			ledgerRecord.budgetRecord = budgetRecord;
+			ledgerRecord.trigger = trigger;
+			ledgerRecord.ledgerRecordItems= Arrays.asList( item1, item2 );
+
+			item1.ledgerRecord = ledgerRecord;
+			item2.ledgerRecord = ledgerRecord;
+
+			entityManager.persist( ledgerRecord );
+		} );
+	}
+
+	@Test
+	public void testCollectionEntityGraph() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final EntityGraph<LedgerRecord> entityGraph = GraphParser.parse( LedgerRecord.class, "budgetRecord, ledgerRecordItems.value(financeEntity)", entityManager );
+			final List<LedgerRecord> records = entityManager.createQuery( "from LedgerRecord", LedgerRecord.class )
+					.setHint( GraphSemantic.FETCH.getJpaHintName(), entityGraph )
+					.getResultList();
+			assertThat( records.size(), is( 1 ) );
+			records.forEach( record -> {
+				assertFalse( Hibernate.isInitialized( record.trigger ) );
+				assertTrue( Hibernate.isInitialized( record.budgetRecord ) );
+				assertFalse( Hibernate.isInitialized( record.budgetRecord.trigger ) );
+				assertTrue( Hibernate.isInitialized( record.ledgerRecordItems) );
+				assertThat( record.ledgerRecordItems.size(), is( 2 ) );
+				record.ledgerRecordItems.forEach( item -> {
+					assertSame( record, item.ledgerRecord );
+					assertTrue( Hibernate.isInitialized( item.financeEntity ) );
+				} );
+			} );
+		} );
+	}
+
+	@Entity(name = "LedgerRecord")
+	@Table(name = "LedgerRecord")
+	static class LedgerRecord {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		@ManyToOne
+		BudgetRecord budgetRecord;
+
+		@OneToMany(mappedBy = "ledgerRecord", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		@Fetch(FetchMode.SUBSELECT)
+		List<LedgerRecordItem> ledgerRecordItems;
+
+		@ManyToOne
+		Trigger trigger;
+	}
+
+	@Entity(name = "LedgerRecordItem")
+	@Table(name = "LedgerRecordItem")
+	static class LedgerRecordItem {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		@ManyToOne
+		LedgerRecord ledgerRecord;
+
+		@ManyToOne
+		FinanceEntity financeEntity;
+	}
+
+	@Entity(name = "BudgetRecord")
+	@Table(name = "BudgetRecord")
+	static class BudgetRecord {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		int amount;
+
+		@ManyToOne
+		Trigger trigger;
+	}
+
+	@Entity(name = "Trigger")
+	@Table(name = "Trigger")
+	static class Trigger {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		String name;
+	}
+
+	@Entity(name = "FinanceEntity")
+	@Table(name = "FinanceEntity")
+	static class FinanceEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Integer id;
+
+		String name;
+	}
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/graphs/LoadAndFetchGraphTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertTrue;
  * @author Andrea Boriero
  * @author Nathan Xu
  */
-@TestForIssue(jiraKey = "HHH-14097")
 public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
@@ -180,6 +179,7 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-14097")
 	public void testQueryById() {
 		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
 		statistics.clear();
@@ -205,6 +205,7 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-14097")
 	public void testQueryByIdWithLoadGraph() {
 		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
 		statistics.clear();
@@ -241,6 +242,7 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-14097")
 	public void testQueryByIdWithFetchGraph() {
 		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
 		statistics.clear();
@@ -275,6 +277,7 @@ public class LoadAndFetchGraphTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-14097")
 	public void testQueryByIdWithFetchGraph2() {
 		Statistics statistics = entityManagerFactory().unwrap( SessionFactory.class ).getStatistics();
 		statistics.clear();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14212

This ticket exposes another regression issue and it forced me to re-consider the previous Fetch Graph implementation I initiated previously. It is becoming more and more difficult to maintain and obviously it is full of bugs and terribly fragile.

Finally I figured out we have a much simpler way to implement Fetch Graph we overlooked previously:

- revert back all the previous PRs related to Fetch Graph implementation and bug fixing (HHH-8776, HHH-14097, HHH-14124);
- simply add a logic in `TwoPhaseLoad` class to check whether Fetch Graph is in effective for now; return false if so in the internal `getOverridingEager()` method in `TwoPhaseLoad` class.

The reason is our HQL to SQL step has added all the JOINs already and we simply keep from loading any other entities during hydrating phase. We don't need to duplicate Fetch Graph enforcement for another time!  Boom, all of sudden, we solve the Fetch Graph issue in a simple and elegant way. My previous initial implementation is purely misled.

I intentionally organized the commit list to streamline code review. All the commits except the last one are reverting back previous PR commits. You can go to the last commit directly to understand the new implementation: https://github.com/hibernate/hibernate-orm/pull/3548/commits/46856068ebd952d181e6314011b782b7b0d80e82