### PR TITLE
HHH-14280 - audit query does not work when @IdClass composite identifier contains association to a not audited entity

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/id/VirtualEntitySingleIdMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/id/VirtualEntitySingleIdMapper.java
@@ -13,6 +13,8 @@ import java.util.Map;
 
 import org.hibernate.Session;
 import org.hibernate.envers.boot.internal.EnversService;
+import org.hibernate.envers.internal.entities.EntitiesConfigurations;
+import org.hibernate.envers.internal.entities.EntityConfiguration;
 import org.hibernate.envers.internal.entities.PropertyData;
 import org.hibernate.envers.internal.tools.ReflectionTools;
 import org.hibernate.property.access.spi.Getter;
@@ -25,7 +27,7 @@ import org.hibernate.type.EntityType;
  * An extension to the {@link SingleIdMapper} implementation that supports the use case of an {@code @IdClass}
  * mapping that contains an entity association where the {@code @IdClass} stores the primary key of the
  * associated entity rather than the entity object itself.
- *
+ * <p>
  * Internally this mapper is capable of transforming the primary key values into the associated entity object
  * and vice versa depending upon the operation.
  *
@@ -203,8 +205,16 @@ public class VirtualEntitySingleIdMapper extends SingleIdMapper {
 	}
 
 	private static IdMapper resolveEntityIdMapper(ServiceRegistry serviceRegistry, String entityName) {
-		final EnversService enversService = serviceRegistry.getService( EnversService.class );
-		return enversService.getEntitiesConfigurations().get( entityName ).getIdMapper();
+		final EntitiesConfigurations entitiesConfigurations = serviceRegistry.getService( EnversService.class )
+				.getEntitiesConfigurations();
+
+		final EntityConfiguration auditedEntityConfiguration = entitiesConfigurations.get( entityName );
+		if ( auditedEntityConfiguration != null ) {
+			return auditedEntityConfiguration.getIdMapper();
+		}
+		else {
+			return entitiesConfigurations.getNotVersionEntityConfiguration( entityName ).getIdMapper();
+		}
 	}
 
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/ids/idclass/ManyToOneNotAuditedMulIdTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/ids/idclass/ManyToOneNotAuditedMulIdTest.java
@@ -1,0 +1,104 @@
+package org.hibernate.envers.test.integration.ids.idclass;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.test.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.envers.test.Priority;
+import org.hibernate.envers.test.entities.UnversionedStrTestEntity;
+import org.hibernate.envers.test.entities.ids.MulId;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@TestForIssue( jiraKey = "HHH-14280" )
+public class ManyToOneNotAuditedMulIdTest extends BaseEnversJPAFunctionalTestCase {
+	private final static String str1 = "str1", str2 = "str2";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { UnversionedStrTestEntity.class, ManyToOneNotAuditedMulIdTestEntity.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		UnversionedStrTestEntity id2 = new UnversionedStrTestEntity( str1 );
+		ManyToOneNotAuditedMulIdTestEntity entity = new ManyToOneNotAuditedMulIdTestEntity( id2, str2 );
+
+		EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		em.persist( id2 );
+		em.persist( entity );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testRevisionQuery() {
+		final List<ManyToOneNotAuditedMulIdTestEntity> entities = getAuditReader().createQuery()
+				.forRevisionsOfEntity( ManyToOneNotAuditedMulIdTestEntity.class, true, true )
+				.getResultList();
+
+		assertEquals( 1, entities.size() );
+		final ManyToOneNotAuditedMulIdTestEntity entity = entities.get( 0 );
+		assertEquals( str1, entity.id2.getStr() );
+		assertEquals( str2, entity.str );
+	}
+
+	@Entity
+	@IdClass(MulId.class)
+	public static class ManyToOneNotAuditedMulIdTestEntity {
+		@Id
+		@GeneratedValue
+		private Integer id1;
+
+		@Id
+		@ManyToOne
+		private UnversionedStrTestEntity id2;
+
+		@Audited
+		private String str;
+
+		public Integer getId1() {
+			return id1;
+		}
+
+		public void setId1(Integer id1) {
+			this.id1 = id1;
+		}
+
+		public UnversionedStrTestEntity getId2() {
+			return id2;
+		}
+
+		public void setId2(UnversionedStrTestEntity id2) {
+			this.id2 = id2;
+		}
+
+		public String getStr() {
+			return str;
+		}
+
+		public void setStr(String str) {
+			this.str = str;
+		}
+
+		public ManyToOneNotAuditedMulIdTestEntity() {
+		}
+
+		public ManyToOneNotAuditedMulIdTestEntity(UnversionedStrTestEntity id2, String str) {
+			this.id2 = id2;
+			this.str = str;
+		}
+	}
+}


### PR DESCRIPTION
The first commit contains test case
The second one contains possible solution