### PR TITLE
Stop generating fragments of uppercase SQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InterbaseDialect.java
@@ -77,7 +77,7 @@ public class InterbaseDialect extends Dialect {
 
 	@Override
 	public String getSequenceNextValString(String sequenceName) {
-		return "select " + getSelectSequenceNextValString( sequenceName ) + " from RDB$DATABASE";
+		return "select " + getSelectSequenceNextValString( sequenceName ) + " from rdb$database";
 	}
 
 	@Override
@@ -92,12 +92,12 @@ public class InterbaseDialect extends Dialect {
 
 	@Override
 	public String getDropSequenceString(String sequenceName) {
-		return "delete from RDB$GENERATORS where RDB$GENERATOR_NAME = '" + sequenceName.toUpperCase(Locale.ROOT) + "'";
+		return "delete from rdb$generators where rdb$generator_name = '" + sequenceName.toUpperCase(Locale.ROOT) + "'";
 	}
 
 	@Override
 	public String getQuerySequencesString() {
-		return "select RDB$GENERATOR_NAME from RDB$GENERATORS";
+		return "select rdb$generator_name from rdb$generators";
 	}
 
 	@Override
@@ -150,7 +150,7 @@ public class InterbaseDialect extends Dialect {
 		// TODO : not sure which (either?) is correct, could not find docs on how to do this.
 		// did find various blogs and forums mentioning that select CURRENT_TIMESTAMP
 		// does not work...
-		return "{?= call CURRENT_TIMESTAMP }";
+		return "{?= call current_timestamp }";
 //		return "select CURRENT_TIMESTAMP from RDB$DATABASE";
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDB103Dialect.java
@@ -57,7 +57,7 @@ public class MariaDB103Dialect extends MariaDB102Dialect {
 
 	@Override
 	public String getQuerySequencesString() {
-		return "select table_name from information_schema.TABLES where table_schema = database() and table_type = 'SEQUENCE'";
+		return "select table_name from information_schema.tables where table_schema = database() and table_type = 'SEQUENCE'";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -745,7 +745,7 @@ public class Oracle8iDialect extends Dialect {
 
 	@Override
 	public String getCurrentSchemaCommand() {
-		return "SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM DUAL";
+		return "select sys_context('USERENV', 'CURRENT_SCHEMA') from dual";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
@@ -49,7 +49,7 @@ public class SQLServer2012Dialect extends SQLServer2008Dialect {
 	@Override
 	public String getQuerySequencesString() {
 		// The upper-case name should work on both case-sensitive and case-insensitive collations.
-		return "select * from INFORMATION_SCHEMA.SEQUENCES";
+		return "select * from information_schema.sequences";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -124,7 +124,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 	@Override
 	public String getCurrentSchemaCommand() {
-		return "SELECT SCHEMA_NAME()";
+		return "select schema_name()";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/hint/IndexQueryHintHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/hint/IndexQueryHintHandler.java
@@ -35,7 +35,7 @@ public class IndexQueryHintHandler implements QueryHintHandler {
 			String endToken = matcher.group( 2 );
 
 			return new StringBuilder( startToken )
-					.append( " USE INDEX (" )
+					.append( " use index (" )
 					.append( hints )
 					.append( ") " )
 					.append( endToken )

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/Informix10LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/Informix10LimitHandler.java
@@ -21,8 +21,8 @@ public class Informix10LimitHandler extends AbstractLimitHandler {
 	@Override
 	public String processSql(String sql, RowSelection selection) {
 		final boolean hasOffset = LimitHelper.hasFirstRow( selection );
-		String sqlOffset = hasOffset ? " SKIP " + selection.getFirstRow() : "";
-		String sqlLimit = " FIRST " + getMaxOrLimit( selection );
+		String sqlOffset = hasOffset ? " skip " + selection.getFirstRow() : "";
+		String sqlLimit = " first " + getMaxOrLimit( selection );
 		String sqlOffsetLimit = sqlOffset + sqlLimit;
 		String result = new StringBuilder( sql.length() + 10 )
 				.append( sql )

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -97,10 +97,10 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 	 * <pre>
 	 * WITH query AS (
 	 *   SELECT inner_query.*
-	 *        , ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__
+	 *        , ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __row__
 	 *     FROM ( original_query_with_top_if_order_by_present_and_all_aliased_columns ) inner_query
 	 * )
-	 * SELECT alias_list FROM query WHERE __hibernate_row_nr__ >= offset AND __hibernate_row_nr__ < offset + last
+	 * SELECT alias_list FROM query WHERE __row__ >= offset AND __row__ < offset + last
 	 * </pre>
 	 *
 	 * When offset equals {@literal 0}, only <code>TOP(?)</code> expression is added to the original query.
@@ -131,9 +131,9 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 
 			encloseWithOuterQuery( sb, offset );
 
-			sb.insert( offset, !isCTE ? "WITH query AS (" : ", query AS (" );
-			sb.append( ") SELECT " ).append( selectClause ).append( " FROM query " );
-			sb.append( "WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?" );
+			sb.insert( offset, !isCTE ? "with query as (" : ", query as (" );
+			sb.append( ") select " ).append( selectClause ).append( " from query " );
+			sb.append( "where __row__ >= ? and __row__ < ?" );
 		}
 
 		return sb.toString();
@@ -298,13 +298,13 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 	}
 
 	/**
-	 * Encloses original SQL statement with outer query that provides {@literal __hibernate_row_nr__} column.
+	 * Encloses original SQL statement with outer query that provides {@literal __row__} column.
 	 *
 	 * @param sql SQL query.
 	 * @param offset SQL query offset.
 	 */
 	protected void encloseWithOuterQuery(StringBuilder sql, int offset) {
-		sql.insert( offset, "SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " );
+		sql.insert( offset, "select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " );
 		sql.append( " ) inner_query " );
 	}
 
@@ -321,11 +321,11 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 		final int selectDistinctPos = shallowIndexOfPattern( sql, SELECT_DISTINCT_PATTERN, offset );
 		if ( selectPos == selectDistinctPos ) {
 			// Place TOP after SELECT DISTINCT
-			sql.insert( selectDistinctPos + SELECT_DISTINCT.length(), " TOP(?)" );
+			sql.insert( selectDistinctPos + SELECT_DISTINCT.length(), " top(?)" );
 		}
 		else {
 			// Place TOP after SELECT
-			sql.insert( selectPos + SELECT.length(), " TOP(?)" );
+			sql.insert( selectPos + SELECT.length(), " top(?)" );
 		}
 		topAdded = true;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/dialect/InformixLimitHandlerTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/InformixLimitHandlerTestCase.java
@@ -19,7 +19,7 @@ public class InformixLimitHandlerTestCase extends
 
 	private Informix10LimitHandler informixLimitHandler;
 
-	private final String TEST_SQL = "SELECT field FROM table";
+	private final String TEST_SQL = "select field from table";
 
 	@Before
 	public void setup() {
@@ -29,10 +29,10 @@ public class InformixLimitHandlerTestCase extends
 	@Test
 	@TestForIssue(jiraKey = "HHH-11509")
 	public void testCorrectLimit() {
-		assertLimitHandlerEquals( "SELECT FIRST 10 field FROM table", 0, 10 );
-		assertLimitHandlerEquals( "SELECT SKIP 3 FIRST 5 field FROM table", 3, 5 );
-		assertLimitHandlerEquals( "SELECT SKIP 10 FIRST 5 field FROM table", 10, 5 );
-		assertLimitHandlerEquals( "SELECT SKIP 55 FIRST 12 field FROM table", 55, 12 );
+		assertLimitHandlerEquals( "select first 10 field from table", 0, 10 );
+		assertLimitHandlerEquals( "select skip 3 first 5 field from table", 3, 5 );
+		assertLimitHandlerEquals( "select skip 10 first 5 field from table", 10, 5 );
+		assertLimitHandlerEquals( "select skip 55 first 12 field from table", 55, 12 );
 	}
 
 	private void assertLimitHandlerEquals(String sql, int firstRow, int maxRows) {

--- a/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2005DialectTestCase.java
@@ -45,19 +45,19 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		String input = "select distinct f1 as f53245 from table849752 order by f234, f67 desc";
 
 		assertEquals(
-				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __hibernate_row_nr__ from ( " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select distinct top(?) f1 as f53245 from table849752 order by f234, f67 desc ) inner_query )" +
-						" select f53245 from query where __hibernate_row_nr__ >= ? and __hibernate_row_nr__ < ?",
+						" select f53245 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( input, toRowSelection( 10, 15 ) ).toLowerCase(Locale.ROOT) );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HHH-10736")
 	public void testGetLimitStringWithNewlineAfterSelect() {
-		final String query = "select" + System.lineSeparator() + "* FROM Employee E WHERE E.firstName = :firstName";
+		final String query = "select" + System.lineSeparator() + "* from Employee E where E.firstName = :firstName";
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						query + " ) inner_query ) SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						query + " ) inner_query ) select * from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 25 ) )
 		);
 	}
@@ -65,10 +65,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10736")
 	public void testGetLimitStringWithNewlineAfterSelectWithMultipleSpaces() {
-		final String query = "select    " + System.lineSeparator() + "* FROM Employee E WHERE E.firstName = :firstName";
+		final String query = "select    " + System.lineSeparator() + "* from employee e where e.firstName = :firstName";
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						query + " ) inner_query ) SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						query + " ) inner_query ) select * from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 25 ) )
 		);
 	}
@@ -76,12 +76,12 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-8507")
 	public void testGetLimitStringWithNewlineAfterColumnList() {
-		final String query = "select E.fieldA,E.fieldB\r\nFROM Employee E WHERE E.firstName = :firstName";
+		final String query = "select e.fielda,e.fieldb\r\nfrom employee e where e.firstname = :firstname";
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select E.fieldA as page0_,E.fieldB as page1_\r\n" +
-						"FROM Employee E WHERE E.firstName = :firstName ) inner_query ) SELECT page0_, page1_ FROM query " +
-						"WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select e.fielda as page0_,e.fieldb as page1_\r\n" +
+						"from employee e where e.firstname = :firstname ) inner_query ) select page0_, page1_ from query " +
+						"where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 25 ) )
 		);
 	}
@@ -96,9 +96,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"where persistent0_.customerid=?";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						fromColumnNameSQL + " ) inner_query ) " +
-						"SELECT rid1688_, deviati16_1688_, sortindex1688_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select rid1688_, deviati16_1688_, sortindex1688_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( fromColumnNameSQL, toRowSelection( 1, 10 ) )
 		);
 	}
@@ -109,9 +109,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String notAliasedSQL = "select column1, column2, column3, column4 from table1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select column1 as page0_, column2 as page1_, column3 as page2_, column4 as page3_ from table1 ) inner_query ) " +
-						"SELECT page0_, page1_, page2_, page3_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select page0_, page1_, page2_, page3_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( notAliasedSQL, toRowSelection( 3, 5 ) )
 		);
 	}
