### PR TITLE
HHH-11076 Snapshot load query influencers on detach and apply in temporary session

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/AbstractPersistentCollection.java
@@ -25,6 +25,7 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.spi.CollectionEntry;
 import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.LoadQueryInfluencersSnapshot;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -58,6 +59,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( AbstractPersistentCollection.class );
 
 	private transient SharedSessionContractImplementor session;
+	private LoadQueryInfluencersSnapshot loadQueryInfluencersSnapshot;
 	private boolean isTempSession = false;
 	private boolean initialized;
 	private transient List<DelayedOperation> operationQueue;
@@ -292,6 +294,7 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 		final SharedSessionContractImplementor session = (SharedSessionContractImplementor) sf.openSession();
 		session.getPersistenceContextInternal().setDefaultReadOnly( true );
 		session.setFlushMode( FlushMode.MANUAL );
+		session.getLoadQueryInfluencers().setSnapshot( loadQueryInfluencersSnapshot );
 		return session;
 	}
 
@@ -655,6 +658,9 @@ public abstract class AbstractPersistentCollection implements Serializable, Pers
 						// Just log the info.
 						LOG.queuedOperationWhenDetachFromSession( collectionInfoString );
 					}
+				}
+				if ( !initialized && allowLoadOutsideTransaction ) {
+					loadQueryInfluencersSnapshot = session.getLoadQueryInfluencers().getSnapshot();
 				}
 				this.session = null;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencersSnapshot.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencersSnapshot.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.spi;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.hibernate.Filter;
+import org.hibernate.internal.FilterImpl;
+
+/**
+ * A snapshot of {@link LoadQueryInfluencers} to apply to lazy loading outside of a transaction.
+ *
+ * @author Christian Beikov
+ */
+public class LoadQueryInfluencersSnapshot implements Serializable {
+
+	final HashSet<String> enabledFetchProfileNames;
+	final HashMap<String, FilterImpl> enabledFilters;
+
+	LoadQueryInfluencersSnapshot(HashSet<String> enabledFetchProfileNames, HashMap<String, FilterImpl> enabledFilters) {
+		this.enabledFetchProfileNames = enabledFetchProfileNames;
+		this.enabledFilters = enabledFilters;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterImpl.java
@@ -46,6 +46,12 @@ public class FilterImpl implements Filter, Serializable {
 		filterName = definition.getFilterName();
 	}
 
+	public FilterImpl(FilterImpl original) {
+		this.definition = original.definition;
+		this.filterName = original.filterName;
+		this.parameters = new HashMap<>( original.parameters );
+	}
+
 	public FilterDefinition getFilterDefinition() {
 		return definition;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/hibernateFilters/ProxyPreservingFiltersOutsideInitialSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/hibernateFilters/ProxyPreservingFiltersOutsideInitialSessionTest.java
@@ -44,7 +44,6 @@ public class ProxyPreservingFiltersOutsideInitialSessionTest
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-11076", message = "Fix rejected, we need another approach to fix this issue!" )
 	public void testPreserveFilters() {
 
 		doInJPA( this::entityManagerFactory, entityManager -> {
@@ -121,7 +120,6 @@ public class ProxyPreservingFiltersOutsideInitialSessionTest
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-11076", message = "Fix rejected, we need another approach to fix this issue!" )
 	public void testChangeFilterBeforeInitializeInTempSession() {
 
 		doInJPA(
@@ -159,10 +157,9 @@ public class ProxyPreservingFiltersOutsideInitialSessionTest
 		} );
 
 		log.info( "Initialize accounts collection" );
-		// What should group.getAccounts() contain? Should it be accounts with regionCode "Europe"
-		// because that was the most recent filter used in the session?
+		// The accounts collection captures a snapshot of the filters when detached
+		// so group.getAccounts() will only contain "Europe" accounts
 		Hibernate.initialize( group.getAccounts() );
-		// The following will fail because the collection will only contain accounts with regionCode "US"
 		assertEquals(2, group.getAccounts().size());
 	}
 


### PR DESCRIPTION
This is a possible solution for the problem as described in the issue. The alternative, which is what has been discussed in the PR meeting, is to log a warning instead: https://github.com/hibernate/hibernate-orm/pull/3775

https://hibernate.atlassian.net/browse/HHH-11076