### PR TITLE
HHH-14370 + HHH-14371 + HHH-14372 - Add required --add-opens options for Gradle, Weld, Javassist

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Keep all these properties in sync unless you know what you are doing!
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+# Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 toolchain.javadoc.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.launcher.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -229,7 +229,7 @@ if ( gradle.ext.javaToolchainEnabled ) {
 		}
 
 		// Configure JVM Options
-		jvmArgs.addAll( getProperty( 'toolchain.launcher.jvmargs' ).toString().split( ' ' ) )
+		jvmArgs( getProperty( 'toolchain.launcher.jvmargs' ).toString().split( ' ' ) )
 
 		// Display version of Java tools
 		doFirst {

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -20,7 +20,7 @@ ext {
     elVersion = '3.0.1-b09'
 
     cdiVersion = '2.0'
-    weldVersion = '3.0.0.Final'
+    weldVersion = '3.1.5.Final'
 
     javassistVersion = '3.27.0-GA'
     byteBuddyVersion = '1.10.17'

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -276,6 +276,11 @@ task testJavassist(type: Test) {
             logger.lifecycle "Testing javassist with '${javaLauncher.get().metadata.installationPath}'"
         }
     }
+
+    if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
+        // Javassist needs this to generate proxies
+        jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
+    }
 }
 
 check.dependsOn testJavassist

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -260,7 +260,7 @@ task testJavassist(type: Test) {
         }
 
         //  Configure JVM Options
