### PR TITLE
Wip/6.0 Implicit join path creation 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
@@ -144,13 +144,19 @@ public class BasicDotIdentifierConsumer implements DotIdentifierConsumer {
 					// identifier is an "unqualified attribute reference"
 					validateAsRoot( pathRootByExposedNavigable );
 
-					final SqmPathSource subPathSource = pathRootByExposedNavigable.getReferencedPathSource().findSubPathSource( identifier );
-					final SqmPath sqmPath = subPathSource.createSqmPath( pathRootByExposedNavigable, creationState );
+					SqmPath sqmPath = pathRootByExposedNavigable.getImplicitJoinPath( identifier );
+					if ( sqmPath == null ) {
+						final SqmPathSource subPathSource = pathRootByExposedNavigable.getReferencedPathSource()
+								.findSubPathSource( identifier );
+						sqmPath = subPathSource.createSqmPath( pathRootByExposedNavigable, creationState );
+						if ( !isTerminal ) {
+							pathRootByExposedNavigable.registerImplicitJoinPath( sqmPath );
+						}
+					}
 					if ( isTerminal ) {
 						return sqmPath;
 					}
 					else {
-						pathRootByExposedNavigable.registerImplicitJoinPath( sqmPath );
 						return new DomainPathPart( sqmPath );
 					}
 				}


### PR DESCRIPTION
Avoid the creation of a new join sqm path when it already exists