### PR TITLE
Support order of fields as order of columns when generate table.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyContainer.java
@@ -9,13 +9,7 @@
 
 package org.hibernate.cfg;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import javax.persistence.Access;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
@@ -63,7 +57,7 @@ class PropertyContainer {
 	 */
 	private final AccessType classLevelAccessType;
 
-	private final TreeMap<String, XProperty> persistentAttributeMap;
+	private final LinkedHashMap<String, XProperty> persistentAttributeMap;
 
 	PropertyContainer(XClass clazz, XClass entityAtStake, AccessType defaultClassLevelAccessType) {
 		this.xClass = clazz;
@@ -83,7 +77,7 @@ class PropertyContainer {
 				: defaultClassLevelAccessType;
 		assert classLevelAccessType == AccessType.FIELD || classLevelAccessType == AccessType.PROPERTY;
 
-		this.persistentAttributeMap = new TreeMap<String, XProperty>();
+		this.persistentAttributeMap = new LinkedHashMap<String, XProperty>();
 
 		final List<XProperty> fields = xClass.getDeclaredProperties( AccessType.FIELD.getType() );
 		final List<XProperty> getters = xClass.getDeclaredProperties( AccessType.PROPERTY.getType() );
@@ -125,7 +119,7 @@ class PropertyContainer {
 	}
 
 	private void collectPersistentAttributesUsingLocalAccessType(
-			TreeMap<String, XProperty> persistentAttributeMap,
+			LinkedHashMap<String, XProperty> persistentAttributeMap,
 			Map<String,XProperty> persistentAttributesFromGetters,
 			List<XProperty> fields,
 			List<XProperty> getters) {
@@ -177,7 +171,7 @@ class PropertyContainer {
 	}
 
 	private void collectPersistentAttributesUsingClassLevelAccessType(
-			TreeMap<String, XProperty> persistentAttributeMap,
+			LinkedHashMap<String, XProperty> persistentAttributeMap,
 			Map<String,XProperty> persistentAttributesFromGetters,
 			List<XProperty> fields,
 			List<XProperty> getters) {


### PR DESCRIPTION
Change 'TreeMap' in class 'PropertyContainer' as 'LinkedHashMap', order columns according to fileds in class.