### PR TITLE
wip/6.0 Correct error in StandardOrderedMapSemantics due to generics checking

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardOrderedMapSemantics.java
@@ -58,6 +58,6 @@ public class StandardOrderedMapSemantics extends AbstractMapSemantics<LinkedHash
 
 	@Override
 	public Iterator getElementIterator(LinkedHashMap rawCollection) {
-		return rawCollection.entrySet().iterator();
+		return rawCollection.values().iterator();
 	}
 }


### PR DESCRIPTION
During tightening the Java generics checking in https://github.com/hibernate/hibernate-orm/pull/3587. Java compiler helps to nail down coding bug automatically. This PR is the first one of such PRs created mainly by Java compiler.

Will create similar PRs in the future to make https://github.com/hibernate/hibernate-orm/pull/3587 manageable, so we can focus on generics tweaking exclusively in that PR.