### PR TITLE
HHH-14443: add hashcode to ObjectTypeCacheEntry

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.EntityMode;
@@ -519,5 +520,19 @@ public class AnyType extends AbstractType implements CompositeType, AssociationT
 			this.entityName = entityName;
 			this.id = id;
 		}
+
+		// hashcode so lookup in cache for any types also works
+		public int hashCode() {
+			return Objects.hash(entityName, id);
+		}
+
+		public boolean equals(Object object) {
+			if (object instanceof  ObjectTypeCacheEntry) {
+				ObjectTypeCacheEntry objectTypeCacheEntry = (ObjectTypeCacheEntry)object;
+				return Objects.equals(objectTypeCacheEntry.entityName, entityName) && Objects.equals(objectTypeCacheEntry.id, id);
+			}
+			return false;
+		}
+
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
@@ -521,7 +521,6 @@ public class AnyType extends AbstractType implements CompositeType, AssociationT
 			this.id = id;
 		}
 
-		// hashcode so lookup in cache for any types also works
 		public int hashCode() {
 			return Objects.hash(entityName, id);
 		}


### PR DESCRIPTION
The hashcode of ObjectTypeCacheEntry is used in the key of the query cache. Without the hashcode implementation, the lookup on a query with an anytype will fail.