### PR TITLE
HHH-14220 Skip test when bytecode provider is Javassist

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/DirtyCheckPrivateUnMappedCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/DirtyCheckPrivateUnMappedCollectionTest.java
@@ -21,6 +21,7 @@ import javax.persistence.MappedSuperclass;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
@@ -35,6 +36,8 @@ import org.junit.runner.RunWith;
 @CustomEnhancementContext({ DirtyCheckEnhancementContext.class })
 public class DirtyCheckPrivateUnMappedCollectionTest extends BaseNonConfigCoreFunctionalTestCase {
 
+	boolean skipTest;
+
 	@Override
 	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
 		super.configureStandardServiceRegistryBuilder( ssrb );
@@ -45,11 +48,21 @@ public class DirtyCheckPrivateUnMappedCollectionTest extends BaseNonConfigCoreFu
 
 	@Override
 	protected void applyMetadataSources(MetadataSources sources) {
-		sources.addAnnotatedClass( Measurement.class );
+		String byteCodeProvider = Environment.getProperties().getProperty( AvailableSettings.BYTECODE_PROVIDER );
+		if ( byteCodeProvider != null && !Environment.BYTECODE_PROVIDER_NAME_BYTEBUDDY.equals( byteCodeProvider ) ) {
+			// skip the test if the bytecode provider is Javassist
+			skipTest = true;
+		}
+		else {
+			sources.addAnnotatedClass( Measurement.class );
+		}
 	}
 
 	@Test
 	public void testIt() {
+		if ( skipTest ) {
+			return;
+		}
 		inTransaction(
 				session -> {
 					Tag tag = new Tag();


### PR DESCRIPTION
This PR skip the execution of the test when the bytecode provides is Javassist, the fix for https://hibernate.atlassian.net/browse/HHH-14220 was implemented only for ByteBuddy.

Not sure this is the best way to skip the test, any suggestion is more than welcome.