@@ -121,9 +121,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	public void testGetLimitStringAliasGenerationWithAliasesNoAs() {
 		final String aliasedSQLNoAs = "select column1 c1, column c2, column c3, column c4 from table1";
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select column1 c1, column c2, column c3, column c4 from table1 ) inner_query ) " +
-						"SELECT c1, c2, c3, c4 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select c1, c2, c3, c4 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( aliasedSQLNoAs, toRowSelection( 3, 5 ) )
 		);
 	}
@@ -132,9 +132,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@TestForIssue(jiraKey = "HHH-11352")
 	public void testPagingWithColumnNameStartingWithFrom() {
 		final String sql = "select column1 c1, from_column c2 from table1";
-		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+		assertEquals( "with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 				"select column1 c1, from_column c2 from table1 ) inner_query ) " +
-				"SELECT c1, c2 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"select c1, c2 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql(sql, toRowSelection(3, 5)));
 	}
 
@@ -149,9 +149,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 				"where persistent0_.type='v'";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						subselectInSelectClauseSQL + " ) inner_query ) " +
-						"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select col_0_0_, col_1_0_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( subselectInSelectClauseSQL, toRowSelection( 2, 5 ) )
 		);
 	}
@@ -159,14 +159,14 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-11084")
 	public void testGetLimitStringWithSelectDistinctSubselect() {
-		final String selectDistinctSubselectSQL = "select page0_.CONTENTID as CONTENT1_12_ " +
-				"where page0_.CONTENTTYPE='PAGE' and (page0_.CONTENTID in " +
-				"(select distinct page2_.PREVVER from CONTENT page2_ where (page2_.PREVVER is not null)))";
+		final String selectDistinctSubselectSQL = "select page0_.contentid as content1_12_ " +
+				"where page0_.contenttype='page' and (page0_.contentid in " +
+				"(select distinct page2_.prevver from content page2_ where (page2_.prevver is not null)))";
 
 		assertEquals(
-				"select TOP(?) page0_.CONTENTID as CONTENT1_12_ " +
-						"where page0_.CONTENTTYPE='PAGE' and (page0_.CONTENTID in " +
-						"(select distinct page2_.PREVVER from CONTENT page2_ where (page2_.PREVVER is not null)))",
+				"select top(?) page0_.contentid as content1_12_ " +
+						"where page0_.contenttype='page' and (page0_.contentid in " +
+						"(select distinct page2_.prevver from content page2_ where (page2_.prevver is not null)))",
 				dialect.getLimitHandler().processSql( selectDistinctSubselectSQL, toRowSelection( 0, 5 ) )
 		);
 	}
