### PR TITLE
HHH-14227 fix some ActionQueue insert ordering regression issues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -45,6 +45,7 @@ import org.hibernate.cache.CacheException;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
@@ -105,7 +106,7 @@ public class ActionQueue {
 	 */
 	private static final LinkedHashMap<Class<? extends Executable>,ListProvider> EXECUTABLE_LISTS_MAP;
 	static {
-		EXECUTABLE_LISTS_MAP = new LinkedHashMap<Class<? extends Executable>,ListProvider>( 8 );
+		EXECUTABLE_LISTS_MAP = new LinkedHashMap<>( CollectionHelper.determineProperSizing( 8 ) );
 
 		EXECUTABLE_LISTS_MAP.put(
 				OrphanRemovalAction.class,
@@ -1101,7 +1102,7 @@ public class ActionQueue {
 			}
 
 			/**
-			 * Check if the this {@link BatchIdentifier} has a parent or grand parent
+			 * Check if this {@link BatchIdentifier} has a parent or grand parent
 			 * matching the given {@link BatchIdentifier} reference.
 			 *
 			 * @param batchIdentifier {@link BatchIdentifier} reference
@@ -1268,7 +1269,9 @@ public class ActionQueue {
 				for ( int i = 0; i < propertyValues.length; i++ ) {
 					Object value = propertyValues[i];
 					Type type = propertyTypes[i];
-					addParentChildEntityNameByPropertyAndValue( action, batchIdentifier, type, value );
+					if ( value != null ) {
+						addParentChildEntityNameByPropertyAndValue( action, batchIdentifier, type, value );
+					}
 				}
 
 				if ( identifierType.isComponentType() ) {
@@ -1300,11 +1303,9 @@ public class ActionQueue {
 					if ( !batchIdentifier.getEntityName().equals( entityName ) ) {
 						batchIdentifier.getParentEntityNames().add( entityName );
 					}
-					if ( value != null ) {
-						String valueClass = value.getClass().getName();
-						if ( !valueClass.equals( entityName ) ) {
-							batchIdentifier.getParentEntityNames().add( valueClass );
-						}
+					String valueClass = value.getClass().getName();
+					if ( !valueClass.equals( entityName ) ) {
+						batchIdentifier.getParentEntityNames().add( valueClass );
 					}
 					if ( !rootEntityName.equals( entityName ) ) {
 						batchIdentifier.getParentEntityNames().add( rootEntityName );

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/BaseInsertOrderingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/BaseInsertOrderingTest.java
@@ -1,0 +1,72 @@
+package org.hibernate.test.insertordering;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Nathan Xu
+ */
+abstract class BaseInsertOrderingTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	static class Batch {
+		String sql;
+		int size;
+
+		Batch(String sql, int size) {
+			this.sql = sql;
+			this.size = size;
+		}
+
+		Batch(String sql) {
+			this( sql, 1 );
+		}
+	}
+
+	private final PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+
+	@Override
+	protected void addSettings(Map settings) {
+		settings.put( Environment.ORDER_INSERTS, "true" );
+		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
+		settings.put( AvailableSettings.CONNECTION_PROVIDER, connectionProvider );
+	}
+
+	@Override
+	public void releaseResources() {
+		super.releaseResources();
+		connectionProvider.stop();
+	}
+
+	void verifyContainsBatches(Batch... expectedBatches) {
+		for ( Batch expectedBatch : expectedBatches ) {
+			PreparedStatement preparedStatement = connectionProvider.getPreparedStatement( expectedBatch.sql );
+			try {
+				verify( preparedStatement, times( expectedBatch.size ) ).addBatch();
+				verify( preparedStatement, times( 1 ) ).executeBatch();
+			} catch (SQLException e) {
+				throw new RuntimeException( e );
+			}
+		}
+	}
+
+	void verifyPreparedStatementCount(int expectedBatchCount) {
+		final int realBatchCount = connectionProvider.getPreparedSQLStatements().size();
+		assertEquals( String.format( "expected %d batch%s; but found %d batch%s", expectedBatchCount, (expectedBatchCount == 1 ? "" : "es"), realBatchCount, (realBatchCount == 1 ? "" : "es" ) ),
+					  expectedBatchCount, realBatchCount );
+	}
+
+	void clearBatches() {
+		connectionProvider.clear();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/BatchSortingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/BatchSortingTest.java
@@ -4,33 +4,32 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.engine.spi;
+package org.hibernate.test.insertordering;
 
-import org.hibernate.cfg.Environment;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.jta.TestingJtaBootstrap;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 
 /*
  * @author gajendra.jatav(raaz2.gajendra@gmail.com)
  */
-public class BatchSortingTest extends BaseNonConfigCoreFunctionalTestCase {
-
-    @Override
-    protected void addSettings(Map settings) {
-        settings.put( Environment.ORDER_INSERTS, "true" );
-        settings.put( Environment.ORDER_UPDATES, "true" );
-        settings.put( Environment.STATEMENT_BATCH_SIZE, "5" );
-        TestingJtaBootstrap.prepare( settings );
-    }
+@RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
+public class BatchSortingTest extends BaseInsertOrderingTest {
 
     protected Class<?>[] getAnnotatedClasses() {
         return new Class<?>[]{
@@ -59,7 +58,10 @@ public class BatchSortingTest extends BaseNonConfigCoreFunctionalTestCase {
             country.setDistricts( geoDistricts );
             session.persist( geoDistrict );
             session.persist( nation );
+            clearBatches();
         });
+
+        verifyPreparedStatementCount( 4 );
     }
 
     @Entity(name = "GeoCountry")

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingReferenceDifferentSubclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingReferenceDifferentSubclassTest.java
@@ -1,0 +1,84 @@
+package org.hibernate.test.insertordering;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * @author Normunds Gavars
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14227" )
+@RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
+public class InsertOrderingReferenceDifferentSubclassTest extends BaseInsertOrderingTest {
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] {
+                SubclassA.class,
+                SubclassB.class
+        };
+    }
+
+    @Test
+    public void testReferenceDifferentSubclass() {
+        doInHibernate(this::sessionFactory, session -> {
+            SubclassA subclassA1 = new SubclassA();
+            SubclassB subclassB1 = new SubclassB();
+
+            SubclassA subclassA2 = new SubclassA();
+            SubclassB subclassB2 = new SubclassB();
+
+            subclassA1.referenceB = subclassB2;
+            subclassB2.referenceA = subclassA2;
+
+            subclassA2.referenceB = subclassB1;
+
+            session.save( subclassA1 );
+            session.save( subclassA2 );
+
+            clearBatches();
+        });
+
+        verifyContainsBatches(
+                new Batch( "insert into SubclassB (referenceA_id, id) values (?, ?)", 2 ),
+                new Batch( "insert into SubclassA (referenceB_id, id) values (?, ?)", 2 )
+        );
+    }
+
+    @MappedSuperclass
+    static class BaseClass {
+
+        @Id @GeneratedValue
+        Long id;
+
+    }
+
+    @Entity(name = "SubclassA")
+    static class SubclassA extends BaseClass {
+
+        @OneToOne(cascade = CascadeType.ALL)
+        SubclassB referenceB;
+
+    }
+
+    @Entity(name = "SubclassB")
+    static class SubclassB extends BaseClass {
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        SubclassA referenceA;
+
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingSelfReferenceSingleTableInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingSelfReferenceSingleTableInheritance.java
@@ -19,17 +19,12 @@ import javax.persistence.OneToOne;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 import org.hibernate.cfg.Environment;
-import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingSelfReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingSelfReferenceTest.java
@@ -1,0 +1,131 @@
+package org.hibernate.test.insertordering;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.SortNatural;
+import org.hibernate.annotations.Where;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+/**
+ * @author Normunds Gavars
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-14227" )
+@RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
+public class InsertOrderingSelfReferenceTest extends BaseInsertOrderingTest {
+
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] {
+                Parameter.class,
+                InputParameter.class,
+                OutputParameter.class,
+                Placeholder.class,
+        };
+    }
+
+    @Test
+    public void testReferenceItself() {
+        doInHibernate( this::sessionFactory, session -> {
+            Placeholder placeholder = new Placeholder();
+            session.save( placeholder );
+
+            OutputParameter outputParameter1 = new OutputParameter();
+
+            OutputParameter childOutputParameter = new OutputParameter();
+            outputParameter1.children.add( childOutputParameter );
+            childOutputParameter.parent = outputParameter1;
+
+            session.save( outputParameter1 );
+
+            Placeholder placeholder2 = new Placeholder();
+            session.save( placeholder2 );
+
+            InputParameter inputParameter = new InputParameter();
+            session.save( inputParameter );
+
+            OutputParameter outputParameter2 = new OutputParameter();
+            session.save( outputParameter2 );
+
+            clearBatches();
+        } );
+
+        verifyContainsBatches(
+                new Batch( "insert into Placeholder (id) values (?)", 2 ),
+                new Batch( "insert into Parameter (parent_id, TYPE, id) values (?, 'INPUT', ?)" ),
+                new Batch( "insert into Parameter (parent_id, TYPE, id) values (?, 'OUTPUT', ?)", 3 )
+        );
+    }
+
+    @MappedSuperclass
+    static class AbstractEntity {
+
+        @Id
+        @GeneratedValue
+        Long id;
+
+    }
+
+    @Entity(name = "Placeholder")
+    static class Placeholder extends AbstractEntity {
+    }
+
+    @Entity(name = "Parameter")
+    @DiscriminatorColumn(name = "TYPE")
+    @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+    static abstract class Parameter extends AbstractEntity {
+    }
+
+    @Entity(name = "InputParameter")
+    @DiscriminatorValue("INPUT")
+    static class InputParameter extends Parameter {
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        InputParameter parent;
+
+        @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
+        @SortNatural
+        @Where(clause = "TYPE = 'INPUT'")
+        @Fetch(FetchMode.SUBSELECT)
+        List<InputParameter> children = new ArrayList<>();
+    }
+
+    @Entity(name = "OutputParameter")
+    @DiscriminatorValue("OUTPUT")
+    static class OutputParameter extends Parameter {
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        OutputParameter parent;
+
+        @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
+        @SortNatural
+        @Where(clause = "TYPE = 'OUTPUT'")
+        @Fetch(FetchMode.SUBSELECT)
+        @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+        List<OutputParameter> children = new ArrayList<>();
+
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBaseClassReferencingSubclass.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBaseClassReferencingSubclass.java
@@ -19,7 +19,6 @@ import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalManyToMany.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalManyToMany.java
@@ -6,11 +6,8 @@
  */
 package org.hibernate.test.insertordering;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -20,53 +17,27 @@ import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
 
-import org.hibernate.cfg.Environment;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithBidirectionalManyToMany
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+public class InsertOrderingWithBidirectionalManyToMany extends BaseInsertOrderingTest {
 
 	@Override
 	protected Class[] getAnnotatedClasses() {
 		return new Class[] { Address.class, Person.class };
 	}
 
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
-	}
-
 	@Test
-	public void testBatching() throws SQLException {
+	public void testBatching() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person father = new Person();
 			Person mother = new Person();
@@ -87,18 +58,14 @@ public class InsertOrderingWithBidirectionalManyToMany
 			session.persist( home );
 			session.persist( office );
 
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		assertEquals( 3, connectionProvider.getPreparedStatements().size() );
-		PreparedStatement addressPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Address (ID) values (?)" );
-		verify( addressPreparedStatement, times( 2 ) ).addBatch();
-		verify( addressPreparedStatement, times( 1 ) ).executeBatch();
-		PreparedStatement personPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Person (ID) values (?)" );
-		verify( personPreparedStatement, times( 4 ) ).addBatch();
-		verify( personPreparedStatement, times( 1 ) ).executeBatch();
+		verifyContainsBatches(
+				new Batch( "insert into Address (ID) values (?)", 2 ),
+				new Batch( "insert into Person (ID) values (?)", 4 ),
+				new Batch( "insert into Person_Address (persons_ID, addresses_ID) values (?, ?)", 6 )
+		);
 	}
 
 	@Entity(name = "Address")

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalMapsIdOneToOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalMapsIdOneToOne.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.test.insertordering;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Map;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -19,52 +16,27 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 
-import org.hibernate.cfg.Environment;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithBidirectionalMapsIdOneToOne
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+public class InsertOrderingWithBidirectionalMapsIdOneToOne extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class };
 	}
 
 	@Test
-	public void testBatching() throws SQLException {
+	public void testBatching() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person worker = new Person();
 			Person homestay = new Person();
@@ -79,17 +51,13 @@ public class InsertOrderingWithBidirectionalMapsIdOneToOne
 			session.persist( home );
 			session.persist( office );
 
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		PreparedStatement addressPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Address (ID) values (?)" );
-		verify( addressPreparedStatement, times( 2 ) ).addBatch();
-		verify( addressPreparedStatement, times( 1 ) ).executeBatch();
-		PreparedStatement personPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Person (address_ID) values (?)" );
-		verify( personPreparedStatement, times( 2 ) ).addBatch();
-		verify( personPreparedStatement, times( 1 ) ).executeBatch();
+		verifyContainsBatches(
+				new Batch( "insert into Address (ID) values (?)", 2 ),
+				new Batch( "insert into Person (address_ID) values (?)", 2 )
+		);
 	}
 
 	@Entity(name = "Address")

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithBidirectionalOneToOne.java
@@ -6,56 +6,36 @@
  */
 package org.hibernate.test.insertordering;
 
-import org.hibernate.cfg.Environment;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
 
-import javax.persistence.*;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Map;
-
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithBidirectionalOneToOne
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+public class InsertOrderingWithBidirectionalOneToOne extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class };
 	}
 
 	@Test
-	public void testBatching() throws SQLException {
+	public void testBatching() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person worker = new Person();
 			Person homestay = new Person();
@@ -70,17 +50,13 @@ public class InsertOrderingWithBidirectionalOneToOne
 			session.persist( home );
 			session.persist( office );
 
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		PreparedStatement addressPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Address (ID) values (?)" );
-		verify( addressPreparedStatement, times( 2 ) ).addBatch();
-		verify( addressPreparedStatement, times( 1 ) ).executeBatch();
-		PreparedStatement personPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Person (address_ID, ID) values (?, ?)" );
-		verify( personPreparedStatement, times( 2 ) ).addBatch();
-		verify( personPreparedStatement, times( 1 ) ).executeBatch();
+		verifyContainsBatches(
+				new Batch( "insert into Address (ID) values (?)", 2 ),
+				new Batch( "insert into Person (address_ID, ID) values (?, ?)", 2 )
+		);
 	}
 
 	@Entity(name = "Address")

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithCascadeOnPersist.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithCascadeOnPersist.java
@@ -72,6 +72,8 @@ public class InsertOrderingWithCascadeOnPersist extends BaseCoreFunctionalTestCa
 			newResult.setMarketBid( newBid );
 			session.persist( newBid );
 			session.persist( newResult );
+
+
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
@@ -7,7 +7,6 @@
 package org.hibernate.test.insertordering;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -28,47 +27,24 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithJoinedTableInheritance
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( false, false );
+public class InsertOrderingWithJoinedTableInheritance extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class, SpecialPerson.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class, SpecialPerson.class };
 	}
 
 	@Test
