### PR TITLE
DB2 did not allow 'boolean' as a column type prior to 11

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -96,6 +96,11 @@ public class DB2Dialect extends Dialect {
 			registerColumnType( Types.BINARY, "varchar($l) for bit data" ); //should use 'binary' since version 11
 			registerColumnType( Types.BINARY, 254, "char($l) for bit data" ); //should use 'binary' since version 11
 			registerColumnType( Types.VARBINARY, "varchar($l) for bit data" ); //should use 'varbinary' since version 11
+
+			//prior to DB2 11, the 'boolean' type existed,
+			//but was not allowed as a column type
+			registerColumnType( Types.BOOLEAN, "smallint" );
+			registerColumnType( Types.BIT, 1, "smallint" );
 		}
 
 		registerColumnType( Types.BLOB, "blob($l)" );
@@ -555,7 +560,10 @@ public class DB2Dialect extends Dialect {
 
 	@Override
 	protected SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
-		if ( getVersion() < 970 ) {
+		if ( getVersion() < 1100 && sqlCode==Types.BOOLEAN ) {
+			return SmallIntTypeDescriptor.INSTANCE;
+		}
+		else if ( getVersion() < 970 ) {
 			return sqlCode == Types.NUMERIC
 					? DecimalTypeDescriptor.INSTANCE
 					: super.getSqlTypeDescriptorOverride(sqlCode);


### PR DESCRIPTION
We should not use the DB2 `boolean` type as a column type on old versions.

cc @beikov