@@ -174,14 +174,14 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-11084")
 	public void testGetLimitStringWithSelectDistinctSubselectNotFirst() {
-		final String selectDistinctSubselectSQL = "select page0_.CONTENTID as CONTENT1_12_ FROM CONTEXT page0_ " +
-				"where page0_.CONTENTTYPE='PAGE' and (page0_.CONTENTID in " +
-				"(select distinct page2_.PREVVER from CONTENT page2_ where (page2_.PREVVER is not null)))";
+		final String selectDistinctSubselectSQL = "select page0_.contentid as content1_12_ from context page0_ " +
+				"where page0_.contenttype='page' and (page0_.contentid in " +
+				"(select distinct page2_.prevver from content page2_ where (page2_.prevver is not null)))";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ " +
-				"FROM ( " + selectDistinctSubselectSQL + " ) inner_query ) " +
-				"SELECT CONTENT1_12_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ " +
+				"from ( " + selectDistinctSubselectSQL + " ) inner_query ) " +
+				"select content1_12_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( selectDistinctSubselectSQL, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -189,18 +189,18 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-6728")
 	public void testGetLimitStringCaseSensitive() {
-		final String caseSensitiveSQL = "select persistent0_.id, persistent0_.uid AS tmp1, " +
+		final String caseSensitiveSQL = "select persistent0_.id, persistent0_.uid as tmp1, " +
 				"(select case when persistent0_.name = 'Smith' then 'Neo' else persistent0_.id end) " +
-				"from C_Customer persistent0_ " +
+				"from c_customer persistent0_ " +
 				"where persistent0_.type='Va' " +
 				"order by persistent0_.Order";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) persistent0_.id as page0_, persistent0_.uid AS tmp1, " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) persistent0_.id as page0_, persistent0_.uid as tmp1, " +
 						"(select case when persistent0_.name = 'Smith' then 'Neo' else persistent0_.id end) as page1_ " +
