### PR TITLE
Revert to HCANN 5.1.0.final compatibility

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -310,7 +310,7 @@ public final class AnnotationBinder {
 		if ( packaze == null ) {
 			return;
 		}
-		final XPackage pckg = context.getBootstrapContext().getReflectionManager().toXPackage( packaze );
+		final XPackage pckg = HCANNHelper.toXPackage( context.getBootstrapContext().getReflectionManager(), packaze );
 
 		if ( pckg.isAnnotationPresent( SequenceGenerator.class ) ) {
 			SequenceGenerator ann = pckg.getAnnotation( SequenceGenerator.class );
@@ -1419,7 +1419,7 @@ public final class AnnotationBinder {
 			return;
 		}
 		final ReflectionManager reflectionManager = context.getBootstrapContext().getReflectionManager();
-		final XPackage pckg = reflectionManager.toXPackage( packaze );
+		final XPackage pckg = HCANNHelper.toXPackage( reflectionManager, packaze );
 		bindFetchProfiles( pckg, context );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/HCANNHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/HCANNHelper.java
@@ -12,16 +12,23 @@ import java.lang.reflect.Method;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
+import org.hibernate.annotations.common.reflection.ReflectionManager;
+import org.hibernate.annotations.common.reflection.XPackage;
 import org.hibernate.annotations.common.reflection.XProperty;
+import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.annotations.common.reflection.java.JavaXMember;
 
 /**
  * Manage the various fun-ness of dealing with HCANN...
  *
+ * @deprecated all these methods are available only to maintain compatibility with older versions of HCANN - stop using
  * @author Steve Ebersole
  */
+@Deprecated
 public class HCANNHelper {
-	private static Method getMemberMethod;
+	private static final Method getMemberMethod;
+	private static final Method RESET_REFLECTIONMANAGER_METHOD; // might not exist: null in such case.
+	private static final Method TOXPACKAGE_REFLECTIONMANAGER_METHOD;
 	static {
 		// The following is in a static block to avoid problems lazy-initializing
 		// and making accessible in a multi-threaded context. See HHH-11289.
@@ -40,6 +47,25 @@ public class HCANNHelper {
 		catch (Exception e) {
 			throw new HibernateException( "Could not access org.hibernate.annotations.common.reflection.java.JavaXMember#getMember method", e );
 		}
+		Method resetMethod;
+		try {
+			resetMethod = ReflectionManager.class.getDeclaredMethod( "reset" );
+		}
+		catch (NoSuchMethodException e) {
+			//Ignore this: we want to be compatible with older versions which don't have this.
+			resetMethod = null;
+		}
+		RESET_REFLECTIONMANAGER_METHOD = resetMethod;
+
+		Method toXpackageMethod;
+		try {
+			toXpackageMethod = JavaReflectionManager.class.getDeclaredMethod( "getXAnnotatedElement", Package.class );
+			toXpackageMethod.setAccessible( true );
+		}
+		catch (NoSuchMethodException e) {
+			throw new AssertionFailure( "org.hibernate.annotations.common.reflection.java.JavaReflectionManager#getXAnnotatedElement method", e );
+		}
+		TOXPACKAGE_REFLECTIONMANAGER_METHOD = toXpackageMethod;
 	}
 
 	public static String annotatedElementSignature(XProperty xProperty) {
@@ -63,4 +89,42 @@ public class HCANNHelper {
 			);
 		}
 	}
+
+	/**
+	 * Attempts to invoke the reset() method on the ReflectionManager.
+	 * Some older versions of HCANN don't have this method, in which case we
+	 * simply won't invoke the reset method.
+	 * If the method doesn't exist, no errors will be propagated.
+	 * @param reflectionManager
+	 * @throws HibernateException if the method seems to exist and still we fail to invoke it.
+	 */
+	public static void resetIfResetMethodExists(ReflectionManager reflectionManager) {
+		if ( RESET_REFLECTIONMANAGER_METHOD != null ) {
+			try {
+				RESET_REFLECTIONMANAGER_METHOD.invoke( reflectionManager );
+			}
+			catch (InvocationTargetException | IllegalAccessException e) {
+				throw new HibernateException( "Could not invoke method " + RESET_REFLECTIONMANAGER_METHOD, e );
+			}
+		}
+	}
+
+	public static XPackage toXPackage(final ReflectionManager reflectionManager, final Package packaze) {
+		if ( ! ( reflectionManager instanceof JavaReflectionManager ) ) {
+			throw new AssertionFailure( "We expect an instance of JavaReflectionManager here" );
+		}
+		// on HCANN 5.1.1 we have both options:
+		//    public XPackage toXPackage(Package pkg);
+		//    XPackage getXAnnotatedElement(Package pkg);
+		// on HCANN 5.1.0 we only have:
+		//    XPackage getXAnnotatedElement(Package pkg);
+		// N.B. the one method which they have in common is not public.
+		try {
+			return (XPackage) TOXPACKAGE_REFLECTIONMANAGER_METHOD.invoke( reflectionManager, packaze );
+		}
+		catch (InvocationTargetException | IllegalAccessException e) {
+			throw new HibernateException( "Could not invoke method " + TOXPACKAGE_REFLECTIONMANAGER_METHOD, e );
+		}
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAMetadataProvider.java
@@ -107,7 +107,9 @@ public final class JPAMetadataProvider implements MetadataProvider {
 		return reader;
 	}
 
-	@Override
+	// @Override
+	// FIXME this method was introduced in HCANN 5.1.1: we can't mark it as @Override yet,
+	// but it's expected to be invoked when we're running with the right HCANN version.
 	public void reset() {
 		//It's better to remove the HashMap, as it could grow rather large:
 		//when doing a clear() the internal buckets array is not scaled down.

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.naming.Reference;
 import javax.naming.StringRefAddr;
@@ -56,6 +55,7 @@ import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.cfg.Settings;
+import org.hibernate.cfg.annotations.HCANNHelper;
 import org.hibernate.context.internal.JTASessionContext;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.hibernate.context.internal.ThreadLocalSessionContext;
@@ -391,7 +391,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 
 			//As last operation, delete all caches from ReflectionManager
 			//(not modelled as a listener as we want this to be last)
-			metadata.getMetadataBuildingOptions().getReflectionManager().reset();
+			HCANNHelper.resetIfResetMethodExists( metadata.getMetadataBuildingOptions().getReflectionManager() );
 		}
 		catch (Exception e) {
 			for ( Integrator integrator : serviceRegistry.getService( IntegratorService.class ).getIntegrators() ) {


### PR DESCRIPTION
This is a *draft* and at best we'll apply it only to 5.4

Created because we suspect enforcing the requirement of updating to HCANN 5.1.1 is not suitable for a micro release, especially as WildFly users would need to also update their HCANN modules.