### PR TITLE
HHH-14234 Fix issue denormalized table inherits unique constraints from parent table

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
@@ -111,10 +111,12 @@ public class DenormalizedTable extends Table {
 
 	@Override
 	public Iterator getUniqueKeyIterator() {
-		Iterator iter = includedTable.getUniqueKeyIterator();
-		while ( iter.hasNext() ) {
-			UniqueKey uk = (UniqueKey) iter.next();
-			createUniqueKey( uk.getColumns() );
+		if ( !includedTable.isPhysicalTable() ) {
+			Iterator iter = includedTable.getUniqueKeyIterator();
+			while ( iter.hasNext() ) {
+				UniqueKey uk = (UniqueKey) iter.next();
+				createUniqueKey( uk.getColumns() );
+			}
 		}
 		return getUniqueKeys().values().iterator();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/DenormalizedTablePhysicalIncludedTableConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/DenormalizedTablePhysicalIncludedTableConstraintTest.java
@@ -1,0 +1,82 @@
+package org.hibernate.test.inheritance;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
+
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.SkipForDialects;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Vlad Paln
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14234" )
+@SkipForDialects( {
+		@SkipForDialect( value = MySQLDialect.class, comment = "skip it for it support constraint name uniqueness in table, not db" ),
+		@SkipForDialect( value = MariaDBDialect.class, comment = "skip it for it support constraint name uniqueness in table, not db" )
+} )
+public class DenormalizedTablePhysicalIncludedTableConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected void addSettings(Map settings) {
+		settings.put( AvailableSettings.HBM2DDL_HALT_ON_ERROR, Boolean.TRUE.toString() );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				SuperClass.class,
+				SubClass.class
+		};
+	}
+
+	@Test
+	public void testUniqueConstraintFromSupTableNotAppliedToSubTable() {
+		// Unique constraint should be unique in db (except for MySQL and Mariadb).
+		// Without fixing, exception will be thrown when unique constraint in 'supTable' is applied to 'subTable' as well
+	}
+
+	@Entity(name = "SuperClass")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Table( name = "supTable",
+			uniqueConstraints = {
+					@UniqueConstraint(  name = "UK",
+							columnNames = {"colOne", "colTwo"})
+			}
+	)
+	static class SuperClass implements Serializable {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@Column(name = "colOne")
+		Long colOne;
+
+		@Column(name = "colTwo")
+		Long colTwo;
+	}
+
+	@Entity(name = "SubClass")
+	@Table( name = "subTable" )
+	static class SubClass extends SuperClass {
+
+		@Column(name = "colThree")
+		Long colThree;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14234

In denormalized table (child table with `TABLE_PER_CLASS` inheritance strategy is the only case in Hibernate), it shares many columns with its parent table, but it should stop duplicating any further. Among others, no need to duplicate unique constraint from parent table to child table or denormalized table.