### PR TITLE
cleaner workaround for Oracle setNull(BOOLEAN) bug

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingWrapperOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingWrapperOptions.java
@@ -29,6 +29,11 @@ public abstract class AbstractDelegatingWrapperOptions implements WrapperOptions
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForBoolean() {
+		return delegate().getPreferredSqlTypeCodeForBoolean();
+	}
+
+	@Override
 	public LobCreator getLobCreator() {
 		return delegate().getLobCreator();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -1096,6 +1096,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForBoolean() {
+		return delegate.getPreferredSqlTypeCodeForBoolean();
+	}
+
+	@Override
 	public LobCreator getLobCreator() {
 		return delegate.getLobCreator();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -558,6 +558,11 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForBoolean() {
+		return fastSessionServices.preferredSqlTypeCodeForBoolean;
+	}
+
+	@Override
 	public LobCreator getLobCreator() {
 		return Hibernate.getLobCreator( this );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
@@ -142,6 +142,7 @@ public final class FastSessionServices {
 	//Intentionally Package private:
 	final boolean disallowOutOfTransactionUpdateOperations;
 	final boolean useStreamForLobBinding;
+	final int preferredSqlTypeCodeForBoolean;
 	final boolean requiresMultiTenantConnectionProvider;
 	final ConnectionProvider connectionProvider;
 	final MultiTenantConnectionProvider multiTenantConnectionProvider;
@@ -210,6 +211,7 @@ public final class FastSessionServices {
 		this.dialect = jdbcServices.getJdbcEnvironment().getDialect();
 		this.disallowOutOfTransactionUpdateOperations = !sessionFactoryOptions.isAllowOutOfTransactionUpdateOperations();
 		this.useStreamForLobBinding = Environment.useStreamsForBinary() || dialect.useInputStreamToInsertBlob();
+		this.preferredSqlTypeCodeForBoolean = sessionFactoryOptions.getPreferredSqlTypeCodeForBoolean();
 		this.requiresMultiTenantConnectionProvider = sf.getSettings().getMultiTenancyStrategy().requiresMultiTenantConnectionProvider();
 
 		//Some "hot" services:
@@ -342,5 +344,9 @@ public final class FastSessionServices {
 
 	public void firePostLoadEvent(final PostLoadEvent postLoadEvent) {
 		eventListenerGroup_POST_LOAD.fireEventOnEachListener( postLoadEvent, PostLoadEventListener::onPostLoad );
+	}
+
+	public int getPreferredSqlTypeCodeForBoolean() {
+		return preferredSqlTypeCodeForBoolean;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -49,7 +49,6 @@ import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.entity.Loadable;
 import org.hibernate.query.ComparisonOperator;
-import org.hibernate.query.FetchClauseType;
 import org.hibernate.query.Limit;
 import org.hibernate.query.NullPrecedence;
 import org.hibernate.query.SortOrder;
@@ -69,7 +68,6 @@ import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteColumn;
 import org.hibernate.sql.ast.tree.cte.CteContainer;
-import org.hibernate.sql.ast.tree.cte.CteSearchClauseKind;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.cte.SearchClauseSpecification;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
@@ -266,6 +264,11 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		@Override
 		public boolean useStreamForLobBinding() {
 			return sessionFactory.getFastSessionServices().useStreamForLobBinding();
+		}
+
+		@Override
+		public int getPreferredSqlTypeCodeForBoolean() {
+			return sessionFactory.getFastSessionServices().getPreferredSqlTypeCodeForBoolean();
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/WrapperOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/WrapperOptions.java
@@ -34,6 +34,11 @@ public interface WrapperOptions {
 	boolean useStreamForLobBinding();
 
 	/**
+	 * Get the JDBC {@link java.sql.Types type code} used to bind a null boolean value
+	 */
+	int getPreferredSqlTypeCodeForBoolean();
+
+	/**
 	 * Obtain access to the {@link LobCreator}
 	 *
 	 * @return The LOB creator

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BasicBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BasicBinder.java
@@ -55,7 +55,7 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 						)
 				);
 			}
-			st.setNull( index, jdbcTypeDescriptor.getJdbcType() );
+			doBindNull( st, index, options );
 		}
 		else {
 			if ( JdbcBindingLogging.TRACE_ENABLED ) {
@@ -84,7 +84,7 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 						)
 				);
 			}
-			st.setNull( name, jdbcTypeDescriptor.getJdbcType() );
+			doBindNull( st, name, options );
 		}
 		else {
 			if ( JdbcBindingLogging.TRACE_ENABLED ) {
@@ -99,6 +99,32 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 			}
 			doBind( st, value, name, options );
 		}
+	}
+
+	/**
+	 * Perform the null binding.
+	 *
+	 * @param st The prepared statement
+	 * @param index The index at which to bind
+	 * @param options The binding options
+	 *
+	 * @throws SQLException Indicates a problem binding to the prepared statement.
+	 */
+	protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+		st.setNull( index, jdbcTypeDescriptor.getJdbcType() );
+	}
+
+	/**
+	 * Perform the null binding.
+	 *
+	 * @param st The CallableStatement
+	 * @param name The name at which to bind
+	 * @param options The binding options
+	 *
+	 * @throws SQLException Indicates a problem binding to the callable statement.
+	 */
+	protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+		st.setNull( name, jdbcTypeDescriptor.getJdbcType() );
 	}
 
 	/**
@@ -122,7 +148,7 @@ public abstract class BasicBinder<J> implements ValueBinder<J> {
 	 * @param name The name at which to bind
 	 * @param options The binding options
 	 *
-	 * @throws SQLException Indicates a problem binding to the prepared statement.
+	 * @throws SQLException Indicates a problem binding to the callable statement.
 	 */
 	protected abstract void doBind(CallableStatement st, J value, String name, WrapperOptions options)
 			throws SQLException;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BooleanTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BooleanTypeDescriptor.java
@@ -64,6 +64,16 @@ public class BooleanTypeDescriptor implements JdbcTypeDescriptor {
 	public <X> ValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
 		return new BasicBinder<X>( javaTypeDescriptor, this ) {
 			@Override
+			protected void doBindNull(PreparedStatement st, int index, WrapperOptions options) throws SQLException {
+				st.setNull( index, options.getPreferredSqlTypeCodeForBoolean() );
+			}
+
+			@Override
+			protected void doBindNull(CallableStatement st, String name, WrapperOptions options) throws SQLException {
+				st.setNull( name, options.getPreferredSqlTypeCodeForBoolean() );;
+			}
+
+			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				st.setBoolean( index, javaTypeDescriptor.unwrap( value, Boolean.class, options ) );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/test/nationalized/MaterializedNClobBindTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/nationalized/MaterializedNClobBindTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Proxy;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.TimeZone;
 
 import org.hibernate.engine.jdbc.LobCreator;
@@ -96,6 +97,11 @@ public class MaterializedNClobBindTest {
 		@Override
 		public boolean useStreamForLobBinding() {
 			return useStreamForLobBinding;
+		}
+
+		@Override
+		public int getPreferredSqlTypeCodeForBoolean() {
+			return Types.BOOLEAN;
 		}
 
 		@Override


### PR DESCRIPTION
Here's what I think is a better way to do this:

I've introduced `doBindNull()` in `BasicBinder` and I'm using `WrapperOptions`, `FastSessionServices`, and `getPreferredSqlTypeCodeForBoolean()` for what they're designed for.

Perhaps one might object that adding `doBindNull()` introduces an additional polymorphic call when binding null values, but if that overhead were measurable, then it would actually be worse in the case of the regular `doBind()` call that exists today for all basic types when the value is not-null, and would be an argument for eliminating `BasicBinder` altogether. So I don't see any reasonable objection to this on performance grounds.