### PR TITLE
HHH-13310 getParameterValue() not working for collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -25,6 +25,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.persistence.CacheRetrieveMode;
@@ -749,57 +754,104 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 	@Override
 	public <T> T getParameterValue(Parameter<T> parameter) {
 		LOGGER.tracef( "#getParameterValue(%s)", parameter );
-
 		getProducer().checkOpen( false );
 
-		if ( !getParameterMetadata().containsReference( (QueryParameter) parameter ) ) {
-			throw new IllegalArgumentException( "Parameter reference [" + parameter + "] did not come from this query" );
-		}
-
-		final QueryParameterBinding<T> binding = getQueryParameterBindings().getBinding( (QueryParameter<T>) parameter );
-		LOGGER.debugf( "Checking whether parameter reference [%s] is bound : %s", parameter, binding.isBound() );
-		if ( !binding.isBound() ) {
-			throw new IllegalStateException( "Parameter value not yet bound : " + parameter.toString() );
-		}
-		return binding.getBindValue();
+		return (T) getParameterValue(
+				(QueryParameter) parameter,
+				(queryParameter) -> new IllegalStateException( "Parameter value not yet bound : " + queryParameter.toString() ),
+				(queryParameter, e) -> {
+					final String message = "Parameter reference [" + queryParameter + "] did not come from this query";
+					if ( e == null ) {
+						return new IllegalArgumentException( message );
+					}
+					return new IllegalArgumentException( message, e );
+				},
+				(queryParameter, isBound) -> LOGGER.debugf(
+						"Checking whether parameter reference [%s] is bound : %s",
+						queryParameter,
+						isBound
+				)
+		);
 	}
 
 	@Override
 	public Object getParameterValue(String name) {
 		getProducer().checkOpen( false );
 
-		final QueryParameterBinding binding;
-		try {
-			binding = getQueryParameterBindings().getBinding( name );
-		}
-		catch (QueryParameterException e) {
-			throw new IllegalArgumentException( "Could not resolve parameter by name - " + name, e );
-		}
-
-		LOGGER.debugf( "Checking whether named parameter [%s] is bound : %s", name, binding.isBound() );
-		if ( !binding.isBound() ) {
-			throw new IllegalStateException( "Parameter value not yet bound : " + name );
-		}
-		return binding.getBindValue();
+		final QueryParameter<Object> queryParameter = getParameterMetadata().getQueryParameter( name );
+		return getParameterValue(
+				queryParameter,
+				(parameter) -> new IllegalStateException( "Parameter value not yet bound : " + parameter.getName() ),
+				(parameter, e) -> {
+					final String message = "Could not resolve parameter by name - " + parameter.getName();
+					if ( e == null ) {
+						return new IllegalArgumentException( message );
+					}
+					return new IllegalArgumentException( message, e );
+				},
+				(parameter, isBound) -> LOGGER.debugf(
+						"Checking whether positional named [%s] is bound : %s",
+						parameter.getName(),
+						isBound
+				)
+		);
 	}
 
 	@Override
 	public Object getParameterValue(int position) {
 		getProducer().checkOpen( false );
 
-		final QueryParameterBinding binding;
+		final QueryParameter<Object> queryParameter = getParameterMetadata().getQueryParameter( position );
+		return getParameterValue(
+				queryParameter,
+				(parameter) -> new IllegalStateException( "Parameter value not yet bound : " + parameter.getPosition() ),
+				(parameter, e) -> {
+					String message = "Could not resolve parameter by position - " + parameter.getPosition();
+					if ( e == null ) {
+						return new IllegalArgumentException( message );
+					}
+					return new IllegalArgumentException( message, e );
+				},
+				(parameter, isBound) -> LOGGER.debugf(
+						"Checking whether positional parameter [%s] is bound : %s",
+						parameter.getPosition(),
+						isBound
+				)
+		);
+	}
+
+	private Object getParameterValue(
+			QueryParameter queryParameter,
+			Function<QueryParameter, IllegalStateException> notBoundParamenterException,
+			BiFunction<QueryParameter, QueryParameterException, IllegalArgumentException> couldNotResolveParameterException,
+			BiConsumer<QueryParameter, Boolean> boundCheckingLogger) {
 		try {
-			binding = getQueryParameterBindings().getBinding( position );
+			final QueryParameterBindings parameterBindings = getQueryParameterBindings();
+
+			if ( queryParameter == null ) {
+				throw couldNotResolveParameterException.apply( queryParameter, null );
+			}
+			if ( parameterBindings.isMultiValuedBinding( queryParameter ) ) {
+				final QueryParameterListBinding<Object> queryParameterListBinding = parameterBindings
+						.getQueryParameterListBinding( queryParameter );
+				final Collection<Object> bindValues = queryParameterListBinding.getBindValues();
+				if ( bindValues == null ) {
+					throw notBoundParamenterException.apply( queryParameter );
+				}
+				return bindValues;
+			}
+
+			final QueryParameterBinding<Object> binding = parameterBindings.getBinding( queryParameter );
+			final boolean bound = binding.isBound();
+			boundCheckingLogger.accept( queryParameter, bound );
+			if ( !bound ) {
+				throw notBoundParamenterException.apply( queryParameter );
+			}
+			return binding.getBindValue();
 		}
 		catch (QueryParameterException e) {
-			throw new IllegalArgumentException( "Could not resolve parameter by position - " + position, e );
+			throw couldNotResolveParameterException.apply( queryParameter, e );
 		}
-
-		LOGGER.debugf( "Checking whether positional  parameter [%s] is bound : %s", (Integer) position, (Boolean) binding.isBound() );
-		if ( !binding.isBound() ) {
-			throw new IllegalStateException( "Parameter value not yet bound : " + position );
-		}
-		return binding.getBindValue();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -317,6 +317,14 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 //		return values.toArray( new Object[values.size()] );
 	}
 
