### PR TITLE
wip/6.0 Fix the typo of `extracter` in codebase

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConverter.java
@@ -18,12 +18,12 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
  */
 @Deprecated
 public class SQLStateConverter extends StandardSQLExceptionConverter implements SQLExceptionConverter {
-	public SQLStateConverter(final ViolatedConstraintNameExtractor extracter) {
+	public SQLStateConverter(final ViolatedConstraintNameExtractor extractor) {
 		super();
 		final ConversionContext conversionContext = new ConversionContext() {
 			@Override
 			public ViolatedConstraintNameExtractor getViolatedConstraintNameExtractor() {
-				return extracter;
+				return extractor;
 			}
 		};
 		addDelegate( new SQLStateConversionDelegate( conversionContext ) );

--- a/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/MultipleLinesSqlCommandExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/hbm2ddl/MultipleLinesSqlCommandExtractor.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.tool.hbm2ddl;
 
-import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtracter;
+import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor;
 
 /**
  * Class responsible for extracting SQL statements from import script. Supports instructions/comments and quoted
@@ -14,8 +14,8 @@ import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtracter;
  * 
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  *
- * @deprecated Use {@link MultiLineSqlScriptExtracter} instead
+ * @deprecated Use {@link MultiLineSqlScriptExtractor} instead
  */
 @Deprecated
-public class MultipleLinesSqlCommandExtractor extends MultiLineSqlScriptExtracter {
+public class MultipleLinesSqlCommandExtractor extends MultiLineSqlScriptExtractor {
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/AbstractScriptSourceInput.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/AbstractScriptSourceInput.java
@@ -31,13 +31,13 @@ public abstract class AbstractScriptSourceInput implements ScriptSourceInput {
 	protected abstract void releaseReader(Reader reader);
 
 	@Override
-	public List<String> extract(Function<Reader, List<String>> extracter) {
+	public List<String> extract(Function<Reader, List<String>> extractor) {
 		log.executingImportScript( getScriptDescription() );
 
 		final Reader inputReader = prepareReader();
 
 		try {
-			return extracter.apply( inputReader );
+			return extractor.apply( inputReader );
 		}
 		finally {
 			releaseReader( inputReader );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputNonExistentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ScriptSourceInputNonExistentImpl.java
@@ -25,7 +25,7 @@ public class ScriptSourceInputNonExistentImpl implements ScriptSourceInput {
 	public static final ScriptSourceInputNonExistentImpl INSTANCE = new ScriptSourceInputNonExistentImpl();
 
 	@Override
-	public List<String> extract(Function<Reader, List<String>> extracter) {
+	public List<String> extract(Function<Reader, List<String>> extractor) {
 		return Collections.emptyList();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/MultiLineSqlScriptExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/MultiLineSqlScriptExtractor.java
@@ -34,10 +34,10 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  * @author Steve Ebersole
  */
-public class MultiLineSqlScriptExtracter implements SqlScriptCommandExtractor {
+public class MultiLineSqlScriptExtractor implements SqlScriptCommandExtractor {
 	public static final String SHORT_NAME = "multi-line";
 
-	public static final MultiLineSqlScriptExtracter INSTANCE = new MultiLineSqlScriptExtracter();
+	public static final MultiLineSqlScriptExtractor INSTANCE = new MultiLineSqlScriptExtractor();
 
 	@Override
 	public List<String> extractCommands(Reader reader, Dialect dialect) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/SqlScriptExtractorInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/SqlScriptExtractorInitiator.java
@@ -43,8 +43,8 @@ public class SqlScriptExtractorInitiator implements StandardServiceInitiator<Sql
 		if ( explicitSettingName.isEmpty() || SingleLineSqlScriptExtractor.SHORT_NAME.equals( explicitSettingName ) ) {
 			return SingleLineSqlScriptExtractor.INSTANCE;
 		}
-		else if ( MultiLineSqlScriptExtracter.SHORT_NAME.equals( explicitSettingName ) ) {
-			return MultiLineSqlScriptExtracter.INSTANCE;
+		else if ( MultiLineSqlScriptExtractor.SHORT_NAME.equals( explicitSettingName ) ) {
+			return MultiLineSqlScriptExtractor.INSTANCE;
 		}
 
 		final ClassLoaderService classLoaderService = registry.getService( ClassLoaderService.class );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ScriptSourceInput.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ScriptSourceInput.java
@@ -20,5 +20,5 @@ public interface ScriptSourceInput {
 	/**
 	 * Allows managed access to the input's Reader, returning a result
 	 */
-	List<String> extract(Function<Reader,List<String>> extracter);
+	List<String> extract(Function<Reader,List<String>> extractor);
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/schema/SchemaManagementScriptTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/schema/SchemaManagementScriptTests.java
@@ -13,7 +13,7 @@ import java.io.StringReader;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtracter;
+import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ public class SchemaManagementScriptTests {
 		final String commands = firstCommand + "; " + secondCommand + "; " + thirdCommand + ";";
 		final Reader reader = new BufferedReader( new StringReader( commands ) );
 
-		final MultiLineSqlScriptExtracter extractor = new MultiLineSqlScriptExtracter();
+		final MultiLineSqlScriptExtractor extractor = new MultiLineSqlScriptExtractor();
 		final String[] extractedCommands = extractor.extractCommands( reader, dialect ).toArray( new String[0] );
 
 		assertThat( extractedCommands.length, is( 3 ) );
@@ -62,7 +62,7 @@ public class SchemaManagementScriptTests {
 		final String commands = firstCommand + "; " + secondCommand + "; " + thirdCommand + ";";
 		final Reader reader = new BufferedReader( new StringReader( commands ) );
 
-		final MultiLineSqlScriptExtracter extractor = new MultiLineSqlScriptExtracter();
+		final MultiLineSqlScriptExtractor extractor = new MultiLineSqlScriptExtractor();
 		final String[] extractedCommands = extractor.extractCommands( reader, dialect ).toArray( new String[0] );
 
 		assertThat( extractedCommands.length, is( 3 ) );
@@ -84,7 +84,7 @@ public class SchemaManagementScriptTests {
 		final String commands = firstCommand + "; " + secondCommand + "; " + thirdCommand + ";";
 		final Reader reader = new BufferedReader( new StringReader( commands ) );
 
-		final MultiLineSqlScriptExtracter extractor = new MultiLineSqlScriptExtracter();
+		final MultiLineSqlScriptExtractor extractor = new MultiLineSqlScriptExtractor();
 		final String[] extractedCommands = extractor.extractCommands( reader, dialect ).toArray( new String[0] );
 
 		assertThat( extractedCommands.length, is( 3 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/CommandExtractorServiceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/CommandExtractorServiceTest.java
@@ -10,7 +10,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtracter;
+import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor;
 import org.hibernate.tool.schema.spi.SqlScriptCommandExtractor;
 
 import org.hibernate.testing.RequiresDialect;
@@ -36,6 +36,6 @@ public class CommandExtractorServiceTest extends MultiLineImportFileTest {
 	@Override
 	protected void prepareBasicRegistryBuilder(StandardServiceRegistryBuilder serviceRegistryBuilder) {
 		super.prepareBasicRegistryBuilder( serviceRegistryBuilder );
-		serviceRegistryBuilder.addService( SqlScriptCommandExtractor.class, MultiLineSqlScriptExtracter.INSTANCE );
+		serviceRegistryBuilder.addService( SqlScriptCommandExtractor.class, MultiLineSqlScriptExtractor.INSTANCE );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/StatementsWithoutTerminalCharsImportFileTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/StatementsWithoutTerminalCharsImportFileTest.java
@@ -23,7 +23,7 @@ import org.hibernate.tool.schema.SourceType;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
-import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtracter;
+import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor;
 import org.hibernate.tool.schema.spi.ContributableMatcher;
 import org.hibernate.tool.schema.spi.ExceptionHandler;
 import org.hibernate.tool.schema.spi.ExecutionOptions;
@@ -76,7 +76,7 @@ public class StatementsWithoutTerminalCharsImportFileTest extends BaseUnitTestCa
 				//		specify anything as single-line is the default
 				.applySetting(
 						Environment.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR,
-						MultiLineSqlScriptExtracter.INSTANCE
+						MultiLineSqlScriptExtractor.INSTANCE
 				)
 				.build();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14601

A simple refactoring to correct the typo of `extracter` (should be `extractor`) which I found during working on my previous PR.