### PR TITLE
HHH-14244 Force dirty mark on write to uninitialized lazy property

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/InlineDirtyCheckingHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/InlineDirtyCheckingHandler.java
@@ -15,6 +15,8 @@ import javax.persistence.Id;
 
 import org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImpl.AnnotatedFieldDescription;
 import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 
 import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.Advice;
@@ -37,10 +39,13 @@ final class InlineDirtyCheckingHandler implements Implementation, ByteCodeAppend
 
 	private final FieldDescription.InDefinedShape persistentField;
 
-	private InlineDirtyCheckingHandler(Implementation delegate, TypeDescription managedCtClass, FieldDescription.InDefinedShape persistentField) {
+	private final boolean checkLazyUninitialized;
+
+	private InlineDirtyCheckingHandler(Implementation delegate, TypeDescription managedCtClass, FieldDescription.InDefinedShape persistentField, boolean checkLazyUninitialized) {
 		this.delegate = delegate;
 		this.managedCtClass = managedCtClass;
 		this.persistentField = persistentField;
+		this.checkLazyUninitialized = checkLazyUninitialized;
 	}
 
 	static Implementation wrap(
@@ -58,7 +63,7 @@ final class InlineDirtyCheckingHandler implements Implementation, ByteCodeAppend
 					&& !( persistentField.getType().asErasure().isAssignableTo( Collection.class )
 					&& enhancementContext.isMappedCollection( persistentField ) ) ) {
 				implementation = new InlineDirtyCheckingHandler( implementation, managedCtClass,
-						persistentField.asDefined() );
+						persistentField.asDefined(), enhancementContext.isLazyLoadable(persistentField) );
 			}
 
 			if ( enhancementContext.isCompositeClass( persistentField.getType().asErasure() )
@@ -96,6 +101,93 @@ final class InlineDirtyCheckingHandler implements Implementation, ByteCodeAppend
 			MethodVisitor methodVisitor,
 			Context implementationContext,
 			MethodDescription instrumentedMethod) {
+
+		// Skip comparaison when lazy not loaded
+		Label uninitializedLazy = new Label();
+
+		if (checkLazyUninitialized) {
+			// No dirty check is required for non initialized lazy fields.
+			Label skipUnitializedCheckWithPersistentAttributeInterceptor = new Label();
+			Label skipUnitializedCheck = new Label();
+
+			// if (value !== null || value !== false || value !== 0 || ...) => np
+			methodVisitor.visitVarInsn( Type.getType( persistentField.getType().asErasure().getDescriptor() ).getOpcode( Opcodes.ILOAD ), 1 );
+			if ( persistentField.getType().isPrimitive() ) {
+				if ( persistentField.getType().represents( long.class ) ) {
+					methodVisitor.visitInsn( Opcodes.LCONST_0);
+					methodVisitor.visitInsn( Opcodes.LCMP );
+					methodVisitor.visitJumpInsn( Opcodes.IFNE, skipUnitializedCheck );
+				}
+				else if ( persistentField.getType().represents( float.class ) ) {
+					methodVisitor.visitInsn( Opcodes.FCONST_0);
+					methodVisitor.visitInsn( Opcodes.FCMPL );
+					methodVisitor.visitJumpInsn( Opcodes.IFNE, skipUnitializedCheck );
+				}
+				else if ( persistentField.getType().represents( double.class ) ) {
+					methodVisitor.visitInsn( Opcodes.DCONST_0);
+					methodVisitor.visitInsn( Opcodes.DCMPL );
+					methodVisitor.visitJumpInsn( Opcodes.IFNE, skipUnitializedCheck );
+				}
+				else {
+					methodVisitor.visitJumpInsn( Opcodes.IFNE, skipUnitializedCheck );
+				}
+			}
+			else {
+				methodVisitor.visitJumpInsn( Opcodes.IFNONNULL, skipUnitializedCheck );
+			}
+	 
+			// if ( this.$$_hibernate_getInterceptor() != null )
+			methodVisitor.visitVarInsn( Opcodes.ALOAD, 0 );
+			methodVisitor.visitMethodInsn(
+					Opcodes.INVOKEVIRTUAL,
+					managedCtClass.getInternalName(),
+					EnhancerConstants.INTERCEPTOR_GETTER_NAME,
+					Type.getMethodDescriptor( Type.getType( PersistentAttributeInterceptor.class ) ),
+					false
+			);
+
+			methodVisitor.visitInsn( Opcodes.DUP );
+
+			// if ( this.$$_hibernate_getInterceptor() == null ) => no dirty check
+			methodVisitor.visitJumpInsn( Opcodes.IFNULL, skipUnitializedCheckWithPersistentAttributeInterceptor );
+
+			// if ( !this.$$_hibernate_getInterceptor() instanceof LazyAttributeLoadingInterceptor) => no dirty check
+			methodVisitor.visitInsn( Opcodes.DUP );
+			methodVisitor.visitTypeInsn( Opcodes.INSTANCEOF, Type.getInternalName(LazyAttributeLoadingInterceptor.class) );
+			methodVisitor.visitJumpInsn( Opcodes.IFEQ, skipUnitializedCheckWithPersistentAttributeInterceptor );
+			methodVisitor.visitTypeInsn( Opcodes.CHECKCAST, Type.getInternalName(LazyAttributeLoadingInterceptor.class) );
+			
+			// call interceptor.isAttributeLoaded(fieldName)
+			methodVisitor.visitLdcInsn( persistentField.getName() );
+			methodVisitor.visitMethodInsn(
+					Opcodes.INVOKEVIRTUAL,
+					Type.getInternalName(LazyAttributeLoadingInterceptor.class),
+					"isAttributeLoaded",
+					Type.getMethodDescriptor(
+							Type.BOOLEAN_TYPE,
+							Type.getType( String.class )
+					),
+					false
+			);
+
+			// When field is not initialized, Comparaison is useless
+			// if (interceptor.isAttributeLoaded(fieldName)) goto skipUnitializedCheck
+			methodVisitor.visitJumpInsn( Opcodes.IFNE, skipUnitializedCheck);
+ 
+			// Sure that the lazy is not initialized. No need for comparaison, directly set dirty
+			methodVisitor.visitJumpInsn( Opcodes.GOTO, uninitializedLazy );
+			
+			methodVisitor.visitLabel( skipUnitializedCheckWithPersistentAttributeInterceptor );
+			if ( implementationContext.getClassFileVersion().isAtLeast( ClassFileVersion.JAVA_V6 ) ) {
+				methodVisitor.visitFrame( Opcodes.F_SAME1, 0, null, 1, new Object[]{Type.getInternalName(PersistentAttributeInterceptor.class)} );
+			}
+			methodVisitor.visitInsn( Opcodes.POP );
+
+			methodVisitor.visitLabel( skipUnitializedCheck );
+			if ( implementationContext.getClassFileVersion().isAtLeast( ClassFileVersion.JAVA_V6 ) ) {
+				methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+			}
+		}
 		// if (arg != field) {
 		methodVisitor.visitVarInsn( Type.getType( persistentField.getType().asErasure().getDescriptor() ).getOpcode( Opcodes.ILOAD ), 1 );
 		methodVisitor.visitVarInsn( Opcodes.ALOAD, 0 );
@@ -142,8 +234,15 @@ final class InlineDirtyCheckingHandler implements Implementation, ByteCodeAppend
 			);
 			branchCode = Opcodes.IFNE;
 		}
