### PR TITLE
HHH-14623 Skip audit non-insertable, non-updateable components

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/AuditedPropertiesReader.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/AuditedPropertiesReader.java
@@ -263,7 +263,10 @@ public class AuditedPropertiesReader {
 			final Property property = propertyIter.next();
 			addPersistentProperty( property );
 			// See HHH-6636
-			if ( "embedded".equals( property.getPropertyAccessorName() ) && !PropertyPath.IDENTIFIER_MAPPER_PROPERTY.equals( property.getName() ) ) {
+			if ( "embedded".equals( property.getPropertyAccessorName() )
+					&& !PropertyPath.IDENTIFIER_MAPPER_PROPERTY.equals( property.getName() )
+					&& (property.isInsertable() || property.isUpdateable())
+			) {
 				createPropertiesGroupMapping( property );
 			}
 		}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/ElementCollectionMultipleJoinColumnEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/entities/collection/ElementCollectionMultipleJoinColumnEntity.java
@@ -1,0 +1,54 @@
+package org.hibernate.envers.test.entities.collection;
+
+import org.hibernate.envers.Audited;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Set;
+
+@Audited
+@Entity
+@Table(name = "foo")
+public class ElementCollectionMultipleJoinColumnEntity implements Serializable {
+    @Id
+    @Column(name = "foo_id")
+    private String fooId;
+
+    @ElementCollection
+    @Column(name = "bar_id")
+    @CollectionTable(
+            name = "foos_bars_mapping",
+            joinColumns = {
+                    @JoinColumn(name = "bazId", referencedColumnName = "baz_id"),
+                    @JoinColumn(name = "fooId", referencedColumnName = "foo_id")
+            }
+    )
+    private Set<String> barIds;
+
+    @Column(name = "baz_id")
+    private String bazId;
+
+    public String getFooId() {
+        return fooId;
+    }
+
+    public void setFooId(String fooId) {
+        this.fooId = fooId;
+    }
+
+    public Set<String> getBarIds() {
+        return barIds;
+    }
+
+    public void setBarIds(Set<String> barIds) {
+        this.barIds = barIds;
+    }
+
+    public String getBazId() {
+        return bazId;
+    }
+
+    public void setBazId(String bazId) {
+        this.bazId = bazId;
+    }
+}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/ElementCollectionMultipleJoinColumnsTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/collection/ElementCollectionMultipleJoinColumnsTest.java
@@ -1,0 +1,51 @@
+package org.hibernate.envers.test.integration.collection;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.entities.collection.ElementCollectionMultipleJoinColumnEntity;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@TestForIssue(jiraKey = "HHH-14263")
+public class ElementCollectionMultipleJoinColumnsTest extends BaseEnversJPAFunctionalTestCase {
+    @Override
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[] { ElementCollectionMultipleJoinColumnEntity.class };
+    }
+
+    @Test
+    public void testAuditForElementCollectionMultipleJoinColumnsWorks() {
+        AuditReader reader = getAuditReader();
+        EntityManager em = getEntityManager();
+        Set<String> barIds = new HashSet<>();
+        barIds.add("bar1");
+        em.getTransaction().begin();
+        ElementCollectionMultipleJoinColumnEntity entity = new ElementCollectionMultipleJoinColumnEntity();
+        entity.setFooId("foo1");
+        entity.setBarIds(new HashSet<>(barIds));
+        entity.setBazId("baz1");
+        em.persist(entity);
+        em.getTransaction().commit();
+
+        Set<String> barIds2 = new HashSet<>();
+        barIds2.add("bar1");
+        barIds2.add("bar2");
+        em.getTransaction().begin();
+        ElementCollectionMultipleJoinColumnEntity entity2 = new ElementCollectionMultipleJoinColumnEntity();
+        entity2.setFooId("foo1");
+        entity2.setBarIds(new HashSet<>(barIds2));
+        entity2.setBazId("baz1");
+        em.merge(entity2);
+        em.getTransaction().commit();
+
+        assertEquals(barIds, reader.find(ElementCollectionMultipleJoinColumnEntity.class, "foo1", 1).getBarIds());
+        assertEquals(barIds2, reader.find(ElementCollectionMultipleJoinColumnEntity.class, "foo1", 2).getBarIds());
+    }
+}


### PR DESCRIPTION
This is hardly an optimal solution. And maybe straight up wrong. Ideally we should skip these synthetic properties that were created for join during audit here https://github.com/hibernate/hibernate-orm/blob/master/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiPropertyMapper.java#L114
However, for some reason propertyData for synthetic property created for join has `isSynthetic == false`. And any attempts to drag that value with correct value of `true` ended with strange errors way earlier, during metadata generation.
