### PR TITLE
Upgrade the DB2 container image boot script

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -22,10 +22,10 @@ postgresql_9_5() {
 
 db2() {
     docker rm -f db2 || true
-    docker run --name db2 --privileged -e DB2INSTANCE=orm_test -e DB2INST1_PASSWORD=orm_test -e DBNAME=orm_test -e LICENSE=accept -p 50000:50000 -d ibmcom/db2:11.5.0.0a
+    docker run --name db2 -e DB2INSTANCE=orm_test -e DB2INST1_PASSWORD=orm_test -e DBNAME=orm_test -e LICENSE=accept -e AUTOCONFIG=false -e ARCHIVE_LOGS=false -e TO_CREATE_SAMPLEDB=false -e REPODB=false -p 50000:50000 -d ibmcom/db2:11.5.5.0
     # Give the container some time to start
     OUTPUT=
-    while [[ $OUTPUT != *"Setup has completed"* ]]; do
+    while [[ $OUTPUT != *"INSTANCE"* ]]; do
         echo "Waiting for DB2 to start..."
         sleep 10
         OUTPUT=$(docker logs db2)


### PR DESCRIPTION
hi @beikov , when updating the DB2 container it no longer required "privileged", and this makes it compatible with podman so more people could use the scripts :)

Also added a couple variables which help a little bit with its horrible boot times.

Finally, changed the message it's waiting for, as "Setup has completed" is a little too early still.

Does this need a JIRA?  Feel free to take the commit and include it in other related works..