### PR TITLE
HHH-14234 Fix CI building error on HANA dialect

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/inheritance/DenormalizedTablePhysicalIncludedTableConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/inheritance/DenormalizedTablePhysicalIncludedTableConstraintTest.java
@@ -12,11 +12,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.dialect.MariaDBDialect;
-import org.hibernate.dialect.MySQLDialect;
 
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.SkipForDialects;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
@@ -26,10 +22,6 @@ import org.junit.Test;
  * @author Nathan Xu
  */
 @TestForIssue( jiraKey = "HHH-14234" )
-@SkipForDialects( {
-		@SkipForDialect( value = MySQLDialect.class, comment = "skip it for it support constraint name uniqueness in table, not db" ),
-		@SkipForDialect( value = MariaDBDialect.class, comment = "skip it for it support constraint name uniqueness in table, not db" )
-} )
 public class DenormalizedTablePhysicalIncludedTableConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
@@ -47,13 +39,14 @@ public class DenormalizedTablePhysicalIncludedTableConstraintTest extends BaseNo
 
 	@Test
 	public void testUniqueConstraintFromSupTableNotAppliedToSubTable() {
-		// Unique constraint should be unique in db (except for MySQL and Mariadb).
-		// Without fixing, exception will be thrown when unique constraint in 'supTable' is applied to 'subTable' as well
+		// Unique constraint should be unique in db
+		// Without fixing, exception will be thrown when unique constraint in 'SUPTABLE' is applied to 'SUBTABLE' as well
+		// Both table names are uppercase to accommodate HANA dialect (see https://stackoverflow.com/questions/29974507/sap-hana-invalid-table-name)
 	}
 
 	@Entity(name = "SuperClass")
 	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
-	@Table( name = "supTable",
+	@Table( name = "SUPTABLE",
 			uniqueConstraints = {
 					@UniqueConstraint(  name = "UK",
 							columnNames = {"colOne", "colTwo"})
@@ -73,7 +66,7 @@ public class DenormalizedTablePhysicalIncludedTableConstraintTest extends BaseNo
 	}
 
 	@Entity(name = "SubClass")
-	@Table( name = "subTable" )
+	@Table( name = "SUBTABLE" )
 	static class SubClass extends SuperClass {
 
 		@Column(name = "colThree")


### PR DESCRIPTION
HANA dialect has special requirement regarding table name in terms of case sensibility. Renaming table names to UPPERCASE should solve the issue (another option is to put quotation marks around table names). See https://stackoverflow.com/questions/29974507/sap-hana-invalid-table-name