### PR TITLE
HHH-10999 Add support for SQL array types mapped as Java arrays

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -396,6 +396,12 @@ Can also specify the name of the constant in `org.hibernate.type.SqlTypes` inste
 Global setting identifying the preferred JDBC type code for storing instant values.
 Can also specify the name of the constant in `org.hibernate.type.SqlTypes` instead.
 
+`*hibernate.type.preferred_array_jdbc_type*` (e.g. `2003` for `java.sql.Types.ARRAY`)::
+Global setting identifying the preferred JDBC type code for storing basic array and collection values.
+Can also specify the name of the constant in `org.hibernate.type.SqlTypes` instead.
++
+The default value is determined via `org.hibernate.dialect.Dialect.getPreferredSqlTypeCodeForArray()`.
+
 ==== Bean Validation options
 `*jakarta.persistence.validation.factory*` (e.g. `jakarta.validation.ValidationFactory` implementation)::
 Specify the  `javax.validation.ValidationFactory` implementation to use for Bean Validation.

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -396,12 +396,6 @@ Can also specify the name of the constant in `org.hibernate.type.SqlTypes` inste
 Global setting identifying the preferred JDBC type code for storing instant values.
 Can also specify the name of the constant in `org.hibernate.type.SqlTypes` instead.
 
-`*hibernate.type.preferred_array_jdbc_type*` (e.g. `2003` for `java.sql.Types.ARRAY`)::
-Global setting identifying the preferred JDBC type code for storing basic array and collection values.
-Can also specify the name of the constant in `org.hibernate.type.SqlTypes` instead.
-+
-The default value is determined via `org.hibernate.dialect.Dialect.getPreferredSqlTypeCodeForArray()`.
-
 ==== Bean Validation options
 `*jakarta.persistence.validation.factory*` (e.g. `jakarta.validation.ValidationFactory` implementation)::
 Specify the  `javax.validation.ValidationFactory` implementation to use for Bean Validation.

--- a/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
@@ -1374,6 +1374,42 @@ include::{sourcedir}/basic/XmlMappingTests.java[tags=basic-xml-example]
 ----
 ====
 
