### PR TITLE
Use java.lang.reflect.Type instead of java.lang.Class for JavaTypeDescriptor#getJavaType to support parameterized types

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/collections/type/CommaDelimitedStringsJavaTypeDescriptor.java
+++ b/documentation/src/test/java/org/hibernate/userguide/collections/type/CommaDelimitedStringsJavaTypeDescriptor.java
@@ -12,14 +12,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 
 /**
  * @author Vlad Mihalcea
  */
 //tag::collections-comma-delimited-collection-example[]
-public class CommaDelimitedStringsJavaTypeDescriptor extends AbstractTypeDescriptor<List> {
+public class CommaDelimitedStringsJavaTypeDescriptor extends AbstractClassTypeDescriptor<List> {
 
     public static final String DELIMITER = ",";
 

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BitSetTypeDescriptor.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BitSetTypeDescriptor.java
@@ -3,13 +3,13 @@ package org.hibernate.userguide.mapping.basic;
 import java.util.BitSet;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 
 /**
  * @author Vlad Mihalcea
  */
 //tag::basic-custom-type-BitSetTypeDescriptor-example[]
-public class BitSetTypeDescriptor extends AbstractTypeDescriptor<BitSet> {
+public class BitSetTypeDescriptor extends AbstractClassTypeDescriptor<BitSet> {
 
     private static final String DELIMITER = ",";
 

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/GenderJavaTypeDescriptor.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/GenderJavaTypeDescriptor.java
@@ -1,14 +1,14 @@
 package org.hibernate.userguide.mapping.basic;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.CharacterTypeDescriptor;
 
 /**
  * @author Vlad Mihalcea
  */
 //tag::basic-enums-custom-type-example[]
-public class GenderJavaTypeDescriptor extends AbstractTypeDescriptor<Gender> {
+public class GenderJavaTypeDescriptor extends AbstractClassTypeDescriptor<Gender> {
 
     public static final GenderJavaTypeDescriptor INSTANCE =
         new GenderJavaTypeDescriptor();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistryStandardImpl.java
@@ -55,7 +55,7 @@ public class TypeDefinitionRegistryStandardImpl implements TypeDefinitionRegistr
 			return null;
 		}
 
-		return typeDefinitionMap.get( jtd.getJavaType().getName() );
+		return typeDefinitionMap.get( jtd.getJavaType().getTypeName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -184,7 +184,7 @@ public class InferredBasicValueResolver {
 			case STRING: {
 				final JavaTypeDescriptor<?> relationalJtd;
 				if ( explicitJavaType != null ) {
-					if ( ! String.class.isAssignableFrom( explicitJavaType.getJavaType() ) ) {
+					if ( ! String.class.isAssignableFrom( explicitJavaType.getJavaTypeClass() ) ) {
 						throw new MappingException(
 								"Explicit JavaTypeDescriptor [" + explicitJavaType +
 										"] applied to enumerated value with EnumType#STRING" +
@@ -210,7 +210,7 @@ public class InferredBasicValueResolver {
 
 				//noinspection unchecked
 				final org.hibernate.type.EnumType legacyEnumType = new org.hibernate.type.EnumType(
-						enumJavaDescriptor.getJavaType(),
+						enumJavaDescriptor.getJavaTypeClass(),
 						valueConverter,
 						typeConfiguration
 				);
@@ -233,7 +233,7 @@ public class InferredBasicValueResolver {
 			case ORDINAL: {
 				final JavaTypeDescriptor<Integer> relationalJtd;
 				if ( explicitJavaType != null ) {
-					if ( ! Integer.class.isAssignableFrom( explicitJavaType.getJavaType() ) ) {
+					if ( ! Integer.class.isAssignableFrom( explicitJavaType.getJavaTypeClass() ) ) {
 						throw new MappingException(
 								"Explicit JavaTypeDescriptor [" + explicitJavaType +
 										"] applied to enumerated value with EnumType#ORDINAL" +
@@ -258,7 +258,7 @@ public class InferredBasicValueResolver {
 
 				//noinspection unchecked
 				final org.hibernate.type.EnumType legacyEnumType = new org.hibernate.type.EnumType(
-						enumJavaDescriptor.getJavaType(),
+						enumJavaDescriptor.getJavaTypeClass(),
 						valueConverter,
 						typeConfiguration
 				);

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
@@ -187,11 +187,11 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 //		this.jdbcMapping = new StandardBasicTypeImpl( relationalJtd, relationalStd );
 
 		this.legacyResolvedType = new AttributeConverterTypeAdapter(
-				ConverterDescriptor.TYPE_NAME_PREFIX + valueConverter.getConverterJavaTypeDescriptor().getJavaType().getName(),
+				ConverterDescriptor.TYPE_NAME_PREFIX + valueConverter.getConverterJavaTypeDescriptor().getJavaType().getTypeName(),
 				String.format(
 						"BasicType adapter for AttributeConverter<%s,%s>",
-						domainJtd.getJavaType().getSimpleName(),
-						relationalJtd.getJavaType().getSimpleName()
+						domainJtd.getJavaType().getTypeName(),
+						relationalJtd.getJavaType().getTypeName()
 				),
 				valueConverter,
 				relationalStd,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3634,14 +3634,14 @@ public abstract class Dialect implements ConversionContext {
 			switch (jdbcTypeCode) {
 				case Types.BIT:
 					// Use the default length for Boolean if we encounter the JPA default 255 instead
-					if ( javaType.getJavaType() == Boolean.class && length != null && length == 255 ) {
+					if ( javaType.getJavaTypeClass() == Boolean.class && length != null && length == 255 ) {
 						length = null;
 					}
 					size.setLength( javaType.getDefaultSqlLength( Dialect.this ) );
 					break;
 				case Types.CHAR:
 					// Use the default length for char if we encounter the JPA default 255 instead
-					if ( javaType.getJavaType() == Character.class && length != null && length == 255 ) {
+					if ( javaType.getJavaTypeClass() == Character.class && length != null && length == 255 ) {
 						length = null;
 					}
 					size.setLength( javaType.getDefaultSqlLength( Dialect.this ) );
@@ -3652,7 +3652,7 @@ public abstract class Dialect implements ConversionContext {
 				case Types.NVARCHAR:
 				case Types.VARBINARY:
 					// Use the default length for UUID if we encounter the JPA default 255 instead
-					if ( javaType.getJavaType() == UUID.class && length != null && length == 255 ) {
+					if ( javaType.getJavaTypeClass() == UUID.class && length != null && length == 255 ) {
 						length = null;
 					}
 					size.setLength( javaType.getDefaultSqlLength( Dialect.this ) );

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/AbstractParameterDescriptor.java
@@ -38,7 +38,7 @@ public abstract class AbstractParameterDescriptor implements QueryParameter {
 
 	@Override
 	public Class getParameterType() {
-		return expectedType == null ? null : expectedType.getExpressableJavaTypeDescriptor().getJavaType();
+		return expectedType == null ? null : expectedType.getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -136,7 +136,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 					final EntityMappingType dependentIdTargetMapping = (EntityMappingType) singleIdAttribute.getMappedType();
 					final EntityIdentifierMapping dependentIdTargetIdMapping = dependentIdTargetMapping.getIdentifierMapping();
 					final JavaTypeDescriptor dependentParentIdJtd = dependentIdTargetIdMapping.getMappedType().getMappedJavaTypeDescriptor();
-					if ( dependentParentIdJtd.getJavaType().isInstance( event.getEntityId() ) ) {
+					if ( dependentParentIdJtd.getJavaTypeClass().isInstance( event.getEntityId() ) ) {
 						// yep that's what we have...
 						loadByDerivedIdentitySimplePkValue(
 								event,

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderProvidedQueryImpl.java
@@ -62,7 +62,7 @@ public class SingleIdEntityLoaderProvidedQueryImpl<T> implements SingleIdEntityL
 		//noinspection unchecked
 		final QueryImplementor<T> query = namedQueryMemento.toQuery(
 				session,
-				entityDescriptor.getMappedJavaTypeDescriptor().getJavaType()
+				entityDescriptor.getMappedJavaTypeDescriptor().getJavaTypeClass()
 		);
 
 		query.setParameter( 0, pkValue );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -607,7 +607,7 @@ public abstract class SimpleValue implements KeyValue {
 				jdbcTypeCode = LobTypeMappings.getLobCodeTypeMapping( jdbcTypeCode );
 			}
 			else {
-				if ( Serializable.class.isAssignableFrom( domainJtd.getJavaType() ) ) {
+				if ( Serializable.class.isAssignableFrom( domainJtd.getJavaTypeClass() ) ) {
 					jdbcTypeCode = Types.BLOB;
 				}
 				else {
@@ -648,11 +648,11 @@ public abstract class SimpleValue implements KeyValue {
 
 		// todo : cache the AttributeConverterTypeAdapter in case that AttributeConverter is applied multiple times.
 
-		final String name = ConverterDescriptor.TYPE_NAME_PREFIX + jpaAttributeConverter.getConverterJavaTypeDescriptor().getJavaType().getName();
+		final String name = ConverterDescriptor.TYPE_NAME_PREFIX + jpaAttributeConverter.getConverterJavaTypeDescriptor().getJavaType().getTypeName();
 		final String description = String.format(
 				"BasicType adapter for AttributeConverter<%s,%s>",
-				jpaAttributeConverter.getDomainJavaTypeDescriptor().getJavaType().getSimpleName(),
-				jpaAttributeConverter.getRelationalJavaTypeDescriptor().getJavaType().getSimpleName()
+				jpaAttributeConverter.getDomainJavaTypeDescriptor().getJavaType().getTypeName(),
+				jpaAttributeConverter.getRelationalJavaTypeDescriptor().getJavaType().getTypeName()
 		);
 		return new AttributeConverterTypeAdapter<>(
 				name,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -589,7 +589,7 @@ public class AttributeFactory {
 		final EmbeddableDomainType<?> ownerType = (EmbeddableDomainType) attributeContext.getOwnerType();
 
 		if ( ownerType.getRepresentationStrategy().getMode() == RepresentationMode.MAP ) {
-			return new MapMember( attributeContext.getPropertyMapping().getName(), ownerType.getExpressableJavaTypeDescriptor().getJavaType() );
+			return new MapMember( attributeContext.getPropertyMapping().getName(), ownerType.getExpressableJavaTypeDescriptor().getJavaTypeClass() );
 		}
 		else {
 			return ownerType.getRepresentationStrategy()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/OptimizedPojoInstantiatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/OptimizedPojoInstantiatorImpl.java
@@ -17,7 +17,7 @@ public class OptimizedPojoInstantiatorImpl<J> extends AbstractPojoInstantiator {
 	private final ReflectionOptimizer.InstantiationOptimizer instantiationOptimizer;
 
 	public OptimizedPojoInstantiatorImpl(JavaTypeDescriptor javaTypeDescriptor, ReflectionOptimizer.InstantiationOptimizer instantiationOptimizer) {
-		super( javaTypeDescriptor.getJavaType() );
+		super( javaTypeDescriptor.getJavaTypeClass() );
 		this.instantiationOptimizer = instantiationOptimizer;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PojoInstantiatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PojoInstantiatorImpl.java
@@ -26,7 +26,7 @@ public class PojoInstantiatorImpl<J> extends AbstractPojoInstantiator {
 
 	@SuppressWarnings("WeakerAccess")
 	public PojoInstantiatorImpl(JavaTypeDescriptor javaTypeDescriptor) {
-		super( javaTypeDescriptor.getJavaType() );
+		super( javaTypeDescriptor.getJavaTypeClass() );
 
 		this.constructor = isAbstract()
 				? null

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEmbeddableRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEmbeddableRepresentationStrategy.java
@@ -126,14 +126,14 @@ public class StandardPojoEmbeddableRepresentationStrategy extends AbstractEmbedd
 					String.format(
 							Locale.ROOT,
 							"Could not resolve PropertyAccess for attribute `%s#%s`",
-							getEmbeddableJavaTypeDescriptor().getJavaType().getName(),
+							getEmbeddableJavaTypeDescriptor().getJavaType().getTypeName(),
 							bootAttributeDescriptor.getName()
 					)
 			);
 		}
 
 		return strategy.buildPropertyAccess(
-				getEmbeddableJavaTypeDescriptor().getJavaType(),
+				getEmbeddableJavaTypeDescriptor().getJavaTypeClass(),
 				bootAttributeDescriptor.getName()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEntityRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/StandardPojoEntityRepresentationStrategy.java
@@ -160,7 +160,7 @@ public class StandardPojoEntityRepresentationStrategy implements EntityRepresent
 
 		if ( identifierProperty == null ) {
 			return PropertyAccessStrategyEmbeddedImpl.INSTANCE.buildPropertyAccess(
-					proxyJtd != null ? proxyJtd.getJavaType() : mappedJtd.getJavaType(),
+					proxyJtd != null ? proxyJtd.getJavaTypeClass() : mappedJtd.getJavaTypeClass(),
 					"id"
 			);
 		}
@@ -175,10 +175,10 @@ public class StandardPojoEntityRepresentationStrategy implements EntityRepresent
 
 		final Set<Class> proxyInterfaces = new java.util.HashSet<>();
 
-		final Class mappedClass = mappedJtd.getJavaType();
+		final Class mappedClass = mappedJtd.getJavaTypeClass();
 		Class proxyInterface;
 		if ( proxyJtd != null ) {
-			proxyInterface = proxyJtd.getJavaType();
+			proxyInterface = proxyJtd.getJavaTypeClass();
 		}
 		else {
 			proxyInterface = null;
@@ -261,10 +261,10 @@ public class StandardPojoEntityRepresentationStrategy implements EntityRepresent
 		final Class javaTypeToReflect;
 		if ( proxyFactory != null ) {
 			assert proxyJtd != null;
-			javaTypeToReflect = proxyJtd.getJavaType();
+			javaTypeToReflect = proxyJtd.getJavaTypeClass();
 		}
 		else {
-			javaTypeToReflect = mappedJtd.getJavaType();
+			javaTypeToReflect = mappedJtd.getJavaTypeClass();
 		}
 
 		final List<String> getterNames = new ArrayList<>();
@@ -348,13 +348,13 @@ public class StandardPojoEntityRepresentationStrategy implements EntityRepresent
 					String.format(
 							Locale.ROOT,
 							"Could not resolve PropertyAccess for attribute `%s#%s`",
-							mappedJtd.getJavaType().getName(),
+							mappedJtd.getJavaType().getTypeName(),
 							bootAttributeDescriptor.getName()
 					)
 			);
 		}
 
-		return strategy.buildPropertyAccess( mappedJtd.getJavaType(), bootAttributeDescriptor.getName() );
+		return strategy.buildPropertyAccess( mappedJtd.getJavaTypeClass(), bootAttributeDescriptor.getName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
@@ -86,7 +86,7 @@ public class EmbeddedAttributeMapping
 
 		if ( parentInjectionAttributeName != null ) {
 			parentInjectionAttributePropertyAccess = PropertyAccessStrategyBasicImpl.INSTANCE.buildPropertyAccess(
-					embeddableMappingType.getMappedJavaTypeDescriptor().getJavaType(),
+					embeddableMappingType.getMappedJavaTypeDescriptor().getJavaTypeClass(),
 					parentInjectionAttributeName
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedCollectionPart.java
@@ -78,7 +78,7 @@ public class EmbeddedCollectionPart implements CollectionPart, EmbeddableValuedF
 		this.nature = nature;
 		if ( parentInjectionAttributeName != null ) {
 			parentInjectionAttributePropertyAccess = PropertyAccessStrategyBasicImpl.INSTANCE.buildPropertyAccess(
-					embeddableMappingType.getMappedJavaTypeDescriptor().getJavaType(),
+					embeddableMappingType.getMappedJavaTypeDescriptor().getJavaTypeClass(),
 					parentInjectionAttributeName
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -102,10 +102,10 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping {
 			}
 		}
 
-		if ( ! getJavaTypeDescriptor().getJavaType().isInstance( naturalIdValue ) ) {
+		if ( ! getJavaTypeDescriptor().getJavaTypeClass().isInstance( naturalIdValue ) ) {
 			throw new IllegalArgumentException(
 					"Incoming natural-id value [" + naturalIdValue + "] is not of expected type ["
-							+ getJavaTypeDescriptor().getJavaType().getName() + "]"
+							+ getJavaTypeDescriptor().getJavaType().getTypeName() + "]"
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractDomainType.java
@@ -32,6 +32,6 @@ public abstract class AbstractDomainType<J> implements SimpleDomainType<J> {
 
 	@Override
 	public Class<J> getJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/DomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/DomainType.java
@@ -35,7 +35,7 @@ public interface DomainType<J> extends SqmExpressable<J> {
 	 */
 	default String getTypeName() {
 		// default impl to handle the general case returning the Java type name
-		return getExpressableJavaTypeDescriptor().getJavaType().getName();
+		return getExpressableJavaTypeDescriptor().getJavaType().getTypeName();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractAttribute.java
@@ -64,7 +64,7 @@ public abstract class AbstractAttribute<D,J,B> implements PersistentAttribute<D,
 
 	@Override
 	public Class<J> getJavaType() {
-		return attributeJtd.getJavaType();
+		return attributeJtd.getJavaTypeClass();
 	}
 
 	public SimpleDomainType<B> getSqmPathType() {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractSqmPathSource.java
@@ -49,6 +49,6 @@ public abstract class AbstractSqmPathSource<J> implements SqmPathSource<J> {
 
 	@Override
 	public Class<J> getBindableJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingDomainTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingDomainTypeImpl.java
@@ -26,7 +26,7 @@ public class AnyMappingDomainTypeImpl<T> implements AnyMappingDomainType<T> {
 
 	@Override
 	public Class<T> getJavaType() {
-		return baseJtd.getJavaType();
+		return baseJtd.getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSqmPathSource.java
@@ -59,7 +59,7 @@ public class BasicSqmPathSource<J>
 
 	@Override
 	public Class<J> getJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicTypeImpl.java
@@ -36,7 +36,7 @@ public class BasicTypeImpl<J> implements BasicDomainType<J>, Serializable {
 	}
 
 	public Class<J> getJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
@@ -56,7 +56,7 @@ public class EmbeddableTypeImpl<J>
 			EmbeddableRepresentationStrategy representationStrategy,
 			boolean isDynamic,
 			JpaMetamodel domainMetamodel) {
-		super( javaTypeDescriptor.getJavaType().getName(), javaTypeDescriptor, null, domainMetamodel );
+		super( javaTypeDescriptor.getJavaType().getTypeName(), javaTypeDescriptor, null, domainMetamodel );
 		this.representationStrategy = representationStrategy;
 		this.isDynamic = isDynamic;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityTypeImpl.java
@@ -102,7 +102,7 @@ public class EntityTypeImpl<J>
 
 				@Override
 				public Class<?> getBindableJavaType() {
-					return getExpressableJavaTypeDescriptor().getJavaType();
+					return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 				}
 
 				@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
@@ -26,7 +26,7 @@ public class MappedSuperclassTypeImpl<X> extends AbstractIdentifiableType<X> imp
 			IdentifiableDomainType<? super X> superType,
 			JpaMetamodel jpaMetamodel) {
 		super(
-				javaTypeDescriptor.getJavaType().getName(),
+				javaTypeDescriptor.getJavaType().getTypeName(),
 				javaTypeDescriptor,
 				superType,
 				mappedSuperclass.getDeclaredIdentifierMapper() != null || ( superType != null && superType.hasIdClass() ),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
@@ -84,42 +84,42 @@ public class PluralAttributeBuilder<D, C, E, K> {
 				attributeMetadata.getMember()
 		);
 
-		if ( Map.class.equals( attributeJtd.getJavaType() ) ) {
+		if ( Map.class.equals( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new MapAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( Set.class.equals( attributeJtd.getJavaType() ) ) {
+		else if ( Set.class.equals( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new SetAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( List.class.equals( attributeJtd.getJavaType() ) ) {
+		else if ( List.class.equals( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new ListAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( Collection.class.equals( attributeJtd.getJavaType() ) ) {
+		else if ( Collection.class.equals( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new BagAttributeImpl<>( builder, metadataContext );
 		}
 
 		//apply loose rules
-		if ( attributeJtd.getJavaType().isArray() ) {
+		if ( attributeJtd.getJavaTypeClass().isArray() ) {
 			//noinspection unchecked
 			return new ListAttributeImpl<>( builder, metadataContext );
 		}
 
-		if ( Map.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
+		if ( Map.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new MapAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( Set.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
+		else if ( Set.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new SetAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( List.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
+		else if ( List.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new ListAttributeImpl<>( builder, metadataContext );
 		}
-		else if ( Collection.class.isAssignableFrom( attributeJtd.getJavaType() ) ) {
+		else if ( Collection.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
 			//noinspection unchecked
 			return new BagAttributeImpl<>( builder, metadataContext );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
@@ -107,7 +107,7 @@ public class SingularAttributeImpl<D,J>
 
 	@Override
 	public Class<J> getBindableJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5320,7 +5320,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	public final Class getMappedClass() {
-		return getMappedJavaTypeDescriptor().getJavaType();
+		return getMappedJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	public boolean implementsLifecycle() {
@@ -5329,7 +5329,7 @@ public abstract class AbstractEntityPersister
 
 	public Class getConcreteProxyClass() {
 		final JavaTypeDescriptor<?> proxyJavaTypeDescriptor = getRepresentationStrategy().getProxyJavaTypeDescriptor();
-		return proxyJavaTypeDescriptor != null ? proxyJavaTypeDescriptor.getJavaType() : javaTypeDescriptor.getJavaType();
+		return proxyJavaTypeDescriptor != null ? proxyJavaTypeDescriptor.getJavaTypeClass() : javaTypeDescriptor.getJavaTypeClass();
 	}
 
 	public void setPropertyValues(Object object, Object[] values) {

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaTupleElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaTupleElement.java
@@ -21,6 +21,6 @@ public interface JpaTupleElement<T> extends TupleElement<T>, JpaCriteriaNode {
 	@Override
 	default Class<? extends T> getJavaType() {
 		// todo (6.0) : can this signature just return `Class<T>`?
-		return getJavaTypeDescriptor() == null ? null : getJavaTypeDescriptor().getJavaType();
+		return getJavaTypeDescriptor() == null ? null : getJavaTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractQueryParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractQueryParameterImpl.java
@@ -36,6 +36,6 @@ public abstract class AbstractQueryParameterImpl<T> implements QueryParameter<T>
 
 	@Override
 	public Class<T> getParameterType() {
-		return expectedType == null ? null : expectedType.getExpressableJavaTypeDescriptor().getJavaType();
+		return expectedType == null ? null : expectedType.getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/BindingTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/BindingTypeHelper.java
@@ -74,7 +74,7 @@ public class BindingTypeHelper {
 			javaType = bindValue.getClass();
 		}
 		else if ( baseType != null ) {
-			javaType = baseType.getExpressableJavaTypeDescriptor().getJavaType();
+			javaType = baseType.getExpressableJavaTypeDescriptor().getJavaTypeClass();
 		}
 		else {
 			javaType = java.sql.Timestamp.class;
@@ -98,7 +98,7 @@ public class BindingTypeHelper {
 
 	public AllowableParameterType resolveTimestampTemporalTypeVariant(Class javaType, AllowableParameterType baseType) {
 		//noinspection unchecked
-		if ( baseType.getExpressableJavaTypeDescriptor().getJavaType().isAssignableFrom( javaType ) ) {
+		if ( baseType.getExpressableJavaTypeDescriptor().getJavaTypeClass().isAssignableFrom( javaType ) ) {
 			return baseType;
 		}
 
@@ -130,7 +130,7 @@ public class BindingTypeHelper {
 	}
 
 	public AllowableParameterType<?> resolveDateTemporalTypeVariant(Class<?> javaType, AllowableParameterType<?> baseType) {
-		if ( baseType.getExpressableJavaTypeDescriptor().getJavaType().isAssignableFrom( javaType ) ) {
+		if ( baseType.getExpressableJavaTypeDescriptor().getJavaTypeClass().isAssignableFrom( javaType ) ) {
 			return baseType;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -170,7 +170,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T> {
 
 		//noinspection unchecked
 		this.bindType = (AllowableParameterType) BindingTypeHelper.INSTANCE.resolveDateTemporalTypeVariant(
-				getBindType().getExpressableJavaTypeDescriptor().getJavaType(),
+				getBindType().getExpressableJavaTypeDescriptor().getJavaTypeClass(),
 				getBindType()
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
@@ -32,7 +32,7 @@ public class QueryParameterBindingValidator {
 			// nothing we can check
 			return;
 		}
-		final Class parameterType = paramType.getExpressableJavaTypeDescriptor().getJavaType();
+		final Class parameterType = paramType.getExpressableJavaTypeDescriptor().getJavaTypeClass();
 		if ( parameterType == null ) {
 			// nothing we can check
 			return;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -141,7 +141,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 					final SqmSelection selection = selections.get( i );
 					tupleElementList.add(
 							new TupleElementImpl<>(
-									selection.getSelectableNode().getJavaTypeDescriptor().getJavaType(),
+									selection.getSelectableNode().getJavaTypeDescriptor().getJavaTypeClass(),
 									selection.getAlias()
 							)
 					);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -323,11 +323,11 @@ public class QuerySqmImpl<R>
 		assert sqmExpressable != null;
 		assert sqmExpressable.getExpressableJavaTypeDescriptor() != null;
 
-		if ( ! resultClass.isAssignableFrom( sqmExpressable.getExpressableJavaTypeDescriptor().getJavaType() ) ) {
+		if ( ! resultClass.isAssignableFrom( sqmExpressable.getExpressableJavaTypeDescriptor().getJavaTypeClass() ) ) {
 			final String errorMessage = String.format(
 					"Specified result type [%s] did not match Query selection type [%s] - multiple selections: use Tuple or array",
 					resultClass.getName(),
-					sqmExpressable.getExpressableJavaTypeDescriptor().getJavaType().getName()
+					sqmExpressable.getExpressableJavaTypeDescriptor().getJavaType().getTypeName()
 			);
 
 			if ( sessionFactory.getSessionFactoryOptions().getJpaCompliance().isJpaQueryComplianceEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -846,7 +846,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 		@Override
 		public Class<T> getJavaType() {
-			return javaTypeDescriptor.getJavaType();
+			return javaTypeDescriptor.getJavaTypeClass();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -282,7 +282,7 @@ public class SqmUtil {
 				if ( type instanceof EntityIdentifierMapping ) {
 					mappingExpressable = type;
 					EntityIdentifierMapping identifierMapping = (EntityIdentifierMapping) type;
-					if ( !identifierMapping.getJavaTypeDescriptor().getJavaType().isInstance( bindValue ) ) {
+					if ( !identifierMapping.getJavaTypeDescriptor().getJavaTypeClass().isInstance( bindValue ) ) {
 						bindValue = identifierMapping.getIdentifier( bindValue, session );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
@@ -193,8 +193,8 @@ public final class StandardArgumentsValidators {
 	public static ArgumentsValidator of(Class<?> javaType) {
 		return arguments -> arguments.forEach(
 				arg -> {
-					Class<?> argType = arg.getNodeJavaTypeDescriptor().getJavaType();
-					if (!javaType.isAssignableFrom(argType)) {
+					Class<?> argType = arg.getNodeJavaTypeDescriptor().getJavaTypeClass();
+					if ( !javaType.isAssignableFrom( argType ) ) {
 						throw new QueryException(
 								String.format(
 										Locale.ROOT,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -102,7 +102,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public String getName() {
-		return polymorphicJavaDescriptor.getJavaType().getName();
+		return polymorphicJavaDescriptor.getJavaType().getTypeName();
 	}
 
 	@Override
@@ -132,7 +132,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public Class<T> getBindableJavaType() {
-		return polymorphicJavaDescriptor.getJavaType();
+		return polymorphicJavaDescriptor.getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AbstractSqmParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AbstractSqmParameter.java
@@ -52,6 +52,6 @@ public abstract class AbstractSqmParameter<T> extends AbstractSqmExpression<T> i
 
 	@Override
 	public Class<T> getParameterType() {
-		return this.getNodeType().getExpressableJavaTypeDescriptor().getJavaType();
+		return this.getNodeType().getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/Compatibility.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/Compatibility.java
@@ -156,7 +156,8 @@ public class Compatibility {
 
 		// todo (6.0) - base this in the descriptor.
 		// 		`JavaTypeDescriptor#assignableFrom` ?
+		//      Note from Christian: I think this is a good idea to allow honoring parameterized types
 
-		return areAssignmentCompatible( to.getJavaType(), from.getJavaType() );
+		return areAssignmentCompatible( to.getJavaTypeClass(), from.getJavaTypeClass() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
@@ -118,7 +118,7 @@ public class JpaCriteriaParameter<T>
 
 	@Override
 	public Class<T> getParameterType() {
-		return this.getNodeType().getExpressableJavaTypeDescriptor().getJavaType();
+		return this.getNodeType().getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEnumLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEnumLiteral.java
@@ -67,7 +67,7 @@ public class SqmEnumLiteral<E extends Enum<E>> extends AbstractSqmExpression<E> 
 				String.format(
 						Locale.ROOT,
 						"Static enum reference [%s#%s] cannot be de-referenced",
-						referencedEnumTypeDescriptor.getJavaType().getName(),
+						referencedEnumTypeDescriptor.getJavaType().getTypeName(),
 						enumValueName
 				)
 		);
@@ -82,7 +82,7 @@ public class SqmEnumLiteral<E extends Enum<E>> extends AbstractSqmExpression<E> 
 				String.format(
 						Locale.ROOT,
 						"Static enum reference [%s#%s] cannot be de-referenced",
-						referencedEnumTypeDescriptor.getJavaType().getName(),
+						referencedEnumTypeDescriptor.getJavaType().getTypeName(),
 						enumValueName
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
@@ -209,7 +209,7 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressable<T>, 
 				String.format(
 						Locale.ROOT,
 						"Static field reference [%s#%s] cannot be de-referenced",
-						fieldJavaTypeDescriptor.getJavaType().getName(),
+						fieldJavaTypeDescriptor.getJavaType().getTypeName(),
 						fieldName
 				)
 		);
@@ -224,7 +224,7 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressable<T>, 
 				String.format(
 						Locale.ROOT,
 						"Static field reference [%s#%s] cannot be de-referenced",
-						fieldJavaTypeDescriptor.getJavaType().getName(),
+						fieldJavaTypeDescriptor.getJavaType().getTypeName(),
 						fieldName
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiationTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiationTarget.java
@@ -36,6 +36,6 @@ public interface SqmDynamicInstantiationTarget<T> extends SqmExpressable<T> {
 	 * @return The type to be instantiated.
 	 */
 	default Class getJavaType() {
-		return getTargetTypeDescriptor().getJavaType();
+		return getTargetTypeDescriptor().getJavaTypeClass();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
@@ -81,7 +81,7 @@ public class SqmJpaCompoundSelection<T>
 
 	@Override
 	public Class<T> getJavaType() {
-		return getJavaTypeDescriptor().getJavaType();
+		return getJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResultAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResultAssembler.java
@@ -63,12 +63,12 @@ public class BasicResultAssembler<J> implements DomainResultAssembler<J> {
 		if ( valueConverter != null ) {
 			if ( jdbcValue != null ) {
 				// the raw value type should be the converter's relational-JTD
-				if ( ! valueConverter.getRelationalJavaDescriptor().getJavaType().isInstance( jdbcValue ) ) {
+				if ( ! valueConverter.getRelationalJavaDescriptor().getJavaTypeClass().isInstance( jdbcValue ) ) {
 					throw new HibernateException(
 							String.format(
 									Locale.ROOT,
 									"Expecting raw JDBC value of type `%s`, but found `%s` : [%s]",
-									valueConverter.getRelationalJavaDescriptor().getJavaType().getName(),
+									valueConverter.getRelationalJavaDescriptor().getJavaType().getTypeName(),
 									jdbcValue.getClass().getName(),
 									jdbcValue
 							)

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiation.java
@@ -55,7 +55,7 @@ public class DynamicInstantiation<T> implements DomainResultProducer {
 	 * todo (6.0) : remove this.  find usages and replace with #getTargetJavaTypeDescriptor
 	 */
 	public Class<T> getTargetJavaType() {
-		return getTargetJavaTypeDescriptor().getJavaType();
+		return getTargetJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	public void addArgument(String alias, DomainResultProducer argumentResultProducer) {
@@ -63,7 +63,7 @@ public class DynamicInstantiation<T> implements DomainResultProducer {
 			throw new ConversionException( "Unexpected call to DynamicInstantiation#addAgument after previously complete" );
 		}
 
-		if ( List.class.equals( getTargetJavaTypeDescriptor().getJavaType() ) ) {
+		if ( List.class.equals( getTargetJavaTypeDescriptor().getJavaTypeClass() ) ) {
 			// really should not have an alias...
 			if ( alias != null && log.isDebugEnabled() ) {
 				log.debugf(
@@ -74,7 +74,7 @@ public class DynamicInstantiation<T> implements DomainResultProducer {
 				);
 			}
 		}
-		else if ( Map.class.equals( getTargetJavaTypeDescriptor().getJavaType() ) ) {
+		else if ( Map.class.equals( getTargetJavaTypeDescriptor().getJavaTypeClass() ) ) {
 			// must have an alias...
 			if ( alias == null ) {
 				log.warnf(
@@ -104,7 +104,7 @@ public class DynamicInstantiation<T> implements DomainResultProducer {
 
 	@Override
 	public String toString() {
-		return "DynamicInstantiation(" + getTargetJavaTypeDescriptor().getJavaType().getName() + ")";
+		return "DynamicInstantiation(" + getTargetJavaTypeDescriptor().getJavaType().getTypeName() + ")";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationAssemblerInjectionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationAssemblerInjectionImpl.java
@@ -31,7 +31,7 @@ public class DynamicInstantiationAssemblerInjectionImpl<T> implements DomainResu
 			JavaTypeDescriptor<T> target,
 			List<ArgumentReader<?>> argumentReaders) {
 		this.target = target;
-		final Class targetJavaType = target.getJavaType();
+		final Class targetJavaType = target.getJavaTypeClass();
 
 		BeanInfoHelper.visitBeanInfo(
 				targetJavaType,
@@ -67,7 +67,7 @@ public class DynamicInstantiationAssemblerInjectionImpl<T> implements DomainResu
 						final Field field = findField(
 								targetJavaType,
 								argumentReader.getAlias(),
-								argumentReader.getAssembledJavaTypeDescriptor().getJavaType()
+								argumentReader.getAssembledJavaTypeDescriptor().getJavaTypeClass()
 						);
 						if ( field != null ) {
 							beanInjections.add(
@@ -116,7 +116,7 @@ public class DynamicInstantiationAssemblerInjectionImpl<T> implements DomainResu
 	@SuppressWarnings("unchecked")
 	public T assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
 		try {
-			final T result = target.getJavaType().newInstance();
+			final T result = target.getJavaTypeClass().newInstance();
 			for ( BeanInjection beanInjection : beanInjections ) {
 				beanInjection.getBeanInjector().inject(
 						result,
@@ -126,7 +126,7 @@ public class DynamicInstantiationAssemblerInjectionImpl<T> implements DomainResu
 			return result;
 		}
 		catch (IllegalAccessException | InstantiationException | java.lang.InstantiationException e) {
-			throw new InstantiationException( "Could not call default constructor [" + target.getJavaType().getSimpleName() + "]", e );
+			throw new InstantiationException( "Could not call default constructor [" + target.getJavaType().getTypeName() + "]", e );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
@@ -142,7 +142,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 		else {
 			// find a constructor matching argument types
 			constructor_loop:
-			for ( Constructor<?> constructor : javaTypeDescriptor.getJavaType().getDeclaredConstructors() ) {
+			for ( Constructor<?> constructor : javaTypeDescriptor.getJavaTypeClass().getDeclaredConstructors() ) {
 				if ( constructor.getParameterTypes().length != argumentReaders.size() ) {
 					continue;
 				}
@@ -165,7 +165,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 									"Skipping constructor for dynamic-instantiation match due to argument mismatch [%s] : %s -> %s",
 									i,
 									constructor.getParameterTypes()[i].getName(),
-									argumentTypeDescriptor.getJavaType().getName()
+									argumentTypeDescriptor.getJavaType().getTypeName()
 							);
 						}
 						continue constructor_loop;
@@ -184,7 +184,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 			if ( log.isDebugEnabled() ) {
 				log.debugf(
 						"Could not locate appropriate constructor for dynamic instantiation of [%s]; attempting bean-injection instantiation",
-						javaTypeDescriptor.getJavaType().getName()
+						javaTypeDescriptor.getJavaType().getTypeName()
 				);
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -86,7 +86,7 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 			else {
 				assert !exploreKeySubgraph;
 				subgraphMap = attributeNode.getSubGraphMap();
-				subgraphMapKey = fetchable.getJavaTypeDescriptor().getJavaType();
+				subgraphMapKey = fetchable.getJavaTypeDescriptor().getJavaTypeClass();
 			}
 			if ( subgraphMap != null && subgraphMapKey != null ) {
 				currentGraphContext = subgraphMap.get( subgraphMapKey );
@@ -108,7 +108,7 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 	private Class<?> getEntityCollectionPartJavaClass(CollectionPart collectionPart) {
 		if ( collectionPart instanceof EntityCollectionPart ) {
 			EntityCollectionPart entityCollectionPart = (EntityCollectionPart) collectionPart;
-			return entityCollectionPart.getEntityMappingType().getJavaTypeDescriptor().getJavaType();
+			return entityCollectionPart.getEntityMappingType().getJavaTypeDescriptor().getJavaTypeClass();
 		}
 		else {
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
@@ -68,7 +68,7 @@ public class StandardRowReader<T> implements RowReader<T> {
 	@SuppressWarnings("unchecked")
 	public Class<T> getResultJavaType() {
 		if ( resultAssemblers.size() == 1 ) {
-			return (Class<T>) resultAssemblers.get( 0 ).getAssembledJavaTypeDescriptor().getJavaType();
+			return (Class<T>) resultAssemblers.get( 0 ).getAssembledJavaTypeDescriptor().getJavaTypeClass();
 		}
 
 		return (Class<T>) Object[].class;

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -83,7 +83,7 @@ public abstract class AbstractStandardBasicType<T>
 
 	@Override
 	public Class<T> getJavaType() {
-		return getExpressableJavaTypeDescriptor().getJavaType();
+		return getExpressableJavaTypeDescriptor().getJavaTypeClass();
 	}
 
 	public T fromString(String string) {
@@ -121,7 +121,7 @@ public abstract class AbstractStandardBasicType<T>
 	@Override
 	public String[] getRegistrationKeys() {
 		return registerUnderJavaType()
-				? new String[] { getName(), javaTypeDescriptor.getJavaType().getName() }
+				? new String[] { getName(), javaTypeDescriptor.getJavaType().getTypeName() }
 				: new String[] { getName() };
 	}
 
@@ -164,7 +164,7 @@ public abstract class AbstractStandardBasicType<T>
 
 	@Override
 	public final Class getReturnedClass() {
-		return javaTypeDescriptor.getJavaType();
+		return javaTypeDescriptor.getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicTypeRegistry.java
@@ -49,6 +49,10 @@ public class BasicTypeRegistry implements Serializable {
 		return (BasicType<J>) typesByName.get( key );
 	}
 
+	public <J> BasicType<J> getRegisteredType(java.lang.reflect.Type javaType) {
+		return getRegisteredType( javaType.getTypeName() );
+	}
+
 	public <J> BasicType<J> getRegisteredType(Class<J> javaType) {
 		return getRegisteredType( javaType.getName() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
@@ -371,7 +371,7 @@ public class CustomType
 
 	@Override
 	public Class getJavaType() {
-		return mappedJavaTypeDescriptor.getJavaType();
+		return mappedJavaTypeDescriptor.getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypeTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypeTemplate.java
@@ -28,7 +28,7 @@ public class StandardBasicTypeTemplate<J> extends AbstractSingleColumnStandardBa
 		super( sqlTypeDescriptor, javaTypeDescriptor );
 		this.registrationKeys = registrationKeys;
 
-		this.name = javaTypeDescriptor.getJavaType() == null ? "(map-mode)" : javaTypeDescriptor.getJavaType().getName()
+		this.name = javaTypeDescriptor.getJavaType() == null ? "(map-mode)" : javaTypeDescriptor.getJavaType().getTypeName()
 				+ " -> " + sqlTypeDescriptor.getSqlType();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractClassTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractClassTypeDescriptor.java
@@ -7,7 +7,6 @@
 package org.hibernate.type.descriptor.java;
 
 import java.io.Serializable;
-import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -24,8 +23,8 @@ import org.hibernate.internal.util.compare.ComparableComparator;
  *
  * @author Steve Ebersole
  */
-public abstract class AbstractTypeDescriptor<T> implements BasicJavaDescriptor<T>, Serializable {
-	private final Type type;
+public abstract class AbstractClassTypeDescriptor<T> implements BasicJavaDescriptor<T>, Serializable {
+	private final Class<T> type;
 	private final MutabilityPlan<T> mutabilityPlan;
 	private final Comparator<T> comparator;
 
@@ -34,10 +33,10 @@ public abstract class AbstractTypeDescriptor<T> implements BasicJavaDescriptor<T
 	 *
 	 * @param type The Java type.
 	 *
-	 * @see #AbstractTypeDescriptor(Type, MutabilityPlan)
+	 * @see #AbstractClassTypeDescriptor(Class, MutabilityPlan)
 	 */
 	@SuppressWarnings({ "unchecked" })
-	protected AbstractTypeDescriptor(Type type) {
+	protected AbstractClassTypeDescriptor(Class<T> type) {
 		this( type, (MutabilityPlan<T>) ImmutableMutabilityPlan.INSTANCE );
 	}
 
@@ -48,10 +47,10 @@ public abstract class AbstractTypeDescriptor<T> implements BasicJavaDescriptor<T
 	 * @param mutabilityPlan The plan for handling mutability aspects of the java type.
 	 */
 	@SuppressWarnings({ "unchecked" })
-	protected AbstractTypeDescriptor(Type type, MutabilityPlan<T> mutabilityPlan) {
+	protected AbstractClassTypeDescriptor(Class<T> type, MutabilityPlan<T> mutabilityPlan) {
 		this.type = type;
 		this.mutabilityPlan = mutabilityPlan;
-		this.comparator = Comparable.class.isAssignableFrom( getJavaTypeClass() )
+		this.comparator = Comparable.class.isAssignableFrom( type )
 				? (Comparator<T>) ComparableComparator.INSTANCE
 				: null;
 	}
@@ -61,9 +60,13 @@ public abstract class AbstractTypeDescriptor<T> implements BasicJavaDescriptor<T
 		return mutabilityPlan;
 	}
 
-	@Override
-	public Type getJavaType() {
+	public Class<T> getJavaType() {
 		return type;
+	}
+
+	@Override
+	public Class<T> getJavaTypeClass() {
+		return getJavaType();
 	}
 
 	@Override
@@ -88,13 +91,13 @@ public abstract class AbstractTypeDescriptor<T> implements BasicJavaDescriptor<T
 
 	protected HibernateException unknownUnwrap(Class conversionType) {
 		throw new HibernateException(
-				"Unknown unwrap conversion requested: " + type.getTypeName() + " to " + conversionType.getName()
+				"Unknown unwrap conversion requested: " + type.getName() + " to " + conversionType.getName()
 		);
 	}
 
 	protected HibernateException unknownWrap(Class conversionType) {
 		throw new HibernateException(
-				"Unknown wrap conversion requested: " + conversionType.getName() + " to " + type.getTypeName()
+				"Unknown wrap conversion requested: " + conversionType.getName() + " to " + type.getName()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTemporalTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTemporalTypeDescriptor.java
@@ -13,7 +13,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 /**
  * @author Steve Ebersole
  */
-public abstract class AbstractTemporalTypeDescriptor<T> extends AbstractTypeDescriptor<T> implements TemporalJavaTypeDescriptor<T> {
+public abstract class AbstractTemporalTypeDescriptor<T> extends AbstractClassTypeDescriptor<T> implements TemporalJavaTypeDescriptor<T> {
 	protected AbstractTemporalTypeDescriptor(Class<T> type) {
 		super( type );
 	}
@@ -70,6 +70,6 @@ public abstract class AbstractTemporalTypeDescriptor<T> extends AbstractTypeDesc
 
 	@Override
 	public String toString() {
-		return "TemporalJavaTypeDescriptor(javaType=" + getJavaType().getName() + ")";
+		return "TemporalJavaTypeDescriptor(javaType=" + getJavaType().getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicJavaDescriptor.java
@@ -30,7 +30,7 @@ public interface BasicJavaDescriptor<T> extends JavaTypeDescriptor<T> {
 	default SqlTypeDescriptor getJdbcRecommendedSqlType(SqlTypeDescriptorIndicators indicators) {
 		// match legacy behavior
 		return indicators.getTypeConfiguration().getSqlTypeDescriptorRegistry().getDescriptor(
-				JdbcTypeJavaClassMappings.INSTANCE.determineJdbcTypeCodeForJavaClass( getJavaType() )
+				JdbcTypeJavaClassMappings.INSTANCE.determineJdbcTypeCodeForJavaClass( getJavaTypeClass() )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalTypeDescriptor.java
@@ -17,7 +17,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class BigDecimalTypeDescriptor extends AbstractTypeDescriptor<BigDecimal> {
+public class BigDecimalTypeDescriptor extends AbstractClassTypeDescriptor<BigDecimal> {
 	public static final BigDecimalTypeDescriptor INSTANCE = new BigDecimalTypeDescriptor();
 
 	public BigDecimalTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerTypeDescriptor.java
@@ -17,7 +17,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class BigIntegerTypeDescriptor extends AbstractTypeDescriptor<BigInteger> {
+public class BigIntegerTypeDescriptor extends AbstractClassTypeDescriptor<BigInteger> {
 	public static final BigIntegerTypeDescriptor INSTANCE = new BigIntegerTypeDescriptor();
 
 	public BigIntegerTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BlobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BlobTypeDescriptor.java
@@ -31,7 +31,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  * @author Steve Ebersole
  * @author Brett Meyer
  */
-public class BlobTypeDescriptor extends AbstractTypeDescriptor<Blob> {
+public class BlobTypeDescriptor extends AbstractClassTypeDescriptor<Blob> {
 	public static final BlobTypeDescriptor INSTANCE = new BlobTypeDescriptor();
 
 	public static class BlobMutabilityPlan implements MutabilityPlan<Blob> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanTypeDescriptor.java
@@ -17,7 +17,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
  *
  * @author Steve Ebersole
  */
-public class BooleanTypeDescriptor extends AbstractTypeDescriptor<Boolean> implements Primitive<Boolean> {
+public class BooleanTypeDescriptor extends AbstractClassTypeDescriptor<Boolean> implements Primitive<Boolean> {
 	public static final BooleanTypeDescriptor INSTANCE = new BooleanTypeDescriptor();
 
 	private final char characterValueTrue;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteArrayTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteArrayTypeDescriptor.java
@@ -23,7 +23,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class ByteArrayTypeDescriptor extends AbstractTypeDescriptor<Byte[]> {
+public class ByteArrayTypeDescriptor extends AbstractClassTypeDescriptor<Byte[]> {
 	public static final ByteArrayTypeDescriptor INSTANCE = new ByteArrayTypeDescriptor();
 
 	@SuppressWarnings({ "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteTypeDescriptor.java
@@ -15,7 +15,7 @@ import org.hibernate.type.descriptor.java.spi.Primitive;
  * @author Steve Ebersole
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
-public class ByteTypeDescriptor extends AbstractTypeDescriptor<Byte> implements Primitive<Byte> {
+public class ByteTypeDescriptor extends AbstractClassTypeDescriptor<Byte> implements Primitive<Byte> {
 	public static final ByteTypeDescriptor INSTANCE = new ByteTypeDescriptor();
 
 	public ByteTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterArrayTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterArrayTypeDescriptor.java
@@ -21,7 +21,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class CharacterArrayTypeDescriptor extends AbstractTypeDescriptor<Character[]> {
+public class CharacterArrayTypeDescriptor extends AbstractClassTypeDescriptor<Character[]> {
 	public static final CharacterArrayTypeDescriptor INSTANCE = new CharacterArrayTypeDescriptor();
 
 	@SuppressWarnings({ "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterTypeDescriptor.java
@@ -5,22 +5,18 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type.descriptor.java;
-import java.sql.Types;
 
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.Primitive;
-import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
-import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Descriptor for {@link Character} handling.
  *
  * @author Steve Ebersole
  */
-public class CharacterTypeDescriptor extends AbstractTypeDescriptor<Character> implements Primitive<Character> {
+public class CharacterTypeDescriptor extends AbstractClassTypeDescriptor<Character> implements Primitive<Character> {
 	public static final CharacterTypeDescriptor INSTANCE = new CharacterTypeDescriptor();
 
 	public CharacterTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClassTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClassTypeDescriptor.java
@@ -14,7 +14,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class ClassTypeDescriptor extends AbstractTypeDescriptor<Class> {
+public class ClassTypeDescriptor extends AbstractClassTypeDescriptor<Class> {
 	public static final ClassTypeDescriptor INSTANCE = new ClassTypeDescriptor();
 
 	public ClassTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClobTypeDescriptor.java
@@ -33,7 +33,7 @@ import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptorRegistry;
  *
  * @author Steve Ebersole
  */
-public class ClobTypeDescriptor extends AbstractTypeDescriptor<Clob> {
+public class ClobTypeDescriptor extends AbstractClassTypeDescriptor<Clob> {
 	public static final ClobTypeDescriptor INSTANCE = new ClobTypeDescriptor();
 
 	public ClobTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyTypeDescriptor.java
@@ -15,7 +15,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class CurrencyTypeDescriptor extends AbstractTypeDescriptor<Currency> {
+public class CurrencyTypeDescriptor extends AbstractClassTypeDescriptor<Currency> {
 	public static final CurrencyTypeDescriptor INSTANCE = new CurrencyTypeDescriptor();
 
 	public CurrencyTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleTypeDescriptor.java
@@ -21,7 +21,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
  *
  * @author Steve Ebersole
  */
-public class DoubleTypeDescriptor extends AbstractTypeDescriptor<Double> implements Primitive<Double> {
+public class DoubleTypeDescriptor extends AbstractClassTypeDescriptor<Double> implements Primitive<Double> {
 	public static final DoubleTypeDescriptor INSTANCE = new DoubleTypeDescriptor();
 
 	public DoubleTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaDescriptor.java
@@ -32,7 +32,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
  * @author Steve Ebersole
  * @author Gavin King
  */
-public class DurationJavaDescriptor extends AbstractTypeDescriptor<Duration> {
+public class DurationJavaDescriptor extends AbstractClassTypeDescriptor<Duration> {
 	/**
 	 * Singleton access
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaTypeDescriptor.java
@@ -22,7 +22,7 @@ import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
  *
  * @author Steve Ebersole
  */
-public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescriptor<T> {
+public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractClassTypeDescriptor<T> {
 	@SuppressWarnings("unchecked")
 	public EnumJavaTypeDescriptor(Class<T> type) {
 		super( type, ImmutableMutabilityPlan.INSTANCE );
@@ -53,7 +53,7 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 
 	@Override
 	public T fromString(String string) {
-		return string == null ? null : Enum.valueOf( getJavaType(), string );
+		return string == null ? null : Enum.valueOf( getJavaTypeClass(), string );
 	}
 
 	@Override
@@ -156,7 +156,7 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 		if ( relationalForm == null ) {
 			return null;
 		}
-		return getJavaType().getEnumConstants()[ relationalForm ];
+		return getJavaTypeClass().getEnumConstants()[ relationalForm ];
 	}
 
 	/**
@@ -166,7 +166,7 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 		if ( relationalForm == null ) {
 			return null;
 		}
-		return getJavaType().getEnumConstants()[ relationalForm ];
+		return getJavaTypeClass().getEnumConstants()[ relationalForm ];
 	}
 
 	/**
@@ -176,7 +176,7 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 		if ( relationalForm == null ) {
 			return null;
 		}
-		return getJavaType().getEnumConstants()[ relationalForm ];
+		return getJavaTypeClass().getEnumConstants()[ relationalForm ];
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 		if ( relationalForm == null ) {
 			return null;
 		}
-		return getJavaType().getEnumConstants()[ relationalForm.intValue() ];
+		return getJavaTypeClass().getEnumConstants()[ relationalForm.intValue() ];
 	}
 
 	/**
@@ -213,19 +213,19 @@ public class EnumJavaTypeDescriptor<T extends Enum<T>> extends AbstractTypeDescr
 		if ( relationalForm == null ) {
 			return null;
 		}
-		return Enum.valueOf( getJavaType(), relationalForm.trim() );
+		return Enum.valueOf( getJavaTypeClass(), relationalForm.trim() );
 	}
 
 	@Override
 	public String getCheckCondition(String columnName, SqlTypeDescriptor sqlTypeDescriptor, Dialect dialect) {
 		if (sqlTypeDescriptor instanceof TinyIntTypeDescriptor
 				|| sqlTypeDescriptor instanceof IntegerTypeDescriptor) {
-			int last = getJavaType().getEnumConstants().length - 1;
+			int last = getJavaTypeClass().getEnumConstants().length - 1;
 			return columnName + " between 0 and " + last;
 		}
 		else if (sqlTypeDescriptor instanceof VarcharTypeDescriptor) {
 			StringBuilder types = new StringBuilder();
-			for ( Enum<T> value : getJavaType().getEnumConstants() ) {
+			for ( Enum<T> value : getJavaTypeClass().getEnumConstants() ) {
 				if (types.length() != 0) {
 					types.append(", ");
 				}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatTypeDescriptor.java
@@ -18,7 +18,7 @@ import org.hibernate.type.descriptor.java.spi.Primitive;
  *
  * @author Steve Ebersole
  */
-public class FloatTypeDescriptor extends AbstractTypeDescriptor<Float> implements Primitive<Float> {
+public class FloatTypeDescriptor extends AbstractClassTypeDescriptor<Float> implements Primitive<Float> {
 	public static final FloatTypeDescriptor INSTANCE = new FloatTypeDescriptor();
 
 	public FloatTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerTypeDescriptor.java
@@ -18,7 +18,7 @@ import org.hibernate.type.descriptor.java.spi.Primitive;
  *
  * @author Steve Ebersole
  */
-public class IntegerTypeDescriptor extends AbstractTypeDescriptor<Integer> implements Primitive<Integer> {
+public class IntegerTypeDescriptor extends AbstractClassTypeDescriptor<Integer> implements Primitive<Integer> {
 	public static final IntegerTypeDescriptor INSTANCE = new IntegerTypeDescriptor();
 
 	public IntegerTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaObjectTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaObjectTypeDescriptor.java
@@ -11,7 +11,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 /**
  * @author Steve Ebersole
  */
-public class JavaObjectTypeDescriptor extends AbstractTypeDescriptor<Object> {
+public class JavaObjectTypeDescriptor extends AbstractClassTypeDescriptor<Object> {
 	/**
 	 * Singleton access
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptorRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptorRegistry.java
@@ -88,7 +88,7 @@ public class JavaTypeDescriptorRegistry implements Serializable {
 	}
 
 	private JavaTypeDescriptor addDescriptorInternal(JavaTypeDescriptor descriptor) {
-		return descriptorsByClass.put( descriptor.getJavaType(), descriptor );
+		return descriptorsByClass.put( descriptor.getJavaTypeClass(), descriptor );
 	}
 
 	/**
@@ -147,7 +147,7 @@ public class JavaTypeDescriptorRegistry implements Serializable {
 	}
 
 
-	public static class FallbackJavaTypeDescriptor<T> extends AbstractTypeDescriptor<T> {
+	public static class FallbackJavaTypeDescriptor<T> extends AbstractClassTypeDescriptor<T> {
 		protected FallbackJavaTypeDescriptor(final Class<T> type) {
 			super( type, createMutabilityPlan( type ) );
 		}
@@ -177,7 +177,7 @@ public class JavaTypeDescriptorRegistry implements Serializable {
 		@Override
 		public T fromString(String string) {
 			throw new HibernateException(
-					"Not known how to convert String to given type [" + getJavaType().getName() + "]"
+					"Not known how to convert String to given type [" + getJavaType().getTypeName() + "]"
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleTypeDescriptor.java
@@ -16,7 +16,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class LocaleTypeDescriptor extends AbstractTypeDescriptor<Locale> {
+public class LocaleTypeDescriptor extends AbstractClassTypeDescriptor<Locale> {
 	public static final LocaleTypeDescriptor INSTANCE = new LocaleTypeDescriptor();
 
 	public static class LocaleComparator implements Comparator<Locale> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongTypeDescriptor.java
@@ -18,7 +18,7 @@ import org.hibernate.type.descriptor.java.spi.Primitive;
  *
  * @author Steve Ebersole
  */
-public class LongTypeDescriptor extends AbstractTypeDescriptor<Long>implements Primitive<Long> {
+public class LongTypeDescriptor extends AbstractClassTypeDescriptor<Long> implements Primitive<Long> {
 	public static final LongTypeDescriptor INSTANCE = new LongTypeDescriptor();
 
 	public LongTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/NClobTypeDescriptor.java
@@ -28,7 +28,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class NClobTypeDescriptor extends AbstractTypeDescriptor<NClob> {
+public class NClobTypeDescriptor extends AbstractClassTypeDescriptor<NClob> {
 	public static final NClobTypeDescriptor INSTANCE = new NClobTypeDescriptor();
 
 	public static class NClobMutabilityPlan implements MutabilityPlan<NClob> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayTypeDescriptor.java
@@ -23,7 +23,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class PrimitiveByteArrayTypeDescriptor extends AbstractTypeDescriptor<byte[]> {
+public class PrimitiveByteArrayTypeDescriptor extends AbstractClassTypeDescriptor<byte[]> {
 	public static final PrimitiveByteArrayTypeDescriptor INSTANCE = new PrimitiveByteArrayTypeDescriptor();
 
 	@SuppressWarnings({ "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayTypeDescriptor.java
@@ -21,7 +21,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class PrimitiveCharacterArrayTypeDescriptor extends AbstractTypeDescriptor<char[]> {
+public class PrimitiveCharacterArrayTypeDescriptor extends AbstractClassTypeDescriptor<char[]> {
 	public static final PrimitiveCharacterArrayTypeDescriptor INSTANCE = new PrimitiveCharacterArrayTypeDescriptor();
 
 	@SuppressWarnings({ "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/RowVersionTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/RowVersionTypeDescriptor.java
@@ -25,7 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  * @author Steve Ebersole
  * @author Gail Badner
  */
-public class RowVersionTypeDescriptor extends AbstractTypeDescriptor<byte[]> {
+public class RowVersionTypeDescriptor extends AbstractClassTypeDescriptor<byte[]> {
 	public static final RowVersionTypeDescriptor INSTANCE = new RowVersionTypeDescriptor();
 
 	@SuppressWarnings({ "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SerializableTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/SerializableTypeDescriptor.java
@@ -26,7 +26,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  * @author Steve Ebersole
  * @author Brett meyer
  */
-public class SerializableTypeDescriptor<T extends Serializable> extends AbstractTypeDescriptor<T> {
+public class SerializableTypeDescriptor<T extends Serializable> extends AbstractClassTypeDescriptor<T> {
 
 	// unfortunately the param types cannot be the same so use something other than 'T' here to make that obvious
 	public static class SerializableMutabilityPlan<S extends Serializable> extends MutableMutabilityPlan<S> {
@@ -123,7 +123,7 @@ public class SerializableTypeDescriptor<T extends Serializable> extends Abstract
 				throw new HibernateException( e );
 			}
 		}
-		else if ( getJavaType().isInstance( value ) ) {
+		else if ( getJavaTypeClass().isInstance( value ) ) {
 			return (T) value;
 		}
 		throw unknownWrap( value.getClass() );
@@ -135,6 +135,6 @@ public class SerializableTypeDescriptor<T extends Serializable> extends Abstract
 
 	@SuppressWarnings({ "unchecked" })
 	protected T fromBytes(byte[] bytes) {
-		return (T) SerializationHelper.deserialize( bytes, getJavaType().getClassLoader() );
+		return (T) SerializationHelper.deserialize( bytes, getJavaTypeClass().getClassLoader() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortTypeDescriptor.java
@@ -14,7 +14,7 @@ import org.hibernate.type.descriptor.java.spi.Primitive;
  *
  * @author Steve Ebersole
  */
-public class ShortTypeDescriptor extends AbstractTypeDescriptor<Short> implements Primitive<Short> {
+public class ShortTypeDescriptor extends AbstractClassTypeDescriptor<Short> implements Primitive<Short> {
 	public static final ShortTypeDescriptor INSTANCE = new ShortTypeDescriptor();
 
 	public ShortTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringTypeDescriptor.java
@@ -14,8 +14,6 @@ import java.sql.Types;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.sql.ClobTypeDescriptor;
-import org.hibernate.type.descriptor.sql.NClobTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
 import org.hibernate.type.descriptor.sql.spi.SqlTypeDescriptorRegistry;
@@ -26,7 +24,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  *
  * @author Steve Ebersole
  */
-public class StringTypeDescriptor extends AbstractTypeDescriptor<String> {
+public class StringTypeDescriptor extends AbstractClassTypeDescriptor<String> {
 	public static final StringTypeDescriptor INSTANCE = new StringTypeDescriptor();
 
 	public StringTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/TimeZoneTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/TimeZoneTypeDescriptor.java
@@ -16,7 +16,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  */
-public class TimeZoneTypeDescriptor extends AbstractTypeDescriptor<TimeZone> {
+public class TimeZoneTypeDescriptor extends AbstractClassTypeDescriptor<TimeZone> {
 	public static final TimeZoneTypeDescriptor INSTANCE = new TimeZoneTypeDescriptor();
 
 	public static class TimeZoneComparator implements Comparator<TimeZone> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UUIDTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UUIDTypeDescriptor.java
@@ -20,7 +20,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
  *
  * @author Steve Ebersole
  */
-public class UUIDTypeDescriptor extends AbstractTypeDescriptor<UUID> {
+public class UUIDTypeDescriptor extends AbstractClassTypeDescriptor<UUID> {
 	public static final UUIDTypeDescriptor INSTANCE = new UUIDTypeDescriptor();
 
 	public UUIDTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UrlTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UrlTypeDescriptor.java
@@ -20,7 +20,7 @@ import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
  *
  * @author Steve Ebersole
  */
-public class UrlTypeDescriptor extends AbstractTypeDescriptor<URL> {
+public class UrlTypeDescriptor extends AbstractClassTypeDescriptor<URL> {
 	public static final UrlTypeDescriptor INSTANCE = new UrlTypeDescriptor();
 
 	public UrlTypeDescriptor() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZoneOffsetJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZoneOffsetJavaDescriptor.java
@@ -19,7 +19,7 @@ import java.util.Comparator;
  *
  * @author Gavin King
  */
-public class ZoneOffsetJavaDescriptor extends AbstractTypeDescriptor<ZoneOffset> {
+public class ZoneOffsetJavaDescriptor extends AbstractClassTypeDescriptor<ZoneOffset> {
 	public static final ZoneOffsetJavaDescriptor INSTANCE = new ZoneOffsetJavaDescriptor();
 
 	public static class ZoneOffsetComparator implements Comparator<ZoneOffset> {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/CollectionJavaTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/CollectionJavaTypeDescriptor.java
@@ -9,7 +9,7 @@ package org.hibernate.type.descriptor.java.spi;
 import org.hibernate.collection.spi.CollectionSemantics;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
 
@@ -23,7 +23,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
  *
  * @author Steve Ebersole
  */
-public class CollectionJavaTypeDescriptor<C> extends AbstractTypeDescriptor<C> {
+public class CollectionJavaTypeDescriptor<C> extends AbstractClassTypeDescriptor<C> {
 	private final CollectionSemantics<C,?> semantics;
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorBasicAdaptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorBasicAdaptor.java
@@ -7,7 +7,7 @@
 package org.hibernate.type.descriptor.java.spi;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
 
@@ -17,7 +17,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
  *
  * @author Steve Ebersole
  */
-public class JavaTypeDescriptorBasicAdaptor<T> extends AbstractTypeDescriptor<T> {
+public class JavaTypeDescriptorBasicAdaptor<T> extends AbstractClassTypeDescriptor<T> {
 	public JavaTypeDescriptorBasicAdaptor(Class<T> type) {
 		super( type );
 	}
@@ -25,7 +25,7 @@ public class JavaTypeDescriptorBasicAdaptor<T> extends AbstractTypeDescriptor<T>
 	@Override
 	public SqlTypeDescriptor getJdbcRecommendedSqlType(SqlTypeDescriptorIndicators context) {
 		throw new UnsupportedOperationException(
-				"Recommended SqlTypeDescriptor not known for this Java type : " + getJavaType().getName()
+				"Recommended SqlTypeDescriptor not known for this Java type : " + getJavaType().getTypeName()
 		);
 	}
 
@@ -37,26 +37,26 @@ public class JavaTypeDescriptorBasicAdaptor<T> extends AbstractTypeDescriptor<T>
 	@Override
 	public T fromString(String string) {
 		throw new UnsupportedOperationException(
-				"Conversion from String strategy not known for this Java type : " + getJavaType().getName()
+				"Conversion from String strategy not known for this Java type : " + getJavaType().getTypeName()
 		);
 	}
 
 	@Override
 	public <X> X unwrap(T value, Class<X> type, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getName()
+				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
 		);
 	}
 
 	@Override
 	public <X> T wrap(X value, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getName()
+				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
 		);
 	}
 
 	@Override
 	public String toString() {
-		return "JavaTypeDescriptorBasicAdaptor(" + getJavaType().getName() + ")";
+		return "JavaTypeDescriptorBasicAdaptor(" + getJavaType().getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorRegistry.java
@@ -47,7 +47,7 @@ public class JavaTypeDescriptorRegistry implements JavaTypeDescriptorBaseline.Ba
 		if ( descriptor.getJavaType() == null ) {
 			throw new IllegalStateException( "Illegal to add BasicJavaTypeDescriptor with null Java type" );
 		}
-		addBaselineDescriptor( descriptor.getJavaType(), descriptor );
+		addBaselineDescriptor( descriptor.getJavaTypeClass(), descriptor );
 	}
 
 	@Override
@@ -99,7 +99,7 @@ public class JavaTypeDescriptorRegistry implements JavaTypeDescriptorBaseline.Ba
 	}
 
 	public void addDescriptor(JavaTypeDescriptor descriptor) {
-		JavaTypeDescriptor old = descriptorsByClass.put( descriptor.getJavaType(), descriptor );
+		JavaTypeDescriptor old = descriptorsByClass.put( descriptor.getJavaTypeClass(), descriptor );
 		if ( old != null ) {
 			log.debugf(
 					"JavaTypeDescriptorRegistry entry replaced : %s -> %s (was %s)",

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/MapEntryJavaDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/MapEntryJavaDescriptor.java
@@ -9,14 +9,14 @@ package org.hibernate.type.descriptor.java.spi;
 import java.util.Map;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptorIndicators;
 
 /**
  * @author Steve Ebersole
  */
-public class MapEntryJavaDescriptor extends AbstractTypeDescriptor<Map.Entry> {
+public class MapEntryJavaDescriptor extends AbstractClassTypeDescriptor<Map.Entry> {
 	/**
 	 * Singleton access
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BitTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/BitTypeDescriptor.java
@@ -60,7 +60,7 @@ public class BitTypeDescriptor implements SqlTypeDescriptor {
 	}
 
 	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaTypeDescriptor<T> javaTypeDescriptor) {
-		if ( javaTypeDescriptor.getJavaType().equals(Boolean.class) ) {
+		if ( javaTypeDescriptor.getJavaTypeClass().equals(Boolean.class) ) {
 			//this is to allow literals to be formatted correctly when
 			//we are in the legacy Boolean-to-BIT JDBC type mapping mode
 			return new BasicJdbcLiteralFormatter( javaTypeDescriptor ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ObjectSqlTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/ObjectSqlTypeDescriptor.java
@@ -51,7 +51,7 @@ public class ObjectSqlTypeDescriptor implements SqlTypeDescriptor {
 
 	@Override
 	public <X> ValueBinder<X> getBinder(JavaTypeDescriptor<X> javaTypeDescriptor) {
-		if ( Serializable.class.isAssignableFrom( javaTypeDescriptor.getJavaType() ) ) {
+		if ( Serializable.class.isAssignableFrom( javaTypeDescriptor.getJavaTypeClass() ) ) {
 			return VarbinaryTypeDescriptor.INSTANCE.getBinder( javaTypeDescriptor );
 		}
 
@@ -73,7 +73,7 @@ public class ObjectSqlTypeDescriptor implements SqlTypeDescriptor {
 	@Override
 	@SuppressWarnings("unchecked")
 	public ValueExtractor getExtractor(JavaTypeDescriptor javaTypeDescriptor) {
-		if ( Serializable.class.isAssignableFrom( javaTypeDescriptor.getJavaType() ) ) {
+		if ( Serializable.class.isAssignableFrom( javaTypeDescriptor.getJavaTypeClass() ) ) {
 			return VarbinaryTypeDescriptor.INSTANCE.getExtractor( javaTypeDescriptor );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -543,7 +543,7 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 
 	private static boolean matchesJavaType(SqmExpressable<?> type, Class<?> javaType) {
 		assert javaType != null;
-		return type != null && javaType.isAssignableFrom( type.getExpressableJavaTypeDescriptor().getJavaType() );
+		return type != null && javaType.isAssignableFrom( type.getExpressableJavaTypeDescriptor().getJavaTypeClass() );
 	}
 
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/basic/CollectionAsBasicTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/basic/CollectionAsBasicTest.java
@@ -22,7 +22,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
 
@@ -72,7 +72,7 @@ public class CollectionAsBasicTest {
 		}
 	}
 
-	public static class DelimitedStringsJavaTypeDescriptor extends AbstractTypeDescriptor<Set> {
+	public static class DelimitedStringsJavaTypeDescriptor extends AbstractClassTypeDescriptor<Set> {
 		public DelimitedStringsJavaTypeDescriptor() {
 			super(
 					Set.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/EnumResolutionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/EnumResolutionTests.java
@@ -142,8 +142,8 @@ public class EnumResolutionTests {
 
 		// verify the interpretations used for reading
 		assertThat( resolution.getRelationalSqlTypeDescriptor().getJdbcTypeCode(), is( jdbcCode ) );
-		assertThat( resolution.getRelationalJavaDescriptor().getJavaType(), equalTo( jdbcJavaType ) );
-		assertThat( resolution.getDomainJavaDescriptor().getJavaType(), equalTo( Values.class ) );
+		assertThat( resolution.getRelationalJavaDescriptor().getJavaTypeClass(), equalTo( jdbcJavaType ) );
+		assertThat( resolution.getDomainJavaDescriptor().getJavaTypeClass(), equalTo( Values.class ) );
 
 		final JdbcMapping jdbcMapping = resolution.getJdbcMapping();
 		assertThat( jdbcMapping.getSqlTypeDescriptor(), equalTo( resolution.getRelationalSqlTypeDescriptor() ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/SimpleEntityTypeResolutionsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/SimpleEntityTypeResolutionsTests.java
@@ -60,7 +60,7 @@ public class SimpleEntityTypeResolutionsTests {
 			switch ( property.getName() ) {
 				case "someDate": {
 					assertThat(
-							propertyResolution.getDomainJavaDescriptor().getJavaType(),
+							propertyResolution.getDomainJavaDescriptor().getJavaTypeClass(),
 							sameInstance( Date.class )
 					);
 					assertThat( propertyValue.getTemporalPrecision(), is( TemporalType.TIMESTAMP ) );
@@ -68,7 +68,7 @@ public class SimpleEntityTypeResolutionsTests {
 				}
 				case "someInstant": {
 					assertThat(
-							propertyResolution.getDomainJavaDescriptor().getJavaType(),
+							propertyResolution.getDomainJavaDescriptor().getJavaTypeClass(),
 							sameInstance( Instant.class )
 					);
 					assertThat( propertyValue.getTemporalPrecision(), nullValue() );
@@ -76,21 +76,21 @@ public class SimpleEntityTypeResolutionsTests {
 				}
 				case "someInteger": {
 					assertThat(
-							propertyResolution.getDomainJavaDescriptor().getJavaType(),
+							propertyResolution.getDomainJavaDescriptor().getJavaTypeClass(),
 							sameInstance( Integer.class )
 					);
 					break;
 				}
 				case "someLong": {
 					assertThat(
-							propertyResolution.getDomainJavaDescriptor().getJavaType(),
+							propertyResolution.getDomainJavaDescriptor().getJavaTypeClass(),
 							sameInstance( Long.class )
 					);
 					break;
 				}
 				case "someString": {
 					assertThat(
-							propertyResolution.getDomainJavaDescriptor().getJavaType(),
+							propertyResolution.getDomainJavaDescriptor().getJavaTypeClass(),
 							sameInstance( String.class )
 					);
 					break;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
@@ -299,7 +299,7 @@ public class CriteriaEntityGraphTest implements SessionFactoryScopeAware {
 
 		final TableGroup joinedGroup = rootTableGroup.getTableGroupJoins().iterator().next().getJoinedGroup();
 		assertThat( joinedGroup.getModelPart().getPartName(), is( expectedAttributeName ) );
-		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( joinedGroup.getModelPart(), instanceOf( EntityValuedModelPart.class ) );
 
 		tableGroupConsumer.accept( joinedGroup );
@@ -340,7 +340,7 @@ public class CriteriaEntityGraphTest implements SessionFactoryScopeAware {
 		assertThat( domainResult, instanceOf( EntityResult.class ) );
 
 		final EntityResult entityResult = (EntityResult) domainResult;
-		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( entityResult.getFetches(), hasSize( 1 ) );
 
 		final Fetch fetch = entityResult.getFetches().get( 0 );
@@ -348,7 +348,7 @@ public class CriteriaEntityGraphTest implements SessionFactoryScopeAware {
 
 		final EntityFetch entityFetch = (EntityFetch) fetch;
 		assertThat( entityFetch.getFetchedMapping().getFetchableName(), is( expectedAttributeName ) );
-		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedAttributeEntityJpaClass ) );
+		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedAttributeEntityJpaClass ) );
 
 		entityFetchConsumer.accept( entityFetch );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/EntityGraphLoadPlanBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/EntityGraphLoadPlanBuilderTest.java
@@ -289,7 +289,7 @@ public class EntityGraphLoadPlanBuilderTest implements SessionFactoryScopeAware 
 
 		final TableGroup joinedGroup = CollectionUtils.getOnlyElement( rootTableGroup.getTableGroupJoins() ).getJoinedGroup();
 		assertThat( joinedGroup.getModelPart().getPartName(), is( expectedAttributeName ) );
-		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( joinedGroup.getModelPart(), instanceOf( EntityValuedModelPart.class ) );
 
 		tableGroupConsumer.accept( joinedGroup );
@@ -330,7 +330,7 @@ public class EntityGraphLoadPlanBuilderTest implements SessionFactoryScopeAware 
 		assertThat( domainResult, instanceOf( EntityResult.class ) );
 
 		final EntityResult entityResult = (EntityResult) domainResult;
-		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( entityResult.getFetches(), hasSize( 1 ) );
 
 		final Fetch fetch = entityResult.getFetches().get( 0 );
@@ -338,7 +338,7 @@ public class EntityGraphLoadPlanBuilderTest implements SessionFactoryScopeAware 
 
 		final EntityFetch entityFetch = (EntityFetch) fetch;
 		assertThat( entityFetch.getFetchedMapping().getFetchableName(), is( expectedAttributeName ) );
-		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedAttributeEntityJpaClass ) );
+		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedAttributeEntityJpaClass ) );
 
 		entityFetchConsumer.accept( entityFetch );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
@@ -295,7 +295,7 @@ public class HqlEntityGraphTest implements SessionFactoryScopeAware {
 
 		final TableGroup joinedGroup = rootTableGroup.getTableGroupJoins().iterator().next().getJoinedGroup();
 		assertThat( joinedGroup.getModelPart().getPartName(), is( expectedAttributeName ) );
-		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( joinedGroup.getModelPart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( joinedGroup.getModelPart(), instanceOf( EntityValuedModelPart.class ) );
 
 		tableGroupConsumer.accept( joinedGroup );
@@ -336,7 +336,7 @@ public class HqlEntityGraphTest implements SessionFactoryScopeAware {
 		assertThat( domainResult, instanceOf( EntityResult.class ) );
 
 		final EntityResult entityResult = (EntityResult) domainResult;
-		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedEntityJpaClass ) );
+		assertThat( entityResult.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedEntityJpaClass ) );
 		assertThat( entityResult.getFetches(), hasSize( 1 ) );
 
 		final Fetch fetch = entityResult.getFetches().get( 0 );
@@ -344,7 +344,7 @@ public class HqlEntityGraphTest implements SessionFactoryScopeAware {
 
 		final EntityFetch entityFetch = (EntityFetch) fetch;
 		assertThat( entityFetch.getFetchedMapping().getFetchableName(), is( expectedAttributeName ) );
-		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaType(), assignableTo( expectedAttributeEntityJpaClass ) );
+		assertThat( entityFetch.getReferencedModePart().getJavaTypeDescriptor().getJavaTypeClass(), assignableTo( expectedAttributeEntityJpaClass ) );
 
 		entityFetchConsumer.accept( entityFetch );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/mapping/SmokeTests.java
@@ -65,7 +65,7 @@ public class SmokeTests {
 
 		final EntityIdentifierMapping identifierMapping = entityDescriptor.getIdentifierMapping();
 		assertThat(
-				identifierMapping.getMappedType().getMappedJavaTypeDescriptor().getJavaType(),
+				identifierMapping.getMappedType().getMappedJavaTypeDescriptor().getJavaTypeClass(),
 				sameInstance( Integer.class )
 		);
 
@@ -83,12 +83,12 @@ public class SmokeTests {
 			assert "mapping_simple_entity".equals( genderAttrMapping.getContainingTableExpression() );
 			assert "gender".equals( genderAttrMapping.getSelectionExpression() );
 
-			assertThat( genderAttrMapping.getJavaTypeDescriptor().getJavaType(), equalTo( Gender.class ) );
+			assertThat( genderAttrMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo( Gender.class ) );
 
 			final BasicValueConverter valueConverter = genderAttrMapping.getValueConverter();
 			assertThat( valueConverter, instanceOf( OrdinalEnumValueConverter.class ) );
 			assertThat( valueConverter.getDomainJavaDescriptor(), is( genderAttrMapping.getJavaTypeDescriptor() ) );
-			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaType(), equalTo( Integer.class ) );
+			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaTypeClass(), equalTo( Integer.class ) );
 
 			assertThat( genderAttrMapping.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode(), is( Types.TINYINT ) );
 		}
@@ -100,12 +100,12 @@ public class SmokeTests {
 			assert "mapping_simple_entity".equals( attrMapping.getContainingTableExpression() );
 			assert "gender2".equals( attrMapping.getSelectionExpression() );
 
-			assertThat( attrMapping.getJavaTypeDescriptor().getJavaType(), equalTo( Gender.class ) );
+			assertThat( attrMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo( Gender.class ) );
 
 			final BasicValueConverter valueConverter = attrMapping.getValueConverter();
 			assertThat( valueConverter, instanceOf( NamedEnumValueConverter.class ) );
 			assertThat( valueConverter.getDomainJavaDescriptor(), is( attrMapping.getJavaTypeDescriptor() ) );
-			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaType(), equalTo( String.class ) );
+			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaTypeClass(), equalTo( String.class ) );
 
 			assertThat( attrMapping.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode(), is( Types.VARCHAR ) );
 		}
@@ -117,12 +117,12 @@ public class SmokeTests {
 			assert "mapping_simple_entity".equals( attrMapping.getContainingTableExpression() );
 			assert "gender3".equals( attrMapping.getSelectionExpression() );
 
-			assertThat( attrMapping.getJavaTypeDescriptor().getJavaType(), equalTo( Gender.class ) );
+			assertThat( attrMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo( Gender.class ) );
 
 			final BasicValueConverter valueConverter = attrMapping.getValueConverter();
 			assertThat( valueConverter, instanceOf( JpaAttributeConverter.class ) );
 			assertThat( valueConverter.getDomainJavaDescriptor(), is( attrMapping.getJavaTypeDescriptor() ) );
-			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaType(), equalTo( Character.class ) );
+			assertThat( valueConverter.getRelationalJavaDescriptor().getJavaTypeClass(), equalTo( Character.class ) );
 
 			assertThat( attrMapping.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode(), is( Types.CHAR ) );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
@@ -140,7 +140,7 @@ public class AttributePathTests extends BaseSqmUnitTest {
 		assertThat( selections.size(), is( 1 ) );
 		final SqmSelection<?> selection = selections.get( 0 );
 		final SqmSelectableNode<?> selectableNode = selection.getSelectableNode();
-		assert Person.class.equals( selectableNode.getJavaTypeDescriptor().getJavaType() );
+		assert Person.class.equals( selectableNode.getJavaTypeDescriptor().getJavaTypeClass() );
 	}
 
 	@Entity( name = "OddOne")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/CaseExpressionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/CaseExpressionsTest.java
@@ -99,7 +99,7 @@ public class CaseExpressionsTest extends BaseSqmUnitTest {
 		);
 
 		assertThat( coalesce.getArguments(), hasSize( 2 ) );
-		assertEquals( coalesce.getJavaTypeDescriptor().getJavaType(), String.class );
+		assertEquals( coalesce.getJavaTypeDescriptor().getJavaTypeClass(), String.class );
 	}
 
 	@Test
@@ -115,7 +115,7 @@ public class CaseExpressionsTest extends BaseSqmUnitTest {
 				.get( 0 )
 				.getSelectableNode();
 
-		assertEquals( selectableNode.getJavaTypeDescriptor().getJavaType(), String.class );
+		assertEquals( selectableNode.getJavaTypeDescriptor().getJavaTypeClass(), String.class );
 
 //		final  nullif = TestingUtil.cast(
 //				selectableNode,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SelectClauseTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SelectClauseTests.java
@@ -298,7 +298,7 @@ public class SelectClauseTests extends BaseSqmUnitTest {
 				.get( 0 )
 				.getSelectableNode();
 
-		assertThat( mapEntryPath.getJavaTypeDescriptor().getJavaType(), is( equalTo( Map.Entry.class ) ) );
+		assertThat( mapEntryPath.getJavaTypeDescriptor().getJavaTypeClass(), is( equalTo( Map.Entry.class ) ) );
 
 		final SqmPath<?> selectedPathLhs = mapEntryPath.getMapPath();
 		assertThat( selectedPathLhs.getExplicitAlias(), is( "m" ) );
@@ -314,7 +314,7 @@ public class SelectClauseTests extends BaseSqmUnitTest {
 				SqmPath.class
 		);
 
-		assertThat( sqmEntityReference.getJavaTypeDescriptor().getJavaType(), equalTo( EntityOfBasics.class ));
+		assertThat( sqmEntityReference.getJavaTypeDescriptor().getJavaTypeClass(), equalTo( EntityOfBasics.class ));
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderTests.java
@@ -284,12 +284,12 @@ public class NativeQueryResultBuilderTests {
 		assertThat( part, instanceOf( BasicValuedSingularAttributeMapping.class ) );
 		final BasicValuedSingularAttributeMapping attrMapping = (BasicValuedSingularAttributeMapping) part;
 
-		assertThat( attrMapping.getJavaTypeDescriptor().getJavaType(), equalTo( EntityOfBasics.Gender.class ) );
+		assertThat( attrMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo( EntityOfBasics.Gender.class ) );
 
 		final BasicValueConverter valueConverter = attrMapping.getValueConverter();
 		assertThat( valueConverter, instanceOf( JpaAttributeConverter.class ) );
 		assertThat( valueConverter.getDomainJavaDescriptor(), is( attrMapping.getJavaTypeDescriptor() ) );
-		assertThat( valueConverter.getRelationalJavaDescriptor().getJavaType(), equalTo( Character.class ) );
+		assertThat( valueConverter.getRelationalJavaDescriptor().getJavaTypeClass(), equalTo( Character.class ) );
 
 		assertThat( attrMapping.getJdbcMapping().getSqlTypeDescriptor().getJdbcTypeCode(), is( Types.CHAR ) );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -184,7 +184,7 @@ public class SmokeTests {
 					final MappingModelExpressable selectedExpressable = selectedExpression.getExpressionType();
 					assertThat( selectedExpressable, instanceOf( StandardBasicTypeImpl.class ) );
 					final StandardBasicTypeImpl basicType = (StandardBasicTypeImpl) selectedExpressable;
-					assertThat( basicType.getJavaTypeDescriptor().getJavaType(), AssignableMatcher.assignableTo( Integer.class ) );
+					assertThat( basicType.getJavaTypeDescriptor().getJavaTypeClass(), AssignableMatcher.assignableTo( Integer.class ) );
 					assertThat( basicType.getSqlTypeDescriptor().getSqlType(), is( Types.TINYINT ) );
 
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/BasicJodaTimeConversionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/BasicJodaTimeConversionTest.java
@@ -78,7 +78,7 @@ public class BasicJodaTimeConversionTest extends BaseNonConfigCoreFunctionalTest
 		final EntityPersister ep = sessionFactory().getEntityPersister( TheEntity.class.getName() );
 		final Type theDatePropertyType = ep.getPropertyType( "theDate" );
 		final AttributeConverterTypeAdapter type = assertTyping( AttributeConverterTypeAdapter.class, theDatePropertyType );
-		assertTrue( JodaLocalDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( JodaLocalDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/ExplicitDateConvertersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/ExplicitDateConvertersTest.java
@@ -86,7 +86,7 @@ public class ExplicitDateConvertersTest extends BaseNonConfigCoreFunctionalTestC
 				AttributeConverterTypeAdapter.class,
 				theDatePropertyType
 		);
-		assertTrue( LongToDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( LongToDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/ExplicitEnumConvertersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/ExplicitEnumConvertersTest.java
@@ -94,7 +94,7 @@ public class ExplicitEnumConvertersTest extends BaseNonConfigCoreFunctionalTestC
 				AttributeConverterTypeAdapter.class,
 				theDatePropertyType
 		);
-		assertTrue( MediaTypeConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( MediaTypeConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleConvertAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleConvertAnnotationTest.java
@@ -45,7 +45,7 @@ public class SimpleConvertAnnotationTest extends BaseNonConfigCoreFunctionalTest
 				AttributeConverterTypeAdapter.class,
 				websitePropertyType
 		);
-		assertTrue( UrlConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( UrlConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleConvertsAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleConvertsAnnotationTest.java
@@ -46,7 +46,7 @@ public class SimpleConvertsAnnotationTest extends BaseNonConfigCoreFunctionalTes
 				AttributeConverterTypeAdapter.class,
 				websitePropertyType
 		);
-		assertTrue( UrlConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( UrlConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleXmlOverriddenTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/SimpleXmlOverriddenTest.java
@@ -59,7 +59,7 @@ public class SimpleXmlOverriddenTest extends BaseUnitTestCase {
 		PersistentClass pc = metadata.getEntityBinding( TheEntity.class.getName() );
 		Type type = pc.getProperty( "it" ).getType();
 		AttributeConverterTypeAdapter adapter = assertTyping( AttributeConverterTypeAdapter.class, type );
-		assertTrue( SillyStringConverter.class.isAssignableFrom( adapter.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( SillyStringConverter.class.isAssignableFrom( adapter.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/XmlWithExplicitConvertAnnotationsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/XmlWithExplicitConvertAnnotationsTest.java
@@ -103,7 +103,7 @@ public class XmlWithExplicitConvertAnnotationsTest extends BaseNonConfigCoreFunc
 				AttributeConverterTypeAdapter.class,
 				theDatePropertyType
 		);
-		assertTrue( LongToDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+		assertTrue( LongToDateConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 
 		resetFlags();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/converter/generics/ParameterizedAttributeConverterParameterTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/converter/generics/ParameterizedAttributeConverterParameterTypeTest.java
@@ -97,7 +97,7 @@ public class ParameterizedAttributeConverterParameterTypeTest extends BaseUnitTe
 					prop.getType()
 			);
 
-			assertTrue( StringListConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+			assertTrue( StringListConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 		}
 
 		{
@@ -107,7 +107,7 @@ public class ParameterizedAttributeConverterParameterTypeTest extends BaseUnitTe
 					prop.getType()
 			);
 
-			assertTrue( IntegerListConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaType() ) );
+			assertTrue( IntegerListConverter.class.isAssignableFrom( type.getAttributeConverter().getConverterJavaTypeDescriptor().getJavaTypeClass() ) );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -276,7 +276,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 					assertEquals( 1, selections.size() );
 					SqmSelection<?> typeSelection = selections.get( 0 );
 					// always integer for joined
-					assertEquals( Integer.class, typeSelection.getNodeJavaTypeDescriptor().getJavaType() );
+					assertEquals( Integer.class, typeSelection.getNodeJavaTypeDescriptor().getJavaTypeClass() );
 
 					// test
 					query = session.createQuery( "select type(a) from Animal a where type(a) = Dog" );
@@ -285,7 +285,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 					selections = sqmStatement.getQuerySpec().getSelectClause().getSelections();
 					assertEquals( 1, selections.size() );
 					typeSelection = selections.get( 0 );
-					assertEquals( Class.class, typeSelection.getNodeJavaTypeDescriptor().getJavaType() );
+					assertEquals( Class.class, typeSelection.getNodeJavaTypeDescriptor().getJavaTypeClass() );
 				}
 		);
 	}
@@ -1546,7 +1546,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 					final SqmSelection<?> selection = sqmStatement.getQuerySpec().getSelectClause().getSelections().get( 0 );
 					final SqmExpressable<?> selectionType = selection.getSelectableNode().getNodeType();
 					assertThat( selectionType, CoreMatchers.instanceOf( EmbeddableDomainType.class ) );
-					assertEquals( Name.class, selection.getNodeJavaTypeDescriptor().getJavaType() );
+					assertEquals( Name.class, selection.getNodeJavaTypeDescriptor().getJavaTypeClass() );
 
 
 					// Test the ability to perform comparisons between component values
@@ -1829,7 +1829,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 					final SqmSelection<?> selection = sqmStatement.getQuerySpec().getSelectClause().getSelections().get( 0 );
 					final SqmExpressable<?> selectionType = selection.getSelectableNode().getNodeType();
 					assertThat( selectionType, instanceOf( EntityDomainType.class ) );
-					assertThat( selectionType.getExpressableJavaTypeDescriptor().getJavaType(), equalTo( Animal.class ) );
+					assertThat( selectionType.getExpressableJavaTypeDescriptor().getJavaTypeClass(), equalTo( Animal.class ) );
 					assertThat( selection.getAlias(), is( "a" ) );
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/QueryParametersValidationArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/QueryParametersValidationArrayTest.java
@@ -26,7 +26,7 @@ import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.BasicBinder;
 import org.hibernate.type.descriptor.sql.BasicExtractor;
@@ -152,7 +152,7 @@ public class QueryParametersValidationArrayTest extends BaseEntityManagerFunctio
 	}
 
 	public static class StringArrayTypeDescriptor
-			extends AbstractTypeDescriptor<String[]> {
+			extends AbstractClassTypeDescriptor<String[]> {
 
 		public static final StringArrayTypeDescriptor INSTANCE = new StringArrayTypeDescriptor();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/id/usertype/inet/InetJavaTypeDescriptor.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/id/usertype/inet/InetJavaTypeDescriptor.java
@@ -7,12 +7,12 @@
 package org.hibernate.test.id.usertype.inet;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 
 /**
  * @author Vlad Mihalcea
  */
-public class InetJavaTypeDescriptor extends AbstractTypeDescriptor<Inet> {
+public class InetJavaTypeDescriptor extends AbstractClassTypeDescriptor<Inet> {
 
 	public static final InetJavaTypeDescriptor INSTANCE = new InetJavaTypeDescriptor();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/id/usertype/json/JsonJavaTypeDescriptor.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/id/usertype/json/JsonJavaTypeDescriptor.java
@@ -7,12 +7,12 @@
 package org.hibernate.test.id.usertype.json;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 
 /**
  * @author Vlad Mihalcea
  */
-public class JsonJavaTypeDescriptor extends AbstractTypeDescriptor<Json> {
+public class JsonJavaTypeDescriptor extends AbstractClassTypeDescriptor<Json> {
 
 	public static final JsonJavaTypeDescriptor INSTANCE = new JsonJavaTypeDescriptor();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/Java8DateTimeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/Java8DateTimeTests.java
@@ -83,7 +83,7 @@ public class Java8DateTimeTests extends BaseNonConfigCoreFunctionalTestCase {
 					String.format(
 							"%s (%s) -> %s",
 							propertyBinding.getName(),
-							javaTypeDescriptor.getJavaType().getSimpleName(),
+							javaTypeDescriptor.getJavaTypeClass().getSimpleName(),
 							javaTypeDescriptor.toString( propertyBinding.getGetter( TheEntity.class ).get( theEntity ) )
 					)
 			);

--- a/hibernate-core/src/test/java/org/hibernate/test/type/LongListTypeContributorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/LongListTypeContributorTest.java
@@ -21,8 +21,7 @@ import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptorRegistry;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 
 import org.hibernate.testing.TestForIssue;
 import org.junit.Test;
@@ -177,7 +176,7 @@ public class LongListTypeContributorTest extends BaseEntityManagerFunctionalTest
 			}
 		}
 
-		private static class StringifiedCollectionJavaTypeDescriptor extends AbstractTypeDescriptor<LongList> {
+		private static class StringifiedCollectionJavaTypeDescriptor extends AbstractClassTypeDescriptor<LongList> {
 
 			public static StringifiedCollectionJavaTypeDescriptor INSTANCE = new StringifiedCollectionJavaTypeDescriptor();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/type/contributor/ArrayTypeDescriptor.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/type/contributor/ArrayTypeDescriptor.java
@@ -3,12 +3,12 @@ package org.hibernate.test.type.contributor;
 import java.util.Arrays;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 
 /**
  * @author Vlad Mihalcea
  */
-public class ArrayTypeDescriptor extends AbstractTypeDescriptor<Array> {
+public class ArrayTypeDescriptor extends AbstractClassTypeDescriptor<Array> {
 
     private static final String DELIMITER = ",";
 

--- a/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/metamodel/model/ObjectFactory.java
+++ b/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/metamodel/model/ObjectFactory.java
@@ -102,7 +102,7 @@ public class ObjectFactory {
 			Consumer<Component> componentConsumer) {
 		if ( propertyValueMapping instanceof BasicValue ) {
 			final BasicValue basicValue = (BasicValue) propertyValueMapping;
-			return basicValue.resolve().getDomainJavaDescriptor().getJavaType();
+			return basicValue.resolve().getDomainJavaDescriptor().getJavaTypeClass();
 		}
 
 		if ( propertyValueMapping instanceof Component ) {
@@ -191,7 +191,7 @@ public class ObjectFactory {
 
 		if ( partJavaType instanceof BasicValue ) {
 			final BasicValue basicValue = (BasicValue) partJavaType;
-			return basicValue.resolve().getDomainJavaDescriptor().getJavaType();
+			return basicValue.resolve().getDomainJavaDescriptor().getJavaTypeClass();
 		}
 
 		if ( partJavaType instanceof Component ) {

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CommaDelimitedStringMapJavaTypeDescriptor.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CommaDelimitedStringMapJavaTypeDescriptor.java
@@ -6,21 +6,17 @@
  */
 package org.hibernate.jpamodelgen.test.collectionbasictype;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 
 /**
  * @author Vlad Mihalcea
  */
-public class CommaDelimitedStringMapJavaTypeDescriptor extends AbstractTypeDescriptor<Map> {
+public class CommaDelimitedStringMapJavaTypeDescriptor extends AbstractClassTypeDescriptor<Map> {
 
     public static final String DELIMITER = ",";
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CommaDelimitedStringsJavaTypeDescriptor.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/collectionbasictype/CommaDelimitedStringsJavaTypeDescriptor.java
@@ -12,13 +12,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.type.descriptor.java.AbstractClassTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 
 /**
  * @author Vlad Mihalcea
  */
-public class CommaDelimitedStringsJavaTypeDescriptor extends AbstractTypeDescriptor<List> {
+public class CommaDelimitedStringsJavaTypeDescriptor extends AbstractClassTypeDescriptor<List> {
 
     public static final String DELIMITER = ",";
 


### PR DESCRIPTION
Change `JavaTypeDescriptor#getJavaType` to return `java.lang.reflect.Type` to support parameterized type access. I also un-deprecated `JavaTypeDescriptor#getJavaTypeClass` which now returns the raw type of `java.lang.reflect.Type`.

The main use case is to support using Java types like e.g. `List<String>` for `varchar[]` and allow to understand the component type in functions.