### PR TITLE
show more detailed errors when getting connection metadata

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -129,7 +129,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 				}
 			}
 			catch (Exception e) {
-				log.unableToObtainConnectionToQueryMetadata( e.getMessage() );
+				log.unableToObtainConnectionToQueryMetadata( e );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1150,19 +1150,19 @@ public interface CoreMessageLogger extends BasicLogger {
 
 	@LogMessage(level = WARN)
 	@Message(value = "Could not obtain connection metadata: %s", id = 339)
-	void unableToObjectConnectionMetadata(SQLException error);
+	void unableToObjectConnectionMetadata(SQLException error); //Object, typo?
 
 	@LogMessage(level = WARN)
 	@Message(value = "Could not obtain connection to query metadata: %s", id = 340)
-	void unableToObjectConnectionToQueryMetadata(SQLException error);
+	void unableToObjectConnectionToQueryMetadata(SQLException error); // Object, typo?
 
 	@LogMessage(level = WARN)
 	@Message(value = "Could not obtain connection metadata : %s", id = 341)
 	void unableToObtainConnectionMetadata(String message);
 
 	@LogMessage(level = WARN)
-	@Message(value = "Could not obtain connection to query metadata : %s", id = 342)
-	void unableToObtainConnectionToQueryMetadata(String message);
+	@Message(value = "Could not obtain connection to query metadata", id = 342)
+	void unableToObtainConnectionToQueryMetadata(@Cause Exception e);
 
 	@LogMessage(level = ERROR)
 	@Message(value = "Could not obtain initial context", id = 343)


### PR DESCRIPTION
We have some customization with the connection and datasource, when exceptions happen we cannot see where the problem is. E.g, when getConnection is called and a NPE is thrown, all we get is a very generic NPE error message. The change is to show more details about the error, easier to troubleshoot.

BTW, I see two methods could have typo, added two lines of comments too.