-						"from C_Customer persistent0_ where persistent0_.type='Va' order by persistent0_.Order ) " +
-						"inner_query ) SELECT page0_, tmp1, page1_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"from c_customer persistent0_ where persistent0_.type='Va' order by persistent0_.Order ) " +
+						"inner_query ) select page0_, tmp1, page1_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( caseSensitiveSQL, toRowSelection( 1, 2 ) )
 		);
 	}
@@ -211,9 +211,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String distinctInAggregateSQL = "select aggregate_function(distinct p.n) as f1 from table849752 p order by f1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) aggregate_function(distinct p.n) as f1 from table849752 p order by f1 ) inner_query ) " +
-						"SELECT f1 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) aggregate_function(distinct p.n) as f1 from table849752 p order by f1 ) inner_query ) " +
+						"select f1 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( distinctInAggregateSQL, toRowSelection( 2, 5 ) )
 		);
 	}
@@ -224,9 +224,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String distinctInAggregateSQL = "select aggregate_function(distinct p.n) from table849752 p order by f1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) aggregate_function(distinct p.n) as page0_ from table849752 p order by f1 ) inner_query ) " +
-						"SELECT page0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) aggregate_function(distinct p.n) as page0_ from table849752 p order by f1 ) inner_query ) " +
+						"select page0_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( distinctInAggregateSQL, toRowSelection( 2, 5 ) )
 		);
 	}
@@ -237,9 +237,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String distinctInAggregateSQL = "select aggregate_function(distinct p.n) f1 from table849752 p order by f1";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) aggregate_function(distinct p.n) f1 from table849752 p order by f1 ) inner_query ) " +
-						"SELECT f1 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) aggregate_function(distinct p.n) f1 from table849752 p order by f1 ) inner_query ) " +
+						"select f1 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( distinctInAggregateSQL, toRowSelection( 2, 5 ) )
 		);
 	}
@@ -248,20 +248,20 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@TestForIssue(jiraKey = "HHH-7370")
 	public void testGetLimitStringWithMaxOnly() {
 		final String query = "select product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
-				"from Product2 product2x0_ order by product2x0_.id";
+				"from product2 product2x0_ order by product2x0_.id";
 
 		assertEquals(
-				"select TOP(?) product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
-						"from Product2 product2x0_ order by product2x0_.id",
+				"select top(?) product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
+						"from product2 product2x0_ order by product2x0_.id",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 0, 1 ) )
 		);
 
 		final String distinctQuery = "select distinct product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
-				"from Product2 product2x0_ order by product2x0_.id";
+				"from product2 product2x0_ order by product2x0_.id";
 
 		assertEquals(
-				"select distinct TOP(?) product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
-						"from Product2 product2x0_ order by product2x0_.id",
+				"select distinct top(?) product2x0_.id as id0_, product2x0_.description as descript2_0_ " +
+						"from product2 product2x0_ order by product2x0_.id",
 				dialect.getLimitHandler().processSql( distinctQuery, toRowSelection( 0, 5 ) )
 		);
 	}
