### PR TITLE
Fixes for testsuite issues

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,0 +1,7 @@
+# Reclaim disk space, otherwise we only have 13 GB free at the start of a job
+
+docker rmi node:10 node:12 mcr.microsoft.com/azure-pipelines/node8-typescript:latest
+# That is 18 GB
+sudo rm -rf /usr/share/dotnet
+# That is 1.2 GB
+sudo rm -rf /usr/share/swift

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -43,6 +43,8 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v2
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
       - name: Set up Java 8
         uses: actions/setup-java@v1
         with:

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -36,7 +36,8 @@ ext {
                         'jdbc.driver': 'org.postgresql.Driver',
                         'jdbc.user'  : 'hibernate_orm_test',
                         'jdbc.pass'  : 'hibernate_orm_test',
-                        'jdbc.url'   : 'jdbc:postgresql:hibernate_orm_test'
+                        // Disable prepared statement caching due to https://www.postgresql.org/message-id/CAEcMXhmmRd4-%2BNQbnjDT26XNdUoXdmntV9zdr8%3DTu8PL9aVCYg%40mail.gmail.com
+                        'jdbc.url'   : 'jdbc:postgresql://' + dbHost + '/hibernate_orm_test?preparedStatementCacheQueries=0'
                 ],
                 pgsql_docker : [
                         'db.dialect' : 'org.hibernate.dialect.PostgreSQL10Dialect',
@@ -87,7 +88,8 @@ ext {
                         'jdbc.driver': 'org.postgresql.Driver',
                         'jdbc.user'  : 'hibernate_orm_test',
                         'jdbc.pass'  : 'hibernate_orm_test',
-                        'jdbc.url'   : 'jdbc:postgresql:hibernate_orm_test'
+                        // Disable prepared statement caching due to https://www.postgresql.org/message-id/CAEcMXhmmRd4-%2BNQbnjDT26XNdUoXdmntV9zdr8%3DTu8PL9aVCYg%40mail.gmail.com
+                        'jdbc.url'   : 'jdbc:postgresql://' + dbHost + '/hibernate_orm_test?preparedStatementCacheQueries=0'
                 ],
                 oracle : [
                         'db.dialect' : 'org.hibernate.dialect.Oracle10gDialect',
@@ -96,15 +98,13 @@ ext {
                         'jdbc.pass'  : 'hibernate_orm_test',
                         'jdbc.url'   : 'jdbc:oracle:thin:@localhost:1521/xe'
                 ],
-                // Uses the default settings for using https://hub.docker.com/_/oracle-database-enterprise-edition
-                // After registering to get access (see instructions at above link), start it for testing with:
-                // docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name ORCLCDB -p 1521:1521 store/oracle/database-enterprise:12.2.0.1-slim
+                // Use ./docker_db.sh oracle_ee to start the database
                 oracle_docker : [
                         'db.dialect' : 'org.hibernate.dialect.Oracle12cDialect',
                         'jdbc.driver': 'oracle.jdbc.OracleDriver',
-                        'jdbc.user'  : 'sys as sysdba',
-                        'jdbc.pass'  : 'Oradoc_db1',
-                        'jdbc.url'   : 'jdbc:oracle:thin:@localhost:1521:ORCLCDB'
+                        'jdbc.user'  : 'c##hibernate_orm_test',
+                        'jdbc.pass'  : 'hibernate_orm_test',
+                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/ORCLPDB1.localdomain'
                 ],
                 oracle_ci : [
                         'db.dialect' : 'org.hibernate.dialect.Oracle12cDialect',
@@ -153,21 +153,32 @@ ext {
                         'jdbc.driver': 'com.sap.db.jdbc.Driver',
                         'jdbc.user'  : 'HIBERNATE_TEST',
                         'jdbc.pass'  : 'H1bernate_test',
-                        'jdbc.url'   : 'jdbc:sap://localhost:30015/'
+                        // Disable prepared statement caching due to https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.04/en-US/78f2163887814223858e4369d18e2847.html
+                        'jdbc.url'   : 'jdbc:sap://localhost:30015/?statementCacheSize=0'
                 ],
                 hana_cloud : [
                         'db.dialect' : 'org.hibernate.dialect.HANACloudColumnStoreDialect',
                         'jdbc.driver': 'com.sap.db.jdbc.Driver',
                         'jdbc.user'  : 'HIBERNATE_TEST',
                         'jdbc.pass'  : 'H1bernate_test',
-                        'jdbc.url'   : 'jdbc:sap://localhost:443/?encrypt=true&validateCertificate=false'
+                        // Disable prepared statement caching due to https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.04/en-US/78f2163887814223858e4369d18e2847.html
+                        'jdbc.url'   : 'jdbc:sap://localhost:443/?encrypt=true&validateCertificate=false&statementCacheSize=0'
                 ],
                 hana_vlad : [
                         'db.dialect' : 'org.hibernate.dialect.HANAColumnStoreDialect',
                         'jdbc.driver': 'com.sap.db.jdbc.Driver',
                         'jdbc.user'  : 'VLAD',
                         'jdbc.pass'  : 'V1ad_test',
-                        'jdbc.url'   : 'jdbc:sap://localhost:39015/'
+                        // Disable prepared statement caching due to https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.04/en-US/78f2163887814223858e4369d18e2847.html
+                        'jdbc.url'   : 'jdbc:sap://localhost:39015/?statementCacheSize=0'
+                ],
+                hana_docker : [
+                        'db.dialect' : 'org.hibernate.dialect.HANAColumnStoreDialect',
+                        'jdbc.driver': 'com.sap.db.jdbc.Driver',
+                        'jdbc.user'  : 'SYSTEM',
+                        'jdbc.pass'  : 'H1bernate_test',
+                        // Disable prepared statement caching due to https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.04/en-US/78f2163887814223858e4369d18e2847.html
+                        'jdbc.url'   : 'jdbc:sap://' + dbHost + ':39017/?statementCacheSize=0'
                 ],
                 cockroachdb : [
                         'db.dialect' : 'org.hibernate.dialect.CockroachDB192Dialect',

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -287,6 +287,8 @@ test {
 	systemProperty 'user.country', 'US'
 	systemProperty 'user.timezone', 'UTC'
 	systemProperty 'file.encoding', 'UTF-8'
+	// Needed for AdoptOpenJDK on alpine? The problem is similar to this: https://github.com/mockito/mockito/issues/978
+	jvmArgs '-XX:+StartAttachListener'
 }
 
 // Enable the experimental features of ByteBuddy with JDK 15+

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANACloudColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANACloudColumnStoreDialect.java
@@ -103,6 +103,11 @@ public class HANACloudColumnStoreDialect extends AbstractHANADialect {
 				return "truncate table";
 			}
 
+			@Override
+			public String getCreateIdTableStatementOptions() {
+				return "on commit delete rows";
+			}
+
 		}, AfterUseAction.CLEAN );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
@@ -62,6 +62,11 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 				return "truncate table";
 			}
 
+			@Override
+			public String getCreateIdTableStatementOptions() {
+				return "on commit delete rows";
+			}
+
 		}, AfterUseAction.CLEAN );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
