### PR TITLE
Various fixes for test migrations

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlLexer.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlLexer.g4
@@ -136,6 +136,7 @@ ARROW :	'->';
 
 ID 				: [iI][dD];
 VERSION			: [vV] [eE] [rR] [sS] [iI] [oO] [nN];
+VERSIONED		: [vV] [eE] [rR] [sS] [iI] [oO] [nN] [eE] [dD];
 NATURALID		: [nN] [aA] [tT] [uU] [rR] [aA] [lL] [iI] [dD];
 
 ABS					: [aA] [bB] [sS];

--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -44,7 +44,7 @@ deleteStatement
 	;
 
 updateStatement
-	: UPDATE dmlTarget setClause whereClause?
+	: UPDATE VERSIONED? dmlTarget setClause whereClause?
 	;
 
 setClause
@@ -1224,6 +1224,7 @@ identifier
 	| UPPER
 	| VALUE
 	| VERSION
+	| VERSIONED
 	| WEEK
 	| WHERE
 	| WITH

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -102,35 +102,35 @@ public class InferredBasicValueResolver {
 				legacyType = jdbcMapping;
 			}
 			else {
-				// here we have the legacy case
-				//		- we mimic how this used to be done
-				final BasicType registeredType = typeConfiguration.getBasicTypeRegistry().getRegisteredType( reflectedJtd.getJavaType() );
+				// Use JTD if we know it to apply any specialized resolutions
 
-				if ( registeredType != null ) {
-					// reuse the "legacy type"
-					legacyType = resolveSqlTypeIndicators( stdIndicators, registeredType );
-					jdbcMapping = legacyType;
+				if ( reflectedJtd instanceof EnumJavaTypeDescriptor ) {
+					return fromEnum(
+							(EnumJavaTypeDescriptor) reflectedJtd,
+							explicitJavaTypeAccess.apply( typeConfiguration ),
+							explicitSqlTypeAccess.apply( typeConfiguration ),
+							stdIndicators,
+							typeConfiguration
+					);
+				}
+				else if ( reflectedJtd instanceof TemporalJavaTypeDescriptor ) {
+					return fromTemporal(
+							(TemporalJavaTypeDescriptor) reflectedJtd,
+							explicitJavaTypeAccess,
+							explicitSqlTypeAccess,
+							stdIndicators,
+							typeConfiguration
+					);
 				}
 				else {
-					// Use JTD if we know it to apply any specialized resolutions
+					// here we have the legacy case
+					//		- we mimic how this used to be done
+					final BasicType registeredType = typeConfiguration.getBasicTypeRegistry().getRegisteredType( reflectedJtd.getJavaType() );
 
-					if ( reflectedJtd instanceof EnumJavaTypeDescriptor ) {
-						return fromEnum(
-								(EnumJavaTypeDescriptor) reflectedJtd,
-								explicitJavaTypeAccess.apply( typeConfiguration ),
-								explicitSqlTypeAccess.apply( typeConfiguration ),
-								stdIndicators,
-								typeConfiguration
-						);
-					}
-					else if ( reflectedJtd instanceof TemporalJavaTypeDescriptor ) {
-						return fromTemporal(
-								(TemporalJavaTypeDescriptor) reflectedJtd,
-								explicitJavaTypeAccess,
-								explicitSqlTypeAccess,
-								stdIndicators,
-								typeConfiguration
-						);
+					if ( registeredType != null ) {
+						// reuse the "legacy type"
+						legacyType = resolveSqlTypeIndicators( stdIndicators, registeredType );
+						jdbcMapping = legacyType;
 					}
 					else if ( reflectedJtd instanceof SerializableTypeDescriptor ) {
 						legacyType = new SerializableType<>( reflectedJtd.getJavaTypeClass() );

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -793,7 +793,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				.getHqlQueryMemento( queryName );
 
 		if ( namedHqlDescriptor != null ) {
-			HqlQueryImplementor query = namedHqlDescriptor.toQuery( this, resultType );
+			HqlQueryImplementor<T> query = namedHqlDescriptor.toQuery( this, resultType );
 			query.setComment( "dynamic HQL query" );
 			applyQuerySettingsAndHints( query );
 			return query;
@@ -805,10 +805,13 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				.getNativeQueryMemento( queryName );
 
 		if ( namedNativeDescriptor != null ) {
-			if( resultType == null){
-				resultType = (Class<T>) namedNativeDescriptor.getResultMappingClass();
+			final NativeQueryImplementor<T> query;
+			if ( resultType == null) {
+				query = namedNativeDescriptor.toQuery( this );
 			}
-			NativeQueryImplementor query = namedNativeDescriptor.toQuery( this, resultType );
+			else {
+				query = namedNativeDescriptor.toQuery( this, resultType );
+			}
 			query.setComment( "dynamic native SQL query" );
 			applyQuerySettingsAndHints( query );
 			return query;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -130,14 +131,19 @@ public class SingleUniqueKeyEntityLoaderStandard<T> implements SingleUniqueKeyEn
 				true
 		);
 
-		int size = list.size();
-		assert size <= 1;
-		if ( size == 0 ) {
-			return null;
+		switch ( list.size() ) {
+			case 0:
+				return null;
+			case 1:
+				//noinspection unchecked
+				return (T) list.get( 0 );
 		}
-
-		//noinspection unchecked
-		return (T) list.get( 0 );
+		throw new HibernateException(
+				"More than one row with the given identifier was found: " +
+						ukValue +
+						", for class: " +
+						entityDescriptor.getEntityName()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableMappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableMappingType.java
@@ -225,7 +225,7 @@ public class EmbeddableMappingType implements ManagedMappingType, SelectableMapp
 						containingTableExpression,
 						columnExpression,
 						selectable.isFormula(),
-						selectable.getTemplate( dialect, sessionFactory.getQueryEngine().getSqmFunctionRegistry() ),
+						selectable.getCustomReadExpression(),
 						selectable.getCustomWriteExpression(),
 						representationStrategy.resolvePropertyAccess( bootPropertyDescriptor ),
 						compositeType.getCascadeStyle( attributeIndex ),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -28,7 +28,7 @@ class ListAttributeImpl<X, E> extends AbstractPluralAttribute<X, List<E>, E> imp
 		super( builder, metadataContext );
 
 		//noinspection unchecked
-		this.indexPathSource = (SqmPathSource) SqmMappingModelHelper.resolveSqmPathSource(
+		this.indexPathSource = (SqmPathSource) SqmMappingModelHelper.resolveSqmKeyPathSource(
 				getName(),
 				builder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -29,7 +29,7 @@ class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K, V>, V>
 	MapAttributeImpl(PluralAttributeBuilder<X, Map<K, V>, V, K> xceBuilder, MetadataContext metadataContext) {
 		super( xceBuilder, metadataContext );
 
-		this.keyPathSource = SqmMappingModelHelper.resolveSqmPathSource(
+		this.keyPathSource = SqmMappingModelHelper.resolveSqmKeyPathSource(
 				CollectionPart.Nature.INDEX.getName(),
 				xceBuilder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE

--- a/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/param/VersionTypeSeedParameterSpecification.java
@@ -11,6 +11,10 @@ import java.sql.SQLException;
 
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.sql.exec.internal.JdbcParameterImpl;
+import org.hibernate.sql.exec.spi.ExecutionContext;
+import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.type.Type;
 import org.hibernate.type.VersionType;
 
@@ -19,7 +23,7 @@ import org.hibernate.type.VersionType;
  *
  * @author Steve Ebersole
  */
-public class VersionTypeSeedParameterSpecification implements ParameterSpecification {
+public class VersionTypeSeedParameterSpecification extends JdbcParameterImpl {
 	private final VersionType type;
 
 	/**
@@ -28,31 +32,16 @@ public class VersionTypeSeedParameterSpecification implements ParameterSpecifica
 	 * @param type The version type.
 	 */
 	public VersionTypeSeedParameterSpecification(VersionType type) {
+		super( (JdbcMapping) type );
 		this.type = type;
 	}
 
 	@Override
-	public int bind(
+	public void bindParameterValue(
 			PreparedStatement statement,
-			QueryParameters qp,
-			SharedSessionContractImplementor session,
-			int position) throws SQLException {
-		type.nullSafeSet( statement, type.seed( session ), position, session );
-		return 1;
-	}
-
-	@Override
-	public Type getExpectedType() {
-		return type;
-	}
-
-	@Override
-	public void setExpectedType(Type expectedType) {
-		// expected type is intrinsic here...
-	}
-
-	@Override
-	public String renderDisplayInfo() {
-		return "version-seed, type=" + type;
+			int startPosition,
+			JdbcParameterBindings jdbcParamBindings,
+			ExecutionContext executionContext) throws SQLException {
+		type.nullSafeSet( statement, type.seed( executionContext.getSession() ), startPosition, executionContext.getSession() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1512,7 +1512,11 @@ public abstract class AbstractEntityPersister
 							),
 							sqlAstProcessingState -> new ColumnReference(
 									rootTableReference.getIdentificationVariable(),
-									selection,
+									rootPkColumnName,
+									false,
+									null,
+									null,
+									selection.getJdbcMapping(),
 									getFactory()
 							)
 					);

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/NamedCallableQueryMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/NamedCallableQueryMementoImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.procedure.spi.ProcedureParameterImplementor;
 import org.hibernate.query.named.AbstractNamedQueryMemento;
 import org.hibernate.query.named.NamedQueryMemento;
 import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.spi.QueryImplementor;
 
 /**
  * Implementation of NamedCallableQueryMemento
@@ -121,7 +122,7 @@ public class NamedCallableQueryMementoImpl extends AbstractNamedQueryMemento imp
 	public ProcedureCall makeProcedureCall(
 			SharedSessionContractImplementor session,
 			String... resultSetMappingNames) {
-		return new ProcedureCallImpl( session, this, resultSetMappingNames );
+		return new ProcedureCallImpl<>( session, this, resultSetMappingNames );
 	}
 
 	@Override
@@ -132,8 +133,8 @@ public class NamedCallableQueryMementoImpl extends AbstractNamedQueryMemento imp
 	}
 
 	@Override
-	public ProcedureCallImplementor<?> toQuery(SharedSessionContractImplementor session) {
-		return makeProcedureCall( session );
+	public <T> QueryImplementor<T> toQuery(SharedSessionContractImplementor session) {
+		return new ProcedureCallImpl<>( session, this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaCriteriaUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaCriteriaUpdate.java
@@ -12,4 +12,10 @@ import javax.persistence.criteria.CriteriaUpdate;
  * @author Steve Ebersole
  */
 public interface JpaCriteriaUpdate<T> extends JpaManipulationCriteria<T>, CriteriaUpdate<T> {
+
+	boolean isVersioned();
+
+	JpaCriteriaUpdate<T> versioned();
+
+	JpaCriteriaUpdate<T> versioned(boolean versioned);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/NamedHqlQueryMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/NamedHqlQueryMementoImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.query.hql.spi.HqlQueryImplementor;
 import org.hibernate.query.hql.spi.NamedHqlQueryMemento;
 import org.hibernate.query.named.AbstractNamedQueryMemento;
 import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sqm.internal.QuerySqmImpl;
 
 import org.jboss.logging.Logger;
@@ -128,7 +129,7 @@ public class NamedHqlQueryMementoImpl extends AbstractNamedQueryMemento implemen
 	}
 
 	@Override
-	public HqlQueryImplementor<?> toQuery(SharedSessionContractImplementor session) {
+	public <T> QueryImplementor<T> toQuery(SharedSessionContractImplementor session) {
 		return toQuery( session, null );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/spi/NamedHqlQueryMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/spi/NamedHqlQueryMemento.java
@@ -16,6 +16,7 @@ import org.hibernate.query.hql.internal.NamedHqlQueryMementoImpl;
 import org.hibernate.query.named.AbstractNamedQueryMemento;
 import org.hibernate.query.named.NameableQuery;
 import org.hibernate.query.named.NamedQueryMemento;
+import org.hibernate.query.spi.QueryImplementor;
 
 /**
  * NamedQueryMemento for HQL queries
@@ -36,7 +37,7 @@ public interface NamedHqlQueryMemento extends NamedQueryMemento {
 	/**
 	 * Convert the memento into an untyped executable query
 	 */
-	HqlQueryImplementor<?> toQuery(SharedSessionContractImplementor session);
+	<T> QueryImplementor<T> toQuery(SharedSessionContractImplementor session);
 
 	Integer getFirstResult();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/named/NamedQueryMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/NamedQueryMemento.java
@@ -54,7 +54,7 @@ public interface NamedQueryMemento {
 	 */
 	NamedQueryMemento makeCopy(String name);
 
-	QueryImplementor<?> toQuery(SharedSessionContractImplementor session);
+	<T> QueryImplementor<T> toQuery(SharedSessionContractImplementor session);
 	<T> QueryImplementor<T> toQuery(SharedSessionContractImplementor session, Class<T> javaType);
 
 	interface ParameterMemento {

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
@@ -33,6 +33,7 @@ import org.hibernate.query.sqm.sql.SqmTranslatorFactory;
 import org.hibernate.query.sqm.sql.StandardSqmTranslatorFactory;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -75,6 +76,7 @@ public class QueryEngine {
 				sqmTranslatorFactory,
 				sessionFactory.getServiceRegistry().getService( NativeQueryInterpreter.class ),
 				buildInterpretationCache( sessionFactory::getStatistics, sessionFactory.getProperties() ),
+				metadata.getTypeConfiguration(),
 				dialect,
 				queryEngineOptions.getCustomSqmFunctionRegistry(),
 				sessionFactory.getServiceRegistry()
@@ -88,6 +90,7 @@ public class QueryEngine {
 	private final NativeQueryInterpreter nativeQueryInterpreter;
 	private final QueryInterpretationCache interpretationCache;
 	private final SqmFunctionRegistry sqmFunctionRegistry;
+	private final TypeConfiguration typeConfiguration;
 	private final int preferredSqlTypeCodeForBoolean;
 
 	public QueryEngine(
@@ -99,6 +102,7 @@ public class QueryEngine {
 			SqmTranslatorFactory sqmTranslatorFactory,
 			NativeQueryInterpreter nativeQueryInterpreter,
 			QueryInterpretationCache interpretationCache,
+			TypeConfiguration typeConfiguration,
 			Dialect dialect,
 			SqmFunctionRegistry userDefinedRegistry,
 			ServiceRegistry serviceRegistry) {
@@ -116,6 +120,7 @@ public class QueryEngine {
 		);
 
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
+		this.typeConfiguration = typeConfiguration;
 		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
 		dialect.initializeFunctionRegistry( this );
 		if ( userDefinedRegistry != null ) {
@@ -151,6 +156,7 @@ public class QueryEngine {
 		this.nativeQueryInterpreter = nativeQueryInterpreter;
 
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
+		this.typeConfiguration = jpaMetamodel.getTypeConfiguration();
 		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
 		dialect.initializeFunctionRegistry( this );
 
@@ -334,6 +340,10 @@ public class QueryEngine {
 
 	public SqmFunctionRegistry getSqmFunctionRegistry() {
 		return sqmFunctionRegistry;
+	}
+
+	public TypeConfiguration getTypeConfiguration() {
+		return typeConfiguration;
 	}
 
 	public void close() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NamedNativeQueryMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NamedNativeQueryMementoImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.named.AbstractNamedQueryMemento;
 import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sql.spi.NamedNativeQueryMemento;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
 
@@ -26,8 +27,8 @@ import org.hibernate.query.sql.spi.NativeQueryImplementor;
 public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento implements NamedNativeQueryMemento {
 	private final String sqlString;
 
-	private String resultSetMappingName;
-	private Class resultSetMappingClass;
+	private final String resultSetMappingName;
+	private final Class<?> resultSetMappingClass;
 
 	private final Set<String> querySpaces;
 
@@ -59,7 +60,9 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 				hints
 		);
 		this.sqlString = sqlString;
-		this.resultSetMappingName = resultSetMappingName;
+		this.resultSetMappingName = resultSetMappingName == null || resultSetMappingName.isEmpty()
+				? null
+				: resultSetMappingName;
 		this.resultSetMappingClass = resultSetMappingClass;
 		this.querySpaces = querySpaces;
 	}
@@ -117,19 +120,17 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 	}
 
 	@Override
-	public NativeQueryImplementor toQuery(SharedSessionContractImplementor session) {
-		return new NativeQueryImpl( this, session );
+	public <T> NativeQueryImplementor<T> toQuery(SharedSessionContractImplementor session) {
+		return new NativeQueryImpl<>( this, session );
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> NativeQueryImplementor<T> toQuery(SharedSessionContractImplementor session, Class<T> resultType) {
-		return new NativeQueryImpl( this, resultType, session );
+		return new NativeQueryImpl<>( this, resultType, session );
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> NativeQueryImplementor<T> toQuery(SharedSessionContractImplementor session, String resultSetMappingName) {
-		return new NativeQueryImpl( this, resultSetMappingName, session );
+		return new NativeQueryImpl<>( this, resultSetMappingName, session );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NamedNativeQueryMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NamedNativeQueryMemento.java
@@ -16,6 +16,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.named.AbstractNamedQueryMemento;
 import org.hibernate.query.named.NamedQueryMemento;
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sql.internal.NamedNativeQueryMementoImpl;
 
 /**
@@ -50,7 +51,7 @@ public interface NamedNativeQueryMemento extends NamedQueryMemento {
 	 * Convert the memento into an untyped executable query
 	 */
 	@Override
-	NativeQueryImplementor<?> toQuery(SharedSessionContractImplementor session);
+	<T> NativeQueryImplementor<T> toQuery(SharedSessionContractImplementor session);
 
 	/**
 	 * Convert the memento into a typed executable query

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
@@ -582,18 +582,18 @@ public interface NodeBuilder extends HibernateCriteriaBuilder {
 	SqmPredicate notLike(Expression<String> x, String pattern, char escapeChar);
 
 	@Override
-	<T> SqmInPredicate in(Expression<? extends T> expression);
+	<T> SqmInPredicate<T> in(Expression<? extends T> expression);
 
 	@Override
-	<T> SqmInPredicate in(Expression<? extends T> expression, Expression<? extends T>... values);
+	<T> SqmInPredicate<T> in(Expression<? extends T> expression, Expression<? extends T>... values);
 
 	@Override
-	<T> SqmInPredicate in(Expression<? extends T> expression, T... values);
+	<T> SqmInPredicate<T> in(Expression<? extends T> expression, T... values);
 
 	@Override
-	<T> SqmInPredicate in(Expression<? extends T> expression, List<T> values);
+	<T> SqmInPredicate<T> in(Expression<? extends T> expression, List<T> values);
 
-	<T> SqmInPredicate in(Expression<? extends T> expression, SqmSubQuery<T> subQuery);
+	<T> SqmInPredicate<T> in(Expression<? extends T> expression, SqmSubQuery<T> subQuery);
 
 	@Override
 	SqmPredicate exists(Subquery<?> subquery);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SemanticQueryWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SemanticQueryWalker.java
@@ -146,13 +146,13 @@ public interface SemanticQueryWalker<T> {
 	
 	T visitIndexedPluralAccessPath(SqmIndexedCollectionAccessPath path);
 
-	T visitMaxElementPath(SqmMaxElementPath path);
+	T visitMaxElementPath(SqmMaxElementPath<?> path);
 
-	T visitMinElementPath(SqmMinElementPath path);
+	T visitMinElementPath(SqmMinElementPath<?> path);
 
-	T visitMaxIndexPath(SqmMaxIndexPath path);
+	T visitMaxIndexPath(SqmMaxIndexPath<?> path);
 
-	T visitMinIndexPath(SqmMinIndexPath path);
+	T visitMinIndexPath(SqmMinIndexPath<?> path);
 
 	T visitTreatedPath(SqmTreatedPath<?, ?> sqmTreatedPath);
 
@@ -168,7 +168,7 @@ public interface SemanticQueryWalker<T> {
 
 	T visitSelectClause(SqmSelectClause selectClause);
 
-	T visitSelection(SqmSelection selection);
+	T visitSelection(SqmSelection<?> selection);
 
 	T visitValues(SqmValues values);
 
@@ -178,7 +178,7 @@ public interface SemanticQueryWalker<T> {
 
 	T visitDynamicInstantiation(SqmDynamicInstantiation<?> sqmDynamicInstantiation);
 
-	default T visitJpaCompoundSelection(SqmJpaCompoundSelection selection) {
+	default T visitJpaCompoundSelection(SqmJpaCompoundSelection<?> selection) {
 		throw new NotYetImplementedFor6Exception( getClass() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -491,7 +491,7 @@ public class QuerySqmImpl<R>
 						queryOptions.getGraph() != null ||
 						hasLimit
 		);
-		ExecutionContext executionContextToUse;
+		final ExecutionContext executionContextToUse;
 		if ( queryOptions.hasLimit() && containsCollectionFetches ) {
 			boolean fail = getSessionFactory().getSessionFactoryOptions().isFailOnPaginationOverCollectionFetchEnabled();
 			if (fail) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreePrinter.java
@@ -352,7 +352,7 @@ public class SqmTreePrinter implements SemanticQueryWalker<Object> {
 	public Object visitUpdateStatement(SqmUpdateStatement<?> statement) {
 		if ( DEBUG_ENABLED ) {
 			processStanza(
-					"update",
+					statement.isVersioned() ? "update versioned" : "update",
 					() -> {
 						logWithIndentation( "[target = %s]", statement.getTarget().getNavigablePath().getFullPath() );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteUpdateHandler.java
@@ -81,6 +81,7 @@ public class CteUpdateHandler extends AbstractCteMutationHandler implements Upda
 				assignments::add,
 				parameterResolutions::put
 		);
+		sqmConverter.addVersionedAssignment( assignments::add, updateStatement );
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// cross-reference the TableReference by alias.  The TableGroup already

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/TableBasedUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/idtable/TableBasedUpdateHandler.java
@@ -156,6 +156,7 @@ public class TableBasedUpdateHandler
 						k -> new ArrayList<>( 1 )
 				).add( jdbcParameters )
 		);
+		converterDelegate.addVersionedAssignment( assignments::add, getSqmDeleteOrUpdateStatement() );
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// visit the where-clause using our special converter, collecting information

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -200,7 +200,7 @@ public class StandardFunctionReturnTypeResolvers {
 		return false;
 	}
 
-	private static AllowableFunctionReturnType<?> extractArgumentType(List<SqmTypedNode<?>> arguments, int position) {
+	public static AllowableFunctionReturnType<?> extractArgumentType(List<SqmTypedNode<?>> arguments, int position) {
 		final SqmTypedNode<?> specifiedArgument = arguments.get( position-1 );
 		final SqmExpressable<?> specifiedArgType = specifiedArgument.getNodeType();
 		if ( !(specifiedArgType instanceof AllowableFunctionReturnType) ) {
@@ -218,7 +218,7 @@ public class StandardFunctionReturnTypeResolvers {
 		return (AllowableFunctionReturnType<?>) specifiedArgType;
 	}
 
-	private static BasicValuedMapping extractArgumentValuedMapping(List<? extends SqlAstNode> arguments, int position) {
+	public static BasicValuedMapping extractArgumentValuedMapping(List<? extends SqlAstNode> arguments, int position) {
 		final SqlAstNode specifiedArgument = arguments.get( position-1 );
 		final MappingModelExpressable<?> specifiedArgType = specifiedArgument instanceof Expression
 				? ( (Expression) specifiedArgument ).getExpressionType()

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/BaseSemanticQueryWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/BaseSemanticQueryWalker.java
@@ -85,12 +85,14 @@ import org.hibernate.query.sqm.tree.predicate.SqmOrPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmPredicate;
 import org.hibernate.query.sqm.tree.predicate.SqmWhereClause;
 import org.hibernate.query.sqm.tree.select.SqmDynamicInstantiation;
+import org.hibernate.query.sqm.tree.select.SqmJpaCompoundSelection;
 import org.hibernate.query.sqm.tree.select.SqmOrderByClause;
 import org.hibernate.query.sqm.tree.select.SqmQueryGroup;
 import org.hibernate.query.sqm.tree.select.SqmQueryPart;
 import org.hibernate.query.sqm.tree.select.SqmQuerySpec;
 import org.hibernate.query.sqm.tree.select.SqmSelectClause;
 import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.query.sqm.tree.select.SqmSelection;
 import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
 import org.hibernate.query.sqm.tree.select.SqmSubQuery;
@@ -287,22 +289,22 @@ public abstract class BaseSemanticQueryWalker implements SemanticQueryWalker<Obj
 	}
 
 	@Override
-	public Object visitMaxElementPath(SqmMaxElementPath path) {
+	public Object visitMaxElementPath(SqmMaxElementPath<?> path) {
 		return path;
 	}
 
 	@Override
-	public Object visitMinElementPath(SqmMinElementPath path) {
+	public Object visitMinElementPath(SqmMinElementPath<?> path) {
 		return path;
 	}
 
 	@Override
-	public Object visitMaxIndexPath(SqmMaxIndexPath path) {
+	public Object visitMaxIndexPath(SqmMaxIndexPath<?> path) {
 		return path;
 	}
 
 	@Override
-	public Object visitMinIndexPath(SqmMinIndexPath path) {
+	public Object visitMinIndexPath(SqmMinIndexPath<?> path) {
 		return path;
 	}
 
@@ -325,8 +327,16 @@ public abstract class BaseSemanticQueryWalker implements SemanticQueryWalker<Obj
 	}
 
 	@Override
-	public Object visitSelection(SqmSelection selection) {
+	public Object visitSelection(SqmSelection<?> selection) {
 		selection.getSelectableNode().accept( this );
+		return selection;
+	}
+
+	@Override
+	public Object visitJpaCompoundSelection(SqmJpaCompoundSelection<?> selection) {
+		for ( SqmSelectableNode<?> selectionItem : selection.getSelectionItems() ) {
+			selectionItem.accept( this );
+		}
 		return selection;
 	}
 
@@ -399,7 +409,9 @@ public abstract class BaseSemanticQueryWalker implements SemanticQueryWalker<Obj
 	public Object visitLikePredicate(SqmLikePredicate predicate) {
 		predicate.getMatchExpression().accept( this );
 		predicate.getPattern().accept( this );
-		predicate.getEscapeCharacter().accept( this );
+		if ( predicate.getEscapeCharacter() != null ) {
+			predicate.getEscapeCharacter().accept( this );
+		}
 		return predicate;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -3733,7 +3733,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					: mappingModelExpressable.getElementDescriptor();
 			final List<SqlAstNode> arguments = new ArrayList<>( 1 );
 
-			collectionPart.forEachSelection(
+			collectionPart.forEachSelectable(
 					(selectionIndex, selectionMapping) -> {
 						arguments.add(
 								new ColumnReference(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -46,7 +46,6 @@ import org.hibernate.query.sqm.tree.from.SqmFrom;
 import org.hibernate.query.sqm.tree.from.SqmJoin;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 
-
 /**
  * Convenience base class for SqmFrom implementations
  *
@@ -55,7 +54,7 @@ import org.hibernate.query.sqm.tree.from.SqmRoot;
 public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements SqmFrom<O,T> {
 	private String alias;
 
-	private List<SqmJoin<T,?>> joins;
+	private List<SqmJoin<T, ?>> joins;
 
 	protected AbstractSqmFrom(
 			NavigablePath navigablePath,
@@ -133,12 +132,12 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	public List<SqmJoin<T,?>> getSqmJoins() {
+	public List<SqmJoin<T, ?>> getSqmJoins() {
 		return joins == null ? Collections.emptyList() : Collections.unmodifiableList( joins );
 	}
 
 	@Override
-	public void addSqmJoin(SqmJoin<T,?> join) {
+	public void addSqmJoin(SqmJoin<T, ?> join) {
 		if ( joins == null ) {
 			joins = new ArrayList<>();
 		}
@@ -146,7 +145,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	public void visitSqmJoins(Consumer<SqmJoin<T,?>> consumer) {
+	public void visitSqmJoins(Consumer<SqmJoin<T, ?>> consumer) {
 		if ( joins != null ) {
 			joins.forEach( consumer );
 		}
@@ -190,84 +189,105 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <A> SqmSingularJoin<T, A> join(SingularAttribute<? super T, A> attribute, JoinType jt) {
-		return buildSingularJoin( (SingularPersistentAttribute) attribute, SqmJoinType.from( jt ), false );
+		final SqmSingularJoin<T, A> join = buildSingularJoin( (SingularPersistentAttribute<? super T, A>) attribute, SqmJoinType.from( jt ), false );
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public <A> SqmBagJoin<T,A> join(CollectionAttribute<? super T, A> attribute) {
+	public <A> SqmBagJoin<T, A> join(CollectionAttribute<? super T, A> attribute) {
 		return join( attribute, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmBagJoin join(CollectionAttribute attribute, JoinType jt) {
-		return buildBagJoin( (BagPersistentAttribute) attribute, SqmJoinType.from( jt ), false );
+	public <E> SqmBagJoin<T, E> join(CollectionAttribute<? super T, E> attribute, JoinType jt) {
+		final SqmBagJoin<T, E> join = buildBagJoin( (BagPersistentAttribute<T, E>) attribute, SqmJoinType.from( jt ), false );
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmSetJoin join(SetAttribute attribute) {
+	public <E> SqmSetJoin<T, E> join(SetAttribute<? super T, E> attribute) {
 		return join( attribute, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmSetJoin join(SetAttribute attribute, JoinType jt) {
-		return buildSetJoin( (SetPersistentAttribute) attribute, SqmJoinType.from( jt ), false );
+	public <E> SqmSetJoin<T, E> join(SetAttribute<? super T, E> attribute, JoinType jt) {
+		final SqmSetJoin<T, E> join = buildSetJoin(
+				(SetPersistentAttribute<? super T, E>) attribute,
+				SqmJoinType.from( jt ),
+				false
+		);
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmListJoin join(ListAttribute attribute) {
+	public <E> SqmListJoin<T, E> join(ListAttribute<? super T, E> attribute) {
 		return join( attribute, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmListJoin join(ListAttribute attribute, JoinType jt) {
-		return buildListJoin( (ListPersistentAttribute) attribute, SqmJoinType.from( jt ), false );
+	public <E> SqmListJoin<T, E> join(ListAttribute<? super T, E> attribute, JoinType jt) {
+		final SqmListJoin<T, E> join = buildListJoin(
+				(ListPersistentAttribute<? super T, E>) attribute,
+				SqmJoinType.from( jt ),
+				false
+		);
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmMapJoin join(MapAttribute attribute) {
+	public <K, V> SqmMapJoin<T, K, V> join(MapAttribute<? super T, K, V> attribute) {
 		return join( attribute, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmMapJoin join(MapAttribute attribute, JoinType jt) {
-		return buildMapJoin( (MapPersistentAttribute) attribute, SqmJoinType.from( jt ), false );
+	public <K, V> SqmMapJoin<T, K, V> join(MapAttribute<? super T, K, V> attribute, JoinType jt) {
+		final SqmMapJoin<T, K, V> join = buildMapJoin(
+				(MapPersistentAttribute<? super T, K, V>) attribute,
+				SqmJoinType.from( jt ),
+				false
+		);
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmAttributeJoin join(String attributeName) {
+	public <X, Y> SqmAttributeJoin<X, Y> join(String attributeName) {
 		return join( attributeName, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmAttributeJoin join(String attributeName, JoinType jt) {
+	public <X, Y> SqmAttributeJoin<X, Y> join(String attributeName, JoinType jt) {
 		final SqmPathSource<?> subPathSource = getReferencedPathSource().findSubPathSource( attributeName );
-
-		return buildJoin( subPathSource, SqmJoinType.from( jt ), false );
+		return (SqmAttributeJoin<X, Y>) buildJoin( subPathSource, SqmJoinType.from( jt ), false );
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmBagJoin joinCollection(String attributeName) {
+	public <X, Y> SqmBagJoin<X, Y> joinCollection(String attributeName) {
 		return joinCollection( attributeName, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmBagJoin joinCollection(String attributeName, JoinType jt) {
+	public <X, Y> SqmBagJoin<X, Y> joinCollection(String attributeName, JoinType jt) {
 		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().findSubPathSource( attributeName );
 
 		if ( joinedPathSource instanceof BagPersistentAttribute ) {
-			return buildBagJoin( (BagPersistentAttribute) joinedPathSource, SqmJoinType.from( jt ), false );
+			final SqmBagJoin<T, Y> join = buildBagJoin(
+					(BagPersistentAttribute<T, Y>) joinedPathSource,
+					SqmJoinType.from( jt ),
+					false
+			);
+			addSqmJoin( join );
+			return (SqmBagJoin<X, Y>) join;
 		}
 
 		throw new IllegalArgumentException(
@@ -282,18 +302,23 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmSetJoin joinSet(String attributeName) {
+	public <X, Y> SqmSetJoin<X, Y> joinSet(String attributeName) {
 		return joinSet( attributeName, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmSetJoin joinSet(String attributeName, JoinType jt) {
+	public <X, Y> SqmSetJoin<X, Y> joinSet(String attributeName, JoinType jt) {
 		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().findSubPathSource( attributeName );
 
 		if ( joinedPathSource instanceof SetPersistentAttribute ) {
-			return buildSetJoin( (SetPersistentAttribute) joinedPathSource, SqmJoinType.from( jt ), false );
+			final SqmSetJoin<T, Y> join = buildSetJoin(
+					(SetPersistentAttribute<T, Y>) joinedPathSource,
+					SqmJoinType.from( jt ),
+					false
+			);
+			addSqmJoin( join );
+			return (SqmSetJoin<X, Y>) join;
 		}
 
 		throw new IllegalArgumentException(
@@ -308,18 +333,23 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmListJoin joinList(String attributeName) {
+	public <X, Y> SqmListJoin<X, Y> joinList(String attributeName) {
 		return joinList( attributeName, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmListJoin joinList(String attributeName, JoinType jt) {
+	public <X, Y> SqmListJoin<X, Y> joinList(String attributeName, JoinType jt) {
 		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().findSubPathSource( attributeName );
 
 		if ( joinedPathSource instanceof ListPersistentAttribute ) {
-			return buildListJoin( (ListPersistentAttribute) joinedPathSource, SqmJoinType.from( jt ), false );
+			final SqmListJoin<T, Y> join = buildListJoin(
+					(ListPersistentAttribute<T, Y>) joinedPathSource,
+					SqmJoinType.from( jt ),
+					false
+			);
+			addSqmJoin( join );
+			return (SqmListJoin<X, Y>) join;
 		}
 
 		throw new IllegalArgumentException(
@@ -334,18 +364,23 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public SqmMapJoin joinMap(String attributeName) {
+	public <X, K, V> SqmMapJoin<X, K, V> joinMap(String attributeName) {
 		return joinMap( attributeName, JoinType.INNER );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public SqmMapJoin joinMap(String attributeName, JoinType jt) {
+	public <X, K, V> SqmMapJoin<X, K, V> joinMap(String attributeName, JoinType jt) {
 		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().findSubPathSource( attributeName );
 
-		if ( joinedPathSource instanceof MapPersistentAttribute ) {
-			return buildMapJoin( (MapPersistentAttribute) joinedPathSource, SqmJoinType.from( jt ), false );
+		if ( joinedPathSource instanceof MapPersistentAttribute<?, ?, ?> ) {
+			final SqmMapJoin<T, K, V> join = buildMapJoin(
+					(MapPersistentAttribute<T, K, V>) joinedPathSource,
+					SqmJoinType.from( jt ),
+					false
+			);
+			addSqmJoin( join );
+			return (SqmMapJoin<X, K, V>) join;
 		}
 
 		throw new IllegalArgumentException(
@@ -374,12 +409,14 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <A> SqmSingularJoin<T,A> fetch(SingularAttribute<? super T, A> attribute, JoinType jt) {
-		return buildSingularJoin(
-				(SingularPersistentAttribute) attribute,
+	public <A> SqmSingularJoin<T, A> fetch(SingularAttribute<? super T, A> attribute, JoinType jt) {
+		final SqmSingularJoin<T, A> join = buildSingularJoin(
+				(SingularPersistentAttribute<? super T, A>) attribute,
 				SqmJoinType.from( jt ),
 				true
 		);
+		addSqmJoin( join );
+		return join;
 	}
 
 	@Override
@@ -391,7 +428,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@SuppressWarnings("unchecked")
 	public <A> SqmAttributeJoin<T, A> fetch(PluralAttribute<? super T, ?, A> attribute, JoinType jt) {
 		return buildJoin(
-				(PluralPersistentAttribute) attribute,
+				(PluralPersistentAttribute<? super T, ?, A>) attribute,
 				SqmJoinType.from( jt ),
 				true
 		);
@@ -404,47 +441,52 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <X,A> SqmAttributeJoin<X,A> fetch(String attributeName, JoinType jt) {
-		final SqmPathSource<?> fetchedPathSource = getReferencedPathSource().findSubPathSource( attributeName );
-		return buildJoin( fetchedPathSource, SqmJoinType.from( jt ), true );
+	public <X, A> SqmAttributeJoin<X, A> fetch(String attributeName, JoinType jt) {
+		final SqmPathSource<A> fetchedPathSource = (SqmPathSource<A>) getReferencedPathSource()
+				.findSubPathSource( attributeName );
+		return (SqmAttributeJoin<X, A>) buildJoin(
+				fetchedPathSource,
+				SqmJoinType.from( jt ),
+				true
+		);
 	}
 
-	private <A> SqmAttributeJoin buildJoin(
+	private <A> SqmAttributeJoin<T, A> buildJoin(
 			SqmPathSource<A> joinedPathSource,
 			SqmJoinType joinType,
 			boolean fetched) {
-		final SqmAttributeJoin sqmJoin;
-		if ( joinedPathSource instanceof SingularPersistentAttribute ) {
+		final SqmAttributeJoin<T, A> sqmJoin;
+		if ( joinedPathSource instanceof SingularPersistentAttribute<?, ?> ) {
 			sqmJoin = buildSingularJoin(
-					(SingularPersistentAttribute<T,A>) joinedPathSource,
+					(SingularPersistentAttribute<T, A>) joinedPathSource,
 					joinType,
 					fetched
 			);
 		}
-		else if ( joinedPathSource instanceof BagPersistentAttribute ) {
+		else if ( joinedPathSource instanceof BagPersistentAttribute<?, ?> ) {
 			sqmJoin = buildBagJoin(
-					(BagPersistentAttribute) joinedPathSource,
+					(BagPersistentAttribute<T, A>) joinedPathSource,
 					joinType,
 					fetched
 			);
 		}
-		else if ( joinedPathSource instanceof ListPersistentAttribute ) {
+		else if ( joinedPathSource instanceof ListPersistentAttribute<?, ?> ) {
 			sqmJoin = buildListJoin(
-					(ListPersistentAttribute) joinedPathSource,
+					(ListPersistentAttribute<T, A>) joinedPathSource,
 					joinType,
 					fetched
 			);
 		}
-		else if ( joinedPathSource instanceof MapPersistentAttribute ) {
+		else if ( joinedPathSource instanceof MapPersistentAttribute<?, ?, ?> ) {
 			sqmJoin = buildMapJoin(
-					(MapPersistentAttribute) joinedPathSource,
+					(MapPersistentAttribute<T, ?, A>) joinedPathSource,
 					joinType,
 					fetched
 			);
 		}
-		else if ( joinedPathSource instanceof SetPersistentAttribute ) {
+		else if ( joinedPathSource instanceof SetPersistentAttribute<?, ?> ) {
 			sqmJoin = buildSetJoin(
-					(SetPersistentAttribute) joinedPathSource,
+					(SetPersistentAttribute<T, A>) joinedPathSource,
 					joinType,
 					fetched
 			);
@@ -464,15 +506,15 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		return sqmJoin;
 	}
 
-	private <A> SqmSingularJoin<T,A> buildSingularJoin(
-			SingularPersistentAttribute<T,A> attribute,
+	@SuppressWarnings("unchecked")
+	private <A> SqmSingularJoin<T, A> buildSingularJoin(
+			SingularPersistentAttribute<? super T, A> attribute,
 			SqmJoinType joinType,
 			boolean fetched) {
 		if ( attribute.getSqmPathType() instanceof ManagedDomainType ) {
-			//noinspection unchecked
-			return new SqmSingularJoin(
+			return new SqmSingularJoin<>(
 					this,
-					attribute,
+					(SingularPersistentAttribute<T, A>) attribute,
 					null,
 					joinType,
 					fetched,
@@ -481,17 +523,16 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		}
 
 		throw new SemanticException( "Attribute [" + attribute + "] is not joinable" );
-
 	}
 
 	@SuppressWarnings("unchecked")
-	private <E> SqmBagJoin<T,E> buildBagJoin(
-			BagPersistentAttribute attribute,
+	private <E> SqmBagJoin<T, E> buildBagJoin(
+			BagPersistentAttribute<? super T, E> attribute,
 			SqmJoinType joinType,
 			boolean fetched) {
-		return new SqmBagJoin(
+		return new SqmBagJoin<>(
 				this,
-				attribute,
+				(BagPersistentAttribute<T, E>)attribute,
 				null,
 				joinType,
 				fetched,
@@ -500,13 +541,13 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@SuppressWarnings("unchecked")
-	private <E> SqmListJoin<T,E> buildListJoin(
-			ListPersistentAttribute attribute,
+	private <E> SqmListJoin<T, E> buildListJoin(
+			ListPersistentAttribute<? super T, E> attribute,
 			SqmJoinType joinType,
 			boolean fetched) {
-		return new SqmListJoin(
+		return new SqmListJoin<>(
 				this,
-				attribute,
+				(ListPersistentAttribute<T, E>) attribute,
 				null,
 				joinType,
 				fetched,
@@ -515,13 +556,13 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@SuppressWarnings("unchecked")
-	private <K,V> SqmMapJoin<T,K,V> buildMapJoin(
-			MapPersistentAttribute attribute,
+	private <K, V> SqmMapJoin<T, K, V> buildMapJoin(
+			MapPersistentAttribute<? super T, K, V> attribute,
 			SqmJoinType joinType,
 			boolean fetched) {
-		return new SqmMapJoin(
+		return new SqmMapJoin<>(
 				this,
-				attribute,
+				(MapPersistentAttribute<T, K, V>) attribute,
 				null,
 				joinType,
 				fetched,
@@ -530,13 +571,13 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@SuppressWarnings("unchecked")
-	private <E> SqmSetJoin<T,E> buildSetJoin(
-			SetPersistentAttribute attribute,
+	private <E> SqmSetJoin<T, E> buildSetJoin(
+			SetPersistentAttribute<? super T, E> attribute,
 			SqmJoinType joinType,
 			boolean fetched) {
-		return new SqmSetJoin(
+		return new SqmSetJoin<>(
 				this,
-				attribute,
+				(SetPersistentAttribute<T, E>) attribute,
 				null,
 				joinType,
 				fetched,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
@@ -28,7 +28,7 @@ public class SqmIndexedCollectionAccessPath<T> extends AbstractSqmPath<T> implem
 			SqmExpression<?> selectorExpression) {
 		//noinspection unchecked
 		super(
-				pluralDomainPath.getNavigablePath().append( "[]" ),
+				pluralDomainPath.getNavigablePath().getParent().append( pluralDomainPath.getNavigablePath().getLocalName(), "[]" ),
 				(PluralPersistentAttribute) pluralDomainPath.getReferencedPathSource(),
 				pluralDomainPath,
 				pluralDomainPath.nodeBuilder()
@@ -50,7 +50,8 @@ public class SqmIndexedCollectionAccessPath<T> extends AbstractSqmPath<T> implem
 	@Override
 	public NavigablePath getNavigablePath() {
 		// todo (6.0) : this would require some String-ified form of the selector
-		return null;
+//		return null;
+		return super.getNavigablePath();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxElementPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxElementPath.java
@@ -23,7 +23,7 @@ public class SqmMaxElementPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 	public SqmMaxElementPath(SqmPath<?> pluralDomainPath) {
 		//noinspection unchecked
 		super(
-				pluralDomainPath.getNavigablePath().append( NAVIGABLE_NAME ),
+				pluralDomainPath.getNavigablePath().getParent().append( pluralDomainPath.getNavigablePath().getLocalName(), NAVIGABLE_NAME ),
 				pluralDomainPath,
 				(PluralPersistentAttribute) pluralDomainPath.getReferencedPathSource()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxIndexPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxIndexPath.java
@@ -25,7 +25,7 @@ public class SqmMaxIndexPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 	public SqmMaxIndexPath(SqmPath<?> pluralDomainPath) {
 		//noinspection unchecked
 		super(
-				pluralDomainPath.getNavigablePath().append( NAVIGABLE_NAME ),
+				pluralDomainPath.getNavigablePath().getParent().append( pluralDomainPath.getNavigablePath().getLocalName(), NAVIGABLE_NAME ),
 				pluralDomainPath,
 				(PluralPersistentAttribute<?, ?, T>) pluralDomainPath.getReferencedPathSource()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinElementPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinElementPath.java
@@ -23,7 +23,7 @@ public class SqmMinElementPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 	public SqmMinElementPath(SqmPath<?> pluralDomainPath) {
 		//noinspection unchecked
 		super(
-				pluralDomainPath.getNavigablePath().append( NAVIGABLE_NAME ),
+				pluralDomainPath.getNavigablePath().getParent().append( pluralDomainPath.getNavigablePath().getLocalName(), NAVIGABLE_NAME ),
 				pluralDomainPath,
 				(PluralPersistentAttribute) pluralDomainPath.getReferencedPathSource()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinIndexPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinIndexPath.java
@@ -25,7 +25,7 @@ public class SqmMinIndexPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 	public SqmMinIndexPath(SqmPath<?> pluralDomainPath) {
 		//noinspection unchecked
 		super(
-				pluralDomainPath.getNavigablePath().append( NAVIGABLE_NAME ),
+				pluralDomainPath.getNavigablePath().getParent().append( pluralDomainPath.getNavigablePath().getLocalName(), NAVIGABLE_NAME ),
 				pluralDomainPath,
 				(PluralPersistentAttribute<?, ?, T>) pluralDomainPath.getReferencedPathSource()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
@@ -85,7 +85,7 @@ public class SqmJpaCompoundSelection<T>
 	}
 
 	@Override
-	public List<? extends JpaSelection<?>> getSelectionItems() {
+	public List<SqmSelectableNode<?>> getSelectionItems() {
 		return selectableNodes;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
@@ -315,7 +315,9 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T> implements 
 	@SuppressWarnings("unchecked")
 	public SqmSelectStatement<T> select(Selection<? extends T> selection) {
 		getQuerySpec().setSelection( (JpaSelection<T>) selection );
-		setResultType( (Class<T>) selection.getJavaType() );
+		if ( getResultType() == null ) {
+			setResultType( (Class<T>) selection.getJavaType() );
+		}
 		return this;
 	}
 
@@ -324,7 +326,9 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T> implements 
 		for ( Selection<?> selection : selections ) {
 			getQuerySpec().getSelectClause().add( (SqmExpression<?>) selection, selection.getAlias() );
 		}
-		setResultType( (Class<T>) Object[].class );
+		if ( getResultType() == null ) {
+			setResultType( (Class<T>) Object[].class );
+		}
 		return this;
 	}
 
@@ -333,7 +337,9 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T> implements 
 		for ( Selection<?> selection : selectionList ) {
 			getQuerySpec().getSelectClause().add( (SqmExpression<?>) selection, selection.getAlias() );
 		}
-		setResultType( (Class<T>) Object[].class );
+		if ( getResultType() == null ) {
+			setResultType( (Class<T>) Object[].class );
+		}
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
@@ -35,6 +35,7 @@ import org.hibernate.query.sqm.tree.predicate.SqmWhereClause;
 public class SqmUpdateStatement<T>
 		extends AbstractSqmDmlStatement<T>
 		implements SqmDeleteOrUpdateStatement<T>, JpaCriteriaUpdate<T> {
+	private boolean versioned;
 	private SqmSetClause setClause;
 	private SqmWhereClause whereClause;
 
@@ -131,6 +132,23 @@ public class SqmUpdateStatement<T>
 	@Override
 	public SqmUpdateStatement<T> set(String attributeName, Object value) {
 		throw new NotYetImplementedFor6Exception();
+	}
+
+	@Override
+	public boolean isVersioned() {
+		return versioned;
+	}
+
+	@Override
+	public SqmUpdateStatement<T> versioned() {
+		this.versioned = true;
+		return this;
+	}
+
+	@Override
+	public SqmUpdateStatement<T> versioned(boolean versioned) {
+		this.versioned = versioned;
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -2662,7 +2662,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			else if ( elementDescriptor instanceof EntityCollectionPart ) {
 				final ForeignKeyDescriptor foreignKeyDescriptor = ( (EntityCollectionPart) elementDescriptor ).getForeignKeyDescriptor();
 				if ( foreignKeyDescriptor instanceof SimpleForeignKeyDescriptor ) {
-					foreignKeyDescriptor.visitTargetColumns(
+					foreignKeyDescriptor.visitTargetSelectables(
 							(selectionIndex, selectionMapping) -> appendSql( selectionMapping.getSelectionExpression() )
 					);
 				}
@@ -2671,7 +2671,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		else if ( modelPart instanceof ToOneAttributeMapping ) {
 			final ForeignKeyDescriptor foreignKeyDescriptor = ( (ToOneAttributeMapping) modelPart ).getForeignKeyDescriptor();
 			if ( foreignKeyDescriptor instanceof SimpleForeignKeyDescriptor ) {
-				foreignKeyDescriptor.visitTargetColumns(
+				foreignKeyDescriptor.visitTargetSelectables(
 						(selectionIndex, selectionMapping) -> appendSql( selectionMapping.getSelectionExpression() )
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSimpleExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSimpleExpression.java
@@ -16,6 +16,8 @@ import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
 import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.basic.BasicResult;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
  * @author Steve Ebersole
@@ -57,17 +59,16 @@ public class CaseSimpleExpression implements Expression, DomainResultProducer {
 	public DomainResult createDomainResult(
 			String resultVariable,
 			DomainResultCreationState creationState) {
-		throw new NotYetImplementedFor6Exception( getClass() );
-
-//		return new BasicResultImpl(
-//				resultVariable,
-//				creationState.getSqlExpressionResolver().resolveSqlSelection(
-//						this,
-//						getType().getJavaTypeDescriptor(),
-//						creationState.getSqlAstCreationState().getCreationContext().getDomainModel().getTypeConfiguration()
-//				),
-//				getType()
-//		);
+		final JavaTypeDescriptor javaTypeDescriptor = type.getJdbcMappings().get( 0 ).getJavaTypeDescriptor();
+		return new BasicResult(
+				creationState.getSqlAstCreationState().getSqlExpressionResolver().resolveSqlSelection(
+						this,
+						javaTypeDescriptor,
+						creationState.getSqlAstCreationState().getCreationContext().getDomainModel().getTypeConfiguration()
+				).getValuesArrayPosition(),
+				resultVariable,
+				javaTypeDescriptor
+		);
 	}
 
 	public List<WhenFragment> getWhenFragments() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ExistsPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/ExistsPredicate.java
@@ -15,7 +15,7 @@ import org.hibernate.sql.ast.tree.select.QueryPart;
  */
 public class ExistsPredicate implements Predicate {
 
-	private QueryPart expression;
+	private final QueryPart expression;
 
 	public ExistsPredicate(QueryPart expression) {
 		this.expression = expression;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryGroup.java
@@ -7,6 +7,7 @@
 package org.hibernate.sql.ast.tree.select;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hibernate.query.SetOperator;
 import org.hibernate.metamodel.mapping.MappingModelExpressable;
@@ -35,6 +36,13 @@ public class QueryGroup extends QueryPart {
 	@Override
 	public QuerySpec getLastQuerySpec() {
 		return queryParts.get( queryParts.size() - 1 ).getLastQuerySpec();
+	}
+
+	@Override
+	public void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer) {
+		for ( int i = 0; i < queryParts.size(); i++ ) {
+			queryParts.get( i ).forEachQuerySpec( querySpecConsumer );
+		}
 	}
 
 	public SetOperator getSetOperator() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryPart.java
@@ -34,6 +34,8 @@ public abstract class QueryPart implements SqlAstNode, Expression, DomainResultP
 
 	public abstract QuerySpec getLastQuerySpec();
 
+	public abstract void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer);
+
 	/**
 	 * Does this QueryPart map to the statement's root query (as
 	 * opposed to one of its sub-queries)?

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.ast.tree.select;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hibernate.metamodel.mapping.MappingModelExpressable;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
@@ -57,6 +58,11 @@ public class QuerySpec extends QueryPart implements SqlAstNode, PredicateContain
 	@Override
 	public QuerySpec getLastQuerySpec() {
 		return this;
+	}
+
+	@Override
+	public void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer) {
+		querySpecConsumer.accept( this );
 	}
 
 	public FromClause getFromClause() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowTransformerJpaTupleImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowTransformerJpaTupleImpl.java
@@ -7,9 +7,7 @@
 
 package org.hibernate.sql.results.internal;
 
-import java.util.List;
 import javax.persistence.Tuple;
-import javax.persistence.TupleElement;
 
 import org.hibernate.sql.results.spi.RowTransformer;
 
@@ -19,15 +17,15 @@ import org.hibernate.sql.results.spi.RowTransformer;
  * @author Steve Ebersole
  */
 public class RowTransformerJpaTupleImpl implements RowTransformer<Tuple> {
-	private final List<TupleElement<?>> tupleElements;
+	private final TupleMetadata tupleMetadata;
 
-	public RowTransformerJpaTupleImpl(List<TupleElement<?>> tupleElements) {
-		this.tupleElements = tupleElements;
+	public RowTransformerJpaTupleImpl(TupleMetadata tupleMetadata) {
+		this.tupleMetadata = tupleMetadata;
 	}
 
 	@Override
 	public Tuple transformRow(Object[] row) {
-		return new TupleImpl( tupleElements, row );
+		return new TupleImpl( tupleMetadata, row );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/TupleImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/TupleImpl.java
@@ -17,19 +17,19 @@ import org.hibernate.query.JpaTuple;
  * @author Steve Ebersole
  */
 public class TupleImpl implements JpaTuple {
-	private final List<TupleElement<?>> tupleElements;
+	private final TupleMetadata tupleMetadata;
 	private final Object[] row;
 
-	public TupleImpl(List<TupleElement<?>> tupleElements, Object[] row) {
-		this.tupleElements = tupleElements;
+	public TupleImpl(TupleMetadata tupleMetadata, Object[] row) {
+		this.tupleMetadata = tupleMetadata;
 		this.row = row;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X> X get(TupleElement<X> tupleElement) {
-		int index = tupleElements.indexOf( tupleElement );
-		if ( index < 0 ) {
+		final Integer index = tupleMetadata.get( tupleElement );
+		if ( index == null ) {
 			throw new IllegalArgumentException(
 					"Requested tuple element did not correspond to element in the result tuple"
 			);
@@ -59,21 +59,8 @@ public class TupleImpl implements JpaTuple {
 
 	@Override
 	public Object get(String alias) {
-		int index = -1;
-		if ( alias != null ) {
-			alias = alias.trim();
-			if ( alias.length() > 0 ) {
-				int i = 0;
-				for ( TupleElement selection : tupleElements ) {
-					if ( alias.equals( selection.getAlias() ) ) {
-						index = i;
-						break;
-					}
-					i++;
-				}
-			}
-		}
-		if ( index < 0 ) {
+		Integer index = tupleMetadata.get( alias );
+		if ( index == null ) {
 			throw new IllegalArgumentException(
 					"Given alias [" + alias + "] did not correspond to an element in the result tuple"
 			);
@@ -115,8 +102,7 @@ public class TupleImpl implements JpaTuple {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<TupleElement<?>> getElements() {
-		return tupleElements;
+		return tupleMetadata.getList();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/TupleMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/TupleMetadata.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.sql.results.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.TupleElement;
+
+/**
+ * Metadata about the tuple structure.
+ *
+ * @author Christian Beikov
+ */
+public final class TupleMetadata {
+	private final Map<TupleElement<?>, Integer> index;
+	private Map<String, Integer> nameIndex;
+	private List<TupleElement<?>> list;
+
+	public TupleMetadata(Map<TupleElement<?>, Integer> index) {
+		this.index = index;
+	}
+
+	public Integer get(TupleElement<?> tupleElement) {
+		return index.get( tupleElement );
+	}
+
+	public Integer get(String name) {
+		Map<String, Integer> nameIndex = this.nameIndex;
+		if ( nameIndex == null ) {
+			nameIndex = new HashMap<>( index.size() );
+			for ( Map.Entry<TupleElement<?>, Integer> entry : index.entrySet() ) {
+				nameIndex.put( entry.getKey().getAlias(), entry.getValue() );
+			}
+			this.nameIndex = nameIndex = Collections.unmodifiableMap( nameIndex );
+		}
+		return nameIndex.get( name );
+	}
+
+	public List<TupleElement<?>> getList() {
+		List<TupleElement<?>> list = this.list;
+		if ( list == null ) {
+			final TupleElement<?>[] array = new TupleElement[index.size()];
+			for ( Map.Entry<TupleElement<?>, Integer> entry : index.entrySet() ) {
+				array[entry.getValue()] = entry.getKey();
+			}
+			this.list = list = Collections.unmodifiableList( Arrays.asList( array ) );
+		}
+		return list;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeDescriptorBaseline.java
@@ -51,9 +51,11 @@ import org.hibernate.type.descriptor.java.IntegerTypeDescriptor;
 import org.hibernate.type.descriptor.java.JavaObjectTypeDescriptor;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.java.JdbcDateTypeDescriptor;
+import org.hibernate.type.descriptor.java.JdbcTimeTypeDescriptor;
 import org.hibernate.type.descriptor.java.JdbcTimestampTypeDescriptor;
 import org.hibernate.type.descriptor.java.LocalDateJavaDescriptor;
 import org.hibernate.type.descriptor.java.LocalDateTimeJavaDescriptor;
+import org.hibernate.type.descriptor.java.LocalTimeJavaDescriptor;
 import org.hibernate.type.descriptor.java.LocaleTypeDescriptor;
 import org.hibernate.type.descriptor.java.LongTypeDescriptor;
 import org.hibernate.type.descriptor.java.NClobTypeDescriptor;
@@ -66,6 +68,7 @@ import org.hibernate.type.descriptor.java.StringTypeDescriptor;
 import org.hibernate.type.descriptor.java.TimeZoneTypeDescriptor;
 import org.hibernate.type.descriptor.java.UUIDTypeDescriptor;
 import org.hibernate.type.descriptor.java.UrlTypeDescriptor;
+import org.hibernate.type.descriptor.java.ZoneOffsetJavaDescriptor;
 import org.hibernate.type.descriptor.java.ZonedDateTimeJavaDescriptor;
 
 /**
@@ -109,6 +112,7 @@ public class JavaTypeDescriptorBaseline {
 		target.addBaselineDescriptor( InstantJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( LocalDateJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( LocalDateTimeJavaDescriptor.INSTANCE );
+		target.addBaselineDescriptor( LocalTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( OffsetDateTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( OffsetTimeJavaDescriptor.INSTANCE );
 		target.addBaselineDescriptor( ZonedDateTimeJavaDescriptor.INSTANCE );
@@ -116,9 +120,10 @@ public class JavaTypeDescriptorBaseline {
 		target.addBaselineDescriptor( CalendarTypeDescriptor.INSTANCE );
 		target.addBaselineDescriptor( DateTypeDescriptor.INSTANCE );
 		target.addBaselineDescriptor( java.sql.Date.class, JdbcDateTypeDescriptor.INSTANCE );
-		target.addBaselineDescriptor( java.sql.Time.class, JdbcTimestampTypeDescriptor.INSTANCE );
+		target.addBaselineDescriptor( java.sql.Time.class, JdbcTimeTypeDescriptor.INSTANCE );
 		target.addBaselineDescriptor( java.sql.Timestamp.class, JdbcTimestampTypeDescriptor.INSTANCE );
 		target.addBaselineDescriptor( TimeZoneTypeDescriptor.INSTANCE );
+		target.addBaselineDescriptor( ZoneOffsetJavaDescriptor.INSTANCE );
 
 		target.addBaselineDescriptor( ClassTypeDescriptor.INSTANCE );
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
@@ -138,7 +138,7 @@ public interface JdbcTypeDescriptor extends Serializable {
 	}
 
 	default boolean isTemporal() {
-		switch ( getSqlType() ) {
+		switch ( getJdbcType() ) {
 			case Types.DATE:
 			case Types.TIME:
 			case Types.TIMESTAMP:

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
@@ -137,6 +137,17 @@ public interface JdbcTypeDescriptor extends Serializable {
 		return false;
 	}
 
+	default boolean isTemporal() {
+		switch ( getSqlType() ) {
+			case Types.DATE:
+			case Types.TIME:
+			case Types.TIMESTAMP:
+			case Types.TIMESTAMP_WITH_TIMEZONE:
+				return true;
+		}
+		return false;
+	}
+
 	default CastType getCastType() {
 		switch ( getJdbcType() ) {
 			case Types.INTEGER:

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyConstraintTest.java
@@ -169,10 +169,9 @@ public class ForeignKeyConstraintTest {
 	}
 
 	@Test
-	@NotImplementedYet( strict = false, reason = "Problem with non-root-entity based FKs" )
 	public void testGet(SessionFactoryScope scope) {
 		scope.inTransaction(
-				session -> session.get( Student.class, 1l )
+				session -> session.get( Student.class, 1L )
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/EntityOfFormulas.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/EntityOfFormulas.hbm.xml
@@ -13,7 +13,8 @@
     <class name="org.hibernate.orm.test.mapping.formula.EntityOfFormulas" table="formulas">
         <id name="id" />
         <property name="realValue" column="real_value" />
-        <property name="stringFormula" formula="real_value || ' a'" />
+        <!-- Workaround for Derby which requires an intermediate cast -->
+        <property name="stringFormula" formula="{fn concat(cast(trim(cast(real_value as char(254))) as varchar(255)), ' a')}" />
         <property name="integerFormula" formula="real_value + 1" />
     </class>
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AggregateFunctionsWithSubSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AggregateFunctionsWithSubSelectTest.java
@@ -19,9 +19,9 @@ import javax.persistence.OneToMany;
 
 import org.hibernate.dialect.H2Dialect;
 
-import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -168,7 +168,7 @@ public class FunctionTests {
 					assertThat( session.createQuery("select round(32.12345,2)").getSingleResult(), is(32.12f) );
 					assertThat( session.createQuery("select mod(3,2)").getSingleResult(), is(1) );
 					assertThat( session.createQuery("select 3%2").getSingleResult(), is(1) );
-					assertThat( session.createQuery("select sqrt(9.0)").getSingleResult(), is(3.0f) );
+					assertThat( session.createQuery("select sqrt(9.0)").getSingleResult(), is(3.0d) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/QueryParametersValidationArrayTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/QueryParametersValidationArrayTest.java
@@ -31,10 +31,10 @@ import org.hibernate.type.descriptor.jdbc.BasicBinder;
 import org.hibernate.type.descriptor.jdbc.BasicExtractor;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeDescriptor;
 
-import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
* Add support for DML with versioned entities
* Resolve return type for `SUM` according to JPA spec
* Specify invariant return types for `SQRT` and `MOD` as required by the JPA spec
* Fix JPA tuple element access support
* Fix join management for JPA related methods
* Handle optional escape character for `LIKE` predicate
* Implement type inference for result arms of `CASE` expressions
* Implement min/max element/index functions as sub-query
* Implement min/max function support
* Implement emptiness, exists and member of predicate for JPA Criteria
* Implement size function as sub-query
* Implement group by entity alias by using FK key