### PR TITLE
natural-id caching (on top of #3735)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/AbstractEntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/AbstractEntityInsertAction.java
@@ -162,12 +162,12 @@ public abstract class AbstractEntityInsertAction extends EntityAction {
 	 * Handle sending notifications needed for natural-id before saving
 	 */
 	protected void handleNaturalIdPreSaveNotifications() {
-		// before save, we need to add a local (transactional) natural id cross-reference
+		// before save, we need to add a natural id cross-reference to the persistence-context
 		final NaturalIdMapping naturalIdMapping = getPersister().getNaturalIdMapping();
 		if ( naturalIdMapping != null ) {
 			getSession().getPersistenceContextInternal().getNaturalIdResolutions().manageLocalResolution(
 					getId(),
-					naturalIdMapping.extractNaturalIdValues( state, getSession() ),
+					naturalIdMapping.extractNaturalIdFromEntityState( state, getSession() ),
 					getPersister(),
 					CachedNaturalIdValueSource.INSERT
 			);
@@ -185,7 +185,7 @@ public abstract class AbstractEntityInsertAction extends EntityAction {
 			return;
 		}
 
-		final Object naturalIdValues = naturalIdMapping.extractNaturalIdValues( state, getSession() );
+		final Object naturalIdValues = naturalIdMapping.extractNaturalIdFromEntityState( state, getSession() );
 
 		if ( isEarlyInsert() ) {
 			// with early insert, we still need to add a local (transactional) natural id cross-reference

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -65,7 +65,7 @@ public class EntityDeleteAction extends EntityAction {
 		if ( naturalIdMapping != null ) {
 			naturalIdValues = session.getPersistenceContextInternal().getNaturalIdResolutions().removeLocalResolution(
 					getId(),
-					naturalIdMapping.extractNaturalIdValues( state, session ),
+					naturalIdMapping.extractNaturalIdFromEntityState( state, session ),
 					getPersister()
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -21,7 +21,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostCommitUpdateEventListener;
 import org.hibernate.event.spi.PostUpdateEvent;
 import org.hibernate.event.spi.PostUpdateEventListener;
@@ -94,7 +93,7 @@ public class EntityUpdateAction extends EntityAction {
 			this.previousNaturalIdValues = determinePreviousNaturalIdValues( persister, naturalIdMapping, id, previousState, session );
 			session.getPersistenceContextInternal().getNaturalIdResolutions().manageLocalResolution(
 					id,
-					naturalIdMapping.extractNaturalIdValues( state, session ),
+					naturalIdMapping.extractNaturalIdFromEntityState( state, session ),
 					persister,
 					CachedNaturalIdValueSource.UPDATE
 			);
@@ -109,7 +108,7 @@ public class EntityUpdateAction extends EntityAction {
 			SharedSessionContractImplementor session) {
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		if ( previousState != null ) {
-			return naturalIdMapping.extractNaturalIdValues( previousState, session );
+			return naturalIdMapping.extractNaturalIdFromEntityState( previousState, session );
 		}
 
 		return persistenceContext.getNaturalIdSnapshot( id, persister );
@@ -226,7 +225,7 @@ public class EntityUpdateAction extends EntityAction {
 		if ( naturalIdMapping != null ) {
 			session.getPersistenceContextInternal().getNaturalIdResolutions().manageSharedResolution(
 					id,
-					naturalIdMapping.extractNaturalIdValues( state, session ),
+					naturalIdMapping.extractNaturalIdFromEntityState( state, session ),
 					previousNaturalIdValues,
 					persister,
 					CachedNaturalIdValueSource.UPDATE

--- a/hibernate-core/src/main/java/org/hibernate/boot/BootLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/BootLogging.java
@@ -8,11 +8,13 @@ package org.hibernate.boot;
 
 import org.jboss.logging.Logger;
 
+import static org.hibernate.internal.CoreLogging.subsystemLoggerName;
+
 /**
- * @author Steve Ebersole
+ * Logging related to Hibernate bootstrapping
  */
 public class BootLogging {
-	public static final String NAME = "org.hibernate.orm.boot";
+	public static String NAME = subsystemLoggerName( "boot" );
 
 	public static final Logger LOGGER = Logger.getLogger( NAME );
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java
@@ -24,8 +24,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.event.spi.PreLoadEvent;
@@ -279,8 +277,8 @@ public final class TwoPhaseLoad {
 
 		final SessionFactoryImplementor factory = session.getFactory();
 		final StatisticsImplementor statistics = factory.getStatistics();
-		if ( persister.canWriteToCache() && session.getCacheMode().isPutEnabled() ) {
 
+		if ( persister.canWriteToCache() && session.getCacheMode().isPutEnabled() ) {
 			if ( debugEnabled ) {
 				LOG.debugf(
 						"Adding entity to second-level cache: %s",
@@ -335,7 +333,9 @@ public final class TwoPhaseLoad {
 
 		if ( persister.hasNaturalIdentifier() ) {
 			persistenceContext.getNaturalIdResolutions().cacheResolutionFromLoad(
-					id, persister.getNaturalIdMapping().extractNaturalIdValues( hydratedState, session ), persister
+					id,
+					persister.getNaturalIdMapping().extractNaturalIdFromEntityState( hydratedState, session ),
+					persister
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/NaturalIdResolutions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/NaturalIdResolutions.java
@@ -51,6 +51,7 @@ public interface NaturalIdResolutions {
 
 	/**
 	 * Removes any local cross-reference, returning the previously cached value if one.
+	 *
 	 * Again, this only effects the persistence-context cache, not the L2 cache
 	 */
 	Object removeLocalResolution(Object id, Object naturalId, EntityMappingType entityDescriptor);

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -533,7 +533,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 		if ( entity != null && persister.hasNaturalIdentifier() ) {
 			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			persistenceContext.getNaturalIdResolutions().cacheResolutionFromLoad(
-					event.getEntityId(), persister.getNaturalIdMapping().extractNaturalIdValues( entity, session ), persister
+					event.getEntityId(), persister.getNaturalIdMapping().extractNaturalIdFromEntity( entity, session ), persister
 			);
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreLogging.java
@@ -14,6 +14,10 @@ import org.jboss.logging.Logger;
  * @author Steve Ebersole
  */
 public class CoreLogging {
+	public static String subsystemLoggerName(String subsystem) {
+		return "org.hibernate.orm." + subsystem;
+	}
+
 	/**
 	 * Disallow instantiation
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -28,6 +28,8 @@ import org.hibernate.query.sqm.sql.FromClauseIndex;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
+import org.hibernate.sql.ast.spi.SqlExpressionResolver;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
@@ -105,10 +107,13 @@ class DatabaseSnapshotExecutor {
 		// We produce the same state array as if we were creating an entity snapshot
 		final List<DomainResult> domainResults = new ArrayList<>();
 
+		final SqlExpressionResolver sqlExpressionResolver = state.getSqlExpressionResolver();
+
 		// We just need a literal to have a result set
 		domainResults.add(
 				new QueryLiteral<>( null, IntegerType.INSTANCE ).createDomainResult( null, state )
 		);
+
 		entityDescriptor.getIdentifierMapping().forEachSelection(
 				(columnIndex, selection) -> {
 					final TableReference tableReference = rootTableGroup.resolveTableReference( selection.getContainingTableExpression() );
@@ -116,7 +121,7 @@ class DatabaseSnapshotExecutor {
 					final JdbcParameter jdbcParameter = new JdbcParameterImpl( selection.getJdbcMapping() );
 					jdbcParameters.add( jdbcParameter );
 
-					final ColumnReference columnReference = (ColumnReference) state.getSqlExpressionResolver()
+					final ColumnReference columnReference = (ColumnReference) sqlExpressionResolver
 							.resolveSqlExpression(
 									createColumnReferenceKey( tableReference, selection.getSelectionExpression() ),
 									s -> new ColumnReference(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -7,6 +7,7 @@
 package org.hibernate.loader.ast.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.LockMode;
@@ -15,17 +16,21 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.metamodel.mapping.EntityAssociationMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
+import org.hibernate.query.sqm.sql.FromClauseIndex;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
-import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.expression.QueryLiteral;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
@@ -41,6 +46,7 @@ import org.hibernate.sql.exec.spi.JdbcSelect;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.internal.RowTransformerDatabaseSnapshotImpl;
+import org.hibernate.type.IntegerType;
 
 import org.jboss.logging.Logger;
 
@@ -63,6 +69,9 @@ class DatabaseSnapshotExecutor {
 			SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
 		this.sessionFactory = sessionFactory;
+		this.jdbcParameters = new ArrayList<>(
+				entityDescriptor.getIdentifierMapping().getJdbcTypeCount()
+		);
 
 		final QuerySpec rootQuerySpec = new QuerySpec( true );
 
@@ -71,7 +80,10 @@ class DatabaseSnapshotExecutor {
 		final LoaderSqlAstCreationState state = new LoaderSqlAstCreationState(
 				rootQuerySpec,
 				sqlAliasBaseManager,
+				new FromClauseIndex( null ),
 				LockOptions.READ,
+				(fetchParent, ast, creationState) -> Collections.emptyList(),
+				true,
 				sessionFactory
 		);
 
@@ -88,14 +100,15 @@ class DatabaseSnapshotExecutor {
 		);
 
 		rootQuerySpec.getFromClause().addRoot( rootTableGroup );
+		state.getFromClauseAccess().registerTableGroup( rootPath, rootTableGroup );
 
-		jdbcParameters = new ArrayList<>(
-				entityDescriptor.getIdentifierMapping().getJdbcTypeCount()
-		);
-
-		//noinspection rawtypes
+		// We produce the same state array as if we were creating an entity snapshot
 		final List<DomainResult> domainResults = new ArrayList<>();
 
+		// We just need a literal to have a result set
+		domainResults.add(
+				new QueryLiteral<>( null, IntegerType.INSTANCE ).createDomainResult( null, state )
+		);
 		entityDescriptor.getIdentifierMapping().forEachSelection(
 				(columnIndex, selection) -> {
 					final TableReference tableReference = rootTableGroup.resolveTableReference( selection.getContainingTableExpression() );
@@ -120,69 +133,54 @@ class DatabaseSnapshotExecutor {
 									jdbcParameter
 							)
 					);
-
-					final SqlSelection sqlSelection = state.getSqlExpressionResolver().resolveSqlSelection(
-							columnReference,
-							selection.getJdbcMapping().getJavaTypeDescriptor(),
-							sessionFactory.getTypeConfiguration()
-					);
-
-					//noinspection unchecked
-					domainResults.add(
-							new BasicResult<Object>(
-									sqlSelection.getValuesArrayPosition(),
-									null,
-									selection.getJdbcMapping().getJavaTypeDescriptor()
-							)
-					);
 				}
 		);
 
 		entityDescriptor.visitStateArrayContributors(
 				contributorMapping -> {
-					rootPath.append( contributorMapping.getAttributeName() );
-					contributorMapping.forEachSelection(
-							(columnIndex, selection) -> {
-								final TableReference tableReference = rootTableGroup.resolveTableReference(
-										selection.getContainingTableExpression() );
-
-								final ColumnReference columnReference = (ColumnReference) state.getSqlExpressionResolver()
-										.resolveSqlExpression(
-												createColumnReferenceKey( tableReference, selection.getSelectionExpression() ),
-												s -> new ColumnReference(
-														tableReference,
-														selection,
-														sessionFactory
-												)
-										);
-
-								final SqlSelection sqlSelection = state.getSqlExpressionResolver()
-										.resolveSqlSelection(
-												columnReference,
-												selection.getJdbcMapping().getJavaTypeDescriptor(),
-												sessionFactory.getTypeConfiguration()
-										);
-
-								//noinspection unchecked
-								domainResults.add(
-										new BasicResult<Object>(
-												sqlSelection.getValuesArrayPosition(),
-												null,
-												selection.getJdbcMapping().getJavaTypeDescriptor()
-										)
-								);
-							}
-					);
+					final NavigablePath navigablePath = rootPath.append( contributorMapping.getAttributeName() );
+					if ( contributorMapping instanceof SingularAttributeMapping ) {
+						if ( contributorMapping instanceof EntityAssociationMapping ) {
+							domainResults.add(
+									( (EntityAssociationMapping) contributorMapping ).createDelayedDomainResult(
+											navigablePath,
+											rootTableGroup,
+											null,
+											state
+									)
+							);
+						}
+						else {
+							domainResults.add(
+									contributorMapping.createDomainResult(
+											navigablePath,
+											rootTableGroup,
+											null,
+											state
+									)
+							);
+						}
+					}
+					else {
+						// TODO: Instead use a delayed collection result? Or will we remove this when redesigning this
+						//noinspection unchecked
+						domainResults.add(
+								new BasicResult<Object>(
+										0,
+										null,
+										contributorMapping.getJavaTypeDescriptor()
+								)
+						);
+					}
 				}
 		);
-
 		final SelectStatement selectStatement = new SelectStatement( rootQuerySpec, domainResults );
 
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 		final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();
 		final SqlAstTranslatorFactory sqlAstTranslatorFactory = jdbcEnvironment.getSqlAstTranslatorFactory();
 
-		jdbcSelect = sqlAstTranslatorFactory.buildSelectTranslator( sessionFactory, selectStatement )
+		this.jdbcSelect = sqlAstTranslatorFactory.buildSelectTranslator( sessionFactory, selectStatement )
 				.translate( null, QueryOptions.NONE );
 	}
 
@@ -232,10 +230,6 @@ class DatabaseSnapshotExecutor {
 				true
 		);
 
-		if ( list.isEmpty() ) {
-			return null;
-		}
-
 		final int size = list.size();
 		assert size <= 1;
 
@@ -243,7 +237,17 @@ class DatabaseSnapshotExecutor {
 			return null;
 		}
 		else {
-			return (Object[]) list.get( 0 );
+			final Object[] entitySnapshot = (Object[]) list.get( 0 );
+			// The result of this method is treated like the entity state array which doesn't include the id
+			// So we must exclude it from the array
+			if ( entitySnapshot.length == 1 ) {
+				return ArrayHelper.EMPTY_OBJECT_ARRAY;
+			}
+			else {
+				final Object[] state = new Object[entitySnapshot.length - 1];
+				System.arraycopy( entitySnapshot, 1, state, 0, state.length );
+				return state;
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.loader.ast.internal;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -16,7 +15,6 @@ import javax.persistence.CacheStoreMode;
 import org.hibernate.FlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.metamodel.mapping.AssociationKey;
 import org.hibernate.metamodel.mapping.ModelPart;
@@ -34,7 +32,6 @@ import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
 import org.hibernate.sql.ast.spi.SqlAstProcessingState;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
-import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
@@ -79,22 +76,6 @@ public class LoaderSqlAstCreationState
 				this,
 				this,
 				() -> Clause.IRRELEVANT
-		);
-	}
-
-	public LoaderSqlAstCreationState(
-			QuerySpec querySpec,
-			SqlAliasBaseManager sqlAliasBaseManager,
-			LockOptions lockOptions,
-			SessionFactoryImplementor sf) {
-		this(
-				querySpec,
-				sqlAliasBaseManager,
-				new FromClauseIndex(),
-				lockOptions,
-				(fetchParent, ast, state) -> Collections.emptyList(),
-				true,
-				sf
 		);
 	}
 
@@ -162,48 +143,6 @@ public class LoaderSqlAstCreationState
 	@Override
 	public SqlAstProcessingState getParentState() {
 		return null;
-	}
-
-	private static class FromClauseIndex implements FromClauseAccess {
-		private TableGroup tableGroup;
-
-		@Override
-		public TableGroup findTableGroup(NavigablePath navigablePath) {
-			if ( tableGroup != null ) {
-				if ( tableGroup.getNavigablePath().equals( navigablePath ) ) {
-					return tableGroup;
-				}
-				if ( tableGroup.getNavigablePath()
-						.getIdentifierForTableGroup()
-						.equals( navigablePath.getIdentifierForTableGroup() ) ) {
-					return tableGroup;
-				}
-
-				throw new IllegalArgumentException(
-						"NavigablePath [" + navigablePath + "] did not match base TableGroup ["
-								+ tableGroup.getNavigablePath() + "]"
-				);
-			}
-
-			return null;
-		}
-
-		@Override
-		public void registerTableGroup(NavigablePath navigablePath, TableGroup tableGroup) {
-			assert tableGroup.getNavigablePath().equals( navigablePath );
-
-			if ( this.tableGroup != null ) {
-				if ( this.tableGroup != tableGroup ) {
-					throw new IllegalArgumentException(
-							"Base TableGroup [" + tableGroup.getNavigablePath() + "] already set - " + navigablePath
-					);
-				}
-				assert this.tableGroup.getNavigablePath().equals( navigablePath );
-			}
-			else {
-				this.tableGroup = tableGroup;
-			}
-		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/AttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/AttributeMapping.java
@@ -14,7 +14,7 @@ import org.hibernate.sql.results.graph.Fetchable;
  *
  * @author Steve Ebersole
  */
-public interface AttributeMapping extends ModelPart, ValueMapping, Fetchable {
+public interface AttributeMapping extends ModelPart, ValueMapping, Fetchable, PropertyBasedMapping {
 	String getAttributeName();
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityAssociationMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityAssociationMapping.java
@@ -6,6 +6,12 @@
  */
 package org.hibernate.metamodel.mapping;
 
+import org.hibernate.NotYetImplementedFor6Exception;
+import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.DomainResultCreationState;
+
 /**
  * Commonality between `many-to-one`, `one-to-one` and `any`, as well as entity-valued collection elements and map-keys
  *
@@ -28,5 +34,16 @@ public interface EntityAssociationMapping extends ModelPart, Association {
 	@Override
 	default boolean incrementFetchDepth(){
 		return true;
+	}
+
+	/**
+	 * Create a delayed DomainResult for a specific reference to this ModelPart.
+	 */
+	default <T> DomainResult<T> createDelayedDomainResult(
+			NavigablePath navigablePath,
+			TableGroup tableGroup,
+			String resultVariable,
+			DomainResultCreationState creationState) {
+		throw new NotYetImplementedFor6Exception( getClass() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdLogging.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.metamodel.mapping;
+
+import org.hibernate.internal.CoreLogging;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Logging related to natural-id operations
+ */
+public interface NaturalIdLogging {
+	String LOGGER_NAME = CoreLogging.subsystemLoggerName( "mapping.natural_id" );
+	Logger LOGGER = Logger.getLogger( LOGGER_NAME );
+
+	boolean DEBUG_ENABLED = LOGGER.isDebugEnabled();
+	boolean TRACE_ENABLED = LOGGER.isTraceEnabled();
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdMapping.java
@@ -57,7 +57,7 @@ public interface NaturalIdMapping extends VirtualModelPart {
 	 *
 	 * @return The extracted natural id values.  This is a normalized
 	 */
-	Object extractNaturalIdValues(Object[] state, SharedSessionContractImplementor session);
+	Object extractNaturalIdFromEntityState(Object[] state, SharedSessionContractImplementor session);
 
 	/**
 	 * Given an entity instance, extract the normalized natural id representation
@@ -66,7 +66,7 @@ public interface NaturalIdMapping extends VirtualModelPart {
 	 *
 	 * @return The extracted natural id values
 	 */
-	Object extractNaturalIdValues(Object entity, SharedSessionContractImplementor session);
+	Object extractNaturalIdFromEntity(Object entity, SharedSessionContractImplementor session);
 
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/PropertyBasedMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/PropertyBasedMapping.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.metamodel.mapping;
+
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.sql.results.graph.Fetchable;
+
+/**
+ * Describes an attribute with a property access.
+ *
+ * @author Christian Beikov
+ */
+public interface PropertyBasedMapping {
+
+	PropertyAccess getPropertyAccess();
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -108,7 +108,7 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 	}
 
 	@Override
-	public Object[] extractNaturalIdValues(Object[] state, SharedSessionContractImplementor session) {
+	public Object[] extractNaturalIdFromEntityState(Object[] state, SharedSessionContractImplementor session) {
 		if ( state == null ) {
 			return null;
 		}
@@ -128,7 +128,7 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 	}
 
 	@Override
-	public Object[] extractNaturalIdValues(Object entity, SharedSessionContractImplementor session) {
+	public Object[] extractNaturalIdFromEntity(Object entity, SharedSessionContractImplementor session) {
 		final Object[] values = new Object[ attributes.size() ];
 
 		for ( int i = 0; i < attributes.size(); i++ ) {
@@ -196,11 +196,11 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityPersister persister = getDeclaringType().getEntityPersister();
 
-		final Object[] naturalId = extractNaturalIdValues( currentState, session );
+		final Object[] naturalId = extractNaturalIdFromEntityState( currentState, session );
 
 		final Object snapshot = loadedState == null
 				? persistenceContext.getNaturalIdSnapshot( id, persister )
-				: persister.getNaturalIdMapping().extractNaturalIdValues( loadedState, session );
+				: persister.getNaturalIdMapping().extractNaturalIdFromEntityState( loadedState, session );
 		final Object[] previousNaturalId = (Object[]) snapshot;
 
 		assert naturalId.length == getNaturalIdAttributes().size();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -121,8 +121,7 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 
 		for ( int i = 0; i <= attributes.size() - 1; i++ ) {
 			final SingularAttributeMapping attributeMapping = attributes.get( i );
-			final Object domainValue = state[ attributeMapping.getStateArrayPosition() ];
-			values[ i ] = attributeMapping.disassemble( domainValue, session );
+			values[ i ] = state[ attributeMapping.getStateArrayPosition() ];
 		}
 
 		return values;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -28,10 +28,12 @@ import org.hibernate.mapping.IndexedConsumer;
 import org.hibernate.mapping.List;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Value;
+import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.CollectionIdentifierDescriptor;
 import org.hibernate.metamodel.mapping.CollectionMappingType;
 import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.PropertyBasedMapping;
 import org.hibernate.metamodel.mapping.SelectionMapping;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -339,7 +341,8 @@ public class PluralAttributeMappingImpl
 			);
 			return new SimpleForeignKeyDescriptor(
 					keySelectionMapping,
-					basicFkTargetPart
+					basicFkTargetPart,
+					( (PropertyBasedMapping) basicFkTargetPart ).getPropertyAccess()
 			);
 		}
 		else if ( fkTargetPart instanceof EmbeddableValuedModelPart ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
@@ -23,6 +23,7 @@ import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.MappingType;
 import org.hibernate.metamodel.model.domain.NavigableRole;
+import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.sql.ast.Clause;
@@ -51,13 +52,16 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicValuedModelPart, FetchOptions {
 	private final SelectionMapping keySelectionMapping;
 	private final SelectionMapping targetSelectionMapping;
+	private final PropertyAccess propertyAccess;
 	private AssociationKey associationKey;
 
 	public SimpleForeignKeyDescriptor(
 			SelectionMapping keySelectionMapping,
-			SelectionMapping targetSelectionMapping) {
+			SelectionMapping targetSelectionMapping,
+			PropertyAccess propertyAccess) {
 		this.keySelectionMapping = keySelectionMapping;
 		this.targetSelectionMapping = targetSelectionMapping;
+		this.propertyAccess = propertyAccess;
 	}
 
 	@Override
@@ -260,7 +264,7 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 
 	@Override
 	public Object disassemble(Object value, SharedSessionContractImplementor session) {
-		return value;
+		return value == null ? null : propertyAccess.getGetter().get( value );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -61,10 +61,10 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping {
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		final EntityPersister persister = getDeclaringType().getEntityPersister();
 
-		final Object naturalId = extractNaturalIdValues( currentState, session );
+		final Object naturalId = extractNaturalIdFromEntityState( currentState, session );
 		final Object snapshot = loadedState == null
 				? persistenceContext.getNaturalIdSnapshot( id, persister )
-				: persister.getNaturalIdMapping().extractNaturalIdValues( loadedState, session );
+				: persister.getNaturalIdMapping().extractNaturalIdFromEntityState( loadedState, session );
 
 		if ( ! areEqual( naturalId, snapshot, session ) ) {
 			throw new HibernateException(
@@ -79,12 +79,20 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping {
 	}
 
 	@Override
-	public Object extractNaturalIdValues(Object[] state, SharedSessionContractImplementor session) {
+	public Object extractNaturalIdFromEntityState(Object[] state, SharedSessionContractImplementor session) {
+		if ( state == null ) {
+			return null;
+		}
+
+		if ( state.length == 1 ) {
+			return state[0];
+		}
+
 		return state[ attribute.getStateArrayPosition() ];
 	}
 
 	@Override
-	public Object extractNaturalIdValues(Object entity, SharedSessionContractImplementor session) {
+	public Object extractNaturalIdFromEntity(Object entity, SharedSessionContractImplementor session) {
 		return attribute.getPropertyAccess().getGetter().get( entity );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingleAttributeIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingleAttributeIdentifierMapping.java
@@ -7,12 +7,13 @@
 package org.hibernate.metamodel.mapping.internal;
 
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
+import org.hibernate.metamodel.mapping.PropertyBasedMapping;
 import org.hibernate.property.access.spi.PropertyAccess;
 
 /**
  * @author Steve Ebersole
  */
-public interface SingleAttributeIdentifierMapping extends EntityIdentifierMapping {
+public interface SingleAttributeIdentifierMapping extends EntityIdentifierMapping, PropertyBasedMapping {
 	/**
 	 * Access to the identifier attribute's PropertyAccess
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -4999,11 +4999,11 @@ public abstract class AbstractEntityPersister
 	}
 
 	private void handleNaturalIdReattachment(Object entity, SharedSessionContractImplementor session) {
-		if ( !hasNaturalIdentifier() ) {
+		if ( naturalIdMapping == null ) {
 			return;
 		}
 
-		if ( getEntityMetamodel().hasImmutableNaturalId() ) {
+		if ( ! naturalIdMapping.isMutable() ) {
 			// we assume there were no changes to natural id during detachment for now, that is validated later
 			// during flush.
 			return;
@@ -5021,13 +5021,13 @@ public abstract class AbstractEntityPersister
 			naturalIdSnapshot = null;
 		}
 		else {
-			naturalIdSnapshot = naturalIdMapping.extractNaturalIdValues( entitySnapshot, session );
+			naturalIdSnapshot = naturalIdMapping.extractNaturalIdFromEntityState( entitySnapshot, session );
 		}
 
 		naturalIdResolutions.removeSharedResolution( id, naturalIdSnapshot, this );
 		naturalIdResolutions.manageLocalResolution(
 				id,
-				naturalIdMapping.extractNaturalIdValues( entity, session ),
+				naturalIdMapping.extractNaturalIdFromEntity( entity, session ),
 				this,
 				CachedNaturalIdValueSource.UPDATE
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/MultiTableDeleteQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/MultiTableDeleteQueryPlan.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.query.sqm.internal;
 
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.NonSelectQueryPlan;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
@@ -30,6 +31,7 @@ public class MultiTableDeleteQueryPlan implements NonSelectQueryPlan {
 
 	@Override
 	public int executeUpdate(ExecutionContext executionContext) {
+		BulkOperationCleanupAction.schedule( executionContext, sqmDelete );
 		return deleteStrategy.executeDelete( sqmDelete, domainParameterXref, executionContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/MultiTableUpdateQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/MultiTableUpdateQueryPlan.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.query.sqm.internal;
 
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.NonSelectQueryPlan;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
@@ -30,6 +31,7 @@ public class MultiTableUpdateQueryPlan implements NonSelectQueryPlan {
 
 	@Override
 	public int executeUpdate(ExecutionContext executionContext) {
+		BulkOperationCleanupAction.schedule( executionContext, sqmUpdate );
 		return mutationStrategy.executeUpdate( sqmUpdate, domainParameterXref, executionContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
@@ -9,7 +9,7 @@ package org.hibernate.query.sqm.internal;
 import java.util.List;
 import java.util.Map;
 
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -28,15 +28,14 @@ import org.hibernate.query.sqm.sql.SqmTranslatorFactory;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
 import org.hibernate.sql.ast.SqlAstTranslator;
-import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.from.MutatingTableReferenceGroupWrapper;
 import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcDelete;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.results.internal.SqlSelectionImpl;
 
@@ -90,6 +89,7 @@ public class SimpleDeleteQueryPlan implements NonSelectQueryPlan {
 
 	@Override
 	public int executeUpdate(ExecutionContext executionContext) {
+		BulkOperationCleanupAction.schedule( executionContext, sqmDelete );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 		final JdbcServices jdbcServices = factory.getJdbcServices();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.query.sqm.internal;
 
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -78,6 +79,7 @@ public class SimpleInsertQueryPlan implements NonSelectQueryPlan {
 
 	@Override
 	public int executeUpdate(ExecutionContext executionContext) {
+		BulkOperationCleanupAction.schedule( executionContext, sqmInsert );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 		final JdbcServices jdbcServices = factory.getJdbcServices();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
@@ -9,6 +9,7 @@ package org.hibernate.query.sqm.internal;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -51,6 +52,7 @@ public class SimpleUpdateQueryPlan implements NonSelectQueryPlan {
 
 	@Override
 	public int executeUpdate(ExecutionContext executionContext) {
+		BulkOperationCleanupAction.schedule( executionContext, sqmUpdate );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 		final JdbcServices jdbcServices = factory.getJdbcServices();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
@@ -25,9 +25,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.event.spi.PreLoadEventListener;
 import org.hibernate.internal.util.StringHelper;
@@ -727,7 +725,7 @@ public abstract class AbstractEntityInitializer extends AbstractFetchParentAcces
 		if ( entityDescriptor.getNaturalIdMapping() != null ) {
 			persistenceContext.getNaturalIdResolutions().cacheResolutionFromLoad(
 					entityIdentifier,
-					entityDescriptor.getNaturalIdMapping().extractNaturalIdValues( resolvedEntityState, session ),
+					entityDescriptor.getNaturalIdMapping().extractNaturalIdFromEntityState( resolvedEntityState, session ),
 					entityDescriptor
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedResultImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.results.graph.entity.internal;
+
+import org.hibernate.metamodel.mapping.EntityAssociationMapping;
+import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
+import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.EntityValuedModelPart;
+import org.hibernate.query.EntityIdentifierNavigablePath;
+import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.results.graph.AssemblerCreationState;
+import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.DomainResultAssembler;
+import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.FetchableContainer;
+import org.hibernate.sql.results.graph.entity.AbstractEntityResultGraphNode;
+import org.hibernate.sql.results.graph.entity.EntityInitializer;
+import org.hibernate.sql.results.graph.entity.EntityResult;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+
+import static org.hibernate.query.results.ResultsHelper.attributeName;
+
+/**
+ * Selects just the FK and builds a proxy
+ *
+ * @author Christian Beikov
+ */
+public class EntityDelayedResultImpl implements DomainResult {
+
+	private final NavigablePath navigablePath;
+	private final EntityAssociationMapping entityValuedModelPart;
+	private final DomainResult identifierResult;
+
+	public EntityDelayedResultImpl(
+			NavigablePath navigablePath,
+			EntityAssociationMapping entityValuedModelPart,
+			TableGroup rootTableGroup,
+			DomainResultCreationState creationState) {
+		this.navigablePath = navigablePath;
+		this.entityValuedModelPart = entityValuedModelPart;
+		this.identifierResult = entityValuedModelPart.getForeignKeyDescriptor()
+				.createDomainResult(
+						navigablePath.append( EntityIdentifierMapping.ROLE_LOCAL_NAME ),
+						rootTableGroup,
+						null,
+						creationState
+				);
+	}
+
+	@Override
+	public JavaTypeDescriptor getResultJavaTypeDescriptor() {
+		return entityValuedModelPart.getAssociatedEntityMappingType().getMappedJavaTypeDescriptor();
+	}
+
+	@Override
+	public NavigablePath getNavigablePath() {
+		return navigablePath;
+	}
+
+	@Override
+	public String getResultVariable() {
+		return null;
+	}
+
+	@Override
+	public DomainResultAssembler createResultAssembler(AssemblerCreationState creationState) {
+		final EntityInitializer initializer = (EntityInitializer) creationState.resolveInitializer(
+				getNavigablePath(),
+				entityValuedModelPart,
+				() -> new EntityDelayedFetchInitializer(
+						getNavigablePath(),
+						(EntityValuedModelPart) entityValuedModelPart,
+						identifierResult.createResultAssembler( creationState )
+				)
+		);
+
+		return new EntityAssembler( getResultJavaTypeDescriptor(), initializer );
+	}
+
+	@Override
+	public String toString() {
+		return "EntityDelayedResultImpl {" + getNavigablePath() + "}";
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/BasicNaturalIdCachingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/BasicNaturalIdCachingTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -74,6 +75,7 @@ public class BasicNaturalIdCachingTests {
 					final Object cacheKey = cacheAccess.generateCacheKey( "abc", entityPersister, session );
 					final Object cached = cacheAccess.get( session, cacheKey );
 					assertThat( cached, notNullValue() );
+					assertThat( cached, equalTo( 1 ) );
 				}
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/MappedSuperclassOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/MappedSuperclassOverrideTest.java
@@ -20,11 +20,11 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @DomainModel( annotatedClasses = { MappedSuperclassOverrideTest.MyMappedSuperclass.class, MappedSuperclassOverrideTest.MyEntity.class } )
 @SessionFactory( exportSchema = false )
-@FailureExpected( jiraKey = "HHH-12085" )
 public class MappedSuperclassOverrideTest {
 	@Test
 	public void testModel(SessionFactoryScope scope) {
@@ -32,7 +32,11 @@ public class MappedSuperclassOverrideTest {
 				.getRuntimeMetamodels()
 				.getEntityMappingType( MyEntity.class )
 				.getEntityPersister();
-		assertTrue( entityPersister.hasNaturalIdentifier() );
+
+		// defining a natural-id on a sub-entity is not allowed, only on the root.
+		// 		- here, because the root does not declare `#getName` as a natural-id
+		//		the hierarchy does not define a natural-id
+		assertFalse( entityPersister.hasNaturalIdentifier() );
 	}
 
 	@MappedSuperclass
@@ -77,7 +81,6 @@ public class MappedSuperclassOverrideTest {
 			super( id, name );
 		}
 
-		// this should not be allowed, and supposedly fails anyway...
 		@Override
 		@NaturalId
 		public String getName() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/cache/InheritedNaturalIdCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/cache/InheritedNaturalIdCacheTest.java
@@ -47,10 +47,12 @@ public class InheritedNaturalIdCacheTest {
 	}
 
 	@Test
-	@NotImplementedYet( reason = "natural-id caching not yet implemented", strict = false )
+	@NotImplementedYet(
+			reason = "We do not throw `WrongClassException` atm, we just return null",
+			strict = false
+	)
 	public void testLoadingInheritedEntitiesByNaturalId(SessionFactoryScope scope) {
 		// load the entities "properly" by natural-id
-
 		scope.inTransaction(
 				(session) -> {
 					final MyEntity entity = session.bySimpleNaturalId( MyEntity.class ).load( "base" );
@@ -61,13 +63,12 @@ public class InheritedNaturalIdCacheTest {
 				}
 		);
 
-		// finally, attempt to load MyEntity#1 as an ExtendedEntity, which should
-		// throw a WrongClassException
+		// baseline: loading the wrong class by id...
 
 		scope.inTransaction(
 				(session) -> {
 					try {
-						session.bySimpleNaturalId( ExtendedEntity.class ).load( "base" );
+						session.byId( ExtendedEntity.class ).load( 1L );
 						fail( "Expecting WrongClassException" );
 					}
 					catch (WrongClassException expected) {
@@ -82,12 +83,14 @@ public class InheritedNaturalIdCacheTest {
 				}
 		);
 
-		// this is functionally equivalent to loading the wrong class by id...
-
+		// finally, attempt to load MyEntity#1 as an ExtendedEntity, which should
+		// throw a `WrongClassException` same as above with loading by id
+		//
+		// NOTE : this is what fails currently
 		scope.inTransaction(
 				(session) -> {
 					try {
-						session.byId( ExtendedEntity.class ).load( 1L );
+						session.bySimpleNaturalId( ExtendedEntity.class ).load( "base" );
 						fail( "Expecting WrongClassException" );
 					}
 					catch (WrongClassException expected) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdNonStrictReadWriteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdNonStrictReadWriteTest.java
@@ -7,10 +7,10 @@
 package org.hibernate.orm.test.mapping.naturalid.mutable.cached;
 
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.Setting;
+
 
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
 import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
@@ -26,4 +26,5 @@ import static org.hibernate.testing.cache.CachingRegionFactory.DEFAULT_ACCESSTYP
 @DomainModel( annotatedClasses = {A.class, Another.class, AllCached.class, B.class, SubClass.class} )
 @SessionFactory
 public class CachedMutableNaturalIdNonStrictReadWriteTest extends CachedMutableNaturalIdTest {
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
@@ -55,28 +55,25 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testInsertedNaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
 		scope.inTransaction(
-				(session) -> session.save( new AllCached( "it" ) )
+				(session) -> session.save( new Another( "it" ) )
 		);
 
 		scope.inTransaction(
 				(session) -> {
 					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
 					assertNotNull( it );
-
-					assertEquals( 1, statistics.getNaturalIdCacheHitCount() );
 				}
 		);
+		assertEquals( 1, statistics.getNaturalIdCacheHitCount() );
 	}
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testInsertedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
@@ -86,7 +83,7 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 					final Transaction transaction = session.getTransaction();
 					transaction.begin();
 
-					session.save( new AllCached( "it" ) );
+					session.save( new Another( "it" ) );
 					session.flush();
 
 					transaction.rollback();
@@ -104,13 +101,12 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testChangedNaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
 		scope.inTransaction(
-				(session) -> session.save( new AllCached( "it" ) )
+				(session) -> session.save( new Another( "it" ) )
 		);
 
 		scope.inTransaction(
@@ -136,13 +132,12 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testChangedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
 		scope.inTransaction(
-				(session) -> session.save( new AllCached( "it" ) )
+				(session) -> session.save( new Another( "it" ) )
 		);
 
 		scope.inTransaction(
@@ -167,13 +162,12 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 					assertNotNull( original );
 				}
 		);
-		
-		assertEquals( 0, statistics );
+
+		assertEquals(0, statistics.getNaturalIdCacheHitCount());
 	}
 	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7309" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testInsertUpdateEntity_NaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
@@ -202,9 +196,8 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-9200" )
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testNaturalIdCacheStatisticsReset(SessionFactoryScope scope) {
-		final String naturalIdCacheRegion = Another.class.getName() + "##NaturalId";
+		final String naturalIdCacheRegion = "hibernate.test." + Another.class.getName() + "##NaturalId";
 
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdTest.java
@@ -64,7 +64,6 @@ public abstract class CachedMutableNaturalIdTest {
 	}
 
 	@Test
-	@NotImplementedYet( reason = "Caching is not yet implemented", strict = false )
 	public void testNaturalIdChangedWhileDetached(SessionFactoryScope scope) {
 		scope.inTransaction(
 				(session) -> session.save( new Another( "it" ) )

--- a/hibernate-core/src/test/resources/log4j.properties
+++ b/hibernate-core/src/test/resources/log4j.properties
@@ -32,6 +32,8 @@ log4j.logger.org.hibernate.orm.query.sqm=debug
 log4j.logger.org.hibernate.orm.query.hql=trace
 log4j.logger.org.hibernate.sql.results.graph.DomainResultGraphPrinter=debug
 
+log4j.logger.org.hibernate.orm.mapping.natural_id=debug
+
 log4j.logger.org.hibernate.tool.hbm2ddl=trace
 log4j.logger.org.hibernate.testing.cache=debug
 


### PR DESCRIPTION
natural-id caching 

- on top of Christian's PR #3735 which fixes a problem with pulling entity snapshots from the database which effects natural-id handling and caused test failures here