### PR TITLE
HHH-14407 NPE in AbstractMultiTableBulkIdStrategyImpl for column 'hib_sess_id' of PersistentTableBulkIdStrategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/AbstractMultiTableBulkIdStrategyImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/AbstractMultiTableBulkIdStrategyImpl.java
@@ -137,13 +137,13 @@ public abstract class AbstractMultiTableBulkIdStrategyImpl<TT extends IdTableInf
 				.append( jdbcEnvironment.getQualifiedObjectNameFormatter().format( idTable.getQualifiedTableName(), dialect ) )
 				.append( " (" );
 
-		Iterator itr = idTable.getColumnIterator();
+		Iterator<Column> itr = idTable.getColumnIterator();
 		while ( itr.hasNext() ) {
-			final Column column = (Column) itr.next();
+			final Column column = itr.next();
 			buffer.append( column.getQuotedName( dialect ) ).append( ' ' );
 			buffer.append( column.getSqlType( dialect, metadata ) );
 
-			final int sqlTypeCode = column.getSqlTypeCode( metadata );
+			final int sqlTypeCode = column.getSqlTypeCode() != null ? column.getSqlTypeCode() : column.getSqlTypeCode( metadata );
 			final String columnAnnotation = dialect.getCreateTemporaryTableColumnAnnotation( sqlTypeCode );
 			if ( !columnAnnotation.isEmpty() ) {
 				buffer.append(" ").append( columnAnnotation );

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/persistent/PersistentTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/persistent/PersistentTableBulkIdStrategy.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.hql.spi.id.persistent;
 
+import java.sql.Types;
+
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.QualifiedTableName;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -111,6 +113,7 @@ public class PersistentTableBulkIdStrategy
 	protected void augmentIdTableDefinition(Table idTable) {
 		Column sessionIdColumn = new Column( Helper.SESSION_ID_COLUMN_NAME );
 		sessionIdColumn.setSqlType( "CHAR(36)" );
+		sessionIdColumn.setSqlTypeCode( Types.VARCHAR );
 		sessionIdColumn.setComment( "Used to hold the Hibernate Session identifier" );
 		idTable.addColumn( sessionIdColumn );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh14407/ChildEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh14407/ChildEntity.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id.hhh14407;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+/**
+ * @author Sönke Reimer
+ */
+@Entity(name="ChildEntity")
+class ChildEntity extends ParentEntity {
+
+  @Basic
+  @Column(name="CHILD")
+  private String ivChild;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh14407/ParentEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh14407/ParentEntity.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id.hhh14407;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Version;
+
+/**
+ * @author Sönke Reimer
+ */
+@Entity(name="ParentEntity")
+@Inheritance(strategy=InheritanceType.TABLE_PER_CLASS)
+class ParentEntity {
+
+  @Id
+  @Column(name = "ID", length = 32)
+  private String Id;
+
+  @Version
+  @Column(name = "LOCK_VERSION")
+  private int Lock_Version;
+  public String getId() {
+    return Id;
+  }
+  
+}

--- a/hibernate-core/src/test/java/org/hibernate/id/hhh14407/PersistentTableBulkIdStrategyNPETest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/hhh14407/PersistentTableBulkIdStrategyNPETest.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id.hhh14407;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.hql.spi.id.MultiTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.persistent.PersistentTableBulkIdStrategy;
+
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Nathan Xu
+ * @author Sönke Reimer
+ */
+@RequiresDialect( value = H2Dialect.class )
+@TestForIssue( jiraKey = "HHH14407" )
+public class PersistentTableBulkIdStrategyNPETest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty(
+				Environment.DIALECT,
+				PersistentTableBulkIdH2Dialect.class.getName()
+		);
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				ParentEntity.class,
+				ChildEntity.class
+		};
+	}
+
+	@Test
+	public void hhh14407Test() {
+		// without fix of HHH14407, the test case will trigger exception due to NPE in PersistentTableBulkIdStrategy
+	}
+
+	public static class PersistentTableBulkIdH2Dialect extends H2Dialect {
+
+		@Override
+		public MultiTableBulkIdStrategy getDefaultMultiTableBulkIdStrategy() {
+			return new PersistentTableBulkIdStrategy();
+		}
+
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14407

The NPE was introduced by https://github.com/hibernate/hibernate-orm/pull/3498. Specifically, the following new line introduced in that PR didn't take into consideration that some Column has null value (like the '**hib_sess_id**' column in **PersistentTableBulkIdStrategy**) so it would trigger NPE:

![Screen Shot 2021-01-14 at 11 37 11 PM](https://user-images.githubusercontent.com/8211458/104681919-7960dc80-56c1-11eb-8f8f-839f69c495ff.png)

The fix is simple as the following two steps:

1. set the sql code type of the '**hib_sess_id**' to **Types.VARCHAR**;
2. in the above highlighted line, the **Column#getSqlTypeCode(Mapping mapping)** method is only invoked when **Column#getSqlTypeCode()** returns null; otherwise simply return the internal sqlTypeCode value directly, which is in line with the Javadoc of the method:

![Screen Shot 2021-01-14 at 11 42 06 PM](https://user-images.githubusercontent.com/8211458/104682219-2dfafe00-56c2-11eb-9b07-9cabd751563e.png)

