### PR TITLE
HHH-14213 Fix query numeric literal of integer representation parsing exception message

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/LiteralProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/LiteralProcessor.java
@@ -219,12 +219,14 @@ public class LiteralProcessor implements HqlSqlTokenTypes {
 	}
 
 	private String determineIntegerRepresentation(String text, int type) {
+		Class<?> javaTypeClass = Integer.class;
 		try {
 			if ( type == NUM_BIG_INTEGER ) {
 				String literalValue = text;
 				if ( literalValue.endsWith( "bi" ) || literalValue.endsWith( "BI" ) ) {
 					literalValue = literalValue.substring( 0, literalValue.length() - 2 );
 				}
+				javaTypeClass = BigInteger.class;
 				return new BigInteger( literalValue ).toString();
 			}
 			if ( type == NUM_INT ) {
@@ -242,10 +244,11 @@ public class LiteralProcessor implements HqlSqlTokenTypes {
 			if ( literalValue.endsWith( "l" ) || literalValue.endsWith( "L" ) ) {
 				literalValue = literalValue.substring( 0, literalValue.length() - 1 );
 			}
+			javaTypeClass = Long.class;
 			return Long.valueOf( literalValue ).toString();
 		}
 		catch (Throwable t) {
-			throw new HibernateException( "Could not parse literal [" + text + "] as integer", t );
+			throw new HibernateException( "Could not parse literal [" + text + "] as " + javaTypeClass.getName(), t );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/query/IntegerRepresentationLiteralParsingExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/IntegerRepresentationLiteralParsingExceptionTest.java
@@ -1,0 +1,52 @@
+package org.hibernate.query;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+/**
+ * @author Andrias Sundskar
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14213" )
+public class IntegerRepresentationLiteralParsingExceptionTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { ExampleEntity.class };
+	}
+
+	@Test
+	public void testAppropriateExceptionMessageGenerated() {
+		try {
+			doInJPA( this::entityManagerFactory, entityManager -> {
+				// -9223372036854775808 is beyond Long range, so an Exception will be thrown
+				entityManager.createQuery( "select count(*) from ExampleEntity where counter = -9223372036854775808L" )
+						.getSingleResult();
+			} );
+			Assert.fail( "Exception should be thrown" );
+		}
+		catch (Exception e) {
+			// without fixing HHH-14213, the following exception would be thrown:
+			// "Could not parse literal [9223372036854775808L] as integer"
+			// which is confusing and misleading
+			Assert.assertTrue( e.getMessage().endsWith( " as java.lang.Long" ) );
+		}
+	}
+
+	@Entity(name = "ExampleEntity")
+	static class ExampleEntity {
+
+		@Id
+		int id;
+
+		long counter;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14213

The root cause is the string literal long value exceeds the Long value range. However, the exception message is misleading if Long string literal is provided. This PR changes the scope of the ticket to fix the exception message, which is confusing and misleading.

See the ticket comments for further details.