### PR TITLE
Wip/6.0 TableGroupJoin rendering

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/results/TableGroupImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/TableGroupImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.query.results;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -35,7 +34,6 @@ public class TableGroupImpl implements TableGroup {
 	private final ModelPartContainer container;
 	private final LockMode lockMode;
 
-	private Set<TableGroupJoin> tableGroupJoins;
 
 	public TableGroupImpl(
 			NavigablePath navigablePath,
@@ -76,32 +74,22 @@ public class TableGroupImpl implements TableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptySet() : tableGroupJoins;
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return Collections.emptyList();
 	}
 
 	@Override
 	public boolean hasTableGroupJoins() {
-		return tableGroupJoins != null && ! tableGroupJoins.isEmpty();
-	}
-
-	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		throw new UnsupportedOperationException();
+		return false;
 	}
 
 	@Override
 	public void addTableGroupJoin(TableGroupJoin join) {
-
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-		if ( tableGroupJoins == null ) {
-			return;
-		}
-
-		tableGroupJoins.forEach( consumer );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
@@ -7,7 +7,6 @@
 package org.hibernate.sql.ast;
 
 import java.util.List;
-import java.util.Set;
 
 import org.hibernate.sql.ast.tree.SqlAstTreeLogger;
 import org.hibernate.sql.ast.tree.Statement;
@@ -130,7 +129,7 @@ public class SqlTreePrinter {
 			);
 		}
 
-		final Set<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
+		final List<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
 		if ( ! tableGroupJoins.isEmpty() ) {
 			logNode(
 					"TableGroupJoins",

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.ast.tree.cte;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -58,8 +57,8 @@ public class CteTableGroup implements TableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return Collections.emptySet();
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return Collections.emptyList();
 	}
 
 	@Override
@@ -80,10 +79,6 @@ public class CteTableGroup implements TableGroup {
 			String tableExpression,
 			Supplier<TableReference> creator) {
 		return cteTableReference;
-	}
-
-	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableGroup.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.sql.ast.tree.from;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.hibernate.LockMode;
@@ -26,7 +26,7 @@ public abstract class AbstractTableGroup extends AbstractColumnReferenceQualifie
 	private final LockMode lockMode;
 	private final SqlAliasBase sqlAliasBase;
 
-	private Set<TableGroupJoin> tableGroupJoins;
+	private List<TableGroupJoin> tableGroupJoins;
 	private boolean isInnerJoinPossible;
 
 	private final SessionFactoryImplementor sessionFactory;
@@ -93,8 +93,8 @@ public abstract class AbstractTableGroup extends AbstractColumnReferenceQualifie
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptySet() : Collections.unmodifiableSet( tableGroupJoins );
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return tableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( tableGroupJoins );
 	}
 
 	@Override
@@ -103,16 +103,13 @@ public abstract class AbstractTableGroup extends AbstractColumnReferenceQualifie
 	}
 
 	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		tableGroupJoins = new HashSet<>( joins );