+	@Override
+	public boolean isMultiValuedBinding(QueryParameter parameter) {
+		if ( parameterListBindingMap == null ) {
+			return false;
+		}
+		return parameterListBindingMap.containsKey( parameter );
+	}
+
 	/**
 	 * @deprecated (since 5.2) expect a different approach to org.hibernate.engine.spi.QueryParameters in 6.0
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindings.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindings.java
@@ -35,4 +35,12 @@ public interface QueryParameterBindings {
 	Type[] collectPositionalBindTypes();
 	Object[] collectPositionalBindValues();
 	Map<String,TypedValue> collectNamedParameterBindings();
+
+	/**
+	 * @deprecated expect a different approach to org.hibernate.engine.spi.QueryParameters in 6.0
+	 */
+	@Deprecated
+	default boolean isMultiValuedBinding(QueryParameter parameter) {
+		return false;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ParameterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ParameterTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.test.hql;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -155,5 +156,103 @@ public class ParameterTest extends BaseCoreFunctionalTestCase {
 
 		s.getTransaction().commit();
 		s.close();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetParameterListValue() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in :ids" );
+					query.setParameterList( "ids", Arrays.asList( 1L, 2L ) );
+
+					Object parameterListValue = query.getParameterValue( "ids" );
+					assertThat( parameterListValue, is( Arrays.asList( 1L, 2L ) ) );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetParameterListValueAfterParameterExpansion() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in :ids" );
+					query.setParameterList( "ids", Arrays.asList( 1L, 2L ) );
+					query.list();
+
+					Object parameterListValue = query.getParameterValue( "ids" );
+					assertThat( parameterListValue, is( Arrays.asList( 1L, 2L ) ) );
+				}
+		);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetNotBoundParameterListValue() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in :ids" );
+					query.getParameterValue( "ids" );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetPositionalParameterListValue() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in ?1" );
+					query.setParameter( 1, Arrays.asList( 1L, 2L ) );
+
+					Object parameterListValue = query.getParameterValue( 1 );
+					assertThat( parameterListValue, is( Arrays.asList( 1L, 2L ) ) );
+
+					query.list();
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetPositionalParameterValue() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id = ?1" );
+					query.setParameter( 1,  1L  );
+
+					Object parameterListValue = query.getParameterValue( 1 );
+					assertThat( parameterListValue, is( 1L ) );
+
+					query.list();
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetParameterByPositionListValueAfterParameterExpansion() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in ?1" );
+					query.setParameterList( 1, Arrays.asList( 1L, 2L ) );
+					query.list();
+
+					Object parameterListValue = query.getParameterValue( 1 );
+					assertThat( parameterListValue, is( Arrays.asList( 1L, 2L ) ) );
+				}
+		);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	@TestForIssue(jiraKey = "HHH-13310")
+	public void testGetPositionalNotBoundParameterListValue() {
+		inTransaction(
+				session -> {
+					Query query = session.createQuery( "from Animal a where a.id in ?1" );
+					query.getParameterValue( 1 );
+				}
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/StoredProcedureApiTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/StoredProcedureApiTests.java
@@ -49,6 +49,20 @@ public class StoredProcedureApiTests extends BaseNonConfigCoreFunctionalTestCase
 	}
 
 	@Test
+	public void parameterValueAccessByName() {
+		inTransaction(
+				session -> {
+					final ProcedureCall call = session.createStoredProcedureCall( "test" );
+
+					call.registerStoredProcedureParameter("a", Integer.class, ParameterMode.IN);
+					call.registerStoredProcedureParameter( "b", String.class, ParameterMode.OUT);
+					call.setParameter( "a", 1 );
+					call.getParameterValue( "a" );
+				}
+		);
+	}
+
+	@Test
 	public void testInvalidParameterReference() {
 		inTransaction(
 				session -> {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13310

I tried to avoid any change to API/SPIs, but I ended up adding the ` isAParameterList` to `org.hibernate.query.spi.QueryParameterBindings`, having this method a default should make the PR backportable also to 5.4 and 5.3.