### PR TITLE
Make AbstractEntityPersister#isValueGenerationRequired public

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5367,7 +5367,7 @@ public abstract class AbstractEntityPersister
 
 	}
 
-	private boolean isValueGenerationRequired(NonIdentifierAttribute attribute, GenerationTiming matchTiming) {
+	public boolean isValueGenerationRequired(NonIdentifierAttribute attribute, GenerationTiming matchTiming) {
 		if ( attribute.getType() instanceof ComponentType ) {
 			final ComponentType type = (ComponentType) attribute.getType();
 			final ValueGeneration[] propertyValueGenerationStrategies = type.getPropertyValueGenerationStrategies();


### PR DESCRIPTION
So that Hibernate Reactive can use it.

A simple one I think, it avoids some duplicated code in HR
Is this fine? I'm going to create an issue if there are no problems.