@@ -98,10 +74,10 @@ public class InsertOrderingWithJoinedTableInheritance
 				specialPerson.addAddress( new Address() );
 				session.persist( specialPerson );
 			}
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		assertEquals( 26, connectionProvider.getPreparedStatements().size() );
+		verifyPreparedStatementCount( 26 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
@@ -8,7 +8,6 @@ package org.hibernate.test.insertordering;
 
 import java.math.BigDecimal;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -27,31 +26,24 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithJoinedTableMultiLevelInheritance
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( false, false );
+public class InsertOrderingWithJoinedTableMultiLevelInheritance extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
 				Address.class,
 				Person.class,
 				SpecialPerson.class,
@@ -59,22 +51,6 @@ public class InsertOrderingWithJoinedTableMultiLevelInheritance
 				President.class,
 				Office.class
 		};
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
 	}
 
 	@Test
@@ -99,10 +75,10 @@ public class InsertOrderingWithJoinedTableMultiLevelInheritance
 				specialPerson.addAddress( new Address() );
 				session.persist( specialPerson );
 			}
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		assertEquals( 17, connectionProvider.getPreparedStatements().size() );
+		verifyPreparedStatementCount( 17 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithManyToOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithManyToOne.java
@@ -6,67 +6,35 @@
  */
 package org.hibernate.test.insertordering;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-
-import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithManyToOne
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+public class InsertOrderingWithManyToOne extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class };
 	}
 
 	@Test