@@ -44,6 +44,11 @@ public class HANARowStoreDialect extends AbstractHANADialect {
 			public String getCreateIdTableCommand() {
 				return "create global temporary row table";
 			}
+
+			@Override
+			public String getCreateIdTableStatementOptions() {
+				return "on commit delete rows";
+			}
 		}, AfterUseAction.CLEAN );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/IdTableHelper.java
@@ -184,7 +184,7 @@ public class IdTableHelper {
 					target.accept( createStatement );
 				}
 				catch ( CommandAcceptanceException e) {
-					// The exception will be logged, so ignore this
+					log.debugf( "Error attempting to export id-table [%s] : %s", createStatement, e.getMessage() );
 				}
 			}
 		}
@@ -215,7 +215,7 @@ public class IdTableHelper {
 					target.accept( dropStatement );
 				}
 				catch ( CommandAcceptanceException e) {
-					// The exception will be logged, so ignore this
+					log.debugf( "Error attempting to drop id-table : [%s]", e.getMessage() );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/BaseEntityManagerFunctionalTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/BaseEntityManagerFunctionalTestCase.java
@@ -228,9 +228,9 @@ public abstract class BaseEntityManagerFunctionalTestCase extends BaseUnitTestCa
 			config.put( AvailableSettings.XML_FILE_NAMES, dds );
 		}
 
