### PR TITLE
HHH-2558: Fix batching inserts for multi-table entities

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/AbstractBatchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/AbstractBatchImpl.java
@@ -134,7 +134,9 @@ public abstract class AbstractBatchImpl implements Batch {
 	}
 
 	private PreparedStatement buildBatchStatement(String sql, boolean callable) {
-		return jdbcCoordinator.getStatementPreparer().prepareStatement( sql, callable );
+		return callable
+				? jdbcCoordinator.getStatementPreparer().prepareStatement( sql, true )
+				: jdbcCoordinator.getStatementPreparer().prepareStatement( sql );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableInheritance.java
@@ -77,7 +77,7 @@ public class InsertOrderingWithJoinedTableInheritance extends BaseInsertOrdering
 			clearBatches();
 		} );
 
-		verifyPreparedStatementCount( 26 );
+		verifyPreparedStatementCount( 4 );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/insertordering/InsertOrderingWithJoinedTableMultiLevelInheritance.java
@@ -78,7 +78,7 @@ public class InsertOrderingWithJoinedTableMultiLevelInheritance extends BaseInse
 			clearBatches();
 		} );
 
-		verifyPreparedStatementCount( 17 );
+		verifyPreparedStatementCount( 10 );
 	}
 
 	@Override


### PR DESCRIPTION
The original fix of https://hibernate.atlassian.net/browse/HHH-2558 caused https://hibernate.atlassian.net/browse/HHH-12470 and was reverted by adding back jdbcCoordinator.executeBatch() in StatementPreparerImpl.prepareStatement(String sql, final boolean isCallable)

The problem with deletes in HHH-12470 was caused by batch deletes not being flushed before non batch delete. That's why we still need executeBatch() in prepareStatement(String sql, final boolean isCallable) that is used by non batch delete

The idea behind this fix is that we use prepareStatement(String sql) (which doesn't trigger executeBatch()) for AbstractBatchImpl.buildBatchStatement with non callable sql