### PR TITLE
HHH-14316 HHH-14317 Avoid accessing potentially null variables

### DIFF
--- a/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/AgroalConnectionProvider.java
+++ b/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/AgroalConnectionProvider.java
@@ -139,6 +139,8 @@ public class AgroalConnectionProvider implements ConnectionProvider, Configurabl
 
 	@Override
 	public void stop() {
-		agroalDataSource.close();
+		if ( agroalDataSource != null ) {
+			agroalDataSource.close();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
@@ -168,11 +168,17 @@ public class DriverManagerConnectionProviderImpl
 
 	@Override
 	public Connection getConnection() throws SQLException {
+		if ( state == null ) {
+			throw new IllegalStateException( "Cannot get a connection as the driver manager is not properly initialized" );
+		}
 		return state.getConnection();
 	}
 
 	@Override
 	public void closeConnection(Connection conn) throws SQLException {
+		if ( state == null ) {
+			throw new IllegalStateException( "Cannot close a connection as the driver manager is not properly initialized" );
+		}
 		state.closeConnection( conn );
 	}
 
@@ -204,13 +210,17 @@ public class DriverManagerConnectionProviderImpl
 
 	@Override
 	public void stop() {
-		state.stop();
+		if ( state != null ) {
+			state.stop();
+		}
 	}
 
 	//CHECKSTYLE:START_ALLOW_FINALIZER
 	@Override
 	protected void finalize() throws Throwable {
-		state.stop();
+		if ( state != null ) {
+			state.stop();
+		}
 		super.finalize();
 	}
 	//CHECKSTYLE:END_ALLOW_FINALIZER


### PR DESCRIPTION
No rocket science here, when something is wrong in the setup (typically we cannot connect to the database), these variables can be null and we shouldn't end up with a NPE.

Noted while debugging a bug report in Quarkus.

https://hibernate.atlassian.net/browse/HHH-14316
https://hibernate.atlassian.net/browse/HHH-14317

Should be backported to 5.4.