### PR TITLE
HHH-14334 Make dom4j jaxb-api optional as possible

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -32,8 +32,11 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataContributor;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.MetadataSourceType;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
@@ -95,10 +98,16 @@ public class MetadataBuildingProcess {
 			final MetadataSources sources,
 			final BootstrapContext bootstrapContext) {
 		final ManagedResourcesImpl managedResources = ManagedResourcesImpl.baseline( sources, bootstrapContext );
+		final ConfigurationService configService = bootstrapContext.getServiceRegistry().getService( ConfigurationService.class );
+		final boolean xmlMappingEnabled = configService.getSetting(
+				AvailableSettings.XML_MAPPING_ENABLED,
+				StandardConverters.BOOLEAN,
+				true
+		);
 		ScanningCoordinator.INSTANCE.coordinateScan(
 				managedResources,
 				bootstrapContext,
-				sources.getXmlMappingBinderAccess()
+				xmlMappingEnabled ? sources.getXmlMappingBinderAccess() : null
 		);
 		return managedResources;
 	}
@@ -290,7 +299,7 @@ public class MetadataBuildingProcess {
 			final EntityHierarchyBuilder hierarchyBuilder = new EntityHierarchyBuilder();
 //			final MappingBinder mappingBinder = new MappingBinder( true );
 			// We need to disable validation here.  It seems Envers is not producing valid (according to schema) XML
-			final MappingBinder mappingBinder = new MappingBinder( classLoaderService, false );
+			final MappingBinder mappingBinder = options.isXmlMappingEnabled() ? new MappingBinder( classLoaderService, false ) : null;
 			for ( AdditionalJaxbMappingProducer producer : producers ) {
 				log.tracef( "Calling AdditionalJaxbMappingProducer : %s", producer );
 				Collection<MappingDocument> additionalMappings = producer.produceAdditionalMappings(


### PR DESCRIPTION
dependency dom4j and jaxb-api is optional if xml mapping disabled
continuation of HHH-13204