### PR TITLE
Resolve JavaTypeDescriptor for StandardRowReader

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
@@ -90,6 +90,15 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 			basicType = jdbcResultsMetadata.resolveType( jdbcPosition, explicitJavaTypeDescriptor );
 		}
 
+		final JavaTypeDescriptor<?> javaTypeDescriptor;
+
+		if ( explicitJavaTypeDescriptor != null ) {
+			javaTypeDescriptor = explicitJavaTypeDescriptor;
+		}
+		else {
+			javaTypeDescriptor = basicType.getJavaTypeDescriptor();
+		}
+
 		final SqlExpressionResolver sqlExpressionResolver = domainResultCreationState.getSqlAstCreationState().getSqlExpressionResolver();
 		sqlExpressionResolver.resolveSqlSelection(
 				sqlExpressionResolver.resolveSqlExpression(
@@ -100,7 +109,10 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 				sessionFactory.getTypeConfiguration()
 		);
 
-		return new BasicResult<>( valuesArrayPosition, resultAlias, explicitJavaTypeDescriptor );
+		// StandardRowReader expects there to be a JavaTypeDescriptor as part of the ResultAssembler.
+		assert javaTypeDescriptor != null;
+
+		return new BasicResult<>( valuesArrayPosition, resultAlias, javaTypeDescriptor );
 	}
 
 }


### PR DESCRIPTION
Assuming a simple query as follows:
```
session.createNativeQuery( "SELECT group_id FROM GroupMember" ).addScalar( "group_id", IntegerType.INSTANCE )
```
This led to a NPE in the `StandardRowReader#getResultJavaType` method because the underlying `ResultAssembler` was passed a null JavaTypeDescriptor.  This change guarantees that if no explicit JavaTypeDescriptor is present but a type has been resolved, we resolve the JavaTypeDescriptor from the resolved type.