### PR TITLE
HHH-14484 Improve support for Firebird 4

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -67,6 +67,7 @@ dependencies {
 	testRuntime( libraries.mssql )
 	testRuntime( libraries.hana )
 	testRuntime( libraries.cockroachdb )
+	testRuntime( libraries.firebird )
 
 	testCompile( project( ':hibernate-jcache' ) )
 	testRuntime( libraries.ehcache3 )

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -236,7 +236,17 @@ ext {
                         'jdbc.pass'  : '',
                         // Disable prepared statement caching due to https://www.postgresql.org/message-id/CAEcMXhmmRd4-%2BNQbnjDT26XNdUoXdmntV9zdr8%3DTu8PL9aVCYg%40mail.gmail.com
                         'jdbc.url'   : 'jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable&preparedStatementCacheQueries=0'
-                ]
+                ],
+                firebird : [
+                        'db.dialect' : 'org.hibernate.dialect.FirebirdDialect',
+                        'jdbc.driver': 'org.firebirdsql.jdbc.FBDriver',
+                        'jdbc.user'  : 'sysdba',
+                        'jdbc.pass'  : 'masterkey',
+                        // Overriding default transaction definition (5 seconds instead of infinite wait) to prevent problems in test cleanup
+                        // Expects alias 'hibernate_orm_test' in aliases.conf (FB2.5 and earlier) or databases.conf (FB3.0 and later)
+                        // Created database must either use default character set NONE, or UTF8 with page size 16384 or higher (to prevent issues with indexes due to keysize)
+                        'jdbc.url'   : 'jdbc:firebirdsql://localhost/hibernate_orm_test?charSet=utf-8;TRANSACTION_READ_COMMITTED=read_committed,rec_version,wait,lock_timeout=5'
+                ],
         ]
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -111,6 +111,7 @@ dependencies {
 	testRuntime( libraries.informix )
 	testRuntime( libraries.hana )
 	testRuntime( libraries.cockroachdb )
+	testRuntime( libraries.firebird )
 
 	testRuntime( libraries.oracle )
 

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -139,6 +139,7 @@ ext {
             jodaTime:        "joda-time:joda-time:${jodaTimeVersion}",
 
             informix:        'com.ibm.informix:jdbc:4.10.12',
+            firebird:        'org.firebirdsql.jdbc:jaybird:4.0.3.java8',
             jboss_jta:       "org.jboss.jbossts:jbossjta:4.16.4.Final",
             xapool:          "com.experlog:xapool:1.5.0",
             mockito:         'org.mockito:mockito-core:2.19.1',

--- a/hibernate-core/src/main/java/org/hibernate/dialect/BooleanDecoder.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/BooleanDecoder.java
@@ -38,7 +38,7 @@ public final class BooleanDecoder {
 			case INTEGER:
 			case LONG:
 			case INTEGER_BOOLEAN:
-				return "decode(?1,abs(sign(?1)),1,true,0,false,null)";
+				return "decode(abs(sign(?1)),1,true,0,false,null)";
 		}
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -186,6 +186,7 @@ public class DB2Dialect extends Dialect {
 		CommonFunctionFactory.median( queryEngine );
 		CommonFunctionFactory.stddev( queryEngine );
 		CommonFunctionFactory.stddevPopSamp( queryEngine );
+		CommonFunctionFactory.regrLinearRegressionAggregates( queryEngine );
 		CommonFunctionFactory.variance( queryEngine );
 		CommonFunctionFactory.stdevVarianceSamp( queryEngine );
 		CommonFunctionFactory.addYearsMonthsDaysHoursMinutesSeconds( queryEngine );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdSqlAstTranslator.java
@@ -6,12 +6,27 @@
  */
 package org.hibernate.dialect;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
+import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.CastTarget;
+import org.hibernate.sql.ast.tree.expression.FunctionExpression;
+import org.hibernate.sql.ast.tree.expression.JdbcLiteral;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.QueryLiteral;
+import org.hibernate.sql.ast.tree.expression.SelfRenderingExpression;
+import org.hibernate.sql.ast.tree.predicate.SelfRenderingPredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -24,6 +39,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
  * @author Christian Beikov
  */
 public class FirebirdSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAstTranslator<T> {
+
+	private boolean inFunction;
 
 	public FirebirdSqlAstTranslator(SessionFactoryImplementor sessionFactory, Statement statement) {
 		super( sessionFactory, statement );
@@ -102,7 +119,85 @@ public class FirebirdSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 		// Firebird does not support this, but it can be emulated
 	}
 
+	@Override
+	protected boolean supportsSimpleQueryGrouping() {
+		// Firebird is quite strict i.e. it requires `select .. union all select * from (select ...)`
+		// rather than `select .. union all (select ...)`
+		return false;
+	}
+
 	private boolean supportsOffsetFetchClause() {
 		return getDialect().getVersion() >= 300;
+	}
+
+	@Override
+	public void visitSelfRenderingPredicate(SelfRenderingPredicate selfRenderingPredicate) {
+		// see comments in visitParameter
+		boolean inFunction = this.inFunction;
+		this.inFunction = true;
+		try {
+			super.visitSelfRenderingPredicate( selfRenderingPredicate );
+		}
+		finally {
+			this.inFunction = inFunction;
+		}
+	}
+
+	@Override
+	public void visitSelfRenderingExpression(SelfRenderingExpression expression) {
+		// see comments in visitParameter
+		boolean inFunction = this.inFunction;
+		this.inFunction = !( expression instanceof FunctionExpression ) || !"cast".equals( ( (FunctionExpression) expression).getFunctionName() );
+		try {
+			super.visitSelfRenderingExpression( expression);
+		}
+		finally {
+			this.inFunction = inFunction;
+		}
+	}
+
+	@Override
+	public void visitParameter(JdbcParameter jdbcParameter) {
+		if ( inFunction ) {
+			// Turn off 'inFunction' to prevent StackOverflowError while rendering the cast
+			inFunction = false;
+			try {
+				// A lot of functions in Firebird are contextually typed and as a result,
+				// Firebird cannot determine the datatype of a parameter as passed to a function,
+				// resulting in a "Datatype unknown" error when the statement is compiled.
+				// This adds an explicit cast so Firebird can infer the type
+				final JdbcMapping jdbcMapping = jdbcParameter.getExpressionType().getJdbcMappings().get( 0 );
+				final List<SqlAstNode> arguments = new ArrayList<>( 2 );
+				arguments.add( jdbcParameter );
+				arguments.add( new CastTarget( (BasicValuedMapping) jdbcMapping ) );
+				castFunction().render( this, arguments, this );
+			}
+			finally {
+				inFunction = true;
+			}
+		}
+		else {
+			super.visitParameter( jdbcParameter );
+		}
+	}
+
+	@Override
+	public void visitJdbcLiteral(JdbcLiteral jdbcLiteral) {
+		visitLiteral( jdbcLiteral );
+	}
+
+	@Override
+	public void visitQueryLiteral(QueryLiteral queryLiteral) {
+		visitLiteral( queryLiteral );
+	}
+
+	private void visitLiteral(Literal literal) {
+		if ( literal.getLiteralValue() == null ) {
+			appendSql( SqlAppender.NULL_KEYWORD );
+		}
+		else {
+			// see comments in visitParameter
+			renderLiteral( literal, inFunction );
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -178,6 +178,9 @@ public class OracleDialect extends Dialect {
 		CommonFunctionFactory.stddevPopSamp( queryEngine );
 		CommonFunctionFactory.variance( queryEngine );
 		CommonFunctionFactory.varPopSamp( queryEngine );
+		CommonFunctionFactory.covarPopSamp( queryEngine );
+		CommonFunctionFactory.corr( queryEngine );
+		CommonFunctionFactory.regrLinearRegressionAggregates( queryEngine );
 
 		if ( getVersion() < 9 ) {
 			queryEngine.getSqmFunctionRegistry().register( "coalesce", new NvlCoalesceEmulation() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -307,6 +307,9 @@ public class PostgreSQLDialect extends Dialect {
 		CommonFunctionFactory.stddevPopSamp( queryEngine );
 		CommonFunctionFactory.variance( queryEngine );
 		CommonFunctionFactory.varPopSamp( queryEngine );
+		CommonFunctionFactory.covarPopSamp( queryEngine );
+		CommonFunctionFactory.corr( queryEngine );
+		CommonFunctionFactory.regrLinearRegressionAggregates( queryEngine );
 		CommonFunctionFactory.insert_overlay( queryEngine );
 		CommonFunctionFactory.overlay( queryEngine );
 		CommonFunctionFactory.soundex( queryEngine ); //was introduced in Postgres 9 apparently

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.dialect.function;
 
+import java.util.Arrays;
+
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.type.StandardBasicTypes;
@@ -212,6 +214,37 @@ public class CommonFunctionFactory {
 				.setInvariantType( StandardBasicTypes.DOUBLE )
 				.setExactArgumentCount( 1 )
 				.register();
+	}
+
+	public static void covarPopSamp(QueryEngine queryEngine) {
+		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "covar_pop" )
+				.setInvariantType( StandardBasicTypes.DOUBLE )
+				.setExactArgumentCount( 2 )
+				.register();
+		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "covar_samp" )
+				.setInvariantType( StandardBasicTypes.DOUBLE )
+				.setExactArgumentCount( 2 )
+				.register();
+	}
+
+	public static void corr(QueryEngine queryEngine) {
+		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "corr" )
+				.setInvariantType( StandardBasicTypes.DOUBLE )
+				.setExactArgumentCount( 2 )
+				.register();
+	}
+
+	public static void regrLinearRegressionAggregates(QueryEngine queryEngine) {
+		Arrays.asList(
+				"regr_avgx", "regr_avgy", "regr_count", "regr_intercept", "regr_r2",
+				"regr_slope", "regr_sxx", "regr_sxy", "regr_syy"
+		)
+				.forEach( fnName ->
+								queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( fnName )
+										.setInvariantType( StandardBasicTypes.DOUBLE )
+										.setExactArgumentCount( 2 )
+										.register()
+				);
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/sequence/FirebirdSequenceSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/sequence/FirebirdSequenceSupport.java
@@ -17,10 +17,11 @@ public class FirebirdSequenceSupport extends ANSISequenceSupport {
 	public static final SequenceSupport INSTANCE = new FirebirdSequenceSupport() {
 		@Override
 		public String getCreateSequenceString(String sequenceName, int initialValue, int incrementSize) {
-			// NOTE currently has an 'off by increment' bug, see
+			// NOTE Firebird 3 has an 'off by increment' bug, see
 			// http://tracker.firebirdsql.org/browse/CORE-6084
 			if (initialValue == 1 && incrementSize == 1) {
 				// Workaround for initial value and increment 1
+				// This workaround also works fine in Firebird 4, so we don't need to add yet another specialization
 				return getCreateSequenceString( sequenceName );
 			}
 			return super.getCreateSequenceString( sequenceName, initialValue, incrementSize);

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/IdentifierHelperBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/IdentifierHelperBuilder.java
@@ -8,6 +8,8 @@ package org.hibernate.engine.jdbc.env.spi;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -175,8 +177,16 @@ public class IdentifierHelperBuilder {
 		this.reservedWords.clear();
 	}
 
-	public void applyReservedWords(Set<String> words) {
+	public void applyReservedWords(String... words) {
+		applyReservedWords( Arrays.asList( words ) );
+	}
+
+	public void applyReservedWords(Collection<String> words) {
 		this.reservedWords.addAll( words );
+	}
+
+	public void applyReservedWords(Set<String> words) {
+		applyReservedWords( (Collection<String>) words );
 	}
 
 	public void setReservedWords(Set<String> words) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/joined/JoinedSubclassAndSecondaryTable.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/inheritance/joined/JoinedSubclassAndSecondaryTable.java
@@ -155,16 +155,17 @@ public class JoinedSubclassAndSecondaryTable {
 	private void assertNumberOfRows(Session s, String tableName, int expectedNumberOfRows, String message) {
 		s.doWork(
 				work -> {
-					PreparedStatement preparedStatement = work.prepareStatement( "select count(*) as row_count from " + tableName );
-					preparedStatement.execute();
-					ResultSet resultSet = preparedStatement.getResultSet();
-					resultSet.next();
-					long rowCount = resultSet.getLong( "row_count" );
-					assertEquals(
-							expectedNumberOfRows,
-							rowCount,
-							message
-					);
+					try (PreparedStatement preparedStatement = work.prepareStatement( "select count(*) as count_of_rows from " + tableName )) {
+						preparedStatement.execute();
+						ResultSet resultSet = preparedStatement.getResultSet();
+						resultSet.next();
+						long rowCount = resultSet.getLong( "count_of_rows" );
+						assertEquals(
+								expectedNumberOfRows,
+								rowCount,
+								message
+						);
+					}
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/SequenceValueExtractor.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/SequenceValueExtractor.java
@@ -17,6 +17,7 @@ import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.FirebirdDialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.OracleDialect;
@@ -58,6 +59,9 @@ public class SequenceValueExtractor {
 		else if ( dialect instanceof MariaDBDialect && dialect.getVersion() >= 1030 ) {
 
 			queryString = "select LASTVAL(" + sequenceName + ")";
+		}
+		else if (dialect instanceof FirebirdDialect ) {
+			queryString = "select gen_id(" + sequenceName + ", 0) from rdb$database";
 		}
 		else {
 			queryString = "select currval('" + sequenceName + "');";

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/identifier/AssignedInitialValueTableGeneratorConfiguredTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/identifier/AssignedInitialValueTableGeneratorConfiguredTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.jpa.identifier;
 
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -79,11 +80,13 @@ public class AssignedInitialValueTableGeneratorConfiguredTest {
 					Session session = entityManager.unwrap( Session.class );
 					session.doWork(
 							connection -> {
-								ResultSet resultSet = connection.createStatement().executeQuery(
-										"select product_id from table_identifier" );
-								resultSet.next();
-								int productIdValue = resultSet.getInt( 1 );
-								assertThat( productIdValue, is( 12 ) );
+								try (Statement statement = connection.createStatement()) {
+									ResultSet resultSet = statement.executeQuery(
+											"select product_id from table_identifier" );
+									resultSet.next();
+									int productIdValue = resultSet.getInt( 1 );
+									assertThat( productIdValue, is( 12 ) );
+								}
 							}
 					);
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/identifier/DefaultInitialValueTableGeneratorConfiguredTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/identifier/DefaultInitialValueTableGeneratorConfiguredTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.jpa.identifier;
 
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -79,11 +80,13 @@ public class DefaultInitialValueTableGeneratorConfiguredTest {
 					Session session = entityManager.unwrap( Session.class );
 					session.doWork(
 							connection -> {
-								ResultSet resultSet = connection.createStatement().executeQuery(
-										"select product_id from table_identifier" );
-								resultSet.next();
-								int productIdValue = resultSet.getInt( 1 );
-								assertThat( productIdValue, is( 10 ) );
+								try (Statement statement = connection.createStatement()) {
+									ResultSet resultSet = statement.executeQuery(
+											"select product_id from table_identifier" );
+									resultSet.next();
+									int productIdValue = resultSet.getInt( 1 );
+									assertThat( productIdValue, is( 10 ) );
+								}
 							}
 					);
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertUpdateTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertUpdateTests.java
@@ -14,9 +14,12 @@ import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+
+import org.hibernate.dialect.FirebirdDialect;
 
 /**
  * @author Gavin King
@@ -86,6 +89,16 @@ public class InsertUpdateTests {
 				session -> {
 					session.createQuery("delete from Ticket").executeUpdate();
 					session.createQuery("insert into Ticket (id, key, subject, details) values (6, 'ABC123', 'Outage', 'Something is broken')").executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	@SkipForDialect( dialectClass = FirebirdDialect.class, reason = "Firebird doesn't support values list in insert" )
+	public void testInsertMultipleValues(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery("delete from Ticket").executeUpdate();
 					session.createQuery("insert into Ticket (id, key, subject, details) values (2, 'XYZ123', 'Outage', 'Something is broken'), (13, 'HIJ456', 'x', 'x')").executeUpdate();
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import org.hibernate.dialect.DerbyDialect;
+import org.hibernate.dialect.FirebirdDialect;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -639,10 +640,17 @@ public class StandardFunctionTests {
 // the grammar rule is defined as `HOUR | MINUTE` so no idea how both ever worked.
 //					session.createQuery("select extract(offset hour minute from e.theZonedDateTime) from EntityOfBasics e")
 //							.list();
-
-					session.createQuery("select extract(offset from e.theZonedDateTime) from EntityOfBasics e")
-							.list();
 				}
+		);
+	}
+
+	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTimezoneTypes.class)
+	@SkipForDialect(dialectClass = FirebirdDialect.class, reason = "Firebird doesn't support formatting temporal types to strings")
+	public void testExtractFunctionTimeZoneOffset(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.createQuery( "select extract(offset from e.theZonedDateTime) from EntityOfBasics e")
+						.list()
 		);
 	}
 
@@ -888,6 +896,7 @@ public class StandardFunctionTests {
 
 	@Test
 	@SkipForDialect(dialectClass = DerbyDialect.class, reason = "Derby doesn't support formatting temporal types to strings")
+	@SkipForDialect(dialectClass = FirebirdDialect.class, reason = "Firebird doesn't support formatting temporal types to strings")
 	public void testFormat(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/set/SetOperationJpaCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/set/SetOperationJpaCriteriaTest.java
@@ -8,8 +8,6 @@ package org.hibernate.orm.test.set;
 
 import java.util.List;
 
-import javax.persistence.Tuple;
-
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaQuery;
 import org.hibernate.query.criteria.JpaRoot;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/set/SetOperationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/set/SetOperationTest.java
@@ -12,8 +12,6 @@ import javax.persistence.Tuple;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfLists;
-import org.hibernate.testing.orm.domain.gambit.EnumValue;
-import org.hibernate.testing.orm.domain.gambit.SimpleComponent;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;


### PR DESCRIPTION
Also includes:
- Some general Firebird improvements
- Tweak tests to run (or be skipped) against Firebird
- Fix to BooleanDecoder
- Add statistical/linear regression function definitions in CommonFunctionFactory
- Added the relevant functions to other dialects where I could verify they apply
- Fix for unions with parenthesized selects
- Add casts for parameters in functions