### PR TITLE
Implicit casting support for numerics and switch to argument type as return for floor/ceiling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -809,7 +809,8 @@ public class CommonFunctionFactory {
 	public static void ceiling_ceil(QueryEngine queryEngine) {
 		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "ceil" )
 				.setExactArgumentCount( 1 )
-				.setInvariantType( StandardBasicTypes.DOUBLE )
+				// To avoid truncating to a specific data type, we default to using the argument type
+				.setReturnTypeResolver( useArgType(1) )
 				.register();
 		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "ceiling", "ceil" );
 	}
@@ -1463,12 +1464,14 @@ public class CommonFunctionFactory {
 				.register();
 
 		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder("floor")
-				.setInvariantType( StandardBasicTypes.LONG )
+				// To avoid truncating to a specific data type, we default to using the argument type
+				.setReturnTypeResolver( useArgType(1) )
 				.setExactArgumentCount(1)
 				.register();
 
 		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder("ceiling")
-				.setInvariantType( StandardBasicTypes.LONG )
+				// To avoid truncating to a specific data type, we default to using the argument type
+				.setReturnTypeResolver( useArgType(1) )
 				.setExactArgumentCount(1)
 				.register();
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
@@ -154,7 +154,7 @@ public class ExtractFunction
 								intType,
 								builder
 						),
-						intType,
+						intType, // Implicit cast to int
 						queryEngine,
 						typeConfiguration
 				);
@@ -177,7 +177,7 @@ public class ExtractFunction
 				.findFunctionDescriptor("floor")
 				.generateSqmExpression(
 						arg,
-						longType,
+						longType, // Implicit cast to long
 						queryEngine,
 						typeConfiguration
 				);

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -2960,7 +2960,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionDescriptor("ceiling").generateSqmExpression(
 				arg,
-				resolveExpressableTypeBasic( Long.class ),
+				(AllowableFunctionReturnType<?>) arg.getNodeType(),
 				creationContext.getQueryEngine(),
 				creationContext.getJpaMetamodel().getTypeConfiguration()
 		);
@@ -2972,7 +2972,7 @@ public class SemanticQueryBuilder extends HqlParserBaseVisitor implements SqmCre
 
 		return getFunctionDescriptor("floor").generateSqmExpression(
 				arg,
-				resolveExpressableTypeBasic( Long.class ),
+				(AllowableFunctionReturnType<?>) arg.getNodeType(),
 				creationContext.getQueryEngine(),
 				creationContext.getJpaMetamodel().getTypeConfiguration()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -140,8 +140,7 @@ public class StandardFunctionReturnTypeResolvers {
 		int impliedTypeCode = ((BasicType<?>) implied).getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode();
 		int definedTypeCode = ((BasicType<?>) defined).getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode();
 		return impliedTypeCode == definedTypeCode
-				|| isInteger(impliedTypeCode) && isInteger(definedTypeCode)
-				|| isFloat(impliedTypeCode) && isFloat(definedTypeCode);
+				|| isNumeric( impliedTypeCode ) && isNumeric( definedTypeCode );
 	}
 
 	private static BasicValuedMapping useImpliedTypeIfPossible(
@@ -181,20 +180,24 @@ public class StandardFunctionReturnTypeResolvers {
 		int impliedTypeCode = implied.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode();
 		int definedTypeCode = defined.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode();
 		return impliedTypeCode == definedTypeCode
-				|| isInteger(impliedTypeCode) && isInteger(definedTypeCode)
-				|| isFloat(impliedTypeCode) && isFloat(definedTypeCode);
+				|| isNumeric( impliedTypeCode ) && isNumeric( definedTypeCode );
 
 	}
 
-	private static boolean isInteger(int type) {
-		return type == Types.INTEGER
-				|| type == Types.BIGINT
-				|| type == Types.SMALLINT
-				|| type == Types.TINYINT;
-	}
-
-	private static boolean isFloat(int type) {
-		return type == Types.FLOAT || type == Types.DOUBLE;
+	private static boolean isNumeric(int type) {
+		switch ( type ) {
+			case Types.SMALLINT:
+			case Types.TINYINT:
+			case Types.INTEGER:
+			case Types.BIGINT:
+			case Types.FLOAT:
+			case Types.REAL:
+			case Types.DOUBLE:
+			case Types.NUMERIC:
+			case Types.DECIMAL:
+				return true;
+		}
+		return false;
 	}
 
 	private static AllowableFunctionReturnType<?> extractArgumentType(List<SqmTypedNode<?>> arguments, int position) {


### PR DESCRIPTION
`floor` and `ceiling` should not return `int` or `long` as that could lead to precision loss when extracting that value. Imagine if one of the two functions used `int`, then a query like this `select ceiling(2147483647.1)` (note that 2147483647 is the maximum integer value) would lead to an overflow error or precision loss as the correct return value is 2147483648.

On top of that, this PR enables "implicit casting" between numerics for the purpose of extraction from a JDBC result set. It should be possible to extract an `int` out of e.g. `double` if known to be compatible with `int` like it would be the case for certain `floor`/`ceiling` invocations, like in `org.hibernate.dialect.function.ExtractFunction#extractWeek`.