### PR TITLE
remove two unnecessary calls to deprecated getEntityTuplizer()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AnyType.java
@@ -156,7 +156,7 @@ public class AnyType extends AbstractType implements CompositeType, AssociationT
 		final EntityPersister concretePersister = guessEntityPersister( entity );
 		return concretePersister == null
 				? null
-				: concretePersister.getEntityTuplizer().getIdentifier( entity, null );
+				: concretePersister.getIdentifier( entity, null );
 	}
 
 	private EntityPersister guessEntityPersister(Object object) {

--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -219,8 +219,8 @@ public abstract class EntityType extends AbstractType implements AssociationType
 			return ReflectHelper.classForName( entityName );
 		}
 		catch (ClassNotFoundException cnfe) {
-			return typeConfiguration.getSessionFactory().getMetamodel().entityPersister( entityName ).
-					getEntityTuplizer().getMappedClass();
+			return typeConfiguration.getSessionFactory().getMetamodel().entityPersister( entityName )
+					.getMappedClass();
 		}
 	}
 


### PR DESCRIPTION
This is quite a minor cleanup, to reduce our internal dependency on `EntityTuplizer`