-	public void testBatching() throws SQLException {
+	public void testBatching() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person father = new Person();
 			Person mother = new Person();
@@ -89,17 +57,13 @@ public class InsertOrderingWithManyToOne
 			session.persist( son );
 			session.persist( daughter );
 
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		PreparedStatement addressPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Address (ID) values (?)" );
-		verify( addressPreparedStatement, times( 2 ) ).addBatch();
-		verify( addressPreparedStatement, times( 1 ) ).executeBatch();
-		PreparedStatement personPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Person (address_ID, ID) values (?, ?)" );
-		verify( personPreparedStatement, times( 4 ) ).addBatch();
-		verify( personPreparedStatement, times( 1 ) ).executeBatch();
+		verifyContainsBatches(
+				new Batch( "insert into Address (ID) values (?)", 2 ),
+				new Batch( "insert into Person (address_ID, ID) values (?, ?)", 4 )
+		);
 	}
 
 	@Entity(name = "Address")

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithSingleTableInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithSingleTableInheritance.java
@@ -7,7 +7,6 @@
 package org.hibernate.test.insertordering;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -28,47 +27,24 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Steve Ebersole
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithSingleTableInheritance
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( false, false );
+public class InsertOrderingWithSingleTableInheritance extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class, SpecialPerson.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class, SpecialPerson.class };
 	}
 
 	@Test
