### PR TITLE
HHH-14319 Test and fix for CollectionType.replaceElements accidently clearing original collection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -742,7 +742,8 @@ public abstract class CollectionType extends AbstractType implements Association
 		// need to put the merged elements in a new collection
 		Object result = ( target == null ||
 				target == original ||
-				target == LazyPropertyInitializer.UNFETCHED_PROPERTY ) ?
+				target == LazyPropertyInitializer.UNFETCHED_PROPERTY ||
+				target instanceof PersistentCollection && ( (PersistentCollection) target ).isWrapper( original ) ) ?
 				instantiateResult( original ) : target;
 
 		//for arrays, replaceElements() may return a different reference, since

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/selectbeforeupdate/UpdateDetachedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/selectbeforeupdate/UpdateDetachedTest.java
@@ -143,7 +143,7 @@ public class UpdateDetachedTest extends BaseCoreFunctionalTestCase{
 	@Test
 	@TestForIssue(jiraKey = "HHH-14319")
 	public void testUpdateDetachedWithAttachedPersistentSet() {
-		final Bar bar = new Bar( 4, "Bar" );
+		final Bar bar = new Bar( 5, "Bar" );
 		final Set<Comment> comments = new HashSet<>();
 		comments.add( new Comment( "abc", "me" ) );
 		bar.comments = comments;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/selectbeforeupdate/UpdateDetachedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/selectbeforeupdate/UpdateDetachedTest.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.test.annotations.selectbeforeupdate;
 
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -136,6 +140,37 @@ public class UpdateDetachedTest extends BaseCoreFunctionalTestCase{
 		assertEquals( Integer.valueOf( 1 ), foo.getVersion() );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-14319")
+	public void testUpdateDetachedWithAttachedPersistentSet() {
+		final Bar bar = new Bar( 4, "Bar" );
+		final Set<Comment> comments = new HashSet<>();
+		comments.add( new Comment( "abc", "me" ) );
+		bar.comments = comments;
+
+		// this should generate versions
+		TransactionUtil.doInHibernate( this::sessionFactory, session -> {
+			session.save( bar );
+		} );
+		final Bar loadedBar = TransactionUtil.doInHibernate( this::sessionFactory, session -> {
+			// We set the comments to the hash set and leave it "dirty"
+			Bar b = session.find( Bar.class, bar.getId() );
+			b.comments = comments;
+
+			// During flushing, the comments HashSet becomes the backing collection of new PersistentSet which replaces the old entry
+			session.flush();
+
+			// Replace the persistent collection with the backing collection in the field
+			b.comments = comments;
+
+			// It's vital that we try merging a detached instance
+			session.detach( b );
+			return (Bar) session.merge( b );
+		} );
+
+		assertEquals( 1, loadedBar.comments.size() );
+	}
+
 	@Entity(name = "Foo")
 	@SelectBeforeUpdate
 	public static class Foo {
@@ -198,6 +233,8 @@ public class UpdateDetachedTest extends BaseCoreFunctionalTestCase{
 		private String name;
 		@Version
 		private Integer version;
+		@ElementCollection
+		private Set<Comment> comments;
 
 		Bar() {
 
@@ -230,6 +267,44 @@ public class UpdateDetachedTest extends BaseCoreFunctionalTestCase{
 
 		public void setVersion(Integer version) {
 			this.version = version;
+		}
+
+		public Set<Comment> getComments() {
+			return comments;
+		}
+
+		public void setComments(Set<Comment> comments) {
+			this.comments = comments;
+		}
+	}
+
+	@Embeddable
+	public static class Comment {
+		private String comment;
+		private String author;
+
+		public Comment() {
+		}
+
+		public Comment(String comment, String author) {
+			this.comment = comment;
+			this.author = author;
+		}
+
+		public String getComment() {
+			return comment;
+		}
+
+		public void setComment(String comment) {
+			this.comment = comment;
+		}
+
+		public String getAuthor() {
+			return author;
+		}
+
+		public void setAuthor(String author) {
+			this.author = author;
 		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14319

Hi @gbadner, I'm not 100% happy with the "fix" as it seems to me that the PersistentCollection entry shouldn't be replaced in the first place during flushing. Even if the replacing is intended, it should at least not wrap the collection that comes from the entity model, but create a copy instead. I think that the additional check in `CollectionType.replace` for `isWrapper` is a good one though and should be kept.