### PR TITLE
HHH-14519 More informative error message for bad logical column name

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -981,15 +981,20 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 
 	@Override
 	public String getPhysicalColumnName(Table table, String logicalName) throws MappingException {
-		return getPhysicalColumnName( table, getDatabase().toIdentifier( logicalName ) );
+		Identifier logicalColumnIdentifier = getDatabase().toIdentifier(logicalName);
+		if (logicalColumnIdentifier == null) {
+			throw new MappingException( String.format(
+					Locale.ENGLISH,
+					"Column with logical name \"[%s]\" in table [%s] cannot be mapped to column identifier.",
+					logicalName,
+					table.getName()
+			) );
+		}
+		return getPhysicalColumnName( table, logicalColumnIdentifier);
 	}
 
 	@Override
 	public String getPhysicalColumnName(Table table, Identifier logicalName) throws MappingException {
-		if ( logicalName == null ) {
-			throw new MappingException( "Logical column name cannot be null" );
-		}
-
 		Table currentTable = table;
 		String physicalName = null;
 


### PR DESCRIPTION
When a logical column name identifier cannot be created, there is only an error message that the "column name must not be null". In the case I experienced, the column name was in fact empty and not null, but the column identifier could not be found. This changes the error message to make the cause more clear and also give information about the context (table name, column name given)