@@ -269,14 +269,14 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-7781")
 	public void testGetLimitStringWithCastOperator() {
-		final String query = "select cast(lc302_doku6_.redniBrojStavke as varchar(255)) as col_0_0_, lc302_doku6_.dokumentiID as col_1_0_ " +
-				"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC";
+		final String query = "select cast(lc302_doku6_.rednibrojstavke as varchar(255)) as col_0_0_, lc302_doku6_.dokumentiid as col_1_0_ " +
+				"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) cast(lc302_doku6_.redniBrojStavke as varchar(255)) as col_0_0_, lc302_doku6_.dokumentiID as col_1_0_ " +
-						"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC ) inner_query ) " +
-						"SELECT col_0_0_, col_1_0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) cast(lc302_doku6_.rednibrojstavke as varchar(255)) as col_0_0_, lc302_doku6_.dokumentiid as col_1_0_ " +
+						"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc ) inner_query ) " +
+						"select col_0_0_, col_1_0_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 3 ) )
 		);
 	}
@@ -284,14 +284,14 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10994")
 	public void testGetLimitStringWithCastOperatorWithAliasNoAs() {
-		final String query = "select cast(lc302_doku6_.redniBrojStavke as varchar(255)) f1, lc302_doku6_.dokumentiID f2 " +
-				"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC";
+		final String query = "select cast(lc302_doku6_.rednibrojstavke as varchar(255)) f1, lc302_doku6_.dokumentiid f2 " +
+				"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) cast(lc302_doku6_.redniBrojStavke as varchar(255)) f1, lc302_doku6_.dokumentiID f2 " +
-						"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC ) inner_query ) " +
-						"SELECT f1, f2 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) cast(lc302_doku6_.rednibrojstavke as varchar(255)) f1, lc302_doku6_.dokumentiid f2 " +
+						"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc ) inner_query ) " +
+						"select f1, f2 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 3 ) )
 		);
 	}
@@ -299,14 +299,14 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10994")
 	public void testGetLimitStringWithCastOperatorWithoutAliases() {
-		final String query = "select cast(lc302_doku6_.redniBrojStavke as varchar(255)), lc302_doku6_.dokumentiID " +
-				"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC";
+		final String query = "select cast(lc302_doku6_.rednibrojstavke as varchar(255)), lc302_doku6_.dokumentiid " +
+				"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) cast(lc302_doku6_.redniBrojStavke as varchar(255)) as page0_, lc302_doku6_.dokumentiID as page1_ " +
-						"from LC302_Dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiID DESC ) inner_query ) " +
-						"SELECT page0_, page1_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) cast(lc302_doku6_.rednibrojstavke as varchar(255)) as page0_, lc302_doku6_.dokumentiid as page1_ " +
+						"from lc302_dokumenti lc302_doku6_ order by lc302_doku6_.dokumentiid desc ) inner_query ) " +
+						"select page0_, page1_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 3 ) )
 		);
 	}
@@ -317,9 +317,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String query = "select t1.*, t2.* from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) t1.*, t2.* from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
-						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) t1.*, t2.* from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
+						"select * from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 3 ) )
 		);
 	}
@@ -330,9 +330,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		final String query = "select * from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) * from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
-						"SELECT * FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) * from tab1 t1, tab2 t2 where t1.ref = t2.ref order by t1.id desc ) inner_query ) " +
+						"select * from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 3 ) )
 		);
 	}