-        jvmArgs.addAll( getProperty( 'toolchain.launcher.jvmargs' ).toString().split( ' ' ) )
+        jvmArgs( getProperty( 'toolchain.launcher.jvmargs' ).toString().split( ' ' ) )
 
         // Display version of Java tools
         doFirst {

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -239,6 +239,12 @@ artifacts {
 
 test {
     systemProperty 'file.encoding', 'utf-8'
+
+    if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
+        // See org.hibernate.boot.model.naming.NamingHelperTest.DefaultCharset.set
+        jvmArgs( ['--add-opens', 'java.base/java.nio.charset=ALL-UNNAMED'] )
+    }
+
     beforeTest { descriptor ->
         //println "Starting test: " + descriptor
     }

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -243,6 +243,9 @@ test {
     if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
         // See org.hibernate.boot.model.naming.NamingHelperTest.DefaultCharset.set
         jvmArgs( ['--add-opens', 'java.base/java.nio.charset=ALL-UNNAMED'] )
+        // Weld needs this to generate proxies
+        jvmArgs( ['--add-opens', 'java.base/java.security=ALL-UNNAMED'] )
+        jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
     }
 
     beforeTest { descriptor ->

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/ReflectionOptimizerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/ReflectionOptimizerTest.java
@@ -9,7 +9,6 @@ package org.hibernate.test.bytecode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.hibernate.bytecode.internal.javassist.BulkAccessor;
 import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.bytecode.spi.ReflectionOptimizer;
 import org.hibernate.cfg.Environment;
@@ -21,15 +20,6 @@ import org.junit.Test;
  * @author Steve Ebersole
  */
 public class ReflectionOptimizerTest extends BaseUnitTestCase {
-	@Test
-	public void testBulkAccessorDirectly() {
-		BulkAccessor bulkAccessor = BulkAccessor.create(
-				Bean.class,
-				BeanReflectionHelper.getGetterNames(),
-				BeanReflectionHelper.getSetterNames(),
-				BeanReflectionHelper.getTypes()
-		);
-	}
 
 	@Test
 	public void testReflectionOptimization() {

--- a/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/Bean.java
+++ b/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/Bean.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.javassist;
+import java.text.ParseException;
+import java.util.Date;
+
+/**
+ * @author Steve Ebersole
+ */
+public class Bean {
+	private String someString;
+	private Long someLong;
+	private Integer someInteger;
+	private Date someDate;
+	private long somelong;
+	private int someint;
+	private Object someObject;
+
+
+	public String getSomeString() {
+		return someString;
+	}
+
+	public void setSomeString(String someString) {
+		this.someString = someString;
+	}
+
+	public Long getSomeLong() {
+		return someLong;
+	}
+
+	public void setSomeLong(Long someLong) {
+		this.someLong = someLong;
+	}
+
+	public Integer getSomeInteger() {
+		return someInteger;
+	}
+
+	public void setSomeInteger(Integer someInteger) {
+		this.someInteger = someInteger;
+	}
+
+	public Date getSomeDate() {
+		return someDate;
+	}
+
+	public void setSomeDate(Date someDate) {
+		this.someDate = someDate;
+	}
+
+	public long getSomelong() {
+		return somelong;
+	}
+
+	public void setSomelong(long somelong) {
+		this.somelong = somelong;
+	}
+
+	public int getSomeint() {
+		return someint;
+	}
+
+	public void setSomeint(int someint) {
+		this.someint = someint;
+	}
+
+	public Object getSomeObject() {
+		return someObject;
+	}
+
+	public void setSomeObject(Object someObject) {
+		this.someObject = someObject;
+	}
+
+	public void throwException() throws ParseException {
+		throw new ParseException( "you asked for it...", 0 );
+	}
+}

--- a/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/BeanReflectionHelper.java
+++ b/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/BeanReflectionHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.javassist;
+import java.util.Date;
+
+import org.hibernate.property.access.internal.PropertyAccessStrategyBasicImpl;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.property.access.spi.Setter;
+
+/**
+ * @author Steve Ebersole
+ */
+public class BeanReflectionHelper {
+
+	public static final Object[] TEST_VALUES = new Object[] {
+			"hello", new Long(1), new Integer(1), new Date(), new Long(1), new Integer(1), new Object()
+	};
+
+	private static final String[] getterNames = new String[7];
+	private static final String[] setterNames = new String[7];
+	private static final Class[] types = new Class[7];
+
+	static {
+		final PropertyAccessStrategyBasicImpl propertyAccessStrategy = new PropertyAccessStrategyBasicImpl();
+
+		PropertyAccess propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someString" );
+		Getter getter = propertyAccess.getGetter();
+		Setter setter = propertyAccess.getSetter();
+		getterNames[0] = getter.getMethodName();
+		types[0] = getter.getReturnType();
+		setterNames[0] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someLong" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[1] = getter.getMethodName();
+		types[1] = getter.getReturnType();
+		setterNames[1] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someInteger" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[2] = getter.getMethodName();
+		types[2] = getter.getReturnType();
+		setterNames[2] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someDate" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[3] = getter.getMethodName();
+		types[3] = getter.getReturnType();
+		setterNames[3] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "somelong" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[4] = getter.getMethodName();
+		types[4] = getter.getReturnType();
+		setterNames[4] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someint" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[5] = getter.getMethodName();
+		types[5] = getter.getReturnType();
+		setterNames[5] = setter.getMethodName();
+
+		propertyAccess = propertyAccessStrategy.buildPropertyAccess( Bean.class, "someObject" );
+		getter = propertyAccess.getGetter();
+		setter = propertyAccess.getSetter();
+		getterNames[6] = getter.getMethodName();
+		types[6] = getter.getReturnType();
+		setterNames[6] = setter.getMethodName();
+	}
+
+	public static String[] getGetterNames() {
+		return getterNames;
+	}
+
+	public static String[] getSetterNames() {
+		return setterNames;
+	}
+
+	public static Class[] getTypes() {
+		return types;
+	}
+}

--- a/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/BulkAccessorTest.java
+++ b/hibernate-core/src/testJavassist/java/org/hibernate/test/bytecode/javassist/BulkAccessorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.javassist;
+
+import org.hibernate.bytecode.internal.javassist.BulkAccessor;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+/**
+ * @author Steve Ebersole
+ */
+// Extracted from org.hibernate.test.bytecode.ReflectionOptimizerTest.
+// I (Yoann) don't know what this tests does, but it's definitely specific to javassist.
+public class BulkAccessorTest extends BaseUnitTestCase {
+
+	@Test
+	public void testBulkAccessorDirectly() {
+		BulkAccessor bulkAccessor = BulkAccessor.create(
+				Bean.class,
+				BeanReflectionHelper.getGetterNames(),
+				BeanReflectionHelper.getSetterNames(),
+				BeanReflectionHelper.getTypes()
+		);
+	}
+}

--- a/hibernate-proxool/hibernate-proxool.gradle
+++ b/hibernate-proxool/hibernate-proxool.gradle
@@ -15,3 +15,15 @@ dependencies {
     compile( libraries.proxool )
     testCompile project( ':hibernate-testing' )
 }
+
+test {
+    if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
+        // Proxool needs this to define classes for some reason. Stack trace:
+        // 	at org.logicalcobwebs.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:372)
+        //	at org.logicalcobwebs.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:193)
+        //	at org.logicalcobwebs.cglib.core.KeyFactory$Generator.create(KeyFactory.java:177)
+        //	at org.logicalcobwebs.cglib.core.KeyFactory.create(KeyFactory.java:149)
+        //	at org.logicalcobwebs.cglib.proxy.Enhancer.<clinit>(Enhancer.java:96)
+        jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
+    }
+}

--- a/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
+++ b/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
@@ -36,3 +36,10 @@ else {
 	logger.warn( "[WARN] Toolchains are not yet supported for Groovy compilation." +
 			" Using the JDK that runs Gradle for Groovy compilation." )
 }
+
+tasks.test {
+	if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
+		// Needs add-opens because Gradle uses illegal accesses to inject... mocks? Something like that.
+		jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14370
https://hibernate.atlassian.net/browse/HHH-14371
https://hibernate.atlassian.net/browse/HHH-14372

Workaround for https://github.com/gradle/gradle/issues/15538 , and a few more `--add-opens` to make tests work when illegal access is disabled. Strangely, we weren't using `--illegal-access=deny`? Anyway, JDK16-ea28 makes that the default.

This should fix compilation and tests on JDK16-ea28.
See https://ci.hibernate.org/view/Personal%20jobs/job/hibernate-orm-personal-yoann-jdk16/20/

Please do not backport to 5.4 yet: we need to backport the upgrade to toochains first.