+[[basic-mapping-array]]
+==== Basic array mapping
+
+Basic arrays, other than `byte[]`/Byte[] and `char[]`/`Character[]`, map to the type code `SqlTypes.ARRAY` by default,
+which maps to the SQL standard `array` type if possible,
+as determined via the new methods `getArrayTypeName` and `supportsStandardArrays` of `org.hibernate.dialect.Dialect`.
+If SQL standard array types are not available, data will be modeled as `SqlTypes.JSON`, `SqlTypes.XML` or `SqlTypes.VARBINARY`,
+depending on the database support as determined via the new method `org.hibernate.dialect.Dialect.getPreferredSqlTypeCodeForArray`.
+
+[[basic-array-example]]
+.Mapping basic arrays
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/basic/BasicArrayMappingTests.java[tags=basic-array-example]
+----
+====
+
+[[basic-mapping-collection]]
+==== Basic collection mapping
+
+Basic collections (only subtypes of `Collection`), which are not annotated with `@ElementCollection`,
+map to the type code `SqlTypes.ARRAY` by default, which maps to the SQL standard `array` type if possible,
+as determined via the new methods `getArrayTypeName` and `supportsStandardArrays` of `org.hibernate.dialect.Dialect`.
+If SQL standard array types are not available, data will be modeled as `SqlTypes.JSON`, `SqlTypes.XML` or `SqlTypes.VARBINARY`,
+depending on the database support as determined via the new method `org.hibernate.dialect.Dialect.getPreferredSqlTypeCodeForArray`.
+
+[[basic-collection-example]]
+.Mapping basic collections
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/basic/BasicCollectionMappingTests.java[tags=basic-collection-example]
+----
+====
+
 
 [[basic-mapping-composition]]
 ==== Compositional basic mapping

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BasicArrayMappingTests.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BasicArrayMappingTests.java
@@ -1,0 +1,95 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.userguide.mapping.basic;
+
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for mapping basic arrays
+ */
+@DomainModel(annotatedClasses = BasicArrayMappingTests.EntityOfArrays.class)
+@SessionFactory
+public class BasicArrayMappingTests {
+
+	@Test
+	public void testMappings(SessionFactoryScope scope) {
+		// first, verify the type selections...
+		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
+				.getRuntimeMetamodels()
+				.getMappingMetamodel();
+		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor( EntityOfArrays.class);
+
+		{
+			final BasicAttributeMapping attribute = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("wrapper");
+			assertThat( attribute.getJavaType().getJavaTypeClass(), equalTo( Short[].class));
+
+			final JdbcMapping jdbcMapping = attribute.getJdbcMapping();
+			assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(Short[].class));
+		}
+
+		{
+			final BasicAttributeMapping attribute = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("primitive");
+			assertThat( attribute.getJavaType().getJavaTypeClass(), equalTo( short[].class));
+
+			final JdbcMapping jdbcMapping = attribute.getJdbcMapping();
+			assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(short[].class));
+		}
+
+
+		// and try to use the mapping
+		scope.inTransaction(
+				(session) -> session.persist(new EntityOfArrays( 1, new Short[]{ (short) 3 }, new short[]{ (short) 5 }))
+		);
+		scope.inTransaction(
+				(session) -> session.get( EntityOfArrays.class, 1)
+		);
+	}
+
+	@AfterEach
+	public void dropData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> session.createQuery("delete EntityOfArrays").executeUpdate()
+		);
+	}
+
+	@Entity(name = "EntityOfArrays")
+	@Table(name = "EntityOfArrays")
+	public static class EntityOfArrays {
+		@Id
+		Integer id;
+
+		//tag::basic-array-example[]
+		Short[] wrapper;
+		short[] primitive;
+		//end::basic-array-example[]
+
+		public EntityOfArrays() {
+		}
+
+		public EntityOfArrays(Integer id, Short[] wrapper, short[] primitive) {
+			this.id = id;
+			this.wrapper = wrapper;
+			this.primitive = primitive;
+		}
+	}
+}

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BasicCollectionMappingTests.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/BasicCollectionMappingTests.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.userguide.mapping.basic;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for mapping basic collections
+ */
+@DomainModel(annotatedClasses = BasicCollectionMappingTests.EntityOfCollections.class)
+@SessionFactory
+public class BasicCollectionMappingTests {
+
+	@Test
+	public void testMappings(SessionFactoryScope scope) {
+		// first, verify the type selections...
+		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
+				.getRuntimeMetamodels()
+				.getMappingMetamodel();
+		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor( EntityOfCollections.class);
+
+		{
+			final BasicAttributeMapping attribute = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("list");
+			assertThat( attribute.getJavaType().getJavaTypeClass(), equalTo( List.class));
+
+			final JdbcMapping jdbcMapping = attribute.getJdbcMapping();
+			assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(List.class));
+		}
+
+		{
+			final BasicAttributeMapping attribute = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("sortedSet");
+			assertThat( attribute.getJavaType().getJavaTypeClass(), equalTo( SortedSet.class));
+
+			final JdbcMapping jdbcMapping = attribute.getJdbcMapping();
+			assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(SortedSet.class));
+		}
+
+
+		// and try to use the mapping
+		scope.inTransaction(
+				(session) -> session.persist(
+						new EntityOfCollections(
+								1,
+								List.of( (short) 3 ),
+								new TreeSet<>( Set.of( (short) 5 ) )
+						)
+				)
+		);
+		scope.inTransaction(
+				(session) -> session.get( EntityOfCollections.class, 1)
+		);
+	}
+
+	@AfterEach
+	public void dropData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> session.createQuery("delete EntityOfCollections").executeUpdate()
+		);
+	}
+
+	@Entity(name = "EntityOfCollections")
+	@Table(name = "EntityOfCollections")
+	public static class EntityOfCollections {
+		@Id
+		Integer id;
+
+		//tag::basic-collection-example[]
+		List<Short> list;
+		SortedSet<Short> sortedSet;
+		//end::basic-collection-example[]
+
+		public EntityOfCollections() {
+		}
+
+		public EntityOfCollections(Integer id, List<Short> list, SortedSet<Short> sortedSet) {
+			this.id = id;
+			this.list = list;
+			this.sortedSet = sortedSet;
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -218,6 +218,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private final int preferredSqlTypeCodeForDuration;
 	private final int preferredSqlTypeCodeForUuid;
 	private final int preferredSqlTypeCodeForInstant;
+	private final int preferredSqlTypeCodeForArray;
 	private final TimeZoneStorageStrategy defaultTimeZoneStorageStrategy;
 
 	// Caching
@@ -428,6 +429,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.preferredSqlTypeCodeForDuration = ConfigurationHelper.getPreferredSqlTypeCodeForDuration( serviceRegistry );
 		this.preferredSqlTypeCodeForUuid = ConfigurationHelper.getPreferredSqlTypeCodeForUuid( serviceRegistry );
 		this.preferredSqlTypeCodeForInstant = ConfigurationHelper.getPreferredSqlTypeCodeForInstant( serviceRegistry );
+		this.preferredSqlTypeCodeForArray = ConfigurationHelper.getPreferredSqlTypeCodeForArray( serviceRegistry );
 		this.defaultTimeZoneStorageStrategy = context.getMetadataBuildingOptions().getDefaultTimeZoneStorage();
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
@@ -1240,6 +1242,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public int getPreferredSqlTypeCodeForInstant() {
 		return preferredSqlTypeCodeForInstant;
+	}
+
+	@Override
+	public int getPreferredSqlTypeCodeForArray() {
+		return preferredSqlTypeCodeForArray;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinition.java
@@ -207,7 +207,7 @@ public class TypeDefinition implements Serializable {
 
 					@Override
 					public BasicValueConverter getValueConverter() {
-						return null;
+						return resolvedBasicType.getValueConverter();
 					}
 
 					@Override
@@ -259,7 +259,7 @@ public class TypeDefinition implements Serializable {
 
 				@Override
 				public BasicValueConverter getValueConverter() {
-					return null;
+					return resolved.getValueConverter();
 				}
 
 				@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -25,6 +25,7 @@ import org.hibernate.type.AdjustableBasicType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CustomType;
 import org.hibernate.type.SerializableType;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.BasicPluralJavaType;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.EnumJavaType;
@@ -144,6 +145,16 @@ public class InferredBasicValueResolver {
 						stdIndicators,
 						typeConfiguration
 				);
+			}
+			else if ( explicitJdbcType != null ) {
+				// we also have an explicit JdbcType
+
+				jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
+						reflectedJtd,
+						explicitJdbcType
+				);
+
+				legacyType = jdbcMapping;
 			}
 			else if ( explicitJdbcType != null ) {
 				// we also have an explicit JdbcType
@@ -417,7 +428,7 @@ public class InferredBasicValueResolver {
 
 		final JdbcType jdbcType = explicitJdbcType != null
 				? explicitJdbcType
-				: typeConfiguration.getJdbcTypeRegistry().getDescriptor( stdIndicators.getPreferredSqlTypeCodeForEnum() );
+				: typeConfiguration.getJdbcTypeRegistry().getDescriptor( SqlTypes.SMALLINT );
 
 		final OrdinalEnumValueConverter<E> valueConverter = new OrdinalEnumValueConverter<>(
 				enumJavaType,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -8,23 +8,24 @@ package org.hibernate.boot.model.process.internal;
 
 import java.io.Serializable;
 import java.lang.reflect.Type;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
 import org.hibernate.metamodel.model.convert.internal.NamedEnumValueConverter;
 import org.hibernate.metamodel.model.convert.internal.OrdinalEnumValueConverter;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.AdjustableBasicType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CustomType;
 import org.hibernate.type.SerializableType;
-import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.java.BasicPluralJavaType;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.EnumJavaType;
 import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
@@ -52,6 +53,7 @@ public class InferredBasicValueResolver {
 			Selectable selectable,
 			String ownerName,
 			String propertyName,
+			Dialect dialect,
 			TypeConfiguration typeConfiguration) {
 		final JavaType<T> reflectedJtd = reflectedJtdResolver.get();
 
@@ -64,8 +66,26 @@ public class InferredBasicValueResolver {
 
 		if ( explicitJavaType != null ) {
 			// we have an explicit JavaType
-
-			if ( explicitJdbcType != null ) {
+			if ( explicitJavaType instanceof EnumJavaType ) {
+				return fromEnum(
+						(EnumJavaType) explicitJavaType,
+						null,
+						explicitJdbcType,
+						stdIndicators,
+						typeConfiguration
+				);
+			}
+			else if ( explicitJavaType instanceof TemporalJavaType ) {
+				return fromTemporal(
+						(TemporalJavaType<T>) explicitJavaType,
+						null,
+						explicitJdbcType,
+						resolvedJavaType,
+						stdIndicators,
+						typeConfiguration
+				);
+			}
+			else if ( explicitJdbcType != null ) {
 				// we also have an explicit JdbcType
 
 				jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
@@ -75,41 +95,12 @@ public class InferredBasicValueResolver {
 				legacyType = jdbcMapping;
 			}
 			else {
-				if ( explicitJavaType instanceof TemporalJavaType ) {
-					return fromTemporal(
-							(TemporalJavaType<T>) explicitJavaType,
-							null,
-							null,
-							resolvedJavaType,
-							stdIndicators,
-							typeConfiguration
-					);
-				}
 				// we need to infer the JdbcType and use that to build the value-mapping
 				final JdbcType inferredJdbcType = explicitJavaType.getRecommendedJdbcType( stdIndicators );
 				if ( inferredJdbcType instanceof ObjectJdbcType ) {
 					// have a "fallback" JDBC type... see if we can decide a better choice
 
-					if ( explicitJavaType instanceof EnumJavaType ) {
-						return fromEnum(
-								(EnumJavaType) reflectedJtd,
-								explicitJavaType,
-								null,
-								stdIndicators,
-								typeConfiguration
-						);
-					}
-					else if ( explicitJavaType instanceof TemporalJavaType ) {
-						return fromTemporal(
-								(TemporalJavaType<T>) reflectedJtd,
-								explicitJavaType,
-								null,
-								resolvedJavaType,
-								stdIndicators,
-								typeConfiguration
-						);
-					}
-					else if ( explicitJavaType instanceof SerializableJavaType
+					if ( explicitJavaType instanceof SerializableJavaType
 							|| explicitJavaType.getJavaType() instanceof Serializable ) {
 						legacyType = new SerializableType( explicitJavaType );
 						jdbcMapping = legacyType;
@@ -133,7 +124,28 @@ public class InferredBasicValueResolver {
 		}
 		else if ( reflectedJtd != null ) {
 			// we were able to determine the "reflected java-type"
-			if ( explicitJdbcType != null ) {
+			// Use JTD if we know it to apply any specialized resolutions
+
+			if ( reflectedJtd instanceof EnumJavaType ) {
+				return fromEnum(
+						(EnumJavaType) reflectedJtd,
+						null,
+						explicitJdbcType,
+						stdIndicators,
+						typeConfiguration
+				);
+			}
+			else if ( reflectedJtd instanceof TemporalJavaType ) {
+				return fromTemporal(
+						(TemporalJavaType<T>) reflectedJtd,
+						null,
+						explicitJdbcType,
+						resolvedJavaType,
+						stdIndicators,
+						typeConfiguration
+				);
+			}
+			else if ( explicitJdbcType != null ) {
 				// we also have an explicit JdbcType
 
 				jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
@@ -144,59 +156,85 @@ public class InferredBasicValueResolver {
 				legacyType = jdbcMapping;
 			}
 			else {
-				// Use JTD if we know it to apply any specialized resolutions
-
-				if ( reflectedJtd instanceof EnumJavaType ) {
-					return fromEnum(
-							(EnumJavaType) reflectedJtd,
-							null,
-							null,
-							stdIndicators,
-							typeConfiguration
+				// see if there is a registered BasicType for this JavaType and, if so, use it.
+				// this mimics the legacy handling
+				final BasicType registeredType;
+				if ( reflectedJtd instanceof BasicPluralJavaType<?> ) {
+					final BasicPluralJavaType<?> containerJtd = (BasicPluralJavaType<?>) reflectedJtd;
+					final JavaType<?> elementJtd = containerJtd.getElementJavaType();
+					final BasicType registeredElementType;
+					if ( elementJtd instanceof EnumJavaType ) {
+						final InferredBasicValueResolution resolution = InferredBasicValueResolver.fromEnum(
+								(EnumJavaType) elementJtd,
+								null,
+								null,
+								stdIndicators,
+								typeConfiguration
+						);
+						registeredElementType = resolution.getLegacyResolvedBasicType();
+					}
+					else if ( elementJtd instanceof TemporalJavaType ) {
+						final InferredBasicValueResolution resolution = InferredBasicValueResolver.fromTemporal(
+								(TemporalJavaType<T>) elementJtd,
+								null,
+								null,
+								resolvedJavaType,
+								stdIndicators,
+								typeConfiguration
+						);
+						registeredElementType = resolution.getLegacyResolvedBasicType();
+					}
+					else {
+						registeredElementType = typeConfiguration.getBasicTypeRegistry()
+								.getRegisteredType( elementJtd.getJavaType() );
+					}
+					final ColumnTypeInformation columnTypeInformation;
+					if ( selectable instanceof ColumnTypeInformation ) {
+						columnTypeInformation = (ColumnTypeInformation) selectable;
+					}
+					else {
+						columnTypeInformation = null;
+					}
+					registeredType = registeredElementType == null ? null : containerJtd.resolveType(
+							typeConfiguration,
+							dialect,
+							registeredElementType,
+							columnTypeInformation
 					);
-				}
-				else if ( reflectedJtd instanceof TemporalJavaType ) {
-					return fromTemporal(
-							(TemporalJavaType<T>) reflectedJtd,
-							null,
-							null,
-							resolvedJavaType,
-							stdIndicators,
-							typeConfiguration
-					);
+					if ( registeredType != null ) {
+						typeConfiguration.getBasicTypeRegistry().register( registeredType );
+					}
 				}
 				else {
-					// see if there is a registered BasicType for this JavaType and, if so, use it.
-					// this mimics the legacy handling
-					final BasicType<T> registeredType = typeConfiguration.getBasicTypeRegistry()
+					registeredType = typeConfiguration.getBasicTypeRegistry()
 							.getRegisteredType( reflectedJtd.getJavaType() );
+				}
 
-					if ( registeredType != null ) {
-						// so here is the legacy resolution
-						legacyType = resolveSqlTypeIndicators( stdIndicators, registeredType, reflectedJtd );
+				if ( registeredType != null ) {
+					// so here is the legacy resolution
+					legacyType = resolveSqlTypeIndicators( stdIndicators, registeredType, reflectedJtd );
+					jdbcMapping = legacyType;
+				}
+				else {
+					// there was not a "legacy" BasicType registration,  so use `JavaType#getRecommendedJdbcType`, if
+					// one, to create a mapping
+					final JdbcType recommendedJdbcType = reflectedJtd.getRecommendedJdbcType( stdIndicators );
+					if ( recommendedJdbcType != null ) {
+						jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
+								reflectedJtd,
+								recommendedJdbcType
+						);
+						legacyType = jdbcMapping;
+					}
+					else if ( reflectedJtd instanceof SerializableJavaType
+							|| Serializable.class.isAssignableFrom( reflectedJtd.getJavaTypeClass() ) ) {
+						legacyType = new SerializableType( reflectedJtd );
 						jdbcMapping = legacyType;
 					}
 					else {
-						// there was not a "legacy" BasicType registration,  so use `JavaType#getRecommendedJdbcType`, if
-						// one, to create a mapping
-						final JdbcType recommendedJdbcType = reflectedJtd.getRecommendedJdbcType( stdIndicators );
-						if ( recommendedJdbcType != null ) {
-							jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
-									reflectedJtd,
-									recommendedJdbcType
-							);
-							legacyType = jdbcMapping;
-						}
-						else if ( reflectedJtd instanceof SerializableJavaType
-								|| Serializable.class.isAssignableFrom( reflectedJtd.getJavaTypeClass() ) ) {
-							legacyType = new SerializableType( reflectedJtd );
-							jdbcMapping = legacyType;
-						}
-						else {
-							// let this fall through to the exception creation below
-							legacyType = null;
-							jdbcMapping = null;
-						}
+						// let this fall through to the exception creation below
+						legacyType = null;
+						jdbcMapping = null;
 					}
 				}
 			}
@@ -271,40 +309,40 @@ public class InferredBasicValueResolver {
 		);
 	}
 
-	/**
-	 * Create an inference-based resolution
-	 */
-	public static <T> BasicValue.Resolution<T> from(
-			Function<TypeConfiguration, BasicJavaType> explicitJavaTypeAccess,
-			Function<TypeConfiguration, JdbcType> explicitSqlTypeAccess,
-			Type resolvedJavaType,
-			Supplier<JavaType<T>> reflectedJtdResolver,
-			JdbcTypeIndicators stdIndicators,
-			Table table,
-			Selectable selectable,
-			String ownerName,
-			String propertyName,
-			TypeConfiguration typeConfiguration) {
-
-		final BasicJavaType<T> explicitJavaType = explicitJavaTypeAccess != null
-				? explicitJavaTypeAccess.apply( typeConfiguration )
-				: null;
-		final JdbcType explicitJdbcType = explicitSqlTypeAccess
-				!= null ? explicitSqlTypeAccess.apply( typeConfiguration )
-				: null;
-		return InferredBasicValueResolver.from(
-				explicitJavaType,
-				explicitJdbcType,
-				resolvedJavaType,
-				reflectedJtdResolver,
-				stdIndicators,
-				table,
-				selectable,
-				ownerName,
-				propertyName,
-				typeConfiguration
-		);
-	}
+//	/**
+//	 * Create an inference-based resolution
+//	 */
+//	public static <T> BasicValue.Resolution<T> from(
+//			Function<TypeConfiguration, BasicJavaType> explicitJavaTypeAccess,
+//			Function<TypeConfiguration, JdbcType> explicitSqlTypeAccess,
+//			Type resolvedJavaType,
+//			Supplier<JavaType<T>> reflectedJtdResolver,
+//			JdbcTypeIndicators stdIndicators,
+//			Table table,
+//			Selectable selectable,
+//			String ownerName,
+//			String propertyName,
+//			TypeConfiguration typeConfiguration) {
+//
+//		final BasicJavaType<T> explicitJavaType = explicitJavaTypeAccess != null
+//				? explicitJavaTypeAccess.apply( typeConfiguration )
+//				: null;
+//		final JdbcType explicitJdbcType = explicitSqlTypeAccess
+//				!= null ? explicitSqlTypeAccess.apply( typeConfiguration )
+//				: null;
+//		return InferredBasicValueResolver.from(
+//				explicitJavaType,
+//				explicitJdbcType,
+//				resolvedJavaType,
+//				reflectedJtdResolver,
+//				stdIndicators,
+//				table,
+//				selectable,
+//				ownerName,
+//				propertyName,
+//				typeConfiguration
+//		);
+//	}
 
 	public static <T> BasicType<T> resolveSqlTypeIndicators(
 			JdbcTypeIndicators stdIndicators,
@@ -345,6 +383,7 @@ public class InferredBasicValueResolver {
 						enumJavaType,
 						explicitJavaType,
 						explicitJdbcType,
+						stdIndicators,
 						typeConfiguration
 				);
 			}
@@ -354,12 +393,13 @@ public class InferredBasicValueResolver {
 		}
 	}
 
-	private static <E extends Enum<E>> InferredBasicValueResolution<E, Integer> ordinalEnumValueResolution(
+	private static <E extends Enum<E>> InferredBasicValueResolution<E, Number> ordinalEnumValueResolution(
 			EnumJavaType<E> enumJavaType,
 			BasicJavaType<?> explicitJavaType,
 			JdbcType explicitJdbcType,
+			JdbcTypeIndicators stdIndicators,
 			TypeConfiguration typeConfiguration) {
-		final JavaType<Integer> relationalJtd;
+		final JavaType<Number> relationalJtd;
 		if ( explicitJavaType != null ) {
 			if ( ! Integer.class.isAssignableFrom( explicitJavaType.getJavaTypeClass() ) ) {
 				throw new MappingException(
@@ -369,7 +409,7 @@ public class InferredBasicValueResolver {
 				);
 			}
 			//noinspection unchecked
-			relationalJtd = (BasicJavaType<Integer>) explicitJavaType;
+			relationalJtd = (BasicJavaType<Number>) explicitJavaType;
 		}
 		else {
 			relationalJtd = typeConfiguration.getJavaTypeRegistry().getDescriptor( Integer.class );
@@ -377,7 +417,7 @@ public class InferredBasicValueResolver {
 
 		final JdbcType jdbcType = explicitJdbcType != null
 				? explicitJdbcType
-				: typeConfiguration.getJdbcTypeRegistry().getDescriptor( SqlTypes.TINYINT );
+				: typeConfiguration.getJdbcTypeRegistry().getDescriptor( stdIndicators.getPreferredSqlTypeCodeForEnum() );
 
 		final OrdinalEnumValueConverter<E> valueConverter = new OrdinalEnumValueConverter<>(
 				enumJavaType,
@@ -386,7 +426,7 @@ public class InferredBasicValueResolver {
 		);
 
 		return new InferredBasicValueResolution<>(
-				typeConfiguration.getBasicTypeRegistry().resolve(relationalJtd, jdbcType),
+				typeConfiguration.getBasicTypeRegistry().resolve( relationalJtd, jdbcType ),
 				enumJavaType,
 				relationalJtd,
 				jdbcType,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/UserTypeResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/UserTypeResolution.java
@@ -58,6 +58,9 @@ public class UserTypeResolution implements BasicValue.Resolution {
 
 	@Override
 	public BasicValueConverter getValueConverter() {
+		// Even though we could expose the value converter of the user type here,
+		// we can not do it, as the conversion is done behind the scenes in the binder/extractor,
+		// whereas the converter returned here would, AFAIU, be used to construct a converted attribute mapping
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ValueConverterTypeAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ValueConverterTypeAdapter.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.ConvertedBasicType;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
@@ -22,7 +23,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 /**
  * @author Steve Ebersole
  */
-public class ValueConverterTypeAdapter<J> extends AbstractSingleColumnStandardBasicType<J> {
+public class ValueConverterTypeAdapter<J> extends AbstractSingleColumnStandardBasicType<J> implements ConvertedBasicType<J> {
 	private final String description;
 	private final BasicValueConverter<J, Object> converter;
 
@@ -73,6 +74,11 @@ public class ValueConverterTypeAdapter<J> extends AbstractSingleColumnStandardBa
 	public boolean isEqual(Object one, Object another) {
 		//noinspection unchecked
 		return ( (JavaType<Object>) converter.getDomainJavaType() ).areEqual( one, another );
+	}
+
+	@Override
+	public BasicValueConverter getValueConverter() {
+		return converter;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -77,6 +77,31 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 						}
 						return context.getBuildingOptions().getDefaultTimeZoneStorage();
 					}
+
+					@Override
+					public int getPreferredSqlTypeCodeForBoolean() {
+						return context.getPreferredSqlTypeCodeForBoolean();
+					}
+
+					@Override
+					public int getPreferredSqlTypeCodeForDuration() {
+						return context.getPreferredSqlTypeCodeForDuration();
+					}
+
+					@Override
+					public int getPreferredSqlTypeCodeForUuid() {
+						return context.getPreferredSqlTypeCodeForUuid();
+					}
+
+					@Override
+					public int getPreferredSqlTypeCodeForInstant() {
+						return context.getPreferredSqlTypeCodeForInstant();
+					}
+
+					@Override
+					public int getPreferredSqlTypeCodeForArray() {
+						return context.getPreferredSqlTypeCodeForArray();
+					}
 				}
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -134,7 +134,7 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 
 	@Override
 	public BasicValueConverter<E,E> getValueConverter() {
-		return null;
+		return legacyType.getValueConverter();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -401,6 +401,15 @@ public class MetadataBuildingProcess {
 		}
 		jdbcTypeRegistry.addDescriptorIfAbsent( JsonJdbcType.INSTANCE );
 		jdbcTypeRegistry.addDescriptorIfAbsent( XmlAsStringJdbcType.INSTANCE );
+
+		final int preferredSqlTypeCodeForArray = ConfigurationHelper.getPreferredSqlTypeCodeForArray( bootstrapContext.getServiceRegistry() );
+		if ( preferredSqlTypeCodeForArray != SqlTypes.ARRAY ) {
+			jdbcTypeRegistry.addDescriptor( SqlTypes.ARRAY, jdbcTypeRegistry.getDescriptor( preferredSqlTypeCodeForArray ) );
+		}
+		else if ( jdbcTypeRegistry.findDescriptor( SqlTypes.ARRAY ) == null ) {
+			// Fallback to VARBINARY
+			jdbcTypeRegistry.addDescriptor( SqlTypes.ARRAY, jdbcTypeRegistry.getDescriptor( SqlTypes.VARBINARY ) );
+		}
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.INET, SqlTypes.VARBINARY );
 		final int preferredSqlTypeCodeForDuration = ConfigurationHelper.getPreferredSqlTypeCodeForDuration( bootstrapContext.getServiceRegistry() );
 		if ( preferredSqlTypeCodeForDuration != SqlTypes.INTERVAL_SECOND ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;
@@ -450,6 +451,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	@Override
 	public int getPreferredSqlTypeCodeForInstant() {
 		return delegate.getPreferredSqlTypeCodeForInstant();
+	}
+
+	@Override
+	public int getPreferredSqlTypeCodeForArray() {
+		return delegate.getPreferredSqlTypeCodeForArray();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -12,7 +12,6 @@ import java.util.function.Supplier;
 
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
-import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
@@ -72,6 +72,11 @@ public interface MetadataBuildingContext {
 		return ConfigurationHelper.getPreferredSqlTypeCodeForInstant( getBootstrapContext().getServiceRegistry() );
 	}
 
+	@Incubating
+	default int getPreferredSqlTypeCodeForArray() {
+		return ConfigurationHelper.getPreferredSqlTypeCodeForArray( getBootstrapContext().getServiceRegistry() );
+	}
+
 	TypeDefinitionRegistry getTypeDefinitionRegistry();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -311,6 +311,9 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	@Incubating
 	int getPreferredSqlTypeCodeForInstant();
 
+	@Incubating
+	int getPreferredSqlTypeCodeForArray();
+
 	TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy();
 
 	FormatMapper getJsonFormatMapper();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -158,6 +158,7 @@ import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.CompositeUserType;
 import org.hibernate.usertype.UserType;
@@ -1702,7 +1703,39 @@ public final class AnnotationBinder {
 
 		final JavaType<Object> jtd = typeConfiguration.getJavaTypeRegistry().findDescriptor( type );
 		if ( jtd != null ) {
-			final JdbcType jdbcType = jtd.getRecommendedJdbcType( typeConfiguration.getCurrentBaseSqlTypeIndicators() );
+			final JdbcType jdbcType = jtd.getRecommendedJdbcType(
+					new JdbcTypeIndicators() {
+						@Override
+						public TypeConfiguration getTypeConfiguration() {
+							return typeConfiguration;
+						}
+
+						@Override
+						public int getPreferredSqlTypeCodeForBoolean() {
+							return context.getPreferredSqlTypeCodeForBoolean();
+						}
+
+						@Override
+						public int getPreferredSqlTypeCodeForDuration() {
+							return context.getPreferredSqlTypeCodeForDuration();
+						}
+
+						@Override
+						public int getPreferredSqlTypeCodeForUuid() {
+							return context.getPreferredSqlTypeCodeForUuid();
+						}
+
+						@Override
+						public int getPreferredSqlTypeCodeForInstant() {
+							return context.getPreferredSqlTypeCodeForInstant();
+						}
+
+						@Override
+						public int getPreferredSqlTypeCodeForArray() {
+							return context.getPreferredSqlTypeCodeForArray();
+						}
+					}
+			);
 			return typeConfiguration.getBasicTypeRegistry().resolve( jtd, jdbcType );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2557,23 +2557,6 @@ public interface AvailableSettings {
 	String PREFERRED_INSTANT_JDBC_TYPE = "hibernate.type.preferred_instant_jdbc_type";
 
 	/**
-	 * Specifies the preferred JDBC type for storing basic array and collection values. When no
-	 * type is explicitly specified, a sensible
-	 * {@link org.hibernate.dialect.Dialect#getPreferredSqlTypeCodeForArray()
-	 * dialect-specific default type code} is used.
-	 *
-	 * Can be overridden locally using {@link org.hibernate.annotations.JdbcType},
-	 * {@link org.hibernate.annotations.JdbcTypeCode} and friends
-	 *
-	 * Can also specify the name of the {@link org.hibernate.type.SqlTypes} constant field.  E.g.
-	 * {@code hibernate.type.preferred_array_jdbc_type=VARBINARY}
-	 *
-	 * @since 6.1
-	 */
-	@Incubating
-	String PREFERRED_ARRAY_JDBC_TYPE = "hibernate.type.preferred_array_jdbc_type";
-
-	/**
 	 * Specifies a {@link org.hibernate.type.FormatMapper} used for JSON serialization
 	 * and deserialization, either:
 	 * <ul>

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2557,6 +2557,23 @@ public interface AvailableSettings {
 	String PREFERRED_INSTANT_JDBC_TYPE = "hibernate.type.preferred_instant_jdbc_type";
 
 	/**
+	 * Specifies the preferred JDBC type for storing basic array and collection values. When no
+	 * type is explicitly specified, a sensible
+	 * {@link org.hibernate.dialect.Dialect#getPreferredSqlTypeCodeForArray()
+	 * dialect-specific default type code} is used.
+	 *
+	 * Can be overridden locally using {@link org.hibernate.annotations.JdbcType},
+	 * {@link org.hibernate.annotations.JdbcTypeCode} and friends
+	 *
+	 * Can also specify the name of the {@link org.hibernate.type.SqlTypes} constant field.  E.g.
+	 * {@code hibernate.type.preferred_array_jdbc_type=VARBINARY}
+	 *
+	 * @since 6.1
+	 */
+	@Incubating
+	String PREFERRED_ARRAY_JDBC_TYPE = "hibernate.type.preferred_array_jdbc_type";
+
+	/**
 	 * Specifies a {@link org.hibernate.type.FormatMapper} used for JSON serialization
 	 * and deserialization, either:
 	 * <ul>

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -232,6 +232,11 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForArray() {
+		return buildingContext.getPreferredSqlTypeCodeForArray();
+	}
+
+	@Override
 	public boolean isNationalized() {
 		return isNationalized;
 	}
@@ -719,10 +724,10 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 			this.temporalPrecision = null;
 		}
 
-		if ( javaTypeClass.isEnum() ) {
-			final Enumerated enumeratedAnn = attributeDescriptor.getAnnotation( Enumerated.class );
-			if ( enumeratedAnn != null ) {
-				this.enumType = enumeratedAnn.value();
+		final Enumerated enumeratedAnn = attributeDescriptor.getAnnotation( Enumerated.class );
+		if ( enumeratedAnn != null ) {
+			this.enumType = enumeratedAnn.value();
+			if ( javaTypeClass.isEnum() || javaTypeClass.isArray() && javaTypeClass.getComponentType().isEnum() ) {
 				if ( this.enumType == null ) {
 					throw new IllegalStateException(
 							"jakarta.persistence.EnumType was null on @jakarta.persistence.Enumerated " +
@@ -731,9 +736,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 					);
 				}
 			}
-		}
-		else {
-			if ( attributeDescriptor.isAnnotationPresent( Enumerated.class ) ) {
+			else {
 				throw new AnnotationException(
 						String.format(
 								"Attribute [%s.%s] was annotated as enumerated, but its java type is not an enum [%s]",
@@ -743,6 +746,8 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 						)
 				);
 			}
+		}
+		else {
 			this.enumType = null;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedMapSemantics.java
@@ -43,7 +43,9 @@ public class StandardSortedMapSemantics<K,V> extends AbstractMapSemantics<Sorted
 	public TreeMap<K,V> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return new TreeMap<K,V>( (Comparator) collectionDescriptor.getSortingComparator() );
+		return new TreeMap<K,V>(
+				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/internal/StandardSortedSetSemantics.java
@@ -44,7 +44,9 @@ public class StandardSortedSetSemantics<E> extends AbstractSetSemantics<SortedSe
 	public SortedSet<E> instantiateRaw(
 			int anticipatedSize,
 			CollectionPersister collectionDescriptor) {
-		return new TreeSet<E>( (Comparator) collectionDescriptor.getSortingComparator() );
+		return new TreeSet<E>(
+				collectionDescriptor == null ? null : (Comparator) collectionDescriptor.getSortingComparator()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -310,6 +310,11 @@ public class CockroachDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsIfExistsBeforeTableName() {
 		return true;
 	}
@@ -425,6 +430,11 @@ public class CockroachDialect extends Dialect {
 	@Override
 	public int getMaxIdentifierLength() {
 		return 63;
+	}
+
+	@Override
+	public boolean supportsStandardArrays() {
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -192,6 +192,11 @@ public class DB2Dialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return getDB2Version().isSameOrAfter( 11, 1 );
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -73,6 +73,11 @@ public class DB2iDialect extends DB2Dialect {
 				: super.createUniqueDelegate();
 	}
 
+	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return true;
+	}
+
 	/**
 	 * No support for sequences.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -79,6 +79,12 @@ public class DB2zDialect extends DB2Dialect {
 	}
 
 	@Override
+	public boolean supportsDistinctFromPredicate() {
+		// Supported at least since DB2 z/OS 9.0
+		return true;
+	}
+
+	@Override
 	public TimeZoneSupport getTimeZoneSupport() {
 		return getVersion().isAfter(10) ? TimeZoneSupport.NATIVE : TimeZoneSupport.NONE;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -146,11 +146,14 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.InstantAsTimestampJdbcType;
 import org.hibernate.type.descriptor.jdbc.InstantAsTimestampWithTimeZoneJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.LongNVarcharJdbcType;
 import org.hibernate.type.descriptor.jdbc.NCharJdbcType;
@@ -472,13 +475,57 @@ public abstract class Dialect implements ConversionContext {
 		return version;
 	}
 
+	/**
+	 * Resolves the {@link SqlTypes} type code for the given column type name as reported by the database,
+	 * or <code>null</code> if it can't be resolved.
+	 */
+	protected Integer resolveSqlTypeCode(String columnTypeName, TypeConfiguration typeConfiguration) {
+		final int parenthesisIndex = columnTypeName.lastIndexOf( '(' );
+		final String baseTypeName;
+		if ( parenthesisIndex == -1 ) {
+			baseTypeName = columnTypeName;
+		}
+		else {
+			baseTypeName = columnTypeName.substring( 0, parenthesisIndex ).trim();
+		}
+		return resolveSqlTypeCode( columnTypeName, baseTypeName, typeConfiguration );
+	}
+
+	/**
+	 * Resolves the {@link SqlTypes} type code for the given column type name as reported by the database
+	 * and the base type name (i.e. without precision/length and scale), or <code>null</code> if it can't be resolved.
+	 */
+	protected Integer resolveSqlTypeCode(String typeName, String baseTypeName, TypeConfiguration typeConfiguration) {
+		return typeConfiguration.getDdlTypeRegistry().getSqlTypeCode( baseTypeName );
+	}
+
 	public JdbcType resolveSqlTypeDescriptor(
 			String columnTypeName,
 			int jdbcTypeCode,
 			int precision,
 			int scale,
 			JdbcTypeRegistry jdbcTypeRegistry) {
-		return jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+		final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+		if ( jdbcTypeCode == Types.ARRAY && jdbcType instanceof ArrayJdbcType ) {
+			// Special handling for array types, because we need the proper element/component type
+			// To determine the element JdbcType, we pass the database reported type to #resolveSqlTypeCode
+			final int arraySuffixIndex = columnTypeName.toLowerCase( Locale.ROOT ).indexOf( " array" );
+			if ( arraySuffixIndex != -1 ) {
+				final String componentTypeName = columnTypeName.substring( 0, arraySuffixIndex );
+				final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
+				if ( sqlTypeCode != null ) {
+					return ( (ArrayJdbcType) jdbcType ).resolveType(
+							jdbcTypeRegistry.getTypeConfiguration(),
+							jdbcTypeRegistry.getTypeConfiguration().getServiceRegistry()
+									.getService( JdbcServices.class )
+									.getDialect(),
+							jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
+							null
+					);
+				}
+			}
+		}
+		return jdbcType;
 	}
 
 	public int resolveSqlTypeLength(
@@ -1170,8 +1217,8 @@ public abstract class Dialect implements ConversionContext {
 	 * {@link Types#LONGVARBINARY LONGVARBINARY} as the same type, since
 	 * Hibernate doesn't really differentiate these types.
 	 *
-	 * @param typeCode1 the first JDBC type code
-	 * @param typeCode2 the second JDBC type code
+	 * @param column1 the first column type info
+	 * @param column2 the second column type info
 	 *
 	 * @return {@code true} if the two type codes are equivalent
 	 */
@@ -1254,6 +1301,10 @@ public abstract class Dialect implements ConversionContext {
 		}
 		else {
 			typeContributions.contributeJdbcType( InstantAsTimestampJdbcType.INSTANCE );
+		}
+
+		if ( supportsStandardArrays() ) {
+			typeContributions.contributeJdbcType( ArrayJdbcType.INSTANCE );
 		}
 	}
 
@@ -3240,6 +3291,84 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
+	 * Database has native support for SQL standard arrays which can be referred to through base type name.
+	 * Oracle for example doesn't support this, but instead has support for named arrays.
+	 *
+	 * @return boolean
+	 * @since 6.1
+	 */
+	public boolean supportsStandardArrays() {
+		return false;
+	}
+
+	/**
+	 * The SQL type name for the array of the given type name.
+	 *
+	 * @since 6.1
+	 */
+	public String getArrayTypeName(String elementTypeName) {
+		if ( supportsStandardArrays() ) {
+			return elementTypeName + " array";
+		}
+		return null;
+	}
+
+	public void appendArrayLiteral(
+			SqlAppender appender,
+			Object[] literal,
+			JdbcLiteralFormatter<Object> elementFormatter,
+			WrapperOptions wrapperOptions) {
+		if ( !supportsStandardArrays() ) {
+			throw new UnsupportedOperationException( getClass().getName() + " does not support array literals" );
+		}
+		appender.appendSql( "ARRAY[" );
+		if ( literal.length != 0 ) {
+			if ( literal[0] == null ) {
+				appender.appendSql( "null" );
+			}
+			else {
+				elementFormatter.appendJdbcLiteral( appender, literal[0], this, wrapperOptions );
+			}
+			for ( int i = 1; i < literal.length; i++ ) {
+				appender.appendSql( ',' );
+				if ( literal[i] == null ) {
+					appender.appendSql( "null" );
+				}
+				else {
+					elementFormatter.appendJdbcLiteral( appender, literal[i], this, wrapperOptions );
+				}
+			}
+		}
+		appender.appendSql( ']' );
+	}
+
+	/**
+	 * Is this SQL dialect known to support some kind of distinct from predicate.
+	 * <p/>
+	 * Basically, does it support syntax like
+	 * "... where FIRST_NAME IS DISTINCT FROM LAST_NAME"
+	 *
+	 * @return True if this SQL dialect is known to support some kind of distinct from predicate; false otherwise
+	 * @since 6.1
+	 */
+	public boolean supportsDistinctFromPredicate() {
+		return false;
+	}
+
+	/**
+	 * The JDBC {@link SqlTypes type code} to use for mapping
+	 * properties of basic Java array or {@code Collection} types.
+	 * <p>
+	 * Usually {@link SqlTypes#ARRAY} or {@link SqlTypes#VARBINARY}.
+	 *
+	 * @return one of the type codes defined by {@link SqlTypes}.
+	 * @since 6.1
+	 */
+	public int getPreferredSqlTypeCodeForArray() {
+		return supportsStandardArrays() ? ARRAY : VARBINARY;
+	}
+
+	/**
 	 * The JDBC {@link Types type code} to use for mapping
 	 * properties of Java type {@code boolean}.
 	 * <p>
@@ -3644,6 +3773,7 @@ public abstract class Dialect implements ConversionContext {
 				case SqlTypes.DOUBLE:
 				case SqlTypes.REAL:
 					// this is almost always the thing we use:
+					length = null;
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
 					if ( scale != null && scale != 0 ) {
 						throw new IllegalArgumentException("scale has no meaning for floating point numbers");
@@ -3658,6 +3788,7 @@ public abstract class Dialect implements ConversionContext {
 				case SqlTypes.TIMESTAMP:
 				case SqlTypes.TIMESTAMP_WITH_TIMEZONE:
 				case SqlTypes.TIMESTAMP_UTC:
+					length = null;
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
 					if ( scale != null && scale != 0 ) {
 						throw new IllegalArgumentException("scale has no meaning for timestamps");

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -8,6 +8,7 @@ package org.hibernate.dialect;
 
 import java.sql.CallableStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 
 import org.hibernate.PessimisticLockException;
@@ -64,6 +65,7 @@ import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import jakarta.persistence.TemporalType;
 
@@ -166,6 +168,11 @@ public class H2Dialect extends Dialect {
 	public boolean getDefaultNonContextualLobCreation() {
 		// http://code.google.com/p/h2database/issues/detail?id=235
 		return true;
+	}
+
+	@Override
+	public boolean supportsStandardArrays() {
+		return getVersion().isSameOrAfter( 2 );
 	}
 
 	@Override
@@ -327,6 +334,16 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
+	protected Integer resolveSqlTypeCode(String columnTypeName, TypeConfiguration typeConfiguration) {
+		switch ( columnTypeName ) {
+			case "FLOAT(24)":
+				// Use REAL instead of FLOAT to get Float as recommended Java type
+				return Types.REAL;
+		}
+		return super.resolveSqlTypeCode( columnTypeName, typeConfiguration );
+	}
+
+	@Override
 	public JdbcType resolveSqlTypeDescriptor(
 			String columnTypeName,
 			int jdbcTypeCode,
@@ -338,6 +355,15 @@ public class H2Dialect extends Dialect {
 			return jdbcTypeRegistry.getDescriptor( DOUBLE );
 		}
 		return super.resolveSqlTypeDescriptor( columnTypeName, jdbcTypeCode, precision, scale, jdbcTypeRegistry );
+	}
+
+	@Override
+	protected Integer resolveSqlTypeCode(String typeName, String baseTypeName, TypeConfiguration typeConfiguration) {
+		switch ( baseTypeName ) {
+			case "CHARACTER VARYING":
+				return VARCHAR;
+		}
+		return super.resolveSqlTypeCode( typeName, baseTypeName, typeConfiguration );
 	}
 
 	@Override
@@ -418,6 +444,11 @@ public class H2Dialect extends Dialect {
 	@Override
 	public LimitHandler getLimitHandler() {
 		return limitHandler;
+	}
+
+	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -76,6 +76,7 @@ import jakarta.persistence.TemporalType;
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.type.SqlTypes.BLOB;
 import static org.hibernate.type.SqlTypes.CLOB;
+import static org.hibernate.type.SqlTypes.DOUBLE;
 import static org.hibernate.type.SqlTypes.NCLOB;
 import static org.hibernate.type.SqlTypes.NUMERIC;
 
@@ -143,6 +144,15 @@ public class HSQLDialect extends Dialect {
 		}
 
 		return super.columnType( sqlTypeCode );
+	}
+
+	@Override
+	protected Integer resolveSqlTypeCode(String typeName, String baseTypeName, TypeConfiguration typeConfiguration) {
+		switch ( baseTypeName ) {
+			case "DOUBLE":
+				return DOUBLE;
+		}
+		return super.resolveSqlTypeCode( typeName, baseTypeName, typeConfiguration );
 	}
 
 	@Override
@@ -365,6 +375,11 @@ public class HSQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsLockTimeouts() {
 		return false;
 	}
@@ -418,6 +433,11 @@ public class HSQLDialect extends Dialect {
 	@Override
 	public SequenceInformationExtractor getSequenceInformationExtractor() {
 		return SequenceInformationExtractorHSQLDBDatabaseImpl.INSTANCE;
+	}
+
+	@Override
+	public boolean supportsStandardArrays() {
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleArrayJdbcType.java
@@ -1,0 +1,190 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicPluralJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.ObjectJdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Descriptor for {@link Types#ARRAY ARRAY} handling.
+ *
+ * @author Christian Beikov
+ * @author Jordan Gigov
+ */
+public class OracleArrayJdbcType extends ArrayJdbcType {
+
+	public static final OracleArrayJdbcType INSTANCE = new OracleArrayJdbcType( null, ObjectJdbcType.INSTANCE );
+	private static final ClassValue<Method> NAME_BINDER = new ClassValue<Method>() {
+		@Override
+		protected Method computeValue(Class<?> type) {
+			try {
+				return type.getMethod( "setArray", String.class, java.sql.Array.class );
+			}
+			catch ( Exception ex ) {
+				// add logging? Did we get NoSuchMethodException or SecurityException?
+				// Doesn't matter which. We can't use it.
+			}
+			return null;
+		}
+	};
+	private static final Class<?> ORACLE_CONNECTION_CLASS;
+	private static final Method CREATE_ARRAY_METHOD;
+
+	static {
+		try {
+			ORACLE_CONNECTION_CLASS = Class.forName( "oracle.jdbc.OracleConnection" );
+			CREATE_ARRAY_METHOD = ORACLE_CONNECTION_CLASS.getMethod( "createOracleArray", String.class, Object.class );
+		}
+		catch (Exception e) {
+			throw new RuntimeException( "Couldn't initialize OracleArrayJdbcType", e );
+		}
+	}
+
+	private final String typeName;
+
+	public OracleArrayJdbcType(String typeName, JdbcType elementJdbcType) {
+		super( elementJdbcType );
+		this.typeName = typeName;
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaTypeDescriptor) {
+		// No array literal support
+		return null;
+	}
+
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		String typeName = columnTypeInformation.getTypeName();
+		if ( typeName == null || typeName.isBlank() ) {
+			typeName = dialect.getArrayTypeName(
+					typeConfiguration.getDdlTypeRegistry().getTypeName(
+							elementType.getDefaultSqlTypeCode(),
+							dialect
+					)
+			);
+		}
+		if ( typeName == null ) {
+			// Fallback to XML type for the representation of arrays as the native JSON type was only introduced in 21
+			return typeConfiguration.getJdbcTypeRegistry().getDescriptor( SqlTypes.SQLXML );
+		}
+		return new OracleArrayJdbcType( typeName, elementType );
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaTypeDescriptor) {
+		//noinspection unchecked
+		final BasicPluralJavaType<X> containerJavaType = (BasicPluralJavaType<X>) javaTypeDescriptor;
+		return new BasicBinder<X>( javaTypeDescriptor, this ) {
+			@Override
+			protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+				st.setNull( index, Types.ARRAY, typeName );
+			}
+
+			@Override
+			protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+				st.setNull( name, Types.ARRAY, typeName );
+			}
+
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final java.sql.Array arr = getArray( value, containerJavaType, options );
+				st.setArray( index, arr );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				final java.sql.Array arr = getArray( value, containerJavaType, options );
+				final Method nameBinder = NAME_BINDER.get( st.getClass() );
+				if ( nameBinder == null ) {
+					try {
+						st.setObject( name, arr, Types.ARRAY );
+						return;
+					}
+					catch (SQLException ex) {
+						throw new HibernateException( "JDBC driver does not support named parameters for setArray. Use positional.", ex );
+					}
+				}
+				// Not that it's supposed to have setArray(String,Array) by standard.
+				// There are numerous missing methods that only have versions for positional parameter,
+				// but not named ones.
+
+				try {
+					nameBinder.invoke( st, name, arr );
+				}
+				catch ( Throwable t ) {
+					throw new HibernateException( t );
+				}
+			}
+
+			private java.sql.Array getArray(
+					X value,
+					BasicPluralJavaType<X> containerJavaType,
+					WrapperOptions options) throws SQLException {
+				//noinspection unchecked
+				final Class<Object[]> arrayClass = (Class<Object[]>) Array.newInstance(
+						getElementJdbcType().getPreferredJavaTypeClass( options ),
+						0
+				).getClass();
+				final Object[] objects = javaTypeDescriptor.unwrap( value, arrayClass, options );
+
+				final SharedSessionContractImplementor session = options.getSession();
+				final Object oracleConnection = session.getJdbcCoordinator().getLogicalConnection().getPhysicalConnection()
+						.unwrap( ORACLE_CONNECTION_CLASS );
+				try {
+					return (java.sql.Array) CREATE_ARRAY_METHOD.invoke( oracleConnection, typeName, objects );
+				}
+				catch (Exception e) {
+					throw new HibernateException( "Couldn't create a java.sql.Array", e );
+				}
+			}
+		};
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+
+		OracleArrayJdbcType that = (OracleArrayJdbcType) o;
+
+		return typeName.equals( that.typeName );
+	}
+
+	@Override
+	public int hashCode() {
+		return typeName.hashCode();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.boot.model.TypeContributions;
@@ -684,6 +685,20 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public String getArrayTypeName(String elementTypeName) {
+		// Return null to signal that there is no array type since Oracle only has named array types
+		// TODO: discuss if it makes sense to parse a config parameter to a map which we can query here
+		//  e.g. `hibernate.oracle.array_types=numeric(10,0)=intarray,...`
+		return null;
+	}
+
+	@Override
+	public int getPreferredSqlTypeCodeForArray() {
+		// Prefer to resolve to the OracleArrayJdbcType, since that will fall back to XML later if needed
+		return ARRAY;
+	}
+
+	@Override
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
 
@@ -705,6 +720,7 @@ public class OracleDialect extends Dialect {
 			typeContributions.contributeJdbcType( descriptor );
 		}
 
+		typeContributions.contributeJdbcType( OracleArrayJdbcType.INSTANCE );
 		// Oracle requires a custom binder for binding untyped nulls with the NULL type
 		typeContributions.contributeJdbcType( NullJdbcType.INSTANCE );
 		typeContributions.contributeJdbcType( ObjectNullAsNullTypeJdbcType.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.query.sqm.BinaryArithmeticOperator;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -40,6 +41,7 @@ import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
 import org.hibernate.sql.ast.tree.select.SortSpecification;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.type.SqlTypes;
 
 /**
  * A SQL AST translator for Oracle.
@@ -352,7 +354,56 @@ public class OracleSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 
 	@Override
 	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
-		renderComparisonEmulateDecode( lhs, operator, rhs );
+		if ( lhs.getExpressionType() == null ) {
+			renderComparisonEmulateDecode( lhs, operator, rhs );
+			return;
+		}
+		final JdbcMapping lhsMapping = lhs.getExpressionType().getJdbcMappings().get( 0 );
+		switch ( lhsMapping.getJdbcType().getJdbcTypeCode() ) {
+			case SqlTypes.SQLXML:
+				// In Oracle, XMLTYPE is not "comparable", so we have to use the xmldiff function for this purpose
+				switch ( operator ) {
+					case EQUAL:
+					case NOT_DISTINCT_FROM:
+						appendSql( "0=" );
+						break;
+					case NOT_EQUAL:
+					case DISTINCT_FROM:
+						appendSql( "1=" );
+						break;
+					default:
+						renderComparisonEmulateDecode( lhs, operator, rhs );
+						return;
+				}
+				appendSql( "existsnode(xmldiff(" );
+				lhs.accept( this );
+				appendSql( ',' );
+				rhs.accept( this );
+				appendSql( "),'/*[local-name()=''xdiff'']/*')" );
+				break;
+			case SqlTypes.BLOB:
+				// In Oracle, BLOB types are not "comparable", so we have to use the dbms_lob.compare function for this purpose
+				switch ( operator ) {
+					case EQUAL:
+						appendSql( "0=" );
+						break;
+					case NOT_EQUAL:
+						appendSql( "-1=" );
+						break;
+					default:
+						renderComparisonEmulateDecode( lhs, operator, rhs );
+						return;
+				}
+				appendSql( "dbms_lob.compare(" );
+				lhs.accept( this );
+				appendSql( ',' );
+				rhs.accept( this );
+				appendSql( ')' );
+				break;
+			default:
+				renderComparisonEmulateDecode( lhs, operator, rhs );
+				break;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -16,6 +16,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import jakarta.persistence.TemporalType;
@@ -38,6 +39,7 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierCaseStrategy;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
@@ -66,6 +68,7 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.type.JavaObjectType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.InstantAsTimestampWithTimeZoneJdbcType;
@@ -74,6 +77,7 @@ import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.XmlJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
+import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
 import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
@@ -85,11 +89,13 @@ import static org.hibernate.query.sqm.TemporalUnit.EPOCH;
 import static org.hibernate.query.sqm.TemporalUnit.MONTH;
 import static org.hibernate.query.sqm.TemporalUnit.QUARTER;
 import static org.hibernate.query.sqm.TemporalUnit.YEAR;
+import static org.hibernate.type.SqlTypes.ARRAY;
 import static org.hibernate.type.SqlTypes.BINARY;
 import static org.hibernate.type.SqlTypes.BLOB;
 import static org.hibernate.type.SqlTypes.CHAR;
 import static org.hibernate.type.SqlTypes.CLOB;
 import static org.hibernate.type.SqlTypes.GEOGRAPHY;
+import static org.hibernate.type.SqlTypes.FLOAT;
 import static org.hibernate.type.SqlTypes.GEOMETRY;
 import static org.hibernate.type.SqlTypes.INET;
 import static org.hibernate.type.SqlTypes.JSON;
@@ -205,6 +211,16 @@ public class PostgreSQLDialect extends Dialect {
 		super.registerColumnTypes( typeContributions, serviceRegistry );
 		final DdlTypeRegistry ddlTypeRegistry = typeContributions.getTypeConfiguration().getDdlTypeRegistry();
 
+		// Register this type to be able to support Float[]
+		// The issue is that the JDBC driver can't handle createArrayOf( "float(24)", ... )
+		// It requires the use of "real" or "float4"
+		// Alternatively we could introduce a new API in Dialect for creating such base names
+		ddlTypeRegistry.addDescriptor(
+				CapacityDependentDdlType.builder( FLOAT, columnType( FLOAT ), castType( FLOAT ), this )
+						.withTypeCapacity( 24, "float4" )
+						.build()
+		);
+
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
@@ -249,30 +265,70 @@ public class PostgreSQLDialect extends Dialect {
 			int precision,
 			int scale,
 			JdbcTypeRegistry jdbcTypeRegistry) {
-		if ( jdbcTypeCode == OTHER ) {
-			switch ( columnTypeName ) {
-				case "uuid":
-					jdbcTypeCode = UUID;
-					break;
-				case "json":
-				case "jsonb":
-					jdbcTypeCode = JSON;
-					break;
-				case "xml":
-					jdbcTypeCode = SQLXML;
-					break;
-				case "inet":
-					jdbcTypeCode = INET;
-					break;
-				case "geometry":
-					jdbcTypeCode = GEOMETRY;
-					break;
-				case "geography":
-					jdbcTypeCode = GEOGRAPHY;
-					break;
-			}
+		switch ( jdbcTypeCode ) {
+			case OTHER:
+				switch ( columnTypeName ) {
+					case "uuid":
+						jdbcTypeCode = UUID;
+						break;
+					case "json":
+					case "jsonb":
+						jdbcTypeCode = JSON;
+						break;
+					case "xml":
+						jdbcTypeCode = SQLXML;
+						break;
+					case "inet":
+						jdbcTypeCode = INET;
+						break;
+					case "geometry":
+						jdbcTypeCode = GEOMETRY;
+						break;
+					case "geography":
+						jdbcTypeCode = GEOGRAPHY;
+						break;
+				}
+				break;
+			case ARRAY:
+				final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+				// PostgreSQL names array types by prepending an underscore to the base name
+				if ( jdbcType instanceof ArrayJdbcType && columnTypeName.charAt( 0 ) == '_' ) {
+					final String componentTypeName = columnTypeName.substring( 1 );
+					final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
+					if ( sqlTypeCode != null ) {
+						return ( (ArrayJdbcType) jdbcType ).resolveType(
+								jdbcTypeRegistry.getTypeConfiguration(),
+								jdbcTypeRegistry.getTypeConfiguration().getServiceRegistry()
+										.getService( JdbcServices.class )
+										.getDialect(),
+								jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
+								null
+						);
+					}
+				}
+				return jdbcType;
 		}
 		return jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+	}
+
+	@Override
+	protected Integer resolveSqlTypeCode(String columnTypeName, TypeConfiguration typeConfiguration) {
+		switch ( columnTypeName ) {
+			case "bool":
+				return Types.BOOLEAN;
+			case "float4":
+				// Use REAL instead of FLOAT to get Float as recommended Java type
+				return Types.REAL;
+			case "float8":
+				return Types.DOUBLE;
+			case "int2":
+				return Types.SMALLINT;
+			case "int4":
+				return Types.INTEGER;
+			case "int8":
+				return Types.BIGINT;
+		}
+		return super.resolveSqlTypeCode( columnTypeName, typeConfiguration );
 	}
 
 	@Override
@@ -505,6 +561,11 @@ public class PostgreSQLDialect extends Dialect {
 	@Override
 	public String getCurrentSchemaCommand() {
 		return "select current_schema()";
+	}
+
+	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return true;
 	}
 
 	@Override
@@ -833,6 +894,11 @@ public class PostgreSQLDialect extends Dialect {
 	@Override
 	public int getMaxIdentifierLength() {
 		return 63;
+	}
+
+	@Override
+	public boolean supportsStandardArrays() {
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLPGObjectJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLPGObjectJdbcType.java
@@ -22,6 +22,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.BasicBinder;
 import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
@@ -79,6 +80,12 @@ public abstract class PostgreSQLPGObjectJdbcType implements JdbcType {
 
 	protected <X> String toString(X value, JavaType<X> javaType, WrapperOptions options) {
 		return javaType.unwrap( value, String.class, options );
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -156,6 +156,16 @@ public class SpannerDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsStandardArrays() {
+		return true;
+	}
+
+	@Override
+	public String getArrayTypeName(String elementTypeName) {
+		return "ARRAY<" + elementTypeName + ">";
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
@@ -209,6 +209,11 @@ public class SybaseASEDialect extends SybaseDialect {
 	}
 
 	@Override
+	public boolean supportsDistinctFromPredicate() {
+		return getVersion().isSameOrAfter( 16, 3 );
+	}
+
+	@Override
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
@@ -237,11 +237,6 @@ public class SybaseASESqlAstTranslator<T extends JdbcOperation> extends Abstract
 	}
 
 	@Override
-	protected boolean supportsDistinctFromPredicate() {
-		return getDialect().getVersion().isSameOrAfter( 16, 3 );
-	}
-
-	@Override
 	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
 		// I think intersect is only supported in 16.0 SP3
 		if ( getDialect().isAnsiNullOn() ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TypeNames.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TypeNames.java
@@ -102,12 +102,24 @@ public final class TypeNames {
 	 *         the default type name otherwise
 	 */
 	public String get(int typeCode, Long size, Integer precision, Integer scale) {
+		final Long compareValue;
 		if ( size != null ) {
+			compareValue = size;
+		}
+		else if ( precision != null ) {
+			// In case size is null, but a precision is available, use that to search a type for that capacity
+			compareValue = precision.longValue();
+		}
+		else {
+			compareValue = null;
+		}
+		if ( compareValue != null ) {
 			final Map<Long, String> map = weighted.get( typeCode );
 			if ( map != null && map.size() > 0 ) {
+				final long value = compareValue;
 				// iterate entries ordered by capacity to find first fit
 				for ( Map.Entry<Long, String> entry : map.entrySet() ) {
-					if ( size <= entry.getKey() ) {
+					if ( value <= entry.getKey() ) {
 						return replace( entry.getValue(), size, precision, scale );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -576,6 +576,24 @@ public final class ConfigurationHelper {
 		return SqlTypes.TIMESTAMP_UTC;
 	}
 
+	@Incubating
+	public static synchronized int getPreferredSqlTypeCodeForArray(StandardServiceRegistry serviceRegistry) {
+		final Integer typeCode = serviceRegistry.getService( ConfigurationService.class ).getSetting(
+				AvailableSettings.PREFERRED_ARRAY_JDBC_TYPE,
+				TypeCodeConverter.INSTANCE
+		);
+		if ( typeCode != null ) {
+			INCUBATION_LOGGER.incubatingSetting( AvailableSettings.PREFERRED_ARRAY_JDBC_TYPE );
+			return typeCode;
+		}
+
+		// default to the Dialect answer
+		return serviceRegistry.getService( JdbcServices.class )
+				.getJdbcEnvironment()
+				.getDialect()
+				.getPreferredSqlTypeCodeForArray();
+	}
+
 	private static class TypeCodeConverter implements ConfigurationService.Converter<Integer> {
 
 		public static final TypeCodeConverter INSTANCE = new TypeCodeConverter();

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal.util.config;
 
+import java.sql.Types;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -578,15 +578,6 @@ public final class ConfigurationHelper {
 
 	@Incubating
 	public static synchronized int getPreferredSqlTypeCodeForArray(StandardServiceRegistry serviceRegistry) {
-		final Integer typeCode = serviceRegistry.getService( ConfigurationService.class ).getSetting(
-				AvailableSettings.PREFERRED_ARRAY_JDBC_TYPE,
-				TypeCodeConverter.INSTANCE
-		);
-		if ( typeCode != null ) {
-			INCUBATION_LOGGER.incubatingSetting( AvailableSettings.PREFERRED_ARRAY_JDBC_TYPE );
-			return typeCode;
-		}
-
 		// default to the Dialect answer
 		return serviceRegistry.getService( JdbcServices.class )
 				.getJdbcEnvironment()

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -589,7 +589,11 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 			}
 			else if ( basicTypeByName instanceof ConvertedBasicType ) {
 				final ConvertedBasicType<?> convertedType = (ConvertedBasicType<?>) basicTypeByName;
-				return new ConvertedBasicTypeResolution<>( convertedType, stdIndicators );
+				if ( convertedType.getValueConverter() != null ) {
+					return new ConvertedBasicTypeResolution<>( convertedType, stdIndicators );
+				}
+				valueConverter = null;
+				domainJtd = basicTypeByName.getJavaTypeDescriptor();
 			}
 			else {
 				valueConverter = null;

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -478,6 +478,7 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 				getColumn(),
 				ownerName,
 				propertyName,
+				getMetadata().getDatabase().getDialect(),
 				typeConfiguration
 		);
 
@@ -692,6 +693,11 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 	@Override
 	public int getPreferredSqlTypeCodeForInstant() {
 		return getBuildingContext().getPreferredSqlTypeCodeForInstant();
+	}
+
+	@Override
+	public int getPreferredSqlTypeCodeForArray() {
+		return getBuildingContext().getPreferredSqlTypeCodeForArray();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/OrdinalEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/convert/internal/OrdinalEnumValueConverter.java
@@ -26,19 +26,19 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
  *
  * @author Steve Ebersole
  */
-public class OrdinalEnumValueConverter<E extends Enum<E>> implements EnumValueConverter<E,Integer>, Serializable {
+public class OrdinalEnumValueConverter<E extends Enum<E>> implements EnumValueConverter<E, Number>, Serializable {
 
 	private final EnumJavaType<E> enumJavaType;
 	private final JdbcType jdbcType;
-	private final JavaType<Integer> relationalJavaType;
+	private final JavaType<Number> relationalJavaType;
 
-	private transient ValueExtractor<Integer> valueExtractor;
-	private transient ValueBinder<Integer> valueBinder;
+	private transient ValueExtractor<Number> valueExtractor;
+	private transient ValueBinder<Number> valueBinder;
 
 	public OrdinalEnumValueConverter(
 			EnumJavaType<E> enumJavaType,
 			JdbcType jdbcType,
-			JavaType<Integer> relationalJavaType) {
+			JavaType<Number> relationalJavaType) {
 		this.enumJavaType = enumJavaType;
 		this.jdbcType = jdbcType;
 		this.relationalJavaType = relationalJavaType;
@@ -48,12 +48,12 @@ public class OrdinalEnumValueConverter<E extends Enum<E>> implements EnumValueCo
 	}
 
 	@Override
-	public E toDomainValue(Integer relationalForm) {
-		return enumJavaType.fromOrdinal( relationalForm );
+	public E toDomainValue(Number relationalForm) {
+		return enumJavaType.fromOrdinal( relationalForm == null ? null : relationalForm.intValue() );
 	}
 
 	@Override
-	public Integer toRelationalValue(E domainForm) {
+	public Number toRelationalValue(E domainForm) {
 		return enumJavaType.toOrdinal( domainForm );
 	}
 
@@ -68,7 +68,7 @@ public class OrdinalEnumValueConverter<E extends Enum<E>> implements EnumValueCo
 	}
 
 	@Override
-	public JavaType<Integer> getRelationalJavaType() {
+	public JavaType<Number> getRelationalJavaType() {
 		return relationalJavaType;
 	}
 
@@ -86,8 +86,7 @@ public class OrdinalEnumValueConverter<E extends Enum<E>> implements EnumValueCo
 	}
 
 	@Override
-	public void writeValue(
-			PreparedStatement statement, E value, int position, SharedSessionContractImplementor session)
+	public void writeValue(PreparedStatement statement, E value, int position, SharedSessionContractImplementor session)
 			throws SQLException {
 		valueBinder.bind( statement, toRelationalValue( value ), position, session );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -103,7 +103,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 
 	@Override
 	public void setBindValue(T value, boolean resolveJdbcTypeIfNecessary) {
-		if ( handleAsMultiValue( value ) ) {
+		if ( handleAsMultiValue( value, null ) ) {
 			return;
 		}
 
@@ -149,7 +149,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 		return sqmExpressible.getExpressibleJavaType().coerce( value, this );
 	}
 
-	private boolean handleAsMultiValue(T value) {
+	private boolean handleAsMultiValue(T value, BindableType<T> bindableType) {
 		if ( ! queryParameter.allowsMultiValuedBinding() ) {
 			return false;
 		}
@@ -158,7 +158,9 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 			return false;
 		}
 
-		if ( value instanceof Collection && !isRegisteredAsBasicType( value.getClass() ) ) {
+		if ( value instanceof Collection
+				&& ( bindableType != null && !bindableType.getBindableJavaType().isInstance( value )
+				|| ( bindableType == null && !isRegisteredAsBasicType( value.getClass() ) ) ) ) {
 			//noinspection unchecked
 			setBindValues( (Collection<T>) value );
 			return true;
@@ -184,7 +186,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 
 	@Override
 	public void setBindValue(T value, BindableType<T> clarifiedType) {
-		if ( handleAsMultiValue( value ) ) {
+		if ( handleAsMultiValue( value, clarifiedType ) ) {
 			return;
 		}
 
@@ -206,7 +208,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 
 	@Override
 	public void setBindValue(T value, TemporalType temporalTypePrecision) {
-		if ( handleAsMultiValue( value ) ) {
+		if ( handleAsMultiValue( value, null ) ) {
 			return;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -5952,7 +5952,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		}
 
 		final EnumJavaType<?> enumJtd = sqmEnumLiteral.getExpressibleJavaType();
-		final JdbcType jdbcType = getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.TINYINT );
+		final JdbcType jdbcType = getTypeConfiguration().getJdbcTypeRegistry()
+				.getDescriptor( SqlTypes.SMALLINT );
 		final BasicJavaType<Number> relationalJtd = (BasicJavaType) getTypeConfiguration()
 				.getJavaTypeRegistry()
 				.getDescriptor( Integer.class );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -5953,7 +5953,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 		final EnumJavaType<?> enumJtd = sqmEnumLiteral.getExpressibleJavaType();
 		final JdbcType jdbcType = getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.TINYINT );
-		final BasicJavaType<Integer> relationalJtd = (BasicJavaType) getTypeConfiguration()
+		final BasicJavaType<Number> relationalJtd = (BasicJavaType) getTypeConfiguration()
 				.getJavaTypeRegistry()
 				.getDescriptor( Integer.class );
 		final BasicType<?> jdbcMappingType = getTypeConfiguration().getBasicTypeRegistry().resolve( relationalJtd, jdbcType );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ColumnInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ColumnInformation.java
@@ -15,7 +15,7 @@ import org.hibernate.boot.model.naming.Identifier;
  * @author Christoph Sturm
  * @author Steve Ebersole
  */
-public interface ColumnInformation {
+public interface ColumnInformation extends ColumnTypeInformation {
 	/**
 	 * Access to the containing table.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ColumnTypeInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ColumnTypeInformation.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.tool.schema.extract.spi;
+
+import java.sql.Types;
+
+import org.hibernate.Incubating;
+import org.hibernate.boot.model.TruthValue;
+
+/**
+ * Provides access to information about existing table columns
+ *
+ * @author Christoph Sturm
+ * @author Steve Ebersole
+ */
+@Incubating
+public interface ColumnTypeInformation {
+
+	ColumnTypeInformation EMPTY = new ColumnTypeInformation() {
+		@Override
+		public TruthValue getNullable() {
+			return TruthValue.UNKNOWN;
+		}
+
+		@Override
+		public int getTypeCode() {
+			return Types.OTHER;
+		}
+
+		@Override
+		public String getTypeName() {
+			return null;
+		}
+
+		@Override
+		public int getColumnSize() {
+			return 0;
+		}
+
+		@Override
+		public int getDecimalDigits() {
+			return 0;
+		}
+	};
+
+	/**
+	 * Is the column nullable.  The database is allowed to report unknown, hence the use of TruthValue
+	 *
+	 * @return nullability.
+	 */
+	TruthValue getNullable();
+
+	/**
+	 * The JDBC type-code.
+	 *
+	 * @return JDBC type-code
+	 */
+	int getTypeCode();
+
+	/**
+	 * The database specific type name.
+	 *
+	 * @return Type name
+	 */
+	public String getTypeName();
+
+	// todo : wrap these in org.hibernate.metamodel.spi.relational.Size ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+	/**
+	 * The column size (length).
+	 *
+	 * @return The column length
+	 */
+	int getColumnSize();
+
+	/**
+	 * The precision, for numeric types
+	 *
+	 * @return The numeric precision
+	 */
+	int getDecimalDigits();
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -210,7 +210,7 @@ public abstract class AbstractStandardBasicType<T>
 	}
 
 	protected void nullSafeSet(PreparedStatement st, T value, int index, WrapperOptions options) throws SQLException {
-		jdbcType.getBinder( javaType ).bind( st, value, index, options );
+		getJdbcValueBinder().bind( st, value, index, options );
 	}
 
 	@Override
@@ -283,7 +283,7 @@ public abstract class AbstractStandardBasicType<T>
 
 	@Override
 	public T extract(CallableStatement statement, int startIndex, final SharedSessionContractImplementor session) throws SQLException {
-		return jdbcType.getExtractor( javaType ).extract(
+		return getJdbcValueExtractor().extract(
 				statement,
 				startIndex,
 				session
@@ -292,7 +292,7 @@ public abstract class AbstractStandardBasicType<T>
 
 	@Override
 	public T extract(CallableStatement statement, String paramName, final SharedSessionContractImplementor session) throws SQLException {
-		return jdbcType.getExtractor( javaType ).extract(
+		return getJdbcValueExtractor().extract(
 				statement,
 				paramName,
 				session
@@ -316,7 +316,7 @@ public abstract class AbstractStandardBasicType<T>
 
 	@SuppressWarnings("unchecked")
 	protected final void nullSafeSet(CallableStatement st, Object value, String name, WrapperOptions options) throws SQLException {
-		jdbcType.getBinder( javaType ).bind( st, (T) value, name, options );
+		getJdbcValueBinder().bind( st, (T) value, name, options );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicArrayType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicArrayType.java
@@ -1,0 +1,175 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type;
+
+import java.lang.reflect.Array;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * A type that maps between {@link java.sql.Types#ARRAY ARRAY} and {@code T[]}
+ *
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+public class BasicArrayType<T>
+		extends AbstractSingleColumnStandardBasicType<T[]>
+		implements AdjustableBasicType<T[]>, BasicPluralType<T[], T> {
+
+	private final BasicType<T> baseDescriptor;
+	private final String name;
+	private final ValueBinder<T[]> jdbcValueBinder;
+	private final ValueExtractor<T[]> jdbcValueExtractor;
+
+	public BasicArrayType(BasicType<T> baseDescriptor, JdbcType arrayJdbcType, JavaType<T[]> arrayTypeDescriptor) {
+		super( arrayJdbcType, arrayTypeDescriptor );
+		this.baseDescriptor = baseDescriptor;
+		this.name = baseDescriptor.getName() + "[]";
+		final ValueBinder<T[]> jdbcValueBinder = super.getJdbcValueBinder();
+		final ValueExtractor<T[]> jdbcValueExtractor = super.getJdbcValueExtractor();
+		//noinspection unchecked
+		final BasicValueConverter<T, Object> valueConverter = (BasicValueConverter<T, Object>) baseDescriptor.getValueConverter();
+		if ( valueConverter != null ) {
+			this.jdbcValueBinder = new ValueBinder<T[]>() {
+				@Override
+				public void bind(PreparedStatement st, T[] value, int index, WrapperOptions options)
+						throws SQLException {
+					jdbcValueBinder.bind( st, getValue( value, valueConverter, options ), index, options );
+				}
+
+				@Override
+				public void bind(CallableStatement st, T[] value, String name, WrapperOptions options)
+						throws SQLException {
+					jdbcValueBinder.bind( st, getValue( value, valueConverter, options ), name, options );
+				}
+
+				private T[] getValue(
+						T[] value,
+						BasicValueConverter<T, Object> valueConverter,
+						WrapperOptions options) {
+					if ( value == null ) {
+						return null;
+					}
+					final JdbcType elementJdbcType = baseDescriptor.getJdbcType();
+					final TypeConfiguration typeConfiguration = options.getSessionFactory().getTypeConfiguration();
+					final JdbcType underlyingJdbcType = typeConfiguration.getJdbcTypeRegistry()
+							.getDescriptor( elementJdbcType.getDefaultSqlTypeCode() );
+					final Class<?> preferredJavaTypeClass = underlyingJdbcType.getPreferredJavaTypeClass( options );
+					final Class<?> elementJdbcJavaTypeClass;
+					if ( preferredJavaTypeClass == null ) {
+						elementJdbcJavaTypeClass = underlyingJdbcType.getJdbcRecommendedJavaTypeMapping(
+								null,
+								null,
+								typeConfiguration
+						).getJavaTypeClass();
+					}
+					else {
+						elementJdbcJavaTypeClass = preferredJavaTypeClass;
+					}
+
+					if ( value.getClass().getComponentType() == elementJdbcJavaTypeClass ) {
+						return value;
+					}
+					final Object[] array = (Object[]) Array.newInstance( elementJdbcJavaTypeClass, value.length );
+					for ( int i = 0; i < value.length; i++ ) {
+						array[i] = valueConverter.getRelationalJavaType().unwrap(
+								valueConverter.toRelationalValue( value[i] ),
+								elementJdbcJavaTypeClass,
+								options
+						);
+					}
+					//noinspection unchecked
+					return (T[]) array;
+				}
+			};
+			this.jdbcValueExtractor = new ValueExtractor<T[]>() {
+				@Override
+				public T[] extract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+					return getValue( jdbcValueExtractor.extract( rs, paramIndex, options ), valueConverter );
+				}
+
+				@Override
+				public T[] extract(CallableStatement statement, int paramIndex, WrapperOptions options)
+						throws SQLException {
+					return getValue( jdbcValueExtractor.extract( statement, paramIndex, options ), valueConverter );
+				}
+
+				@Override
+				public T[] extract(CallableStatement statement, String paramName, WrapperOptions options)
+						throws SQLException {
+					return getValue( jdbcValueExtractor.extract( statement, paramName, options ), valueConverter );
+				}
+
+				private T[] getValue(T[] value, BasicValueConverter<T, Object> valueConverter) {
+					if ( value == null ) {
+						return null;
+					}
+					if ( value.getClass().getComponentType() == valueConverter.getDomainJavaType().getJavaTypeClass() ) {
+						return value;
+					}
+					//noinspection unchecked
+					final T[] array = (T[]) Array.newInstance(
+							valueConverter.getDomainJavaType().getJavaTypeClass(),
+							value.length
+					);
+					for ( int i = 0; i < value.length; i++ ) {
+						array[i] = valueConverter.toDomainValue( value[i] );
+					}
+					return array;
+				}
+			};
+		}
+		else {
+			this.jdbcValueBinder = jdbcValueBinder;
+			this.jdbcValueExtractor = jdbcValueExtractor;
+		}
+	}
+
+	@Override
+	public BasicType<T> getElementType() {
+		return baseDescriptor;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+	@Override
+	public ValueExtractor<T[]> getJdbcValueExtractor() {
+		return jdbcValueExtractor;
+	}
+
+	@Override
+	public ValueBinder<T[]> getJdbcValueBinder() {
+		return jdbcValueBinder;
+	}
+
+	@Override
+	public <X> BasicType<X> resolveIndicatedType(JdbcTypeIndicators indicators, JavaType<X> domainJtd) {
+		// TODO: maybe fallback to some encoding by default if the DB doesn't support arrays natively?
+		//  also, maybe move that logic into the ArrayJdbcType
+		//noinspection unchecked
+		return (BasicType<X>) this;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicCollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicCollectionType.java
@@ -1,0 +1,187 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.spi.BasicCollectionJavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * A type that maps between {@link java.sql.Types#ARRAY ARRAY} and {@code Collection<T>}
+ *
+ * @author Christian Beikov
+ */
+public class BasicCollectionType<C extends Collection<E>, E>
+		extends AbstractSingleColumnStandardBasicType<C>
+		implements AdjustableBasicType<C>, BasicPluralType<C, E> {
+
+	private final BasicType<E> baseDescriptor;
+	private final String name;
+	private final ValueBinder<C> jdbcValueBinder;
+	private final ValueExtractor<C> jdbcValueExtractor;
+
+	public BasicCollectionType(BasicType<E> baseDescriptor, JdbcType arrayJdbcType, BasicCollectionJavaType<C, E> collectionTypeDescriptor) {
+		super( arrayJdbcType, collectionTypeDescriptor );
+		this.baseDescriptor = baseDescriptor;
+		this.name = determineName( collectionTypeDescriptor, baseDescriptor );
+		final ValueBinder<C> jdbcValueBinder = super.getJdbcValueBinder();
+		final ValueExtractor<C> jdbcValueExtractor = super.getJdbcValueExtractor();
+		//noinspection unchecked
+		final BasicValueConverter<E, Object> valueConverter = (BasicValueConverter<E, Object>) baseDescriptor.getValueConverter();
+		if ( valueConverter != null ) {
+			this.jdbcValueBinder = new ValueBinder<C>() {
+				@Override
+				public void bind(PreparedStatement st, C value, int index, WrapperOptions options)
+						throws SQLException {
+					jdbcValueBinder.bind( st, getValue( value, valueConverter, options ), index, options );
+				}
+
+				@Override
+				public void bind(CallableStatement st, C value, String name, WrapperOptions options)
+						throws SQLException {
+					jdbcValueBinder.bind( st, getValue( value, valueConverter, options ), name, options );
+				}
+
+				private C getValue(
+						C value,
+						BasicValueConverter<E, Object> valueConverter,
+						WrapperOptions options) {
+					if ( value == null ) {
+						return null;
+					}
+					final JdbcType elementJdbcType = baseDescriptor.getJdbcType();
+					final TypeConfiguration typeConfiguration = options.getSessionFactory().getTypeConfiguration();
+					final JdbcType underlyingJdbcType = typeConfiguration.getJdbcTypeRegistry()
+							.getDescriptor( elementJdbcType.getDefaultSqlTypeCode() );
+					final Class<?> preferredJavaTypeClass = underlyingJdbcType.getPreferredJavaTypeClass( options );
+					final Class<?> elementJdbcJavaTypeClass;
+					if ( preferredJavaTypeClass == null ) {
+						elementJdbcJavaTypeClass = underlyingJdbcType.getJdbcRecommendedJavaTypeMapping(
+								null,
+								null,
+								typeConfiguration
+						).getJavaTypeClass();
+					}
+					else {
+						elementJdbcJavaTypeClass = preferredJavaTypeClass;
+					}
+
+					//noinspection unchecked
+					final Collection<Object> converted = (Collection<Object>) collectionTypeDescriptor.getSemantics()
+							.instantiateRaw( value.size(), null );
+					for ( E element : value ) {
+						converted.add(
+								valueConverter.getRelationalJavaType().unwrap(
+										valueConverter.toRelationalValue( element ),
+										elementJdbcJavaTypeClass,
+										options
+								)
+						);
+					}
+					//noinspection unchecked
+					return (C) converted;
+				}
+			};
+			this.jdbcValueExtractor = new ValueExtractor<C>() {
+				@Override
+				public C extract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+					return getValue( jdbcValueExtractor.extract( rs, paramIndex, options ), valueConverter );
+				}
+
+				@Override
+				public C extract(CallableStatement statement, int paramIndex, WrapperOptions options)
+						throws SQLException {
+					return getValue( jdbcValueExtractor.extract( statement, paramIndex, options ), valueConverter );
+				}
+
+				@Override
+				public C extract(CallableStatement statement, String paramName, WrapperOptions options)
+						throws SQLException {
+					return getValue( jdbcValueExtractor.extract( statement, paramName, options ), valueConverter );
+				}
+
+				private C getValue(C value, BasicValueConverter<E, Object> valueConverter) {
+					if ( value == null ) {
+						return null;
+					}
+					final C converted = collectionTypeDescriptor.getSemantics()
+							.instantiateRaw( value.size(), null );
+					for ( E element : value ) {
+						converted.add( valueConverter.toDomainValue( element ) );
+					}
+					return converted;
+				}
+			};
+		}
+		else {
+			this.jdbcValueBinder = jdbcValueBinder;
+			this.jdbcValueExtractor = jdbcValueExtractor;
+		}
+	}
+
+	private static String determineName(BasicCollectionJavaType<?, ?> collectionTypeDescriptor, BasicType<?> baseDescriptor) {
+		switch ( collectionTypeDescriptor.getSemantics().getCollectionClassification() ) {
+			case BAG:
+			case ID_BAG:
+				return "Collection<" + baseDescriptor.getName() + ">";
+			case LIST:
+				return "List<" + baseDescriptor.getName() + ">";
+			case SET:
+				return "Set<" + baseDescriptor.getName() + ">";
+			case SORTED_SET:
+				return "SortedSet<" + baseDescriptor.getName() + ">";
+			case ORDERED_SET:
+				return "OrderedSet<" + baseDescriptor.getName() + ">";
+		}
+		return null;
+	}
+
+	@Override
+	public BasicType<E> getElementType() {
+		return baseDescriptor;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	protected boolean registerUnderJavaType() {
+		return true;
+	}
+
+	@Override
+	public ValueExtractor<C> getJdbcValueExtractor() {
+		return jdbcValueExtractor;
+	}
+
+	@Override
+	public ValueBinder<C> getJdbcValueBinder() {
+		return jdbcValueBinder;
+	}
+
+	@Override
+	public <X> BasicType<X> resolveIndicatedType(JdbcTypeIndicators indicators, JavaType<X> domainJtd) {
+		// TODO: maybe fallback to some encoding by default if the DB doesn't support arrays natively?
+		//  also, maybe move that logic into the ArrayJdbcType
+		//noinspection unchecked
+		return (BasicType<X>) this;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicPluralType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicPluralType.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type;
+
+import org.hibernate.Incubating;
+
+/**
+ * A basic plural type. Represents a type, that is mapped to a single column instead of multiple rows.
+ * This is used for array or collection types, that are backed by e.g. SQL array or JSON/XML DDL types.
+ *
+ * @see BasicCollectionType
+ * @see BasicArrayType
+ */
+@Incubating
+public interface BasicPluralType<C, E> extends BasicType<C> {
+	/**
+	 * Get element type
+	 */
+	BasicType<E> getElementType();
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
@@ -9,12 +9,14 @@ package org.hibernate.type;
 import java.util.Collections;
 import java.util.List;
 
+import org.hibernate.Incubating;
 import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.mapping.IndexedConsumer;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.MappingType;
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.type.descriptor.ValueBinder;
@@ -73,6 +75,15 @@ public interface BasicType<T> extends Type, BasicDomainType<T>, MappingType, Bas
 	@Override
 	default JavaType<T> getMappedJavaType() {
 		return getJavaTypeDescriptor();
+	}
+
+	/**
+	 * Returns the converter that this basic type uses for transforming from the domain type, to the relational type,
+	 * or <code>null</code> if there is no conversion.
+	 */
+	@Incubating
+	default BasicValueConverter<T, ?> getValueConverter() {
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
@@ -19,6 +19,7 @@ import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.java.BasicJavaType;
@@ -30,6 +31,7 @@ import org.hibernate.type.internal.UserTypeSqlTypeAdapter;
 import org.hibernate.type.internal.UserTypeVersionJavaTypeWrapper;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.EnhancedUserType;
+import org.hibernate.usertype.LoggableUserType;
 import org.hibernate.usertype.UserType;
 import org.hibernate.usertype.UserVersionType;
 
@@ -49,7 +51,7 @@ import org.hibernate.usertype.UserVersionType;
  */
 public class CustomType<J>
 		extends AbstractType
-		implements BasicType<J>, ProcedureParameterNamedBinder<J>, ProcedureParameterExtractionAware<J> {
+		implements ConvertedBasicType<J>, ProcedureParameterNamedBinder<J>, ProcedureParameterExtractionAware<J> {
 
 	private final UserType<J> userType;
 	private final String[] registrationKeys;
@@ -205,6 +207,9 @@ public class CustomType<J>
 		if ( value == null ) {
 			return "null";
 		}
+		else if ( userType instanceof LoggableUserType ) {
+			return ( (LoggableUserType) userType ).toLoggableString( value, factory );
+		}
 		else if ( userType instanceof EnhancedUserType<?> ) {
 			return ( (EnhancedUserType<Object>) userType ).toString( value );
 		}
@@ -312,5 +317,10 @@ public class CustomType<J>
 	@Override
 	public JavaType<J> getJavaTypeDescriptor() {
 		return this.getMappedJavaType();
+	}
+
+	@Override
+	public BasicValueConverter<J, Object> getValueConverter() {
+		return userType.getValueConverter();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -27,6 +27,7 @@ import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.metamodel.model.convert.internal.NamedEnumValueConverter;
 import org.hibernate.metamodel.model.convert.internal.OrdinalEnumValueConverter;
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.metamodel.model.convert.spi.EnumValueConverter;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -103,6 +104,11 @@ public class EnumType<T extends Enum<T>>
 	}
 
 	public EnumValueConverter getEnumValueConverter() {
+		return enumValueConverter;
+	}
+
+	@Override
+	public BasicValueConverter<T, Object> getValueConverter() {
 		return enumValueConverter;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -433,13 +433,13 @@ public class EnumType<T extends Enum<T>>
 	@Override
 	public String toString(T value) {
 		verifyConfigured();
-		return enumValueConverter.getDomainJavaType().unwrap( value, String.class, null );
+		return enumValueConverter.getRelationalJavaType().toString( enumValueConverter.toRelationalValue( value ) );
 	}
 
 	@Override
 	public T fromStringValue(CharSequence sequence) {
 		verifyConfigured();
-		return enumValueConverter.getDomainJavaType().wrap( sequence, null );
+		return enumValueConverter.toDomainValue( enumValueConverter.getRelationalJavaType().fromString( sequence ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
@@ -1252,9 +1252,8 @@ public final class StandardBasicTypes {
 		basicTypeRegistry.primed();
 	}
 
-	@SuppressWarnings("rawtypes")
 	private static void handle(
-			BasicType type,
+			BasicType<?> type,
 			String legacyTypeClassName,
 			BasicTypeRegistry basicTypeRegistry,
 			String... registrationKeys) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterJdbcTypeAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/AttributeConverterJdbcTypeAdapter.java
@@ -65,6 +65,11 @@ public class AttributeConverterJdbcTypeAdapter implements JdbcType {
 		return "AttributeConverterSqlTypeDescriptorAdapter(" + converter.getClass().getName() + ")";
 	}
 
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return delegate.getPreferredJavaTypeClass( options );
+	}
+
 
 	// Binding ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.sql.Types;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicArrayType;
+import org.hibernate.type.BasicPluralType;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public abstract class AbstractArrayJavaType<T, E> extends AbstractClassJavaType<T>
+		implements BasicPluralJavaType<E> {
+
+	private final JavaType<E> componentJavaType;
+
+	public AbstractArrayJavaType(Class<T> clazz, BasicType<E> baseDescriptor, MutabilityPlan<T> mutabilityPlan) {
+		this( clazz, baseDescriptor.getJavaTypeDescriptor(), mutabilityPlan );
+	}
+
+	public AbstractArrayJavaType(Class<T> clazz, JavaType<E> baseDescriptor, MutabilityPlan<T> mutabilityPlan) {
+		super( clazz, mutabilityPlan );
+		this.componentJavaType = baseDescriptor;
+	}
+
+	@Override
+	public JavaType<E> getElementJavaType() {
+		return componentJavaType;
+	}
+
+	@Override
+	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators indicators) {
+		final int preferredSqlTypeCodeForArray = indicators.getPreferredSqlTypeCodeForArray();
+		// Always determine the recommended type to make sure this is a valid basic java type
+		final JdbcType recommendedComponentJdbcType = componentJavaType.getRecommendedJdbcType( indicators );
+		final TypeConfiguration typeConfiguration = indicators.getTypeConfiguration();
+		final JdbcType jdbcType = typeConfiguration.getJdbcTypeRegistry().getDescriptor( preferredSqlTypeCodeForArray );
+		if ( jdbcType instanceof ArrayJdbcType ) {
+			return ( (ArrayJdbcType) jdbcType ).resolveType(
+					typeConfiguration,
+					typeConfiguration.getServiceRegistry()
+							.getService( JdbcServices.class )
+							.getDialect(),
+					recommendedComponentJdbcType,
+					ColumnTypeInformation.EMPTY
+			);
+		}
+		return jdbcType;
+	}
+
+	@Override
+	public BasicType<?> resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<E> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		final Class<?> elementJavaTypeClass = elementType.getJavaTypeDescriptor().getJavaTypeClass();
+		if ( elementType instanceof BasicPluralType<?, ?> || elementJavaTypeClass != null && elementJavaTypeClass.isArray() ) {
+			return null;
+		}
+		return typeConfiguration.standardBasicTypeForJavaType(
+				getJavaType(),
+				javaType -> {
+					JdbcType arrayJdbcType = typeConfiguration.getJdbcTypeRegistry().getDescriptor( Types.ARRAY );
+					if ( arrayJdbcType instanceof ArrayJdbcType ) {
+						arrayJdbcType = ( (ArrayJdbcType) arrayJdbcType ).resolveType(
+								typeConfiguration,
+								dialect,
+								elementType,
+								columnTypeInformation
+						);
+					}
+					//noinspection unchecked,rawtypes
+					return new BasicArrayType( elementType, arrayJdbcType, javaType );
+				}
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayJavaType.java
@@ -1,0 +1,368 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicArrayType;
+import org.hibernate.type.BasicPluralType;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Descriptor for {@code T[]} handling.
+ *
+ * @author Christian Beikov
+ * @author Jordan Gigov
+ */
+public class ArrayJavaType<T> extends AbstractArrayJavaType<T[], T> {
+
+	public ArrayJavaType(BasicType<T> baseDescriptor) {
+		this( baseDescriptor.getJavaTypeDescriptor() );
+	}
+
+	public ArrayJavaType(JavaType<T> baseDescriptor) {
+		super(
+				(Class<T[]>) Array.newInstance( baseDescriptor.getJavaTypeClass(), 0 ).getClass(),
+				baseDescriptor,
+				new ArrayMutabilityPlan<>( baseDescriptor )
+		);
+	}
+
+	@Override
+	public BasicType<?> resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<T> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		final Class<?> elementJavaTypeClass = elementType.getJavaTypeDescriptor().getJavaTypeClass();
+		if ( elementType instanceof BasicPluralType<?, ?> || elementJavaTypeClass != null && elementJavaTypeClass.isArray() ) {
+			return null;
+		}
+		final ArrayJavaType<T> arrayJavaType;
+		if ( getElementJavaType() == elementType.getJavaTypeDescriptor() ) {
+			arrayJavaType = this;
+		}
+		else {
+			arrayJavaType = new ArrayJavaType<>( elementType.getJavaTypeDescriptor() );
+			// Register the array type as that will be resolved in the next step
+			typeConfiguration.getJavaTypeRegistry().addDescriptor( arrayJavaType );
+		}
+		return typeConfiguration.standardBasicTypeForJavaType(
+				arrayJavaType.getJavaType(),
+				javaType -> {
+					JdbcType arrayJdbcType = typeConfiguration.getJdbcTypeRegistry().getDescriptor( Types.ARRAY );
+					if ( arrayJdbcType instanceof ArrayJdbcType ) {
+						arrayJdbcType = ( (ArrayJdbcType) arrayJdbcType ).resolveType(
+								typeConfiguration,
+								dialect,
+								elementType,
+								columnTypeInformation
+						);
+					}
+					return new BasicArrayType<>( elementType, arrayJdbcType, javaType );
+				}
+		);
+	}
+
+	@Override
+	public String extractLoggableRepresentation(T[] value) {
+		if ( value == null ) {
+			return "null";
+		}
+		int iMax = value.length - 1;
+		if ( iMax == -1 ) {
+			return "[]";
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '[' );
+		for ( int i = 0; ; i++ ) {
+			sb.append( getElementJavaType().extractLoggableRepresentation( value[i] ) );
+			if ( i == iMax ) {
+				return sb.append( ']' ).toString();
+			}
+			sb.append( ", " );
+		}
+	}
+
+	@Override
+	public boolean areEqual(T[] one, T[] another) {
+		if ( one == null && another == null ) {
+			return true;
+		}
+		if ( one == null || another == null ) {
+			return false;
+		}
+		if ( one.length != another.length ) {
+			return false;
+		}
+		int l = one.length;
+		for ( int i = 0; i < l; i++ ) {
+			if ( !getElementJavaType().areEqual( one[i], another[i] )) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int extractHashCode(T[] value) {
+		if ( value == null ) {
+			return 0;
+		}
+
+		int result = 1;
+
+		for ( T element : value ) {
+			result = 31 * result + ( element == null ? 0 : getElementJavaType().extractHashCode( element ) );
+		}
+		return result;
+	}
+
+	@Override
+	public String toString(T[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		String glue = "";
+		for ( T v : value ) {
+			sb.append( glue );
+			if ( v == null ) {
+				sb.append( "null" );
+				glue = ",";
+				continue;
+			}
+			sb.append( '"' );
+			String valstr = getElementJavaType().toString( v );
+			// using replaceAll is a shorter, but much slower way to do this
+			for (int i = 0, len = valstr.length(); i < len; i ++ ) {
+				char c = valstr.charAt( i );
+				// Surrogate pairs. This is how they're done.
+				if (c == '\\' || c == '"') {
+					sb.append( '\\' );
+				}
+				sb.append( c );
+			}
+			sb.append( '"' );
+			glue = ",";
+		}
+		sb.append( '}' );
+		final String result = sb.toString();
+		return result;
+	}
+
+	@Override
+	public T[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		java.util.ArrayList<String> lst = new java.util.ArrayList<>();
+		StringBuilder sb = null;
+		char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		int len = charSequence.length();
+		boolean inquote = false;
+		for ( int i = 1; i < len; i ++ ) {
+			char c = charSequence.charAt( i );
+			if ( c == '"' ) {
+				if (inquote) {
+					lst.add( sb.toString() );
+				}
+				else {
+					sb = new StringBuilder();
+				}
+				inquote = !inquote;
+				continue;
+			}
+			else if ( !inquote ) {
+				if ( Character.isWhitespace( c ) ) {
+					continue;
+				}
+				else if ( c == ',' ) {
+					// treat no-value between commas to mean null
+					if ( sb == null ) {
+						lst.add( null );
+					}
+					else {
+						sb = null;
+					}
+					continue;
+				}
+				else {
+					// i + 4, because there has to be a comma or closing brace after null
+					if ( i + 4 < len
+							&& charSequence.charAt( i ) == 'n'
+							&& charSequence.charAt( i + 1 ) == 'u'
+							&& charSequence.charAt( i + 2 ) == 'l'
+							&& charSequence.charAt( i + 3 ) == 'l') {
+						lst.add( null );
+						i += 4;
+						continue;
+					}
+					if (i + 1 == len) {
+						break;
+					}
+					throw new IllegalArgumentException( "Cannot parse given string into array of strings."
+																+ " Outside of quote, but neither whitespace, comma, array end, nor null found." );
+				}
+			}
+			else if ( c == '\\' && i + 2 < len && (charSequence.charAt( i + 1 ) == '\\' || charSequence.charAt( i + 1 ) == '"')) {
+				c = charSequence.charAt( ++i );
+			}
+			// If there is ever a null-pointer here, the if-else logic before is incomplete
+			sb.append( c );
+		}
+		//noinspection unchecked
+		final T[] result = (T[]) Array.newInstance( getElementJavaType().getJavaTypeClass(), lst.size() );
+		for ( int i = 0; i < result.length; i ++ ) {
+			if ( lst.get( i ) != null ) {
+				result[i] = getElementJavaType().fromString( lst.get( i ) );
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(T[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			//noinspection unchecked
+			return (X) value;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			//noinspection unchecked
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> T[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof Object[] ) {
+			final Object[] raw = (Object[]) value;
+			final Class<T> componentClass = getElementJavaType().getJavaTypeClass();
+			//noinspection unchecked
+			final T[] wrapped = (T[]) java.lang.reflect.Array.newInstance( componentClass, raw.length );
+			if ( componentClass.isAssignableFrom( value.getClass().getComponentType() ) ) {
+				for (int i = 0; i < raw.length; i++) {
+					//noinspection unchecked
+					wrapped[i] = (T) raw[i];
+				}
+			}
+			else {
+				for ( int i = 0; i < raw.length; i++ ) {
+					wrapped[i] = getElementJavaType().wrap( raw[i], options );
+				}
+			}
+			return wrapped;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			//noinspection unchecked
+			return (T[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			//noinspection unchecked
+			return (T[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan<T> implements MutabilityPlan<T[]> {
+
+		private final Class<T> componentClass;
+		private final MutabilityPlan<T> componentPlan;
+
+		public ArrayMutabilityPlan(JavaType<T> baseDescriptor) {
+			this.componentClass = baseDescriptor.getJavaTypeClass();
+			this.componentPlan = baseDescriptor.getMutabilityPlan();
+		}
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public T[] deepCopy(T[] value) {
+			if ( value == null ) {
+				return null;
+			}
+			//noinspection unchecked
+			T[] copy = (T[]) Array.newInstance( componentClass, value.length );
+			for ( int i = 0; i < value.length; i ++ ) {
+				copy[ i ] = componentPlan.deepCopy( value[ i ] );
+			}
+			return copy;
+		}
+
+		@Override
+		public Serializable disassemble(T[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public T[] assemble(Serializable cached, SharedSessionContract session) {
+			//noinspection unchecked
+			return deepCopy( (T[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicJavaType.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.descriptor.java;
 
+import org.hibernate.type.descriptor.jdbc.AdjustableJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeJavaClassMappings;
@@ -24,9 +25,13 @@ public interface BasicJavaType<T> extends JavaType<T> {
 	 */
 	default JdbcType getRecommendedJdbcType(JdbcTypeIndicators indicators) {
 		// match legacy behavior
-		return indicators.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor(
+		final JdbcType descriptor = indicators.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor(
 				JdbcTypeJavaClassMappings.INSTANCE.determineJdbcTypeCodeForJavaClass( getJavaTypeClass() )
 		);
+		if ( descriptor instanceof AdjustableJdbcType ) {
+			return ( (AdjustableJdbcType) descriptor ).resolveIndicatedType( indicators, this );
+		}
+		return descriptor;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicPluralJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BasicPluralJavaType.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+
+import org.hibernate.Incubating;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Descriptor for a basic plural Java type.
+ * A basic plural type represents a type, that is mapped to a single column instead of multiple rows.
+ * This is used for array or collection types, that are backed by e.g. SQL array or JSON/XML DDL types.
+ *
+ * The interface can be implemented by a plural java type e.g. {@link org.hibernate.type.descriptor.java.spi.BasicCollectionJavaType}
+ * and provides access to the element java type, as well as a hook to resolve the {@link BasicType} based on the element {@link BasicType},
+ * in order to gain enough information to implement storage and retrieval of the composite data type via JDBC.
+ *
+ * @see org.hibernate.type.descriptor.java.spi.BasicCollectionJavaType
+ */
+@Incubating
+public interface BasicPluralJavaType<T> extends Serializable {
+	/**
+	 * Get the Java type descriptor for the element type
+	 */
+	JavaType<T> getElementJavaType();
+	/**
+	 * Creates a container type for the given element type
+	 */
+	BasicType<?> resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<T> elementType,
+			ColumnTypeInformation columnTypeInformation);
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code boolean[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class BooleanPrimitiveArrayJavaType extends AbstractArrayJavaType<boolean[], Boolean> {
+
+	public static final BooleanPrimitiveArrayJavaType INSTANCE = new BooleanPrimitiveArrayJavaType();
+
+	private BooleanPrimitiveArrayJavaType() {
+		this( BooleanJavaType.INSTANCE );
+	}
+
+	protected BooleanPrimitiveArrayJavaType(JavaType<Boolean> baseDescriptor) {
+		super( boolean[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(boolean[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(boolean[] one, boolean[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(boolean[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(boolean[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public boolean[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Boolean> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Boolean.parseBoolean( charSequence.subSequence( elementStart, i ).toString() ) );
+				elementStart = i + 1;
+			}
+		}
+		final boolean[] result = new boolean[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(boolean[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> boolean[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof boolean[] ) {
+			return (boolean[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (boolean[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (boolean[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final boolean[] wrapped = new boolean[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<boolean[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public boolean[] deepCopy(boolean[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(boolean[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public boolean[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (boolean[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code double[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class DoublePrimitiveArrayJavaType extends AbstractArrayJavaType<double[], Double> {
+
+	public static final DoublePrimitiveArrayJavaType INSTANCE = new DoublePrimitiveArrayJavaType();
+
+	private DoublePrimitiveArrayJavaType() {
+		this( DoubleJavaType.INSTANCE );
+	}
+
+	protected DoublePrimitiveArrayJavaType(JavaType<Double> baseDescriptor) {
+		super( double[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(double[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(double[] one, double[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(double[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(double[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public double[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Double> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Double.parseDouble( charSequence.subSequence( elementStart, i ).toString() ) );
+				elementStart = i + 1;
+			}
+		}
+		final double[] result = new double[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(double[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> double[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof double[] ) {
+			return (double[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (double[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (double[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final double[] wrapped = new double[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<double[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public double[] deepCopy(double[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(double[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public double[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (double[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
@@ -10,6 +10,7 @@ import java.sql.Types;
 import jakarta.persistence.EnumType;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -40,7 +41,7 @@ public class EnumJavaType<T extends Enum<T>> extends AbstractClassJavaType<T> {
 					: registry.getDescriptor( Types.VARCHAR );
 		}
 		else {
-			return registry.getDescriptor( Types.TINYINT );
+			return registry.getDescriptor( SqlTypes.SMALLINT );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code float[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class FloatPrimitiveArrayJavaType extends AbstractArrayJavaType<float[], Float> {
+
+	public static final FloatPrimitiveArrayJavaType INSTANCE = new FloatPrimitiveArrayJavaType();
+
+	private FloatPrimitiveArrayJavaType() {
+		this( FloatJavaType.INSTANCE );
+	}
+
+	protected FloatPrimitiveArrayJavaType(JavaType<Float> baseDescriptor) {
+		super( float[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(float[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(float[] one, float[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(float[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(float[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public float[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Float> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Float.parseFloat( charSequence.subSequence( elementStart, i ).toString() ) );
+				elementStart = i + 1;
+			}
+		}
+		final float[] result = new float[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(float[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> float[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof float[] ) {
+			return (float[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (float[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (float[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final float[] wrapped = new float[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<float[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public float[] deepCopy(float[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(float[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public float[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (float[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code int[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class IntegerPrimitiveArrayJavaType extends AbstractArrayJavaType<int[], Integer> {
+
+	public static final IntegerPrimitiveArrayJavaType INSTANCE = new IntegerPrimitiveArrayJavaType();
+
+	private IntegerPrimitiveArrayJavaType() {
+		this( IntegerJavaType.INSTANCE );
+	}
+
+	protected IntegerPrimitiveArrayJavaType(JavaType<Integer> baseDescriptor) {
+		super( int[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(int[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(int[] one, int[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(int[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(int[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public int[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Integer> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Integer.parseInt( charSequence, elementStart, i, 10 ) );
+				elementStart = i + 1;
+			}
+		}
+		final int[] result = new int[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(int[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> int[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof int[] ) {
+			return (int[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (int[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (int[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final int[] wrapped = new int[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<int[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public int[] deepCopy(int[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(int[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public int[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (int[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.Objects;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -253,8 +254,24 @@ public interface JavaType<T> extends Serializable {
 	/**
 	 * Creates the {@link JavaType} for the given {@link ParameterizedType} based on this {@link JavaType} registered
 	 * for the raw type.
+	 *
+	 * @deprecated Use {@link #createJavaType(ParameterizedType, TypeConfiguration)} instead
 	 */
+	@Deprecated(since = "6.1")
 	default JavaType<T> createJavaType(ParameterizedType parameterizedType) {
 		return this;
+	}
+
+	/**
+	 * Creates the {@link JavaType} for the given {@link ParameterizedType} based on this {@link JavaType} registered
+	 * for the raw type.
+	 *
+	 * @since 6.1
+	 */
+	@Incubating
+	default JavaType<T> createJavaType(
+			ParameterizedType parameterizedType,
+			TypeConfiguration typeConfiguration) {
+		return createJavaType( parameterizedType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code long[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class LongPrimitiveArrayJavaType extends AbstractArrayJavaType<long[], Long> {
+
+	public static final LongPrimitiveArrayJavaType INSTANCE = new LongPrimitiveArrayJavaType();
+
+	private LongPrimitiveArrayJavaType() {
+		this( LongJavaType.INSTANCE );
+	}
+
+	protected LongPrimitiveArrayJavaType(JavaType<Long> baseDescriptor) {
+		super( long[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(long[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(long[] one, long[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(long[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(long[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public long[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Long> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Long.parseLong( charSequence, elementStart, i, 10 ) );
+				elementStart = i + 1;
+			}
+		}
+		final long[] result = new long[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(long[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> long[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof long[] ) {
+			return (long[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (long[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (long[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final long[] wrapped = new long[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<long[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public long[] deepCopy(long[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(long[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public long[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (long[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.HibernateException;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+/**
+ * Descriptor for {@code short[]} handling.
+ *
+ * @author Christian Beikov
+ */
+public class ShortPrimitiveArrayJavaType extends AbstractArrayJavaType<short[], Short> {
+
+	public static final ShortPrimitiveArrayJavaType INSTANCE = new ShortPrimitiveArrayJavaType();
+
+	private ShortPrimitiveArrayJavaType() {
+		this( ShortJavaType.INSTANCE );
+	}
+
+	protected ShortPrimitiveArrayJavaType(JavaType<Short> baseDescriptor) {
+		super( short[].class, baseDescriptor, new ArrayMutabilityPlan() );
+	}
+
+	@Override
+	public String extractLoggableRepresentation(short[] value) {
+		return value == null ? super.extractLoggableRepresentation( null ) : Arrays.toString( value );
+	}
+
+	@Override
+	public boolean areEqual(short[] one, short[] another) {
+		return Arrays.equals( one, another );
+	}
+
+	@Override
+	public int extractHashCode(short[] value) {
+		return Arrays.hashCode( value );
+	}
+
+	@Override
+	public String toString(short[] value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		sb.append( value[0] );
+		for ( int i = 1; i < value.length; i++ ) {
+			sb.append( value[i] );
+			sb.append( ',' );
+		}
+		sb.append( '}' );
+		return sb.toString();
+	}
+
+	@Override
+	public short[] fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		final List<Short> list = new ArrayList<>();
+		final char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		final char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		final int len = charSequence.length();
+		int elementStart = 1;
+		for ( int i = elementStart; i < len; i ++ ) {
+			final char c = charSequence.charAt( i );
+			if ( c == ',' ) {
+				list.add( Short.parseShort( charSequence.subSequence( elementStart, i ).toString(), 10 ) );
+				elementStart = i + 1;
+			}
+		}
+		final short[] result = new short[list.size()];
+		for ( int i = 0; i < result.length; i ++ ) {
+			result[ i ] = list.get( i );
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(short[] value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			return (X) value;
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				unwrapped[i] = getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options );
+			}
+			return (X) unwrapped;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( value );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( value ) );
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object unwrapped = Array.newInstance( preferredJavaTypeClass, value.length );
+			for ( int i = 0; i < value.length; i++ ) {
+				Array.set( unwrapped, i, getElementJavaType().unwrap( value[i], preferredJavaTypeClass, options ) );
+			}
+			return (X) unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> short[] wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof short[] ) {
+			return (short[]) value;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			return (short[]) SerializationHelper.deserialize( (byte[]) value );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			return (short[]) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() );
+		}
+		else if ( value.getClass().isArray() ) {
+			final short[] wrapped = new short[Array.getLength( value )];
+			for ( int i = 0; i < wrapped.length; i++ ) {
+				wrapped[i] = getElementJavaType().wrap( Array.get( value, i ), options );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private static class ArrayMutabilityPlan implements MutabilityPlan<short[]> {
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public short[] deepCopy(short[] value) {
+			return value == null ? null : value.clone();
+		}
+
+		@Override
+		public Serializable disassemble(short[] value, SharedSessionContract session) {
+			return deepCopy( value );
+		}
+
+		@Override
+		public short[] assemble(Serializable cached, SharedSessionContract session) {
+			return deepCopy( (short[]) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/BasicCollectionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/BasicCollectionJavaType.java
@@ -1,0 +1,473 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java.spi;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Incubating;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.collection.spi.CollectionSemantics;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.BinaryStream;
+import org.hibernate.engine.jdbc.internal.BinaryStreamImpl;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicCollectionType;
+import org.hibernate.type.BasicPluralType;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractJavaType;
+import org.hibernate.type.descriptor.java.BasicPluralJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.MutabilityPlan;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Descriptor for {@code Collection<T>} handling.
+ *
+ * @author Christian Beikov
+ */
+@Incubating
+public class BasicCollectionJavaType<C extends Collection<E>, E> extends AbstractJavaType<C> implements
+		BasicPluralJavaType<E> {
+
+	private final CollectionSemantics<C, E> semantics;
+	private final JavaType<E> componentJavaType;
+
+	public BasicCollectionJavaType(ParameterizedType type, JavaType<E> componentJavaType, CollectionSemantics<C, E> semantics) {
+		super( type, new CollectionMutabilityPlan<>( componentJavaType, semantics ) );
+		this.semantics = semantics;
+		this.componentJavaType = componentJavaType;
+	}
+
+	@Override
+	public JavaType<E> getElementJavaType() {
+		return componentJavaType;
+	}
+
+	@Override
+	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators indicators) {
+		final int preferredSqlTypeCodeForArray = indicators.getPreferredSqlTypeCodeForArray();
+		// Always determine the recommended type to make sure this is a valid basic java type
+		final JdbcType recommendedComponentJdbcType = componentJavaType.getRecommendedJdbcType( indicators );
+		final TypeConfiguration typeConfiguration = indicators.getTypeConfiguration();
+		final JdbcType jdbcType = typeConfiguration.getJdbcTypeRegistry().getDescriptor( preferredSqlTypeCodeForArray );
+		if ( jdbcType instanceof ArrayJdbcType ) {
+			return ( (ArrayJdbcType) jdbcType ).resolveType(
+					typeConfiguration,
+					typeConfiguration.getServiceRegistry()
+							.getService( JdbcServices.class )
+							.getDialect(),
+					recommendedComponentJdbcType,
+					ColumnTypeInformation.EMPTY
+			);
+		}
+		return indicators.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( preferredSqlTypeCodeForArray );
+	}
+
+	public CollectionSemantics<C, E> getSemantics() {
+		return semantics;
+	}
+
+	@Override
+	public BasicType<?> resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<E> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		final Class<?> elementJavaTypeClass = elementType.getJavaTypeDescriptor().getJavaTypeClass();
+		if ( elementType instanceof BasicPluralType<?, ?> || elementJavaTypeClass != null && elementJavaTypeClass.isArray() ) {
+			return null;
+		}
+		final BasicCollectionJavaType<C, E> collectionJavaType;
+		if ( componentJavaType == elementType.getJavaTypeDescriptor() ) {
+			collectionJavaType = this;
+		}
+		else {
+			collectionJavaType = new BasicCollectionJavaType<>(
+					(ParameterizedType) getJavaType(),
+					elementType.getJavaTypeDescriptor(),
+					semantics
+			);
+			// Register the collection type as that will be resolved in the next step
+			typeConfiguration.getJavaTypeRegistry().addDescriptor( collectionJavaType );
+		}
+		return typeConfiguration.standardBasicTypeForJavaType(
+				collectionJavaType.getJavaType(),
+				javaType -> {
+					JdbcType arrayJdbcType = typeConfiguration.getJdbcTypeRegistry().getDescriptor( Types.ARRAY );
+					if ( arrayJdbcType instanceof ArrayJdbcType ) {
+						arrayJdbcType = ( (ArrayJdbcType) arrayJdbcType ).resolveType(
+								typeConfiguration,
+								dialect,
+								elementType,
+								columnTypeInformation
+						);
+					}
+					//noinspection unchecked,rawtypes
+					return new BasicCollectionType( elementType, arrayJdbcType, collectionJavaType );
+				}
+		);
+	}
+
+	@Override
+	public String extractLoggableRepresentation(C value) {
+		if ( value == null ) {
+			return "null";
+		}
+		final Iterator<E> iterator = value.iterator();
+		if ( !iterator.hasNext() ) {
+			return "[]";
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '[' );
+		do {
+			final E element = iterator.next();
+			sb.append( componentJavaType.toString( element ) );
+			if ( !iterator.hasNext() ) {
+				return sb.append( ']' ).toString();
+			}
+			sb.append( ", " );
+		} while ( true );
+	}
+
+	@Override
+	public boolean areEqual(C one, C another) {
+		if ( one == null && another == null ) {
+			return true;
+		}
+		if ( one == null || another == null ) {
+			return false;
+		}
+		if ( one.size() != another.size() ) {
+			return false;
+		}
+		switch ( semantics.getCollectionClassification() ) {
+			case ARRAY:
+			case LIST:
+			case ORDERED_SET:
+			case SORTED_SET:
+				final Iterator<E> iterator1 = one.iterator();
+				final Iterator<E> iterator2 = another.iterator();
+				while ( iterator1.hasNext() ) {
+					if ( !componentJavaType.areEqual( iterator1.next(), iterator2.next() ) ) {
+						return false;
+					}
+				}
+			default: {
+				OUTER: for ( E e1 : one ) {
+					for ( E e2 : another ) {
+						if ( componentJavaType.areEqual( e1, e2 ) ) {
+							continue OUTER;
+						}
+					}
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int extractHashCode(C value) {
+		int result = 0;
+		if ( value != null && !value.isEmpty() ) {
+			for ( E element : value ) {
+				if ( element != null ) {
+					result += componentJavaType.extractHashCode( element );
+				}
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public String toString(C value) {
+		if ( value == null ) {
+			return null;
+		}
+		final StringBuilder sb = new StringBuilder();
+		sb.append( '{' );
+		String glue = "";
+		for ( E v : value ) {
+			sb.append( glue );
+			if ( v == null ) {
+				sb.append( "null" );
+				glue = ",";
+				continue;
+			}
+			sb.append( '"' );
+			String valstr = this.componentJavaType.toString( v );
+			// using replaceAll is a shorter, but much slower way to do this
+			for (int i = 0, len = valstr.length(); i < len; i ++ ) {
+				char c = valstr.charAt( i );
+				// Surrogate pairs. This is how they're done.
+				if (c == '\\' || c == '"') {
+					sb.append( '\\' );
+				}
+				sb.append( c );
+			}
+			sb.append( '"' );
+			glue = ",";
+		}
+		sb.append( '}' );
+		final String result = sb.toString();
+		return result;
+	}
+
+	@Override
+	public C fromString(CharSequence charSequence) {
+		if ( charSequence == null ) {
+			return null;
+		}
+		java.util.ArrayList<String> lst = new java.util.ArrayList<>();
+		StringBuilder sb = null;
+		char lastChar = charSequence.charAt( charSequence.length() - 1 );
+		char firstChar = charSequence.charAt( 0 );
+		if ( firstChar != '{' || lastChar != '}' ) {
+			throw new IllegalArgumentException( "Cannot parse given string into array of strings. First and last character must be { and }" );
+		}
+		int len = charSequence.length();
+		boolean inquote = false;
+		for ( int i = 1; i < len; i ++ ) {
+			char c = charSequence.charAt( i );
+			if ( c == '"' ) {
+				if (inquote) {
+					lst.add( sb.toString() );
+				}
+				else {
+					sb = new StringBuilder();
+				}
+				inquote = !inquote;
+				continue;
+			}
+			else if ( !inquote ) {
+				if ( Character.isWhitespace( c ) ) {
+					continue;
+				}
+				else if ( c == ',' ) {
+					// treat no-value between commas to mean null
+					if ( sb == null ) {
+						lst.add( null );
+					}
+					else {
+						sb = null;
+					}
+					continue;
+				}
+				else {
+					// i + 4, because there has to be a comma or closing brace after null
+					if ( i + 4 < len
+							&& charSequence.charAt( i ) == 'n'
+							&& charSequence.charAt( i + 1 ) == 'u'
+							&& charSequence.charAt( i + 2 ) == 'l'
+							&& charSequence.charAt( i + 3 ) == 'l') {
+						lst.add( null );
+						i += 4;
+						continue;
+					}
+					if (i + 1 == len) {
+						break;
+					}
+					throw new IllegalArgumentException( "Cannot parse given string into array of strings."
+																+ " Outside of quote, but neither whitespace, comma, array end, nor null found." );
+				}
+			}
+			else if ( c == '\\' && i + 2 < len && (charSequence.charAt( i + 1 ) == '\\' || charSequence.charAt( i + 1 ) == '"')) {
+				c = charSequence.charAt( ++i );
+			}
+			// If there is ever a null-pointer here, the if-else logic before is incomplete
+			sb.append( c );
+		}
+		final C result = semantics.instantiateRaw( lst.size(), null );
+		for ( int i = 0; i < lst.size(); i ++ ) {
+			if ( lst.get( i ) != null ) {
+				result.add( componentJavaType.fromString( lst.get( i ) ) );
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public <X> X unwrap(C value, Class<X> type, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( type.isInstance( value ) ) {
+			//noinspection unchecked
+			return (X) value;
+		}
+		else if ( type == byte[].class ) {
+			// byte[] can only be requested if the value should be serialized
+			return (X) SerializationHelper.serialize( asArrayList( value ) );
+		}
+		else if ( type == BinaryStream.class ) {
+			// BinaryStream can only be requested if the value should be serialized
+			//noinspection unchecked
+			return (X) new BinaryStreamImpl( SerializationHelper.serialize( asArrayList( value ) ) );
+		}
+		else if ( Object[].class.isAssignableFrom( type ) ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			final Object[] unwrapped = (Object[]) Array.newInstance( preferredJavaTypeClass, value.size() );
+			int i = 0;
+			for ( E element : value ) {
+				unwrapped[i] = componentJavaType.unwrap( element, preferredJavaTypeClass, options );
+				i++;
+			}
+			//noinspection unchecked
+			return (X) unwrapped;
+		}
+		else if ( type.isArray() ) {
+			final Class<?> preferredJavaTypeClass = type.getComponentType();
+			//noinspection unchecked
+			final X unwrapped = (X) Array.newInstance( preferredJavaTypeClass, value.size() );
+			int i = 0;
+			for ( E element : value ) {
+				Array.set( unwrapped, i, componentJavaType.unwrap( element, preferredJavaTypeClass, options ) );
+				i++;
+			}
+			return unwrapped;
+		}
+
+		throw unknownUnwrap( type );
+	}
+
+	@Override
+	public <X> C wrap(X value, WrapperOptions options) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof java.sql.Array ) {
+			try {
+				//noinspection unchecked
+				value = (X) ( (java.sql.Array) value ).getArray();
+			}
+			catch ( SQLException ex ) {
+				// This basically shouldn't happen unless you've lost connection to the database.
+				throw new HibernateException( ex );
+			}
+		}
+
+		if ( value instanceof Object[] ) {
+			final Object[] raw = (Object[]) value;
+			final C wrapped = semantics.instantiateRaw( raw.length, null );
+			if ( componentJavaType.getJavaTypeClass().isAssignableFrom( value.getClass().getComponentType() ) ) {
+				for ( Object o : raw ) {
+					//noinspection unchecked
+					wrapped.add( (E) o );
+				}
+			}
+			else {
+				for ( Object o : raw ) {
+					wrapped.add( componentJavaType.wrap( o, options ) );
+				}
+			}
+			return wrapped;
+		}
+		else if ( value instanceof byte[] ) {
+			// When the value is a byte[], this is a deserialization request
+			//noinspection unchecked
+			return fromCollection( (ArrayList<E>) SerializationHelper.deserialize( (byte[]) value ) );
+		}
+		else if ( value instanceof BinaryStream ) {
+			// When the value is a BinaryStream, this is a deserialization request
+			//noinspection unchecked
+			return fromCollection( (ArrayList<E>) SerializationHelper.deserialize( ( (BinaryStream) value ).getBytes() ) );
+		}
+		else if ( value instanceof Collection<?> ) {
+			//noinspection unchecked
+			return fromCollection( (Collection<E>) value );
+		}
+		else if ( value.getClass().isArray() ) {
+			final int length = Array.getLength( value );
+			final C wrapped = semantics.instantiateRaw( length, null );
+			for ( int i = 0; i < length; i++ ) {
+				wrapped.add( componentJavaType.wrap( Array.get( value, i ), options ) );
+			}
+			return wrapped;
+		}
+
+		throw unknownWrap( value.getClass() );
+	}
+
+	private ArrayList<E> asArrayList(C value) {
+		if ( value instanceof ArrayList ) {
+			//noinspection unchecked
+			return (ArrayList<E>) value;
+		}
+		return new ArrayList<>( value );
+	}
+
+	private C fromCollection(Collection<E> value) {
+		switch ( semantics.getCollectionClassification() ) {
+			case LIST:
+			case BAG:
+				if ( value instanceof ArrayList<?> ) {
+					//noinspection unchecked
+					return (C) value;
+				}
+			default:
+				final C collection = semantics.instantiateRaw( value.size(), null );
+				collection.addAll( value );
+				return collection;
+		}
+	}
+
+	private static class CollectionMutabilityPlan<C extends Collection<E>, E> implements MutabilityPlan<C> {
+
+		private final CollectionSemantics<C, E> semantics;
+		private final MutabilityPlan<E> componentPlan;
+
+		public CollectionMutabilityPlan(JavaType<E> baseDescriptor, CollectionSemantics<C, E> semantics) {
+			this.semantics = semantics;
+			this.componentPlan = baseDescriptor.getMutabilityPlan();
+		}
+
+		@Override
+		public boolean isMutable() {
+			return true;
+		}
+
+		@Override
+		public C deepCopy(C value) {
+			if ( value == null ) {
+				return null;
+			}
+			final C copy = semantics.instantiateRaw( value.size(), null );
+			for ( E element : value ) {
+				copy.add( componentPlan.deepCopy( element ) );
+			}
+			return copy;
+		}
+
+		@Override
+		public Serializable disassemble(C value, SharedSessionContract session) {
+			return (Serializable) deepCopy( value );
+		}
+
+		@Override
+		public C assemble(Serializable cached, SharedSessionContract session) {
+			//noinspection unchecked
+			return deepCopy( (C) cached );
+		}
+
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/CollectionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/CollectionJavaType.java
@@ -17,6 +17,7 @@ import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Extension of the general JavaType for "collection types"
@@ -47,9 +48,27 @@ public class CollectionJavaType<C> extends AbstractClassJavaType<C> {
 	}
 
 	@Override
-	public JavaType<C> createJavaType(ParameterizedType parameterizedType) {
-		//noinspection unchecked
+	public JavaType<C> createJavaType(
+			ParameterizedType parameterizedType,
+			TypeConfiguration typeConfiguration) {
+		switch ( semantics.getCollectionClassification() ) {
+			case ARRAY:
+			case BAG:
+			case ID_BAG:
+			case LIST:
+			case SET:
+			case SORTED_SET:
+			case ORDERED_SET:
+				//noinspection unchecked,rawtypes
+				return new BasicCollectionJavaType(
+						parameterizedType,
+						typeConfiguration.getJavaTypeRegistry()
+								.resolveDescriptor( parameterizedType.getActualTypeArguments()[0] ),
+						semantics
+				);
+		}
 		// Construct a basic java type that knows its parametrization
+		//noinspection unchecked
 		return new UnknownBasicJavaType<>( parameterizedType, (MutabilityPlan<C>) MutableMutabilityPlan.INSTANCE );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBaseline.java
@@ -34,6 +34,7 @@ import org.hibernate.type.descriptor.java.BigDecimalJavaType;
 import org.hibernate.type.descriptor.java.BigIntegerJavaType;
 import org.hibernate.type.descriptor.java.BlobJavaType;
 import org.hibernate.type.descriptor.java.BooleanJavaType;
+import org.hibernate.type.descriptor.java.BooleanPrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.ByteArrayJavaType;
 import org.hibernate.type.descriptor.java.ByteJavaType;
 import org.hibernate.type.descriptor.java.CalendarJavaType;
@@ -44,12 +45,16 @@ import org.hibernate.type.descriptor.java.ClobJavaType;
 import org.hibernate.type.descriptor.java.CurrencyJavaType;
 import org.hibernate.type.descriptor.java.DateJavaType;
 import org.hibernate.type.descriptor.java.DoubleJavaType;
+import org.hibernate.type.descriptor.java.DoublePrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.DurationJavaType;
 import org.hibernate.type.descriptor.java.FloatJavaType;
+import org.hibernate.type.descriptor.java.FloatPrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.InetAddressJavaType;
 import org.hibernate.type.descriptor.java.InstantJavaType;
+import org.hibernate.type.descriptor.java.IntegerPrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.IntegerJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.LongPrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.ObjectJavaType;
 import org.hibernate.type.descriptor.java.JdbcDateJavaType;
 import org.hibernate.type.descriptor.java.JdbcTimeJavaType;
@@ -65,6 +70,7 @@ import org.hibernate.type.descriptor.java.OffsetTimeJavaType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.descriptor.java.PrimitiveCharacterArrayJavaType;
 import org.hibernate.type.descriptor.java.ShortJavaType;
+import org.hibernate.type.descriptor.java.ShortPrimitiveArrayJavaType;
 import org.hibernate.type.descriptor.java.StringJavaType;
 import org.hibernate.type.descriptor.java.TimeZoneJavaType;
 import org.hibernate.type.descriptor.java.UUIDJavaType;
@@ -96,7 +102,6 @@ public class JavaTypeBaseline {
 	/**
 	 * The process of registering all the baseline registrations
 	 */
-	@SuppressWarnings("unchecked")
 	public static void prime(BaselineTarget target) {
 		primePrimitive( target, ByteJavaType.INSTANCE );
 		primePrimitive( target, BooleanJavaType.INSTANCE );
@@ -122,6 +127,14 @@ public class JavaTypeBaseline {
 		target.addBaselineDescriptor( CharacterArrayJavaType.INSTANCE );
 		target.addBaselineDescriptor( PrimitiveByteArrayJavaType.INSTANCE );
 		target.addBaselineDescriptor( PrimitiveCharacterArrayJavaType.INSTANCE );
+
+		// Register special ArrayJavaType implementations for primitive types
+		target.addBaselineDescriptor( BooleanPrimitiveArrayJavaType.INSTANCE );
+		target.addBaselineDescriptor( ShortPrimitiveArrayJavaType.INSTANCE );
+		target.addBaselineDescriptor( IntegerPrimitiveArrayJavaType.INSTANCE );
+		target.addBaselineDescriptor( LongPrimitiveArrayJavaType.INSTANCE );
+		target.addBaselineDescriptor( FloatPrimitiveArrayJavaType.INSTANCE );
+		target.addBaselineDescriptor( DoublePrimitiveArrayJavaType.INSTANCE );
 
 		target.addBaselineDescriptor( DurationJavaType.INSTANCE );
 		target.addBaselineDescriptor( InstantJavaType.INSTANCE );
@@ -173,8 +186,8 @@ public class JavaTypeBaseline {
 		target.addBaselineDescriptor( new CollectionJavaType( LinkedHashMap.class, StandardOrderedMapSemantics.INSTANCE ) );
 	}
 
-	private static void primePrimitive(BaselineTarget target, JavaType descriptor) {
+	private static void primePrimitive(BaselineTarget target, JavaType<?> descriptor) {
 		target.addBaselineDescriptor( descriptor );
-		target.addBaselineDescriptor( ( (PrimitiveJavaType) descriptor ).getPrimitiveClass(), descriptor );
+		target.addBaselineDescriptor( ( (PrimitiveJavaType<?>) descriptor ).getPrimitiveClass(), descriptor );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
@@ -52,6 +52,10 @@ public class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 
 	@Override
 	public <X> X unwrap(T value, Class<X> type, WrapperOptions options) {
+		if ( type.isAssignableFrom( getJavaTypeClass() ) ) {
+			//noinspection unchecked
+			return (X) value;
+		}
 		throw new UnsupportedOperationException(
 				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
 		);
@@ -59,6 +63,10 @@ public class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 
 	@Override
 	public <X> T wrap(X value, WrapperOptions options) {
+		if ( getJavaTypeClass().isInstance( value ) ) {
+			//noinspection unchecked
+			return (T) value;
+		}
 		throw new UnsupportedOperationException(
 				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -1,0 +1,248 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.hibernate.HibernateException;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicPluralJavaType;
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.internal.JdbcLiteralFormatterArray;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Descriptor for {@link Types#ARRAY ARRAY} handling.
+ *
+ * @author Christian Beikov
+ * @author Jordan Gigov
+ */
+public class ArrayJdbcType implements JdbcType {
+
+	public static final ArrayJdbcType INSTANCE = new ArrayJdbcType( ObjectJdbcType.INSTANCE );
+	private static final ClassValue<Method> NAME_BINDER = new ClassValue<Method>() {
+		@Override
+		protected Method computeValue(Class<?> type) {
+			try {
+				return type.getMethod( "setArray", String.class, java.sql.Array.class );
+			}
+			catch ( Exception ex ) {
+				// add logging? Did we get NoSuchMethodException or SecurityException?
+				// Doesn't matter which. We can't use it.
+			}
+			return null;
+		}
+	};
+
+	private final JdbcType elementJdbcType;
+
+	public ArrayJdbcType(JdbcType elementJdbcType) {
+		this.elementJdbcType = elementJdbcType;
+	}
+
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return resolveType( typeConfiguration, dialect, elementType.getJdbcType(), columnTypeInformation );
+	}
+
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return new ArrayJdbcType( elementType );
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.ARRAY;
+	}
+
+	public JdbcType getElementJdbcType() {
+		return elementJdbcType;
+	}
+
+	@Override
+	public <T> BasicJavaType<T> getJdbcRecommendedJavaTypeMapping(
+			Integer precision,
+			Integer scale,
+			TypeConfiguration typeConfiguration) {
+		final BasicJavaType<Object> elementJavaType = elementJdbcType.getJdbcRecommendedJavaTypeMapping(
+				precision,
+				scale,
+				typeConfiguration
+		);
+		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().resolveDescriptor(
+				Array.newInstance( elementJavaType.getJavaTypeClass(), 0 ).getClass()
+		);
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaTypeDescriptor) {
+		//noinspection unchecked
+		final BasicPluralJavaType<T> basicPluralJavaType = (BasicPluralJavaType<T>) javaTypeDescriptor;
+		final JdbcLiteralFormatter<T> elementFormatter = elementJdbcType.getJdbcLiteralFormatter( basicPluralJavaType.getElementJavaType() );
+		return new JdbcLiteralFormatterArray<>( javaTypeDescriptor, elementFormatter );
+	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return java.sql.Array.class;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaTypeDescriptor) {
+		//noinspection unchecked
+		final BasicPluralJavaType<X> containerJavaType = (BasicPluralJavaType<X>) javaTypeDescriptor;
+		return new BasicBinder<X>( javaTypeDescriptor, this ) {
+
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final java.sql.Array arr = getArray( value, containerJavaType, options );
+				st.setArray( index, arr );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				final java.sql.Array arr = getArray( value, containerJavaType, options );
+				final Method nameBinder = NAME_BINDER.get( st.getClass() );
+				if ( nameBinder == null ) {
+					try {
+						st.setObject( name, arr, java.sql.Types.ARRAY );
+						return;
+					}
+					catch (SQLException ex) {
+						throw new HibernateException( "JDBC driver does not support named parameters for setArray. Use positional.", ex );
+					}
+				}
+				// Not that it's supposed to have setArray(String,Array) by standard.
+				// There are numerous missing methods that only have versions for positional parameter,
+				// but not named ones.
+
+				try {
+					nameBinder.invoke( st, name, arr );
+				}
+				catch ( Throwable t ) {
+					throw new HibernateException( t );
+				}
+			}
+
+			private java.sql.Array getArray(
+					X value,
+					BasicPluralJavaType<X> containerJavaType,
+					WrapperOptions options) throws SQLException {
+				final TypeConfiguration typeConfiguration = options.getSessionFactory().getTypeConfiguration();
+				final JdbcType underlyingJdbcType = typeConfiguration.getJdbcTypeRegistry()
+						.getDescriptor( elementJdbcType.getDefaultSqlTypeCode() );
+				final Class<?> preferredJavaTypeClass = underlyingJdbcType.getPreferredJavaTypeClass( options );
+				final Class<?> elementJdbcJavaTypeClass;
+				if ( preferredJavaTypeClass == null ) {
+					elementJdbcJavaTypeClass = underlyingJdbcType.getJdbcRecommendedJavaTypeMapping(
+							null,
+							null,
+							typeConfiguration
+					).getJavaTypeClass();
+				}
+				else {
+					elementJdbcJavaTypeClass = preferredJavaTypeClass;
+				}
+				//noinspection unchecked
+				final Class<Object[]> arrayClass = (Class<Object[]>) Array.newInstance(
+						elementJdbcJavaTypeClass,
+						0
+				).getClass();
+				final Object[] objects = javaTypeDescriptor.unwrap( value, arrayClass, options );
+
+				final SharedSessionContractImplementor session = options.getSession();
+				// TODO: ideally, we would have the actual size or the actual type/column accessible
+				//  this is something that we would need for supporting composite types anyway
+				final Size size = session.getJdbcServices()
+						.getDialect()
+						.getSizeStrategy()
+						.resolveSize( elementJdbcType, containerJavaType.getElementJavaType(), null, null, null );
+				String typeName = session.getTypeConfiguration()
+						.getDdlTypeRegistry()
+						.getDescriptor( elementJdbcType.getDefaultSqlTypeCode() )
+						.getTypeName( size );
+				int cutIndex = typeName.indexOf( '(' );
+				if ( cutIndex > 0 ) {
+					// getTypeName for this case required length, etc, parameters.
+					// Cut them out and use database defaults.
+					typeName = typeName.substring( 0, cutIndex );
+				}
+				return session.getJdbcCoordinator().getLogicalConnection().getPhysicalConnection().createArrayOf( typeName, objects );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaTypeDescriptor) {
+		return new BasicExtractor<X>( javaTypeDescriptor, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( rs.getArray( paramIndex ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( statement.getArray( index ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaTypeDescriptor.wrap( statement.getArray( name ), options );
+			}
+		};
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return "ARRAY";
+	}
+
+	@Override
+	public String toString() {
+		return "ArrayTypeDescriptor(" + getFriendlyName() + ")";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+
+		ArrayJdbcType that = (ArrayJdbcType) o;
+
+		return elementJdbcType.equals( that.elementJdbcType );
+	}
+
+	@Override
+	public int hashCode() {
+		return elementJdbcType.hashCode();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BigIntJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BigIntJdbcType.java
@@ -50,6 +50,11 @@ public class BigIntJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Long.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
@@ -90,6 +90,11 @@ public abstract class BlobJdbcType implements JdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return byte[].class;
+		}
+
+		@Override
 		public <X> BasicBinder<X> getBlobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -130,6 +135,11 @@ public abstract class BlobJdbcType implements JdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return byte[].class;
+		}
+
+		@Override
 		public <X> BasicBinder<X> getBlobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -154,6 +164,11 @@ public abstract class BlobJdbcType implements JdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return Blob.class;
+		}
+
+		@Override
 		public <X> BasicBinder<X> getBlobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -175,6 +190,11 @@ public abstract class BlobJdbcType implements JdbcType {
 		@Override
 		public String toString() {
 			return "BlobTypeDescriptor(STREAM_BINDING)";
+		}
+
+		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return BinaryStream.class;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BooleanJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BooleanJdbcType.java
@@ -70,6 +70,11 @@ public class BooleanJdbcType implements AdjustableJdbcType {
 		return this;
 	}
 
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Boolean.class;
+	}
+
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
@@ -91,6 +91,13 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return options.useStreamForLobBinding() ?
+					STREAM_BINDING.getPreferredJavaTypeClass( options ) :
+					CLOB_BINDING.getPreferredJavaTypeClass( options );
+		}
+
+		@Override
 		public <X> BasicBinder<X> getClobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -122,6 +129,11 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		@Override
 		public String toString() {
 			return "ClobTypeDescriptor(STRING_BINDING)";
+		}
+
+		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return String.class;
 		}
 
 		@Override
@@ -171,6 +183,11 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return Clob.class;
+		}
+
+		@Override
 		public <X> BasicBinder<X> getClobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -192,6 +209,11 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		@Override
 		public String toString() {
 			return "ClobTypeDescriptor(STREAM_BINDING)";
+		}
+
+		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return CharacterStream.class;
 		}
 
 		@Override
@@ -226,6 +248,11 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		@Override
 		public String toString() {
 			return "ClobTypeDescriptor(STREAM_BINDING_EXTRACTING)";
+		}
+
+		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return CharacterStream.class;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DateJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DateJdbcType.java
@@ -64,6 +64,11 @@ public class DateJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Date.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DecimalJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DecimalJdbcType.java
@@ -61,6 +61,11 @@ public class DecimalJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return BigDecimal.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DoubleJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DoubleJdbcType.java
@@ -71,6 +71,11 @@ public class DoubleJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Double.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/FloatJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/FloatJdbcType.java
@@ -64,6 +64,11 @@ public class FloatJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Float.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/IntegerJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/IntegerJdbcType.java
@@ -60,6 +60,11 @@ public class IntegerJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Integer.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
@@ -9,11 +9,13 @@ package org.hibernate.type.descriptor.jdbc;
 import java.io.Serializable;
 import java.sql.Types;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
@@ -108,6 +110,14 @@ public interface JdbcType extends Serializable {
 	 * @return The appropriate extractor
 	 */
 	<X> ValueExtractor<X> getExtractor(JavaType<X> javaType);
+
+	/**
+	 * The Java type class that is preferred by the binder or null.
+	 */
+	@Incubating
+	default Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return null;
+	}
 
 	default boolean isInteger() {
 		return isInteger( getJdbcTypeCode() );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
@@ -70,7 +70,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForBoolean() {
-		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getPreferredSqlTypeCodeForBoolean();
 	}
 
 	/**
@@ -80,7 +80,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForDuration() {
-		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForDuration();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getPreferredSqlTypeCodeForDuration();
 	}
 
 	/**
@@ -90,7 +90,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForUuid() {
-		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForUuid();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getPreferredSqlTypeCodeForUuid();
 	}
 
 	/**
@@ -100,7 +100,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForInstant() {
-		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForInstant();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getPreferredSqlTypeCodeForInstant();
 	}
 
 	/**
@@ -108,9 +108,10 @@ public interface JdbcTypeIndicators {
 	 * <p/>
 	 * Specifically names the key into the
 	 * {@link JdbcTypeRegistry}.
+	 * @since 6.1
 	 */
 	default int getPreferredSqlTypeCodeForArray() {
-		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForArray();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getPreferredSqlTypeCodeForArray();
 	}
 
 	/**
@@ -135,7 +136,7 @@ public interface JdbcTypeIndicators {
 	}
 
 	default TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy() {
-		return getTypeConfiguration().getSessionFactory().getFastSessionServices().getDefaultTimeZoneStorageStrategy();
+		return getTypeConfiguration().getCurrentBaseSqlTypeIndicators().getDefaultTimeZoneStorageStrategy();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
@@ -70,7 +70,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForBoolean() {
-		return Types.BOOLEAN;
+		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
 	}
 
 	/**
@@ -80,7 +80,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForDuration() {
-		return SqlTypes.INTERVAL_SECOND;
+		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForDuration();
 	}
 
 	/**
@@ -90,7 +90,7 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForUuid() {
-		return SqlTypes.UUID;
+		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForUuid();
 	}
 
 	/**
@@ -100,7 +100,17 @@ public interface JdbcTypeIndicators {
 	 * {@link JdbcTypeRegistry}.
 	 */
 	default int getPreferredSqlTypeCodeForInstant() {
-		return SqlTypes.TIMESTAMP_UTC;
+		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForInstant();
+	}
+
+	/**
+	 * When mapping a basic array or collection type to the database what is the preferred SQL type code to use?
+	 * <p/>
+	 * Specifically names the key into the
+	 * {@link JdbcTypeRegistry}.
+	 */
+	default int getPreferredSqlTypeCodeForArray() {
+		return getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForArray();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonJdbcType.java
@@ -44,6 +44,12 @@ public class JsonJdbcType implements JdbcType {
 	}
 
 	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
@@ -78,6 +78,13 @@ public abstract class NClobJdbcType implements JdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return options.useStreamForLobBinding() ?
+					STREAM_BINDING.getPreferredJavaTypeClass( options ) :
+					NCLOB_BINDING.getPreferredJavaTypeClass( options );
+		}
+
+		@Override
 		public <X> BasicBinder<X> getNClobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -112,6 +119,11 @@ public abstract class NClobJdbcType implements JdbcType {
 		}
 
 		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return NClob.class;
+		}
+
+		@Override
 		public <X> BasicBinder<X> getNClobBinder(final JavaType<X> javaType) {
 			return new BasicBinder<>( javaType, this ) {
 				@Override
@@ -133,6 +145,11 @@ public abstract class NClobJdbcType implements JdbcType {
 		@Override
 		public String toString() {
 			return "NClobTypeDescriptor(STREAM_BINDING)";
+		}
+
+		@Override
+		public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+			return CharacterStream.class;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
@@ -85,6 +85,11 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return String.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/RealJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/RealJdbcType.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.jdbc;
 
 import java.sql.Types;
 
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -47,4 +48,10 @@ public class RealJdbcType extends FloatJdbcType {
 			TypeConfiguration typeConfiguration) {
 		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().getDescriptor( Float.class );
 	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Float.class;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/SmallIntJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/SmallIntJdbcType.java
@@ -60,6 +60,11 @@ public class SmallIntJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Short.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimeJdbcType.java
@@ -64,6 +64,11 @@ public class TimeJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Time.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampJdbcType.java
@@ -64,6 +64,11 @@ public class TimestampJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Timestamp.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampWithTimeZoneJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampWithTimeZoneJdbcType.java
@@ -63,6 +63,11 @@ public class TimestampWithTimeZoneJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return OffsetDateTime.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TinyIntJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TinyIntJdbcType.java
@@ -63,6 +63,11 @@ public class TinyIntJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return Byte.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/UUIDJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/UUIDJdbcType.java
@@ -46,6 +46,11 @@ public class UUIDJdbcType implements JdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return UUID.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/VarbinaryJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/VarbinaryJdbcType.java
@@ -63,6 +63,11 @@ public class VarbinaryJdbcType implements AdjustableJdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return byte[].class;
+	}
+
+	@Override
 	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
 		return supportsLiterals ? new JdbcLiteralFormatterBinary<>( javaType ) : null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/VarcharJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/VarcharJdbcType.java
@@ -85,6 +85,11 @@ public class VarcharJdbcType implements AdjustableJdbcType {
 	}
 
 	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return String.class;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
@@ -44,6 +44,12 @@ public class XmlAsStringJdbcType implements JdbcType {
 	}
 
 	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
 		return new BasicBinder<>( javaType, this ) {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlJdbcType.java
@@ -40,6 +40,12 @@ public class XmlJdbcType implements JdbcType {
 	}
 
 	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
+	}
+
+	@Override
 	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
 		return new XmlValueBinder<>( javaType, this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcLiteralFormatterArray.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcLiteralFormatterArray.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.type.descriptor.jdbc.internal;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.spi.BasicJdbcLiteralFormatter;
+
+public class JdbcLiteralFormatterArray<T> extends BasicJdbcLiteralFormatter<T> {
+
+	private final JdbcLiteralFormatter<Object> elementFormatter;
+
+	public JdbcLiteralFormatterArray(JavaType<T> javaType, JdbcLiteralFormatter<?> elementFormatter) {
+		super( javaType );
+		//noinspection unchecked
+		this.elementFormatter = (JdbcLiteralFormatter<Object>) elementFormatter;
+	}
+
+	@Override
+	public void appendJdbcLiteral(SqlAppender appender, Object value, Dialect dialect, WrapperOptions wrapperOptions) {
+		dialect.appendArrayLiteral(
+				appender,
+				unwrap( value, Object[].class, wrapperOptions ),
+				elementFormatter,
+				wrapperOptions
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
@@ -32,6 +32,7 @@ import org.hibernate.type.descriptor.jdbc.TimestampWithTimeZoneJdbcType;
 import org.hibernate.type.descriptor.jdbc.TinyIntJdbcType;
 import org.hibernate.type.descriptor.jdbc.VarbinaryJdbcType;
 import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 
 /**
  * Registers the base {@link JdbcType} instances.

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/spi/JdbcTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/spi/JdbcTypeRegistry.java
@@ -29,14 +29,18 @@ import org.jboss.logging.Logger;
 public class JdbcTypeRegistry implements JdbcTypeBaseline.BaselineTarget, Serializable {
 	private static final Logger log = Logger.getLogger( JdbcTypeRegistry.class );
 
+	private final TypeConfiguration typeConfiguration;
 	private final ConcurrentHashMap<Integer, JdbcType> descriptorMap = new ConcurrentHashMap<>();
 
 	public JdbcTypeRegistry(TypeConfiguration typeConfiguration) {
-//		this.typeConfiguration = typeConfiguration;
+		this.typeConfiguration = typeConfiguration;
 		JdbcTypeBaseline.prime( this );
 	}
 
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	public TypeConfiguration getTypeConfiguration() {
+		return typeConfiguration;
+	}
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// baseline descriptors
 
 	@Override
@@ -61,6 +65,10 @@ public class JdbcTypeRegistry implements JdbcTypeBaseline.BaselineTarget, Serial
 
 	public void addDescriptorIfAbsent(int typeCode, JdbcType jdbcType) {
 		descriptorMap.putIfAbsent( typeCode, jdbcType );
+	}
+
+	public JdbcType findDescriptor(int jdbcTypeCode) {
+		return descriptorMap.get( jdbcTypeCode );
 	}
 
 	public JdbcType getDescriptor(int jdbcTypeCode) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/DdlType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/DdlType.java
@@ -9,6 +9,7 @@ package org.hibernate.type.descriptor.sql;
 import java.io.Serializable;
 import java.sql.Types;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SqlExpressible;
@@ -30,7 +31,18 @@ public interface DdlType extends Serializable {
 	 */
 	int getSqlTypeCode();
 
+	/**
+	 * Returns the default type name without precision/length and scale parameters.
+	 */
 	String getRawTypeName();
+
+	/**
+	 * Returns all type names without precision/length and scale parameters.
+	 */
+	@Incubating
+	default String[] getRawTypeNames() {
+		return new String[] { getRawTypeName() };
+	}
 
 	String getTypeNamePattern();
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/internal/CapacityDependentDdlType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/internal/CapacityDependentDdlType.java
@@ -32,6 +32,26 @@ public class CapacityDependentDdlType extends DdlTypeImpl {
 		this.typeEntries = builder.typeEntries.toArray(new TypeEntry[0]);
 	}
 
+	public String[] getRawTypeNames() {
+		final String[] rawTypeNames = new String[typeEntries.length + 1];
+		for ( int i = 0; i < typeEntries.length; i++ ) {
+			//trim off the length/precision/scale
+			final String typeNamePattern = typeEntries[i].typeNamePattern;
+			final int paren = typeNamePattern.indexOf( '(' );
+			if ( paren > 0 ) {
+				final int parenEnd = typeNamePattern.lastIndexOf( ')' );
+				rawTypeNames[i] = parenEnd + 1 == typeNamePattern.length()
+						? typeNamePattern.substring( 0, paren )
+						: ( typeNamePattern.substring( 0, paren ) + typeNamePattern.substring( parenEnd + 1 ) );
+			}
+			else {
+				rawTypeNames[i] = typeNamePattern;
+			}
+		}
+		rawTypeNames[typeEntries.length] = getRawTypeName();
+		return rawTypeNames;
+	}
+
 	@Override
 	public String getTypeName(Long size, Integer precision, Integer scale) {
 		if ( size != null && size > 0 ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/internal/DdlTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/internal/DdlTypeImpl.java
@@ -54,7 +54,13 @@ public class DdlTypeImpl implements DdlType {
 	public String getRawTypeName() {
 		//trim off the length/precision/scale
 		final int paren = typeNamePattern.indexOf( '(' );
-		return paren > 0 ? typeNamePattern.substring( 0, paren ) : typeNamePattern;
+		if ( paren > 0 ) {
+			final int parenEnd = typeNamePattern.lastIndexOf( ')' );
+			return parenEnd == typeNamePattern.length()
+					? typeNamePattern.substring( 0, paren )
+					: ( typeNamePattern.substring( 0, paren ) + typeNamePattern.substring( parenEnd + 1 ) );
+		}
+		return typeNamePattern;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/DdlTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/DdlTypeRegistry.java
@@ -10,11 +10,14 @@ import java.io.Serializable;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.JdbcTypeNameMapper;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.sql.DdlType;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -31,6 +34,7 @@ public class DdlTypeRegistry implements Serializable {
 	private static final Logger log = Logger.getLogger( DdlTypeRegistry.class );
 
 	private final Map<Integer, DdlType> ddlTypes = new HashMap<>();
+	private final Map<String, Integer> sqlTypes = new TreeMap<>( String.CASE_INSENSITIVE_ORDER );
 
 	public DdlTypeRegistry(TypeConfiguration typeConfiguration) {
 //		this.typeConfiguration = typeConfiguration;
@@ -40,25 +44,45 @@ public class DdlTypeRegistry implements Serializable {
 	// baseline descriptors
 
 	public void addDescriptor(DdlType ddlType) {
-		final DdlType previous = ddlTypes.put( ddlType.getSqlTypeCode(), ddlType );
-		if ( previous != null && previous != ddlType ) {
-			log.debugf( "addDescriptor(%s) replaced previous registration(%s)", ddlType, previous );
-		}
+		addDescriptor( ddlType.getSqlTypeCode(), ddlType );
 	}
 
 	public void addDescriptor(int sqlTypeCode, DdlType ddlType) {
 		final DdlType previous = ddlTypes.put( sqlTypeCode, ddlType );
 		if ( previous != null && previous != ddlType ) {
+			for ( String rawTypeName : previous.getRawTypeNames() ) {
+				sqlTypes.remove( rawTypeName );
+			}
 			log.debugf( "addDescriptor(%d, %s) replaced previous registration(%s)", sqlTypeCode, ddlType, previous );
+		}
+		addSqlType( ddlType, sqlTypeCode );
+	}
+
+	public void addDescriptorIfAbsent(DdlType ddlType) {
+		addDescriptorIfAbsent( ddlType.getSqlTypeCode(), ddlType );
+	}
+
+	public void addDescriptorIfAbsent(int sqlTypeCode, DdlType ddlType) {
+		if ( ddlTypes.putIfAbsent( sqlTypeCode, ddlType ) == null ) {
+			addSqlType( ddlType, sqlTypeCode );
 		}
 	}
 
-	public void addDescriptorIfAbsent(DdlType jdbcType) {
-		ddlTypes.putIfAbsent( jdbcType.getSqlTypeCode(), jdbcType );
+	private void addSqlType(DdlType ddlType, int sqlTypeCode) {
+		for ( String rawTypeName : ddlType.getRawTypeNames() ) {
+			final Integer previousSqlTypeCode = sqlTypes.put( rawTypeName, sqlTypeCode );
+			// Prefer the standard code over a custom code for a certain type name
+			if ( previousSqlTypeCode != null && JdbcTypeNameMapper.isStandardTypeCode( previousSqlTypeCode ) ) {
+				sqlTypes.put( rawTypeName, previousSqlTypeCode );
+			}
+		}
 	}
 
-	public void addDescriptorIfAbsent(int sqlTypeCode, DdlType jdbcType) {
-		ddlTypes.putIfAbsent( sqlTypeCode, jdbcType );
+	/**
+	 * Returns the {@link SqlTypes} type code for the given DDL raw type name, or <code>null</code> if it is unknown.
+	 */
+	public Integer getSqlTypeCode(String rawTypeName) {
+		return sqlTypes.get( rawTypeName );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
@@ -28,7 +28,7 @@ public class ConvertedBasicTypeImpl<J> extends NamedBasicTypeImpl<J> implements 
 	}
 
 	@Override
-	public BasicValueConverter<J, ?> getValueConverter() {
+	public BasicValueConverter getValueConverter() {
 		return converter;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/UserTypeJavaTypeWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/UserTypeJavaTypeWrapper.java
@@ -20,6 +20,7 @@ import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.java.MutabilityPlanExposer;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.usertype.EnhancedUserType;
 import org.hibernate.usertype.UserType;
 
 /**
@@ -115,7 +116,18 @@ public class UserTypeJavaTypeWrapper<J> implements BasicJavaType<J> {
 
 	@Override
 	public J fromString(CharSequence string) {
+		if ( userType instanceof EnhancedUserType<?> ) {
+			return ( (EnhancedUserType<J>) userType ).fromStringValue( string );
+		}
 		throw new UnsupportedOperationException( "No support for parsing UserType values from String: " + userType );
+	}
+
+	@Override
+	public String toString(J value) {
+		if ( userType.returnedClass().isInstance( value ) && userType instanceof EnhancedUserType<?> ) {
+			return ( (EnhancedUserType<J>) userType ).toString( value );
+		}
+		return value == null ? "null" : value.toString();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -34,6 +34,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.annotations.common.reflection.java.generics.ParameterizedTypeImpl;
 import org.hibernate.boot.cfgxml.spi.CfgXmlAccessService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -351,6 +352,48 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			@Override
 			public TypeConfiguration getTypeConfiguration() {
 				return typeConfiguration;
+			}
+
+			@Override
+			public TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getBuildingOptions().getDefaultTimeZoneStorage()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getDefaultTimeZoneStorageStrategy();
+			}
+
+			@Override
+			public int getPreferredSqlTypeCodeForBoolean() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getPreferredSqlTypeCodeForBoolean()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
+			}
+
+			@Override
+			public int getPreferredSqlTypeCodeForDuration() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getPreferredSqlTypeCodeForDuration()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForDuration();
+			}
+
+			@Override
+			public int getPreferredSqlTypeCodeForUuid() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getPreferredSqlTypeCodeForUuid()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForUuid();
+			}
+
+			@Override
+			public int getPreferredSqlTypeCodeForInstant() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getPreferredSqlTypeCodeForInstant()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForInstant();
+			}
+
+			@Override
+			public int getPreferredSqlTypeCodeForArray() {
+				return sessionFactory == null
+						? getMetadataBuildingContext().getPreferredSqlTypeCodeForArray()
+						: getTypeConfiguration().getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForArray();
 			}
 		};
 

--- a/hibernate-core/src/main/java/org/hibernate/usertype/StaticUserTypeSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/StaticUserTypeSupport.java
@@ -79,6 +79,7 @@ public class StaticUserTypeSupport<T> implements UserType<T> {
 		return mutabilityPlan;
 	}
 
+	@Override
 	public BasicValueConverter<T, Object> getValueConverter() {
 		return valueConverter;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/UserType.java
@@ -11,9 +11,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
@@ -154,5 +156,14 @@ public interface UserType<J> {
 
 	default int getDefaultSqlScale(Dialect dialect, JdbcType jdbcType) {
 		return Size.DEFAULT_SCALE;
+	}
+
+	/**
+	 * Returns the converter that this user type uses for transforming from the domain type, to the relational type,
+	 * or <code>null</code> if there is no conversion.
+	 */
+	@Incubating
+	default BasicValueConverter<J, Object> getValueConverter() {
+		return null;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/EnumeratedSmokeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/EnumeratedSmokeTest.java
@@ -78,7 +78,7 @@ public class EnumeratedSmokeTest extends BaseUnitTestCase {
 		assertThat( hibernateMappingEnumType.isOrdinal(), is(expectedJpaEnumType==EnumType.ORDINAL) );
 		final int expectedJdbcTypeCode = jdbcRegistry.getDescriptor(
 				expectedJpaEnumType == EnumType.ORDINAL ?
-						Types.TINYINT :
+						Types.SMALLINT :
 						Types.VARCHAR
 		).getJdbcTypeCode();
 		assertThat(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/EnumResolutionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/basics/EnumResolutionTests.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -59,7 +60,7 @@ public class EnumResolutionTests {
 
 		verifyEnumResolution(
 				entityBinding.getProperty( "rawEnum" ),
-				Types.TINYINT,
+				Types.SMALLINT,
 				Integer.class,
 				OrdinalEnumValueConverter.class,
 				true
@@ -74,7 +75,7 @@ public class EnumResolutionTests {
 
 		verifyEnumResolution(
 				entityBinding.getProperty( "unspecifiedMappingEnum" ),
-				Types.TINYINT,
+				Types.SMALLINT,
 				Integer.class,
 				OrdinalEnumValueConverter.class,
 				true
@@ -89,7 +90,7 @@ public class EnumResolutionTests {
 
 		verifyEnumResolution(
 				entityBinding.getProperty( "ordinalEnum" ),
-				Types.TINYINT,
+				Types.SMALLINT,
 				Integer.class,
 				OrdinalEnumValueConverter.class,
 				true
@@ -131,6 +132,21 @@ public class EnumResolutionTests {
 				(legacyResolution) -> {
 					assertThat( legacyResolution, instanceOf( AttributeConverterTypeAdapter.class ) );
 				}
+		);
+	}
+
+	@Test
+	public void testExplicitEnumResolution(DomainModelScope scope) {
+		final PersistentClass entityBinding = scope
+				.getDomainModel()
+				.getEntityBinding( EntityWithEnums.class.getName() );
+
+		verifyEnumResolution(
+				entityBinding.getProperty( "explicitEnum" ),
+				Types.TINYINT,
+				Integer.class,
+				OrdinalEnumValueConverter.class,
+				true
 		);
 	}
 
@@ -204,6 +220,10 @@ public class EnumResolutionTests {
 
 		@Enumerated( STRING )
 		private Values namedEnum;
+
+		@Enumerated( ORDINAL )
+		@JdbcTypeCode( Types.TINYINT )
+		private Values explicitEnum;
 	}
 
 	enum Values { FIRST, SECOND }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/SmokeTests.java
@@ -96,7 +96,7 @@ public class SmokeTests {
 
 			assertThat(
 					genderAttrMapping.getJdbcMapping().getJdbcType(),
-					is( jdbcTypeRegistry.getDescriptor( Types.TINYINT ) )
+					is( jdbcTypeRegistry.getDescriptor( Types.SMALLINT ) )
 			);
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/AbstractDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/AbstractDescriptorTest.java
@@ -48,6 +48,10 @@ public abstract class AbstractDescriptorTest<T> extends BaseUnitTestCase {
 		testData = getTestData();
 	}
 
+	protected JavaType<T> typeDescriptor() {
+		return typeDescriptor;
+	}
+
 	protected abstract Data<T> getTestData();
 
 	protected abstract boolean shouldBeMutable();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/EnumValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/EnumValidationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.schemavalidation;
+
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Map;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.JdbcMetadaAccessStrategy;
+import org.hibernate.tool.schema.SourceType;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl;
+import org.hibernate.tool.schema.spi.ContributableMatcher;
+import org.hibernate.tool.schema.spi.ExceptionHandler;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaFilter;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+import org.hibernate.tool.schema.spi.ScriptSourceInput;
+import org.hibernate.tool.schema.spi.ScriptTargetOutput;
+import org.hibernate.tool.schema.spi.SourceDescriptor;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+
+/**
+ * Test that an existing tinyint column works even if we switch to smallint type code for enums.
+ */
+@TestForIssue(jiraKey = "HHH-15288")
+@RunWith(Parameterized.class)
+public class EnumValidationTest implements ExecutionOptions {
+	@Parameterized.Parameters
+	public static Collection<String> parameters() {
+		return Arrays.asList(
+				JdbcMetadaAccessStrategy.GROUPED.toString(),
+				JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
+		);
+	}
+
+	@Parameterized.Parameter
+	public String jdbcMetadataExtractorStrategy;
+
+	private StandardServiceRegistry ssr;
+	private MetadataImplementor metadata;
+	private MetadataImplementor oldMetadata;
+
+	@Before
+	public void beforeTest() {
+		ssr = new StandardServiceRegistryBuilder()
+				.applySetting(
+						AvailableSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY,
+						jdbcMetadataExtractorStrategy
+				)
+				.build();
+		oldMetadata = (MetadataImplementor) new MetadataSources( ssr )
+				.addAnnotatedClass( TestEntityOld.class )
+				.buildMetadata();
+		oldMetadata.validate();
+		metadata = (MetadataImplementor) new MetadataSources( ssr )
+				.addAnnotatedClass( TestEntity.class )
+				.buildMetadata();
+		metadata.validate();
+
+		try {
+			dropSchema();
+			// create the schema
+			createSchema();
+		}
+		catch (Exception e) {
+			tearDown();
+			throw e;
+		}
+	}
+
+	@After
+	public void tearDown() {
+		dropSchema();
+		if ( ssr != null ) {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+	@Test
+	public void testValidation() {
+		doValidation();
+	}
+
+	private void doValidation() {
+		ssr.getService( SchemaManagementTool.class ).getSchemaValidator( null )
+				.doValidation( metadata, this, ContributableMatcher.ALL );
+	}
+
+	private void createSchema() {
+		ssr.getService( SchemaManagementTool.class ).getSchemaCreator( null ).doCreation(
+				oldMetadata,
+				this,
+				ContributableMatcher.ALL,
+				new SourceDescriptor() {
+					@Override
+					public SourceType getSourceType() {
+						return SourceType.METADATA;
+					}
+
+					@Override
+					public ScriptSourceInput getScriptSourceInput() {
+						return null;
+					}
+				},
+				new TargetDescriptor() {
+					@Override
+					public EnumSet<TargetType> getTargetTypes() {
+						return EnumSet.of( TargetType.DATABASE );
+					}
+
+					@Override
+					public ScriptTargetOutput getScriptTargetOutput() {
+						return null;
+					}
+				}
+		);
+	}
+
+	private void dropSchema() {
+		new SchemaExport()
+				.drop( EnumSet.of( TargetType.DATABASE ), oldMetadata );
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntityOld {
+		@Id
+		public Integer id;
+
+		@Enumerated(EnumType.ORDINAL)
+		@Column(name = "enumVal")
+		@JdbcTypeCode(Types.TINYINT)
+		TestEnum enumVal;
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		public Integer id;
+
+		@Enumerated(EnumType.ORDINAL)
+		@Column(name = "enumVal")
+		TestEnum enumVal;
+	}
+
+	public enum TestEnum {
+		VALUE1,
+		VALUE2
+	}
+
+	@Override
+	public Map getConfigurationValues() {
+		return ssr.getService( ConfigurationService.class ).getSettings();
+	}
+
+	@Override
+	public boolean shouldManageNamespaces() {
+		return false;
+	}
+
+	@Override
+	public ExceptionHandler getExceptionHandler() {
+		return ExceptionHandlerLoggedImpl.INSTANCE;
+	}
+
+	@Override
+	public SchemaFilter getSchemaFilter() {
+		return SchemaFilter.ALL;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -187,7 +187,7 @@ public class SmokeTests {
 					assertThat( basicType.getJavaTypeDescriptor().getJavaTypeClass(), AssignableMatcher.assignableTo( Integer.class ) );
 					assertThat(
 							basicType.getJdbcType(),
-							is( jdbcTypeRegistry.getDescriptor( Types.TINYINT ) )
+							is( jdbcTypeRegistry.getDescriptor( Types.SMALLINT ) )
 					);
 
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicListTest.java
@@ -1,0 +1,178 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.query.BindableType;
+import org.hibernate.query.spi.QueryImplementor;
+
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Beikov
+ */
+public class BasicListTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private BindableType<List<Integer>> integerListType;
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithIntegerList.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			integerListType = em.getTypeConfiguration().getBasicTypeForGenericJavaType( List.class, Integer.class );
+			em.persist( new TableWithIntegerList( 1L, Collections.emptyList() ) );
+			em.persist( new TableWithIntegerList( 2L, Arrays.asList( 512, 112, null, 0 ) ) );
+			em.persist( new TableWithIntegerList( 3L, null ) );
+
+			QueryImplementor q;
+			q = em.createNamedQuery( "TableWithIntegerList.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", Arrays.asList( null, null, 0 ), integerListType );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_integer_list(id, the_list) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", Arrays.asList( null, null, 0 ), integerListType );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithIntegerList tableRecord;
+			tableRecord = em.find( TableWithIntegerList.class, 1L );
+			assertThat( tableRecord.getTheList(), is( Collections.emptyList() ) );
+
+			tableRecord = em.find( TableWithIntegerList.class, 2L );
+			assertThat( tableRecord.getTheList(), is( Arrays.asList( 512, 112, null, 0 ) ) );
+
+			tableRecord = em.find( TableWithIntegerList.class, 3L );
+			assertThat( tableRecord.getTheList(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerList> tq = em.createNamedQuery( "TableWithIntegerList.JPQL.getById", TableWithIntegerList.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerList tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheList(), is( Arrays.asList( 512, 112, null, 0 ) ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerList> tq = em.createNamedQuery( "TableWithIntegerList.JPQL.getByData", TableWithIntegerList.class );
+			tq.setParameter( "data", Collections.emptyList() );
+			TableWithIntegerList tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerList> tq = em.createNamedQuery( "TableWithIntegerList.Native.getById", TableWithIntegerList.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerList tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheList(), is( Arrays.asList( 512, 112, null, 0 ) ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			QueryImplementor<TableWithIntegerList> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_integer_list t WHERE the_list " + op + " :data",
+					TableWithIntegerList.class
+			);
+			tq.setParameter( "data", Arrays.asList( 512, 112, null, 0 ), integerListType );
+			TableWithIntegerList tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Entity( name = "TableWithIntegerList" )
+	@Table( name = "table_with_integer_list" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithIntegerList.JPQL.getById",
+				query = "SELECT t FROM TableWithIntegerList t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithIntegerList.JPQL.getByData",
+				query = "SELECT t FROM TableWithIntegerList t WHERE theList IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithIntegerList.Native.getById",
+				query = "SELECT * FROM table_with_integer_list t WHERE id = :id",
+				resultClass = TableWithIntegerList.class ),
+		@NamedNativeQuery( name = "TableWithIntegerList.Native.insert",
+				query = "INSERT INTO table_with_integer_list(id, the_list) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithIntegerList {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_list" )
+		private List<Integer> theList;
+
+		public TableWithIntegerList() {
+		}
+
+		public TableWithIntegerList(Long id, List<Integer> theList) {
+			this.id = id;
+			this.theList = theList;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<Integer> getTheList() {
+			return theList;
+		}
+
+		public void setTheList(List<Integer> theList) {
+			this.theList = theList;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicSortedSetTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicSortedSetTest.java
@@ -1,0 +1,182 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.query.BindableType;
+import org.hibernate.query.spi.QueryImplementor;
+
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Beikov
+ */
+public class BasicSortedSetTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private BindableType<SortedSet<Integer>> integerSortedSetType;
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithIntegerSortedSet.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			integerSortedSetType = em.getTypeConfiguration().getBasicTypeForGenericJavaType( SortedSet.class, Integer.class );
+			em.persist( new TableWithIntegerSortedSet( 1L, Collections.emptySortedSet() ) );
+			em.persist( new TableWithIntegerSortedSet( 2L, new TreeSet<>( Arrays.asList( 512, 112, 0 ) ) ) );
+			em.persist( new TableWithIntegerSortedSet( 3L, null ) );
+
+			QueryImplementor q;
+			q = em.createNamedQuery( "TableWithIntegerSortedSet.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new TreeSet<>( Arrays.asList( 0 ) ), integerSortedSetType );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_integer_sorted_set(id, the_sorted_set) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new TreeSet<>( Arrays.asList( 0 ) ), integerSortedSetType );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithIntegerSortedSet tableRecord;
+			tableRecord = em.find( TableWithIntegerSortedSet.class, 1L );
+			assertThat( tableRecord.getTheSortedSet(), is( Collections.emptySortedSet() ) );
+
+			tableRecord = em.find( TableWithIntegerSortedSet.class, 2L );
+			assertThat( tableRecord.getTheSortedSet(), is( new TreeSet<>( Arrays.asList( 512, 112, 0 ) ) ) );
+
+			tableRecord = em.find( TableWithIntegerSortedSet.class, 3L );
+			assertThat( tableRecord.getTheSortedSet(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerSortedSet> tq = em.createNamedQuery( "TableWithIntegerSortedSet.JPQL.getById", TableWithIntegerSortedSet.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerSortedSet tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheSortedSet(), is( new TreeSet<>( Arrays.asList( 512, 112, 0 ) ) ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerSortedSet> tq = em.createNamedQuery( "TableWithIntegerSortedSet.JPQL.getByData", TableWithIntegerSortedSet.class );
+			tq.setParameter( "data", Collections.emptySortedSet() );
+			TableWithIntegerSortedSet tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerSortedSet> tq = em.createNamedQuery( "TableWithIntegerSortedSet.Native.getById", TableWithIntegerSortedSet.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerSortedSet tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheSortedSet(), is( new TreeSet<>( Arrays.asList( 512, 112, 0 ) ) ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			QueryImplementor<TableWithIntegerSortedSet> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_integer_sorted_set t WHERE the_sorted_set " + op + " :data",
+					TableWithIntegerSortedSet.class
+			);
+			tq.setParameter( "data", new TreeSet<>( Arrays.asList( 512, 112, 0 ) ), integerSortedSetType );
+			TableWithIntegerSortedSet tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Entity( name = "TableWithIntegerSortedSet" )
+	@Table( name = "table_with_integer_sorted_set" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithIntegerSortedSet.JPQL.getById",
+				query = "SELECT t FROM TableWithIntegerSortedSet t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithIntegerSortedSet.JPQL.getByData",
+				query = "SELECT t FROM TableWithIntegerSortedSet t WHERE theSortedSet IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithIntegerSortedSet.Native.getById",
+				query = "SELECT * FROM table_with_integer_sorted_set t WHERE id = :id",
+				resultClass = TableWithIntegerSortedSet.class ),
+		@NamedNativeQuery( name = "TableWithIntegerSortedSet.Native.getByData",
+				query = "SELECT * FROM table_with_integer_sorted_set t WHERE the_sorted_set IS NOT DISTINCT FROM :data",
+				resultClass = TableWithIntegerSortedSet.class ),
+		@NamedNativeQuery( name = "TableWithIntegerSortedSet.Native.insert",
+				query = "INSERT INTO table_with_integer_sorted_set(id, the_sorted_set) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithIntegerSortedSet {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_sorted_set" )
+		private SortedSet<Integer> theSortedSet;
+
+		public TableWithIntegerSortedSet() {
+		}
+
+		public TableWithIntegerSortedSet(Long id, SortedSet<Integer> theSortedSet) {
+			this.id = id;
+			this.theSortedSet = theSortedSet;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public SortedSet<Integer> getTheSortedSet() {
+			return theSortedSet;
+		}
+
+		public void setTheSortedSet(SortedSet<Integer> theSortedSet) {
+			this.theSortedSet = theSortedSet;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/BooleanArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/BooleanArrayTest.java
@@ -1,0 +1,203 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaRoot;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class BooleanArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithBooleanArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithBooleanArrays( 1L, new Boolean[]{} ) );
+			em.persist( new TableWithBooleanArrays( 2L, new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) );
+			em.persist( new TableWithBooleanArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithBooleanArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Boolean[]{ Boolean.TRUE, null, Boolean.FALSE } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_boolean_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Boolean[]{ Boolean.TRUE, null, Boolean.FALSE } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithBooleanArrays tableRecord;
+			tableRecord = em.find( TableWithBooleanArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Boolean[]{} ) );
+
+			tableRecord = em.find( TableWithBooleanArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) );
+
+			tableRecord = em.find( TableWithBooleanArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithBooleanArrays> tq = em.createNamedQuery( "TableWithBooleanArrays.JPQL.getById", TableWithBooleanArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithBooleanArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithBooleanArrays> tq = em.createNamedQuery( "TableWithBooleanArrays.JPQL.getByData", TableWithBooleanArrays.class );
+			tq.setParameter( "data", new Boolean[]{} );
+			TableWithBooleanArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithBooleanArrays> tq = em.createNamedQuery( "TableWithBooleanArrays.Native.getById", TableWithBooleanArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithBooleanArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithBooleanArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_boolean_arrays t WHERE the_array " + op + " :data",
+					TableWithBooleanArrays.class
+			);
+			tq.setParameter( "data", new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } );
+			TableWithBooleanArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithBooleanArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testLiteral() {
+		inSession( em -> {
+			final HibernateCriteriaBuilder cb = em.getCriteriaBuilder();
+			final JpaCriteriaQuery<TableWithBooleanArrays> query = cb.createQuery( TableWithBooleanArrays.class );
+			final JpaRoot<TableWithBooleanArrays> root = query.from( TableWithBooleanArrays.class );
+			query.where( cb.notDistinctFrom( root.get( "theArray" ), cb.literal( new Boolean[]{ Boolean.FALSE, Boolean.FALSE, null, Boolean.TRUE } ) ) );
+			TableWithBooleanArrays tableRecord = em.createQuery( query ).getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Entity( name = "TableWithBooleanArrays" )
+	@Table( name = "table_with_boolean_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithBooleanArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithBooleanArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithBooleanArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithBooleanArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithBooleanArrays.Native.getById",
+				query = "SELECT * FROM table_with_boolean_arrays t WHERE id = :id",
+				resultClass = TableWithBooleanArrays.class ),
+		@NamedNativeQuery( name = "TableWithBooleanArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_boolean_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithBooleanArrays.Native.insert",
+				query = "INSERT INTO table_with_boolean_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithBooleanArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Boolean[] theArray;
+
+		public TableWithBooleanArrays() {
+		}
+
+		public TableWithBooleanArrays(Long id, Boolean[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Boolean[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Boolean[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/DateArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/DateArrayTest.java
@@ -1,0 +1,206 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class DateArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithDateArrays.class };
+	}
+
+	private LocalDate date1;
+	private LocalDate date2;
+	private LocalDate date3;
+	private LocalDate date4;
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			// I can't believe anyone ever thought this Date API is a good idea
+			date1 = LocalDate.now();
+			date2 = date1.plusDays( 5 );
+			date3 = date1.plusMonths( 4 );
+			date4 = date1.plusYears( 3 );
+			em.persist( new TableWithDateArrays( 1L, new LocalDate[]{} ) );
+			em.persist( new TableWithDateArrays( 2L, new LocalDate[]{ date1, date2, date3 } ) );
+			em.persist( new TableWithDateArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithDateArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new LocalDate[]{ null, date4, date2 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_date_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new LocalDate[]{ null, date4, date2 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithDateArrays tableRecord;
+			tableRecord = em.find( TableWithDateArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDate[]{} ) );
+
+			tableRecord = em.find( TableWithDateArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDate[]{ date1, date2, date3 } ) );
+
+			tableRecord = em.find( TableWithDateArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+
+			tableRecord = em.find( TableWithDateArrays.class, 4L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDate[]{ null, date4, date2 } ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithDateArrays> tq = em.createNamedQuery( "TableWithDateArrays.JPQL.getById", TableWithDateArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithDateArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalDate[]{ date1, date2, date3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithDateArrays> tq = em.createNamedQuery( "TableWithDateArrays.JPQL.getByData", TableWithDateArrays.class );
+			tq.setParameter( "data", new LocalDate[]{} );
+			TableWithDateArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithDateArrays> tq = em.createNamedQuery( "TableWithDateArrays.Native.getById", TableWithDateArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithDateArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalDate[]{ date1, date2, date3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithDateArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_date_arrays t WHERE the_array " + op + " :data",
+					TableWithDateArrays.class
+			);
+			tq.setParameter( "data", new LocalDate[]{ date1, date2, date3 } );
+			TableWithDateArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithDateArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat(
+					tuple[1],
+					is( new Date[] { Date.valueOf( date1 ), Date.valueOf( date2 ), Date.valueOf( date3 ) } )
+			);
+		} );
+	}
+
+	@Entity( name = "TableWithDateArrays" )
+	@Table( name = "table_with_date_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithDateArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithDateArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithDateArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithDateArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithDateArrays.Native.getById",
+				query = "SELECT * FROM table_with_date_arrays t WHERE id = :id",
+				resultClass = TableWithDateArrays.class ),
+		@NamedNativeQuery( name = "TableWithDateArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_date_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithDateArrays.Native.insert",
+				query = "INSERT INTO table_with_date_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithDateArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private LocalDate[] theArray;
+
+		public TableWithDateArrays() {
+		}
+
+		public TableWithDateArrays(Long id, LocalDate[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public LocalDate[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(LocalDate[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/DoubleArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/DoubleArrayTest.java
@@ -1,0 +1,187 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class DoubleArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithDoubleArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithDoubleArrays( 1L, new Double[]{} ) );
+			em.persist( new TableWithDoubleArrays( 2L, new Double[]{ 512.5, 112.0, null, -0.5 } ) );
+			em.persist( new TableWithDoubleArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithDoubleArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Double[]{ null, null, 0.0 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_double_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Double[]{ null, null, 0.0 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithDoubleArrays tableRecord;
+			tableRecord = em.find( TableWithDoubleArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Double[]{} ) );
+
+			tableRecord = em.find( TableWithDoubleArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Double[]{ 512.5, 112.0, null, -0.5 } ) );
+
+			tableRecord = em.find( TableWithDoubleArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithDoubleArrays> tq = em.createNamedQuery( "TableWithDoubleArrays.JPQL.getById", TableWithDoubleArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithDoubleArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Double[]{ 512.5, 112.0, null, -0.5 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithDoubleArrays> tq = em.createNamedQuery( "TableWithDoubleArrays.JPQL.getByData", TableWithDoubleArrays.class );
+			tq.setParameter( "data", new Double[]{} );
+			TableWithDoubleArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithDoubleArrays> tq = em.createNamedQuery( "TableWithDoubleArrays.Native.getById", TableWithDoubleArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithDoubleArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Double[]{ 512.5, 112.0, null, -0.5 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithDoubleArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_double_arrays t WHERE the_array " + op + " :data",
+					TableWithDoubleArrays.class
+			);
+			tq.setParameter( "data", new Double[]{ 512.5, 112.0, null, -0.5 } );
+			TableWithDoubleArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithDoubleArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new Double[]{ 512.5, 112.0, null, -0.5 } ) );
+		} );
+	}
+
+	@Entity( name = "TableWithDoubleArrays" )
+	@Table( name = "table_with_double_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithDoubleArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithDoubleArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithDoubleArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithDoubleArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithDoubleArrays.Native.getById",
+				query = "SELECT * FROM table_with_double_arrays t WHERE id = :id",
+				resultClass = TableWithDoubleArrays.class ),
+		@NamedNativeQuery( name = "TableWithDoubleArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_double_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithDoubleArrays.Native.insert",
+				query = "INSERT INTO table_with_double_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithDoubleArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Double[] theArray;
+
+		public TableWithDoubleArrays() {
+		}
+
+		public TableWithDoubleArrays(Long id, Double[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Double[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Double[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/EnumArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/EnumArrayTest.java
@@ -1,0 +1,180 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class EnumArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithEnumArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithEnumArrays( 1L, new MyEnum[]{} ) );
+			em.persist( new TableWithEnumArrays( 2L, new MyEnum[]{ MyEnum.FALSE, MyEnum.FALSE, null, MyEnum.TRUE } ) );
+			em.persist( new TableWithEnumArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithEnumArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Short[]{ (short) MyEnum.TRUE.ordinal(), null, (short) MyEnum.FALSE.ordinal() } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_enum_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Short[]{ (short) MyEnum.TRUE.ordinal(), null, (short) MyEnum.FALSE.ordinal() } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithEnumArrays tableRecord;
+			tableRecord = em.find( TableWithEnumArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new MyEnum[]{} ) );
+
+			tableRecord = em.find( TableWithEnumArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new MyEnum[]{ MyEnum.FALSE, MyEnum.FALSE, null, MyEnum.TRUE } ) );
+
+			tableRecord = em.find( TableWithEnumArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithEnumArrays> tq = em.createNamedQuery( "TableWithEnumArrays.JPQL.getById", TableWithEnumArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithEnumArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new MyEnum[]{ MyEnum.FALSE, MyEnum.FALSE, null, MyEnum.TRUE } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithEnumArrays> tq = em.createNamedQuery( "TableWithEnumArrays.JPQL.getByData", TableWithEnumArrays.class );
+			tq.setParameter( "data", new MyEnum[]{} );
+			TableWithEnumArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithEnumArrays> tq = em.createNamedQuery( "TableWithEnumArrays.Native.getById", TableWithEnumArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithEnumArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new MyEnum[]{ MyEnum.FALSE, MyEnum.FALSE, null, MyEnum.TRUE } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithEnumArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_enum_arrays t WHERE the_array " + op + " :data",
+					TableWithEnumArrays.class
+			);
+			tq.setParameter( "data", new Short[]{ (short) MyEnum.FALSE.ordinal(), (short) MyEnum.FALSE.ordinal(), null, (short) MyEnum.TRUE.ordinal() } );
+			TableWithEnumArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Entity( name = "TableWithEnumArrays" )
+	@Table( name = "table_with_enum_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithEnumArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithEnumArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithEnumArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithEnumArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithEnumArrays.Native.getById",
+				query = "SELECT * FROM table_with_enum_arrays t WHERE id = :id",
+				resultClass = TableWithEnumArrays.class ),
+		@NamedNativeQuery( name = "TableWithEnumArrays.Native.insert",
+				query = "INSERT INTO table_with_enum_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithEnumArrays {
+
+		@Id
+		private Long id;
+
+		@Enumerated(EnumType.ORDINAL)
+		@Column( name = "the_array" )
+		private MyEnum[] theArray;
+
+		public TableWithEnumArrays() {
+		}
+
+		public TableWithEnumArrays(Long id, MyEnum[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public MyEnum[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(MyEnum[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+	public enum MyEnum {
+		FALSE, TRUE
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/FloatArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/FloatArrayTest.java
@@ -1,0 +1,193 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class FloatArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithFloatArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithFloatArrays( 1L, new Float[]{} ) );
+			em.persist( new TableWithFloatArrays( 2L, new Float[]{ 512.5f, 112.0f, null, -0.5f } ) );
+			em.persist( new TableWithFloatArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithFloatArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Float[]{ null, null, 0.0f } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_float_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Float[]{ null, null, 0.0f } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithFloatArrays tableRecord;
+			tableRecord = em.find( TableWithFloatArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Float[]{} ) );
+
+			tableRecord = em.find( TableWithFloatArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Float[]{ 512.5f, 112.0f, null, -0.5f } ) );
+
+			tableRecord = em.find( TableWithFloatArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithFloatArrays> tq = em.createNamedQuery( "TableWithFloatArrays.JPQL.getById", TableWithFloatArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithFloatArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Float[]{ 512.5f, 112.0f, null, -0.5f } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithFloatArrays> tq = em.createNamedQuery( "TableWithFloatArrays.JPQL.getByData", TableWithFloatArrays.class );
+			tq.setParameter( "data", new Float[]{} );
+			TableWithFloatArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithFloatArrays> tq = em.createNamedQuery( "TableWithFloatArrays.Native.getById", TableWithFloatArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithFloatArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Float[]{ 512.5f, 112.0f, null, -0.5f } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithFloatArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_float_arrays t WHERE the_array " + op + " :data",
+					TableWithFloatArrays.class
+			);
+			tq.setParameter( "data", new Float[]{ 512.5f, 112.0f, null, -0.5f } );
+			TableWithFloatArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithFloatArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			if ( em.getSessionFactory().getJdbcServices().getDialect() instanceof HSQLDialect ) {
+				// In HSQL, float is a synonym for double
+				assertThat( tuple[1], is( new Double[] { 512.5d, 112.0d, null, -0.5d } ) );
+			}
+			else {
+				assertThat( tuple[1], is( new Float[] { 512.5f, 112.0f, null, -0.5f } ) );
+			}
+		} );
+	}
+
+	@Entity( name = "TableWithFloatArrays" )
+	@Table( name = "table_with_float_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithFloatArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithFloatArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithFloatArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithFloatArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithFloatArrays.Native.getById",
+				query = "SELECT * FROM table_with_float_arrays t WHERE id = :id",
+				resultClass = TableWithFloatArrays.class ),
+		@NamedNativeQuery( name = "TableWithFloatArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_float_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithFloatArrays.Native.insert",
+				query = "INSERT INTO table_with_float_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithFloatArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Float[] theArray;
+
+		public TableWithFloatArrays() {
+		}
+
+		public TableWithFloatArrays(Long id, Float[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Float[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Float[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/IntegerArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/IntegerArrayTest.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class IntegerArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithIntegerArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithIntegerArrays( 1L, new Integer[]{} ) );
+			em.persist( new TableWithIntegerArrays( 2L, new Integer[]{ 512, 112, null, 0 } ) );
+			em.persist( new TableWithIntegerArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithIntegerArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Integer[]{ null, null, 0 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_integer_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Integer[]{ null, null, 0 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithIntegerArrays tableRecord;
+			tableRecord = em.find( TableWithIntegerArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Integer[]{} ) );
+
+			tableRecord = em.find( TableWithIntegerArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Integer[]{ 512, 112, null, 0 } ) );
+
+			tableRecord = em.find( TableWithIntegerArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerArrays> tq = em.createNamedQuery( "TableWithIntegerArrays.JPQL.getById", TableWithIntegerArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Integer[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerArrays> tq = em.createNamedQuery( "TableWithIntegerArrays.JPQL.getByData", TableWithIntegerArrays.class );
+			tq.setParameter( "data", new Integer[]{} );
+			TableWithIntegerArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithIntegerArrays> tq = em.createNamedQuery( "TableWithIntegerArrays.Native.getById", TableWithIntegerArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithIntegerArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Integer[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithIntegerArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_integer_arrays t WHERE the_array " + op + " :data",
+					TableWithIntegerArrays.class
+			);
+			tq.setParameter( "data", new Integer[]{ 512, 112, null, 0 } );
+			TableWithIntegerArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithIntegerArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new Integer[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Entity( name = "TableWithIntegerArrays" )
+	@Table( name = "table_with_integer_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithIntegerArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithIntegerArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithIntegerArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithIntegerArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithIntegerArrays.Native.getById",
+				query = "SELECT * FROM table_with_integer_arrays t WHERE id = :id",
+				resultClass = TableWithIntegerArrays.class ),
+		@NamedNativeQuery( name = "TableWithIntegerArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_integer_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithIntegerArrays.Native.insert",
+				query = "INSERT INTO table_with_integer_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithIntegerArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Integer[] theArray;
+
+		public TableWithIntegerArrays() {
+		}
+
+		public TableWithIntegerArrays(Long id, Integer[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Integer[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Integer[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongArrayTest.java
@@ -1,0 +1,192 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class LongArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithLongArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithLongArrays( 1L, new Long[]{} ) );
+
+			em.persist( new TableWithLongArrays( 2L, new Long[]{ 4L, 8L, 15L, 16L, 23L, 42L } ) );
+
+			em.persist( new TableWithLongArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithLongArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Long[]{ 4L, 8L, 15L, 16L, null, 23L, 42L } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_bigint_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Long[]{ 4L, 8L, null, 16L, null, 23L, 42L } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithLongArrays tableRecord;
+			tableRecord = em.find( TableWithLongArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Long[]{} ) );
+
+			tableRecord = em.find( TableWithLongArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Long[]{ 4L, 8L, 15L, 16L, 23L, 42L } ) );
+
+			tableRecord = em.find( TableWithLongArrays.class, 4L );
+			assertThat( tableRecord.getTheArray(), is( new Long[]{ 4L, 8L, 15L, 16L, null, 23L, 42L } ) );
+
+			tableRecord = em.find( TableWithLongArrays.class, 5L );
+			assertThat( tableRecord.getTheArray(), is( new Long[]{ 4L, 8L, null, 16L, null, 23L, 42L } ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithLongArrays> tq = em.createNamedQuery( "TableWithLongArrays.JPQL.getById", TableWithLongArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithLongArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Long[]{ 4L, 8L, 15L, 16L, 23L, 42L } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithLongArrays> tq = em.createNamedQuery( "TableWithLongArrays.JPQL.getByData", TableWithLongArrays.class );
+			tq.setParameter( "data", new Long[]{ 4L, 8L, 15L, 16L, null, 23L, 42L } );
+			TableWithLongArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 4L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithLongArrays> tq = em.createNamedQuery( "TableWithLongArrays.Native.getById", TableWithLongArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithLongArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Long[]{ 4L, 8L, 15L, 16L, 23L, 42L } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithLongArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_bigint_arrays t WHERE the_array " + op + " :data",
+					TableWithLongArrays.class
+			);
+			tq.setParameter( "data", new Long[]{ 4L, 8L, 15L, 16L, null, 23L, 42L } );
+			TableWithLongArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 4L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithLongArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new Long[]{ 4L, 8L, 15L, 16L, 23L, 42L } ) );
+		} );
+	}
+
+	@Entity( name = "TableWithLongArrays" )
+	@Table( name = "table_with_bigint_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithLongArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithLongArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithLongArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithLongArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithLongArrays.Native.getById",
+				query = "SELECT * FROM table_with_bigint_arrays t WHERE id = :id",
+				resultClass = TableWithLongArrays.class ),
+		@NamedNativeQuery( name = "TableWithLongArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_bigint_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithLongArrays.Native.insert",
+				query = "INSERT INTO table_with_bigint_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithLongArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Long[] theArray;
+
+		public TableWithLongArrays() {
+		}
+
+		public TableWithLongArrays(Long id, Long[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Long[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Long[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/OracleArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/OracleArrayTest.java
@@ -1,0 +1,203 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+@RequiresDialect( OracleDialect.class )
+@TestForIssue( jiraKey = "HHH-10999")
+public class OracleArrayTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty(
+				Environment.DIALECT,
+				MyOracleDialect.class.getName()
+		);
+	}
+
+	@Override
+	protected void releaseSessionFactory() {
+		super.releaseSessionFactory();
+		BootstrapServiceRegistry bootRegistry = buildBootstrapServiceRegistry();
+		StandardServiceRegistryImpl serviceRegistry = buildServiceRegistry(
+				bootRegistry,
+				constructAndConfigureConfiguration( bootRegistry )
+		);
+		try {
+			TransactionUtil.doWithJDBC(
+					serviceRegistry,
+					connection -> {
+						try (Statement statement = connection.createStatement()) {
+							connection.setAutoCommit( true );
+							statement.execute( "DROP TYPE INTARRAY" );
+							statement.execute( "DROP TYPE TEXTARRAY" );
+						}
+					}
+			);
+		}
+		catch (SQLException e) {
+			throw new RuntimeException( "Failed to drop type", e );
+		}
+		finally {
+			serviceRegistry.destroy();
+		}
+	}
+
+	@Override
+	protected void buildSessionFactory() {
+		BootstrapServiceRegistry bootRegistry = buildBootstrapServiceRegistry();
+		StandardServiceRegistryImpl serviceRegistry =
+				buildServiceRegistry( bootRegistry, constructAndConfigureConfiguration( bootRegistry ) );
+
+		try {
+			TransactionUtil.doWithJDBC(
+					serviceRegistry,
+					connection -> {
+						try (Statement statement = connection.createStatement()) {
+							connection.setAutoCommit( true );
+							if ( statement.executeQuery( "SELECT 1 FROM ALL_TYPES WHERE TYPE_NAME = 'INTARRAY'" ).next() ) {
+								statement.execute( "DROP TYPE INTARRAY" );
+							}
+							if ( statement.executeQuery( "SELECT 1 FROM ALL_TYPES WHERE TYPE_NAME = 'TEXTARRAY'" ).next() ) {
+								statement.execute( "DROP TYPE TEXTARRAY" );
+							}
+							statement.execute( "CREATE TYPE INTARRAY AS VARRAY(10) OF NUMBER(10,0)");
+							statement.execute( "CREATE TYPE TEXTARRAY AS VARRAY(10) OF VARCHAR2(255)");
+						}
+					}
+			);
+		}
+		catch ( SQLException e ) {
+			throw new RuntimeException( e );
+		}
+		finally {
+			serviceRegistry.destroy();
+		}
+		super.buildSessionFactory();
+	}
+
+	@Test
+	public void test() {
+		doInHibernate( this::sessionFactory, session -> {
+			ArrayHolder expected = new ArrayHolder( 1, new Integer[] { 1, 2, 3 }, new String[] { "abc", "def" } );
+			session.persist( expected );
+			session.flush();
+			session.clear();
+
+			ArrayHolder arrayHolder = session.find( ArrayHolder.class, 1 );
+			Assert.assertEquals( expected.getIntArray(), arrayHolder.getIntArray() );
+			Assert.assertEquals( expected.getTextArray(), arrayHolder.getTextArray() );
+		} );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				ArrayHolder.class
+		};
+	}
+
+	@Entity(name = "ArrayHolder")
+	public static class ArrayHolder {
+		@Id
+		Integer id;
+
+		@Column(columnDefinition = "TEXTARRAY")
+		String[] textArray;
+
+		@Column(columnDefinition = "TEXTARRAY")
+		String[] textArray2;
+
+		Integer[] intArray;
+
+		public ArrayHolder() {
+		}
+
+		public ArrayHolder(Integer id, Integer[] intArray, String[] textArray) {
+			this.id = id;
+			this.intArray = intArray;
+			this.textArray = textArray;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Integer[] getIntArray() {
+			return intArray;
+		}
+
+		public void setIntArray(Integer[] intArray) {
+			this.intArray = intArray;
+		}
+
+		public String[] getTextArray() {
+			return textArray;
+		}
+
+		public void setTextArray(String[] textArray) {
+			this.textArray = textArray;
+		}
+
+		public String[] getTextArray2() {
+			return textArray2;
+		}
+
+		public void setTextArray2(String[] textArray2) {
+			this.textArray2 = textArray2;
+		}
+	}
+
+	public static class MyOracleDialect extends OracleDialect {
+
+		public MyOracleDialect() {
+		}
+
+		public MyOracleDialect(DatabaseVersion version) {
+			super( version );
+		}
+
+		public MyOracleDialect(DialectResolutionInfo info) {
+			super( info );
+		}
+
+		@Override
+		public String getArrayTypeName(String elementTypeName) {
+			if ( "number(10,0)".equals( elementTypeName ) ) {
+				return "INTARRAY";
+			}
+			return super.getArrayTypeName( elementTypeName );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/ShortArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/ShortArrayTest.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class ShortArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithShortArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithShortArrays( 1L, new Short[] {} ) );
+			em.persist( new TableWithShortArrays( 2L, new Short[] { 512, 112, null, 0 } ) );
+			em.persist( new TableWithShortArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithShortArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new Short[] { null, null, 0 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_short_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new Short[] { null, null, 0 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithShortArrays tableRecord;
+			tableRecord = em.find( TableWithShortArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new Short[]{} ) );
+
+			tableRecord = em.find( TableWithShortArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new Short[]{ 512, 112, null, 0 } ) );
+
+			tableRecord = em.find( TableWithShortArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithShortArrays> tq = em.createNamedQuery( "TableWithShortArrays.JPQL.getById", TableWithShortArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithShortArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Short[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithShortArrays> tq = em.createNamedQuery( "TableWithShortArrays.JPQL.getByData", TableWithShortArrays.class );
+			tq.setParameter( "data", new Short[]{} );
+			TableWithShortArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithShortArrays> tq = em.createNamedQuery( "TableWithShortArrays.Native.getById", TableWithShortArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithShortArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new Short[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithShortArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_short_arrays t WHERE the_array " + op + " :data",
+					TableWithShortArrays.class
+			);
+			tq.setParameter( "data", new Short[]{ 512, 112, null, 0 } );
+			TableWithShortArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithShortArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new Short[]{ 512, 112, null, 0 } ) );
+		} );
+	}
+
+	@Entity( name = "TableWithShortArrays" )
+	@Table( name = "table_with_short_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithShortArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithShortArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithShortArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithShortArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithShortArrays.Native.getById",
+				query = "SELECT * FROM table_with_short_arrays t WHERE id = :id",
+				resultClass = TableWithShortArrays.class ),
+		@NamedNativeQuery( name = "TableWithShortArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_short_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithShortArrays.Native.insert",
+				query = "INSERT INTO table_with_short_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithShortArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private Short[] theArray;
+
+		public TableWithShortArrays() {
+		}
+
+		public TableWithShortArrays(Long id, Short[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Short[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(Short[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/StringArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/StringArrayTest.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class StringArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithStringArrays.class };
+	}
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			em.persist( new TableWithStringArrays( 1L, new String[]{} ) );
+			em.persist( new TableWithStringArrays( 2L, new String[]{ "", "test", null, "text" } ) );
+			em.persist( new TableWithStringArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithStringArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new String[]{ null, null, "1234" } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_string_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new String[]{ null, null, "1234" } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithStringArrays tableRecord;
+			tableRecord = em.find( TableWithStringArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new String[]{} ) );
+
+			tableRecord = em.find( TableWithStringArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new String[]{ "", "test", null, "text" } ) );
+
+			tableRecord = em.find( TableWithStringArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithStringArrays> tq = em.createNamedQuery( "TableWithStringArrays.JPQL.getById", TableWithStringArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithStringArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new String[]{ "", "test", null, "text" } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithStringArrays> tq = em.createNamedQuery( "TableWithStringArrays.Native.getById", TableWithStringArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithStringArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new String[]{ "", "test", null, "text" } ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithStringArrays> tq = em.createNamedQuery("TableWithStringArrays.Native.getById", TableWithStringArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithStringArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new String[]{ "", "test", null, "text" } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithStringArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_string_arrays t WHERE the_array " + op + " :data",
+					TableWithStringArrays.class
+			);
+			tq.setParameter( "data", new String[]{ "", "test", null, "text" } );
+			TableWithStringArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithStringArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat( tuple[1], is( new String[]{ "", "test", null, "text" } ) );
+		} );
+	}
+
+	@Entity( name = "TableWithStringArrays" )
+	@Table( name = "table_with_string_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithStringArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithStringArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithStringArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithStringArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithStringArrays.Native.getById",
+				query = "SELECT * FROM table_with_string_arrays t WHERE id = :id",
+				resultClass = TableWithStringArrays.class ),
+		@NamedNativeQuery( name = "TableWithStringArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_string_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithStringArrays.Native.insert",
+				query = "INSERT INTO table_with_string_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithStringArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private String[] theArray;
+
+		public TableWithStringArrays() {
+		}
+
+		public TableWithStringArrays(Long id, String[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(String[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/TimeArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/TimeArrayTest.java
@@ -1,0 +1,206 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class TimeArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithTimeArrays.class };
+	}
+
+	private LocalTime time1;
+	private LocalTime time2;
+	private LocalTime time3;
+	private LocalTime time4;
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			time1 = LocalTime.of( 0, 0, 0 );
+			time2 = LocalTime.of( 6, 15, 0 );
+			time3 = LocalTime.of( 12, 30, 0 );
+			time4 = LocalTime.of( 23, 59, 59 );
+			em.persist( new TableWithTimeArrays( 1L, new LocalTime[]{} ) );
+			em.persist( new TableWithTimeArrays( 2L, new LocalTime[]{ time1, time2, time3 } ) );
+			em.persist( new TableWithTimeArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithTimeArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new LocalTime[]{ null, time4, time2 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_time_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new LocalTime[]{ null, time4, time2 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithTimeArrays tableRecord;
+			tableRecord = em.find( TableWithTimeArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new LocalTime[]{} ) );
+
+			tableRecord = em.find( TableWithTimeArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new LocalTime[]{ time1, time2, time3 } ) );
+
+			tableRecord = em.find( TableWithTimeArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+
+			tableRecord = em.find( TableWithTimeArrays.class, 4L );
+			assertThat( tableRecord.getTheArray(), is( new LocalTime[]{ null, time4, time2 } ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithTimeArrays> tq = em.createNamedQuery( "TableWithTimeArrays.JPQL.getById", TableWithTimeArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithTimeArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalTime[]{ time1, time2, time3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithTimeArrays> tq = em.createNamedQuery( "TableWithTimeArrays.JPQL.getByData", TableWithTimeArrays.class );
+			tq.setParameter( "data", new LocalTime[]{} );
+			TableWithTimeArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithTimeArrays> tq = em.createNamedQuery( "TableWithTimeArrays.Native.getById", TableWithTimeArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithTimeArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalTime[]{ time1, time2, time3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithTimeArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_time_arrays t WHERE the_array " + op + " :data",
+					TableWithTimeArrays.class
+			);
+			tq.setParameter( "data", new LocalTime[]{ time1, time2, time3 } );
+			TableWithTimeArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithTimeArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat(
+					tuple[1],
+					is( new Time[] { Time.valueOf( time1 ), Time.valueOf( time2 ), Time.valueOf( time3 ) } )
+			);
+		} );
+	}
+
+	@Entity( name = "TableWithTimeArrays" )
+	@Table( name = "table_with_time_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithTimeArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithTimeArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithTimeArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithTimeArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithTimeArrays.Native.getById",
+				query = "SELECT * FROM table_with_time_arrays t WHERE id = :id",
+				resultClass = TableWithTimeArrays.class ),
+		@NamedNativeQuery( name = "TableWithTimeArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_time_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithTimeArrays.Native.insert",
+				query = "INSERT INTO table_with_time_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithTimeArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private LocalTime[] theArray;
+
+		public TableWithTimeArrays() {
+		}
+
+		public TableWithTimeArrays(Long id, LocalTime[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public LocalTime[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(LocalTime[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/TimestampArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/TimestampArrayTest.java
@@ -1,0 +1,215 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.Month;
+
+import org.hibernate.dialect.AbstractHANADialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.persistence.TypedQuery;
+
+import org.hibernate.testing.DialectChecks;
+import org.hibernate.testing.RequiresDialectFeature;
+import org.hibernate.testing.SkipForDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Jordan Gigov
+ * @author Christian Beikov
+ */
+@SkipForDialect(value = SybaseASEDialect.class, comment = "Sybase or the driver are trimming trailing zeros in byte arrays")
+public class TimestampArrayTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{ TableWithTimestampArrays.class };
+	}
+
+	private LocalDateTime time1;
+	private LocalDateTime time2;
+	private LocalDateTime time3;
+	private LocalDateTime time4;
+
+	public void startUp() {
+		super.startUp();
+		inTransaction( em -> {
+			// Unix epoch start if you're in the UK
+			time1 = LocalDateTime.of( 1970, Month.JANUARY, 1, 0, 0, 0, 0 );
+			// pre-Y2K
+			time2 = LocalDateTime.of( 1999, Month.DECEMBER, 31, 23, 59, 59, 0 );
+			// We survived! Why was anyone worried?
+			time3 = LocalDateTime.of( 2000, Month.JANUARY, 1, 0, 0, 0, 0 );
+			// Silence will fall!
+			time4 = LocalDateTime.of( 2010, Month.JUNE, 26, 20, 4, 0, 0 );
+			em.persist( new TableWithTimestampArrays( 1L, new LocalDateTime[]{} ) );
+			em.persist( new TableWithTimestampArrays( 2L, new LocalDateTime[]{ time1, time2, time3 } ) );
+			em.persist( new TableWithTimestampArrays( 3L, null ) );
+
+			Query q;
+			q = em.createNamedQuery( "TableWithTimestampArrays.Native.insert" );
+			q.setParameter( "id", 4L );
+			q.setParameter( "data", new LocalDateTime[]{ null, time4, time2 } );
+			q.executeUpdate();
+
+			q = em.createNativeQuery( "INSERT INTO table_with_timestamp_arrays(id, the_array) VALUES ( :id , :data )" );
+			q.setParameter( "id", 5L );
+			q.setParameter( "data", new LocalDateTime[]{ null, time4, time2 } );
+			q.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testById() {
+		inSession( em -> {
+			TableWithTimestampArrays tableRecord;
+			tableRecord = em.find( TableWithTimestampArrays.class, 1L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDateTime[]{} ) );
+
+			tableRecord = em.find( TableWithTimestampArrays.class, 2L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDateTime[]{ time1, time2, time3 } ) );
+
+			tableRecord = em.find( TableWithTimestampArrays.class, 3L );
+			assertThat( tableRecord.getTheArray(), is( (Object) null ) );
+
+			tableRecord = em.find( TableWithTimestampArrays.class, 4L );
+			assertThat( tableRecord.getTheArray(), is( new LocalDateTime[]{ null, time4, time2 } ) );
+		} );
+	}
+
+	@Test
+	public void testQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithTimestampArrays> tq = em.createNamedQuery( "TableWithTimestampArrays.JPQL.getById", TableWithTimestampArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithTimestampArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalDateTime[]{ time1, time2, time3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = AbstractHANADialect.class, comment = "For some reason, HANA can't intersect VARBINARY values, but funnily can do a union...")
+	public void testQuery() {
+		inSession( em -> {
+			TypedQuery<TableWithTimestampArrays> tq = em.createNamedQuery( "TableWithTimestampArrays.JPQL.getByData", TableWithTimestampArrays.class );
+			tq.setParameter( "data", new LocalDateTime[]{} );
+			TableWithTimestampArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 1L ) );
+		} );
+	}
+
+	@Test
+	public void testNativeQueryById() {
+		inSession( em -> {
+			TypedQuery<TableWithTimestampArrays> tq = em.createNamedQuery( "TableWithTimestampArrays.Native.getById", TableWithTimestampArrays.class );
+			tq.setParameter( "id", 2L );
+			TableWithTimestampArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getTheArray(), is( new LocalDateTime[]{ time1, time2, time3 } ) );
+		} );
+	}
+
+	@Test
+	@SkipForDialect( value = HSQLDialect.class, comment = "HSQL does not like plain parameters in the distinct from predicate")
+	@SkipForDialect( value = OracleDialect.class, comment = "Oracle requires a special function to compare XML")
+	public void testNativeQuery() {
+		inSession( em -> {
+			final String op = em.getJdbcServices().getDialect().supportsDistinctFromPredicate() ? "IS NOT DISTINCT FROM" : "=";
+			TypedQuery<TableWithTimestampArrays> tq = em.createNativeQuery(
+					"SELECT * FROM table_with_timestamp_arrays t WHERE the_array " + op + " :data",
+					TableWithTimestampArrays.class
+			);
+			tq.setParameter( "data", new LocalDateTime[]{ time1, time2, time3 } );
+			TableWithTimestampArrays tableRecord = tq.getSingleResult();
+			assertThat( tableRecord.getId(), is( 2L ) );
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature(DialectChecks.SupportsArrayDataTypes.class)
+	public void testNativeQueryUntyped() {
+		inSession( em -> {
+			Query q = em.createNamedQuery( "TableWithTimestampArrays.Native.getByIdUntyped" );
+			q.setParameter( "id", 2L );
+			Object[] tuple = (Object[]) q.getSingleResult();
+			assertThat(
+					tuple[1],
+					is( new Timestamp[] {
+							Timestamp.valueOf( time1 ),
+							Timestamp.valueOf( time2 ),
+							Timestamp.valueOf( time3 )
+					} )
+			);
+		} );
+	}
+
+	@Entity( name = "TableWithTimestampArrays" )
+	@Table( name = "table_with_timestamp_arrays" )
+	@NamedQueries( {
+		@NamedQuery( name = "TableWithTimestampArrays.JPQL.getById",
+				query = "SELECT t FROM TableWithTimestampArrays t WHERE id = :id" ),
+		@NamedQuery( name = "TableWithTimestampArrays.JPQL.getByData",
+				query = "SELECT t FROM TableWithTimestampArrays t WHERE theArray IS NOT DISTINCT FROM :data" ), } )
+	@NamedNativeQueries( {
+		@NamedNativeQuery( name = "TableWithTimestampArrays.Native.getById",
+				query = "SELECT * FROM table_with_timestamp_arrays t WHERE id = :id",
+				resultClass = TableWithTimestampArrays.class ),
+		@NamedNativeQuery( name = "TableWithTimestampArrays.Native.getByIdUntyped",
+				query = "SELECT * FROM table_with_timestamp_arrays t WHERE id = :id" ),
+		@NamedNativeQuery( name = "TableWithTimestampArrays.Native.insert",
+				query = "INSERT INTO table_with_timestamp_arrays(id, the_array) VALUES ( :id , :data )" )
+	} )
+	public static class TableWithTimestampArrays {
+
+		@Id
+		private Long id;
+
+		@Column( name = "the_array" )
+		private LocalDateTime[] theArray;
+
+		public TableWithTimestampArrays() {
+		}
+
+		public TableWithTimestampArrays(Long id, LocalDateTime[] theArray) {
+			this.id = id;
+			this.theArray = theArray;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public LocalDateTime[] getTheArray() {
+			return theArray;
+		}
+
+		public void setTheArray(LocalDateTime[] theArray) {
+			this.theArray = theArray;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/LocalDateArrayDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/LocalDateArrayDescriptorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type.descriptor.java;
+
+import java.time.LocalDate;
+
+import org.hibernate.orm.test.mapping.type.java.AbstractDescriptorTest;
+import org.hibernate.type.descriptor.java.ArrayJavaType;
+import org.hibernate.type.descriptor.java.LocalDateJavaType;
+
+/**
+ * @author Jordan Gigov
+ */
+public class LocalDateArrayDescriptorTest extends AbstractDescriptorTest<LocalDate[]> {
+
+	final LocalDate[] original = new LocalDate[]{
+		LocalDate.of( 2016, 10, 8 ),
+		LocalDate.of( 2016, 9, 3 ),
+		LocalDate.of( 2013, 8, 8 )
+	};
+	final LocalDate[] copy = new LocalDate[]{
+		LocalDate.of( 2016, 10, 8 ),
+		LocalDate.of( 2016, 9, 3 ),
+		LocalDate.of( 2013, 8, 8 )
+	};
+	final LocalDate[] different = new LocalDate[]{
+		LocalDate.of( 2016, 10, 8 ),
+		LocalDate.of( 2016, 9, 7 ),
+		LocalDate.of( 2013, 8, 8 )
+	};
+
+	public LocalDateArrayDescriptorTest() {
+		super( new ArrayJavaType<>( LocalDateJavaType.INSTANCE ) );
+	}
+
+	@Override
+	protected Data<LocalDate[]> getTestData() {
+		return new Data<LocalDate[]>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return true;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/LongArrayDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/LongArrayDescriptorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type.descriptor.java;
+
+import org.hibernate.orm.test.mapping.type.java.AbstractDescriptorTest;
+import org.hibernate.type.descriptor.java.ArrayJavaType;
+import org.hibernate.type.descriptor.java.LongJavaType;
+
+/**
+ * @author Jordan Gigov
+ */
+public class LongArrayDescriptorTest extends AbstractDescriptorTest<Long[]> {
+	final Long[] original = new Long[]{ 13L, -2L, 666L };
+	final Long[] copy = new Long[]{ 13L, -2L, 666L };
+	final Long[] different = new Long[]{ -2L, 666L, 13L };
+
+	public LongArrayDescriptorTest() {
+		super( new ArrayJavaType<>( LongJavaType.INSTANCE ) );
+	}
+
+	@Override
+	protected Data<Long[]> getTestData() {
+		return new Data<Long[]>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return true;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/StringArrayDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/StringArrayDescriptorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.type.descriptor.java;
+
+import org.hibernate.orm.test.mapping.type.java.AbstractDescriptorTest;
+import org.hibernate.type.descriptor.java.ArrayJavaType;
+import org.hibernate.type.descriptor.java.StringJavaType;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * @author Jordan Gigov
+ */
+public class StringArrayDescriptorTest extends AbstractDescriptorTest<String[]> {
+
+	final String[] original = new String[]{null, "double-quote at end\"", "\' single quote at start", "escape at end\\", "escape and quote at end\\\""};
+	final String[] copy = new String[]{null, "double-quote at end\"", "\' single quote at start", "escape at end\\", "escape and quote at end\\\""};
+	final String[] different = new String[]{"null", "double-quote at end\"", "\' single quote at start", "escape at end\\", "escape and quote at end\\\""};
+
+	public StringArrayDescriptorTest() {
+		super( new ArrayJavaType<>( StringJavaType.INSTANCE ) );
+	}
+
+	@Override
+	protected Data<String[]> getTestData() {
+		return new Data<String[]>( original, copy, different );
+	}
+
+	@Override
+	protected boolean shouldBeMutable() {
+		return true;
+	}
+
+	@Test
+	public void testEmptyArrayExternalization() {
+		// ensure the symmetry of toString/fromString
+		String[] emptyArray = new String[]{};
+		String externalized = typeDescriptor().toString( emptyArray );
+		String[] consumed = typeDescriptor().fromString( externalized );
+		assertTrue( typeDescriptor().areEqual( emptyArray, consumed ) );
+	}
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -280,4 +280,10 @@ abstract public class DialectChecks {
 		}
 	}
 
+	public static class SupportsArrayDataTypes implements DialectCheck {
+		@Override
+		public boolean isMatch(Dialect dialect) {
+			return dialect.supportsStandardArrays();
+		}
+	}
 }

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -30,8 +30,6 @@ A possible migration could involve the following steps in a migration script:
 5. For every result, load the Hibernate entity by primary key and set the deserialized value
 6. Finally, drop the old column `alter table tbl drop column array_col_old`
 
-To retain backwards compatibility, configure the setting `hibernate.type.preferred_array_jdbc_type` to `VARBINARY`.
-
 
 == Enum mapping changes
 

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -38,14 +38,12 @@ This mapping was not quite correct as Java effectively allows up to 32K enum ent
 
 In practice, this isn't a big issue though for two reasons. A lot of databases do not support a 1 byte integer DDL type,
 so Hibernate falls back to the 2+ byte integer type as DDL type. Apart from that, enums in ORM models usually do not exceed the 255 value limit.
-Even though a migration is not necessary, schema validation errors could occur as of 6.1 due to the switch to a bigger data type.
+Note that the migration is not required as schema validation is able to handle the use of `SMALLINT` when the DDL type is `TINYINT`.
 
 The migration usually requires running only a simple alter command `alter table tbl alter column enum_col smallint`
 or `alter table tbl modify column enum_col smallint`, depending on your database dialect.
 
-To retain backwards compatibility, configure the setting `hibernate.type.preferred_enum_jdbc_type` to `TINYINT`.
-
-The following dialects currently have DDL types registered for `TINYINT` and might require migration:
+The following dialects currently have DDL types registered for `TINYINT` and might produce a different schema now:
 
 * Cachè
 * Ingres

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -9,3 +9,52 @@
 This guide discusses migration from Hibernate ORM version 6.1.  For migration from
 earlier versions, see any other pertinent migration guides as well.
 
+== Basic array/collection mapping
+
+Basic arrays, other than `byte[]`/Byte[] and `char[]`/`Character[]`, and basic collections (only subtypes of `Collection`)
+now map to the type code `SqlTypes.ARRAY` by default, which maps to the SQL standard `array` type if possible,
+as determined via the new methods `getArrayTypeName` and `supportsStandardArrays` of `org.hibernate.dialect.Dialect`.
+If SQL standard array types are not available, data will be modeled as `SqlTypes.JSON`, `SqlTypes.XML` or `SqlTypes.VARBINARY`,
+depending on the database support as determined via the new method `org.hibernate.dialect.Dialect.getPreferredSqlTypeCodeForArray`.
+
+Due to this change, schema validation errors could occur as 5.x and 6.0 used the type code `SqlTypes.VARBINARY` unconditionally
+and serialized the contents with Java serialization. The migration to native array or JSON/XML types is non-trivial and requires
+that the data is first read through the Java serialization mechanism and then written back through the respective JDBC method for the type.
+
+A possible migration could involve the following steps in a migration script:
+
+1. Execute `alter table tbl rename column array_col to array_col_old` to have the old format available
+2. Execute `alter table tbl add column array_col DATATYPE array` to add the column like the new mapping expects it to be
+3. Run the query `select t.primary_key, t.array_col_old from table t`
+4. For every result, deserialize the old representation via e.g. `org.hibernate.internal.util.SerializationHelper.deserialize(java.io.InputStream)`
+5. For every result, load the Hibernate entity by primary key and set the deserialized value
+6. Finally, drop the old column `alter table tbl drop column array_col_old`
+
+To retain backwards compatibility, configure the setting `hibernate.type.preferred_array_jdbc_type` to `VARBINARY`.
+
+
+== Enum mapping changes
+
+Enums now map to the type code `SqlType.SMALLINT` by default, whereas before it mapped to `TINYINT`.
+This mapping was not quite correct as Java effectively allows up to 32K enum entries, but `TINYINT` is only a 1 byte type.
+
+In practice, this isn't a big issue though for two reasons. A lot of databases do not support a 1 byte integer DDL type,
+so Hibernate falls back to the 2+ byte integer type as DDL type. Apart from that, enums in ORM models usually do not exceed the 255 value limit.
+Even though a migration is not necessary, schema validation errors could occur as of 6.1 due to the switch to a bigger data type.
+
+The migration usually requires running only a simple alter command `alter table tbl alter column enum_col smallint`
+or `alter table tbl modify column enum_col smallint`, depending on your database dialect.
+
+To retain backwards compatibility, configure the setting `hibernate.type.preferred_enum_jdbc_type` to `TINYINT`.
+
+The following dialects currently have DDL types registered for `TINYINT` and might require migration:
+
+* Cachè
+* Ingres
+* Teradata
+* TimesTen
+* H2
+* HSQL
+* MySQL
+* MariaDB
+* Oracle

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,7 +58,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             version( "antlr", "4.10" )
-            version( "hcann", "6.0.1.Final" )
+            version( "hcann", "6.0.2.Final" )
             version( "geolatte", "1.8.2" )
             version( "byteBuddy", "1.12.9" )
             version( "agroal", "2.0" )


### PR DESCRIPTION
This work and the tests are based on https://github.com/hibernate/hibernate-orm/pull/1499 for implementing https://hibernate.atlassian.net/browse/HHH-10999

https://hibernate.atlassian.net/browse/HHH-15288

This PR implements support for mapping basic (as in `@Basic`) Java arrays and collections to JDBC array types. It registers special `JavaType` variants for primitive array types, except for `byte[]` and `char[]` since these are mapped differently. For other array types, the java type resolving was updated to specially handle when an array `Class` is resolved, to resolve `ArrayJavaType`.

The resolving for collections works a bit differently and is in general extendible:

1. Initially, an attribute with a subtype of `Collection` is resolved to `CollectionJavaType`
2. `CollectionJavaType#createJavaType` refines this into the new `BasicCollectionJavaType`, which implements `BasicContainerJavaType` (like `ArrayJavaType`)

After this point, we treat all `BasicContainerJavaType` equally, regardless if we have arrays or collections.
`BasicContainerJavaType#resolveType` is called to determine the resulting `BasicType` based on the element `BasicType`.

The idea of `BasicContainerJavaType#resolveType` is, that every container type (array, collection etc.) parameterization will resolve to a dedicated `BasicType` which will contain a properly configured `ArrayJdbcType` instance. Properly configured means, that the `ArrayJdbcType` will know the array component `JdbcType` and in case of Oracle also the SQL type name for the Oracle varray. This is determined through the `ColumnTypeInformation` which essentially exposes the `Column#columnDefinition` with a fallback to asking `Dialect#getArrayTypeName`.

Here an outline of the changes:

* Add `ArrayJdbcType`
* Enable array types for H2 2.0+, HSQL, PostgreSQL, CockroachDB, Spanner and Oracle
* Introduce possibility to customize array DDL via `Dialect#getArrayTypeName`
* Add `ArrayJavaType` for mapping Java arrays `T[]`
* Register `XPrimitiveArrayJavaType` instances for primitive arrays in `JavaTypeBaseline`
* Add `getPreferredJavaTypeClass` to `JdbcType` to enable unwrapping to arrays of appropriate type
* Add array emulation based on XML/JSON types
* Introduce `ColumnTypeInformation` containing DDL information methods from `ColumnInformation` and use that in `Dialect#equivalentTypes` to allow type validation based on proper column type information
  => JDBC reports the ARRAY type code for array columns, so we need more information to do DDL validation, because `varchar[]` != `smallint[]`
  => `org.hibernate.mapping.Column` imlpements `ColumnTypeInformation` to provide necessary information for DDL validation

Here are some of the follow-ups that I have planned:

* Add support for `EnumSet` container type
* Add functions for accessing and replacing array elements (as well as JSON/XML emulation)
* Add functions for checking array contains one more elements (as well as JSON/XML emulation)