### PR TITLE
HHH-11692 Introduce DISTINCT predicate in HQL and JPA Criteria extensions and implement emulations

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -415,6 +415,8 @@ comparisonOperator
 	| GREATER_EQUAL
 	| LESS
 	| LESS_EQUAL
+	| IS DISTINCT FROM
+	| IS NOT DISTINCT FROM
 	;
 
 inList

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CUBRIDSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CUBRIDSqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -37,5 +45,61 @@ public class CUBRIDSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// CUBRID does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		//TODO: is this really needed?
+		//TODO: would "from table({0})" be better?
+		return " from db_root";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CacheSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CacheSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -68,5 +75,49 @@ public class CacheSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Cache does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
@@ -7,7 +7,9 @@
 package org.hibernate.dialect;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
@@ -41,5 +43,9 @@ public class DB2iSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 		return version >= 710;
 	}
 
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonStandard( lhs, operator, rhs );
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
@@ -7,7 +7,9 @@
 package org.hibernate.dialect;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
@@ -40,6 +42,12 @@ public class DB2zSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 	@Override
 	protected boolean supportsOffsetClause() {
 		return version >= 1200;
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		// Supported at least since DB2 z/OS 9.0
+		renderComparisonStandard( lhs, operator, rhs );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -73,6 +73,7 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.*;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.ANSICaseExpressionWalker;
+import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
 import org.hibernate.sql.ast.spi.CaseExpressionWalker;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
@@ -1517,12 +1518,18 @@ public abstract class Dialect implements ConversionContext {
 	 * there are no tables in the from clause.
 	 *
 	 * @return the SQL equivalent to Oracle's {@code from dual}.
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public String getFromDual() {
 		// The standard SQL solution to get a dual table is to use the VALUES clause
 		return "from (values (0)) as dual";
 	}
 
+	/**
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
+	 */
+	@Deprecated
 	public boolean supportsSelectQueryWithoutFromClause() {
 		return true;
 	}
@@ -1895,12 +1902,6 @@ public abstract class Dialect implements ConversionContext {
 	public SqmMultiTableMutationStrategy getFallbackSqmMutationStrategy(
 			EntityMappingType entityDescriptor,
 			RuntimeModelCreationContext runtimeModelCreationContext) {
-		if ( entityDescriptor.getIdentifierMapping() instanceof CompositeIdentifierMapping) {
-			if ( !supportsTuplesInSubqueries() ) {
-				return new InlineStrategy( this );
-			}
-		}
-
 		return new PersistentTableStrategy(
 				new IdTable( entityDescriptor, name -> name, this ),
 				AfterUseAction.CLEAN,
@@ -2836,7 +2837,9 @@ public abstract class Dialect implements ConversionContext {
 	 * @return True if this SQL dialect is known to support "row value
 	 * constructor" syntax; false otherwise.
 	 * @since 3.2
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public boolean supportsRowValueConstructorSyntax() {
 		// return false here, as most databases do not properly support this construct...
 		return false;
@@ -2850,7 +2853,9 @@ public abstract class Dialect implements ConversionContext {
 	 * "... SET (FIRST_NAME, LAST_NAME) = ('Steve', 'Ebersole') ...".
 	 *
 	 * @return True if this SQL dialect is known to support "row value constructor" syntax in the SET clause; false otherwise.
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public boolean supportsRowValueConstructorSyntaxInSet() {
 		return supportsRowValueConstructorSyntax();
 	}
@@ -2865,7 +2870,9 @@ public abstract class Dialect implements ConversionContext {
 	 * @return True if this SQL dialect is known to support "row value
 	 * constructor" syntax with quantified predicates; false otherwise.
 	 * @since 6.0
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
 		// return false here, as most databases do not properly support this construct...
 		return false;
@@ -2880,11 +2887,17 @@ public abstract class Dialect implements ConversionContext {
 	 * @return True if this SQL dialect is known to support "row value
 	 * constructor" syntax in the IN list; false otherwise.
 	 * @since 3.2
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public boolean supportsRowValueConstructorSyntaxInInList() {
 		return false;
 	}
 
+	/**
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
+	 */
+	@Deprecated
 	public boolean supportsRowValueConstructorSyntaxInInSubquery() {
 		return supportsRowValueConstructorSyntaxInInList();
 	}
@@ -2893,7 +2906,9 @@ public abstract class Dialect implements ConversionContext {
 	 * The strategy to use for rendering summarizations in the GROUP BY clause.
 	 *
 	 * @since 6.0
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public GroupBySummarizationRenderingStrategy getGroupBySummarizationRenderingStrategy() {
 		return GroupBySummarizationRenderingStrategy.NONE;
 	}
@@ -2902,7 +2917,9 @@ public abstract class Dialect implements ConversionContext {
 	 * The strategy to use for rendering constants in the GROUP BY clause.
 	 *
 	 * @since 6.0
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public GroupByConstantRenderingStrategy getGroupByConstantRenderingStrategy() {
 		return GroupByConstantRenderingStrategy.CONSTANT_EXPRESSION;
 	}
@@ -3006,7 +3023,9 @@ public abstract class Dialect implements ConversionContext {
 	 *
 	 * @return True if select clause parameter must be cast()ed
 	 * @since 3.2
+	 * @deprecated Moved to {@link AbstractSqlAstTranslator}
 	 */
+	@Deprecated
 	public boolean requiresCastingOfParametersInSelectClause() {
 		return false;
 	}
@@ -3364,7 +3383,9 @@ public abstract class Dialect implements ConversionContext {
 	 * delete from Table1 where (col1, col2) in (select col1, col2 from Table2)
 	 *
 	 * @return boolean
+	 * @deprecated See {@link #supportsRowValueConstructorSyntaxInInSubquery()}
 	 */
+	@Deprecated
 	public boolean supportsTuplesInSubqueries() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdDialect.java
@@ -614,7 +614,7 @@ public class FirebirdDialect extends Dialect {
 	public String getSelectGUIDString() {
 		return getVersion() < 210
 				? super.getSelectGUIDString()
-				: "select uuid_to_char(gen_uuid()) " + getFromDual();
+				: "select uuid_to_char(gen_uuid()) from rdb$database";
 	}
 
 	@Override
@@ -637,7 +637,7 @@ public class FirebirdDialect extends Dialect {
 
 	@Override
 	public String getCurrentTimestampSelectString() {
-		return "select current_timestamp " + getFromDual();
+		return "select current_timestamp from rdb$database";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/FirebirdSqlAstTranslator.java
@@ -13,10 +13,13 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.query.ComparisonOperator;
+import org.hibernate.query.sqm.sql.internal.SqmParameterInterpretation;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.CastTarget;
@@ -27,6 +30,12 @@ import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
 import org.hibernate.sql.ast.tree.expression.SelfRenderingExpression;
 import org.hibernate.sql.ast.tree.predicate.SelfRenderingPredicate;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.NullnessLiteral;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -124,6 +133,75 @@ public class FirebirdSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 		// Firebird is quite strict i.e. it requires `select .. union all select * from (select ...)`
 		// rather than `select .. union all (select ...)`
 		return false;
+	}
+
+	@Override
+	protected void renderSelectExpression(Expression expression) {
+		// Null literals have to be casted in the select clause
+		if ( expression instanceof Literal ) {
+			final Literal literal = (Literal) expression;
+			if ( literal.getLiteralValue() == null ) {
+				renderCasted( literal );
+			}
+			else {
+				renderLiteral( literal, true );
+			}
+		}
+		else if ( expression instanceof NullnessLiteral || expression instanceof JdbcParameter || expression instanceof SqmParameterInterpretation ) {
+			renderCasted( expression );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from rdb$database";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 
 	private boolean supportsOffsetFetchClause() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -53,6 +61,50 @@ public class H2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAstT
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// H2 does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from dual";
 	}
 
 	private boolean supportsOffsetFetchClause() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANASqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANASqlAstTranslator.java
@@ -7,9 +7,13 @@
 package org.hibernate.dialect;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -68,5 +72,38 @@ public class HANASqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAs
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// HANA does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "()" );
+		}
+		else if ( expression instanceof Summarization ) {
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from sys.dummy";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
@@ -6,10 +6,21 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
+import org.hibernate.query.sqm.sql.internal.SqmParameterInterpretation;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.NullnessLiteral;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -43,6 +54,75 @@ public class HSQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAs
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// HSQL does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderSelectExpression(Expression expression) {
+		// Null literals have to be casted in the select clause
+		if ( expression instanceof Literal ) {
+			final Literal literal = (Literal) expression;
+			if ( literal.getLiteralValue() == null ) {
+				renderCasted( literal );
+			}
+			else {
+				renderLiteral( literal, true );
+			}
+		}
+		else if ( expression instanceof NullnessLiteral || expression instanceof JdbcParameter || expression instanceof SqmParameterInterpretation ) {
+			renderCasted( expression );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from (values(0))";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 
 	private boolean supportsOffsetFetchClause() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/InformixSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/InformixSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -87,6 +94,66 @@ public class InformixSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Informix does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		// We render an empty group instead of literals as some DBs don't support grouping by literals
+		// Note that integer literals, which refer to select item positions, are handled in #visitGroupByClause
+		if ( expression instanceof Literal ) {
+			// todo (6.0): We need to introduce a dummy from clause item
+//			String fromItem = ", (select 1 x " + dialect.getFromDual() + ") dummy";
+//			sqlBuffer.insert( fromEndIndex, fromItem );
+//			appendSql( "dummy.x" );
+			throw new UnsupportedOperationException( "Column reference strategy is not yet implemented!" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from (select 0 from systables where tabid = 1) as dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 
 	private boolean supportsParameterOffsetFetchExpression() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/IngresSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/IngresSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -81,6 +88,65 @@ public class IngresSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Ingres does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			// todo (6.0): We need to introduce a dummy from clause item
+//			String fromItem = ", (select 1 x " + dialect.getFromDual() + ") dummy";
+//			sqlBuffer.insert( fromEndIndex, fromItem );
+//			appendSql( "dummy.x" );
+			throw new UnsupportedOperationException( "Column reference strategy is not yet implemented!" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		//this is only necessary if the query has a where clause
+		return " from (select 0) as dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MaxDBSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MaxDBSqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -37,5 +45,59 @@ public class MaxDBSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// MaxDB does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	public String getFromDual() {
+		return " from dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MimerSQLSqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -38,5 +46,59 @@ public class MimerSQLSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// MimerSQL does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from (values(0))";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle10gDialect.java
@@ -21,6 +21,6 @@ package org.hibernate.dialect;
 public class Oracle10gDialect extends OracleDialect {
 
 	public Oracle10gDialect() {
-		super(10);
+		super( 1000 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle12cDialect.java
@@ -17,6 +17,6 @@ package org.hibernate.dialect;
 public class Oracle12cDialect extends OracleDialect {
 
 	public Oracle12cDialect() {
-		super(12);
+		super( 1200 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle8iDialect.java
@@ -15,7 +15,7 @@ package org.hibernate.dialect;
 public class Oracle8iDialect extends OracleDialect {
 
 	public Oracle8iDialect() {
-		super(8);
+		super( 800 );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Oracle9iDialect.java
@@ -20,7 +20,7 @@ package org.hibernate.dialect;
 public class Oracle9iDialect extends OracleDialect {
 
 	public Oracle9iDialect() {
-		super(9);
+		super( 900 );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -94,7 +94,7 @@ public class OracleDialect extends Dialect {
 	private final int version;
 
 	public OracleDialect(DialectResolutionInfo info) {
-		this( info.getDatabaseMajorVersion() );
+		this( info.getDatabaseMajorVersion() * 100 + info.getDatabaseMinorVersion() );
 	}
 
 	private static final Pattern DISTINCT_KEYWORD_PATTERN = Pattern.compile( "\\bdistinct\\b" );
@@ -114,7 +114,7 @@ public class OracleDialect extends Dialect {
 	private final LimitHandler limitHandler;
 
 	public OracleDialect() {
-		this(8);
+		this( 800 );
 	}
 
 	public OracleDialect(int version) {
@@ -128,7 +128,7 @@ public class OracleDialect extends Dialect {
 		registerReverseHibernateTypeMappings();
 		registerDefaultProperties();
 
-		limitHandler = getVersion() < 12
+		limitHandler = getVersion() < 1200
 				? new LegacyOracleLimitHandler( getVersion() )
 				: OffsetFetchLimitHandler.INSTANCE;
 	}
@@ -182,7 +182,7 @@ public class OracleDialect extends Dialect {
 		CommonFunctionFactory.corr( queryEngine );
 		CommonFunctionFactory.regrLinearRegressionAggregates( queryEngine );
 
-		if ( getVersion() < 9 ) {
+		if ( getVersion() < 900 ) {
 			queryEngine.getSqmFunctionRegistry().register( "coalesce", new NvlCoalesceEmulation() );
 		}
 		else {
@@ -211,7 +211,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String currentDate() {
-		return getVersion() < 9 ? currentTimestamp() : "current_date";
+		return getVersion() < 900 ? currentTimestamp() : "current_date";
 	}
 
 	@Override
@@ -221,7 +221,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String currentTimestamp() {
-		return getVersion() < 9 ? "sysdate" : currentTimestampWithTimeZone();
+		return getVersion() < 900 ? "sysdate" : currentTimestampWithTimeZone();
 	}
 
 	@Override
@@ -231,12 +231,12 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String currentLocalTimestamp() {
-		return getVersion() < 9 ? currentTimestamp() : "localtimestamp";
+		return getVersion() < 900 ? currentTimestamp() : "localtimestamp";
 	}
 
 	@Override
 	public String currentTimestampWithTimeZone() {
-		return getVersion() < 9 ? currentTimestamp() : "current_timestamp";
+		return getVersion() < 900 ? currentTimestamp() : "current_timestamp";
 	}
 
 
@@ -523,7 +523,7 @@ public class OracleDialect extends Dialect {
 	}
 
 	protected void registerCharacterTypeMappings() {
-		if ( getVersion() < 9) {
+		if ( getVersion() < 900) {
 			registerColumnType( Types.VARCHAR, 4000, "varchar2($l)" );
 			registerColumnType( Types.VARCHAR, "clob" );
 		}
@@ -549,7 +549,7 @@ public class OracleDialect extends Dialect {
 	}
 
 	protected void registerDateTimeTypeMappings() {
-		if ( getVersion() < 9 ) {
+		if ( getVersion() < 900 ) {
 			registerColumnType( Types.DATE, "date" );
 			registerColumnType( Types.TIME, "date" );
 			registerColumnType( Types.TIMESTAMP, "date" );
@@ -567,7 +567,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public boolean supportsTimezoneTypes() {
-		return getVersion() >= 9;
+		return getVersion() >= 900;
 	}
 
 	protected void registerBinaryTypeMappings() {
@@ -585,7 +585,7 @@ public class OracleDialect extends Dialect {
 		getDefaultProperties().setProperty( Environment.USE_STREAMS_FOR_BINARY, "true" );
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
 
-		if ( getVersion() < 12 ) {
+		if ( getVersion() < 1200 ) {
 			// Oracle driver reports to support getGeneratedKeys(), but they only
 			// support the version taking an array of the names of the columns to
 			// be returned (via its RETURNING clause).  No other driver seems to
@@ -641,7 +641,7 @@ public class OracleDialect extends Dialect {
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
 
-		if ( getVersion() >= 12 ) {
+		if ( getVersion() >= 1200 ) {
 			// account for Oracle's deprecated support for LONGVARBINARY
 			// prefer BLOB, unless the user explicitly opts out
 			boolean preferLong = serviceRegistry.getService( ConfigurationService.class ).getSetting(
@@ -745,7 +745,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public IdentityColumnSupport getIdentityColumnSupport() {
-		return getVersion() < 12
+		return getVersion() < 1200
 				? super.getIdentityColumnSupport()
 				: new Oracle12cIdentityColumnSupport();
 	}
@@ -753,12 +753,12 @@ public class OracleDialect extends Dialect {
 	@Override
 	@SuppressWarnings("deprecation")
 	public JoinFragment createOuterJoinFragment() {
-		return getVersion() < 10 ? new OracleJoinFragment() : new ANSIJoinFragment();
+		return getVersion() < 1000 ? new OracleJoinFragment() : new ANSIJoinFragment();
 	}
 
 	@Override
 	public String getCrossJoinSeparator() {
-		return getVersion() < 10 ? ", " : " cross join ";
+		return getVersion() < 1000 ? ", " : " cross join ";
 	}
 
 	/**
@@ -770,7 +770,7 @@ public class OracleDialect extends Dialect {
 	@Override
 	@SuppressWarnings("deprecation")
 	public CaseFragment createCaseFragment() {
-		return getVersion() < 9
+		return getVersion() < 900
 				? new DecodeCaseFragment()
 				// Oracle did add support for ANSI CASE statements in 9i
 				: new ANSICaseFragment();
@@ -783,7 +783,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String getSelectClauseNullString(int sqlType) {
-		if ( getVersion() >= 9  ) {
+		if ( getVersion() >= 900 ) {
 			return super.getSelectClauseNullString(sqlType);
 		}
 		else {
@@ -804,7 +804,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String getCurrentTimestampSelectString() {
-		return getVersion() < 9
+		return getVersion() < 900
 				? "select sysdate from dual"
 				: "select systimestamp from dual";
 	}
@@ -812,7 +812,7 @@ public class OracleDialect extends Dialect {
 	@Override
 	@SuppressWarnings("deprecation")
 	public String getCurrentTimestampSQLFunctionName() {
-		return getVersion() < 9
+		return getVersion() < 900
 				? "sysdate"
 				// the standard SQL function name is current_timestamp...
 				: "current_timestamp";
@@ -1118,7 +1118,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public boolean supportsRowValueConstructorSyntaxInInSubquery() {
-		return getVersion() >= 9;
+		return getVersion() >= 900;
 	}
 
 	@Override
@@ -1128,12 +1128,12 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public boolean supportsNoWait() {
-		return getVersion() >= 9;
+		return getVersion() >= 900;
 	}
 
 	@Override
 	public boolean supportsSkipLocked() {
-		return getVersion() >= 10;
+		return getVersion() >= 1000;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
@@ -10,9 +10,15 @@ import java.util.List;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.insert.Values;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -104,8 +110,68 @@ public class OracleSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 		}
 	}
 
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateDecode( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "()" );
+		}
+		else if ( expression instanceof Summarization ) {
+			Summarization summarization = (Summarization) expression;
+			appendSql( summarization.getKind().name().toLowerCase() );
+			appendSql( OPEN_PARENTHESIS );
+			renderCommaSeparated( summarization.getGroupings() );
+			appendSql( CLOSE_PARENTHESIS );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return getDialect().getVersion() >= 820;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInSubQuery() {
+		return getDialect().getVersion() >= 900;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
+	}
+
 	private boolean supportsOffsetFetchClause() {
-		return getDialect().getVersion() >= 12;
+		return getDialect().getVersion() >= 1200;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/RDBMSOS2200SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/RDBMSOS2200SqlAstTranslator.java
@@ -6,12 +6,20 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.query.FetchClauseType;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
+import org.hibernate.query.Limit;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -63,5 +71,59 @@ public class RDBMSOS2200SqlAstTranslator<T extends JdbcOperation> extends Abstra
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Unisys 2200 does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from rdms.rdms_dummy where key_col = 1";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerSqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -37,5 +45,49 @@ public class SpannerSqlAstTranslator<T extends JdbcOperation> extends AbstractSq
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Spanner does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -84,6 +91,39 @@ public class SybaseASESqlAstTranslator<T extends JdbcOperation> extends Abstract
 	}
 
 	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			// todo (6.0): We need to introduce a dummy from clause item
+//			String fromItem = ", (select 1 x " + dialect.getFromDual() + ") dummy";
+//			sqlBuffer.insert( fromEndIndex, fromItem );
+//			appendSql( "dummy.x" );
+			throw new UnsupportedOperationException( "Column reference strategy is not yet implemented!" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
 	protected boolean needsRowsToSkip() {
 		return true;
 	}
@@ -91,6 +131,21 @@ public class SybaseASESqlAstTranslator<T extends JdbcOperation> extends Abstract
 	@Override
 	protected boolean needsMaxRows() {
 		return !supportsTopClause();
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 
 	private boolean supportsTopClause() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseAnywhereSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseAnywhereSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -80,5 +87,59 @@ public class SybaseAnywhereSqlAstTranslator<T extends JdbcOperation> extends Abs
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Sybase Anywhere does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "()" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
+	}
+
+	@Override
+	protected String getFromDual() {
+		return " from sys.dummy";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getFromDual();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
@@ -6,10 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -40,6 +48,54 @@ public class SybaseSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 		if ( !queryPart.isRoot() && queryPart.getOffsetClauseExpression() != null ) {
 			throw new IllegalArgumentException( "Can't emulate offset clause in subquery" );
 		}
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			// todo (6.0): We need to introduce a dummy from clause item
+//			String fromItem = ", (select 1 x " + dialect.getFromDual() + ") dummy";
+//			sqlBuffer.insert( fromEndIndex, fromItem );
+//			appendSql( "dummy.x" );
+			throw new UnsupportedOperationException( "Column reference strategy is not yet implemented!" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TeradataSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TeradataSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -62,5 +69,49 @@ public class TeradataSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	@Override
 	protected void renderCycleClause(CteStatement cte) {
 		// Teradata does not support this, but it can be emulated
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "()" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TimesTenSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -54,5 +61,49 @@ public class TimesTenSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	@Override
 	public void visitOffsetFetchClause(QueryPart queryPart) {
 		// TimesTen uses ROWS TO clause
+	}
+
+	@Override
+	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
+		renderComparisonEmulateIntersect( lhs, operator, rhs );
+	}
+
+	@Override
+	protected void renderSelectTupleComparison(
+			List<SqlSelection> lhsExpressions,
+			SqlTuple tuple,
+			ComparisonOperator operator) {
+		emulateTupleComparison( lhsExpressions, tuple.getExpressions(), operator, true );
+	}
+
+	@Override
+	protected void renderPartitionItem(Expression expression) {
+		if ( expression instanceof Literal ) {
+			appendSql( "'0' || '0'" );
+		}
+		else if ( expression instanceof Summarization ) {
+			// This could theoretically be emulated by rendering all grouping variations of the query and
+			// connect them via union all but that's probably pretty inefficient and would have to happen
+			// on the query spec level
+			throw new UnsupportedOperationException( "Summarization is not supported by DBMS!" );
+		}
+		else {
+			expression.accept( this );
+		}
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntax() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
+	protected boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/LegacyOracleLimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/LegacyOracleLimitHandler.java
@@ -16,7 +16,7 @@ import java.util.regex.Matcher;
  */
 public class LegacyOracleLimitHandler extends AbstractLimitHandler {
 
-	private int version;
+	private final int version;
 
 	public LegacyOracleLimitHandler(int version) {
 		this.version = version;
@@ -39,7 +39,7 @@ public class LegacyOracleLimitHandler extends AbstractLimitHandler {
 		final StringBuilder pagingSelect = new StringBuilder( sql.length() + 100 );
 		if ( hasOffset ) {
 			pagingSelect.append( "select * from (select row_.*, rownum rownum_ from (" ).append( sql );
-			if ( version < 9 ) {
+			if ( version < 900 ) {
 				pagingSelect.append( ") row_) where rownum_ <= ? and rownum_ > ?" );
 			}
 			else {
@@ -74,7 +74,7 @@ public class LegacyOracleLimitHandler extends AbstractLimitHandler {
 		final StringBuilder pagingSelect = new StringBuilder( sql.length() + 100 );
 		if ( hasOffset ) {
 			pagingSelect.append( "select * from (select row_.*, rownum rownum_ from (" ).append( sql );
-			if ( version < 9 ) {
+			if ( version < 900 ) {
 				pagingSelect.append( ") row_) where rownum_ <= ? and rownum_ > ?" );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/query/ComparisonOperator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/ComparisonOperator.java
@@ -64,6 +64,59 @@ public enum ComparisonOperator {
 			return "!=";
 		}
 	},
+	NOT_DISTINCT_FROM {
+		@Override
+		public ComparisonOperator negated() {
+			return DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator invert() {
+			return NOT_DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator broader() {
+			return NOT_DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator sharper() {
+			return NOT_DISTINCT_FROM;
+		}
+
+		@Override
+		public String sqlText() {
+			return "is not distinct from";
+		}
+	},
+
+	DISTINCT_FROM {
+		@Override
+		public ComparisonOperator negated() {
+			return NOT_DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator invert() {
+			return DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator broader() {
+			return DISTINCT_FROM;
+		}
+
+		@Override
+		public ComparisonOperator sharper() {
+			return DISTINCT_FROM;
+		}
+
+		@Override
+		public String sqlText() {
+			return "is distinct from";
+		}
+	},
 
 	LESS_THAN {
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/HibernateCriteriaBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/HibernateCriteriaBuilder.java
@@ -512,6 +512,14 @@ public interface HibernateCriteriaBuilder extends CriteriaBuilder {
 	@Override
 	JpaPredicate notEqual(Expression<?> x, Object y);
 
+	JpaPredicate distinctFrom(Expression<?> x, Expression<?> y);
+
+	JpaPredicate distinctFrom(Expression<?> x, Object y);
+
+	JpaPredicate notDistinctFrom(Expression<?> x, Expression<?> y);
+
+	JpaPredicate notDistinctFrom(Expression<?> x, Object y);
+
 	@Override
 	<Y extends Comparable<? super Y>> JpaPredicate greaterThan(
 			Expression<? extends Y> x,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
@@ -467,6 +467,18 @@ public interface NodeBuilder extends HibernateCriteriaBuilder {
 	SqmPredicate notEqual(Expression<?> x, Object y);
 
 	@Override
+	SqmPredicate distinctFrom(Expression<?> x, Expression<?> y);
+
+	@Override
+	SqmPredicate distinctFrom(Expression<?> x, Object y);
+
+	@Override
+	SqmPredicate notDistinctFrom(Expression<?> x, Expression<?> y);
+
+	@Override
+	SqmPredicate notDistinctFrom(Expression<?> x, Object y);
+
+	@Override
 	<Y extends Comparable<? super Y>> SqmPredicate greaterThan(Expression<? extends Y> x, Expression<? extends Y> y);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -1708,6 +1708,46 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
+	public SqmPredicate distinctFrom(Expression<?> x, Expression<?> y) {
+		return new SqmComparisonPredicate(
+				(SqmExpression<?>) x,
+				ComparisonOperator.DISTINCT_FROM,
+				(SqmExpression<?>) y,
+				this
+		);
+	}
+
+	@Override
+	public SqmPredicate distinctFrom(Expression<?> x, Object y) {
+		return new SqmComparisonPredicate(
+				(SqmExpression<?>) x,
+				ComparisonOperator.DISTINCT_FROM,
+				value( y ),
+				this
+		);
+	}
+
+	@Override
+	public SqmPredicate notDistinctFrom(Expression<?> x, Expression<?> y) {
+		return new SqmComparisonPredicate(
+				(SqmExpression<?>) x,
+				ComparisonOperator.NOT_DISTINCT_FROM,
+				(SqmExpression<?>) y,
+				this
+		);
+	}
+
+	@Override
+	public SqmPredicate notDistinctFrom(Expression<?> x, Object y) {
+		return new SqmComparisonPredicate(
+				(SqmExpression<?>) x,
+				ComparisonOperator.NOT_DISTINCT_FROM,
+				value( y ),
+				this
+		);
+	}
+
+	@Override
 	public <Y extends Comparable<? super Y>> SqmPredicate greaterThan(Expression<? extends Y> x, Expression<? extends Y> y) {
 		return new SqmComparisonPredicate(
 				(SqmExpression<?>) x,

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.ast.spi;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.MappingModelExpressable;
+import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
@@ -28,7 +29,7 @@ import org.hibernate.type.descriptor.ValueExtractor;
  *
  * @author Steve Ebersole
  */
-public interface SqlSelection {
+public interface SqlSelection extends SqlAstNode {
 	/**
 	 * Get the extractor that can be used to extract JDBC values for this selection
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ComparisonPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ComparisonPredicate.java
@@ -15,7 +15,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
  */
 public class ComparisonPredicate implements Predicate {
 	private final Expression leftHandExpression;
-	private ComparisonOperator operator;
+	private final ComparisonOperator operator;
 	private final Expression rightHandExpression;
 
 	public ComparisonPredicate(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/DistinctFromTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/DistinctFromTest.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql;
+
+import org.hibernate.testing.orm.domain.StandardDomainModel;
+import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Christian Beikov
+ */
+@ServiceRegistry
+@DomainModel(standardModels = StandardDomainModel.GAMBIT)
+@SessionFactory
+public class DistinctFromTest {
+
+	@BeforeAll
+	public void prepareData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					EntityOfBasics entity1 = new EntityOfBasics();
+					entity1.setId( 123 );
+					em.persist( entity1 );
+					EntityOfBasics entity = new EntityOfBasics();
+					entity.setId( 456 );
+					entity.setTheString( "abc" );
+					em.persist( entity );
+				}
+		);
+	}
+
+	@Test
+	public void testDistinctFrom(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Assertions.assertEquals(
+							456,
+							session.createQuery(
+									"select e.id from EntityOfBasics e where e.theString is distinct from :param",
+									Integer.class
+							)
+									.setParameter( "param", null )
+									.list()
+									.get( 0 )
+					);
+					Assertions.assertEquals(
+							123,
+							session.createQuery(
+									"select e.id from EntityOfBasics e where e.theString is distinct from :param",
+									Integer.class
+							)
+									.setParameter( "param", "abc" )
+									.list()
+									.get( 0 )
+					);
+					Assertions.assertEquals(
+							123,
+							session.createQuery(
+									"select e.id from EntityOfBasics e where e.theString is not distinct from :param",
+									Integer.class
+							)
+									.setParameter( "param", null )
+									.list()
+									.get( 0 )
+					);
+					Assertions.assertEquals(
+							456,
+							session.createQuery(
+									"select e.id from EntityOfBasics e where e.theString is not distinct from :param",
+									Integer.class
+							)
+									.setParameter( "param", "abc" )
+									.list()
+									.get( 0 )
+					);
+				}
+		);
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/EmbeddedIdEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/EmbeddedIdEntityTest.java
@@ -53,8 +53,8 @@ public class EmbeddedIdEntityTest {
 	@AfterEach
 	public void tearDown(SessionFactoryScope scope) {
 		scope.inTransaction(
-				sesison ->
-						sesison.createQuery( "delete from EmbeddedIdEntity" ).executeUpdate()
+				session ->
+						session.createQuery( "delete from EmbeddedIdEntity" ).executeUpdate()
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/component/basic/ComponentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/component/basic/ComponentTest.java
@@ -24,6 +24,7 @@ import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Formula;
 import org.hibernate.mapping.PersistentClass;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
@@ -214,7 +215,7 @@ public class ComponentTest extends BaseNonConfigCoreFunctionalTestCase {
 //			.add( Property.forName("person.yob").between( new Integer(1999), new Integer(2002) ) )
 //			.list();
 
-		if ( getDialect().supportsRowValueConstructorSyntax() ) {
+		if ( new DialectChecks.SupportsRowValueConstructorSyntaxCheck().isMatch( getDialect() ) ) {
 			s.createQuery("from User u where u.person = ('gavin', :dob, 'Peachtree Rd', 'Karbarook Ave', 1974, 34, 'Peachtree Rd')")
 				.setParameter("dob", new Date("March 25, 1974")).list();
 			s.createQuery("from User where person = ('gavin', :dob, 'Peachtree Rd', 'Karbarook Ave', 1974, 34, 'Peachtree Rd')")

--- a/hibernate-core/src/test/java/org/hibernate/test/idprops/IdentifierPropertyReferencesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idprops/IdentifierPropertyReferencesTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.hibernate.query.Query;
 import org.hibernate.Session;
 
+import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import static org.junit.Assert.assertEquals;
@@ -54,7 +55,7 @@ public class IdentifierPropertyReferencesTest extends BaseCoreFunctionalTestCase
 					count = extractCount( s, "select count(*) from LineItem l where l.id = '456'" );
 					assertEquals( "LineItem by id prop (non-identifier", 1, count );
 
-					if ( getDialect().supportsRowValueConstructorSyntax() ) {
+					if ( new DialectChecks.SupportsRowValueConstructorSyntaxCheck().isMatch( getDialect() ) ) {
 						Query q = s.createQuery( "select count(*) from LineItem l where l.pk = (:order, :product)" )
 								.setParameter( "order", o )
 								.setParameter( "product", "my-product" );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/DialectChecks.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.testing;
 
+import org.hibernate.dialect.AbstractHANADialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.Dialect;
@@ -17,6 +18,7 @@ import org.hibernate.dialect.IngresDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
+import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.dialect.TeradataDialect;
 import org.hibernate.dialect.TimesTenDialect;
@@ -132,7 +134,10 @@ abstract public class DialectChecks {
 
 	public static class SupportsRowValueConstructorSyntaxCheck implements DialectCheck {
 		public boolean isMatch(Dialect dialect) {
-			return dialect.supportsRowValueConstructorSyntax();
+			return dialect instanceof AbstractHANADialect
+					|| dialect instanceof CockroachDialect
+					|| dialect instanceof MySQLDialect
+					|| dialect instanceof PostgreSQLDialect;
 		}
 	}
 
@@ -200,12 +205,6 @@ abstract public class DialectChecks {
 	public static class SupportCatalogCreation implements DialectCheck {
 		public boolean isMatch(Dialect dialect) {
 			return dialect.canCreateCatalog();
-		}
-	}
-
-	public static class DoesNotSupportRowValueConstructorSyntax implements DialectCheck {
-		public boolean isMatch(Dialect dialect) {
-			return dialect.supportsRowValueConstructorSyntax() == false;
 		}
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -137,7 +137,10 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsRowValueConstructorSyntaxCheck implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			return dialect.supportsRowValueConstructorSyntax();
+			return dialect instanceof AbstractHANADialect
+					|| dialect instanceof CockroachDialect
+					|| dialect instanceof MySQLDialect
+					|| dialect instanceof PostgreSQLDialect;
 		}
 	}
 
@@ -240,18 +243,22 @@ abstract public class DialectFeatureChecks {
 
 	public static class SupportsGroupByRollup implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			return dialect.getGroupBySummarizationRenderingStrategy() != GroupBySummarizationRenderingStrategy.NONE;
+			return dialect instanceof DB2Dialect
+					|| dialect instanceof OracleDialect
+					|| dialect instanceof PostgreSQLDialect && dialect.getVersion() >= 950
+					|| dialect instanceof SQLServerDialect
+					|| dialect instanceof DerbyDialect
+					|| dialect instanceof MySQLDialect
+					|| dialect instanceof MariaDBDialect;
 		}
 	}
 
 	public static class SupportsGroupByGroupingSets implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
-			return dialect.getGroupBySummarizationRenderingStrategy() != GroupBySummarizationRenderingStrategy.NONE
-					&& !( dialect instanceof DerbyDialect )
-					// MariaDB only supports ROLLUP
-					&& !( dialect instanceof MariaDBDialect )
-					// MySQL only supports ROLLUP
-					&& !( dialect instanceof MySQLDialect );
+			return dialect instanceof DB2Dialect
+					|| dialect instanceof OracleDialect
+					|| dialect instanceof PostgreSQLDialect && dialect.getVersion() >= 950
+					|| dialect instanceof SQLServerDialect;
 		}
 	}
 


### PR DESCRIPTION
[HHH-11692](https://hibernate.atlassian.net/browse/HHH-11692)

This is a long requested feature. The example criterion in the legacy Criteria API used the same semantics. This PR introduces the SQL standard `DISTINCT` predicate for this purpose. I can imagine adding an operator as well, but that would be a minor addition to the parser and I wanted to get the feature done first.

I also deprecated some methods of `Dialect`:

* `getFromDual()`
* `supportsSelectQueryWithoutFromClause()`
* `supportsRowValueConstructorSyntax()`
* `supportsRowValueConstructorSyntaxInSet()`
* `supportsRowValueConstructorSyntaxInQuantifiedPredicates()`
* `supportsRowValueConstructorSyntaxInInList()`
* `supportsRowValueConstructorSyntaxInInSubquery()`
* `getGroupBySummarizationRenderingStrategy()`
* `getGroupByConstantRenderingStrategy()`
* `requiresCastingOfParametersInSelectClause()`
* `supportsTuplesInSubqueries()`

These were moved to `AbstractSqlAstTranslator` and/or inlined into the `SqlAstTranslator` implementations for the dialects. Since some of these methods were only introduced in 6.0 and are now unused anyway, I would suggest we remove them in 6.0.

The reasoning for this is that I wanted to inline as much of the logic as possible into the `SqlAstTranslator` implementations to avoid cluttering the code with even more if-else chains to handle emulations for the `DISTINCT` predicate. Since these methods were only ever used within the `SqlAstTranslator` implementations anyway, it's IMO nicer to move this "supports" logic there.