### PR TITLE
wip/6.0 HHH-14250 get rid of generics warnings as many as possible

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Cache.java
+++ b/hibernate-core/src/main/java/org/hibernate/Cache.java
@@ -44,7 +44,7 @@ public interface Cache extends javax.persistence.Cache {
 	 * @return True if the underlying cache contains corresponding data; false
 	 * otherwise.
 	 */
-	boolean containsEntity(Class entityClass, Serializable identifier);
+	boolean containsEntity(Class<?> entityClass, Serializable identifier);
 
 	/**
 	 * Determine whether the cache contains data for the given entity "instance".
@@ -67,7 +67,7 @@ public interface Cache extends javax.persistence.Cache {
 	 *
 	 * @since 5.3
 	 */
-	void evictEntityData(Class entityClass, Serializable identifier);
+	void evictEntityData(Class<?> entityClass, Serializable identifier);
 
 	/**
 	 * Evicts the entity data for a particular entity "instance".
@@ -87,7 +87,7 @@ public interface Cache extends javax.persistence.Cache {
 	 *
 	 * @since 5.3
 	 */
-	void evictEntityData(Class entityClass);
+	void evictEntityData(Class<?> entityClass);
 
 	/**
 	 * Evicts all entity data from the given region (i.e. for all entities of
@@ -118,7 +118,7 @@ public interface Cache extends javax.persistence.Cache {
 	 *
 	 * @since 5.3
 	 */
-	void evictNaturalIdData(Class entityClass);
+	void evictNaturalIdData(Class<?> entityClass);
 
 	/**
 	 * Evict cached data for the given entity's natural-id

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
@@ -106,8 +106,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 	 * @param session The session to which this request is tied.
 	 * @param tableSpaces The table spaces.
 	 */
-	@SuppressWarnings({ "unchecked" })
-	public BulkOperationCleanupAction(SharedSessionContractImplementor session, Set tableSpaces) {
+	public BulkOperationCleanupAction(SharedSessionContractImplementor session, Set<String> tableSpaces) {
 		final LinkedHashSet<String> spacesList = new LinkedHashSet<>( tableSpaces );
 
 		final SessionFactoryImplementor factory = session.getFactory();
@@ -154,7 +153,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 	 * @return True if there are affected table spaces and any of the incoming
 	 * check table spaces occur in that set.
 	 */
-	private boolean affectedEntity(Set affectedTableSpaces, Serializable[] checkTableSpaces) {
+	private boolean affectedEntity(Set<? extends Serializable> affectedTableSpaces, Serializable[] checkTableSpaces) {
 		if ( affectedTableSpaces == null || affectedTableSpaces.isEmpty() ) {
 			return true;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -29,7 +29,7 @@ import org.hibernate.pretty.MessageHelper;
  *
  * @author Gavin King
  */
-public abstract class CollectionAction implements Executable, Serializable, Comparable {
+public abstract class CollectionAction implements Executable, Serializable, Comparable<CollectionAction> {
 	private transient CollectionPersister persister;
 	private transient SharedSessionContractImplementor session;
 	private final PersistentCollection collection;
@@ -146,9 +146,7 @@ public abstract class CollectionAction implements Executable, Serializable, Comp
 	}
 
 	@Override
-	public int compareTo(Object other) {
-		final CollectionAction action = (CollectionAction) other;
-
+	public int compareTo(CollectionAction action) {
 		// sort first by role name
 		final int roleComparison = collectionRole.compareTo( action.collectionRole );
 		if ( roleComparison != 0 ) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -31,7 +31,7 @@ import org.jboss.logging.Logger;
  * @author Gavin King
  */
 public abstract class EntityAction
-		implements Executable, Serializable, Comparable, AfterTransactionCompletionProcess {
+		implements Executable, Serializable, Comparable<EntityAction>, AfterTransactionCompletionProcess {
 	private static final Logger LOG = Logger.getLogger(EntityAction.class);
 
 	private final String entityName;
@@ -157,8 +157,7 @@ public abstract class EntityAction
 	}
 
 	@Override
-	public int compareTo(Object other) {
-		final EntityAction action = (EntityAction) other;
+	public int compareTo(EntityAction action) {
 		//sort first by entity name
 		final int roleComparison = entityName.compareTo( action.entityName );
 		if ( roleComparison != 0 ) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
@@ -156,7 +156,6 @@ public class UnresolvedEntityInsertActions {
 		return dependenciesByAction.isEmpty();
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	private void addDependenciesByTransientEntity(AbstractEntityInsertAction insert, NonNullableTransientDependencies dependencies) {
 		for ( Object transientEntity : dependencies.getNonNullableTransientEntities() ) {
 			Set<AbstractEntityInsertAction> dependentActions = dependentActionsByTransientEntity.get( transientEntity );
@@ -178,7 +177,6 @@ public class UnresolvedEntityInsertActions {
 	 *
 	 * @throws IllegalArgumentException if {@code managedEntity} did not have managed or read-only status.
 	 */
-	@SuppressWarnings({ "unchecked" })
 	public Set<AbstractEntityInsertAction> resolveDependentActions(Object managedEntity, SessionImplementor session) {
 		final EntityEntry entityEntry = session.getPersistenceContextInternal().getEntry( managedEntity );
 		if ( entityEntry.getStatus() != Status.MANAGED && entityEntry.getStatus() != Status.READ_ONLY ) {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Proxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Proxy.java
@@ -28,5 +28,5 @@ public @interface Proxy {
 	/**
 	 * Proxy class or interface used.  Default is to use the entity class name.
 	 */
-	Class proxyClass() default void.class;
+	Class<?> proxyClass() default void.class;
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Sort.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Sort.java
@@ -8,6 +8,7 @@ package org.hibernate.annotations;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.Comparator;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -36,5 +37,5 @@ public @interface Sort {
 	 *
 	 * TODO find a way to use {@code Class<Comparator>} -> see HHH-8164
 	 */
-	Class comparator() default void.class;
+	Class<?> comparator() default void.class;
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
@@ -290,7 +290,7 @@ public interface MetadataBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	MetadataBuilder applyBasicType(BasicType type);
+	<T> MetadataBuilder applyBasicType(BasicType<T> type);
 
 	/**
 	 * Specify an additional or overridden basic type mapping supplying specific
@@ -301,7 +301,7 @@ public interface MetadataBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	MetadataBuilder applyBasicType(BasicType type, String... keys);
+	<T> MetadataBuilder applyBasicType(BasicType<T> type, String... keys);
 
 	/**
 	 * Register an additional or overridden custom type mapping.
@@ -311,7 +311,7 @@ public interface MetadataBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	MetadataBuilder applyBasicType(UserType type, String... keys);
+	<T> MetadataBuilder applyBasicType(UserType type, String... keys);
 
 	/**
 	 * Apply an explicit TypeContributor (implicit application via ServiceLoader will still happen too)
@@ -417,7 +417,7 @@ public interface MetadataBuilder {
 	 *
 	 * @return {@code this} for method chaining
 	 */
-	MetadataBuilder applyAttributeConverter(AttributeConverter attributeConverter, boolean autoApply);
+	<O,R> MetadataBuilder applyAttributeConverter(AttributeConverter<O,R> attributeConverter, boolean autoApply);
 
 	MetadataBuilder applyIdGenerationTypeInterpreter(IdGeneratorStrategyInterpreter interpreter);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -426,7 +426,7 @@ public interface SessionFactoryBuilder {
 	 * @deprecated This is a legacy feature and should never be needed anymore...
 	 */
 	@Deprecated
-	SessionFactoryBuilder applyQuerySubstitutions(Map substitutions);
+	SessionFactoryBuilder applyQuerySubstitutions(Map<String, String> substitutions);
 
 	/**
 	 * Should we strictly adhere to JPA Query Language (JPQL) syntax, or more broadly support

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceImpl.java
@@ -17,7 +17,7 @@ import org.hibernate.boot.cfgxml.spi.LoadedConfig;
 public class CfgXmlAccessServiceImpl implements CfgXmlAccessService {
 	private final LoadedConfig aggregatedCfgXml;
 
-	public CfgXmlAccessServiceImpl(Map configurationValues) {
+	public CfgXmlAccessServiceImpl(Map<String, Object> configurationValues) {
 		aggregatedCfgXml = (LoadedConfig) configurationValues.get( LOADED_CONFIG_KEY );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceInitiator.java
@@ -22,7 +22,7 @@ public class CfgXmlAccessServiceInitiator implements StandardServiceInitiator<Cf
 	public static final CfgXmlAccessServiceInitiator INSTANCE = new CfgXmlAccessServiceInitiator();
 
 	@Override
-	public CfgXmlAccessService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public CfgXmlAccessService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new CfgXmlAccessServiceImpl( configurationValues );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/JaxbCfgProcessor.java
@@ -94,7 +94,6 @@ public class JaxbCfgProcessor {
 		return staxFactory;
 	}
 
-	@SuppressWarnings( { "unchecked" })
 	private JaxbCfgHibernateConfiguration unmarshal(XMLEventReader staxEventReader, final Origin origin) {
 		XMLEvent event;
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/spi/LoadedConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/spi/LoadedConfig.java
@@ -40,12 +40,12 @@ public class LoadedConfig {
 
 	private String sessionFactoryName;
 
-	private final Map configurationValues = new ConcurrentHashMap( 16, 0.75f, 1 );
+	private final Map<String, Object> configurationValues = new ConcurrentHashMap<>( 16, 0.75f, 1 );
 
 	private Map<String,JaccPermissionDeclarations> jaccPermissionsByContextId;
 	private List<CacheRegionDefinition> cacheRegionDefinitions;
 	private List<MappingReference> mappingReferences;
-	private Map<EventType,Set<String>> eventListenerMap;
+	private Map<EventType<?>, Set<String>> eventListenerMap;
 
 	public LoadedConfig(String sessionFactoryName) {
 		this.sessionFactoryName = sessionFactoryName;
@@ -55,7 +55,7 @@ public class LoadedConfig {
 		return sessionFactoryName;
 	}
 
-	public Map getConfigurationValues() {
+	public Map<String, Object> getConfigurationValues() {
 		return configurationValues;
 	}
 
@@ -75,7 +75,7 @@ public class LoadedConfig {
 		return mappingReferences == null ? Collections.emptyList() : mappingReferences;
 	}
 
-	public Map<EventType, Set<String>> getEventListenerMap() {
+	public Map<EventType<?>, Set<String>> getEventListenerMap() {
 		return eventListenerMap == null ? Collections.emptyMap() : eventListenerMap;
 	}
 
@@ -120,7 +120,7 @@ public class LoadedConfig {
 
 		if ( !jaxbCfg.getSessionFactory().getListener().isEmpty() ) {
 			for ( JaxbCfgEventListenerType listener : jaxbCfg.getSessionFactory().getListener() ) {
-				final EventType eventType = EventType.resolveEventTypeByName( listener.getType().value() );
+				final EventType<?> eventType = EventType.resolveEventTypeByName( listener.getType().value() );
 				cfg.addEventListener( eventType, listener.getClazz() );
 			}
 		}
@@ -132,7 +132,7 @@ public class LoadedConfig {
 				}
 
 				final String eventTypeName = listenerGroup.getType().value();
-				final EventType eventType = EventType.resolveEventTypeByName( eventTypeName );
+				final EventType<?> eventType = EventType.resolveEventTypeByName( eventTypeName );
 
 				for ( JaxbCfgEventListenerType listener : listenerGroup.getListener() ) {
 					if ( listener.getType() != null ) {
@@ -154,7 +154,6 @@ public class LoadedConfig {
 		return value.trim();
 	}
 
-	@SuppressWarnings("unchecked")
 	private void addConfigurationValue(String propertyName, String value) {
 		value = trim( value );
 		configurationValues.put( propertyName, value );
@@ -202,7 +201,7 @@ public class LoadedConfig {
 		cacheRegionDefinitions.add( cacheRegionDefinition );
 	}
 
-	public void addEventListener(EventType eventType, String listenerClass) {
+	public void addEventListener(EventType<?> eventType, String listenerClass) {
 		if ( eventListenerMap == null ) {
 			eventListenerMap = new HashMap<>();
 		}
@@ -258,8 +257,7 @@ public class LoadedConfig {
 		addEventListeners( incoming.getEventListenerMap() );
 	}
 
-	@SuppressWarnings("unchecked")
-	protected void addConfigurationValues(Map configurationValues) {
+	protected void addConfigurationValues(Map<String, Object> configurationValues) {
 		if ( configurationValues == null ) {
 			return;
 		}
@@ -309,7 +307,7 @@ public class LoadedConfig {
 		}
 	}
 
-	private void addEventListeners(Map<EventType, Set<String>> eventListenerMap) {
+	private void addEventListeners(Map<EventType<?>, Set<String>> eventListenerMap) {
 		if ( eventListenerMap == null ) {
 			return;
 		}
@@ -318,7 +316,7 @@ public class LoadedConfig {
 			this.eventListenerMap = new HashMap<>();
 		}
 
-		for ( Map.Entry<EventType, Set<String>> incomingEntry : eventListenerMap.entrySet() ) {
+		for ( Map.Entry<EventType<?>, Set<String>> incomingEntry : eventListenerMap.entrySet() ) {
 			Set<String> listenerClasses = this.eventListenerMap.get( incomingEntry.getKey() );
 			if ( listenerClasses == null ) {
 				listenerClasses = new HashSet<>();

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
@@ -47,7 +47,6 @@ public class ClassLoaderAccessImpl implements ClassLoaderAccess {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Class<?> classForName(String name) {
 		if ( name == null ) {
 			throw new IllegalArgumentException( "Name of class to load cannot be null" );

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/DefaultSessionFactoryBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/DefaultSessionFactoryBuilderInitiator.java
@@ -20,7 +20,7 @@ public final class DefaultSessionFactoryBuilderInitiator implements StandardServ
 	}
 
 	@Override
-	public SessionFactoryBuilderService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public SessionFactoryBuilderService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return DefaultSessionFactoryBuilderService.INSTANCE;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/IdGeneratorInterpreterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/IdGeneratorInterpreterImpl.java
@@ -115,7 +115,7 @@ public class IdGeneratorInterpreterImpl implements IdGeneratorStrategyInterprete
 						return IncrementGenerator.class.getName();
 					}
 
-					final Class javaType = context.getIdType();
+					final Class<?> javaType = context.getIdType();
 					if ( UUID.class.isAssignableFrom( javaType ) ) {
 						return UUIDGenerator.class.getName();
 					}
@@ -227,7 +227,7 @@ public class IdGeneratorInterpreterImpl implements IdGeneratorStrategyInterprete
 						return IncrementGenerator.class.getName();
 					}
 
-					final Class javaType = context.getIdType();
+					final Class<?> javaType = context.getIdType();
 					if ( UUID.class.isAssignableFrom( javaType ) ) {
 						return UUIDGenerator.class.getName();
 					}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -238,20 +238,20 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 	}
 
 	@Override
-	public MetadataBuilder applyBasicType(BasicType type) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type ) );
+	public <T> MetadataBuilder applyBasicType(BasicType<T> type) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type ) );
 		return this;
 	}
 
 	@Override
-	public MetadataBuilder applyBasicType(BasicType type, String... keys) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type, keys ) );
+	public <T> MetadataBuilder applyBasicType(BasicType<T> type, String... keys) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type, keys ) );
 		return this;
 	}
 
 	@Override
-	public MetadataBuilder applyBasicType(UserType type, String... keys) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type, keys, getTypeConfiguration() ) );
+	public <T> MetadataBuilder applyBasicType(UserType type, String... keys) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type, keys, getTypeConfiguration() ) );
 		return this;
 	}
 
@@ -262,22 +262,22 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 	}
 
 	@Override
-	public void contributeType(BasicType type) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type ) );
+	public <T> void contributeType(BasicType<T> type) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type ) );
 	}
 
 	@Override
-	public void contributeType(BasicType type, String... keys) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type, keys ) );
+	public <T> void contributeType(BasicType<T> type, String... keys) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type, keys ) );
 	}
 
 	@Override
-	public void contributeType(UserType type, String[] keys) {
-		options.basicTypeRegistrations.add( new BasicTypeRegistration( type, keys, getTypeConfiguration() ) );
+	public <T> void contributeType(UserType<T> type, String[] keys) {
+		options.basicTypeRegistrations.add( new BasicTypeRegistration<T>( type, keys, getTypeConfiguration() ) );
 	}
 
 	@Override
-	public void contributeJavaTypeDescriptor(JavaTypeDescriptor descriptor) {
+	public <T> void contributeJavaTypeDescriptor(JavaTypeDescriptor<T> descriptor) {
 		this.bootstrapContext.getTypeConfiguration().getJavaTypeDescriptorRegistry().addDescriptor( descriptor );
 	}
 
@@ -361,7 +361,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 	}
 
 	@Override
-	public MetadataBuilder applyAttributeConverter(AttributeConverter attributeConverter, boolean autoApply) {
+	public <O,R> MetadataBuilder applyAttributeConverter(AttributeConverter<O,R> attributeConverter, boolean autoApply) {
 		bootstrapContext.addAttributeConverterDescriptor(
 				new InstanceBasedConverterDescriptor( attributeConverter, autoApply, bootstrapContext.getClassmateContext() )
 		);
@@ -386,9 +386,8 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T extends MetadataBuilder> T unwrap(Class<T> type) {
-		return (T) this;
+		return type.cast( this );
 	}
 
 	@Override
@@ -529,7 +528,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		// todo (6.0) : remove bootstrapContext property along with the deprecated methods
 		private BootstrapContext bootstrapContext;
 
-		private ArrayList<BasicTypeRegistration> basicTypeRegistrations = new ArrayList<>();
+		private ArrayList<BasicTypeRegistration<?>> basicTypeRegistrations = new ArrayList<>();
 
 		private ImplicitNamingStrategy implicitNamingStrategy;
 		private PhysicalNamingStrategy physicalNamingStrategy;
@@ -715,7 +714,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		}
 
 		@Override
-		public List<BasicTypeRegistration> getBasicTypeRegistrations() {
+		public List<BasicTypeRegistration<?>> getBasicTypeRegistrations() {
 			return basicTypeRegistrations;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedNativeQueryDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedNativeQueryDefinitionImpl.java
@@ -79,7 +79,7 @@ public class NamedNativeQueryDefinitionImpl extends AbstractNamedQueryDefinition
 
 	@Override
 	public NamedNativeQueryMemento resolve(SessionFactoryImplementor factory) {
-		final Class resultSetMappingClass = StringHelper.isNotEmpty( resultSetMappingClassName )
+		final Class<?> resultSetMappingClass = StringHelper.isNotEmpty( resultSetMappingClassName )
 				? factory.getServiceRegistry().getService( ClassLoaderService.class ).classForName( resultSetMappingClassName )
 				: null;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -269,7 +269,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
-	public SessionFactoryBuilder applyQuerySubstitutions(@SuppressWarnings("rawtypes") Map substitutions) {
+	public SessionFactoryBuilder applyQuerySubstitutions(Map<String, String> substitutions) {
 		this.optionsBuilder.applyQuerySubstitutions( substitutions );
 		return this;
 	}
@@ -454,9 +454,8 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T extends SessionFactoryBuilder> T unwrap(Class<T> type) {
-		return (T) this;
+		return type.cast( this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -217,7 +217,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private SqmFunctionRegistry sqmFunctionRegistry;
 	private SqmTranslatorFactory sqmTranslatorFactory;
 	private Boolean useOfJdbcNamedParametersEnabled;
-	private Map querySubstitutions;
+	private Map<String, String> querySubstitutions;
 	private boolean namedQueryStartupCheckingEnabled;
 	private boolean conventionalJavaConstants;
 	private final boolean procedureParameterNullPassingEnabled;
@@ -979,7 +979,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	@Override
-	public Map getQuerySubstitutions() {
+	public Map<String, String> getQuerySubstitutions() {
 		return querySubstitutions;
 	}
 
@@ -1341,8 +1341,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.currentTenantIdentifierResolver = resolver;
 	}
 
-	@SuppressWarnings("unchecked")
-	public void applyQuerySubstitutions(Map substitutions) {
+	public void applyQuerySubstitutions(Map<String, String> substitutions) {
 		this.querySubstitutions.putAll( substitutions );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/IdGeneratorStrategyInterpreter.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/IdGeneratorStrategyInterpreter.java
@@ -22,7 +22,7 @@ public interface IdGeneratorStrategyInterpreter {
 		 * The Java type of the attribute defining the id whose value is to
 		 * be generated.
 		 */
-		Class getIdType();
+		Class<?> getIdType();
 
 		/**
 		 * The {@link GeneratedValue#generator()} name.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributions.java
@@ -26,7 +26,7 @@ public interface TypeContributions {
 	 * Add the JavaTypeDescriptor to the {@link TypeConfiguration}'s
 	 * {@link JavaTypeDescriptorRegistry}
 	 */
-	void contributeJavaTypeDescriptor(JavaTypeDescriptor descriptor);
+	<T> void contributeJavaTypeDescriptor(JavaTypeDescriptor<T> descriptor);
 
 	/**
 	 * Add the JavaTypeDescriptor to the {@link TypeConfiguration}'s
@@ -34,7 +34,7 @@ public interface TypeContributions {
 	 */
 	void contributeSqlTypeDescriptor(SqlTypeDescriptor descriptor);
 
-	void contributeType(BasicType type);
+	<T> void contributeType(BasicType<T> type);
 
 	/**
 	 * @deprecated (since 5.3) Use {@link #contributeType(BasicType)} instead.  Basic
@@ -47,7 +47,7 @@ public interface TypeContributions {
 	 * registration keys and call {@link #contributeType(BasicType)} instead
 	 */
 	@Deprecated
-	void contributeType(BasicType type, String... keys);
+	<T> void contributeType(BasicType<T> type, String... keys);
 
 	/**
 	 * @deprecated (since 5.3) Use {@link #contributeType(BasicType)} instead.
@@ -60,5 +60,5 @@ public interface TypeContributions {
 	 * and call {@link #contributeType(BasicType)} instead
 	 */
 	@Deprecated
-	void contributeType(UserType type, String... keys);
+	<T> void contributeType(UserType<T> type, String... keys);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/convert/spi/ConverterDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/convert/spi/ConverterDescriptor.java
@@ -45,5 +45,5 @@ public interface ConverterDescriptor {
 	/**
 	 * Factory for the runtime representation of the converter
 	 */
-	JpaAttributeConverter createJpaAttributeConverter(JpaAttributeConverterCreationContext context);
+	JpaAttributeConverter<?, ?> createJpaAttributeConverter(JpaAttributeConverterCreationContext context);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -41,7 +41,7 @@ public class InferredBasicValueResolver {
 	 */
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public static BasicValue.Resolution from(
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJavaTypeAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJavaTypeAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitSqlTypeAccess,
 			Supplier<JavaTypeDescriptor> reflectedJtdResolver,
 			SqlTypeDescriptorIndicators stdIndicators,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
@@ -27,7 +27,6 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
-import org.hibernate.type.internal.StandardBasicTypeImpl;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -38,9 +37,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 
 	public static NamedConverterResolution from(
 			ConverterDescriptor converterDescriptor,
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitStdAccess,
-			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
+			Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess,
 			SqlTypeDescriptorIndicators sqlTypeIndicators,
 			JpaAttributeConverterCreationContext converterCreationContext,
 			MetadataBuildingContext context) {
@@ -54,11 +53,12 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 		);
 	}
 
+	@SuppressWarnings( "unchecked" )
 	public static NamedConverterResolution from(
 			String name,
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitStdAccess,
-			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
+			Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess,
 			SqlTypeDescriptorIndicators sqlTypeIndicators,
 			JpaAttributeConverterCreationContext converterCreationContext,
 			MetadataBuildingContext context) {
@@ -85,9 +85,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 	}
 
 	private static NamedConverterResolution fromInternal(
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitStdAccess,
-			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
+			Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess,
 			JpaAttributeConverter converter, SqlTypeDescriptorIndicators sqlTypeIndicators,
 			MetadataBuildingContext context) {
 		final TypeConfiguration typeConfiguration = context.getBootstrapContext().getTypeConfiguration();
@@ -126,24 +126,23 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 	}
 
 
-	private final JavaTypeDescriptor domainJtd;
-	private final JavaTypeDescriptor relationalJtd;
+	private final JavaTypeDescriptor<J> domainJtd;
+	private final JavaTypeDescriptor<?> relationalJtd;
 	private final SqlTypeDescriptor relationalStd;
 
-	private final JpaAttributeConverter valueConverter;
-	private final MutabilityPlan mutabilityPlan;
+	private final JpaAttributeConverter<J, ?> valueConverter;
+	private final MutabilityPlan<J> mutabilityPlan;
 
 	private final JdbcMapping jdbcMapping;
 
-	private final BasicType legacyResolvedType;
+	private final BasicType<J> legacyResolvedType;
 
-	@SuppressWarnings("unchecked")
 	public NamedConverterResolution(
-			JavaTypeDescriptor domainJtd,
-			JavaTypeDescriptor relationalJtd,
+			JavaTypeDescriptor<J> domainJtd,
+			JavaTypeDescriptor<?> relationalJtd,
 			SqlTypeDescriptor relationalStd,
-			JpaAttributeConverter valueConverter,
-			MutabilityPlan mutabilityPlan) {
+			JpaAttributeConverter<J, ?> valueConverter,
+			MutabilityPlan<J> mutabilityPlan) {
 		assert domainJtd != null;
 		this.domainJtd = domainJtd;
 
@@ -227,7 +226,7 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 	}
 
 	@Override
-	public JpaAttributeConverter getValueConverter() {
+	public JpaAttributeConverter<J, ?> getValueConverter() {
 		return valueConverter;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
@@ -115,7 +115,7 @@ public class ScanningCoordinator {
 				scannerImplClass = (Class<? extends Scanner>) scannerSetting;
 			}
 			else {
-				scannerImplClass = classLoaderAccess.classForName( scannerSetting.toString() );
+				scannerImplClass = (Class<? extends  Scanner>) classLoaderAccess.classForName( scannerSetting.toString() );
 			}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -35,8 +35,8 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public static <E> VersionResolution<E> from(
-			Function<TypeConfiguration, Class> implicitJavaTypeAccess,
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess,
+			Function<TypeConfiguration, Class<?>> implicitJavaTypeAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitStdAccess,
 			TypeConfiguration typeConfiguration,
 			@SuppressWarnings("unused") MetadataBuildingContext context) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -336,7 +336,7 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 			rootMetadataBuildingContext.getMetadataCollector().addAttributeConverter( descriptor );
 		}
 
-		public void addAttributeConverter(Class<? extends AttributeConverter> converterClass) {
+		public <X, Y> void addAttributeConverter(Class<? extends AttributeConverter<X, Y>> converterClass) {
 			rootMetadataBuildingContext.getMetadataCollector().addAttributeConverter( converterClass );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceInitiator.java
@@ -28,5 +28,5 @@ public interface StandardServiceInitiator<R extends Service> extends ServiceInit
 	 *
 	 * @return The initiated service.
 	 */
-	public R initiateService(Map configurationValues, ServiceRegistryImplementor registry);
+	public R initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceRegistryBuilder.java
@@ -47,13 +47,13 @@ public class StandardServiceRegistryBuilder {
 	public static StandardServiceRegistryBuilder forJpa(BootstrapServiceRegistry bootstrapServiceRegistry) {
 		final LoadedConfig loadedConfig = new LoadedConfig( null ) {
 			@Override
-			protected void addConfigurationValues(Map configurationValues) {
+			protected void addConfigurationValues(Map<String, Object> configurationValues) {
 				// here, do nothing
 			}
 		};
 		return new StandardServiceRegistryBuilder(
 				bootstrapServiceRegistry,
-				new HashMap(),
+				new HashMap<>(),
 				loadedConfig
 		) {
 			@Override
@@ -70,7 +70,7 @@ public class StandardServiceRegistryBuilder {
 	 */
 	public static final String DEFAULT_CFG_RESOURCE_NAME = "hibernate.cfg.xml";
 
-	private final Map settings;
+	private final Map<String, Object> settings;
 	private final List<StandardServiceInitiator> initiators;
 	private final List<ProvidedService> providedServices = new ArrayList<>();
 
@@ -104,7 +104,7 @@ public class StandardServiceRegistryBuilder {
 	 */
 	protected StandardServiceRegistryBuilder(
 			BootstrapServiceRegistry bootstrapServiceRegistry,
-			Map settings,
+			Map<String, Object> settings,
 			LoadedConfig loadedConfig) {
 		this.bootstrapServiceRegistry = bootstrapServiceRegistry;
 		this.configLoader = new ConfigLoader( bootstrapServiceRegistry );
@@ -135,10 +135,11 @@ public class StandardServiceRegistryBuilder {
 	 *
 	 * @param bootstrapServiceRegistry Provided bootstrap registry to use.
 	 */
+	@SuppressWarnings( {"rawtypes", "unchecked"} )
 	public StandardServiceRegistryBuilder(
 			BootstrapServiceRegistry bootstrapServiceRegistry,
 			LoadedConfig loadedConfigBaseline) {
-		this.settings = Environment.getProperties();
+		this.settings = (Map) Environment.getProperties();
 		this.bootstrapServiceRegistry = bootstrapServiceRegistry;
 		this.configLoader = new ConfigLoader( bootstrapServiceRegistry );
 		this.aggregatedCfgXml = loadedConfigBaseline;
@@ -185,9 +186,9 @@ public class StandardServiceRegistryBuilder {
 	 * @see #configure()
 	 * @see #configure(String)
 	 */
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public StandardServiceRegistryBuilder loadProperties(String resourceName) {
-		settings.putAll( configLoader.loadProperties( resourceName ) );
+		settings.putAll( (Map) configLoader.loadProperties( resourceName ) );
 		return this;
 	}
 
@@ -204,9 +205,9 @@ public class StandardServiceRegistryBuilder {
 	 * @see #configure()
 	 * @see #configure(String)
 	 */
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public StandardServiceRegistryBuilder loadProperties(File file) {
-		settings.putAll( configLoader.loadProperties( file ) );
+		settings.putAll( (Map) configLoader.loadProperties( file ) );
 		return this;
 	}
 
@@ -242,7 +243,6 @@ public class StandardServiceRegistryBuilder {
 		return configure( configLoader.loadConfigXmlUrl( url ) );
 	}
 
-	@SuppressWarnings({"unchecked"})
 	public StandardServiceRegistryBuilder configure(LoadedConfig loadedConfig) {
 		aggregatedCfgXml.merge( loadedConfig );
 		settings.putAll( loadedConfig.getConfigurationValues() );
@@ -342,12 +342,11 @@ public class StandardServiceRegistryBuilder {
 	 *
 	 * @return The StandardServiceRegistry.
 	 */
-	@SuppressWarnings("unchecked")
 	public StandardServiceRegistry build() {
 		applyServiceContributingIntegrators();
 		applyServiceContributors();
 
-		final Map settingsCopy = new HashMap( settings );
+		final Map<String, Object> settingsCopy = new HashMap<>( settings );
 		settingsCopy.put( org.hibernate.boot.cfgxml.spi.CfgXmlAccessService.LOADED_CONFIG_KEY, aggregatedCfgXml );
 		ConfigurationHelper.resolvePlaceHolders( settingsCopy );
 
@@ -391,7 +390,7 @@ public class StandardServiceRegistryBuilder {
 	 * This allows code to configure the builder and access that to configure Configuration object.
 	 */
 	@Deprecated
-	public Map getSettings() {
+	public Map<String, Object> getSettings() {
 		return settings;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/internal/StandardServiceRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/internal/StandardServiceRegistryImpl.java
@@ -28,7 +28,7 @@ import org.hibernate.service.spi.ServiceInitiator;
 public class StandardServiceRegistryImpl extends AbstractServiceRegistryImpl implements StandardServiceRegistry {
 
 	//Access to this field requires synchronization on -this-
-	private Map configurationValues;
+	private Map<String, Object> configurationValues;
 
 	/**
 	 * Constructs a StandardServiceRegistryImpl.  Should not be instantiated directly; use
@@ -41,12 +41,11 @@ public class StandardServiceRegistryImpl extends AbstractServiceRegistryImpl imp
 	 *
 	 * @see org.hibernate.boot.registry.StandardServiceRegistryBuilder
 	 */
-	@SuppressWarnings( {"unchecked"})
 	public StandardServiceRegistryImpl(
 			BootstrapServiceRegistry bootstrapServiceRegistry,
 			List<StandardServiceInitiator> serviceInitiators,
 			List<ProvidedService> providedServices,
-			Map<?, ?> configurationValues) {
+			Map<String, Object> configurationValues) {
 		this( true, bootstrapServiceRegistry, serviceInitiators, providedServices, configurationValues );
 	}
 
@@ -63,13 +62,12 @@ public class StandardServiceRegistryImpl extends AbstractServiceRegistryImpl imp
 	 *
 	 * @see org.hibernate.boot.registry.StandardServiceRegistryBuilder
 	 */
-	@SuppressWarnings( {"unchecked"})
 	public StandardServiceRegistryImpl(
 			boolean autoCloseRegistry,
 			BootstrapServiceRegistry bootstrapServiceRegistry,
 			List<StandardServiceInitiator> serviceInitiators,
 			List<ProvidedService> providedServices,
-			Map<?, ?> configurationValues) {
+			Map<String, Object> configurationValues) {
 		super( bootstrapServiceRegistry, autoCloseRegistry );
 
 		this.configurationValues = configurationValues;
@@ -114,12 +112,12 @@ public class StandardServiceRegistryImpl extends AbstractServiceRegistryImpl imp
 	public synchronized void resetAndReactivate(BootstrapServiceRegistry bootstrapServiceRegistry,
 									List<StandardServiceInitiator> serviceInitiators,
 									List<ProvidedService> providedServices,
-									Map<?, ?> configurationValues) {
+									Map<String, Object> configurationValues) {
 		if ( super.isActive() ) {
 			throw new IllegalStateException( "Can't reactivate an active registry!" );
 		}
 		super.resetParent( bootstrapServiceRegistry );
-		this.configurationValues = new HashMap( configurationValues );
+		this.configurationValues = new HashMap<>( configurationValues );
 		super.reactivate();
 		applyServiceRegistrations( serviceInitiators, providedServices );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
@@ -55,7 +55,7 @@ public abstract class AbstractDelegatingMetadataBuildingOptions implements Metad
 	}
 
 	@Override
-	public List<BasicTypeRegistration> getBasicTypeRegistrations() {
+	public List<BasicTypeRegistration<?>> getBasicTypeRegistrations() {
 		return delegate.getBasicTypeRegistrations();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/BasicTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/BasicTypeRegistration.java
@@ -14,15 +14,15 @@ import org.hibernate.usertype.UserType;
 /**
  * @author Steve Ebersole
  */
-public class BasicTypeRegistration {
-	private final BasicType basicType;
+public class BasicTypeRegistration<T> {
+	private final BasicType<T> basicType;
 	private final String[] registrationKeys;
 
-	public BasicTypeRegistration(BasicType basicType) {
+	public BasicTypeRegistration(BasicType<T> basicType) {
 		this( basicType, basicType.getRegistrationKeys() );
 	}
 
-	public BasicTypeRegistration(BasicType basicType, String[] registrationKeys) {
+	public BasicTypeRegistration(BasicType<T> basicType, String[] registrationKeys) {
 		this.basicType = basicType;
 		this.registrationKeys = registrationKeys;
 	}
@@ -31,7 +31,7 @@ public class BasicTypeRegistration {
 		this( new CustomType( type, keys, typeConfiguration ), keys );
 	}
 
-	public BasicType getBasicType() {
+	public BasicType<T> getBasicType() {
 		return basicType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/ClassLoaderAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/ClassLoaderAccess.java
@@ -25,7 +25,7 @@ public interface ClassLoaderAccess {
 	 *
 	 * @return The Class.
 	 */
-	public <T> Class<T> classForName(String name);
+	public Class<?> classForName(String name);
 
 	/**
 	 * Locate a resource by name

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/ClassLoaderAccessDelegateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/ClassLoaderAccessDelegateImpl.java
@@ -17,7 +17,7 @@ public abstract class ClassLoaderAccessDelegateImpl implements ClassLoaderAccess
 	protected abstract ClassLoaderAccess getDelegate();
 
 	@Override
-	public <T> Class<T> classForName(String name) {
+	public Class<?> classForName(String name) {
 		return getDelegate().classForName( name );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/InFlightMetadataCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/InFlightMetadataCollector.java
@@ -231,7 +231,7 @@ public interface InFlightMetadataCollector extends Mapping, MetadataImplementor 
 
 	void addAttributeConverter(ConverterDescriptor descriptor);
 
-	void addAttributeConverter(Class<? extends AttributeConverter> converterClass);
+	<X, Y> void addAttributeConverter(Class<? extends AttributeConverter<X, Y>> converterClass);
 
 	ConverterAutoApplyHandler getAttributeConverterAutoApplyHandler();
 
@@ -281,8 +281,8 @@ public interface InFlightMetadataCollector extends Mapping, MetadataImplementor 
 	AnnotatedClassType addClassType(XClass clazz);
 	AnnotatedClassType getClassType(XClass clazz);
 
-	void addMappedSuperclass(Class type, MappedSuperclass mappedSuperclass);
-	MappedSuperclass getMappedSuperclass(Class type);
+	void addMappedSuperclass(Class<?> type, MappedSuperclass mappedSuperclass);
+	MappedSuperclass getMappedSuperclass(Class<?> type);
 
 	PropertyData getPropertyAnnotatedWithMapsId(XClass persistentXClass, String propertyName);
 	void addPropertyAnnotatedWithMapsId(XClass entity, PropertyData propertyAnnotatedElement);
@@ -325,7 +325,7 @@ public interface InFlightMetadataCollector extends Mapping, MetadataImplementor 
 	void addMappedBy(String name, String mappedBy, String propertyName);
 	String getFromMappedBy(String ownerEntityName, String propertyName);
 
-	void addUniqueConstraints(Table table, List uniqueConstraints);
+	void addUniqueConstraints(Table table, List<String[]> uniqueConstraints);
 	void addUniqueConstraintHolders(Table table, List<UniqueConstraintHolder> uniqueConstraints);
 	void addJpaIndexHolders(Table table, List<JPAIndexHolder> jpaIndexHolders);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
@@ -71,7 +71,7 @@ public interface MetadataBuildingOptions {
 	 *
 	 * @return The BasicType registrations
 	 */
-	List<BasicTypeRegistration> getBasicTypeRegistrations();
+	List<BasicTypeRegistration<?>> getBasicTypeRegistrations();
 
 	/**
 	 * Retrieve the Hibernate Commons Annotations ReflectionManager to use.

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -187,7 +187,7 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	boolean isJtaTrackByThread();
 
-	Map getQuerySubstitutions();
+	Map<String, String> getQuerySubstitutions();
 
 	/**
 	 * @deprecated Use {@link JpaCompliance#isJpaQueryComplianceEnabled()} instead

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -231,9 +231,9 @@ public class EnhancerImpl implements Enhancer {
 					Implementation isDirty = StubMethod.INSTANCE, getDirtyNames = StubMethod.INSTANCE, clearDirtyNames = StubMethod.INSTANCE;
 					for ( AnnotatedFieldDescription collectionField : collectionFields ) {
 						String collectionFieldName = collectionField.getName();
-						Class adviceIsDirty;
-						Class adviceGetDirtyNames;
-						Class adviceClearDirtyNames;
+						Class<?> adviceIsDirty;
+						Class<?> adviceGetDirtyNames;
+						Class<?> adviceClearDirtyNames;
 						if ( collectionField.getType().asErasure().isAssignableTo( Map.class ) ) {
 							adviceIsDirty = CodeTemplates.MapAreCollectionFieldsDirty.class;
 							adviceGetDirtyNames = CodeTemplates.MapGetCollectionFieldDirtyNames.class;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributeLoadingInterceptor.java
@@ -156,7 +156,7 @@ public class LazyAttributeLoadingInterceptor extends AbstractLazyLoadInterceptor
 				( (SelfDirtinessTracker) target ).$$_hibernate_clearDirtyAttributes();
 				tracker = ( (SelfDirtinessTracker) target ).$$_hibernate_getCollectionTracker();
 			}
-			tracker.add( fieldName, ( (Collection) value ).size() );
+			tracker.add( fieldName, ( (Collection<?>) value ).size() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
@@ -41,10 +41,10 @@ public class LazyAttributesMetadata implements Serializable {
 
 		int i = -1;
 		int x = 0;
-		final Iterator itr = mappedEntity.getPropertyClosureIterator();
+		final Iterator<Property> itr = mappedEntity.getPropertyClosureIterator();
 		while ( itr.hasNext() ) {
 			i++;
-			final Property property = (Property) itr.next();
+			final Property property = itr.next();
 			final boolean lazy = ! EnhancementHelper.includeInBaseFetchGroup(
 					property,
 					isEnhanced,

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
@@ -21,7 +21,7 @@ public final class BytecodeProviderInitiator implements StandardServiceInitiator
 	public static final StandardServiceInitiator<BytecodeProvider> INSTANCE = new BytecodeProviderInitiator();
 
 	@Override
-	public BytecodeProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public BytecodeProvider initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		// TODO in 6 this will no longer use Environment, which is configured via global environment variables,
 		// but move to a component which can be reconfigured differently in each registry.
 		return Environment.getBytecodeProvider();

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
@@ -27,7 +27,7 @@ public final class ProxyFactoryFactoryInitiator implements StandardServiceInitia
 	public static final StandardServiceInitiator<ProxyFactoryFactory> INSTANCE = new ProxyFactoryFactoryInitiator();
 
 	@Override
-	public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public ProxyFactoryFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final BytecodeProvider bytecodeProvider = registry.getService( BytecodeProvider.class );
 		return bytecodeProvider.getProxyFactoryFactory();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
@@ -23,14 +23,13 @@ import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
 
 public class BasicProxyFactoryImpl implements BasicProxyFactory {
 
-	private static final Class[] NO_INTERFACES = new Class[0];
+	private static final Class<?>[] NO_INTERFACES = new Class<?>[0];
 	private static final String PROXY_NAMING_SUFFIX = Environment.useLegacyProxyClassnames() ? "HibernateBasicProxy$" : "HibernateBasicProxy";
 
-	private final Class proxyClass;
+	private final Class<?> proxyClass;
 	private final ProxyConfiguration.Interceptor interceptor;
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public BasicProxyFactoryImpl(Class superClass, Class[] interfaces, ByteBuddyState byteBuddyState) {
+	public BasicProxyFactoryImpl(Class<?> superClass, Class<?>[] interfaces, ByteBuddyState byteBuddyState) {
 		if ( superClass == null && ( interfaces == null || interfaces.length < 1 ) ) {
 			throw new AssertionFailure( "attempting to build proxy without any superclass or interfaces" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/HibernateMethodLookupDispatcher.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/HibernateMethodLookupDispatcher.java
@@ -200,10 +200,9 @@ public class HibernateMethodLookupDispatcher {
 			}
 		}
 
-		@SuppressWarnings({ "unchecked", "rawtypes" })
-		private final Function<Stream, Object> stackFrameExtractFunction = new Function<Stream, Object>() {
+		private final Function<Stream<?>, Object> stackFrameExtractFunction = new Function<Stream<?>, Object>() {
 			@Override
-			public Object apply(Stream stream) {
+			public Object apply(Stream<?> stream) {
 				return stream.map( stackFrameGetDeclaringClassFunction )
 						.limit( MAX_STACK_FRAMES )
 						.toArray( Class<?>[]::new );

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ProxyFactoryFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ProxyFactoryFactoryImpl.java
@@ -30,7 +30,7 @@ public class ProxyFactoryFactoryImpl implements ProxyFactoryFactory {
 	}
 
 	@Override
-	public BasicProxyFactory buildBasicProxyFactory(Class superClass, Class[] interfaces) {
+	public BasicProxyFactory buildBasicProxyFactory(Class<?> superClass, Class<?>[] interfaces) {
 		return new BasicProxyFactoryImpl( superClass, interfaces, byteBuddyState );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/BytecodeProviderImpl.java
@@ -33,10 +33,10 @@ public final class BytecodeProviderImpl implements BytecodeProvider {
 
 	@Override
 	public ReflectionOptimizer getReflectionOptimizer(
-			Class clazz,
+			Class<?> clazz,
 			String[] getterNames,
 			String[] setterNames,
-			Class[] types) {
+			Class<?>[] types) {
 		throw new HibernateException( "Using the ReflectionOptimizer is not possible when the configured BytecodeProvider is 'none'. Disable " + AvailableSettings.USE_REFLECTION_OPTIMIZER + " or use a different BytecodeProvider");
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/DisallowedProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/DisallowedProxyFactory.java
@@ -22,8 +22,8 @@ final class DisallowedProxyFactory implements ProxyFactory {
 	@Override
 	public void postInstantiate(
 			String entityName,
-			Class persistentClass,
-			Set<Class> interfaces,
+			Class<?> persistentClass,
+			Set<Class<?>> interfaces,
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) throws HibernateException {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/NoProxyFactoryFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/NoProxyFactoryFactory.java
@@ -23,7 +23,7 @@ final class NoProxyFactoryFactory implements ProxyFactoryFactory {
 	}
 
 	@Override
-	public BasicProxyFactory buildBasicProxyFactory(Class superClass, Class[] interfaces) {
+	public BasicProxyFactory buildBasicProxyFactory(Class<?> superClass, Class<?>[] interfaces) {
 		return new NoneBasicProxyFactory( superClass, interfaces );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/NoneBasicProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/none/NoneBasicProxyFactory.java
@@ -16,10 +16,10 @@ import org.hibernate.bytecode.spi.BasicProxyFactory;
  */
 final class NoneBasicProxyFactory implements BasicProxyFactory {
 
-	private final Class superClass;
-	private final Class[] interfaces;
+	private final Class<?> superClass;
+	private final Class<?>[] interfaces;
 
-	public NoneBasicProxyFactory(Class superClass, Class[] interfaces) {
+	public NoneBasicProxyFactory(Class<?> superClass, Class<?>[] interfaces) {
 		this.superClass = superClass;
 		this.interfaces = interfaces;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/BytecodeProvider.java
@@ -39,7 +39,7 @@ public interface BytecodeProvider extends Service {
 	 * @param types The types of all properties to be accessed.
 	 * @return The reflection optimization delegate.
 	 */
-	ReflectionOptimizer getReflectionOptimizer(Class clazz, String[] getterNames, String[] setterNames, Class[] types);
+	ReflectionOptimizer getReflectionOptimizer(Class<?> clazz, String[] getterNames, String[] setterNames, Class<?>[] types);
 
 	/**
 	 * Returns a byte code enhancer that implements the enhancements described in the supplied enhancement context.

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ProxyFactoryFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/spi/ProxyFactoryFactory.java
@@ -41,5 +41,5 @@ public interface ProxyFactoryFactory extends Service {
 	 * @param interfaces Interfaces to be proxied (or null if none).
 	 * @return The proxy class
 	 */
-	public BasicProxyFactory buildBasicProxyFactory(Class superClass, Class[] interfaces);
+	public BasicProxyFactory buildBasicProxyFactory(Class<?> superClass, Class<?>[] interfaces);
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/CollectionDataCachingConfigImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/CollectionDataCachingConfigImpl.java
@@ -42,11 +42,11 @@ public class CollectionDataCachingConfigImpl
 	}
 
 	@Override
-	public Comparator getOwnerVersionComparator() {
+	public Comparator<?> getOwnerVersionComparator() {
 		if ( !isVersioned() ) {
 			return null;
 		}
-		return ( (VersionType) collectionDescriptor.getOwner().getVersion().getType() ).getComparator();
+		return ( (VersionType<?>) collectionDescriptor.getOwner().getVersion().getType() ).getComparator();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/DomainDataRegionConfigImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/DomainDataRegionConfigImpl.java
@@ -8,11 +8,9 @@ package org.hibernate.cache.cfg.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
 import org.hibernate.cache.cfg.spi.DomainDataCachingConfig;
@@ -34,15 +32,15 @@ import org.hibernate.type.VersionType;
 public class DomainDataRegionConfigImpl implements DomainDataRegionConfig {
 	private final String regionName;
 
-	private final List<EntityDataCachingConfig> entityConfigs;
-	private final List<NaturalIdDataCachingConfig> naturalIdConfigs;
-	private final List<CollectionDataCachingConfig> collectionConfigs;
+	private final List<? extends EntityDataCachingConfig> entityConfigs;
+	private final List<? extends NaturalIdDataCachingConfig> naturalIdConfigs;
+	private final List<? extends CollectionDataCachingConfig> collectionConfigs;
 
 	private DomainDataRegionConfigImpl(
 			String regionName,
-			List<EntityDataCachingConfig> entityConfigs,
-			List<NaturalIdDataCachingConfig> naturalIdConfigs,
-			List<CollectionDataCachingConfig> collectionConfigs) {
+			List<? extends EntityDataCachingConfig> entityConfigs,
+			List<? extends NaturalIdDataCachingConfig> naturalIdConfigs,
+			List<? extends CollectionDataCachingConfig> collectionConfigs) {
 		this.regionName = regionName;
 		this.entityConfigs = entityConfigs;
 		this.naturalIdConfigs = naturalIdConfigs;
@@ -55,17 +53,17 @@ public class DomainDataRegionConfigImpl implements DomainDataRegionConfig {
 	}
 
 	@Override
-	public List<EntityDataCachingConfig> getEntityCaching() {
+	public List<? extends EntityDataCachingConfig> getEntityCaching() {
 		return entityConfigs;
 	}
 
 	@Override
-	public List<NaturalIdDataCachingConfig> getNaturalIdCaching() {
+	public List<? extends NaturalIdDataCachingConfig> getNaturalIdCaching() {
 		return naturalIdConfigs;
 	}
 
 	@Override
-	public List<CollectionDataCachingConfig> getCollectionCaching() {
+	public List<? extends CollectionDataCachingConfig> getCollectionCaching() {
 		return collectionConfigs;
 	}
 
@@ -99,7 +97,7 @@ public class DomainDataRegionConfigImpl implements DomainDataRegionConfig {
 					x -> new EntityDataCachingConfigImpl(
 							rootEntityName,
 							bootEntityDescriptor.isVersioned()
-									? (Supplier<Comparator>) () -> ( (VersionType) bootEntityDescriptor.getVersion().getType() ).getComparator()
+									? () -> ( (VersionType<?>) bootEntityDescriptor.getVersion().getType() ).getComparator()
 									: null,
 							bootEntityDescriptor.isMutable(),
 							accessType
@@ -151,11 +149,10 @@ public class DomainDataRegionConfigImpl implements DomainDataRegionConfig {
 			);
 		}
 
-		@SuppressWarnings("unchecked")
-		private <T extends DomainDataCachingConfig> List<T> finalize(Map configs) {
+		private <T extends DomainDataCachingConfig> List<T> finalize(Map<NavigableRole, T> configs) {
 			return configs == null
 					? Collections.emptyList()
-					: Collections.unmodifiableList( new ArrayList( configs.values() ) );
+					: Collections.unmodifiableList( new ArrayList<>( configs.values() ) );
 		}
 
 		private <T extends DomainDataCachingConfig> List<T> finalize(List<T> configs) {

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/EntityDataCachingConfigImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/EntityDataCachingConfigImpl.java
@@ -22,14 +22,14 @@ public class EntityDataCachingConfigImpl
 		extends AbstractDomainDataCachingConfig
 		implements EntityDataCachingConfig {
 	private final NavigableRole navigableRole;
-	private final Supplier<Comparator> versionComparatorAccess;
+	private final Supplier<Comparator<?>> versionComparatorAccess;
 	private final boolean isEntityMutable;
 
 	private final Set<NavigableRole> cachedTypes = new HashSet<>();
 
 	public EntityDataCachingConfigImpl(
 			NavigableRole rootEntityName,
-			Supplier<Comparator> versionComparatorAccess,
+			Supplier<Comparator<?>> versionComparatorAccess,
 			boolean isEntityMutable,
 			AccessType accessType) {
 		super( accessType );
@@ -39,7 +39,7 @@ public class EntityDataCachingConfigImpl
 	}
 
 	@Override
-	public Supplier<Comparator> getVersionComparatorAccess() {
+	public Supplier<Comparator<?>> getVersionComparatorAccess() {
 		return versionComparatorAccess;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/NaturalIdDataCachingConfigImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/NaturalIdDataCachingConfigImpl.java
@@ -36,9 +36,9 @@ public class NaturalIdDataCachingConfigImpl
 	}
 
 	private boolean hasAnyMutableNaturalIdProps() {
-		final Iterator itr = rootEntityDescriptor.getDeclaredPropertyIterator();
+		final Iterator<Property> itr = rootEntityDescriptor.getDeclaredPropertyIterator();
 		while ( itr.hasNext() ) {
-			final Property prop = (Property) itr.next();
+			final Property prop = itr.next();
 			if ( prop.isNaturalIdentifier() && prop.isUpdateable() ) {
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/CollectionDataCachingConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/CollectionDataCachingConfig.java
@@ -8,6 +8,8 @@ package org.hibernate.cache.cfg.spi;
 
 import java.util.Comparator;
 
+import org.hibernate.type.VersionType;
+
 /**
  * Specialized DomainDataCachingConfig describing the requested
  * caching config for a particular persistent collection's data
@@ -18,5 +20,5 @@ public interface CollectionDataCachingConfig extends DomainDataCachingConfig {
 	/**
 	 * The comparator to be used with the owning entity's version (if it has one).
 	 */
-	Comparator getOwnerVersionComparator();
+	Comparator<?> getOwnerVersionComparator();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/DomainDataRegionConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/DomainDataRegionConfig.java
@@ -27,15 +27,15 @@ public interface DomainDataRegionConfig {
 	/**
 	 * Retrieve the list of all entity data to be stored in this region
 	 */
-	List<EntityDataCachingConfig> getEntityCaching();
+	List<? extends EntityDataCachingConfig> getEntityCaching();
 
 	/**
 	 * Retrieve the list of all natural-id data to be stored in this region
 	 */
-	List<NaturalIdDataCachingConfig> getNaturalIdCaching();
+	List<? extends NaturalIdDataCachingConfig> getNaturalIdCaching();
 
 	/**
 	 * Retrieve the list of all collection data to be stored in this region
 	 */
-	List<CollectionDataCachingConfig> getCollectionCaching();
+	List<? extends CollectionDataCachingConfig> getCollectionCaching();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/EntityDataCachingConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/spi/EntityDataCachingConfig.java
@@ -34,7 +34,7 @@ public interface EntityDataCachingConfig extends DomainDataCachingConfig {
 	 * version.  If the entity is not versioned, then this method
 	 * returns {@code null}.
 	 */
-	Supplier<Comparator> getVersionComparatorAccess();
+	Supplier<Comparator<?>> getVersionComparatorAccess();
 
 	/**
 	 * The list of specific subclasses of the root that are actually

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
@@ -157,7 +157,7 @@ public class CollectionCacheInvalidator
 			if ( PROPAGATE_EXCEPTION ) {
 				throw new IllegalStateException( e );
 			}
-			// don't let decaching influence other logic
+			// don't let detaching influence other logic
 			LOG.error( "", e );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DisabledCaching.java
@@ -52,7 +52,7 @@ public class DisabledCaching implements CacheImplementor {
 	}
 
 	@Override
-	public boolean containsEntity(Class entityClass, Serializable identifier) {
+	public boolean containsEntity(Class<?> entityClass, Serializable identifier) {
 		return false;
 	}
 
@@ -62,7 +62,7 @@ public class DisabledCaching implements CacheImplementor {
 	}
 
 	@Override
-	public void evictEntityData(Class entityClass, Serializable identifier) {
+	public void evictEntityData(Class<?> entityClass, Serializable identifier) {
 		// nothing to do
 
 	}
@@ -74,7 +74,7 @@ public class DisabledCaching implements CacheImplementor {
 	}
 
 	@Override
-	public void evictEntityData(Class entityClass) {
+	public void evictEntityData(Class<?> entityClass) {
 		// nothing to do
 	}
 
@@ -89,7 +89,7 @@ public class DisabledCaching implements CacheImplementor {
 	}
 
 	@Override
-	public void evictNaturalIdData(Class entityClass) {
+	public void evictNaturalIdData(Class<?> entityClass) {
 		// nothing to do
 	}
 
@@ -218,9 +218,8 @@ public class DisabledCaching implements CacheImplementor {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> T unwrap(Class<T> cls) {
-		return (T) this;
+		return cls.cast( this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/EnabledCaching.java
@@ -56,15 +56,15 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	private final SessionFactoryImplementor sessionFactory;
 	private final RegionFactory regionFactory;
 
-	private final Map<String,Region> regionsByName = new ConcurrentHashMap<>();
+	private final Map<String, Region> regionsByName = new ConcurrentHashMap<>();
 
 	// A map by name for QueryResultsRegion instances that have the same name as a Region
 	// in #regionsByName.
 	private final Map<String, QueryResultsRegion> queryResultsRegionsByDuplicateName = new ConcurrentHashMap<>();
 
-	private final Map<NavigableRole,EntityDataAccess> entityAccessMap = new ConcurrentHashMap<>();
-	private final Map<NavigableRole,NaturalIdDataAccess> naturalIdAccessMap = new ConcurrentHashMap<>();
-	private final Map<NavigableRole,CollectionDataAccess> collectionAccessMap = new ConcurrentHashMap<>();
+	private final Map<NavigableRole, EntityDataAccess> entityAccessMap = new ConcurrentHashMap<>();
+	private final Map<NavigableRole, NaturalIdDataAccess> naturalIdAccessMap = new ConcurrentHashMap<>();
+	private final Map<NavigableRole, CollectionDataAccess> collectionAccessMap = new ConcurrentHashMap<>();
 
 	private final TimestampsCache timestampsCache;
 
@@ -73,7 +73,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 
 
 	private final Set<String> legacySecondLevelCacheNames = new LinkedHashSet<>();
-	private final Map<String,Set<NaturalIdDataAccess>> legacyNaturalIdAccessesForRegion = new ConcurrentHashMap<>();
+	private final Map<String, Set<NaturalIdDataAccess>> legacyNaturalIdAccessesForRegion = new ConcurrentHashMap<>();
 
 	public EnabledCaching(SessionFactoryImplementor sessionFactory) {
 		this.sessionFactory = sessionFactory;
@@ -220,7 +220,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	// Entity data
 
 	@Override
-	public boolean containsEntity(Class entityClass, Serializable identifier) {
+	public boolean containsEntity(Class<?> entityClass, Serializable identifier) {
 		return containsEntity( entityClass.getName(), identifier );
 	}
 
@@ -261,7 +261,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	}
 
 	@Override
-	public void evictEntityData(Class entityClass) {
+	public void evictEntityData(Class<?> entityClass) {
 		evictEntityData( entityClass.getName() );
 	}
 
@@ -306,7 +306,7 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	// Natural-id data
 
 	@Override
-	public void evictNaturalIdData(Class entityClass) {
+	public void evictNaturalIdData(Class<?> entityClass) {
 		evictNaturalIdData( entityClass.getName() );
 	}
 
@@ -538,14 +538,13 @@ public class EnabledCaching implements CacheImplementor, DomainDataRegionBuildin
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> T unwrap(Class<T> cls) {
 		if ( org.hibernate.Cache.class.isAssignableFrom( cls ) ) {
-			return (T) this;
+			return cls.cast( this );
 		}
 
 		if ( RegionFactory.class.isAssignableFrom( cls ) ) {
-			return (T) regionFactory;
+			return cls.cast( regionFactory );
 		}
 
 		throw new PersistenceException( "Hibernate cannot unwrap Cache as " + cls.getName() );

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
@@ -40,7 +40,7 @@ public class NoCachingRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	public void start(SessionFactoryOptions settings, Map configValues) throws CacheException {
+	public void start(SessionFactoryOptions settings, Map<String, Object> configValues) throws CacheException {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
@@ -48,10 +48,9 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked" })
 	public boolean put(
 			final QueryKey key,
-			final List results,
+			final List<?> results,
 			final SharedSessionContractImplementor session) throws HibernateException {
 		if ( SecondLevelCacheLogger.DEBUG_ENABLED ) {
 			SecondLevelCacheLogger.INSTANCE.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getTransactionStartTimestamp() );
@@ -78,8 +77,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked" })
-	public List get(
+	public List<?> get(
 			final QueryKey key,
 			final Set<String> spaces,
 			final SharedSessionContractImplementor session) throws HibernateException {
@@ -110,8 +108,7 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked" })
-	public List get(
+	public List<?> get(
 			final QueryKey key,
 			final String[] spaces,
 			final SharedSessionContractImplementor session) throws HibernateException {
@@ -160,9 +157,9 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 
 	public static class CacheItem implements Serializable {
 		private final long timestamp;
-		private final List results;
+		private final List<?> results;
 
-		CacheItem(long timestamp, List results) {
+		CacheItem(long timestamp, List<?> results) {
 			this.timestamp = timestamp;
 			this.results = results;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/RegionFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/RegionFactoryInitiator.java
@@ -43,7 +43,7 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 	}
 
 	@Override
-	public RegionFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public RegionFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final RegionFactory regionFactory = resolveRegionFactory( configurationValues, registry );
 
 		LOG.debugf( "Cache region factory : %s", regionFactory.getClass().getName() );
@@ -52,8 +52,8 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 	}
 
 
-	@SuppressWarnings({"unchecked", "WeakerAccess"})
-	protected RegionFactory resolveRegionFactory(Map configurationValues, ServiceRegistryImplementor registry) {
+	@SuppressWarnings({"WeakerAccess"})
+	protected RegionFactory resolveRegionFactory(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Properties p = new Properties();
 		p.putAll( configurationValues );
 
@@ -126,8 +126,8 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 		return NoCachingRegionFactory.INSTANCE;
 	}
 
-	@SuppressWarnings({"WeakerAccess", "unused"})
-	protected RegionFactory getFallback(Map configurationValues, ServiceRegistryImplementor registry) {
+	@SuppressWarnings({"WeakerAccess"})
+	protected RegionFactory getFallback(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
@@ -83,7 +83,7 @@ public abstract class AbstractRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	public final void start(SessionFactoryOptions settings, Map configValues) throws CacheException {
+	public final void start(SessionFactoryOptions settings, Map<String, Object> configValues) throws CacheException {
 		if ( started.compareAndSet( false, true ) ) {
 			synchronized (this) {
 				this.options = settings;
@@ -103,7 +103,7 @@ public abstract class AbstractRegionFactory implements RegionFactory {
 		}
 	}
 
-	protected abstract void prepareForUse(SessionFactoryOptions settings, Map configValues);
+	protected abstract void prepareForUse(SessionFactoryOptions settings, Map<String, Object> configValues);
 
 	@Override
 	public final void stop() {

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/QueryResultsCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/QueryResultsCache.java
@@ -39,7 +39,7 @@ public interface QueryResultsCache {
 	 */
 	boolean put(
 			QueryKey key,
-			List result,
+			List<?> result,
 			SharedSessionContractImplementor session) throws HibernateException;
 
 	/**
@@ -53,7 +53,7 @@ public interface QueryResultsCache {
 	 *
 	 * @throws HibernateException Indicates a problem delegating to the underlying cache.
 	 */
-	List get(
+	List<?> get(
 			QueryKey key,
 			Set<String> spaces,
 			SharedSessionContractImplementor session) throws HibernateException;
@@ -69,7 +69,7 @@ public interface QueryResultsCache {
 	 *
 	 * @throws HibernateException Indicates a problem delegating to the underlying cache.
 	 */
-	List get(
+	List<?> get(
 			QueryKey key,
 			String[] spaces,
 			SharedSessionContractImplementor session) throws HibernateException;

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/QuerySpacesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/QuerySpacesHelper.java
@@ -23,8 +23,8 @@ public class QuerySpacesHelper {
 	private QuerySpacesHelper() {
 	}
 
-	public String[] toStringArray(Set spacesSet) {
-		return (String[]) spacesSet.toArray( new String[0] );
+	public String[] toStringArray(Set<String> spacesSet) {
+		return spacesSet.toArray( new String[0] );
 	}
 
 	public Set<String> toStringSet(String[] spacesArray) {

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/RegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/RegionFactory.java
@@ -48,7 +48,7 @@ public interface RegionFactory extends Service, Stoppable {
 	 * considered as a sign to stop {@link org.hibernate.SessionFactory}
 	 * building.
 	 */
-	void start(SessionFactoryOptions settings, Map configValues) throws CacheException;
+	void start(SessionFactoryOptions settings, Map<String, Object> configValues) throws CacheException;
 
 	/**
 	 * By default should we perform "minimal puts" when using this second

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCacheEntry.java
@@ -38,7 +38,7 @@ public class StructuredCacheEntry implements CacheEntryStructure {
 	@Override
 	@SuppressWarnings("unchecked")
 	public Object destructure(Object structured, SessionFactoryImplementor factory) {
-		final Map map = (Map) structured;
+		final Map<String, Object> map = (Map<String, Object>) structured;
 		final String subclass = (String) map.get( SUBCLASS_KEY );
 		final Object version = map.get( VERSION_KEY );
 		final EntityPersister subclassPersister = factory.getEntityPersister( subclass );
@@ -55,11 +55,10 @@ public class StructuredCacheEntry implements CacheEntryStructure {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Object structure(Object item) {
 		final CacheEntry entry = (CacheEntry) item;
 		final String[] names = persister.getPropertyNames();
-		final Map map = new HashMap( names.length + 3, 1f );
+		final Map<String, Object> map = new HashMap<>( names.length + 3, 1f );
 		map.put( SUBCLASS_KEY, entry.getSubclass() );
 		map.put( VERSION_KEY, entry.getVersion() );
 		for ( int i=0; i<names.length; i++ ) {

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCollectionCacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredCollectionCacheEntry.java
@@ -30,8 +30,9 @@ public class StructuredCollectionCacheEntry implements CacheEntryStructure {
 	}
 
 	@Override
+	@SuppressWarnings( "unchecked" )
 	public Object destructure(Object structured, SessionFactoryImplementor factory) {
-		final List list = (List) structured;
+		final List<Serializable> list = (List<Serializable>) structured;
 		return new CollectionCacheEntry( list.toArray( new Serializable[list.size()] ) );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredMapCacheEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StructuredMapCacheEntry.java
@@ -24,11 +24,10 @@ public class StructuredMapCacheEntry implements CacheEntryStructure {
 	public static final StructuredMapCacheEntry INSTANCE = new StructuredMapCacheEntry();
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Object structure(Object item) {
 		final CollectionCacheEntry entry = (CollectionCacheEntry) item;
 		final Serializable[] state = entry.getState();
-		final Map map = CollectionHelper.mapOfSize( state.length );
+		final Map<Serializable, Serializable> map = CollectionHelper.mapOfSize( state.length );
 		int i = 0;
 		while ( i < state.length ) {
 			map.put( state[i++], state[i++] );
@@ -37,13 +36,14 @@ public class StructuredMapCacheEntry implements CacheEntryStructure {
 	}
 
 	@Override
+	@SuppressWarnings( "unchecked" )
 	public Object destructure(Object structured, SessionFactoryImplementor factory) {
-		final Map<?,?> map = (Map<?,?>) structured;
+		final Map<Serializable, Serializable> map = (Map<Serializable, Serializable>) structured;
 		final Serializable[] state = new Serializable[ map.size()*2 ];
 		int i = 0;
-		for ( Map.Entry me : map.entrySet() ) {
-			state[i++] = (Serializable) me.getKey();
-			state[i++] = (Serializable) me.getValue();
+		for ( Map.Entry<Serializable, Serializable> me : map.entrySet() ) {
+			state[i++] = me.getKey();
+			state[i++] = me.getValue();
 		}
 		return new CollectionCacheEntry(state);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractDomainDataRegion.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractDomainDataRegion.java
@@ -123,7 +123,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 
 	private Map<NavigableRole, EntityDataAccess> generateEntityDataAccessMap(
 			DomainDataRegionConfig regionConfig) {
-		final List<EntityDataCachingConfig> entityCaching = regionConfig.getEntityCaching();
+		final List<? extends EntityDataCachingConfig> entityCaching = regionConfig.getEntityCaching();
 		if ( entityCaching.isEmpty() ) {
 			return Collections.emptyMap();
 		}
@@ -140,7 +140,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 	}
 
 	private Map<NavigableRole, NaturalIdDataAccess> generateNaturalIdDataAccessMap(DomainDataRegionConfig regionConfig) {
-		final List<NaturalIdDataCachingConfig> naturalIdCaching = regionConfig.getNaturalIdCaching();
+		final List<? extends NaturalIdDataCachingConfig> naturalIdCaching = regionConfig.getNaturalIdCaching();
 		if ( naturalIdCaching.isEmpty() ) {
 			return Collections.emptyMap();
 		}
@@ -158,7 +158,7 @@ public abstract class AbstractDomainDataRegion extends AbstractRegion implements
 
 	private Map<NavigableRole, CollectionDataAccess> generateCollectionDataAccessMap(
 			DomainDataRegionConfig regionConfig) {
-		final List<CollectionDataCachingConfig> collectionCaching = regionConfig.getCollectionCaching();
+		final List<? extends CollectionDataCachingConfig> collectionCaching = regionConfig.getCollectionCaching();
 		if ( collectionCaching.isEmpty() ) {
 			return Collections.emptyMap();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
@@ -16,6 +16,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.IndexedCollection;
 import org.hibernate.mapping.OneToMany;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Value;
 
@@ -68,7 +69,7 @@ public abstract class CollectionSecondPass implements SecondPass {
 		}
 	}
 
-	abstract public void secondPass(java.util.Map persistentClasses, java.util.Map inheritedMetas)
+	abstract public void secondPass(java.util.Map<String, PersistentClass> persistentClasses, java.util.Map<String, PersistentClass> inheritedMetas)
 			throws MappingException;
 
 	private static String columns(Value val) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SecondPass.java
@@ -8,6 +8,7 @@ package org.hibernate.cfg;
 import java.io.Serializable;
 
 import org.hibernate.MappingException;
+import org.hibernate.mapping.PersistentClass;
 
 /**
  * Second pass operation
@@ -16,7 +17,7 @@ import org.hibernate.MappingException;
  */
 public interface SecondPass extends Serializable {
 
-	void doSecondPass(java.util.Map persistentClasses)
+	void doSecondPass(java.util.Map<String, PersistentClass> persistentClasses)
 				throws MappingException;
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -93,12 +93,12 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 	// in-flight info
 
 	private String explicitBasicTypeName;
-	private Map explicitLocalTypeParams;
+	private Map<String, String> explicitLocalTypeParams;
 
 	private Function<TypeConfiguration,SqlTypeDescriptor> explicitSqlTypeAccess;
-	private Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess;
-	private Function<TypeConfiguration, MutabilityPlan> explicitMutabilityAccess;
-	private Function<TypeConfiguration, Class> implicitJavaTypeAccess;
+	private Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess;
+	private Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityAccess;
+	private Function<TypeConfiguration, Class<?>> implicitJavaTypeAccess;
 
 	private AccessType accessType;
 
@@ -239,12 +239,12 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 
 		// If we get into this method we know that there is a Java type for the value
 		//		and that it is safe to load on the app classloader.
-		final Class modelJavaType = resolveJavaType( modelTypeXClass, buildingContext );
+		final Class<?> modelJavaType = resolveJavaType( modelTypeXClass, buildingContext );
 		if ( modelJavaType == null ) {
 			throw new IllegalStateException( "BasicType requires Java type" );
 		}
 
-		final Class modelPropertyJavaType = buildingContext.getBootstrapContext()
+		final Class<?> modelPropertyJavaType = buildingContext.getBootstrapContext()
 				.getReflectionManager()
 				.toClass( modelXProperty.getType() );
 
@@ -380,12 +380,12 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 		implicitJavaTypeAccess = typeConfiguration -> Integer.class;
 	}
 
+	@SuppressWarnings( "unchecked" )
 	private void prepareCollectionElement(XProperty attributeXProperty, XClass elementTypeXClass) {
 
 		// todo (6.0) : @SqlType / @SqlTypeDescriptor
 
 		Class<T> javaType;
-		//noinspection unchecked
 		if ( elementTypeXClass == null && attributeXProperty.isArray() ) {
 			javaType = buildingContext.getBootstrapContext()
 					.getReflectionManager()
@@ -608,7 +608,7 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 		}
 	}
 
-	private static Class resolveJavaType(XClass returnedClassOrElement, MetadataBuildingContext buildingContext) {
+	private static Class<?> resolveJavaType(XClass returnedClassOrElement, MetadataBuildingContext buildingContext) {
 		return buildingContext.getBootstrapContext()
 					.getReflectionManager()
 					.toClass( returnedClassOrElement );
@@ -685,8 +685,7 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 		this.explicitLocalTypeParams = extractTypeParams( typeAnn.parameters() );
 	}
 
-	@SuppressWarnings("unchecked")
-	private Map extractTypeParams(Parameter[] parameters) {
+	private Map<String, String> extractTypeParams(Parameter[] parameters) {
 		if ( parameters == null || parameters.length == 0 ) {
 			return Collections.emptyMap();
 		}
@@ -695,7 +694,7 @@ public class BasicValueBinder<T> implements SqlTypeDescriptorIndicators {
 			return Collections.singletonMap( parameters[0].name(), parameters[0].value() );
 		}
 
-		final Map map = new HashMap();
+		final Map<String, String> map = new HashMap<>();
 		for ( Parameter parameter: parameters ) {
 			map.put( parameter.name(), parameter.value() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -324,7 +324,7 @@ public class EntityBinder {
 
 		//set persister if needed
 		Persister persisterAnn = annotatedClass.getAnnotation( Persister.class );
-		Class persister = null;
+		Class<?> persister = null;
 		if ( persisterAnn != null ) {
 			persister = persisterAnn.impl();
 		}
@@ -520,7 +520,6 @@ public class EntityBinder {
 		}
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	public void setProxy(Proxy proxy) {
 		if ( proxy != null ) {
 			lazy = proxy.lazy();
@@ -883,12 +882,12 @@ public class EntityBinder {
 		 * Those operations has to be done after the id definition of the persistence class.
 		 * ie after the properties parsing
 		 */
-		Iterator joins = secondaryTables.values().iterator();
-		Iterator joinColumns = secondaryTableJoins.values().iterator();
+		Iterator<Join> joins = secondaryTables.values().iterator();
+		Iterator<Object> joinColumns = secondaryTableJoins.values().iterator();
 
 		while ( joins.hasNext() ) {
 			Object uncastedColumn = joinColumns.next();
-			Join join = (Join) joins.next();
+			Join join = joins.next();
 			createPrimaryColumnsToSecondaryTable( uncastedColumn, propertyHolder, join );
 		}
 	}
@@ -1239,10 +1238,10 @@ public class EntityBinder {
 		//comment and index are processed here
 		if ( table == null ) return;
 		String appliedTable = table.appliesTo();
-		Iterator tables = persistentClass.getTableClosureIterator();
+		Iterator<Table> tables = persistentClass.getTableClosureIterator();
 		Table hibTable = null;
 		while ( tables.hasNext() ) {
-			Table pcTable = (Table) tables.next();
+			Table pcTable = tables.next();
 			if ( pcTable.getQuotedName().equals( appliedTable ) ) {
 				//we are in the correct table to find columns
 				hibTable = pcTable;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -44,7 +44,7 @@ public class IdBagBinder extends BagBinder {
 
 	@Override
 	protected boolean bindStarToManySecondPass(
-			Map persistentClasses,
+			Map<String, PersistentClass> persistentClasses,
 			XClass collType,
 			Ejb3JoinColumn[] fkJoinColumns,
 			Ejb3JoinColumn[] keyColumns,
@@ -83,7 +83,7 @@ public class IdBagBinder extends BagBinder {
 				Nullability.FORCED_NOT_NULL,
 				propertyHolder,
 				propertyData,
-				Collections.EMPTY_MAP,
+				Collections.emptyMap(),
 				buildingContext
 		);
 
@@ -92,7 +92,7 @@ public class IdBagBinder extends BagBinder {
 			idColumn.setNullable( false );
 		}
 
-		final BasicValueBinder valueBinder = new BasicValueBinder( BasicValueBinder.Kind.COLLECTION_ID, buildingContext );
+		final BasicValueBinder<?> valueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.COLLECTION_ID, buildingContext );
 
 		final Table table = collection.getCollectionTable();
 		valueBinder.setTable( table );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
@@ -38,7 +38,7 @@ import org.jboss.logging.Logger;
  * @author Matthew Inger
  * @author Emmanuel Bernard
  */
-@SuppressWarnings({"unchecked", "serial"})
+@SuppressWarnings({"serial"})
 public class ListBinder extends CollectionBinder {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, ListBinder.class.getName() );
 
@@ -82,7 +82,7 @@ public class ListBinder extends CollectionBinder {
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( getBuildingContext(), ListBinder.this.collection ) {
 			@Override
-            public void secondPass(Map persistentClasses, Map inheritedMetas)
+            public void secondPass(Map<String, PersistentClass> persistentClasses, Map<String, PersistentClass> inheritedMetas)
 					throws MappingException {
 				bindStarToManySecondPass(
 						persistentClasses,
@@ -116,7 +116,7 @@ public class ListBinder extends CollectionBinder {
 			List list = (List) this.collection;
 			if ( !list.isOneToMany() ) indexColumn.forceNotNull();
 			indexColumn.setPropertyHolder( valueHolder );
-			final BasicValueBinder valueBinder = new BasicValueBinder( BasicValueBinder.Kind.LIST_INDEX, buildingContext );
+			final BasicValueBinder<?> valueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.LIST_INDEX, buildingContext );
 			valueBinder.setColumns( new Ejb3Column[] { indexColumn } );
 			valueBinder.setExplicitType( "integer" );
 			SimpleValue indexValue = valueBinder.make();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -94,7 +94,7 @@ public class MapBinder extends CollectionBinder {
 			final TableBinder assocTableBinder,
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( buildingContext, MapBinder.this.collection ) {
-			public void secondPass(Map persistentClasses, Map inheritedMetas)
+			public void secondPass(Map<String, PersistentClass> persistentClasses, Map<String, PersistentClass> inheritedMetas)
 					throws MappingException {
 				bindStarToManySecondPass(
 						persistentClasses, collType, fkJoinColumns, keyColumns, inverseColumns, elementColumns,
@@ -138,9 +138,9 @@ public class MapBinder extends CollectionBinder {
 		}
 	}
 
-	private boolean propertyIteratorContainsColumn(Iterator propertyIterator, Column column) {
-		for ( Iterator it = propertyIterator; it.hasNext(); ) {
-			final Property property = (Property) it.next();
+	private boolean propertyIteratorContainsColumn(Iterator<Property> propertyIterator, Column column) {
+		for ( Iterator<Property> it = propertyIterator; it.hasNext(); ) {
+			final Property property = it.next();
 			for ( Iterator<Selectable> selectableIterator = property.getColumnIterator(); selectableIterator.hasNext(); ) {
 				final Selectable selectable = selectableIterator.next();
 				if ( column.equals( selectable ) ) {
@@ -156,7 +156,7 @@ public class MapBinder extends CollectionBinder {
 
 	private void bindKeyFromAssociationTable(
 			XClass collType,
-			Map persistentClasses,
+			Map<String, PersistentClass> persistentClasses,
 			String mapKeyPropertyName,
 			XProperty property,
 			boolean isEmbedded,
@@ -166,7 +166,7 @@ public class MapBinder extends CollectionBinder {
 			String targetPropertyName) {
 		if ( mapKeyPropertyName != null ) {
 			//this is an EJB3 @MapKey
-			PersistentClass associatedClass = (PersistentClass) persistentClasses.get( collType.getName() );
+			PersistentClass associatedClass = persistentClasses.get( collType.getName() );
 			if ( associatedClass == null ) throw new AnnotationException( "Associated class not found: " + collType );
 			Property mapProperty = BinderHelper.findPropertyByName( associatedClass, mapKeyPropertyName );
 			if ( mapProperty == null ) {
@@ -189,7 +189,7 @@ public class MapBinder extends CollectionBinder {
 			//this is a true Map mapping
 			//TODO ugly copy/paste from CollectionBinder.bindManyToManySecondPass
 			String mapKeyType;
-			Class target = void.class;
+			Class<?> target = void.class;
 			/*
 			 * target has priority over reflection for the map key type
 			 * JPA 2 has priority
@@ -203,7 +203,7 @@ public class MapBinder extends CollectionBinder {
 			else {
 				mapKeyType = property.getMapKey().getName();
 			}
-			PersistentClass collectionEntity = (PersistentClass) persistentClasses.get( mapKeyType );
+			PersistentClass collectionEntity = persistentClasses.get( mapKeyType );
 			boolean isIndexOfEntities = collectionEntity != null;
 			ManyToOne element = null;
 			org.hibernate.mapping.Map mapValue = (org.hibernate.mapping.Map) this.collection;
@@ -301,7 +301,7 @@ public class MapBinder extends CollectionBinder {
 					mapValue.setIndex( component );
 				}
 				else {
-					final BasicValueBinder elementBinder = new BasicValueBinder( BasicValueBinder.Kind.MAP_KEY, buildingContext );
+					final BasicValueBinder<?> elementBinder = new BasicValueBinder<>( BasicValueBinder.Kind.MAP_KEY, buildingContext );
 					elementBinder.setReturnedClassName( mapKeyType );
 
 					Ejb3Column[] elementColumns = mapKeyColumns;
@@ -421,11 +421,11 @@ public class MapBinder extends CollectionBinder {
 
 		if ( value instanceof Component ) {
 			Component component = (Component) value;
-			Iterator properties = component.getPropertyIterator();
+			Iterator<Property> properties = component.getPropertyIterator();
 			Component indexComponent = new Component( getBuildingContext(), collection );
 			indexComponent.setComponentClassName( component.getComponentClassName() );
 			while ( properties.hasNext() ) {
-				Property current = (Property) properties.next();
+				Property current = properties.next();
 				Property newProperty = new Property();
 				newProperty.setCascade( current.getCascade() );
 				newProperty.setValueGenerationStrategy( current.getValueGenerationStrategy() );
@@ -498,7 +498,7 @@ public class MapBinder extends CollectionBinder {
 				targetValue = new BasicValue( getBuildingContext(), collection.getCollectionTable() );
 				targetValue.copyTypeFrom( sourceValue );
 			}
-			Iterator columns = sourceValue.getColumnIterator();
+			Iterator<Selectable> columns = sourceValue.getColumnIterator();
 			Random random = new Random();
 			while ( columns.hasNext() ) {
 				Object current = columns.next();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -67,7 +67,7 @@ public class PropertyBinder {
 	private boolean insertable = true;
 	private boolean updatable = true;
 	private String cascade;
-	private BasicValueBinder basicValueBinder;
+	private BasicValueBinder<?> basicValueBinder;
 	private XClass declaringClass;
 	private boolean declaringClassSet;
 	private boolean embedded;
@@ -176,7 +176,7 @@ public class PropertyBinder {
 		final String containerClassName = holder.getClassName();
 		holder.startingProperty( property );
 
-		basicValueBinder = new BasicValueBinder( BasicValueBinder.Kind.ATTRIBUTE, buildingContext );
+		basicValueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.ATTRIBUTE, buildingContext );
 		basicValueBinder.setPropertyName( name );
 		basicValueBinder.setReturnedClassName( returnedClassName );
 		basicValueBinder.setColumns( columns );
@@ -482,7 +482,7 @@ public class PropertyBinder {
 		this.returnedClass = returnedClass;
 	}
 
-	public BasicValueBinder getBasicValueBinder() {
+	public BasicValueBinder<?> getBasicValueBinder() {
 		return basicValueBinder;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
@@ -41,7 +41,7 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		if ( ann == null ) {
 			return;
 		}
@@ -201,7 +201,7 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 		return context.getMetadataCollector().getDatabase().toIdentifier( name ).render();
 	}
 
-	private List<String> getFollowers(Iterator parentPropIter, String reducedName, String name) {
+	private List<String> getFollowers(Iterator<Property> parentPropIter, String reducedName, String name) {
 		boolean hasFollowers = false;
 		List<String> followers = new ArrayList<>();
 		while ( parentPropIter.hasNext() ) {
@@ -217,9 +217,9 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 		return followers;
 	}
 
-	private Iterator getSubPropertyIterator(PersistentClass pc, String reducedName) {
+	private Iterator<Property> getSubPropertyIterator(PersistentClass pc, String reducedName) {
 		Value value = pc.getRecursiveProperty( reducedName ).getValue();
-		Iterator parentPropIter;
+		Iterator<Property> parentPropIter;
 		if ( value instanceof Component ) {
 			Component comp = (Component) value;
 			parentPropIter = comp.getPropertyIterator();
@@ -262,10 +262,10 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 		return parentPropIter;
 	}
 
-	private static int getIndexOfFirstMatchingProperty(List propertyNames, String follower) {
+	private static int getIndexOfFirstMatchingProperty(List<String> propertyNames, String follower) {
 		int propertySize = propertyNames.size();
 		for (int propIndex = 0; propIndex < propertySize; propIndex++) {
-			if ( ( (String) propertyNames.get( propIndex ) ).startsWith( follower ) ) {
+			if ( propertyNames.get( propIndex ).startsWith( follower ) ) {
 				return propIndex;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
@@ -38,6 +38,7 @@ import org.hibernate.mapping.DependantValue;
 import org.hibernate.mapping.JoinedSubclass;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.ToOne;
@@ -50,7 +51,6 @@ import org.jboss.logging.Logger;
  *
  * @author Emmanuel Bernard
  */
-@SuppressWarnings("unchecked")
 public class TableBinder {
 	//TODO move it to a getter/setter strategy
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, TableBinder.class.getName() );
@@ -554,7 +554,7 @@ public class TableBinder {
 			LOG.debugf( "Retrieving property %s.%s", associatedClass.getEntityName(), mappedByProperty );
 
 			final Property property = associatedClass.getRecursiveProperty( columns[0].getMappedBy() );
-			Iterator mappedByColumns;
+			Iterator<Selectable> mappedByColumns;
 			if ( property.getValue() instanceof Collection ) {
 				Collection collection = ( (Collection) property.getValue() );
 				Value element = collection.getElement();
@@ -580,7 +580,7 @@ public class TableBinder {
 			 * if columns are implicit, then create the columns based on the
 			 * referenced entity id columns
 			 */
-			Iterator idColumns;
+			Iterator<Selectable> idColumns;
 			if ( referencedEntity instanceof JoinedSubclass ) {
 				idColumns = referencedEntity.getKey().getColumnIterator();
 			}
@@ -655,7 +655,7 @@ public class TableBinder {
 				}
 				else {
 					//explicit referencedColumnName
-					Iterator idColItr = referencedEntity.getKey().getColumnIterator();
+					Iterator<Selectable> idColItr = referencedEntity.getKey().getColumnIterator();
 					org.hibernate.mapping.Column col;
 					//works cause the pk has to be on the primary table
 					Table table = referencedEntity.getTable();
@@ -706,7 +706,7 @@ public class TableBinder {
 
 	public static void linkJoinColumnWithValueOverridingNameIfImplicit(
 			PersistentClass referencedEntity,
-			Iterator columnIterator,
+			Iterator<Selectable> columnIterator,
 			Ejb3JoinColumn[] columns,
 			SimpleValue value) {
 		for (Ejb3JoinColumn joinCol : columns) {
@@ -723,10 +723,10 @@ public class TableBinder {
 	}
 
 	public static void createUniqueConstraint(Value value) {
-		Iterator iter = value.getColumnIterator();
-		ArrayList cols = new ArrayList();
+		Iterator<Selectable> iter = value.getColumnIterator();
+		ArrayList<Column> cols = new ArrayList<>();
 		while ( iter.hasNext() ) {
-			cols.add( iter.next() );
+			cols.add( (Column) iter.next() );
 		}
 		value.getTable().createUniqueKey( cols );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/ClassLoaderAccessLazyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/ClassLoaderAccessLazyImpl.java
@@ -24,7 +24,7 @@ public class ClassLoaderAccessLazyImpl implements ClassLoaderAccess {
 	}
 
 	@Override
-	public <T> Class<T> classForName(String name) {
+	public Class<?> classForName(String name) {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
@@ -119,7 +119,7 @@ public class JPAMetadataProvider implements MetadataProvider {
 				defaults.put( "catalog", xmlDefaults.getCatalog() );
 				defaults.put( "delimited-identifier", xmlDefaults.getDelimitedIdentifier() );
 				defaults.put( "cascade-persist", xmlDefaults.getCascadePersist() );
-				List<Class> entityListeners = new ArrayList<>();
+				List<Class<?>> entityListeners = new ArrayList<>();
 				for ( String className : xmlContext.getDefaultEntityListeners() ) {
 					try {
 						entityListeners.add( classLoaderAccess.classForName( className ) );
@@ -130,7 +130,6 @@ public class JPAMetadataProvider implements MetadataProvider {
 				}
 				defaults.put( EntityListeners.class, entityListeners );
 				for ( Element element : xmlContext.getAllDocuments() ) {
-					@SuppressWarnings( "unchecked" )
 					List<Element> elements = element.elements( "sequence-generator" );
 					List<SequenceGenerator> sequenceGenerators = ( List<SequenceGenerator> ) defaults.get( SequenceGenerator.class );
 					if ( sequenceGenerators == null ) {
@@ -160,7 +159,7 @@ public class JPAMetadataProvider implements MetadataProvider {
 						namedQueries = new ArrayList<>();
 						defaults.put( NamedQuery.class, namedQueries );
 					}
-					List<NamedQuery> currentNamedQueries = JPAOverriddenAnnotationReader.buildNamedQueries(
+					List<NamedQuery> currentNamedQueries = (List<NamedQuery>) JPAOverriddenAnnotationReader.buildNamedQueries(
 							element,
 							false,
 							xmlDefaults,
@@ -173,7 +172,7 @@ public class JPAMetadataProvider implements MetadataProvider {
 						namedNativeQueries = new ArrayList<>();
 						defaults.put( NamedNativeQuery.class, namedNativeQueries );
 					}
-					List<NamedNativeQuery> currentNamedNativeQueries = JPAOverriddenAnnotationReader.buildNamedQueries(
+					List<NamedNativeQuery> currentNamedNativeQueries = (List<NamedNativeQuery>) JPAOverriddenAnnotationReader.buildNamedQueries(
 							element,
 							true,
 							xmlDefaults,

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -61,7 +61,6 @@ public class XMLContext implements Serializable {
 	 * @param doc The xml document to add
 	 * @return Add an xml document to this context and return the list of added class names.
 	 */
-	@SuppressWarnings( "unchecked" )
 	public List<String> addDocument(Document doc) {
 		hasContext = true;
 		List<String> addedClasses = new ArrayList<>();
@@ -170,7 +169,6 @@ public class XMLContext implements Serializable {
 		List<String> localAddedClasses = new ArrayList<>();
 		Element listeners = element.element( "entity-listeners" );
 		if ( listeners != null ) {
-			@SuppressWarnings( "unchecked" )
 			List<Element> elements = listeners.elements( "entity-listener" );
 			for (Element listener : elements) {
 				String listenerClassName = buildSafeClassName( listener.attributeValue( "class" ), packageName );
@@ -199,7 +197,7 @@ public class XMLContext implements Serializable {
 			final boolean autoApply = Boolean.parseBoolean( autoApplyAttribute );
 
 			try {
-				final Class<? extends AttributeConverter> attributeConverterClass = classLoaderAccess.classForName(
+				final Class<? extends AttributeConverter<?, ?>> attributeConverterClass = (Class<? extends AttributeConverter<?, ?>>)classLoaderAccess.classForName(
 						className
 				);
 				attributeConverterInfoList.add(

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractBagSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractBagSemantics.java
@@ -28,10 +28,10 @@ import org.hibernate.sql.results.graph.FetchParent;
 /**
  * @author Steve Ebersole
  */
-public abstract class AbstractBagSemantics<B extends Collection<?>> implements BagSemantics<B> {
+public abstract class AbstractBagSemantics<B extends Collection<Object>> implements BagSemantics<B> {
 	@Override
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	public Class<B> getCollectionJavaType() {
-		//noinspection unchecked
 		return (Class) Collection.class;
 	}
 
@@ -41,7 +41,7 @@ public abstract class AbstractBagSemantics<B extends Collection<?>> implements B
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		if ( anticipatedSize < 1 ) {
-			return (B) new ArrayList();
+			return (B) new ArrayList<>();
 		}
 		else {
 			return (B) CollectionHelper.arrayList( anticipatedSize );
@@ -49,7 +49,7 @@ public abstract class AbstractBagSemantics<B extends Collection<?>> implements B
 	}
 
 	@Override
-	public Iterator getElementIterator(B rawCollection) {
+	public Iterator<Object> getElementIterator(B rawCollection) {
 		if ( rawCollection == null ) {
 			return null;
 		}
@@ -57,8 +57,7 @@ public abstract class AbstractBagSemantics<B extends Collection<?>> implements B
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitElements(B rawCollection, Consumer action) {
+	public void visitElements(B rawCollection, Consumer<Object> action) {
 		if ( rawCollection != null ) {
 			rawCollection.forEach( action );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractMapSemantics.java
@@ -27,15 +27,15 @@ import org.hibernate.sql.results.graph.FetchParent;
 /**
  * @author Steve Ebersole
  */
-public abstract class AbstractMapSemantics<M extends Map<?,?>> implements MapSemantics<M> {
+public abstract class AbstractMapSemantics<M extends Map<Object, Object>> implements MapSemantics<M> {
 	@Override
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	public Class<M> getCollectionJavaType() {
-		//noinspection unchecked
 		return (Class) Map.class;
 	}
 
 	@Override
-	public Iterator getKeyIterator(M rawMap) {
+	public Iterator<Object> getKeyIterator(M rawMap) {
 		if ( rawMap == null ) {
 			return null;
 		}
@@ -44,16 +44,14 @@ public abstract class AbstractMapSemantics<M extends Map<?,?>> implements MapSem
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitKeys(M rawMap, Consumer action) {
+	public void visitKeys(M rawMap, Consumer<Object> action) {
 		if ( rawMap != null ) {
 			rawMap.keySet().forEach( action );
 		}
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitEntries(M rawMap, BiConsumer action) {
+	public void visitEntries(M rawMap, BiConsumer<Object, Object> action) {
 		if ( rawMap != null ) {
 			rawMap.forEach( action );
 		}
@@ -61,7 +59,7 @@ public abstract class AbstractMapSemantics<M extends Map<?,?>> implements MapSem
 
 
 	@Override
-	public Iterator getElementIterator(Map rawMap) {
+	public Iterator<Object> getElementIterator(M rawMap) {
 		if ( rawMap == null ) {
 			return Collections.emptyIterator();
 		}
@@ -70,8 +68,7 @@ public abstract class AbstractMapSemantics<M extends Map<?,?>> implements MapSem
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitElements(M rawMap, Consumer action) {
+	public void visitElements(M rawMap, Consumer<Object> action) {
 		if ( rawMap != null ) {
 			rawMap.values().forEach( action );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -356,7 +356,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 
 	protected Object readElementByIndex(final Object index) {
 		if ( !initialized ) {
-			class ExtraLazyElementByIndexReader implements LazyInitializationWork {
+			class ExtraLazyElementByIndexReader implements LazyInitializationWork<Object> {
 				private boolean isExtraLazy;
 				private Object element;
 
@@ -379,7 +379,6 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			}
 
 			final ExtraLazyElementByIndexReader reader = new ExtraLazyElementByIndexReader();
-			//noinspection unchecked
 			withTemporarySessionIfNeeded( reader );
 			if ( reader.isExtraLazy ) {
 				return reader.element;
@@ -502,7 +501,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	 * @param copyCache - mapping from entity in the process of being
 	 *                    merged to managed copy.
 	 */
-	public final void replaceQueuedOperationValues(CollectionPersister persister, Map copyCache) {
+	public final void replaceQueuedOperationValues(CollectionPersister persister, Map<Object, Object> copyCache) {
 		for ( DelayedOperation operation : operationQueue ) {
 			if ( ValueDelayedOperation.class.isInstance( operation ) ) {
 				( (ValueDelayedOperation) operation ).replace( persister, copyCache );
@@ -813,9 +812,9 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	}
 
 	@Override
-	public final Iterator queuedAdditionIterator() {
+	public final Iterator<Object> queuedAdditionIterator() {
 		if ( hasQueuedOperations() ) {
-			return new Iterator() {
+			return new Iterator<Object>() {
 				private int index;
 
 				@Override
@@ -840,11 +839,10 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked"})
-	public final Collection getQueuedOrphans(String entityName) {
+	public final Collection<Object> getQueuedOrphans(String entityName) {
 		if ( hasQueuedOperations() ) {
-			final Collection additions = new ArrayList( operationQueue.size() );
-			final Collection removals = new ArrayList( operationQueue.size() );
+			final Collection<Object> additions = new ArrayList<>( operationQueue.size() );
+			final Collection<Object> removals = new ArrayList<>( operationQueue.size() );
 			for ( DelayedOperation operation : operationQueue ) {
 				additions.add( operation.getAddedInstance() );
 				removals.add( operation.getOrphan() );
@@ -852,7 +850,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			return getOrphans( removals, additions, entityName, session );
 		}
 		else {
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		}
 	}
 
@@ -865,7 +863,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	}
 
 	@Override
-	public abstract Collection getOrphans(Serializable snapshot, String entityName) throws HibernateException;
+	public abstract Collection<Object> getOrphans(Serializable snapshot, String entityName) throws HibernateException;
 
 	/**
 	 * Get the session currently associated with this collection.
@@ -876,10 +874,10 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		return session;
 	}
 
-	protected final class IteratorProxy implements Iterator {
-		protected final Iterator itr;
+	protected final class IteratorProxy implements Iterator<Object> {
+		protected final Iterator<Object> itr;
 
-		public IteratorProxy(Iterator itr) {
+		public IteratorProxy(Iterator<Object> itr) {
 			this.itr = itr;
 		}
 
@@ -900,15 +898,14 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 	}
 
-	protected final class ListIteratorProxy implements ListIterator {
-		protected final ListIterator itr;
+	protected final class ListIteratorProxy implements ListIterator<Object> {
+		protected final ListIterator<Object> itr;
 
-		public ListIteratorProxy(ListIterator itr) {
+		public ListIteratorProxy(ListIterator<Object> itr) {
 			this.itr = itr;
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public void add(Object o) {
 			write();
 			itr.add( o );
@@ -951,30 +948,27 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public void set(Object o) {
 			write();
 			itr.set( o );
 		}
 	}
 
-	protected class SetProxy implements java.util.Set {
-		protected final Collection set;
+	protected class SetProxy implements java.util.Set<Object> {
+		protected final Collection<Object> set;
 
-		public SetProxy(Collection set) {
+		public SetProxy(Collection<Object> set) {
 			this.set = set;
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public boolean add(Object o) {
 			write();
 			return set.add( o );
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
-		public boolean addAll(Collection c) {
+		public boolean addAll(Collection<?> c) {
 			write();
 			return set.addAll( c );
 		}
@@ -991,8 +985,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean containsAll(Collection c) {
+		public boolean containsAll(Collection<?> c) {
 			return set.containsAll( c );
 		}
 
@@ -1002,7 +995,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		public Iterator iterator() {
+		public Iterator<Object> iterator() {
 			return new IteratorProxy( set.iterator() );
 		}
 
@@ -1013,15 +1006,13 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean removeAll(Collection c) {
+		public boolean removeAll(Collection<?> c) {
 			write();
 			return set.removeAll( c );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean retainAll(Collection c) {
+		public boolean retainAll(Collection<?> c) {
 			write();
 			return set.retainAll( c );
 		}
@@ -1037,43 +1028,39 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
+		@SuppressWarnings( "unchecked" )
 		public Object[] toArray(Object[] array) {
 			return set.toArray( array );
 		}
 	}
 
-	protected final class ListProxy implements java.util.List {
-		protected final List list;
+	protected final class ListProxy implements java.util.List<Object> {
+		protected final List<Object> list;
 
-		public ListProxy(List list) {
+		public ListProxy(List<Object> list) {
 			this.list = list;
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public void add(int index, Object value) {
 			write();
 			list.add( index, value );
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public boolean add(Object o) {
 			write();
 			return list.add( o );
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
-		public boolean addAll(Collection c) {
+		public boolean addAll(Collection<?> c) {
 			write();
 			return list.addAll( c );
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
-		public boolean addAll(int i, Collection c) {
+		public boolean addAll(int i, Collection<?> c) {
 			write();
 			return list.addAll( i, c );
 		}
@@ -1090,8 +1077,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean containsAll(Collection c) {
+		public boolean containsAll(Collection<?> c) {
 			return list.containsAll( c );
 		}
 
@@ -1111,7 +1097,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		public Iterator iterator() {
+		public Iterator<Object> iterator() {
 			return new IteratorProxy( list.iterator() );
 		}
 
@@ -1121,12 +1107,12 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		public ListIterator listIterator() {
+		public ListIterator<Object> listIterator() {
 			return new ListIteratorProxy( list.listIterator() );
 		}
 
 		@Override
-		public ListIterator listIterator(int i) {
+		public ListIterator<Object> listIterator(int i) {
 			return new ListIteratorProxy( list.listIterator( i ) );
 		}
 
@@ -1143,21 +1129,18 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean removeAll(Collection c) {
+		public boolean removeAll(Collection<?> c) {
 			write();
 			return list.removeAll( c );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public boolean retainAll(Collection c) {
+		public boolean retainAll(Collection<?> c) {
 			write();
 			return list.retainAll( c );
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
 		public Object set(int i, Object o) {
 			write();
 			return list.set( i, o );
@@ -1169,7 +1152,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		public List subList(int i, int j) {
+		public List<Object> subList(int i, int j) {
 			return list.subList( i, j );
 		}
 
@@ -1179,7 +1162,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		}
 
 		@Override
-		@SuppressWarnings({"unchecked"})
+		@SuppressWarnings( "unchecked" )
 		public Object[] toArray(Object[] array) {
 			return list.toArray( array );
 		}
@@ -1198,7 +1181,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	}
 
 	protected interface ValueDelayedOperation extends DelayedOperation {
-		void replace(CollectionPersister collectionPersister, Map copyCache);
+		void replace(CollectionPersister collectionPersister, Map<Object, Object> copyCache);
 	}
 
 	protected abstract class AbstractValueDelayedOperation implements ValueDelayedOperation {
@@ -1210,13 +1193,13 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			this.orphan = orphan;
 		}
 
-		public void replace(CollectionPersister persister, Map copyCache) {
+		public void replace(CollectionPersister persister, Map<Object, Object> copyCache) {
 			if ( addedValue != null ) {
 				addedValue = getReplacement( persister.getElementType(), addedValue, copyCache );
 			}
 		}
 
-		protected final Object getReplacement(Type type, Object current, Map copyCache) {
+		protected final Object getReplacement(Type type, Object current, Map<Object, Object> copyCache) {
 			return type.replace( current, null, session, owner, copyCache );
 		}
 
@@ -1236,10 +1219,10 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	 * belong to the collection, and a collection of instances
 	 * that currently belong, return a collection of orphans
 	 */
-	@SuppressWarnings({"JavaDoc", "unchecked"})
-	protected static Collection getOrphans(
-			Collection oldElements,
-			Collection currentElements,
+	@SuppressWarnings("JavaDoc")
+	protected static Collection<Object> getOrphans(
+			Collection<Object> oldElements,
+			Collection<Object> currentElements,
 			String entityName,
 			SharedSessionContractImplementor session) throws HibernateException {
 
@@ -1258,11 +1241,11 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		final boolean useIdDirect = mayUseIdDirect( idType );
 
 		// create the collection holding the Orphans
-		final Collection res = new ArrayList();
+		final Collection<Object> res = new ArrayList<>();
 
 		// collect EntityIdentifier(s) of the *current* elements - add them into a HashSet for fast access
-		final java.util.Set currentIds = new HashSet();
-		final java.util.Set currentSaving = new IdentitySet();
+		final java.util.Set<Object> currentIds = new HashSet<>();
+		final java.util.Set<Object> currentSaving = new IdentitySet<>();
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		for ( Object current : currentElements ) {
 			if ( current != null && ForeignKeys.isNotTransient( entityName, current, null, session ) ) {
@@ -1312,7 +1295,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	 * @param session The session
 	 */
 	public static void identityRemove(
-			Collection list,
+			Collection<Object> list,
 			Object entityInstance,
 			String entityName,
 			SharedSessionContractImplementor session) {
@@ -1322,7 +1305,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 			final Type idType = entityPersister.getIdentifierType();
 
 			final Object idOfCurrent = ForeignKeys.getEntityIdentifierIfNotUnsaved( entityName, entityInstance, session );
-			final Iterator itr = list.iterator();
+			final Iterator<Object> itr = list.iterator();
 			while ( itr.hasNext() ) {
 				final Object idOfOld = ForeignKeys.getEntityIdentifierIfNotUnsaved( entityName, itr.next(), session );
 				if ( idType.isEqual( idOfCurrent, idOfOld, session.getFactory() ) ) {
@@ -1347,7 +1330,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	 */
 	@Deprecated
 	public static void identityRemove(
-			Collection list,
+			Collection<Object> list,
 			Object entityInstance,
 			String entityName,
 			SessionImplementor session) {

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractSetSemantics.java
@@ -25,15 +25,15 @@ import org.hibernate.sql.results.graph.FetchParent;
 /**
  * @author Steve Ebersole
  */
-public abstract class AbstractSetSemantics<S extends Set<?>> implements CollectionSemantics<S> {
+public abstract class AbstractSetSemantics<S extends Set<Object>> implements CollectionSemantics<S> {
 	@Override
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	public Class<S> getCollectionJavaType() {
-		//noinspection unchecked
 		return (Class) Set.class;
 	}
 
 	@Override
-	public Iterator getElementIterator(Set rawCollection) {
+	public Iterator<Object> getElementIterator(S rawCollection) {
 		if ( rawCollection == null ) {
 			return null;
 		}
@@ -41,8 +41,7 @@ public abstract class AbstractSetSemantics<S extends Set<?>> implements Collecti
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitElements(S rawCollection, Consumer action) {
+	public void visitElements(S rawCollection, Consumer<Object> action) {
 		if ( rawCollection != null ) {
 			rawCollection.forEach( action );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSortedSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/PersistentSortedSet.java
@@ -138,45 +138,39 @@ public class PersistentSortedSet extends PersistentSet implements SortedSet {
 	/**
 	 * wrapper for subSets to propagate write to its backing set
 	 */
-	class SubSetProxy extends SetProxy implements SortedSet {
-		SubSetProxy(SortedSet s) {
+	class SubSetProxy extends SetProxy implements SortedSet<Object> {
+		SubSetProxy(SortedSet<Object> s) {
 			super( s );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public Comparator comparator() {
-			return ( (SortedSet) this.set ).comparator();
+		public Comparator<Object> comparator() {
+			return ( (SortedSet<Object>) this.set ).comparator();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public Object first() {
-			return ( (SortedSet) this.set ).first();
+			return ( (SortedSet<Object>) this.set ).first();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public SortedSet headSet(Object toValue) {
-			return new SubSetProxy( ( (SortedSet) this.set ).headSet( toValue ) );
+		public SortedSet<Object> headSet(Object toValue) {
+			return new SubSetProxy( ( (SortedSet<Object>) this.set ).headSet( toValue ) );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public Object last() {
-			return ( (SortedSet) this.set ).last();
+			return ( (SortedSet<Object>) this.set ).last();
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public SortedSet subSet(Object fromValue, Object toValue) {
-			return new SubSetProxy( ( (SortedSet) this.set ).subSet( fromValue, toValue ) );
+		public SortedSet<Object> subSet(Object fromValue, Object toValue) {
+			return new SubSetProxy( ( (SortedSet<Object>) this.set ).subSet( fromValue, toValue ) );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
-		public SortedSet tailSet(Object fromValue) {
-			return new SubSetProxy( ( (SortedSet) this.set ).tailSet( fromValue ) );
+		public SortedSet<Object> tailSet(Object fromValue) {
+			return new SubSetProxy( ( (SortedSet<Object>) this.set ).tailSet( fromValue ) );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardArraySemantics.java
@@ -72,20 +72,19 @@ public class StandardArraySemantics implements CollectionSemantics<Object[]> {
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			Object[] rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
 		return new PersistentArrayHolder( session, rawCollection );
 	}
 
 	@Override
-	public Iterator getElementIterator(Object[] rawCollection) {
+	public Iterator<Object> getElementIterator(Object[] rawCollection) {
 		return Arrays.stream( rawCollection ).iterator();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitElements(Object[] array, Consumer action) {
+	public void visitElements(Object[] array, Consumer<Object> action) {
 		if ( array == null ) {
 			return;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardBagSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardBagSemantics.java
@@ -18,7 +18,7 @@ import org.hibernate.persister.collection.CollectionPersister;
  *
  * @author Steve Ebersole
  */
-public class StandardBagSemantics extends AbstractBagSemantics<Collection<?>> {
+public class StandardBagSemantics extends AbstractBagSemantics<Collection<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -42,10 +42,10 @@ public class StandardBagSemantics extends AbstractBagSemantics<Collection<?>> {
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			Collection<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentBag( session, (Collection) rawCollection );
+		return new PersistentBag( session, rawCollection );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardIdentifierBagSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardIdentifierBagSemantics.java
@@ -18,7 +18,7 @@ import org.hibernate.persister.collection.CollectionPersister;
  *
  * @author Steve Ebersole
  */
-public class StandardIdentifierBagSemantics<E> extends AbstractBagSemantics<Collection<?>> {
+public class StandardIdentifierBagSemantics extends AbstractBagSemantics<Collection<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -42,9 +42,9 @@ public class StandardIdentifierBagSemantics<E> extends AbstractBagSemantics<Coll
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			Collection<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentIdentifierBag( session, (Collection) rawCollection );
+		return new PersistentIdentifierBag( session, rawCollection );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardListSemantics.java
@@ -32,7 +32,7 @@ import org.hibernate.sql.results.graph.FetchParent;
  *
  * @author Steve Ebersole
  */
-public class StandardListSemantics implements CollectionSemantics<List> {
+public class StandardListSemantics implements CollectionSemantics<List<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -47,25 +47,25 @@ public class StandardListSemantics implements CollectionSemantics<List> {
 	}
 
 	@Override
-	public Class<List> getCollectionJavaType() {
-		return List.class;
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public Class<List<Object>> getCollectionJavaType() {
+		return (Class) List.class;
 	}
 
 	@Override
-	public List instantiateRaw(
+	public List<Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return CollectionHelper.arrayList( anticipatedSize );
 	}
 
 	@Override
-	public Iterator getElementIterator(List rawCollection) {
+	public Iterator<Object> getElementIterator(List<Object> rawCollection) {
 		return rawCollection.iterator();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void visitElements(List rawCollection, Consumer action) {
+	public void visitElements(List<Object> rawCollection, Consumer<Object> action) {
 		rawCollection.forEach( action );
 	}
 
@@ -151,9 +151,9 @@ public class StandardListSemantics implements CollectionSemantics<List> {
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			List<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentList( session, (List) rawCollection );
+		return new PersistentList( session, rawCollection );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardMapSemantics.java
@@ -19,7 +19,7 @@ import org.hibernate.persister.collection.CollectionPersister;
  *
  * @author Steve Ebersole
  */
-public class StandardMapSemantics extends AbstractMapSemantics<Map<?,?>> {
+public class StandardMapSemantics extends AbstractMapSemantics<Map<Object, Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -34,7 +34,7 @@ public class StandardMapSemantics extends AbstractMapSemantics<Map<?,?>> {
 	}
 
 	@Override
-	public Map<?, ?> instantiateRaw(
+	public Map<Object, Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return CollectionHelper.mapOfSize( anticipatedSize );
@@ -50,9 +50,9 @@ public class StandardMapSemantics extends AbstractMapSemantics<Map<?,?>> {
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			Map<Object, Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentMap( session, (Map) rawCollection );
+		return new PersistentMap( session, rawCollection );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
@@ -19,7 +19,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * @author Steve Ebersole
  */
-public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHashMap<?,?>> {
+public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHashMap<Object, Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -34,7 +34,7 @@ public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHash
 	}
 
 	@Override
-	public LinkedHashMap<?, ?> instantiateRaw(
+	public LinkedHashMap<Object, Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? CollectionHelper.linkedMap() : CollectionHelper.linkedMapOfSize( anticipatedSize );
@@ -50,14 +50,14 @@ public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHash
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			LinkedHashMap<Object, Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentMap( session, (Map) rawCollection );
+		return new PersistentMap( session, rawCollection );
 	}
 
 	@Override
-	public Iterator getElementIterator(LinkedHashMap rawCollection) {
+	public Iterator<Object> getElementIterator(LinkedHashMap<Object, Object> rawCollection) {
 		return rawCollection.values().iterator();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedSetSemantics.java
@@ -19,7 +19,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * @author Steve Ebersole
  */
-public class StandardOrderedSetSemantics extends AbstractSetSemantics<LinkedHashSet<?>> {
+public class StandardOrderedSetSemantics extends AbstractSetSemantics<LinkedHashSet<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -34,7 +34,7 @@ public class StandardOrderedSetSemantics extends AbstractSetSemantics<LinkedHash
 	}
 
 	@Override
-	public LinkedHashSet<?> instantiateRaw(
+	public LinkedHashSet<Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? CollectionHelper.linkedSet() : CollectionHelper.linkedSetOfSize( anticipatedSize );
@@ -50,14 +50,14 @@ public class StandardOrderedSetSemantics extends AbstractSetSemantics<LinkedHash
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			LinkedHashSet<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentSet( session, (Set) rawCollection );
+		return new PersistentSet( session, rawCollection );
 	}
 
 	@Override
-	public Iterator getElementIterator(LinkedHashSet rawCollection) {
+	public Iterator<Object> getElementIterator(LinkedHashSet<Object> rawCollection) {
 		return rawCollection.iterator();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSetSemantics.java
@@ -17,7 +17,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * @author Steve Ebersole
  */
-public class StandardSetSemantics extends AbstractSetSemantics<Set<?>> {
+public class StandardSetSemantics extends AbstractSetSemantics<Set<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -32,7 +32,7 @@ public class StandardSetSemantics extends AbstractSetSemantics<Set<?>> {
 	}
 
 	@Override
-	public Set<?> instantiateRaw(
+	public Set<Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
 		return anticipatedSize < 1 ? new HashSet<>() : CollectionHelper.setOfSize( anticipatedSize );
@@ -48,10 +48,10 @@ public class StandardSetSemantics extends AbstractSetSemantics<Set<?>> {
 
 	@Override
 	public PersistentSet wrap(
-			Object rawCollection,
+			Set<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentSet( session, (Set) rawCollection );
+		return new PersistentSet( session, rawCollection );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
@@ -17,7 +17,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * @author Steve Ebersole
  */
-public class StandardSortedMapSemantics extends AbstractMapSemantics<SortedMap<?,?>> {
+public class StandardSortedMapSemantics extends AbstractMapSemantics<SortedMap<Object, Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -32,16 +32,16 @@ public class StandardSortedMapSemantics extends AbstractMapSemantics<SortedMap<?
 	}
 
 	@Override
-	public Class<SortedMap<?, ?>> getCollectionJavaType() {
-		//noinspection unchecked
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public Class<SortedMap<Object, Object>> getCollectionJavaType() {
 		return (Class) SortedMap.class;
 	}
 
 	@Override
-	public TreeMap<?, ?> instantiateRaw(
+	public SortedMap<Object, Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return new TreeMap( collectionDescriptor.getSortingComparator() );
+		return new TreeMap<>( collectionDescriptor.getSortingComparator() );
 	}
 
 	@Override
@@ -54,9 +54,9 @@ public class StandardSortedMapSemantics extends AbstractMapSemantics<SortedMap<?
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			SortedMap<Object, Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentSortedMap( session, (SortedMap) rawCollection );
+		return new PersistentSortedMap( session, rawCollection );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
@@ -18,7 +18,7 @@ import org.hibernate.persister.collection.CollectionPersister;
 /**
  * @author Steve Ebersole
  */
-public class StandardSortedSetSemantics extends AbstractSetSemantics<SortedSet<?>> {
+public class StandardSortedSetSemantics extends AbstractSetSemantics<SortedSet<Object>> {
 	/**
 	 * Singleton access
 	 */
@@ -33,16 +33,16 @@ public class StandardSortedSetSemantics extends AbstractSetSemantics<SortedSet<?
 	}
 
 	@Override
-	public Class<SortedSet<?>> getCollectionJavaType() {
-		//noinspection unchecked
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	public Class<SortedSet<Object>> getCollectionJavaType() {
 		return (Class) SortedSet.class;
 	}
 
 	@Override
-	public SortedSet instantiateRaw(
+	public SortedSet<Object> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return new TreeSet( collectionDescriptor.getSortingComparator() );
+		return new TreeSet<>( collectionDescriptor.getSortingComparator() );
 	}
 
 	@Override
@@ -55,14 +55,14 @@ public class StandardSortedSetSemantics extends AbstractSetSemantics<SortedSet<?
 
 	@Override
 	public PersistentCollection wrap(
-			Object rawCollection,
+			SortedSet<Object> rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session) {
-		return new PersistentSortedSet( session, (SortedSet) rawCollection );
+		return new PersistentSortedSet( session, rawCollection );
 	}
 
 	@Override
-	public Iterator getElementIterator(SortedSet<?> rawCollection) {
+	public Iterator<Object> getElementIterator(SortedSet<Object> rawCollection) {
 		return rawCollection.iterator();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/CollectionSemantics.java
@@ -48,13 +48,13 @@ public interface CollectionSemantics<C> {
 			SharedSessionContractImplementor session);
 
 	PersistentCollection wrap(
-			Object rawCollection,
+			C rawCollection,
 			CollectionPersister collectionDescriptor,
 			SharedSessionContractImplementor session);
 
-	Iterator getElementIterator(C rawCollection);
+	Iterator<Object> getElementIterator(C rawCollection);
 
-	void visitElements(C rawCollection, Consumer action);
+	void visitElements(C rawCollection, Consumer<Object> action);
 
 	/**
 	 * todo (6.0) : clean this contract up!

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/MapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/MapSemantics.java
@@ -16,9 +16,9 @@ import java.util.function.Consumer;
  * @author Steve Ebersole
  */
 public interface MapSemantics<M> extends CollectionSemantics<M> {
-	Iterator getKeyIterator(M rawMap);
+	Iterator<Object> getKeyIterator(M rawMap);
 
-	void visitKeys(M rawMap, Consumer action);
+	void visitKeys(M rawMap, Consumer<Object> action);
 
-	void visitEntries(M rawMap, BiConsumer action);
+	void visitEntries(M rawMap, BiConsumer<Object, Object> action);
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -342,7 +342,7 @@ public interface PersistentCollection {
 	 *
 	 * @return The iterator
 	 */
-	Iterator queuedAdditionIterator();
+	Iterator<Object> queuedAdditionIterator();
 
 	/**
 	 * Get the "queued" orphans
@@ -351,7 +351,7 @@ public interface PersistentCollection {
 	 *
 	 * @return The orphaned elements
 	 */
-	Collection getQueuedOrphans(String entityName);
+	Collection<Object> getQueuedOrphans(String entityName);
 
 	/**
 	 * Get the current collection key value
@@ -446,7 +446,7 @@ public interface PersistentCollection {
 	 *
 	 * @return The orphans
 	 */
-	Collection getOrphans(Serializable snapshot, String entityName);
+	Collection<Object> getOrphans(Serializable snapshot, String entityName);
 
 	void initializeEmptyCollection(CollectionPersister persister);
 

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
@@ -63,7 +63,7 @@ public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 			ThreadLocalSessionContext.class.getName()
 	);
 
-	private static final Class[] SESSION_PROXY_INTERFACES = new Class[] {
+	private static final Class<?>[] SESSION_PROXY_INTERFACES = new Class<?>[] {
 			Session.class,
 			SessionImplementor.class,
 			EventSource.class,
@@ -241,7 +241,6 @@ public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 		return CONTEXT_TL.get();
 	}
 
-	@SuppressWarnings({"unchecked"})
 	private static void doBind(org.hibernate.Session session, SessionFactory factory) {
 		Session orphanedPreviousSession = sessionMap().put( factory, session );
 		terminateOrphanedSession( orphanedPreviousSession );

--- a/hibernate-core/src/main/java/org/hibernate/context/spi/AbstractCurrentSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/spi/AbstractCurrentSessionContext.java
@@ -34,8 +34,8 @@ public abstract class AbstractCurrentSessionContext implements CurrentSessionCon
 		return factory;
 	}
 
-	protected SessionBuilder baseSessionBuilder() {
-		final SessionBuilder builder = factory.withOptions();
+	protected SessionBuilder<?> baseSessionBuilder() {
+		final SessionBuilder<?> builder = factory.withOptions();
 		final CurrentTenantIdentifierResolver resolver = factory.getCurrentTenantIdentifierResolver();
 		if ( resolver != null ) {
 			builder.tenantIdentifier( resolver.resolveCurrentTenantIdentifier() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -149,14 +149,14 @@ abstract class AbstractTransactSQLDialect extends Dialect {
 	@Override
 	public String applyLocksToSql(String sql, LockOptions aliasedLockOptions, Map<String, String[]> keyColumnNames) {
 		// TODO:  merge additional lock options support in Dialect.applyLocksToSql
-		final Iterator itr = aliasedLockOptions.getAliasLockIterator();
+		final Iterator<Map.Entry<String, LockMode>> itr = aliasedLockOptions.getAliasLockIterator();
 		final StringBuilder buffer = new StringBuilder( sql );
 
 		while ( itr.hasNext() ) {
-			final Map.Entry entry = (Map.Entry) itr.next();
-			final LockMode lockMode = (LockMode) entry.getValue();
+			final Map.Entry<String, LockMode> entry = itr.next();
+			final LockMode lockMode = entry.getValue();
 			if ( lockMode.greaterThan( LockMode.READ ) ) {
-				final String alias = (String) entry.getKey();
+				final String alias = entry.getKey();
 				int start = -1;
 				int end = -1;
 				if ( sql.endsWith( " " + alias ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1168,7 +1168,7 @@ public abstract class Dialect implements ConversionContext {
 	 * @deprecated use {@link #getNativeIdentifierGeneratorStrategy()} instead
 	 */
 	@Deprecated
-	public Class getNativeIdentifierGeneratorClass() {
+	public Class<?> getNativeIdentifierGeneratorClass() {
 		return getIdentityColumnSupport().supportsIdentityColumns()
 				? IdentityGenerator.class
 				: SequenceStyleGenerator.class;
@@ -3359,12 +3359,12 @@ public abstract class Dialect implements ConversionContext {
 		 *
 		 * @return a non-null {@link Size}
 		 */
-		Size resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor javaType);
+		Size resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor<?> javaType);
 	}
 
 	public class DefaultSizeStrategyImpl implements DefaultSizeStrategy {
 		@Override
-		public Size resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor javaType) {
+		public Size resolveDefaultSize(SqlTypeDescriptor sqlType, JavaTypeDescriptor<?> javaType) {
 			final Size size = new Size();
 			int jdbcTypeCode = sqlType.getJdbcTypeCode();
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -126,7 +126,7 @@ public class HSQLDialect extends Dialect {
 
 	private static int reflectedVersion(int version) {
 		try {
-			final Class props = ReflectHelper.classForName("org.hsqldb.persist.HsqlDatabaseProperties");
+			final Class<?> props = ReflectHelper.classForName("org.hsqldb.persist.HsqlDatabaseProperties");
 			final String versionString = (String) props.getDeclaredField("THIS_VERSION").get( null );
 
 			return Integer.parseInt( versionString.substring(0, 1) ) * 100

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleTypesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleTypesHelper.java
@@ -50,7 +50,7 @@ public class OracleTypesHelper {
 		}
 	}
 
-	private Class locateOracleTypesClass() {
+	private Class<?> locateOracleTypesClass() {
 		try {
 			return ReflectHelper.classForName( ORACLE_TYPES_CLASS_NAME );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -50,9 +50,14 @@ public class SpannerDialect extends Dialect {
 
 	private static final LockingStrategy LOCKING_STRATEGY = new DoNothingLockingStrategy();
 
-	private static final EmptyExporter NOOP_EXPORTER = new EmptyExporter();
+	private static final EmptyExporter<Exportable> NOOP_EXPORTER = new EmptyExporter<>();
 
 	private static final UniqueDelegate NOOP_UNIQUE_DELEGATE = new DoNothingUniqueDelegate();
+
+	@SuppressWarnings( "unchecked" )
+	private static <T extends Exportable> EmptyExporter<T> emptyExporter() {
+		return (EmptyExporter<T>) NOOP_EXPORTER;
+	}
 
 	public SpannerDialect() {
 		registerColumnType( Types.BOOLEAN, "bool" );
@@ -680,17 +685,17 @@ public class SpannerDialect extends Dialect {
 
 	@Override
 	public Exporter<Sequence> getSequenceExporter() {
-		return NOOP_EXPORTER;
+		return emptyExporter();
 	}
 
 	@Override
 	public Exporter<ForeignKey> getForeignKeyExporter() {
-		return NOOP_EXPORTER;
+		return emptyExporter();
 	}
 
 	@Override
 	public Exporter<Constraint> getUniqueKeyExporter() {
-		return NOOP_EXPORTER;
+		return emptyExporter();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CurrentFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CurrentFunction.java
@@ -24,7 +24,7 @@ public class CurrentFunction
 
 	private final String sql;
 
-	public CurrentFunction(String name, String sql, BasicType type) {
+	public CurrentFunction(String name, String sql, BasicType<?> type) {
 		super(
 				name,
 				StandardArgumentsValidators.NO_ARGS,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
@@ -47,7 +47,8 @@ public class ExtractFunction
 	}
 
 	@Override
-	protected <T> SelfRenderingSqmFunction generateSqmFunctionExpression(
+	@SuppressWarnings( "unchecked" )
+	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
 			List<SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
@@ -58,25 +59,25 @@ public class ExtractFunction
 		TemporalUnit unit = field.getUnit();
 		switch ( unit ) {
 			case NANOSECOND:
-				return extractNanoseconds( expression, queryEngine, typeConfiguration );
+				return (SelfRenderingSqmFunction<T>) extractNanoseconds( expression, queryEngine, typeConfiguration );
 			case NATIVE:
 				throw new SemanticException("can't extract() the field TemporalUnit.NATIVE");
 			case OFFSET:
 				// use format(arg, 'xxx') to get the offset
-				return extractOffsetUsingFormat( expression, queryEngine, typeConfiguration );
+				return (SelfRenderingSqmFunction<T>) extractOffsetUsingFormat( expression, queryEngine, typeConfiguration );
 			case DATE:
 			case TIME:
 				// use cast(arg as Type) to get the date or time part
 				// which might be javax.sql.Date / javax.sql.Time or
 				// java.time.LocalDate / java.time.LocalTime depending
 				// on the type of the expression we're extracting from
-				return extractDateOrTimeUsingCast( expression, field.getType(), queryEngine, typeConfiguration );
+				return (SelfRenderingSqmFunction<T>) extractDateOrTimeUsingCast( expression, field.getType(), queryEngine, typeConfiguration );
 			case WEEK_OF_MONTH:
 				// use ceiling(extract(day of month, arg)/7.0)
-				return extractWeek( expression, field, DAY_OF_MONTH, queryEngine, typeConfiguration);
+				return (SelfRenderingSqmFunction<T>) extractWeek( expression, field, DAY_OF_MONTH, queryEngine, typeConfiguration);
 			case WEEK_OF_YEAR:
 				// use ceiling(extract(day of year, arg)/7.0)
-				return extractWeek( expression, field, DAY_OF_YEAR, queryEngine, typeConfiguration);
+				return (SelfRenderingSqmFunction<T>) extractWeek( expression, field, DAY_OF_YEAR, queryEngine, typeConfiguration);
 			default:
 				// otherwise it's something we expect the SQL dialect
 				// itself to understand, either natively, or via the

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/StandardSQLFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/StandardSQLFunction.java
@@ -16,23 +16,23 @@ import org.hibernate.query.sqm.function.NamedSqmFunctionDescriptor;
  *
  * @author David Channon
  */
-public class StandardSQLFunction extends NamedSqmFunctionDescriptor {
-	private final AllowableFunctionReturnType type;
+public class StandardSQLFunction<T> extends NamedSqmFunctionDescriptor {
+	private final AllowableFunctionReturnType<T> type;
 
 	public StandardSQLFunction(String name) {
 		this( name, null );
 	}
 
-	public StandardSQLFunction(String name, AllowableFunctionReturnType type) {
+	public StandardSQLFunction(String name, AllowableFunctionReturnType<T> type) {
 		this( name, true, type );
 	}
 
-	public StandardSQLFunction(String name, boolean useParentheses, AllowableFunctionReturnType type) {
+	public StandardSQLFunction(String name, boolean useParentheses, AllowableFunctionReturnType<T> type) {
 		super( name, useParentheses, null, null );
 		this.type = type;
 	}
 
-	public AllowableFunctionReturnType getType() {
+	public AllowableFunctionReturnType<T> getType() {
 		return type;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/TrimFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/TrimFunction.java
@@ -42,6 +42,7 @@ public class TrimFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 	@Override
 	public void render(SqlAppender sqlAppender, List<SqlAstNode> sqlAstArguments, SqlAstWalker walker) {
 		final TrimSpec specification = ( (TrimSpecification) sqlAstArguments.get( 0 ) ).getSpecification();
+		@SuppressWarnings( "unchecked" )
 		final Character trimCharacter = ( (QueryLiteral<Character>) sqlAstArguments.get( 1 ) ).getLiteralValue();
 		final Expression sourceExpr = (Expression) sqlAstArguments.get( 2 );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -84,7 +84,7 @@ public class UpdateLockingStrategy implements LockingStrategy {
 			final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
 			final PreparedStatement st = jdbcCoordinator.getStatementPreparer().prepareStatement( sql );
 			try {
-				final VersionType lockableVersionType = lockable.getVersionType();
+				final VersionType<?> lockableVersionType = lockable.getVersionType();
 				lockableVersionType.nullSafeSet( st, version, 1, session );
 				int offset = 2;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
@@ -29,7 +29,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 			ConfigurationServiceImpl.class.getName()
 	);
 
-	private final Map settings;
+	private final Map<String, Object> settings;
 	private ServiceRegistryImplementor serviceRegistry;
 
 	/**
@@ -37,13 +37,12 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 	 *
 	 * @param settings The map of settings
 	 */
-	@SuppressWarnings( "unchecked" )
-	public ConfigurationServiceImpl(Map settings) {
+	public ConfigurationServiceImpl(Map<String, Object> settings) {
 		this.settings = Collections.unmodifiableMap( settings );
 	}
 
 	@Override
-	public Map getSettings() {
+	public Map<String, Object> getSettings() {
 		return settings;
 	}
 
@@ -75,14 +74,13 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> T cast(Class<T> expected, Object candidate){
 		if (candidate == null) {
 			return null;
 		}
 
 		if ( expected.isInstance( candidate ) ) {
-			return (T) candidate;
+			return expected.cast( candidate );
 		}
 
 		Class<T> target;

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceInitiator.java
@@ -24,7 +24,7 @@ public class ConfigurationServiceInitiator implements StandardServiceInitiator<C
 	public static final ConfigurationServiceInitiator INSTANCE = new ConfigurationServiceInitiator();
 
 	@Override
-	public ConfigurationService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public ConfigurationService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new ConfigurationServiceImpl( configurationValues );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/spi/ConfigurationService.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/spi/ConfigurationService.java
@@ -27,7 +27,7 @@ public interface ConfigurationService extends Service {
 	 *
 	 * @return The immutable map of config settings.
 	 */
-	public Map getSettings();
+	public Map<String, Object> getSettings();
 
 	/**
 	 * Get the named setting, using the specified converter.

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -440,7 +440,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 			return null;
 		}
 		if ( extraStateType.isAssignableFrom( next.getClass() ) ) {
-			return (T) next;
+			return extraStateType.cast( next );
 		}
 		else {
 			return next.getExtraState( extraStateType );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
@@ -520,7 +520,7 @@ public final class Cascade {
 				LOG.tracev( "Cascade {0} for collection: {1}", action, collectionType.getRole() );
 			}
 
-			final Iterator itr = action.getCascadableChildrenIterator( eventSource, collectionType, child );
+			final Iterator<Object> itr = action.getCascadableChildrenIterator( eventSource, collectionType, child );
 			while ( itr.hasNext() ) {
 				cascadeProperty(
 						action,
@@ -571,11 +571,11 @@ public final class Cascade {
 	 */
 	private static void deleteOrphans(EventSource eventSource, String entityName, PersistentCollection pc) throws HibernateException {
 		//TODO: suck this logic into the collection!
-		final Collection orphans;
+		final Collection<Object> orphans;
 		if ( pc.wasInitialized() ) {
 			final CollectionEntry ce = eventSource.getPersistenceContextInternal().getCollectionEntry( pc );
 			orphans = ce==null
-					? java.util.Collections.EMPTY_LIST
+					? java.util.Collections.emptyList()
 					: ce.getOrphans( entityName, pc );
 		}
 		else {
@@ -585,7 +585,7 @@ public final class Cascade {
 		for ( Object orphan : orphans ) {
 			if ( orphan != null ) {
 				LOG.tracev( "Deleting orphaned entity instance: {0}", entityName );
-				eventSource.delete( entityName, orphan, false, new HashSet() );
+				eventSource.delete( entityName, orphan, false, new HashSet<>() );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -51,8 +51,7 @@ public class EntityEntryContext {
 
 	private transient IdentityHashMap<Object,ManagedEntity> nonEnhancedEntityXref;
 
-	@SuppressWarnings( {"unchecked"})
-	private transient Map.Entry<Object,EntityEntry>[] reentrantSafeEntries = new Map.Entry[0];
+	private transient Map.Entry<Object,EntityEntry>[] reentrantSafeEntries = new EntityEntryCrossRefImpl[0];
 	private transient boolean dirty;
 
 	/**
@@ -488,7 +487,7 @@ public class EntityEntryContext {
 		EntityEntry entry = null;
 
 		final String entityEntryClassName = new String( entityEntryClassNameArr );
-		final Class entityEntryClass =   rtn.getSession().getFactory().getServiceRegistry().getService( ClassLoaderService.class ).classForName( entityEntryClassName );
+		final Class<?> entityEntryClass =   rtn.getSession().getFactory().getServiceRegistry().getService( ClassLoaderService.class ).classForName( entityEntryClassName );
 
 		try {
 			final Method deserializeMethod = entityEntryClass.getDeclaredMethod( "deserialize", ObjectInputStream.class,	PersistenceContext.class );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryExtraStateHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryExtraStateHolder.java
@@ -44,7 +44,7 @@ public class EntityEntryExtraStateHolder implements EntityEntryExtraState {
 			return null;
 		}
 		if ( extraStateType.isAssignableFrom( next.getClass() ) ) {
-			return (T) next;
+			return extraStateType.cast( next );
 		}
 		else {
 			return next.getExtraState( extraStateType );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
@@ -153,7 +153,7 @@ public final class Nullability {
 			if ( collectionElementType.isComponentType() ) {
 				// check for all components values in the collection
 				final CompositeType componentType = (CompositeType) collectionElementType;
-				final Iterator itr = CascadingActions.getLoadedElementsIterator( session, collectionType, value );
+				final Iterator<Object> itr = CascadingActions.getLoadedElementsIterator( session, collectionType, value );
 				while ( itr.hasNext() ) {
 					final Object compositeElement = itr.next();
 					if ( compositeElement != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/ParameterBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/ParameterBinder.java
@@ -116,18 +116,18 @@ public class ParameterBinder {
 
 	private static int bindNamedParameters(
 			final PreparedStatement ps,
-			final Map namedParams,
+			final Map<String, TypedValue> namedParams,
 			final int start,
 			final NamedParameterSource source,
 			final SessionImplementor session) throws SQLException, HibernateException {
 		if ( namedParams != null ) {
 			// assumes that types are all of span 1
-			final Iterator iter = namedParams.entrySet().iterator();
+			final Iterator<Map.Entry<String, TypedValue>> iter = namedParams.entrySet().iterator();
 			int result = 0;
 			while ( iter.hasNext() ) {
-				final Map.Entry e = (Map.Entry) iter.next();
-				final String name = (String) e.getKey();
-				final TypedValue typedVal = (TypedValue) e.getValue();
+				final Map.Entry<String, TypedValue> e = iter.next();
+				final String name = e.getKey();
+				final TypedValue typedVal = e.getValue();
 				final int[] locations = source.getNamedParameterLocations( name );
 				for ( int location : locations ) {
 					if ( LOG.isDebugEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -171,7 +171,6 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 	private ConcurrentMap<EntityKey, Object> getOrInitializeProxiesByKey() {
 		if ( proxiesByKey == null ) {
-			//noinspection unchecked
 			proxiesByKey = new ConcurrentReferenceHashMap<>(
 					INIT_COLL_SIZE,
 					.75f,
@@ -418,7 +417,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		if ( entitiesByKey != null ) {
 			entity = entitiesByKey.remove( key );
 			if ( entitiesByUniqueKey != null ) {
-				final Iterator itr = entitiesByUniqueKey.values().iterator();
+				final Iterator<Object> itr = entitiesByUniqueKey.values().iterator();
 				while ( itr.hasNext() ) {
 					if ( itr.next() == entity ) {
 						itr.remove();
@@ -699,11 +698,10 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Object narrowProxy(Object proxy, EntityPersister persister, EntityKey key, Object object)
 			throws HibernateException {
 
-		final Class concreteProxyClass = persister.getConcreteProxyClass();
+		final Class<?> concreteProxyClass = persister.getConcreteProxyClass();
 		final boolean alreadyNarrow = concreteProxyClass.isInstance( proxy );
 
 		if ( !alreadyNarrow ) {
@@ -1080,7 +1078,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public HashSet getNullifiableEntityKeys() {
+	public HashSet<EntityKey> getNullifiableEntityKeys() {
 		if ( nullifiableEntityKeys == null ) {
 			nullifiableEntityKeys = new HashSet<>();
 		}
@@ -1094,12 +1092,12 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 */
 	@Deprecated
 	@Override
-	public Map getEntitiesByKey() {
+	public Map<EntityKey, Object> getEntitiesByKey() {
 		return entitiesByKey == null ? Collections.emptyMap() : entitiesByKey;
 	}
 
 	@Override
-	public Iterator managedEntitiesIterator() {
+	public Iterator<Object> managedEntitiesIterator() {
 		if ( entitiesByKey == null ) {
 			return Collections.emptyIterator();
 		}
@@ -1114,7 +1112,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Map getEntityEntries() {
+	public Map<Object, EntityEntry> getEntityEntries() {
 		return null;
 	}
 
@@ -1125,7 +1123,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 */
 	@Override
 	@Deprecated
-	public Map getCollectionEntries() {
+	public Map<PersistentCollection, CollectionEntry> getCollectionEntries() {
 		return getOrInitializeCollectionEntries();
 	}
 
@@ -1144,7 +1142,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Map getCollectionsByKey() {
+	public Map<CollectionKey, PersistentCollection> getCollectionsByKey() {
 		if ( collectionsByKey == null ) {
 			return Collections.emptyMap();
 		}
@@ -1252,7 +1250,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Object getOwnerId(String entityName, String propertyName, Object childEntity, Map mergeMap) {
+	public Object getOwnerId(String entityName, String propertyName, Object childEntity, Map<Object, Object> mergeMap) {
 		final String collectionRole = entityName + '.' + propertyName;
 		final EntityPersister persister = session.getFactory().getMetamodel().entityPersister( entityName );
 		final CollectionPersister collectionPersister = session.getFactory().getMetamodel().collectionPersister( collectionRole );
@@ -1319,8 +1317,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		// 		NOTE: decided to put this here rather than in the above loop as I was nervous about the performance
 		//		of the loop-in-loop especially considering this is far more likely the 'edge case'
 		if ( mergeMap != null ) {
-			for ( Object o : mergeMap.entrySet() ) {
-				final Entry mergeMapEntry = (Entry) o;
+			for ( Map.Entry<Object, Object> mergeMapEntry : mergeMap.entrySet() ) {
 				if ( mergeMapEntry.getKey() instanceof HibernateProxy ) {
 					final HibernateProxy proxy = (HibernateProxy) mergeMapEntry.getKey();
 					if ( persister.isSubclassEntityName( proxy.getHibernateLazyInitializer().getEntityName() ) ) {
@@ -1379,7 +1376,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Object getIndexInOwner(String entity, String property, Object childEntity, Map mergeMap) {
+	public Object getIndexInOwner(String entity, String property, Object childEntity, Map<Object, Object> mergeMap) {
 		final MetamodelImplementor metamodel = session.getFactory().getMetamodel();
 		final EntityPersister persister = metamodel.entityPersister( entity );
 		final CollectionPersister cp = metamodel.collectionPersister( entity + '.' + property );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/UnsavedValueFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/UnsavedValueFactory.java
@@ -35,7 +35,7 @@ public class UnsavedValueFactory {
 	 *
 	 * @throws InstantiationException if something went wrong
 	 */
-	private static Object instantiate(Constructor constructor) {
+	private static Object instantiate(Constructor<?> constructor) {
 		try {
 			return constructor.newInstance();
 		}
@@ -61,7 +61,7 @@ public class UnsavedValueFactory {
 			String unsavedValue,
 			Getter identifierGetter,
 			Type identifierType,
-			Constructor constructor) {
+			Constructor<?> constructor) {
 		if ( unsavedValue == null ) {
 			if ( identifierGetter != null && constructor != null ) {
 				// use the id value of a newly instantiated instance as the unsaved-value
@@ -69,7 +69,7 @@ public class UnsavedValueFactory {
 				return new IdentifierValue( defaultValue );
 			}
 			else if ( identifierGetter != null && (identifierType instanceof PrimitiveType) ) {
-				final Serializable defaultValue = ( (PrimitiveType) identifierType ).getDefaultValue();
+				final Serializable defaultValue = ( (PrimitiveType<?>) identifierType ).getDefaultValue();
 				return new IdentifierValue( defaultValue );
 			}
 			else {
@@ -90,7 +90,7 @@ public class UnsavedValueFactory {
 		}
 		else {
 			try {
-				return new IdentifierValue( (Serializable) ( (IdentifierType) identifierType ).stringToObject( unsavedValue ) );
+				return new IdentifierValue( (Serializable) ( (IdentifierType<?>) identifierType ).stringToObject( unsavedValue ) );
 			}
 			catch ( ClassCastException cce ) {
 				throw new MappingException( "Bad identifier type: " + identifierType.getName() );
@@ -117,8 +117,8 @@ public class UnsavedValueFactory {
 	public static VersionValue getUnsavedVersionValue(
 			String versionUnsavedValue, 
 			Getter versionGetter,
-			VersionType versionType,
-			Constructor constructor) {
+			VersionType<?> versionType,
+			Constructor<?> constructor) {
 		
 		if ( versionUnsavedValue == null ) {
 			if ( constructor!=null ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
@@ -38,7 +38,7 @@ public final class Versioning {
 	 * @param session The originating session
 	 * @return The initial optimistic locking value
 	 */
-	private static Object seed(VersionType versionType, SharedSessionContractImplementor session) {
+	private static Object seed(VersionType<?> versionType, SharedSessionContractImplementor session) {
 		final Object seed = versionType.seed( session );
 		LOG.tracef( "Seeding: %s", seed );
 		return seed;
@@ -59,7 +59,7 @@ public final class Versioning {
 	public static boolean seedVersion(
 			Object[] fields,
 			int versionProperty,
-			VersionType versionType,
+			VersionType<?> versionType,
 			SharedSessionContractImplementor session) {
 		final Object initialVersion = fields[versionProperty];
 		if (
@@ -87,8 +87,7 @@ public final class Versioning {
 	 * @param session The originating session
 	 * @return The incremented optimistic locking value.
 	 */
-	@SuppressWarnings("unchecked")
-	public static Object increment(Object version, VersionType versionType, SharedSessionContractImplementor session) {
+	public static Object increment(Object version, VersionType<Object> versionType, SharedSessionContractImplementor session) {
 		final Object next = versionType.next( version, session );
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingAction.java
@@ -49,7 +49,7 @@ public interface CascadingAction {
 	 * @param collection The collection instance.
 	 * @return The children iterator.
 	 */
-	Iterator getCascadableChildrenIterator(
+	Iterator<Object> getCascadableChildrenIterator(
 			EventSource session,
 			CollectionType collectionType,
 			Object collection);

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
@@ -470,7 +470,7 @@ public class CascadingActions {
 	 *
 	 * @return The children iterator.
 	 */
-	public static Iterator getAllElementsIterator(
+	public static Iterator<Object> getAllElementsIterator(
 			EventSource session,
 			CollectionType collectionType,
 			Object collection) {
@@ -481,7 +481,7 @@ public class CascadingActions {
 	 * Iterate just the elements of the collection that are already there. Don't load
 	 * any new elements from the database.
 	 */
-	public static Iterator getLoadedElementsIterator(
+	public static Iterator<Object> getLoadedElementsIterator(
 			SharedSessionContractImplementor session,
 			CollectionType collectionType,
 			Object collection) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
@@ -380,7 +380,7 @@ public final class CollectionEntry implements Serializable {
 	/**
 	 * Get the collection orphans (entities which were removed from the collection)
 	 */
-	public Collection getOrphans(String entityName, PersistentCollection collection) throws HibernateException {
+	public Collection<Object> getOrphans(String entityName, PersistentCollection collection) throws HibernateException {
 		if ( snapshot == null ) {
 			throw new AssertionFailure( "no collection snapshot for orphan delete" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -484,7 +484,7 @@ public interface PersistenceContext {
 	 * @deprecated Use {@link #containsNullifiableEntityKey(Supplier)} or {@link #registerNullifiableEntityKey(EntityKey)} or {@link #isNullifiableEntityKeysEmpty()}
 	 */
 	@Deprecated
-	HashSet getNullifiableEntityKeys();
+	HashSet<EntityKey> getNullifiableEntityKeys();
 
 	/**
 	 * Get the mapping from key value to entity instance
@@ -492,7 +492,7 @@ public interface PersistenceContext {
 	 * for specific access needs. Consider using #iterateEntities instead.
 	 */
 	@Deprecated
-	Map getEntitiesByKey();
+	Map<EntityKey, Object> getEntitiesByKey();
 
 	/**
 	 * Provides access to the entity/EntityEntry combos associated with the persistence context in a manner that
@@ -508,7 +508,7 @@ public interface PersistenceContext {
 	 * {@link #reentrantSafeEntityEntries}
 	 */
 	@Deprecated
-	Map getEntityEntries();
+	Map<Object, EntityEntry> getEntityEntries();
 
 	int getNumberOfManagedEntities();
 
@@ -517,7 +517,7 @@ public interface PersistenceContext {
 	 * @deprecated use {@link #removeCollectionEntry(PersistentCollection)} or {@link #getCollectionEntriesSize()}, {@link #forEachCollectionEntry(BiConsumer,boolean)}.
 	 */
 	@Deprecated
-	Map getCollectionEntries();
+	Map<PersistentCollection, CollectionEntry> getCollectionEntries();
 
 	/**
 	 * Execute some action on each entry of the collectionEntries map, optionally iterating on a defensive copy.
@@ -534,7 +534,7 @@ public interface PersistenceContext {
 	 * N.B. This might return an immutable map: do not use for mutations!
 	 */
 	@Deprecated
-	Map getCollectionsByKey();
+	Map<CollectionKey, PersistentCollection> getCollectionsByKey();
 
 	/**
 	 * How deep are we cascaded?
@@ -604,13 +604,13 @@ public interface PersistenceContext {
 	 * @return The id of the entityName instance which is said to own the child; null if an appropriate owner not
 	 * located.
 	 */
-	Object getOwnerId(String entityName, String propertyName, Object childEntity, Map mergeMap);
+	Object getOwnerId(String entityName, String propertyName, Object childEntity, Map<Object, Object> mergeMap);
 
 	/**
 	 * Search the persistence context for an index of the child object,
 	 * given a collection role
 	 */
-	Object getIndexInOwner(String entity, String property, Object childObject, Map mergeMap);
+	Object getIndexInOwner(String entity, String property, Object childObject, Map<Object, Object> mergeMap);
 
 	/**
 	 * Record the fact that the association belonging to the keyed
@@ -798,7 +798,7 @@ public interface PersistenceContext {
 	/**
 	 * A read-only iterator on all entities managed by this persistence context
 	 */
-	Iterator managedEntitiesIterator();
+	Iterator<Object> managedEntitiesIterator();
 
 	/**
 	 * Provides centralized access to natural-id-related functionality.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -150,7 +150,7 @@ public interface SessionImplementor extends Session, SharedSessionContractImplem
 	 * @deprecated  OperationalContext should cover this overload I believe; Gail?
 	 */
 	@Deprecated
-	void delete(String entityName, Object child, boolean isCascadeDeleteEnabled, Set transientEntities);
+	void delete(String entityName, Object child, boolean isCascadeDeleteEnabled, Set<Object> transientEntities);
 
 	/**
 	 * @deprecated  OperationalContext should cover this overload I believe; Gail?

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -103,7 +103,6 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 		logFlushResults( event );
 	}
 
-	@SuppressWarnings( value = {"unchecked"} )
 	private void logFlushResults(FlushEvent event) {
 		if ( !LOG.isDebugEnabled() ) {
 			return;
@@ -164,7 +163,7 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 
 	protected Object getAnything() {
 		if ( jpaBootstrap ) {
-			return new IdentityHashMap( 10 );
+			return new IdentityHashMap<>( 10 );
 		}
 		else {
 			return null;
@@ -243,7 +242,6 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 	 * process any unreferenced collections and then inspect all known collections,
 	 * scheduling creates/removes/updates
 	 */
-	@SuppressWarnings("unchecked")
 	private int flushCollections(final EventSource session, final PersistenceContext persistenceContext) throws HibernateException {
 		LOG.trace( "Processing unreferenced collections" );
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -352,7 +352,7 @@ public abstract class AbstractSaveEventListener
 		}
 	}
 
-	protected Map getMergeMap(Object anything) {
+	protected Map<Object, Object> getMergeMap(Object anything) {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -69,7 +69,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 	 * @throws HibernateException
 	 */
 	public void onDelete(DeleteEvent event) throws HibernateException {
-		onDelete( event, new IdentitySet() );
+		onDelete( event, new IdentitySet<>() );
 	}
 
 	/**
@@ -80,7 +80,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 	 *
 	 * @throws HibernateException
 	 */
-	public void onDelete(DeleteEvent event, Set transientEntities) throws HibernateException {
+	public void onDelete(DeleteEvent event, Set<Object> transientEntities) throws HibernateException {
 
 		final EventSource source = event.getSession();
 
@@ -210,7 +210,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			Object entity,
 			boolean cascadeDeleteEnabled,
 			EntityPersister persister,
-			Set transientEntities) {
+			Set<Object> transientEntities) {
 		LOG.handlingTransientEntity();
 		if ( transientEntities.contains( entity ) ) {
 			LOG.trace( "Already handled transient entity; skipping" );
@@ -240,7 +240,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			final boolean isCascadeDeleteEnabled,
 			final boolean isOrphanRemovalBeforeUpdates,
 			final EntityPersister persister,
-			final Set transientEntities) {
+			final Set<Object> transientEntities) {
 
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracev(
@@ -347,7 +347,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			EntityPersister persister,
 			Object entity,
 			EntityEntry entityEntry,
-			Set transientEntities) throws HibernateException {
+			Set<Object> transientEntities) throws HibernateException {
 
 		CacheMode cacheMode = session.getCacheMode();
 		session.setCacheMode( CacheMode.GET );
@@ -374,7 +374,7 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 			EventSource session,
 			EntityPersister persister,
 			Object entity,
-			Set transientEntities) throws HibernateException {
+			Set<Object> transientEntities) throws HibernateException {
 
 		CacheMode cacheMode = session.getCacheMode();
 		session.setCacheMode( CacheMode.GET );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -65,7 +65,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			throw new HibernateException( "Unable to locate persister: " + event.getEntityClassName() );
 		}
 
-		final Class idClass = persister.getIdentifierType().getReturnedClass();
+		final Class<?> idClass = persister.getIdentifierType().getReturnedClass();
 		if ( idClass != null &&
 				!idClass.isInstance( event.getEntityId() ) &&
 				!(event.getEntityId() instanceof DelayedPostInsertIdentifier) ) {
@@ -123,7 +123,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 			final EntityPersister persister,
 			final LoadEvent event,
 			final LoadEventListener.LoadType loadType,
-			final Class idClass) {
+			final Class<?> idClass) {
 		// we may have the jpa requirement of allowing find-by-id where id is the "simple pk value" of a
 		// dependent objects parent.  This is part of its generally goofy derived identity "feature"
 		final EntityIdentifierMapping idMapping = persister.getIdentifierMapping();
@@ -135,7 +135,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 				if ( singleIdAttribute.getMappedType() instanceof EntityMappingType ) {
 					final EntityMappingType dependentIdTargetMapping = (EntityMappingType) singleIdAttribute.getMappedType();
 					final EntityIdentifierMapping dependentIdTargetIdMapping = dependentIdTargetMapping.getIdentifierMapping();
-					final JavaTypeDescriptor dependentParentIdJtd = dependentIdTargetIdMapping.getMappedType().getMappedJavaTypeDescriptor();
+					final JavaTypeDescriptor<?> dependentParentIdJtd = dependentIdTargetIdMapping.getMappedType().getMappedJavaTypeDescriptor();
 					if ( dependentParentIdJtd.getJavaType().isInstance( event.getEntityId() ) ) {
 						// yep that's what we have...
 						loadByDerivedIdentitySimplePkValue(

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -53,7 +53,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( DefaultMergeEventListener.class );
 
 	@Override
-	protected Map getMergeMap(Object anything) {
+	protected Map<Object, Object> getMergeMap(Object anything) {
 		return ( (MergeContext) anything ).invertMap();
 	}
 
@@ -90,7 +90,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 	 *
 	 * @throws HibernateException
 	 */
-	public void onMerge(MergeEvent event, Map copiedAlready) throws HibernateException {
+	public void onMerge(MergeEvent event, Map<Object, Object> copiedAlready) throws HibernateException {
 
 		final MergeContext copyCache = (MergeContext) copiedAlready;
 		final EventSource source = event.getSession();
@@ -191,7 +191,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 
 	}
 
-	protected void entityIsPersistent(MergeEvent event, Map copyCache) {
+	protected void entityIsPersistent(MergeEvent event, Map<Object, Object> copyCache) {
 		LOG.trace( "Ignoring persistent instance" );
 
 		//TODO: check that entry.getIdentifier().equals(requestedId)
@@ -208,7 +208,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 		event.setResult( entity );
 	}
 
-	protected void entityIsTransient(MergeEvent event, Map copyCache) {
+	protected void entityIsTransient(MergeEvent event, Map<Object, Object> copyCache) {
 
 		LOG.trace( "Merging transient instance" );
 
@@ -264,7 +264,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			String entityName,
 			Serializable requestedId,
 			EventSource source,
-			Map copyCache) {
+			Map<Object, Object> copyCache) {
 		//this bit is only *really* absolutely necessary for handling
 		//requestedId, but is also good if we merge multiple object
 		//graphs, since it helps ensure uniqueness
@@ -276,7 +276,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 		}
 	}
 
-	protected void entityIsDetached(MergeEvent event, Map copyCache) {
+	protected void entityIsDetached(MergeEvent event, Map<Object, Object> copyCache) {
 
 		LOG.trace( "Merging detached instance" );
 
@@ -448,7 +448,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			final Object entity,
 			final Object target,
 			final SessionImplementor source,
-			final Map copyCache) {
+			final Map<Object, Object> copyCache) {
 		final Object[] copiedValues = TypeHelper.replace(
 				persister.getPropertyValues( entity ),
 				persister.getPropertyValues( target ),
@@ -466,7 +466,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			final Object entity,
 			final Object target,
 			final SessionImplementor source,
-			final Map copyCache,
+			final Map<Object, Object> copyCache,
 			final ForeignKeyDirection foreignKeyDirection) {
 
 		final Object[] copiedValues;
@@ -512,7 +512,7 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 			final EventSource source,
 			final EntityPersister persister,
 			final Object entity,
-			final Map copyCache
+			final Map<Object, Object> copyCache
 	) {
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		persistenceContext.incrementCascadeLevel();

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
@@ -52,7 +52,7 @@ public class DefaultPersistEventListener
 	 *
 	 */
 	public void onPersist(PersistEvent event) throws HibernateException {
-		onPersist( event, new IdentityHashMap( 10 ) );
+		onPersist( event, new IdentityHashMap<>( 10 ) );
 	}
 
 	/**
@@ -61,7 +61,7 @@ public class DefaultPersistEventListener
 	 * @param event The create event to be handled.
 	 *
 	 */
-	public void onPersist(PersistEvent event, Map createCache) throws HibernateException {
+	public void onPersist(PersistEvent event, Map<Object, Object> createCache) throws HibernateException {
 		final SessionImplementor source = event.getSession();
 		final Object object = event.getObject();
 
@@ -147,7 +147,7 @@ public class DefaultPersistEventListener
 	}
 
 	@SuppressWarnings({"unchecked"})
-	protected void entityIsPersistent(PersistEvent event, Map createCache) {
+	protected void entityIsPersistent(PersistEvent event, Map<Object, Object> createCache) {
 		LOG.trace( "Ignoring persistent instance" );
 		final EventSource source = event.getSession();
 
@@ -162,7 +162,7 @@ public class DefaultPersistEventListener
 		}
 	}
 
-	private void justCascade(Map createCache, EventSource source, Object entity, EntityPersister persister) {
+	private void justCascade(Map<Object, Object> createCache, EventSource source, Object entity, EntityPersister persister) {
 		//TODO: merge into one method!
 		cascadeBeforeSave( source, persister, entity, createCache );
 		cascadeAfterSave( source, persister, entity, createCache );
@@ -174,8 +174,7 @@ public class DefaultPersistEventListener
 	 * @param event The save event to be handled.
 	 * @param createCache The copy cache of entity instance to merge/copy instance.
 	 */
-	@SuppressWarnings({"unchecked"})
-	protected void entityIsTransient(PersistEvent event, Map createCache) {
+	protected void entityIsTransient(PersistEvent event, Map<Object, Object> createCache) {
 		LOG.trace( "Saving transient instance" );
 
 		final EventSource source = event.getSession();
@@ -186,8 +185,7 @@ public class DefaultPersistEventListener
 		}
 	}
 
-	@SuppressWarnings({"unchecked"})
-	private void entityIsDeleted(PersistEvent event, Map createCache) {
+	private void entityIsDeleted(PersistEvent event, Map<Object, Object> createCache) {
 		final EventSource source = event.getSession();
 
 		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -57,7 +57,7 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 	 *
 	 * @param event The refresh event to be handled.
 	 */
-	public void onRefresh(RefreshEvent event, Map refreshedAlready) {
+	public void onRefresh(RefreshEvent event, Map<Object, Object> refreshedAlready) {
 
 		final EventSource source = event.getSession();
 		boolean isTransient;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyAllowedLoggedObserver.java
@@ -76,7 +76,7 @@ public final class EntityCopyAllowedLoggedObserver implements EntityCopyObserver
 		}
 		if ( detachedEntitiesForManaged == null ) {
 			// There were no existing representations for this particular managed entity;
-			detachedEntitiesForManaged = new IdentitySet();
+			detachedEntitiesForManaged = new IdentitySet<>();
 			managedToMergeEntitiesXref.put( managedEntity, detachedEntitiesForManaged );
 			incrementEntityNameCount( entityName );
 		}
@@ -135,7 +135,7 @@ public final class EntityCopyAllowedLoggedObserver implements EntityCopyObserver
 		if ( managedToMergeEntitiesXref != null ) {
 			for ( Map.Entry<Object,Set<Object>> entry : managedToMergeEntitiesXref.entrySet() ) {
 				Object managedEntity = entry.getKey();
-				Set mergeEntities = entry.getValue();
+				Set<Object> mergeEntities = entry.getValue();
 				StringBuilder sb = new StringBuilder( "Details: merged ")
 						.append( mergeEntities.size() )
 						.append( " representations of the same entity " )

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyObserverFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyObserverFactoryInitiator.java
@@ -32,7 +32,7 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( EntityCopyObserverFactoryInitiator.class );
 
 	@Override
-	public EntityCopyObserverFactory initiateService(final Map configurationValues, final ServiceRegistryImplementor registry) {
+	public EntityCopyObserverFactory initiateService(final Map<String, Object> configurationValues, final ServiceRegistryImplementor registry) {
 		final Object value = getConfigurationValue( configurationValues );
 		if ( value.equals( EntityCopyNotAllowedObserver.SHORT_NAME ) || value.equals( EntityCopyNotAllowedObserver.class.getName() ) ) {
 			LOG.debugf( "Configured EntityCopyObserver strategy: %s", EntityCopyNotAllowedObserver.SHORT_NAME );
@@ -51,13 +51,13 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 			//this might look excessive, but it also happens to test eagerly (at boot) that we can actually construct these
 			//and that they are indeed of the right type.
 			EntityCopyObserver exampleInstance = registry.getService( StrategySelector.class ).resolveStrategy( EntityCopyObserver.class, value );
-			Class observerType = exampleInstance.getClass();
+			Class<?> observerType = exampleInstance.getClass();
 			LOG.debugf( "Configured EntityCopyObserver is a custom implementation of type %s", observerType.getName() );
 			return new EntityObserversFactoryFromClass( observerType );
 		}
 	}
 
-	private Object getConfigurationValue(final Map configurationValues) {
+	private Object getConfigurationValue(final Map<String, Object> configurationValues) {
 		final Object o = configurationValues.get( AvailableSettings.MERGE_ENTITY_COPY_OBSERVER );
 		if ( o == null ) {
 			return EntityCopyNotAllowedObserver.SHORT_NAME; //default
@@ -77,9 +77,9 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 
 	private static class EntityObserversFactoryFromClass implements EntityCopyObserverFactory {
 
-		private final Class value;
+		private final Class<?> value;
 
-		public EntityObserversFactoryFromClass(Class value) {
+		public EntityObserversFactoryFromClass(Class<?> value) {
 			this.value = value;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/MergeContext.java
@@ -77,7 +77,7 @@ import org.jboss.logging.Logger;
  *
  * @author Gail Badner
  */
-public class MergeContext implements Map {
+public class MergeContext implements Map<Object, Object> {
 	private static final Logger LOG = Logger.getLogger( MergeContext.class );
 
 	private final EventSource session;
@@ -87,7 +87,7 @@ public class MergeContext implements Map {
 		// key is an entity to be merged;
 		// value is the associated managed entity (result) in the persistence context.
 
-	private Map<Object,Object> managedToMergeEntityXref = new IdentityHashMap<Object,Object>( 10 );
+	private Map<Object,Object> managedToMergeEntityXref = new IdentityHashMap<>( 10 );
 		// maintains the inverse of the mergeToManagedEntityXref for performance reasons.
 		// key is the managed entity result in the persistence context.
 		// value is the associated entity to be merged; if multiple
@@ -151,7 +151,7 @@ public class MergeContext implements Map {
 	 *
 	 * @see Collections#unmodifiableSet(java.util.Set)
 	 */
-	public Set entrySet() {
+	public Set<Map.Entry<Object, Object>> entrySet() {
 		return Collections.unmodifiableSet( mergeToManagedEntityXref.entrySet() );
 	}
 
@@ -182,7 +182,7 @@ public class MergeContext implements Map {
 	 *
 	 * @see Collections#unmodifiableSet(java.util.Set)
 	 */
-	public Set keySet() {
+	public Set<Object> keySet() {
 		return Collections.unmodifiableSet( mergeToManagedEntityXref.keySet() );
 	}
 
@@ -289,9 +289,8 @@ public class MergeContext implements Map {
 	 * but associated value in <code>map</code> is different from the previous value in this MergeContext.
 	 * @throws IllegalStateException if internal cross-references are out of sync,
 	 */
-	public void putAll(Map map) {
-		for ( Object o : map.entrySet() ) {
-			Entry entry = (Entry) o;
+	public void putAll(Map<?, ?> map) {
+		for ( Map.Entry<?, ?> entry : map.entrySet() ) {
 			put( entry.getKey(), entry.getValue() );
 		}
 	}
@@ -321,7 +320,7 @@ public class MergeContext implements Map {
 	 *
 	 * @see Collections#unmodifiableSet(java.util.Set)
 	 */
-	public Collection values() {
+	public Collection<Object> values() {
 		return Collections.unmodifiableSet( managedToMergeEntityXref.keySet() );
 	}
 
@@ -369,7 +368,7 @@ public class MergeContext implements Map {
 	 *
 	 * @see Collections#unmodifiableMap(java.util.Map)
 	 */
-	public Map invertMap() {
+	public Map<Object, Object> invertMap() {
 		return Collections.unmodifiableMap( managedToMergeEntityXref );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/service/internal/PostCommitEventListenerGroupImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/internal/PostCommitEventListenerGroupImpl.java
@@ -26,7 +26,7 @@ import org.hibernate.jpa.event.spi.CallbackRegistry;
 class PostCommitEventListenerGroupImpl<T> extends EventListenerGroupImpl<T> {
 	private static final CoreMessageLogger log = CoreLogging.messageLogger( PostCommitEventListenerGroupImpl.class );
 
-	private final Class extendedListenerContract;
+	private final Class<?> extendedListenerContract;
 
 	public PostCommitEventListenerGroupImpl(
 			EventType<T> eventType,

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AutoFlushEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AutoFlushEvent.java
@@ -14,19 +14,19 @@ import java.util.Set;
  */
 public class AutoFlushEvent extends FlushEvent {
 
-	private Set querySpaces;
+	private Set<String> querySpaces;
 	private boolean flushRequired;
 
-	public AutoFlushEvent(Set querySpaces, EventSource source) {
+	public AutoFlushEvent(Set<String> querySpaces, EventSource source) {
 		super(source);
 		this.querySpaces = querySpaces;
 	}
 
-	public Set getQuerySpaces() {
+	public Set<String> getQuerySpaces() {
 		return querySpaces;
 	}
 
-	public void setQuerySpaces(Set querySpaces) {
+	public void setQuerySpaces(Set<String> querySpaces) {
 		this.querySpaces = querySpaces;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/DeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/DeleteEventListener.java
@@ -25,5 +25,5 @@ public interface DeleteEventListener extends Serializable {
      */
 	public void onDelete(DeleteEvent event) throws HibernateException;
 
-	public void onDelete(DeleteEvent event, Set transientEntities) throws HibernateException;
+	public void onDelete(DeleteEvent event, Set<Object> transientEntities) throws HibernateException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngine.java
@@ -34,8 +34,7 @@ import org.hibernate.service.spi.Stoppable;
  * @author Steve Ebersole
  */
 public class EventEngine {
-	@SuppressWarnings("rawtypes")
-	private final Map<String,EventType> registeredEventTypes;
+	private final Map<String,EventType<?>> registeredEventTypes;
 	private final EventListenerRegistry listenerRegistry;
 
 	private final CallbackRegistryImplementor callbackRegistry;
@@ -85,13 +84,12 @@ public class EventEngine {
 				sessionFactory.getSessionFactoryOptions().isJpaBootstrap()
 		);
 
-		final Map<String,EventType> eventTypes = new HashMap<>();
+		final Map<String,EventType<?>> eventTypes = new HashMap<>();
 		EventType.registerStandardTypes( eventTypes );
 
 		final EventEngineContributions contributionManager = new EventEngineContributions() {
 			@Override
-			public <T> EventType<T> findEventType(String name) {
-				//noinspection unchecked
+			public  EventType<?> findEventType(String name) {
 				return eventTypes.get( name );
 			}
 
@@ -169,13 +167,12 @@ public class EventEngine {
 	}
 
 	public Collection<EventType<?>> getRegisteredEventTypes() {
-		//noinspection unchecked,rawtypes
-		return (Collection) registeredEventTypes.values();
+		return registeredEventTypes.values();
 	}
 
 	public <T> EventType<T> findRegisteredEventType(String name) {
 		//noinspection unchecked
-		return registeredEventTypes.get( name );
+		return (EventType<T>) registeredEventTypes.get( name );
 	}
 
 	public EventListenerRegistry getListenerRegistry() {

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngineContributions.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventEngineContributions.java
@@ -19,7 +19,7 @@ public interface EventEngineContributions {
 	/**
 	 * Return the EventType by name, if one
 	 */
-	<T> EventType<T> findEventType(String name);
+	EventType<?> findEventType(String name);
 
 	/**
 	 * Register a custom event type.

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventSource.java
@@ -56,7 +56,7 @@ public interface EventSource extends SessionImplementor {
 	/**
 	 * Cascade delete an entity instance
 	 */
-	void delete(String entityName, Object child, boolean isCascadeDeleteEnabled, Set transientEntities);
+	void delete(String entityName, Object child, boolean isCascadeDeleteEnabled, Set<Object> transientEntities);
 	/**
 	 * A specialized type of deletion for orphan removal that must occur prior to queued inserts and updates.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventType.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventType.java
@@ -83,16 +83,16 @@ public final class EventType<T> {
 	 * Maintain a map of {@link EventType} instances keyed by name for lookup by name as well as {@link #values()}
 	 * resolution.
 	 */
-	@SuppressWarnings({"rawtypes", "Convert2Lambda"})
-	private static final Map<String,EventType> STANDARD_TYPE_BY_NAME_MAP = AccessController.doPrivileged(
-			new PrivilegedAction<Map<String, EventType>>() {
+	@SuppressWarnings("Convert2Lambda")
+	private static final Map<String,EventType<?>> STANDARD_TYPE_BY_NAME_MAP = AccessController.doPrivileged(
+			new PrivilegedAction<Map<String, EventType<?>>>() {
 				@Override
-				public Map<String, EventType> run() {
-					final Map<String, EventType> typeByNameMap = new HashMap<>();
+				public Map<String, EventType<?>> run() {
+					final Map<String, EventType<?>> typeByNameMap = new HashMap<>();
 					for ( Field field : EventType.class.getDeclaredFields() ) {
 						if ( EventType.class.isAssignableFrom( field.getType() ) ) {
 							try {
-								final EventType typeField = (EventType) field.get( null );
+								final EventType<?> typeField = (EventType<?>) field.get( null );
 								typeByNameMap.put( typeField.eventName(), typeField );
 							}
 							catch (Exception t) {
@@ -123,12 +123,11 @@ public final class EventType<T> {
 	 *
 	 * @throws HibernateException If eventName is null, or if eventName does not correlate to any known event type.
 	 */
-	@SuppressWarnings("rawtypes")
-	public static EventType resolveEventTypeByName(final String eventName) {
+	public static EventType<?> resolveEventTypeByName(final String eventName) {
 		if ( eventName == null ) {
 			throw new HibernateException( "event name to resolve cannot be null" );
 		}
-		final EventType eventType = STANDARD_TYPE_BY_NAME_MAP.get( eventName );
+		final EventType<?> eventType = STANDARD_TYPE_BY_NAME_MAP.get( eventName );
 		if ( eventType == null ) {
 			throw new HibernateException( "Unable to locate proper event type for event name [" + eventName + "]" );
 		}
@@ -138,8 +137,7 @@ public final class EventType<T> {
 	/**
 	 * Get a collection of all the standard {@link EventType} instances.
 	 */
-	@SuppressWarnings("rawtypes")
-	public static Collection<EventType> values() {
+	public static Collection<EventType<?>> values() {
 		return STANDARD_TYPE_BY_NAME_MAP.values();
 	}
 
@@ -148,8 +146,7 @@ public final class EventType<T> {
 	 *
 	 * Simply copy the values into its (passed) Map
 	 */
-	@SuppressWarnings("rawtypes")
-	static void registerStandardTypes(Map<String, EventType> eventTypes) {
+	static void registerStandardTypes(Map<String, EventType<?>> eventTypes) {
 		eventTypes.putAll( STANDARD_TYPE_BY_NAME_MAP );
 	}
 
@@ -169,8 +166,7 @@ public final class EventType<T> {
 		return eventName;
 	}
 
-	@SuppressWarnings("rawtypes")
-	public Class baseListenerInterface() {
+	public Class<T> baseListenerInterface() {
 		return baseListenerInterface;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/MergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/MergeEventListener.java
@@ -32,6 +32,6 @@ public interface MergeEventListener extends Serializable {
      * @param event The merge event to be handled.
      * @throws HibernateException
      */
-	public void onMerge(MergeEvent event, Map copiedAlready) throws HibernateException;
+	public void onMerge(MergeEvent event, Map<Object, Object> copiedAlready) throws HibernateException;
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PersistEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PersistEventListener.java
@@ -32,6 +32,6 @@ public interface PersistEventListener extends Serializable {
      * @param event The create event to be handled.
      * @throws HibernateException
      */
-	public void onPersist(PersistEvent event, Map createdAlready) throws HibernateException;
+	public void onPersist(PersistEvent event, Map<Object, Object> createdAlready) throws HibernateException;
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/RefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/RefreshEventListener.java
@@ -26,6 +26,6 @@ public interface RefreshEventListener extends Serializable {
      */
 	public void onRefresh(RefreshEvent event) throws HibernateException;
 	
-	public void onRefresh(RefreshEvent event, Map refreshedAlready) throws HibernateException;
+	public void onRefresh(RefreshEvent event, Map<Object, Object> refreshedAlready) throws HibernateException;
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
@@ -54,7 +54,7 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 		return Collections.unmodifiableSet( categories );
 	}
 
-	private static final Set DATA_CATEGORIES = buildDataCategories();
+	private static final Set<String> DATA_CATEGORIES = buildDataCategories();
 	private static Set<String> buildDataCategories() {
 		HashSet<String> categories = new HashSet<>(
 				Arrays.asList(
@@ -65,7 +65,7 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 		return Collections.unmodifiableSet( categories );
 	}
 
-	private static final Set INTEGRITY_VIOLATION_CATEGORIES = buildContraintCategories();
+	private static final Set<String> INTEGRITY_VIOLATION_CATEGORIES = buildContraintCategories();
 	private static Set<String> buildContraintCategories() {
 		HashSet<String> categories = new HashSet<>(
 				Arrays.asList(
@@ -77,7 +77,7 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 		return Collections.unmodifiableSet( categories );
 	}
 
-	private static final Set CONNECTION_CATEGORIES = buildConnectionCategories();
+	private static final Set<String> CONNECTION_CATEGORIES = buildConnectionCategories();
 	private static Set<String> buildConnectionCategories() {
 		HashSet<String> categories = new HashSet<>();
 		categories.add(

--- a/hibernate-core/src/main/java/org/hibernate/exception/spi/SQLExceptionConverterFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/spi/SQLExceptionConverterFactory.java
@@ -89,12 +89,12 @@ public class SQLExceptionConverterFactory {
 	private static SQLExceptionConverter constructConverter(String converterClassName, ViolatedConstraintNameExtractor violatedConstraintNameExtractor) {
 		try {
 			LOG.tracev( "Attempting to construct instance of specified SQLExceptionConverter [{0}]", converterClassName );
-			final Class converterClass = ReflectHelper.classForName( converterClassName );
+			final Class<?> converterClass = ReflectHelper.classForName( converterClassName );
 
 			// First, try to find a matching constructor accepting a ViolatedConstraintNameExtractor param...
-			final Constructor[] ctors = converterClass.getDeclaredConstructors();
-			for ( Constructor ctor : ctors ) {
-				final Class[] parameterTypes = ctor.getParameterTypes();
+			final Constructor<?>[] ctors = converterClass.getDeclaredConstructors();
+			for ( Constructor<?> ctor : ctors ) {
+				final Class<?>[] parameterTypes = ctor.getParameterTypes();
 				if ( parameterTypes != null && ctor.getParameterCount() == 1 ) {
 					if ( ViolatedConstraintNameExtractor.class.isAssignableFrom( parameterTypes[0] ) ) {
 						try {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -169,7 +169,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 
 	private final transient SessionFactoryOptions sessionFactoryOptions;
 	private final transient Settings settings;
-	private final transient Map<String,Object> properties;
+	private final transient Map<String, Object> properties;
 
 	private final transient SessionFactoryServiceRegistry serviceRegistry;
 	private final transient EventEngine eventEngine;
@@ -472,7 +472,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		if ( aggregatedConfig.getEventListenerMap() != null ) {
 			final ClassLoaderService cls = serviceRegistry.getService( ClassLoaderService.class );
 			final EventListenerRegistry eventListenerRegistry = serviceRegistry.getService( EventListenerRegistry.class );
-			for ( Map.Entry<EventType, Set<String>> entry : aggregatedConfig.getEventListenerMap().entrySet() ) {
+			for ( Map.Entry<EventType<?>, Set<String>> entry : aggregatedConfig.getEventListenerMap().entrySet() ) {
 				final EventListenerGroup group = eventListenerRegistry.getEventListenerGroup( entry.getKey() );
 				for ( String listenerClassName : entry.getValue() ) {
 					try {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -313,7 +313,7 @@ public final class ConfigurationHelper {
 	 * @param properties The properties object
 	 * @return The property value; may be null.
 	 */
-	public static String extractPropertyValue(String propertyName, Map properties) {
+	public static String extractPropertyValue(String propertyName, Map<Object, Object> properties) {
 		String value = (String) properties.get( propertyName );
 		if ( value == null ) {
 			return null;
@@ -327,7 +327,7 @@ public final class ConfigurationHelper {
 
 	public static String extractValue(
 			String name,
-			Map values,
+			Map<Object, Object> values,
 			Supplier<String> fallbackValueFactory) {
 		final String value = extractPropertyValue( name, values );
 		if ( value != null ) {
@@ -350,8 +350,8 @@ public final class ConfigurationHelper {
 	 * @param properties The properties object
 	 * @return The resulting map; never null, though perhaps empty.
 	 */
-	public static Map toMap(String propertyName, String delim, Properties properties) {
-		Map map = new HashMap();
+	public static Map<Object, Object> toMap(String propertyName, String delim, Properties properties) {
+		Map<Object, Object> map = new HashMap<>();
 		String value = extractPropertyValue( propertyName, properties );
 		if ( value != null ) {
 			StringTokenizer tokens = new StringTokenizer( value, delim );
@@ -375,8 +375,8 @@ public final class ConfigurationHelper {
 	 * @param properties The properties object
 	 * @return The resulting map; never null, though perhaps empty.
 	 */
-	public static Map toMap(String propertyName, String delim, Map properties) {
-		Map map = new HashMap();
+	public static Map<String, String> toMap(String propertyName, String delim, Map<Object, Object> properties) {
+		Map<String, String> map = new HashMap<>();
 		String value = extractPropertyValue( propertyName, properties );
 		if ( value != null ) {
 			StringTokenizer tokens = new StringTokenizer( value, delim );

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/WorkExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/WorkExecutor.java
@@ -33,7 +33,7 @@ public class WorkExecutor<T> {
 	 * @throws SQLException Thrown during execution of the underlying JDBC interaction.
 	 * @throws org.hibernate.HibernateException Generally indicates a wrapped SQLException.
 	 */
-	public <T> T executeWork(Work work, Connection connection) throws SQLException {
+	public T executeWork(Work work, Connection connection) throws SQLException {
 		work.execute( connection );
 		return null;
 	}
@@ -51,7 +51,7 @@ public class WorkExecutor<T> {
 	 * @throws SQLException Thrown during execution of the underlying JDBC interaction.
 	 * @throws org.hibernate.HibernateException Generally indicates a wrapped SQLException.
 	 */
-	public <T> T executeReturningWork(ReturningWork<T> work, Connection connection) throws SQLException {
+	public T executeReturningWork(ReturningWork<T> work, Connection connection) throws SQLException {
 		return work.execute( connection );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/jmx/internal/DisabledJmxServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/internal/DisabledJmxServiceImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.jmx.internal;
 import javax.management.ObjectName;
 
 import org.hibernate.jmx.spi.JmxService;
+import org.hibernate.service.Service;
 import org.hibernate.service.spi.Manageable;
 
 /**
@@ -19,7 +20,7 @@ public class DisabledJmxServiceImpl  implements JmxService {
 	public static final DisabledJmxServiceImpl INSTANCE = new DisabledJmxServiceImpl();
 
 	@Override
-	public void registerService(Manageable service, Class serviceRole) {
+	public void registerService(Manageable service, Class<? extends Service> serviceRole) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceImpl.java
@@ -41,7 +41,7 @@ public class JmxServiceImpl implements JmxService, Stoppable {
 	private final String defaultDomain;
 	private final String sessionFactoryName;
 
-	public JmxServiceImpl(Map configValues) {
+	public JmxServiceImpl(Map<String, Object> configValues) {
 		usePlatformServer = ConfigurationHelper.getBoolean( AvailableSettings.JMX_PLATFORM_SERVER, configValues );
 		agentId = (String) configValues.get( AvailableSettings.JMX_AGENT_ID );
 		defaultDomain = (String) configValues.get( AvailableSettings.JMX_DOMAIN_NAME );

--- a/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/jmx/internal/JmxServiceInitiator.java
@@ -28,7 +28,7 @@ public class JmxServiceInitiator implements StandardServiceInitiator<JmxService>
 	}
 
 	@Override
-	public JmxService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JmxService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return ConfigurationHelper.getBoolean( AvailableSettings.JMX_ENABLED, configurationValues, false )
 				? new JmxServiceImpl( configurationValues )
 				: DisabledJmxServiceImpl.INSTANCE;

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -1347,7 +1347,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 	}
 
 	private static class MergedSettings {
-		private final Map configurationValues = new ConcurrentHashMap( 16, 0.75f, 1 );
+		private final Map<Object, Object> configurationValues = new ConcurrentHashMap<>( 16, 0.75f, 1 );
 
 		private Map<String, JaccPermissionDeclarations> jaccPermissionsByContextId;
 		private List<CacheRegionDefinition> cacheRegionDefinitions;
@@ -1384,7 +1384,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 			configurationValues.putAll( loadedConfig.getConfigurationValues() );
 		}
 
-		public Map getConfigurationValues() {
+		public Map<Object, Object> getConfigurationValues() {
 			return configurationValues;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -49,7 +49,6 @@ import org.hibernate.type.spi.TypeConfiguration;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings({"unchecked", "rawtypes"})
 public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicators, Resolvable {
 	private static final CoreMessageLogger log = CoreLogging.messageLogger( BasicValue.class );
 
@@ -61,12 +60,12 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 	// incoming "configuration" values
 
 	private String explicitTypeName;
-	private Map explicitLocalTypeParams;
+	private Map<Object, Object> explicitLocalTypeParams;
 
-	private Function<TypeConfiguration,BasicJavaDescriptor> explicitJavaTypeAccess;
-	private Function<TypeConfiguration,SqlTypeDescriptor> explicitSqlTypeAccess;
-	private Function<TypeConfiguration,MutabilityPlan> explicitMutabilityPlanAccess;
-	private Function<TypeConfiguration,Class> implicitJavaTypeAccess;
+	private Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJavaTypeAccess;
+	private Function<TypeConfiguration, SqlTypeDescriptor> explicitSqlTypeAccess;
+	private Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess;
+	private Function<TypeConfiguration, Class<?>> implicitJavaTypeAccess;
 
 	private boolean isNationalized;
 	private boolean isLob;
@@ -146,8 +145,7 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 		super.setJpaAttributeConverterDescriptor( descriptor );
 	}
 
-	@SuppressWarnings({"rawtypes"})
-	public void setExplicitJavaTypeAccess(Function<TypeConfiguration, BasicJavaDescriptor> explicitJavaTypeAccess) {
+	public void setExplicitJavaTypeAccess(Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJavaTypeAccess) {
 		this.explicitJavaTypeAccess = explicitJavaTypeAccess;
 	}
 
@@ -155,11 +153,11 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 		this.explicitSqlTypeAccess = sqlTypeAccess;
 	}
 
-	public void setExplicitMutabilityPlanAccess(Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess) {
+	public void setExplicitMutabilityPlanAccess(Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess) {
 		this.explicitMutabilityPlanAccess = explicitMutabilityPlanAccess;
 	}
 
-	public void setImplicitJavaTypeAccess(Function<TypeConfiguration, Class> implicitJavaTypeAccess) {
+	public void setImplicitJavaTypeAccess(Function<TypeConfiguration, Class<?>> implicitJavaTypeAccess) {
 		this.implicitJavaTypeAccess = implicitJavaTypeAccess;
 	}
 
@@ -445,17 +443,15 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 		return typeConfiguration.getJavaTypeDescriptorRegistry().resolveDescriptor( impliedJavaType );
 	}
 
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	private static Resolution interpretExplicitlyNamedType(
 			String name,
 			EnumType enumerationStyle,
-			Function<TypeConfiguration, Class> implicitJavaTypeAccess,
-			Function<TypeConfiguration, BasicJavaDescriptor> explicitJtdAccess,
+			Function<TypeConfiguration, Class<?>> implicitJavaTypeAccess,
+			Function<TypeConfiguration, BasicJavaDescriptor<?>> explicitJtdAccess,
 			Function<TypeConfiguration, SqlTypeDescriptor> explicitStdAccess,
-			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
+			Function<TypeConfiguration, MutabilityPlan<?>> explicitMutabilityPlanAccess,
 			ConverterDescriptor converterDescriptor,
-			Map localTypeParams,
+			Map<Object, Object> localTypeParams,
 			SqlTypeDescriptorIndicators stdIndicators,
 			TypeConfiguration typeConfiguration,
 			MetadataBuildingContext context) {
@@ -497,7 +493,7 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 		// see if it is a named basic type
 		final BasicType basicTypeByName = typeConfiguration.getBasicTypeRegistry().getRegisteredType( name );
 		if ( basicTypeByName != null ) {
-			final BasicValueConverter valueConverter;
+			final BasicValueConverter<?, ?> valueConverter;
 			final JavaTypeDescriptor<?> domainJtd;
 			if ( converterDescriptor == null ) {
 				valueConverter = null;
@@ -618,8 +614,7 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 						.getServiceRegistry()
 						.getService( ClassLoaderService.class );
 				try {
-					//noinspection rawtypes
-					final Class<AttributeConverter> converterClass = cls.classForName( converterClassName );
+					final Class<AttributeConverter<?, ?>> converterClass = cls.classForName( converterClassName );
 					attributeConverterDescriptor = new ClassBasedConverterDescriptor(
 							converterClass,
 							false,
@@ -690,7 +685,7 @@ public class BasicValue extends SimpleValue implements SqlTypeDescriptorIndicato
 		 * Converter, if any, to convert values between the
 		 * domain and relational JavaTypeDescriptor representations
 		 */
-		BasicValueConverter getValueConverter();
+		BasicValueConverter<J, ?> getValueConverter();
 
 		/**
 		 * The resolved MutabilityPlan

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -79,7 +79,7 @@ public class Component extends SimpleValue implements MetaAttributable {
 		return properties.size();
 	}
 
-	public Iterator getPropertyIterator() {
+	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -201,9 +201,9 @@ public class ForeignKey extends Constraint {
 	}
 
 	/**
-	 * Returns the referenced columns if the foreignkey does not refer to the primary key
+	 * Returns the referenced columns if the foreign key does not refer to the primary key
 	 */
-	public List getReferencedColumns() {
+	public List<Column> getReferencedColumns() {
 		return referencedColumns;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -20,8 +20,8 @@ public class Join implements AttributeContainer, Serializable {
 
 	private static final Alias PK_ALIAS = new Alias(15, "PK");
 
-	private ArrayList properties = new ArrayList();
-	private ArrayList declaredProperties = new ArrayList();
+	private ArrayList<Property> properties = new ArrayList<>();
+	private ArrayList<Property> declaredProperties = new ArrayList<>();
 	private Table table;
 	private KeyValue key;
 	private PersistentClass persistentClass;
@@ -52,14 +52,14 @@ public class Join implements AttributeContainer, Serializable {
 		prop.setPersistentClass( getPersistentClass() );
 	}
 
-	public Iterator getDeclaredPropertyIterator() {
+	public Iterator<Property> getDeclaredPropertyIterator() {
 		return declaredProperties.iterator();
 	}
 
 	public boolean containsProperty(Property prop) {
 		return properties.contains(prop);
 	}
-	public Iterator getPropertyIterator() {
+	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -307,11 +307,11 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 
 	public abstract boolean isDiscriminatorInsertable();
 
-	public abstract Iterator getPropertyClosureIterator();
+	public abstract Iterator<Property> getPropertyClosureIterator();
 
-	public abstract Iterator getTableClosureIterator();
+	public abstract Iterator<Table> getTableClosureIterator();
 
-	public abstract Iterator getKeyClosureIterator();
+	public abstract Iterator<KeyValue> getKeyClosureIterator();
 
 	protected void addSubclassProperty(Property prop) {
 		subclassProperties.add( prop );
@@ -325,23 +325,23 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		subclassTables.add( subclassTable );
 	}
 
-	public Iterator getSubclassPropertyClosureIterator() {
-		ArrayList iters = new ArrayList();
+	public Iterator<Property> getSubclassPropertyClosureIterator() {
+		ArrayList<Iterator<Property>> iters = new ArrayList<>();
 		iters.add( getPropertyClosureIterator() );
 		iters.add( subclassProperties.iterator() );
 		for ( int i = 0; i < subclassJoins.size(); i++ ) {
 			Join join = subclassJoins.get( i );
 			iters.add( join.getPropertyIterator() );
 		}
-		return new JoinedIterator( iters );
+		return new JoinedIterator<>( iters );
 	}
 
-	public Iterator getSubclassJoinClosureIterator() {
-		return new JoinedIterator( getJoinClosureIterator(), subclassJoins.iterator() );
+	public Iterator<Join> getSubclassJoinClosureIterator() {
+		return new JoinedIterator<>( getJoinClosureIterator(), subclassJoins.iterator() );
 	}
 
-	public Iterator getSubclassTableClosureIterator() {
-		return new JoinedIterator( getTableClosureIterator(), subclassTables.iterator() );
+	public Iterator<Table> getSubclassTableClosureIterator() {
+		return new JoinedIterator<>( getTableClosureIterator(), subclassTables.iterator() );
 	}
 
 	public boolean isClassOrSuperclassJoin(Join join) {
@@ -674,11 +674,11 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		return getClass().getName() + '(' + getEntityName() + ')';
 	}
 
-	public Iterator getJoinIterator() {
+	public Iterator<Join> getJoinIterator() {
 		return joins.iterator();
 	}
 
-	public Iterator getJoinClosureIterator() {
+	public Iterator<Join> getJoinClosureIterator() {
 		return joins.iterator();
 	}
 
@@ -725,14 +725,14 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 	 *
 	 * @return An iterator over the "normal" properties.
 	 */
-	public Iterator getPropertyIterator() {
-		ArrayList iterators = new ArrayList();
+	public Iterator<Property> getPropertyIterator() {
+		ArrayList<Iterator<Property>> iterators = new ArrayList<>();
 		iterators.add( properties.iterator() );
 		for ( int i = 0; i < joins.size(); i++ ) {
 			Join join = joins.get( i );
 			iterators.add( join.getPropertyIterator() );
 		}
-		return new JoinedIterator( iterators );
+		return new JoinedIterator<>( iterators );
 	}
 
 	/**
@@ -985,14 +985,14 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 	}
 
 	// The following methods are added to support @MappedSuperclass in the metamodel
-	public Iterator getDeclaredPropertyIterator() {
-		ArrayList iterators = new ArrayList();
+	public Iterator<Property> getDeclaredPropertyIterator() {
+		ArrayList<Iterator<Property>> iterators = new ArrayList<>();
 		iterators.add( declaredProperties.iterator() );
 		for ( int i = 0; i < joins.size(); i++ ) {
 			Join join = joins.get( i );
 			iterators.add( join.getDeclaredPropertyIterator() );
 		}
-		return new JoinedIterator( iterators );
+		return new JoinedIterator<>( iterators );
 	}
 
 	public void addMappedsuperclassProperty(Property p) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -73,7 +73,7 @@ public class Property implements Serializable, MetaAttributable {
 		return value.getColumnSpan();
 	}
 	
-	public Iterator getColumnIterator() {
+	public Iterator<Selectable> getColumnIterator() {
 		return value.getColumnIterator();
 	}
 	

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -126,18 +126,18 @@ public class RootClass extends PersistentClass implements TableOwner {
 	}
 
 	@Override
-	public Iterator getPropertyClosureIterator() {
+	public Iterator<Property> getPropertyClosureIterator() {
 		return getPropertyIterator();
 	}
 
 	@Override
-	public Iterator getTableClosureIterator() {
-		return new SingletonIterator( getTable() );
+	public Iterator<Table> getTableClosureIterator() {
+		return new SingletonIterator<>( getTable() );
 	}
 
 	@Override
-	public Iterator getKeyClosureIterator() {
-		return new SingletonIterator( getKey() );
+	public Iterator<KeyValue> getKeyClosureIterator() {
+		return new SingletonIterator<>( getKey() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -200,7 +200,7 @@ public abstract class SimpleValue implements KeyValue {
 					.getServiceRegistry()
 					.getService( ClassLoaderService.class );
 			try {
-				final Class<? extends AttributeConverter> converterClass = cls.classForName( converterClassName );
+				final Class<? extends AttributeConverter<?, ?>> converterClass = cls.classForName( converterClassName );
 				this.attributeConverterDescriptor = new ClassBasedConverterDescriptor(
 						converterClass,
 						false,

--- a/hibernate-core/src/main/java/org/hibernate/metadata/ClassMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/metadata/ClassMetadata.java
@@ -127,7 +127,7 @@ public interface ClassMetadata {
 	 */
 	@Deprecated
 	@SuppressWarnings({"UnusedDeclaration"})
-	default Object[] getPropertyValuesToInsert(Object entity, Map mergeMap, SessionImplementor session)
+	default Object[] getPropertyValuesToInsert(Object entity, Map<Object, Object> mergeMap, SessionImplementor session)
 			throws HibernateException {
 		return getPropertyValuesToInsert( entity, mergeMap, (SharedSessionContractImplementor) session );
 	}
@@ -136,7 +136,7 @@ public interface ClassMetadata {
 	 * Return the values of the mapped properties of the object
 	 */
 	@SuppressWarnings( {"UnusedDeclaration"})
-	Object[] getPropertyValuesToInsert(Object entity, Map mergeMap, SharedSessionContractImplementor session) throws HibernateException;
+	Object[] getPropertyValuesToInsert(Object entity, Map<Object, Object> mergeMap, SharedSessionContractImplementor session) throws HibernateException;
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,7 +146,7 @@ public interface ClassMetadata {
 	/**
 	 * The persistent class, or null
 	 */
-	Class getMappedClass();
+	Class<?> getMappedClass();
 
 	/**
 	 * Create a class instance initialized with the given identifier

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEntityRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEntityRepresentationStrategy.java
@@ -160,10 +160,10 @@ public class StandardPojoEntityRepresentationStrategy implements EntityRepresent
 			BytecodeProvider bytecodeProvider,
 			RuntimeModelCreationContext creationContext) {
 
-		final Set<Class> proxyInterfaces = new java.util.HashSet<>();
+		final Set<Class<?>> proxyInterfaces = new java.util.HashSet<>();
 
-		final Class mappedClass = mappedJtd.getJavaType();
-		Class proxyInterface;
+		final Class<?> mappedClass = mappedJtd.getJavaType();
+		Class<?> proxyInterface;
 		if ( proxyJtd != null ) {
 			proxyInterface = proxyJtd.getJavaType();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -407,9 +407,10 @@ public class JpaMetamodelImpl implements JpaMetamodel {
 		}
 	}
 
+	@SuppressWarnings( "unchecked" )
 	private <X> Class<X> resolveRequestedClass(String entityName) {
 		try {
-			return getServiceRegistry().getService( ClassLoaderService.class ).classForName( entityName );
+			return (Class<X>) getServiceRegistry().getService( ClassLoaderService.class ).classForName( entityName );
 		}
 		catch (ClassLoadingException e) {
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/param/DynamicFilterParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/DynamicFilterParameterSpecification.java
@@ -55,7 +55,7 @@ public class DynamicFilterParameterSpecification implements ParameterSpecificati
 		final Type type = session.getLoadQueryInfluencers().getFilterParameterType(fullParamName);
 		if ( Collection.class.isInstance( value ) ) {
 			int positions = 0;
-			Iterator itr = ( ( Collection ) value ).iterator();
+			Iterator<?> itr = ( ( Collection<?> ) value ).iterator();
 			while ( itr.hasNext() ) {
 				Object next = itr.next();
 				qp.bindDynamicParameter( type, next );

--- a/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
@@ -20,14 +20,14 @@ import org.hibernate.type.VersionType;
  * @author Steve Ebersole
  */
 public class VersionTypeSeedParameterSpecification implements ParameterSpecification {
-	private final VersionType type;
+	private final VersionType<?> type;
 
 	/**
 	 * Constructs a version seed parameter bind specification.
 	 *
 	 * @param type The version type.
 	 */
-	public VersionTypeSeedParameterSpecification(VersionType type) {
+	public VersionTypeSeedParameterSpecification(VersionType<?> type) {
 		this.type = type;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -205,7 +205,7 @@ public abstract class AbstractCollectionPersister
 	private final boolean subselectLoadable;
 
 	// extra information about the element type
-	private final Class elementClass;
+	private final Class<?> elementClass;
 	private final String entityName;
 
 	private final Dialect dialect;
@@ -243,7 +243,7 @@ public abstract class AbstractCollectionPersister
 
 	private Map collectionPropertyColumnAliases = new HashMap();
 
-	private final Comparator comparator;
+	private final Comparator<Object> comparator;
 
 	private CollectionLoader collectionLoader;
 	private volatile CollectionLoader standardCollectionLoader;
@@ -652,7 +652,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	@Override
-	public Comparator<?> getSortingComparator() {
+	public Comparator<Object> getSortingComparator() {
 		return comparator;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -371,7 +371,7 @@ public interface CollectionPersister extends CollectionDefinition {
 	 * @see CollectionClassification#SORTED_MAP
 	 * @see CollectionClassification#SORTED_SET
 	 */
-	Comparator<?> getSortingComparator();
+	Comparator<Object> getSortingComparator();
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -4828,8 +4828,9 @@ public abstract class AbstractEntityPersister
 		return !entityMetamodel.getIdentifierProperty().isVirtual();
 	}
 
-	public VersionType getVersionType() {
-		return (VersionType) locateVersionType();
+	@SuppressWarnings( "unchecked" )
+	public VersionType<Object> getVersionType() {
+		return (VersionType<Object>) locateVersionType();
 	}
 
 	private Type locateVersionType() {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -359,7 +359,7 @@ public interface EntityPersister
 	 *
 	 * @return The type of the version property; or null, if not versioned.
 	 */
-	VersionType getVersionType();
+	VersionType<Object> getVersionType();
 
 	/**
 	 * If {@link #isVersioned()}, then what is the index of the property

--- a/hibernate-core/src/main/java/org/hibernate/proxy/ProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/ProxyFactory.java
@@ -46,8 +46,8 @@ public interface ProxyFactory {
 	 */
 	void postInstantiate(
 			String entityName,
-			Class persistentClass,
-			Set<Class> interfaces,
+			Class<?> persistentClass,
+			Set<Class<?>> interfaces,
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) throws HibernateException;

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
@@ -37,10 +37,10 @@ public final class ProxyFactoryHelper {
 		//not meant to be instantiated
 	}
 
-	public static Set<Class> extractProxyInterfaces(final PersistentClass persistentClass, final String entityName) {
-		final Set<Class> proxyInterfaces = new java.util.HashSet<>();
-		final Class mappedClass = persistentClass.getMappedClass();
-		final Class proxyInterface = persistentClass.getProxyInterface();
+	public static Set<Class<?>> extractProxyInterfaces(final PersistentClass persistentClass, final String entityName) {
+		final Set<Class<?>> proxyInterfaces = new java.util.HashSet<>();
+		final Class<?> mappedClass = persistentClass.getMappedClass();
+		final Class<?> proxyInterface = persistentClass.getProxyInterface();
 
 		if ( proxyInterface != null && !mappedClass.equals( proxyInterface ) ) {
 			if ( !proxyInterface.isInterface() ) {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyProxyFactory.java
@@ -28,15 +28,15 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 
 	private final ByteBuddyProxyHelper byteBuddyProxyHelper;
 
-	private Class persistentClass;
+	private Class<?> persistentClass;
 	private String entityName;
-	private Class[] interfaces;
+	private Class<?>[] interfaces;
 	private Method getIdentifierMethod;
 	private Method setIdentifierMethod;
 	private CompositeType componentIdType;
 	private boolean overridesEquals;
 
-	private Class proxyClass;
+	private Class<?> proxyClass;
 
 	public ByteBuddyProxyFactory(ByteBuddyProxyHelper byteBuddyProxyHelper) {
 		this.byteBuddyProxyHelper = byteBuddyProxyHelper;
@@ -45,8 +45,8 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 	@Override
 	public void postInstantiate(
 			String entityName,
-			Class persistentClass,
-			Set<Class> interfaces,
+			Class<?> persistentClass,
+			Set<Class<?>> interfaces,
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) throws HibernateException {
@@ -61,7 +61,7 @@ public class ByteBuddyProxyFactory implements ProxyFactory, Serializable {
 		this.proxyClass = byteBuddyProxyHelper.buildProxy( persistentClass, this.interfaces );
 	}
 
-	private Class[] toArray(Set<Class> interfaces) {
+	private Class<?>[] toArray(Set<Class<?>> interfaces) {
 		if ( interfaces == null ) {
 			return ArrayHelper.EMPTY_CLASS_ARRAY;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -270,7 +270,7 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 					executionContext.getSession()
 			);
 
-			cachedResults = queryCache.get(
+			cachedResults = (List<Object[]>) queryCache.get(
 					// todo (6.0) : QueryCache#get takes the `queryResultsCacheKey` see tat discussion above
 					queryResultsCacheKey,
 					// todo (6.0) : `querySpaces` and `session` make perfect sense as args, but its odd passing those into this method just to pass along

--- a/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizerFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/component/ComponentTuplizerFactory.java
@@ -79,7 +79,7 @@ public class ComponentTuplizerFactory implements Serializable {
 	@SuppressWarnings({ "unchecked" })
 	public ComponentTuplizer constructTuplizer(String tuplizerClassName, Component metadata) {
 		try {
-			Class<? extends ComponentTuplizer> tuplizerClass = classLoaderAccess.classForName( tuplizerClassName );
+			Class<? extends ComponentTuplizer> tuplizerClass = (Class<? extends ComponentTuplizer>) classLoaderAccess.classForName( tuplizerClassName );
 			return constructTuplizer( tuplizerClass, metadata );
 		}
 		catch ( ClassLoadingException e ) {

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/PojoEntityTuplizer.java
@@ -83,10 +83,10 @@ public class PojoEntityTuplizer extends AbstractEntityTuplizer {
 		// determine the id getter and setter methods from the proxy interface (if any)
 		// determine all interfaces needed by the resulting proxy
 		final String entityName = getEntityName();
-		final Class mappedClass = persistentClass.getMappedClass();
-		final Class proxyInterface = persistentClass.getProxyInterface();
+		final Class<?> mappedClass = persistentClass.getMappedClass();
+		final Class<?> proxyInterface = persistentClass.getProxyInterface();
 
-		final Set<Class> proxyInterfaces = ProxyFactoryHelper.extractProxyInterfaces( persistentClass, entityName );
+		final Set<Class<?>> proxyInterfaces = ProxyFactoryHelper.extractProxyInterfaces( persistentClass, entityName );
 
 		Method proxyGetIdentifierMethod = ProxyFactoryHelper.extractProxyGetIdentifierMethod( idGetter, proxyInterface );
 		Method proxySetIdentifierMethod = ProxyFactoryHelper.extractProxySetIdentifierMethod( idSetter, proxyInterface );

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -244,7 +244,7 @@ public abstract class CollectionType extends AbstractType implements Association
 	 * @param session The session from which the request is originating.
 	 * @return The iterator.
 	 */
-	public Iterator getElementsIterator(Object collection, SharedSessionContractImplementor session) {
+	public Iterator<Object> getElementsIterator(Object collection, SharedSessionContractImplementor session) {
 		return getElementsIterator( collection );
 	}
 
@@ -254,8 +254,9 @@ public abstract class CollectionType extends AbstractType implements Association
 	 * @param collection The collection to be iterated
 	 * @return The iterator.
 	 */
-	protected Iterator getElementsIterator(Object collection) {
-		return ( (Collection) collection ).iterator();
+	@SuppressWarnings( "unchecked" )
+	protected Iterator<Object> getElementsIterator(Object collection) {
+		return ( (Collection<Object>) collection ).iterator();
 	}
 
 	@Override
@@ -706,7 +707,7 @@ public abstract class CollectionType extends AbstractType implements Association
 			final Object target,
 			final SharedSessionContractImplementor session,
 			final Object owner,
-			final Map copyCache) throws HibernateException {
+			final Map<Object, Object> copyCache) throws HibernateException {
 		if ( original == null ) {
 			return null;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/Type.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/Type.java
@@ -535,7 +535,7 @@ public interface Type extends Serializable {
 			Object target,
 			SharedSessionContractImplementor session,
 			Object owner,
-			Map copyCache) throws HibernateException;
+			Map<Object, Object> copyCache) throws HibernateException;
 
 	/**
 	 * During merge, replace the existing (target) value in the entity we are merging to

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -218,9 +218,9 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 		// 		valid while the TypeConfiguration is scoped to SessionFactory
 	}
 
-	public void addBasicTypeRegistrationContributions(List<BasicTypeRegistration> contributions) {
-		for ( BasicTypeRegistration basicTypeRegistration : contributions ) {
-			BasicType basicType = basicTypeRegistration.getBasicType();
+	public void addBasicTypeRegistrationContributions(List<BasicTypeRegistration<?>> contributions) {
+		for ( BasicTypeRegistration<?> basicTypeRegistration : contributions ) {
+			BasicType<?> basicType = basicTypeRegistration.getBasicType();
 
 			basicTypeRegistry.register(
 					basicType,

--- a/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
@@ -48,7 +48,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  *
  * @author Gavin King
  */
-public interface UserType {
+public interface UserType<T> {
 
 	/**
 	 * Return the SQL type codes for the columns mapped by this type. The
@@ -63,7 +63,7 @@ public interface UserType {
 	 *
 	 * @return Class
 	 */
-	Class returnedClass();
+	Class<T> returnedClass();
 
 	/**
 	 * Compare two instances of the class mapped by this type for persistence "equality".

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/ejb3configuration/PersisterClassProviderTest.java
@@ -264,7 +264,7 @@ public class PersisterClassProviderTest {
 		}
 
 		@Override
-		public VersionType getVersionType() {
+		public VersionType<Object> getVersionType() {
 			return null;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -238,7 +238,7 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
-		public VersionType getVersionType() {
+		public VersionType<Object> getVersionType() {
 			return null;
 		}
 
@@ -962,7 +962,7 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
-		public Comparator<?> getSortingComparator() {
+		public Comparator<Object> getSortingComparator() {
 			return null;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/legacy/CustomPersister.java
@@ -297,7 +297,7 @@ public class CustomPersister implements EntityPersister {
 	/**
 	 * @see EntityPersister#getVersionType()
 	 */
-	public VersionType getVersionType() {
+	public VersionType<Object> getVersionType() {
 		return null;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/stateless/StatelessSessionPersistentContextTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/stateless/StatelessSessionPersistentContextTest.java
@@ -17,6 +17,8 @@ import javax.persistence.Table;
 
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -126,7 +128,7 @@ public class StatelessSessionPersistentContextTest extends BaseCoreFunctionalTes
 		);
 		assertTrue(
 				"StatelessSession: PersistenceContext has not been cleared",
-				persistenceContextInternal.getCollectionsByKey() == Collections.emptyMap()
+				persistenceContextInternal.getCollectionsByKey() == Collections.<CollectionKey, PersistentCollection>emptyMap()
 		);
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
@@ -69,6 +69,7 @@ import org.hibernate.envers.internal.tools.Tools;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.IndexedCollection;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.OneToMany;
 import org.hibernate.mapping.PersistentClass;
@@ -1010,7 +1011,7 @@ public final class CollectionMetadataGenerator {
 
 	@SuppressWarnings({"unchecked"})
 	private String searchMappedByKey(PersistentClass referencedClass, Collection collectionValue) {
-		final Iterator<Value> assocIdClassProps = referencedClass.getKeyClosureIterator();
+		final Iterator<KeyValue> assocIdClassProps = referencedClass.getKeyClosureIterator();
 		while ( assocIdClassProps.hasNext() ) {
 			final Value value = assocIdClassProps.next();
 			// make sure its a 'Component' because IdClass is registered as this type.

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/JoinNaming.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/JoinNaming.java
@@ -13,6 +13,7 @@ import javax.persistence.EntityManager;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Selectable;
 
 import org.junit.Test;
 
@@ -108,14 +109,13 @@ public class JoinNaming extends BaseEnversJPAFunctionalTestCase {
 		);
 	}
 
-	@SuppressWarnings({"unchecked"})
 	@Test
 	public void testJoinColumnName() {
-		Iterator<Column> columns = metadata().getEntityBinding(
+		Iterator<Selectable> columns = metadata().getEntityBinding(
 				"org.hibernate.envers.test.integration.naming.JoinNamingRefIngEntity_AUD"
 		).getProperty( "reference_id" ).getColumnIterator();
 		assertTrue( columns.hasNext() );
-		assertEquals( "jnree_column_reference", columns.next().getName() );
+		assertEquals( "jnree_column_reference", ( (Column) columns.next() ).getName() );
 		assertFalse( columns.hasNext() );
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/ids/JoinEmbIdNaming.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/ids/JoinEmbIdNaming.java
@@ -13,6 +13,7 @@ import javax.persistence.EntityManager;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Selectable;
 
 import org.junit.Test;
 
@@ -121,15 +122,14 @@ public class JoinEmbIdNaming extends BaseEnversJPAFunctionalTestCase {
 		);
 	}
 
-	@SuppressWarnings({"unchecked"})
 	@Test
 	public void testJoinColumnNames() {
-		Iterator<Column> columns = metadata().getEntityBinding(
+		Iterator<Selectable> columns = metadata().getEntityBinding(
 				"org.hibernate.envers.test.integration.naming.ids.JoinEmbIdNamingRefIngEntity_AUD"
 		).getProperty( "reference_x" ).getColumnIterator();
 
 		assertTrue( columns.hasNext() );
-		assertEquals( "XX_reference", columns.next().getName() );
+		assertEquals( "XX_reference", ( (Column) columns.next() ).getName() );
 		assertFalse( columns.hasNext() );
 
 		columns = metadata().getEntityBinding(
@@ -137,7 +137,7 @@ public class JoinEmbIdNaming extends BaseEnversJPAFunctionalTestCase {
 		).getProperty( "reference_y" ).getColumnIterator();
 
 		assertTrue( columns.hasNext() );
-		assertEquals( "YY_reference", columns.next().getName() );
+		assertEquals( "YY_reference", ( (Column) columns.next() ).getName() );
 		assertFalse( columns.hasNext() );
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/ids/JoinMulIdNaming.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/naming/ids/JoinMulIdNaming.java
@@ -13,6 +13,7 @@ import javax.persistence.EntityManager;
 import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.envers.test.Priority;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Selectable;
 
 import org.junit.Test;
 
@@ -124,12 +125,12 @@ public class JoinMulIdNaming extends BaseEnversJPAFunctionalTestCase {
 	@SuppressWarnings({"unchecked"})
 	@Test
 	public void testJoinColumnNames() {
-		Iterator<Column> columns = metadata().getEntityBinding(
+		Iterator<Selectable> columns = metadata().getEntityBinding(
 				"org.hibernate.envers.test.integration.naming.ids.JoinMulIdNamingRefIngEntity_AUD"
 		).getProperty( "reference_id1" ).getColumnIterator();
 
 		assertTrue( columns.hasNext() );
-		assertEquals( "ID1_reference", columns.next().getName() );
+		assertEquals( "ID1_reference", ( (Column) columns.next() ).getName() );
 		assertFalse( columns.hasNext() );
 
 		columns = metadata().getEntityBinding(
@@ -137,7 +138,7 @@ public class JoinMulIdNaming extends BaseEnversJPAFunctionalTestCase {
 		).getProperty( "reference_id2" ).getColumnIterator();
 
 		assertTrue( columns.hasNext() );
-		assertEquals( "ID2_reference", columns.next().getName() );
+		assertEquals( "ID2_reference", ( (Column) columns.next() ).getName() );
 		assertFalse( columns.hasNext() );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/ClassLoaderAccessTestingImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/ClassLoaderAccessTestingImpl.java
@@ -21,10 +21,9 @@ public class ClassLoaderAccessTestingImpl implements ClassLoaderAccess {
 	public static final ClassLoaderAccessTestingImpl INSTANCE = new ClassLoaderAccessTestingImpl();
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public <T> Class<T> classForName(String name) {
+	public Class<?> classForName(String name) {
 		try {
-			return (Class<T>) getClass().getClassLoader().loadClass( name );
+			return getClass().getClassLoader().loadClass( name );
 		}
 		catch (ClassNotFoundException e) {
 			throw new ClassLoadingException( "Could not load class by name : " + name, e );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/ServiceRegistryTestingImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/ServiceRegistryTestingImpl.java
@@ -32,6 +32,7 @@ public class ServiceRegistryTestingImpl
 		extends StandardServiceRegistryImpl
 		implements ServiceRegistryImplementor {
 
+	@SuppressWarnings( {"rawtypes", "unchecked"} )
 	public static ServiceRegistryTestingImpl forUnitTesting() {
 		return new ServiceRegistryTestingImpl(
 				true,
@@ -41,11 +42,11 @@ public class ServiceRegistryTestingImpl
 						dialectFactoryService(),
 						connectionProviderService()
 				),
-				Environment.getProperties()
+				(Map) Environment.getProperties()
 		);
 	}
 
-	public static ServiceRegistryTestingImpl forUnitTesting(Map settings) {
+	public static ServiceRegistryTestingImpl forUnitTesting(Map<String, Object> settings) {
 		return new ServiceRegistryTestingImpl(
 				true,
 				new BootstrapServiceRegistryBuilder().build(),
@@ -74,7 +75,7 @@ public class ServiceRegistryTestingImpl
 			BootstrapServiceRegistry bootstrapServiceRegistry,
 			List<StandardServiceInitiator> serviceInitiators,
 			List<ProvidedService> providedServices,
-			Map<?, ?> configurationValues) {
+			Map<String, Object> configurationValues) {
 		super( autoCloseRegistry, bootstrapServiceRegistry, serviceInitiators, providedServices, configurationValues );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14250

This is an ambitious goal! But as https://hibernate.atlassian.net/browse/HHH-14230#icft=HHH-14230 demonstrated, it is still highly relevant. Improving our generics usage is also always in my wish list.

Given v6 is not released, it is a good timing to do it. Gonna spend a couple of weeks or even months to finish it. The benefit would be long-term and time will tell it is worthwhile.

Top level packages are listed below to monitor job progress intuitively:

- [x] action
- [x] annotations
- [x] boot
- [x] bytecode
- [x] cache
- [x] cfg
- [x] classic
- [x] collection
- [x] context
- [x] dialect
- [x] ejb
- [x] engine
- [x] event
- [x] exception
- [ ] graph
- [ ] id
- [x] integrator
- [ ] internal
- [x] jdbc
- [x] jmx
- [ ] jpa
- [ ] loader
- [x] lob
- [ ] mapping
- [x] metadata
- [ ] metamodel
- [x] param
- [ ] persister
- [ ] pretty
- [ ] procedure
- [ ] property
- [ ] proxy
- [ ] query
- [ ] resource
- [ ] result
- [ ] secure
- [ ] service
- [ ] sql
- [ ] stat
- [ ] tool
- [ ] transform
- [ ] tuple
- [ ] type
- [ ] usertype
- [ ] other