+
 		Label skip = new Label();
 		methodVisitor.visitJumpInsn( branchCode, skip );
+
+		methodVisitor.visitLabel(uninitializedLazy);
+		if ( implementationContext.getClassFileVersion().isAtLeast( ClassFileVersion.JAVA_V6 ) ) {
+			methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+		}
+
 		// this.$$_hibernate_trackChange(fieldName)
 		methodVisitor.visitVarInsn( Opcodes.ALOAD, 0 );
 		methodVisitor.visitLdcInsn( persistentField.getName() );

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/enhancement/TestDirtyCheckOnLazy.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/enhancement/TestDirtyCheckOnLazy.java
@@ -70,8 +70,6 @@ public class TestDirtyCheckOnLazy extends BaseEntityManagerFunctionalTestCase {
      */
     @Test
     public void testNoUpdate() {
-        byte[] testArray = new byte[]{0x2A};
-
         doInJPA( this::entityManagerFactory, new JPATransactionVoidFunction() {
             @Override
             public void accept(EntityManager em) {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/enhancement/TestDirtyCheckOnLazy.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/enhancement/TestDirtyCheckOnLazy.java
@@ -1,0 +1,174 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.enhancement;
+
+import org.hibernate.Hibernate;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.transaction.TransactionUtil.JPATransactionVoidFunction;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@TestForIssue( jiraKey = "HHH-14244" )
+@RunWith( BytecodeEnhancerRunner.class )
+public class TestDirtyCheckOnLazy extends BaseEntityManagerFunctionalTestCase {
+
+    private EntityWithLazyProperty entity;
+
+    @Override
+    public Class[] getAnnotatedClasses() {
+        return new Class[]{EntityWithLazyProperty.class};
+    }
+
+    @Override
+    protected void addConfigOptions(Map options) {
+        options.put( AvailableSettings.CLASSLOADERS, getClass().getClassLoader() );
+    }
+
+    @Before
+    public void prepare() throws Exception {
+        EntityPersister ep = entityManagerFactory().getMetamodel().entityPersister( EntityWithLazyProperty.class.getName() );
+        assertTrue( ep.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading() );
+
+        byte[] testArray = new byte[]{0x2A};
+
+        doInJPA( this::entityManagerFactory, em -> {
+            //persist the test entity.d
+            entity = new EntityWithLazyProperty();
+            entity.setSomeField( "TEST" );
+            entity.setLazyData( testArray );
+            em.persist( entity );
+        } );
+
+        checkLazyField( entity, testArray );
+    }
+
+    /**
+     * Check the dirty check is actually taking place, preventing update of the lazy field
+     */
+    @Test
+    public void testNoUpdate() {
+        byte[] testArray = new byte[]{0x2A};
+
+        doInJPA( this::entityManagerFactory, new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager em) {
+                entity = em.find( EntityWithLazyProperty.class, entity.id );
+                assertFalse( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+                entity.setSomeField( "TEST1" );
+            }
+
+            @Override
+            public void afterTransactionCompletion() {
+                assertFalse( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+            }
+        } );
+    }
+
+    /**
+     * Update a lazy field to a value and check the value is read back.
+     */
+    @Test
+    public void testUpdate() {
+        byte[] testArray = new byte[]{0x44};
+
+        doInJPA( this::entityManagerFactory, new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager em) {
+                entity = em.find( EntityWithLazyProperty.class, entity.id );
+                assertFalse( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+                entity.setLazyData(testArray);
+            }
+
+            @Override
+            public void afterTransactionCompletion() {
+                assertTrue( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+            }
+        } );
+
+        checkLazyField( entity, testArray );
+    }
+
+    /**
+     * Update a lazy field to null and check the value is read back.
+     */
+    @Test
+    public void testUpdateToNull() {
+        byte[] testArray = null;
+
+        doInJPA( this::entityManagerFactory, new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager em) {
+                entity = em.find( EntityWithLazyProperty.class, entity.id );
+                assertFalse( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+                entity.setLazyData(testArray);
+            }
+
+            @Override
+            public void afterTransactionCompletion() {
+                assertTrue( Hibernate.isPropertyInitialized( entity, "lazyData" ) );
+            }
+        } );
+
+        checkLazyField( entity, testArray );
+    }
+
+
+    private void checkLazyField(EntityWithLazyProperty entity, byte[] expected) {
+        // reload the entity and check the lazy value matches what we expect.
+        doInJPA( this::entityManagerFactory, em -> {
+            EntityWithLazyProperty testEntity = em.find( EntityWithLazyProperty.class, entity.id );
+            assertFalse( Hibernate.isPropertyInitialized( testEntity, "lazyData" ) );
+            assertTrue( Arrays.equals( expected, testEntity.lazyData ) );
+            assertTrue( Hibernate.isPropertyInitialized( testEntity, "lazyData" ) );
+        } );
+    }
+
+    // --- //
+
+    /**
+     * Test entity with a lazy property which requires build time instrumentation.
+     */
+    @Entity
+    @Table( name = "ENTITY_WITH_LAZY_PROPERTY" )
+    private static class EntityWithLazyProperty {
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Basic( fetch = FetchType.LAZY )
+        private byte[] lazyData;
+
+        private String someField;
+
+        public void setLazyData(byte[] lazyData) {
+            this.lazyData = lazyData;
+        }
+
+        public void setSomeField(String someField) {
+            this.someField = someField;
+        }
+    }
+}


### PR DESCRIPTION
The generated field writer method is modified. 

I added a check to detect an uninitialized lazy field and force marking it dirty.
But that check is only usefull when the new value is the default for the type (null/0/false...). For other values, the existing comparison is enough to mark the dirty. So, the new code is only triggered when received the default value, to avoid doing the check  too frequently