@@ -99,10 +75,10 @@ public class InsertOrderingWithSingleTableInheritance
 				specialPerson.addAddress( new Address() );
 				session.persist( specialPerson );
 			}
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		assertEquals( 3, connectionProvider.getPreparedStatements().size() );
+		verifyPreparedStatementCount( 3 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithTablePerClassInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithTablePerClassInheritance.java
@@ -7,7 +7,6 @@
 package org.hibernate.test.insertordering;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -28,47 +27,24 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.cfg.Environment;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithTablePerClassInheritance
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( false, false );
+public class InsertOrderingWithTablePerClassInheritance extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class, SpecialPerson.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class, SpecialPerson.class };
 	}
 
 	@Test
@@ -99,10 +75,10 @@ public class InsertOrderingWithTablePerClassInheritance
 				specialPerson.addAddress( new Address() );
 				session.persist( specialPerson );
 			}
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		assertEquals( 3, connectionProvider.getPreparedStatements().size() );
+		verifyPreparedStatementCount( 3 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithUnidirectionalOneToOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithUnidirectionalOneToOne.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.test.insertordering;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Map;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -18,52 +15,27 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 
-import org.hibernate.cfg.Environment;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
 @TestForIssue(jiraKey = "HHH-9864")
 @RequiresDialectFeature(DialectChecks.SupportsJdbcDriverProxying.class)
-public class InsertOrderingWithUnidirectionalOneToOne
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider( true, false );
+public class InsertOrderingWithUnidirectionalOneToOne extends BaseInsertOrderingTest {
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { Address.class, Person.class };
-	}
-
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.ORDER_INSERTS, "true" );
-		settings.put( Environment.STATEMENT_BATCH_SIZE, "10" );
-		settings.put(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-	}
-
-	@Override
-	public void releaseResources() {
-		super.releaseResources();
-		connectionProvider.stop();
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Address.class, Person.class };
 	}
 
 	@Test
