### PR TITLE
HHH-11076 Log a warning if uninitialized collection unsets session when filters are enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -656,6 +656,10 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 						LOG.queuedOperationWhenDetachFromSession( collectionInfoString );
 					}
 				}
+				if ( allowLoadOutsideTransaction && !initialized && session.getLoadQueryInfluencers().hasEnabledFilters() ) {
+					final String collectionInfoString = MessageHelper.collectionInfoString( getRole(), getKey() );
+					LOG.enabledFiltersWhenDetachFromSession( collectionInfoString );
+				}
 				this.session = null;
 			}
 			return true;

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1856,4 +1856,8 @@ public interface CoreMessageLogger extends BasicLogger {
 	@Message(value = "Ignoring ServiceConfigurationError caught while trying to instantiate service '%s'.", id = 505)
 	void ignoringServiceConfigurationError(Class<?> serviceContract, @Cause ServiceConfigurationError error);
 
+	@LogMessage(level = WARN)
+	@Message(value = "Detaching an uninitialized collection with enabled filters from a session: %s", id = 506)
+	void enabledFiltersWhenDetachFromSession(String collectionInfoString);
+
 }


### PR DESCRIPTION
This is the implementation that was discussed during the PR meet-up. Note that I also provided an alternative implementation that snapshots the load query influencers on detach: https://github.com/hibernate/hibernate-orm/pull/3776

https://hibernate.atlassian.net/browse/HHH-11076