@@ -342,9 +342,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	public void testGetLimitStringWithFromInColumnName() {
 		final String query = "select [Created From Nonstock Item], field2 from table1";
 
-		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+		assertEquals( "with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select [Created From Nonstock Item] as page0_, field2 as page1_ from table1 ) inner_query ) " +
-						"SELECT page0_, page1_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select page0_, page1_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -354,9 +354,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	public void testGetLimitStringWithQuotedColumnNamesAndAlias() {
 		final String query = "select [Created From Item] c1, field2 from table1";
 
-		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+		assertEquals( "with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select [Created From Item] c1, field2 as page0_ from table1 ) inner_query ) " +
-						"SELECT c1, page0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select c1, page0_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -366,9 +366,9 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	public void testGetLimitStringWithQuotedColumnNamesAndAliasWithAs() {
 		final String query = "select [Created From Item] as c1, field2 from table1";
 
-		assertEquals( "WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
+		assertEquals( "with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
 						"select [Created From Item] as c1, field2 as page0_ from table1 ) inner_query ) " +
-						"SELECT c1, page0_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+						"select c1, page0_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -376,12 +376,12 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-11324")
 	public void testGetLimitStringWithSelectClauseNestedQueryUsingParenthesis() {
-		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC";
+		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'added' else 'unmodified' end from table2 t2 where (t2.c1 in (?))) as col_1_0 from table1 t1 where 1=1 order by t1.c1 asc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC ) inner_query ) " +
-						"SELECT col_0_0, col_1_0 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'added' else 'unmodified' end from table2 t2 where (t2.c1 in (?))) as col_1_0 from table1 t1 where 1=1 order by t1.c1 asc ) inner_query ) " +
+						"select col_0_0, col_1_0 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -389,11 +389,11 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-11650")
 	public void testGetLimitWithStringValueContainingParenthesis() {
-		final String query = "select t1.c1 as col_0_0 FROM table1 t1 where t1.c1 = '(123' ORDER BY t1.c1 ASC";
+		final String query = "select t1.c1 as col_0_0 from table1 t1 where t1.c1 = '(123' order by t1.c1 asc";
 
 		assertEquals(
-				"WITH query AS (SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( " +
-						"select TOP(?) t1.c1 as col_0_0 FROM table1 t1 where t1.c1 = '(123' ORDER BY t1.c1 ASC ) inner_query ) SELECT col_0_0 FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ from ( " +
+						"select top(?) t1.c1 as col_0_0 from table1 t1 where t1.c1 = '(123' order by t1.c1 asc ) inner_query ) select col_0_0 from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 1, 5 ) )
 		);
 	}
@@ -401,10 +401,10 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-11324")
 	public void testGetLimitStringWithSelectClauseNestedQueryUsingParenthesisOnlyTop() {
-		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC";
+		final String query = "select t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 where (t2.c1 in (?))) as col_1_0 from table1 t1 where 1=1 order by t1.c1 asc";
 
 		assertEquals(
-				"select TOP(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 WHERE (t2.c1 in (?))) as col_1_0 from table1 t1 WHERE 1=1 ORDER BY t1.c1 ASC",
+				"select top(?) t1.c1 as col_0_0, (select case when count(t2.c1)>0 then 'ADDED' else 'UNMODIFIED' end from table2 t2 where (t2.c1 in (?))) as col_1_0 from table1 t1 where 1=1 order by t1.c1 asc",
 				dialect.getLimitHandler().processSql( query, toRowSelection( 0, 5 ) )
 		);
 	}
@@ -415,34 +415,34 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		RowSelection selection = toRowSelection( 0, 5 );
 
 		// test top-based CTE with single CTE query definition with no odd formatting
-		final String query1 = "WITH a (c1, c2) AS (SELECT c1, c2 FROM t) SELECT c1, c2 FROM a";
+		final String query1 = "with a (c1, c2) as (select c1, c2 from t) select c1, c2 from a";
 		assertEquals(
-				"WITH a (c1, c2) AS (SELECT c1, c2 FROM t) SELECT TOP(?) c1, c2 FROM a",
+				"with a (c1, c2) as (select c1, c2 from t) select top(?) c1, c2 from a",
 				dialect.getLimitHandler().processSql( query1, selection )
 		);
 
 		// test top-based CTE with single CTE query definition and various tab, newline spaces
-		final String query2 = "  \n\tWITH a (c1\n\t,c2)\t\nAS (SELECT\n\tc1,c2 FROM t)\t\nSELECT c1, c2 FROM a";
+		final String query2 = "  \n\twith a (c1\n\t,c2)\t\nas (select\n\tc1,c2 from t)\t\nselect c1, c2 from a";
 		assertEquals(
-				"  \n\tWITH a (c1\n\t,c2)\t\nAS (SELECT\n\tc1,c2 FROM t)\t\nSELECT TOP(?) c1, c2 FROM a",
+				"  \n\twith a (c1\n\t,c2)\t\nas (select\n\tc1,c2 from t)\t\nselect top(?) c1, c2 from a",
 				dialect.getLimitHandler().processSql( query2, selection )
 		);
 
 		// test top-based CTE with multiple CTE query definitions with no odd formatting
-		final String query3 = "WITH a (c1, c2) AS (SELECT c1, c2 FROM t1), b (b1, b2) AS (SELECT b1, b2 FROM t2) " +
-				"SELECT c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1";
+		final String query3 = "with a (c1, c2) as (select c1, c2 from t1), b (b1, b2) as (select b1, b2 from t2) " +
+				"select c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1";
 		assertEquals(
-				"WITH a (c1, c2) AS (SELECT c1, c2 FROM t1), b (b1, b2) AS (SELECT b1, b2 FROM t2) " +
-						"SELECT TOP(?) c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1",
+				"with a (c1, c2) as (select c1, c2 from t1), b (b1, b2) as (select b1, b2 from t2) " +
+						"select top(?) c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1",
 				dialect.getLimitHandler().processSql( query3, selection )
 		);
 
 		// test top-based CTE with multiple CTE query definitions and various tab, newline spaces
-		final String query4 = "  \n\r\tWITH a (c1, c2) AS\n\r (SELECT c1, c2 FROM t1)\n\r, b (b1, b2)\tAS\t" +
-				"(SELECT b1, b2 FROM t2)    SELECT c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1";
+		final String query4 = "  \n\r\twith a (c1, c2) as\n\r (select c1, c2 from t1)\n\r, b (b1, b2)\tas\t" +
+				"(select b1, b2 from t2)    select c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1";
 		assertEquals(
-				"  \n\r\tWITH a (c1, c2) AS\n\r (SELECT c1, c2 FROM t1)\n\r, b (b1, b2)\tAS\t(SELECT b1, b2 FROM t2)" +
-						"    SELECT TOP(?) c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1",
+				"  \n\r\twith a (c1, c2) as\n\r (select c1, c2 from t1)\n\r, b (b1, b2)\tas\t(select b1, b2 from t2)" +
+						"    select top(?) c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1",
 				dialect.getLimitHandler().processSql( query4, selection )
 		);
 	}
@@ -453,44 +453,44 @@ public class SQLServer2005DialectTestCase extends BaseUnitTestCase {
 		RowSelection selection = toRowSelection( 1, 5 );
 
 		// test non-top based CTE with single CTE query definition with no odd formatting
-		final String query1 = "WITH a (c1, c2) AS (SELECT c1, c2 FROM t) SELECT c1, c2 FROM a";
+		final String query1 = "with a (c1, c2) as (select c1, c2 from t) select c1, c2 from a";
 		assertEquals(
-				"WITH a (c1, c2) AS (SELECT c1, c2 FROM t), query AS (SELECT inner_query.*, ROW_NUMBER() OVER " +
-						"(ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM (  SELECT c1 as page0_, c2 as page1_ " +
-						"FROM a ) inner_query ) SELECT page0_, page1_ FROM query WHERE __hibernate_row_nr__ >= ? " +
-						"AND __hibernate_row_nr__ < ?",
+				"with a (c1, c2) as (select c1, c2 from t), query as (select inner_query.*, row_number() over " +
+						"(order by current_timestamp) as __row__ from (  select c1 as page0_, c2 as page1_ " +
+						"from a ) inner_query ) select page0_, page1_ from query where __row__ >= ? " +
+						"and __row__ < ?",
 				dialect.getLimitHandler().processSql( query1, selection )
 		);
 
 		// test non-top based CTE with single CTE query definition and various tab, newline spaces
-		final String query2 = "  \n\tWITH a (c1\n\t,c2)\t\nAS (SELECT\n\tc1,c2 FROM t)\t\nSELECT c1, c2 FROM a";
+		final String query2 = "  \n\twith a (c1\n\t,c2)\t\nas (select\n\tc1,c2 from t)\t\nselect c1, c2 from a";
 		assertEquals(
-				"  \n\tWITH a (c1\n\t,c2)\t\nAS (SELECT\n\tc1,c2 FROM t), query AS (SELECT inner_query.*, ROW_NUMBER()" +
-						" OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM ( \t\nSELECT c1 as page0_, c2 " +
-						"as page1_ FROM a ) inner_query ) SELECT page0_, page1_ FROM query WHERE __hibernate_row_nr__ >= " +
-						"? AND __hibernate_row_nr__ < ?",
+				"  \n\twith a (c1\n\t,c2)\t\nas (select\n\tc1,c2 from t), query as (select inner_query.*, row_number()" +
+						" over (order by current_timestamp) as __row__ from ( \t\nselect c1 as page0_, c2 " +
+						"as page1_ from a ) inner_query ) select page0_, page1_ from query where __row__ >= " +
+						"? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query2, selection )
 		);
 
 		// test non-top based CTE with multiple CTE query definitions with no odd formatting
-		final String query3 = "WITH a (c1, c2) AS (SELECT c1, c2 FROM t1), b (b1, b2) AS (SELECT b1, b2 FROM t2) " +
-				" SELECT c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1";
+		final String query3 = "with a (c1, c2) as (select c1, c2 from t1), b (b1, b2) as (select b1, b2 from t2) " +
+				" select c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1";
 		assertEquals(
-				"WITH a (c1, c2) AS (SELECT c1, c2 FROM t1), b (b1, b2) AS (SELECT b1, b2 FROM t2), query AS (" +
-						"SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM (" +
-						"   SELECT c1 as page0_, c2 as page1_, b1 as page2_, b2 as page3_ FROM t1, t2 WHERE t1.c1 = t2.b1 ) inner_query )" +
-						" SELECT page0_, page1_, page2_, page3_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"with a (c1, c2) as (select c1, c2 from t1), b (b1, b2) as (select b1, b2 from t2), query as (" +
+						"select inner_query.*, row_number() over (order by current_timestamp) as __row__ from (" +
+						"   select c1 as page0_, c2 as page1_, b1 as page2_, b2 as page3_ from t1, t2 where t1.c1 = t2.b1 ) inner_query )" +
+						" select page0_, page1_, page2_, page3_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query3, selection )
 		);
 
 		// test top-based CTE with multiple CTE query definitions and various tab, newline spaces
-		final String query4 = "  \n\r\tWITH a (c1, c2) AS\n\r (SELECT c1, c2 FROM t1)\n\r, b (b1, b2)\tAS\t(SELECT b1, " +
-				"b2 FROM t2)    SELECT c1, c2, b1, b2 FROM t1, t2 WHERE t1.c1 = t2.b1";
+		final String query4 = "  \n\r\twith a (c1, c2) as\n\r (select c1, c2 from t1)\n\r, b (b1, b2)\tas\t(select b1, " +
+				"b2 from t2)    select c1, c2, b1, b2 from t1, t2 where t1.c1 = t2.b1";
 		assertEquals(
-				"  \n\r\tWITH a (c1, c2) AS\n\r (SELECT c1, c2 FROM t1)\n\r, b (b1, b2)\tAS\t(SELECT b1, b2 FROM t2), query AS (" +
-						"SELECT inner_query.*, ROW_NUMBER() OVER (ORDER BY CURRENT_TIMESTAMP) as __hibernate_row_nr__ FROM (" +
-						"     SELECT c1 as page0_, c2 as page1_, b1 as page2_, b2 as page3_ FROM t1, t2 WHERE t1.c1 = t2.b1 ) inner_query )" +
-						" SELECT page0_, page1_, page2_, page3_ FROM query WHERE __hibernate_row_nr__ >= ? AND __hibernate_row_nr__ < ?",
+				"  \n\r\twith a (c1, c2) as\n\r (select c1, c2 from t1)\n\r, b (b1, b2)\tas\t(select b1, b2 from t2), query as (" +
+						"select inner_query.*, row_number() over (order by current_timestamp) as __row__ from (" +
+						"     select c1 as page0_, c2 as page1_, b1 as page2_, b2 as page3_ from t1, t2 where t1.c1 = t2.b1 ) inner_query )" +
+						" select page0_, page1_, page2_, page3_ from query where __row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( query4, selection )
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2012DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/SQLServer2012DialectTestCase.java
@@ -75,9 +75,9 @@ public class SQLServer2012DialectTestCase extends BaseUnitTestCase {
 		// See SQLServer2012LimitHandler for why this falls back
 		final String input = "select f1 from table";
 		assertEquals(
-				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __hibernate_row_nr__ " +
+				"with query as (select inner_query.*, row_number() over (order by current_timestamp) as __row__ " +
 						"from ( select f1 as page0_ from table ) inner_query ) select page0_ from query where " +
-						"__hibernate_row_nr__ >= ? and __hibernate_row_nr__ < ?",
+						"__row__ >= ? and __row__ < ?",
 				dialect.getLimitHandler().processSql( input, toRowSelection( 5, 10 ) ).toLowerCase( Locale.ROOT )
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NamedQueryCommentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/NamedQueryCommentTest.java
@@ -207,7 +207,7 @@ public class NamedQueryCommentTest extends BaseEntityManagerFunctionalTestCase {
 			sqlStatementInterceptor.assertExecutedCount(1);
 
 			sqlStatementInterceptor.assertExecuted(
-					"/* COMMENT_SELECT_INDEX_game_title */ select namedquery0_.id as id1_0_, namedquery0_.title as title2_0_ from game namedquery0_  USE INDEX (idx_game_id) where namedquery0_.title=?"			)
+					"/* COMMENT_SELECT_INDEX_game_title */ select namedquery0_.id as id1_0_, namedquery0_.title as title2_0_ from game namedquery0_  use index (idx_game_id) where namedquery0_.title=?"			)
 			;
 		} );
 	}


### PR DESCRIPTION
Hibernate generates lowercase SQL, because it isn't 1980 anymore, and hasn't been for a while.

(I already fixed this in H6, this fix is for H5.)