-	public void testBatching() throws SQLException {
+	public void testBatching() {
 		doInHibernate( this::sessionFactory, session -> {
 			Person worker = new Person();
 			Person homestay = new Person();
@@ -78,17 +50,13 @@ public class InsertOrderingWithUnidirectionalOneToOne
 			session.persist( home );
 			session.persist( office );
 
-			connectionProvider.clear();
+			clearBatches();
 		} );
 
-		PreparedStatement addressPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Address (person_ID, ID) values (?, ?)" );
-		verify( addressPreparedStatement, times( 2 ) ).addBatch();
-		verify( addressPreparedStatement, times( 1 ) ).executeBatch();
-		PreparedStatement personPreparedStatement = connectionProvider.getPreparedStatement(
-				"insert into Person (ID) values (?)" );
-		verify( personPreparedStatement, times( 2 ) ).addBatch();
-		verify( personPreparedStatement, times( 1 ) ).executeBatch();
+		verifyContainsBatches(
+				new Batch( "insert into Address (person_ID, ID) values (?, ?)", 2 ),
+				new Batch( "insert into Person (ID) values (?)", 2 )
+		);
 	}
 
 	@Entity(name = "Address")

--- a/hibernate-core/src/test/java/org/hibernate/test/util/jdbc/PreparedStatementSpyConnectionProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/util/jdbc/PreparedStatementSpyConnectionProvider.java
@@ -157,11 +157,11 @@ public class PreparedStatementSpyConnectionProvider extends ConnectionProviderDe
 		List<PreparedStatement> preparedStatements = getPreparedStatements( sql );
 		if ( preparedStatements.isEmpty() ) {
 			throw new IllegalArgumentException(
-					"There is no PreparedStatement for this SQL statement " + sql );
+					"There is no PreparedStatement for this SQL statement: " + sql );
 		}
 		else if ( preparedStatements.size() > 1 ) {
 			throw new IllegalArgumentException( "There are " + preparedStatements
-					.size() + " PreparedStatements for this SQL statement " + sql );
+					.size() + " PreparedStatements for this SQL statement: " + sql );
 		}
 		return preparedStatements.get( 0 );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14227

It turns out to be a simple regression issue. 

We have complete insert ordering testing cases, but a good portion of them lacks SQL ordering verification (no referential integrity exception thrown is not necessarily identical to insert ordering correctness). In light of this big defect in existing testing code, I tried to add as many as possible SQL batch ordering verification.

The two new testing cases demonstrating regression failure are:
* `org.hibernate.test.insertordering.InsertOrderingSelfReferenceTest`
* `org.hibernate.test.insertordering.InsertOrderingReferenceDifferentSubclassTest`

The share the same pattern that null foreign keys are not ignored during dependency checking.