### PR TITLE
more efficient loading by @NaturalId

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
@@ -7,7 +7,6 @@
 package org.hibernate.event.internal;
 
 import java.io.Serializable;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.hibernate.HibernateException;
@@ -128,12 +127,10 @@ public class DefaultResolveNaturalIdEventListener
 		final Serializable pk;
 		EntityPersister persister = event.getEntityPersister();
 		LockOptions lockOptions = event.getLockOptions();
-		if ( persister instanceof UniqueKeyLoadable
-				&& naturalIdValues.length==1 ) {
+		if ( persister instanceof UniqueKeyLoadable) {
 			UniqueKeyLoadable rootPersister = (UniqueKeyLoadable)
 					persister.getFactory().getMetamodel().entityPersister( persister.getRootEntityName() );
-			Map.Entry<String, Object> e = event.getNaturalIdValues().entrySet().iterator().next();
-			Object entity = rootPersister.loadByUniqueKey( e.getKey(), e.getValue(), lockOptions, session );
+			Object entity = rootPersister.loadByNaturalId( naturalIdValues, lockOptions, session );
 			if ( entity == null ) {
 				pk = null;
 			}
@@ -141,7 +138,7 @@ public class DefaultResolveNaturalIdEventListener
 				if ( !persister.isInstance(entity) ) {
 					throw new WrongClassException(
 							"loaded object was of wrong class " + entity.getClass(),
-							e.getKey(),
+							naturalIdValues,
 							persister.getEntityName()
 					);
 				}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultResolveNaturalIdEventListener.java
@@ -7,11 +7,12 @@
 package org.hibernate.event.internal;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.hibernate.HibernateException;
-import org.hibernate.cache.spi.access.NaturalIdDataAccess;
-import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.LockOptions;
+import org.hibernate.WrongClassException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.ResolveNaturalIdEvent;
@@ -19,6 +20,7 @@ import org.hibernate.event.spi.ResolveNaturalIdEventListener;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.persister.entity.UniqueKeyLoadable;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
@@ -96,10 +98,11 @@ public class DefaultResolveNaturalIdEventListener
 	 * @return The entity from the cache, or null.
 	 */
 	protected Serializable resolveFromCache(final ResolveNaturalIdEvent event) {
-		return event.getSession().getPersistenceContextInternal().getNaturalIdHelper().findCachedNaturalIdResolution(
-				event.getEntityPersister(),
-				event.getOrderedNaturalIdValues()
-		);
+		return event.getSession().getPersistenceContextInternal().getNaturalIdHelper()
+				.findCachedNaturalIdResolution(
+						event.getEntityPersister(),
+						event.getOrderedNaturalIdValues()
+				);
 	}
 
 	/**
@@ -120,29 +123,48 @@ public class DefaultResolveNaturalIdEventListener
 			startTime = System.nanoTime();
 		}
 
-		final Serializable pk = event.getEntityPersister().loadEntityIdByNaturalId(
-				event.getOrderedNaturalIdValues(),
-				event.getLockOptions(),
-				session
-		);
+		Object[] naturalIdValues = event.getOrderedNaturalIdValues();
+
+		final Serializable pk;
+		EntityPersister persister = event.getEntityPersister();
+		LockOptions lockOptions = event.getLockOptions();
+		if ( persister instanceof UniqueKeyLoadable
+				&& naturalIdValues.length==1 ) {
+			UniqueKeyLoadable rootPersister = (UniqueKeyLoadable)
+					persister.getFactory().getMetamodel().entityPersister( persister.getRootEntityName() );
+			Map.Entry<String, Object> e = event.getNaturalIdValues().entrySet().iterator().next();
+			Object entity = rootPersister.loadByUniqueKey( e.getKey(), e.getValue(), lockOptions, session );
+			if ( entity == null ) {
+				pk = null;
+			}
+			else {
+				if ( !persister.isInstance(entity) ) {
+					throw new WrongClassException(
+							"loaded object was of wrong class " + entity.getClass(),
+							e.getKey(),
+							persister.getEntityName()
+					);
+				}
+				pk = persister.getIdentifier( entity, session );
+			}
+		}
+		else {
+			pk = persister.loadEntityIdByNaturalId( naturalIdValues, lockOptions, session );
+		}
 
 		if ( stats ) {
 			final long endTime = System.nanoTime();
 			final long milliseconds = TimeUnit.MILLISECONDS.convert( endTime - startTime, TimeUnit.NANOSECONDS );
 			statistics.naturalIdQueryExecuted(
-					event.getEntityPersister().getRootEntityName(),
+					persister.getRootEntityName(),
 					milliseconds
 			);
 		}
 
 		//PK can be null if the entity doesn't exist
 		if (pk != null) {
-			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-			persistenceContext.getNaturalIdHelper().cacheNaturalIdCrossReferenceFromLoad(
-					event.getEntityPersister(),
-					pk,
-					event.getOrderedNaturalIdValues()
-			);
+			session.getPersistenceContextInternal().getNaturalIdHelper()
+					.cacheNaturalIdCrossReferenceFromLoad( persister, pk, naturalIdValues );
 		}
 
 		return pk;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -237,6 +237,15 @@ public final class ArrayHelper {
 		return true;
 	}
 
+	public static boolean[] negate(boolean[] valueNullness) {
+		boolean[] result = new boolean[valueNullness.length];
+		for (int i = 0; i < valueNullness.length; i++) {
+			result[i] = !valueNullness[i];
+		}
+		return result;
+	}
+
+
 	public static <T> void addAll(Collection<T> collection, T[] array) {
 		collection.addAll( Arrays.asList( array ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/EntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/EntityLoader.java
@@ -6,14 +6,27 @@
  */
 package org.hibernate.loader.entity;
 
+import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
+import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.persister.entity.OuterJoinLoadable;
+import org.hibernate.type.AbstractType;
 import org.hibernate.type.Type;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Loads an entity instance using outerjoin fetching to fetch associated entities.
@@ -97,7 +110,7 @@ public class EntityLoader extends AbstractEntityLoader {
 				loadQueryInfluencers
 		);
 		initFromWalker( walker );
-		this.compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
+		compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
 		postInstantiate();
 
 		batchLoader = batchSize > 1;
@@ -126,7 +139,7 @@ public class EntityLoader extends AbstractEntityLoader {
 				loadQueryInfluencers
 		);
 		initFromWalker( walker );
-		this.compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
+		compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
 		postInstantiate();
 
 		batchLoader = batchSize > 1;
@@ -138,6 +151,58 @@ public class EntityLoader extends AbstractEntityLoader {
 					lockOptions.getTimeOut(),
 					getSQLString() );
 		}
+	}
+
+	public EntityLoader(
+			OuterJoinLoadable persister,
+			boolean[] valueNullness,
+			int batchSize,
+			LockOptions lockOptions,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		super( persister, new NaturalIdType( persister, valueNullness ), factory, loadQueryInfluencers );
+
+		EntityJoinWalker walker = new EntityJoinWalker(
+				persister,
+				naturalIdColumns( valueNullness ),
+				batchSize,
+				lockOptions,
+				factory,
+				loadQueryInfluencers
+		) {
+			@Override
+			protected StringBuilder whereString(String alias, String[] columnNames, int batchSize) {
+				StringBuilder sql = super.whereString(alias, columnNames, batchSize);
+				for (String nullCol : naturalIdColumns( ArrayHelper.negate( valueNullness ) ) ) {
+					sql.append(" and ").append( getAlias() ).append('.').append(nullCol).append(" is null");
+				}
+				return sql;
+			}
+		};
+		initFromWalker( walker );
+		compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
+		postInstantiate();
+
+		batchLoader = batchSize > 1;
+
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debugf( "Static select for entity %s [%s:%s]: %s",
+					entityName,
+					lockOptions.getLockMode(),
+					lockOptions.getTimeOut(),
+					getSQLString() );
+		}
+	}
+
+	private String[] naturalIdColumns(boolean[] valueNullness) {
+		int i = 0;
+		List<String> columns = new ArrayList<>();
+		for ( int p : persister.getNaturalIdentifierProperties() ) {
+			if ( !valueNullness[i++] ) {
+				columns.addAll( Arrays.asList( persister.getPropertyColumnNames(p) ) );
+			}
+		}
+		return columns.toArray(ArrayHelper.EMPTY_STRING_ARRAY);
 	}
 
 	public Object loadByUniqueKey(SharedSessionContractImplementor session, Object key) {
@@ -156,5 +221,119 @@ public class EntityLoader extends AbstractEntityLoader {
 	@Override
 	public int[][] getCompositeKeyManyToOneTargetIndices() {
 		return compositeKeyManyToOneTargetIndices;
+	}
+
+	static class NaturalIdType extends AbstractType {
+		private OuterJoinLoadable persister;
+		private boolean[] valueNullness;
+
+		NaturalIdType(OuterJoinLoadable persister, boolean[] valueNullness) {
+			this.persister = persister;
+			this.valueNullness = valueNullness;
+		}
+
+		@Override
+		public int getColumnSpan(Mapping mapping) throws MappingException {
+			int span = 0;
+			int i = 0;
+			for ( int p : persister.getNaturalIdentifierProperties() ) {
+				if ( !valueNullness[i++] ) {
+					span += persister.getPropertyColumnNames(p).length;
+				}
+			}
+			return span;
+		}
+
+		@Override
+		public int[] sqlTypes(Mapping mapping) throws MappingException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Size[] dictatedSizes(Mapping mapping) throws MappingException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Size[] defaultSizes(Mapping mapping) throws MappingException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Class getReturnedClass() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isDirty(Object oldState, Object currentState, boolean[] checkable, SharedSessionContractImplementor session)
+				throws HibernateException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+				throws HibernateException, SQLException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object nullSafeGet(ResultSet rs, String name, SharedSessionContractImplementor session, Object owner)
+				throws HibernateException, SQLException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void nullSafeSet(PreparedStatement st, Object value, int index, boolean[] settable, SharedSessionContractImplementor session)
+				throws HibernateException, SQLException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+				throws HibernateException, SQLException {
+			Object[] keys = (Object[]) value;
+			int i = 0;
+			for ( int p : persister.getNaturalIdentifierProperties() ) {
+				if ( !valueNullness[i] ) {
+					persister.getPropertyTypes()[p].nullSafeSet( st, keys[i], index++, session );
+				}
+				i++;
+			}
+		}
+
+		@Override
+		public String toLoggableString(Object value, SessionFactoryImplementor factory) {
+			return "natural id";
+		}
+
+		@Override
+		public String getName() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object deepCopy(Object value, SessionFactoryImplementor factory) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isMutable() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner, Map copyCache) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean[] toColumnNullness(Object value, Mapping mapping) {
+			throw new UnsupportedOperationException();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/EntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/EntityLoader.java
@@ -6,27 +6,14 @@
  */
 package org.hibernate.loader.entity;
 
-import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
-import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
-import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.persister.entity.OuterJoinLoadable;
-import org.hibernate.type.AbstractType;
 import org.hibernate.type.Type;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Loads an entity instance using outerjoin fetching to fetch associated entities.
@@ -162,23 +149,14 @@ public class EntityLoader extends AbstractEntityLoader {
 			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
 		super( persister, new NaturalIdType( persister, valueNullness ), factory, loadQueryInfluencers );
 
-		EntityJoinWalker walker = new EntityJoinWalker(
+		EntityJoinWalker walker = new NaturalIdEntityJoinWalker(
 				persister,
-				naturalIdColumns( valueNullness ),
+				valueNullness,
 				batchSize,
 				lockOptions,
 				factory,
 				loadQueryInfluencers
-		) {
-			@Override
-			protected StringBuilder whereString(String alias, String[] columnNames, int batchSize) {
-				StringBuilder sql = super.whereString(alias, columnNames, batchSize);
-				for (String nullCol : naturalIdColumns( ArrayHelper.negate( valueNullness ) ) ) {
-					sql.append(" and ").append( getAlias() ).append('.').append(nullCol).append(" is null");
-				}
-				return sql;
-			}
-		};
+		);
 		initFromWalker( walker );
 		compositeKeyManyToOneTargetIndices = walker.getCompositeKeyManyToOneTargetIndices();
 		postInstantiate();
@@ -192,17 +170,6 @@ public class EntityLoader extends AbstractEntityLoader {
 					lockOptions.getTimeOut(),
 					getSQLString() );
 		}
-	}
-
-	private String[] naturalIdColumns(boolean[] valueNullness) {
-		int i = 0;
-		List<String> columns = new ArrayList<>();
-		for ( int p : persister.getNaturalIdentifierProperties() ) {
-			if ( !valueNullness[i++] ) {
-				columns.addAll( Arrays.asList( persister.getPropertyColumnNames(p) ) );
-			}
-		}
-		return columns.toArray(ArrayHelper.EMPTY_STRING_ARRAY);
 	}
 
 	public Object loadByUniqueKey(SharedSessionContractImplementor session, Object key) {
@@ -223,117 +190,4 @@ public class EntityLoader extends AbstractEntityLoader {
 		return compositeKeyManyToOneTargetIndices;
 	}
 
-	static class NaturalIdType extends AbstractType {
-		private OuterJoinLoadable persister;
-		private boolean[] valueNullness;
-
-		NaturalIdType(OuterJoinLoadable persister, boolean[] valueNullness) {
-			this.persister = persister;
-			this.valueNullness = valueNullness;
-		}
-
-		@Override
-		public int getColumnSpan(Mapping mapping) throws MappingException {
-			int span = 0;
-			int i = 0;
-			for ( int p : persister.getNaturalIdentifierProperties() ) {
-				if ( !valueNullness[i++] ) {
-					span += persister.getPropertyColumnNames(p).length;
-				}
-			}
-			return span;
-		}
-
-		@Override
-		public int[] sqlTypes(Mapping mapping) throws MappingException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Size[] dictatedSizes(Mapping mapping) throws MappingException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Size[] defaultSizes(Mapping mapping) throws MappingException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Class getReturnedClass() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isDirty(Object oldState, Object currentState, boolean[] checkable, SharedSessionContractImplementor session)
-				throws HibernateException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
-				throws HibernateException, SQLException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object nullSafeGet(ResultSet rs, String name, SharedSessionContractImplementor session, Object owner)
-				throws HibernateException, SQLException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void nullSafeSet(PreparedStatement st, Object value, int index, boolean[] settable, SharedSessionContractImplementor session)
-				throws HibernateException, SQLException {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
-				throws HibernateException, SQLException {
-			Object[] keys = (Object[]) value;
-			int i = 0;
-			for ( int p : persister.getNaturalIdentifierProperties() ) {
-				if ( !valueNullness[i] ) {
-					persister.getPropertyTypes()[p].nullSafeSet( st, keys[i], index++, session );
-				}
-				i++;
-			}
-		}
-
-		@Override
-		public String toLoggableString(Object value, SessionFactoryImplementor factory) {
-			return "natural id";
-		}
-
-		@Override
-		public String getName() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object deepCopy(Object value, SessionFactoryImplementor factory) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isMutable() {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner, Map copyCache) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean[] toColumnNullness(Object value, Mapping mapping) {
-			throw new UnsupportedOperationException();
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/NaturalIdEntityJoinWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/NaturalIdEntityJoinWalker.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.loader.entity;
+
+import org.hibernate.LockOptions;
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.Loadable;
+import org.hibernate.persister.entity.OuterJoinLoadable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hibernate.internal.util.collections.ArrayHelper.EMPTY_STRING_ARRAY;
+import static org.hibernate.internal.util.collections.ArrayHelper.negate;
+
+/**
+ * An {@link EntityJoinWalker} that uses 'is null' predicates to match
+ * null {@link org.hibernate.annotations.NaturalId} properties.
+ *
+ * @author Gavin King
+ */
+public class NaturalIdEntityJoinWalker extends EntityJoinWalker {
+
+	private static String[] naturalIdColumns(Loadable persister, boolean[] valueNullness) {
+		int i = 0;
+		List<String> columns = new ArrayList<>();
+		for ( int p : persister.getNaturalIdentifierProperties() ) {
+			if ( !valueNullness[i++] ) {
+				columns.addAll( asList( persister.getPropertyColumnNames(p) ) );
+			}
+		}
+		return columns.toArray(EMPTY_STRING_ARRAY);
+	}
+
+	public NaturalIdEntityJoinWalker(
+			OuterJoinLoadable persister,
+			boolean[] valueNullness,
+			int batchSize,
+			LockOptions lockOptions,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		super(persister, naturalIdColumns( persister, valueNullness ), batchSize, lockOptions, factory, loadQueryInfluencers);
+		StringBuilder sql = new StringBuilder( getSQLString() );
+		for ( String nullCol : naturalIdColumns( getPersister(), negate( valueNullness ) ) ) {
+			sql.append(" and ").append( getAlias() ).append('.').append( nullCol ).append(" is null");
+		}
+		setSql( sql.toString() );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/loader/entity/NaturalIdType.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/entity/NaturalIdType.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.loader.entity;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.entity.OuterJoinLoadable;
+import org.hibernate.type.AbstractType;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+/**
+ * Workaround for the fact that we don't have a well-defined Hibernate
+ * type when loading by multiple {@link org.hibernate.annotations.NaturalId}
+ * properties.
+ *
+ * @author Gavin King
+ */
+public class NaturalIdType extends AbstractType {
+	private OuterJoinLoadable persister;
+	private boolean[] valueNullness;
+
+	public NaturalIdType(OuterJoinLoadable persister, boolean[] valueNullness) {
+		this.persister = persister;
+		this.valueNullness = valueNullness;
+	}
+
+	@Override
+	public int getColumnSpan(Mapping mapping) throws MappingException {
+		int span = 0;
+		int i = 0;
+		for (int p : persister.getNaturalIdentifierProperties() ) {
+			if ( !valueNullness[i++] ) {
+				span += persister.getPropertyColumnNames(p).length;
+			}
+		}
+		return span;
+	}
+
+	@Override
+	public int[] sqlTypes(Mapping mapping) throws MappingException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Size[] dictatedSizes(Mapping mapping) throws MappingException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Size[] defaultSizes(Mapping mapping) throws MappingException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Class getReturnedClass() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isDirty(Object oldState, Object currentState, boolean[] checkable, SharedSessionContractImplementor session)
+			throws HibernateException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+			throws HibernateException, SQLException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object nullSafeGet(ResultSet rs, String name, SharedSessionContractImplementor session, Object owner)
+			throws HibernateException, SQLException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void nullSafeSet(PreparedStatement st, Object value, int index, boolean[] settable, SharedSessionContractImplementor session)
+			throws HibernateException, SQLException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+			throws HibernateException, SQLException {
+		Object[] keys = (Object[]) value;
+		int i = 0;
+		for ( int p : persister.getNaturalIdentifierProperties() ) {
+			if ( !valueNullness[i] ) {
+				persister.getPropertyTypes()[p].nullSafeSet( st, keys[i], index++, session );
+			}
+			i++;
+		}
+	}
+
+	@Override
+	public String toLoggableString(Object value, SessionFactoryImplementor factory) {
+		return "natural id";
+	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object deepCopy(Object value, SessionFactoryImplementor factory) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isMutable() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner, Map copyCache) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean[] toColumnNullness(Object value, Mapping mapping) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5578,7 +5578,7 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
-	@Override
+	@Override @Deprecated
 	public Serializable loadEntityIdByNaturalId(
 			Object[] naturalIdValues,
 			LockOptions lockOptions,
@@ -5653,6 +5653,7 @@ public abstract class AbstractEntityPersister
 	private Boolean naturalIdIsNonNullable;
 	private String cachedPkByNonNullableNaturalIdQuery;
 
+	@Deprecated
 	protected String determinePkByNaturalIdQuery(boolean[] valueNullness) {
 		if ( !hasNaturalIdentifier() ) {
 			throw new HibernateException(
@@ -5694,6 +5695,7 @@ public abstract class AbstractEntityPersister
 		return true;
 	}
 
+	@Deprecated
 	private String generateEntityIdByNaturalIdSql(boolean[] valueNullness) {
 		EntityPersister rootPersister = getFactory().getEntityPersister( getRootEntityName() );
 		if ( rootPersister != this ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2481,6 +2481,23 @@ public abstract class AbstractEntityPersister
 		return getAppropriateUniqueKeyLoader( propertyName, session ).loadByUniqueKey( session, uniqueKey );
 	}
 
+	public Object loadByUniqueKey(
+			String propertyName,
+			Object uniqueKey,
+			LockOptions lockOptions,
+			SharedSessionContractImplementor session) throws HibernateException {
+		//TODO: cache this
+		return new EntityLoader(
+				this,
+				propertyMapping.toColumns( propertyName ),
+				propertyMapping.toType( propertyName ),
+				1,
+				lockOptions,
+				getFactory(),
+				session.getLoadQueryInfluencers()
+		).loadByUniqueKey( session, uniqueKey );
+	}
+
 	private EntityLoader getAppropriateUniqueKeyLoader(String propertyName, SharedSessionContractImplementor session) {
 		final boolean useStaticLoader = !session.getLoadQueryInfluencers().hasEnabledFilters()
 				&& !session.getLoadQueryInfluencers().hasEnabledFetchProfiles()

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2481,21 +2481,19 @@ public abstract class AbstractEntityPersister
 		return getAppropriateUniqueKeyLoader( propertyName, session ).loadByUniqueKey( session, uniqueKey );
 	}
 
-	public Object loadByUniqueKey(
-			String propertyName,
-			Object uniqueKey,
+	public Object loadByNaturalId(
+			Object[] naturalIdValues,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session) throws HibernateException {
 		//TODO: cache this
 		return new EntityLoader(
 				this,
-				propertyMapping.toColumns( propertyName ),
-				propertyMapping.toType( propertyName ),
+				determineValueNullness( naturalIdValues ),
 				1,
 				lockOptions,
 				getFactory(),
 				session.getLoadQueryInfluencers()
-		).loadByUniqueKey( session, uniqueKey );
+		).loadByUniqueKey( session, naturalIdValues );
 	}
 
 	private EntityLoader getAppropriateUniqueKeyLoader(String propertyName, SharedSessionContractImplementor session) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -365,7 +365,10 @@ public interface EntityPersister extends EntityDefinition {
 
 	/**
 	 * Load the id for the entity based on the natural id.
+	 * 
+	 * @deprecated use {@link UniqueKeyLoadable#loadByNaturalId(Object[], LockOptions, SharedSessionContractImplementor)}
 	 */
+	@Deprecated
 	Serializable loadEntityIdByNaturalId(
 			Object[] naturalIdValues, LockOptions lockOptions,
 			SharedSessionContractImplementor session);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UniqueKeyLoadable.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UniqueKeyLoadable.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.persister.entity;
 
+import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -16,7 +17,19 @@ public interface UniqueKeyLoadable extends Loadable {
 	 * Load an instance of the persistent class, by a unique key other
 	 * than the primary key.
 	 */
-	Object loadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session);
+	Object loadByUniqueKey(
+			String propertyName,
+			Object uniqueKey,
+			SharedSessionContractImplementor session);
+
+	/**
+	 * Load an instance of the persistent class, by a natural id.
+	 */
+	Object loadByUniqueKey(
+			String propertyName,
+			Object uniqueKey,
+			LockOptions lockOptions,
+			SharedSessionContractImplementor session);
 
 	/**
 	 * Get the property number of the unique key property

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UniqueKeyLoadable.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UniqueKeyLoadable.java
@@ -25,9 +25,8 @@ public interface UniqueKeyLoadable extends Loadable {
 	/**
 	 * Load an instance of the persistent class, by a natural id.
 	 */
-	Object loadByUniqueKey(
-			String propertyName,
-			Object uniqueKey,
+	Object loadByNaturalId(
+			Object[] naturalIds,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session);
 

--- a/hibernate-core/src/test/java/org/hibernate/test/naturalid/inheritance/cache/InheritedNaturalIdNoCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/naturalid/inheritance/cache/InheritedNaturalIdNoCacheTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.test.naturalid.inheritance.cache;
 
+import org.hibernate.WrongClassException;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 
@@ -14,7 +15,7 @@ import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class InheritedNaturalIdNoCacheTest extends BaseCoreFunctionalTestCase {
 
@@ -57,10 +58,21 @@ public class InheritedNaturalIdNoCacheTest extends BaseCoreFunctionalTestCase {
 		});
 
 		doInHibernate( this::sessionFactory, session -> {
-			ExtendedEntity user = session.byNaturalId( ExtendedEntity.class )
-				.using( "uid", "base" )
-				.load();
-			assertNull( user );
+			try {
+				session.byNaturalId( ExtendedEntity.class )
+						.using( "uid", "base" )
+						.load();
+				fail( "Expecting WrongClassException" );
+			}
+			catch (WrongClassException expected) {
+				// expected outcome
+			}
+			catch (Exception other) {
+				throw new AssertionError(
+						"Unexpected exception type : " + other.getClass().getName(),
+						other
+				);
+			}
 		});
 	}
 }


### PR DESCRIPTION
More efficient loading for entities with a single @NaturalId property only.

Uses a unique key EntityLoader instead of two SQL selects.

This is just a proof of concept for @sebersole to take a look at and give his feedback on.