-	}
-
-	@Override
 	public void addTableGroupJoin(TableGroupJoin join) {
 		if ( tableGroupJoins == null ) {
-			tableGroupJoins = new HashSet<>();
+			tableGroupJoins = new ArrayList<>();
 		}
-		tableGroupJoins.add( join );
+		if ( !tableGroupJoins.contains( join ) ) {
+			tableGroupJoins.add( join );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CompositeTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CompositeTableGroup.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.sql.ast.tree.from;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -26,7 +25,7 @@ public class CompositeTableGroup implements VirtualTableGroup {
 
 	private final TableGroup underlyingTableGroup;
 
-	private Set<TableGroupJoin> tableGroupJoins;
+	private List<TableGroupJoin> tableGroupJoins;
 
 	public CompositeTableGroup(
 			NavigablePath navigablePath,
@@ -64,8 +63,8 @@ public class CompositeTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptySet() : Collections.unmodifiableSet( tableGroupJoins );
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return tableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( tableGroupJoins );
 	}
 
 	@Override
@@ -74,16 +73,13 @@ public class CompositeTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		tableGroupJoins = new HashSet<>( joins );
-	}
-
-	@Override
 	public void addTableGroupJoin(TableGroupJoin join) {
 		if ( tableGroupJoins == null ) {
-			tableGroupJoins = new HashSet<>();
+			tableGroupJoins = new ArrayList<>();
 		}
-		tableGroupJoins.add( join );
+		if ( !tableGroupJoins.contains( join ) ) {
+			tableGroupJoins.add( join );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.ast.tree.from;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -90,18 +89,13 @@ public class MutatingTableReferenceGroupWrapper implements VirtualTableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return Collections.emptySet();
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return Collections.emptyList();
 	}
 
 	@Override
 	public boolean hasTableGroupJoins() {
 		return false;
-	}
-
-	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
@@ -12,7 +12,6 @@ import java.util.function.Consumer;
 
 import org.hibernate.LockMode;
 import org.hibernate.metamodel.mapping.ModelPartContainer;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
 import org.hibernate.query.sqm.sql.internal.SqmPathInterpretation;
@@ -41,11 +40,9 @@ public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, SqmPat
 
 	LockMode getLockMode();
 
-	Set<TableGroupJoin> getTableGroupJoins();
+	List<TableGroupJoin> getTableGroupJoins();
 
 	boolean hasTableGroupJoins();
-
-	void setTableGroupJoins(Set<TableGroupJoin> joins);
 
 	void addTableGroupJoin(TableGroupJoin join);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.sql.ast.tree.from;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -24,7 +23,7 @@ import org.hibernate.query.NavigablePath;
  */
 public class UnionTableGroup implements VirtualTableGroup {
 	private final NavigablePath navigablePath;
-	private Set<TableGroupJoin> tableGroupJoins;
+	private List<TableGroupJoin> tableGroupJoins;
 
 	private final UnionSubclassEntityPersister modelPart;
 	private final TableReference tableReference;
@@ -64,8 +63,8 @@ public class UnionTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptySet() : Collections.unmodifiableSet( tableGroupJoins );
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return tableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( tableGroupJoins );
 	}
 
 	@Override
@@ -74,16 +73,13 @@ public class UnionTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		tableGroupJoins = new HashSet<>( joins );
-	}
-
-	@Override
 	public void addTableGroupJoin(TableGroupJoin join) {
 		if ( tableGroupJoins == null ) {
-			tableGroupJoins = new HashSet<>();
+			tableGroupJoins = new ArrayList<>();
 		}
-		tableGroupJoins.add( join );
+		if ( !tableGroupJoins.contains( join ) ) {
+			tableGroupJoins.add( join );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EntityCollectionPartTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/EntityCollectionPartTableGroup.java
@@ -7,7 +7,6 @@
 package org.hibernate.sql.results.graph.collection.internal;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -64,18 +63,13 @@ public class EntityCollectionPartTableGroup implements TableGroup {
 	}
 
 	@Override
-	public Set<TableGroupJoin> getTableGroupJoins() {
+	public List<TableGroupJoin> getTableGroupJoins() {
 		return collectionTableGroup.getTableGroupJoins();
 	}
 
 	@Override
 	public boolean hasTableGroupJoins() {
 		return collectionTableGroup.hasTableGroupJoins();
-	}
-
-	@Override
-	public void setTableGroupJoins(Set<TableGroupJoin> joins) {
-		collectionTableGroup.setTableGroupJoins( joins );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
@@ -160,7 +160,7 @@ public class CriteriaEntityGraphTest implements SessionFactoryScopeAware {
 
 					// Check the from-clause
 					assertEntityValuedJoinedGroup( sqlAst, "owner", Person.class, tableGroup -> {
-						Set<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
+						List<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
 						Map<String, Class<? extends TableGroup>> tableGroupByName = tableGroupJoins.stream()
 								.map( TableGroupJoin::getJoinedGroup )
 								.collect( Collectors.toMap(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/EntityGraphLoadPlanBuilderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/EntityGraphLoadPlanBuilderTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.entitygraph.ast;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -155,7 +156,7 @@ public class EntityGraphLoadPlanBuilderTest implements SessionFactoryScopeAware 
 
 					// Check the from-clause
 					assertEntityValuedJoinedGroup( sqlAst, "owner", Person.class, tableGroup -> {
-						Set<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
+						List<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
 						Map<String, Class<? extends TableGroup>> tableGroupByName = tableGroupJoins.stream()
 								.map( TableGroupJoin::getJoinedGroup )
 								.collect( Collectors.toMap(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.entitygraph.ast;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -157,7 +158,7 @@ public class HqlEntityGraphTest implements SessionFactoryScopeAware {
 
 					// Check the from-clause
 					assertEntityValuedJoinedGroup( sqlAst, "owner", Person.class, tableGroup -> {
-						Set<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
+						List<TableGroupJoin> tableGroupJoins = tableGroup.getTableGroupJoins();
 						Map<String, Class<? extends TableGroup>> tableGroupByName = tableGroupJoins.stream()
 								.map( TableGroupJoin::getJoinedGroup )
 								.collect( Collectors.toMap(


### PR DESCRIPTION
Fix issue with the order the `TableGroupJoin`s are rendered, this fix few envers test failures