### PR TITLE
Add syntax highlighting to the logged SQL

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -621,6 +621,9 @@ Write all SQL statements to the console. This is an alternative to setting the l
 `*hibernate.format_sql*` (e.g. `true` or `false` (default value))::
 Pretty-print the SQL in the log and console.
 
+`*hibernate.highlight_sql*` (e.g. `true` (default value) or `false`)::
+Colorize the SQL in the console using ANSI escape codes.
+
 `*hibernate.use_sql_comments*` (e.g. `true` or `false` (default value))::
 If true, Hibernate generates comments inside the SQL, for easier debugging.
 

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -621,7 +621,7 @@ Write all SQL statements to the console. This is an alternative to setting the l
 `*hibernate.format_sql*` (e.g. `true` or `false` (default value))::
 Pretty-print the SQL in the log and console.
 
-`*hibernate.highlight_sql*` (e.g. `true` (default value) or `false`)::
+`*hibernate.highlight_sql*` (e.g. `true` or `false` (default value))::
 Colorize the SQL in the console using ANSI escape codes.
 
 `*hibernate.use_sql_comments*` (e.g. `true` or `false` (default value))::

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -743,6 +743,11 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String FORMAT_SQL ="hibernate.format_sql";
 
 	/**
+	 * Enable highlighting of SQL logged to the console using ANSI escape codes
+	 */
+	String HIGHLIGHT_SQL ="hibernate.highlight_sql";
+
+	/**
 	 * Add comments to the generated SQL
 	 */
 	String USE_SQL_COMMENTS ="hibernate.use_sql_comments";

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/FormatStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/FormatStyle.java
@@ -21,6 +21,10 @@ public enum FormatStyle {
 	 */
 	DDL( "ddl", DDLFormatterImpl.INSTANCE ),
 	/**
+	 * Syntax highlighting via ANSI escape codes
+	 */
+	HIGHLIGHT( "highlight", HighlightingFormatter.INSTANCE ),
+	/**
 	 * No formatting
 	 */
 	NONE( "none", NoFormatImpl.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/HighlightingFormatter.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/HighlightingFormatter.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.jdbc.internal;
+
+import org.hibernate.engine.jdbc.env.spi.AnsiSqlKeywords;
+import org.hibernate.internal.util.StringHelper;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+/**
+ * Performs basic syntax highlighting for SQL using ANSI escape codes.
+ *
+ * @author Gavin King
+ */
+public class HighlightingFormatter implements Formatter {
+
+	private static final Set<String> KEYWORDS = new HashSet<>( AnsiSqlKeywords.INSTANCE.sql2003() );
+	static {
+		// additional keywords not reserved by ANSI SQL 2003
+		KEYWORDS.addAll( Arrays.asList( "KEY", "SEQUENCE", "CASCADE", "INCREMENT" ) );
+	}
+
+	public static final Formatter INSTANCE =
+			new HighlightingFormatter(
+					"34", // blue
+					"36", // cyan
+					"32"
+			);
+
+	private static String escape(String code) {
+		return "\u001b[" + code + "m";
+	};
+
+	private final String keywordEscape;
+	private final String stringEscape;
+	private final String quotedEscape;
+	private final String normalEscape;
+
+	/**
+	 * @param keywordCode the ANSI escape code to use for highlighting SQL keywords
+	 * @param stringCode the ANSI escape code to use for highlighting SQL strings
+	 */
+	public HighlightingFormatter(String keywordCode, String stringCode, String quotedCode) {
+		keywordEscape =escape(keywordCode);
+		stringEscape = escape(stringCode);
+		quotedEscape = escape(quotedCode);
+		normalEscape = escape("0");
+	}
+
+	@Override
+	public String format(String sql) {
+		String symbolsAndWs = "=><!+-*/()',.|&`\"?" + StringHelper.WHITESPACE;
+		StringBuilder result = new StringBuilder();
+		boolean inString = false;
+		boolean inQuoted = false;
+		for (StringTokenizer tokenizer = new StringTokenizer( sql, symbolsAndWs, true );
+				tokenizer.hasMoreTokens(); ) {
+			String token = tokenizer.nextToken();
+			switch (token) {
+				case "\"":
+				case "`": // for MySQL
+					if (inString) {
+						result.append(token);
+					}
+					else if (inQuoted) {
+						inQuoted = false;
+						result.append(token).append(normalEscape);
+					}
+					else {
+						inQuoted = true;
+						result.append(quotedEscape).append(token);
+					}
+					break;
+				case "'":
+					if (inQuoted) {
+						result.append("'");
+					}
+					else if (inString) {
+						inString = false;
+						result.append("'").append(normalEscape);
+					}
+					else {
+						inString = true;
+						result.append(stringEscape).append("'");
+					}
+					break;
+				default:
+					if ( KEYWORDS.contains( token.toUpperCase() ) ) {
+						result.append(keywordEscape).append(token).append(normalEscape);
+					}
+					else {
+						result.append(token);
+					}
+			}
+		}
+		return result.toString();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
@@ -55,9 +55,10 @@ public class JdbcServicesImpl implements JdbcServices, ServiceRegistryAwareServi
 
 		final boolean showSQL = ConfigurationHelper.getBoolean( Environment.SHOW_SQL, configValues, false );
 		final boolean formatSQL = ConfigurationHelper.getBoolean( Environment.FORMAT_SQL, configValues, false );
+		final boolean highlightSQL = ConfigurationHelper.getBoolean( Environment.HIGHLIGHT_SQL, configValues, false );
 		final long logSlowQuery = ConfigurationHelper.getLong( Environment.LOG_SLOW_QUERY, configValues, 0 );
 
-		this.sqlStatementLogger = new SqlStatementLogger( showSQL, formatSQL, logSlowQuery );
+		this.sqlStatementLogger = new SqlStatementLogger( showSQL, formatSQL, highlightSQL, logSlowQuery );
 
 		resultSetWrapper = new ResultSetWrapperImpl( serviceRegistry );
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/BasicTestingJdbcServiceImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/BasicTestingJdbcServiceImpl.java
@@ -57,7 +57,7 @@ public class BasicTestingJdbcServiceImpl implements JdbcServices, ServiceRegistr
 	public void prepare(boolean allowAggressiveRelease) throws SQLException {
 		dialect = ConnectionProviderBuilder.getCorrespondingDialect();
 		connectionProvider = ConnectionProviderBuilder.buildConnectionProvider( allowAggressiveRelease );
-		sqlStatementLogger = new SqlStatementLogger( true, false );
+		sqlStatementLogger = new SqlStatementLogger( true, false, false );
 
 		Connection jdbcConnection = connectionProvider.getConnection();
 		try {


### PR DESCRIPTION
Using ANSI escape codes, we can make the logged SQL a little more readable.

For https://hibernate.atlassian.net/browse/HHH-14217