+		config.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		config.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 		if ( !config.containsKey( Environment.CONNECTION_PROVIDER ) ) {
-			config.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
-			config.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 			config.put(
 					AvailableSettings.CONNECTION_PROVIDER,
 					SharedDriverManagerConnectionProviderImpl.getInstance()

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/LockTest.java
@@ -61,8 +61,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
 	protected void addConfigOptions(Map options) {
 		super.addConfigOptions( options );
-		// Looks like Oracle Connections that experience a timeout produce different errors when they timeout again?!
-		SharedDriverManagerConnectionProviderImpl.getInstance().reset();
+		// We can't use a shared connection provider if we use TransactionUtil.setJdbcTimeout because that is set on the connection level
 		options.remove( org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -44,7 +44,7 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 	@Override
 	protected Map getConfig() {
 		Map config = super.getConfig();
-		CONNECTION_PROVIDER.setConnectionProvider( (ConnectionProvider) config.get( AvailableSettings.CONNECTION_PROVIDER ) );
+		// We can't use a shared connection provider if we use TransactionUtil.setJdbcTimeout because that is set on the connection level
 		config.put(
 			org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
 			CONNECTION_PROVIDER

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/AbstractBulkCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/AbstractBulkCompositeIdTest.java
@@ -35,7 +35,10 @@ public abstract class AbstractBulkCompositeIdTest extends BaseCoreFunctionalTest
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.setProperty( AvailableSettings.HQL_BULK_ID_STRATEGY, getMultiTableBulkIdStrategyClass().getName() );
+		Class<? extends MultiTableBulkIdStrategy> strategyClass = getMultiTableBulkIdStrategyClass();
+		if ( strategyClass != null ) {
+			configuration.setProperty( AvailableSettings.HQL_BULK_ID_STRATEGY, strategyClass.getName() );
+		}
 		return configuration;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bulkid/GlobalTemporaryTableBulkCompositeIdTest.java
@@ -14,6 +14,8 @@ public class GlobalTemporaryTableBulkCompositeIdTest extends AbstractBulkComposi
 
 	@Override
 	protected Class<? extends MultiTableBulkIdStrategy> getMultiTableBulkIdStrategyClass() {
-		return GlobalTemporaryTableBulkIdStrategy.class;
+		// Since we only allow dialects that support global temporary tables, we avoid overriding the strategy
+		// This is important because otherwise we would loose id table configurations that are made in the dialects
+		return null;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/locking/LockModeTest.java
@@ -14,6 +14,8 @@ import javax.persistence.LockModeType;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASE15Dialect;
@@ -51,6 +53,12 @@ public class LockModeTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return  new Class[] { A.class };
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		// We can't use a shared connection provider if we use TransactionUtil.setJdbcTimeout because that is set on the connection level
+		configuration.getProperties().remove( AvailableSettings.CONNECTION_PROVIDER );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/custom/oracle/Mappings.hbm.xml
@@ -125,6 +125,7 @@
         FROM ORGANIZATION org
         LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER
         WHERE org.ORGID=?
+        ORDER BY emp.EMPID
     </sql-query>
 
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/BaseEnversJPAFunctionalTestCase.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/BaseEnversJPAFunctionalTestCase.java
@@ -143,9 +143,9 @@ public abstract class BaseEnversJPAFunctionalTestCase extends AbstractEnversTest
 			config.put( AvailableSettings.XML_FILE_NAMES, dds );
 		}
 
+		config.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		config.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
-			config.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
-			config.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 			config.put(
 					org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
 					SharedDriverManagerConnectionProviderImpl.getInstance()

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/OracleDatabaseCleaner.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/OracleDatabaseCleaner.java
@@ -67,8 +67,8 @@ public class OracleDatabaseCleaner implements DatabaseCleaner {
 						return statement.executeQuery(
 								"SELECT 'DROP TABLE ' || owner || '.\"' || table_name || '\" CASCADE CONSTRAINTS' " +
 										"FROM all_tables " +
-										// Exclude the tables owner by sys
-										"WHERE owner NOT IN ('SYS')" +
+										// Only look at tables owned by the current user
+										"WHERE owner = sys_context('USERENV', 'SESSION_USER')" +
 										// Normally, user tables aren't in sysaux
 										"      AND tablespace_name NOT IN ('SYSAUX')" +
 										// Apparently, user tables have global stats off
@@ -76,7 +76,7 @@ public class OracleDatabaseCleaner implements DatabaseCleaner {
 										// Exclude the tables with names starting like 'DEF$_'
 										"      AND table_name NOT LIKE 'DEF$\\_%' ESCAPE '\\'" +
 										" UNION ALL " +
-										"SELECT 'DROP SEQUENCE ' || sequence_owner || '.' || sequence_name FROM all_sequences WHERE sequence_owner NOT IN (" + SYSTEM_SEQUENCE_OWNERS + ")"
+										"SELECT 'DROP SEQUENCE ' || sequence_owner || '.' || sequence_name FROM all_sequences WHERE sequence_owner = sys_context('USERENV', 'SESSION_USER') and sequence_name not like 'ISEQ$$%'"
 						);
 					}
 					catch (SQLException sqlException) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -179,9 +179,9 @@ public abstract class BaseCoreFunctionalTestCase extends BaseUnitTestCase {
 		}
 		configuration.setImplicitNamingStrategy( ImplicitNamingStrategyLegacyJpaImpl.INSTANCE );
 		configuration.setProperty( Environment.DIALECT, getDialect().getClass().getName() );
+		configuration.getProperties().put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		configuration.getProperties().put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
-			configuration.getProperties().put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
-			configuration.getProperties().put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 			configuration.getProperties().put(
 					AvailableSettings.CONNECTION_PROVIDER,
 					SharedDriverManagerConnectionProviderImpl.getInstance()

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
@@ -179,9 +179,9 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 		afterBootstrapServiceRegistryBuilt( bsr );
 
 		final Map settings = new HashMap();
+		settings.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		settings.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
-			settings.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
-			settings.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
 			settings.put(
 					AvailableSettings.CONNECTION_PROVIDER,
 					SharedDriverManagerConnectionProviderImpl.getInstance()


### PR DESCRIPTION
This should fix issues that our testsuite has on PostGIS, Oracle and HANA.

* Recreate PostgreSQL extensions after schema clearing
* Avoid dropping system generated sequences in Oracle cleaner
* Always drop id tables in tests
* Fix global temp table test to use actual dialect strategy
* Add `on commit delete rows` option for hana dialects to avoid https://answers.sap.com/questions/8824628/error-while-trying-to-drop-global-temporary-table.html