### PR TITLE
Fix NPE with DelayedCollectionInitializer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.results.graph.collection.internal;
 
 import org.hibernate.collection.spi.CollectionSemantics;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.log.LoggingHelper;
@@ -93,5 +94,21 @@ public class DelayedCollectionInitializer extends AbstractCollectionInitializer 
 	public void finishUpRow(RowProcessingState rowProcessingState) {
 		super.finishUpRow( rowProcessingState );
 		collectionInstance = null;
+	}
+
+	@Override
+	public void resolveKey(RowProcessingState rowProcessingState) {
+		if ( collectionKey != null ) {
+			// already resolved
+			return;
+		}
+
+		final Object parentKey = parentAccess.getParentKey();
+		if ( parentKey != null ) {
+			collectionKey = new CollectionKey(
+					collectionAttributeMapping.getCollectionDescriptor(),
+					parentKey
+			);
+		}
 	}
 }


### PR DESCRIPTION
A NPE is thrown due to `DelayedCollectionInitializer` relying on the `AbstractCollectionInitializer` behavior for `resolveKey`.  The overridden method does not register the resolution listener since the instance hasn't yet been resolved but only resolves the key.