### PR TITLE
Unused parameter on createCriteriaUpdate(Delete)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/AbstractManipulationCriteriaQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/AbstractManipulationCriteriaQuery.java
@@ -40,8 +40,9 @@ public abstract class AbstractManipulationCriteriaQuery<T> implements Compilable
 	private RootImpl<T> root;
 	private Predicate restriction;
 
-	protected AbstractManipulationCriteriaQuery(CriteriaBuilderImpl criteriaBuilder) {
+	protected AbstractManipulationCriteriaQuery(CriteriaBuilderImpl criteriaBuilder, Class<T> rootClass) {
 		this.criteriaBuilder = criteriaBuilder;
+		from(rootClass);
 	}
 
 	protected CriteriaBuilderImpl criteriaBuilder() {

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaBuilderImpl.java
@@ -124,12 +124,12 @@ public class CriteriaBuilderImpl implements HibernateCriteriaBuilder, Serializab
 
 	@Override
 	public <T> CriteriaUpdate<T> createCriteriaUpdate(Class<T> targetEntity) {
-		return new CriteriaUpdateImpl<T>( this );
+		return new CriteriaUpdateImpl<T>( this, targetEntity );
 	}
 
 	@Override
 	public <T> CriteriaDelete<T> createCriteriaDelete(Class<T> targetEntity) {
-		return new CriteriaDeleteImpl<T>( this );
+		return new CriteriaDeleteImpl<T>( this, targetEntity );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaDeleteImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaDeleteImpl.java
@@ -18,8 +18,8 @@ import org.hibernate.query.criteria.internal.compile.RenderingContext;
  * @author Steve Ebersole
  */
 public class CriteriaDeleteImpl<T> extends AbstractManipulationCriteriaQuery<T> implements CriteriaDelete<T> {
-	protected CriteriaDeleteImpl(CriteriaBuilderImpl criteriaBuilder) {
-		super( criteriaBuilder );
+	protected CriteriaDeleteImpl(CriteriaBuilderImpl criteriaBuilder, Class<T> rootClass) {
+		super( criteriaBuilder, rootClass );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaUpdateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/internal/CriteriaUpdateImpl.java
@@ -26,8 +26,8 @@ import org.hibernate.sql.ast.Clause;
 public class CriteriaUpdateImpl<T> extends AbstractManipulationCriteriaQuery<T> implements CriteriaUpdate<T> {
 	private List<Assignment> assignments = new ArrayList<Assignment>();
 
-	public CriteriaUpdateImpl(CriteriaBuilderImpl criteriaBuilder) {
-		super( criteriaBuilder );
+	public CriteriaUpdateImpl(CriteriaBuilderImpl criteriaBuilder, Class<T> rootClass) {
+		super( criteriaBuilder, rootClass );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13691

In order to create a manipulation query I have to pass the entity class twice because the first time it's not used:
```java
CriteriaDelete<T> criteriaDelete = entityManager.getCriteriaBuilder().createCriteriaDelete(User.class);
criteriaDelete.from(User.class);
```
This change makes it so that the first time I pass it, the class actually gets registered.