### PR TITLE
Create special grammar extending the base grammar for better parsing

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -1,0 +1,54 @@
+parser grammar HqlParser;
+import HqlParserBase;
+
+options {
+	tokenVocab=HqlLexer;
+}
+
+function
+	: standardFunction
+	| aggregateFunction
+	| jpaCollectionFunction
+	| hqlCollectionFunction
+	| jpaNonStandardFunction
+	| genericFunction
+	;
+
+aggregateFunction
+	: everyFunction
+	| anyFunction
+	;
+
+genericFunction
+	: genericFunctionName LEFT_PAREN (nonStandardFunctionArguments | ASTERISK)? RIGHT_PAREN
+	;
+
+genericFunctionName
+	: dotIdentifierSequence
+	;
+
+nonStandardFunctionArguments
+	: (DISTINCT | datetimeField COMMA)? expression (COMMA expression)*
+	;
+
+standardFunction
+	:	castFunction
+	|	extractFunction
+	|	formatFunction
+	|	substringFunction
+	|	overlayFunction
+	|	trimFunction
+	|	padFunction
+	|	positionFunction
+	|	currentDateFunction
+	|	currentTimeFunction
+	|	currentTimestampFunction
+	|	instantFunction
+	|	localDateFunction
+	|	localTimeFunction
+	|	localDateTimeFunction
+	|	offsetDateTimeFunction
+	|	cube
+	|	rollup
+	;
+

--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParserBase.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParserBase.g4
@@ -1,4 +1,4 @@
-parser grammar HqlParser;
+parser grammar HqlParserBase;
 
 options {
 	tokenVocab=HqlLexer;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -63,6 +63,8 @@ import java.sql.Types;
 
 import javax.persistence.TemporalType;
 
+import static org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers.useArgType;
+
 /**
  * Hibernate Dialect for Apache Derby / Cloudscape 10
  *
@@ -194,8 +196,8 @@ public class DerbyDialect extends Dialect {
 		CommonFunctionFactory.power_expLn( queryEngine );
 
 		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "round", "floor(?1*1e?2+0.5)/1e?2")
+				.setReturnTypeResolver( useArgType(1) )
 				.setExactArgumentCount( 2 )
-				.setInvariantType( StandardBasicTypes.DOUBLE )
 				.register();
 
 		//no way I can see to pad with anything other than spaces

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CastStrEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CastStrEmulation.java
@@ -47,7 +47,7 @@ public class CastStrEmulation
 						asList(
 								argument,
 								new SqmCastTarget<>(
-										impliedResultType,
+										StandardBasicTypes.STRING,
 										argument.nodeBuilder()
 								)
 						),

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/InsertSubstringOverlayEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/InsertSubstringOverlayEmulation.java
@@ -55,7 +55,8 @@ public class InsertSubstringOverlayEmulation
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
-		BasicType<Integer> intType = typeConfiguration.getBasicTypeForJavaType(Integer.class);
+		final BasicType<Integer> intType = typeConfiguration.getBasicTypeForJavaType( Integer.class );
+		final BasicType<String> stringType = typeConfiguration.getBasicTypeForJavaType( String.class );
 
 		SqmTypedNode<?> string = arguments.get(0);
 		SqmTypedNode<?> replacement = arguments.get(1);
@@ -93,7 +94,6 @@ public class InsertSubstringOverlayEmulation
 					intType,
 					queryEngine.getCriteriaBuilder()
 			);
-			SqmExpressable<Object> stringType = (SqmExpressable<Object>) impliedResultType;
 			SqmTypedNode<?> restString = substring.generateSqmExpression(
 					asList( string, startPlusLength ),
 					impliedResultType,
@@ -101,7 +101,7 @@ public class InsertSubstringOverlayEmulation
 					typeConfiguration
 			);
 			if ( strictSubstring ) {
-				restString = (SqmTypedNode<?>) new SqmCaseSearched<>( stringType, start.nodeBuilder() )
+				restString = new SqmCaseSearched<>( stringType, start.nodeBuilder() )
 						.when(
 								new SqmComparisonPredicate(
 										startPlusLength,
@@ -114,8 +114,8 @@ public class InsertSubstringOverlayEmulation
 										),
 										string.nodeBuilder()
 								),
-								(Expression<?>) new SqmLiteral<>( "", stringType, string.nodeBuilder() )
-						).otherwise( (Expression<?>) restString );
+								new SqmLiteral<>( "", stringType, string.nodeBuilder() )
+						).otherwise( (Expression<? extends String>) restString );
 			}
 			return concat.generateSqmExpression(
 					asList(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
@@ -44,14 +44,16 @@ public class SqmCaseSearched<R>
 		return otherwise;
 	}
 
-	public void when(SqmPredicate predicate, SqmExpression<R> result) {
+	public SqmCaseSearched<R> when(SqmPredicate predicate, SqmExpression<R> result) {
 		whenFragments.add( new WhenFragment<>( predicate, result ) );
 		applyInferableResultType( result.getNodeType() );
+		return this;
 	}
 
-	public void otherwise(SqmExpression<R> otherwiseExpression) {
+	public SqmCaseSearched<R> otherwise(SqmExpression<R> otherwiseExpression) {
 		this.otherwise = otherwiseExpression;
 		applyInferableResultType( otherwiseExpression.getNodeType() );
+		return this;
 	}
 
 	private void applyInferableResultType(SqmExpressable<?> type) {
@@ -121,20 +123,20 @@ public class SqmCaseSearched<R>
 	}
 
 	@Override
-	public JpaSearchedCase<R> when(Expression<Boolean> condition, Expression<? extends R> result) {
+	public SqmCaseSearched<R> when(Expression<Boolean> condition, Expression<? extends R> result) {
 		//noinspection unchecked
 		when( nodeBuilder().wrap( condition ), (SqmExpression) result );
 		return this;
 	}
 
 	@Override
-	public JpaExpression<R> otherwise(R result) {
+	public SqmExpression<R> otherwise(R result) {
 		otherwise( nodeBuilder().value( result ) );
 		return this;
 	}
 
 	@Override
-	public JpaExpression<R> otherwise(Expression<? extends R> result) {
+	public SqmExpression<R> otherwise(Expression<? extends R> result) {
 		//noinspection unchecked
 		otherwise( (SqmExpression) result );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
@@ -107,6 +107,25 @@ public interface JdbcTypeDescriptor extends Serializable {
 		return false;
 	}
 
+	default boolean isFloat() {
+		switch ( getJdbcType() ) {
+			case Types.FLOAT:
+			case Types.REAL:
+			case Types.DOUBLE:
+				return true;
+		}
+		return false;
+	}
+
+	default boolean isDecimal() {
+		switch ( getJdbcType() ) {
+			case Types.DECIMAL:
+			case Types.NUMERIC:
+				return true;
+		}
+		return false;
+	}
+
 	default boolean isNumber() {
 		switch ( getJdbcType() ) {
 			case Types.BIT:

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -164,7 +164,7 @@ public class FunctionTests {
 							.list();
 					assertThat( session.createQuery("select abs(-2)").getSingleResult(), is(2) );
 					assertThat( session.createQuery("select sign(-2)").getSingleResult(), is(-1) );
-					assertThat( session.createQuery("select power(3.0,2.0)").getSingleResult(), is(9.0f) );
+					assertThat( session.createQuery("select power(3.0,2.0)").getSingleResult(), is(9.0d) );
 					assertThat( session.createQuery("select round(32.12345,2)").getSingleResult(), is(32.12f) );
 					assertThat( session.createQuery("select mod(3,2)").getSingleResult(), is(1) );
 					assertThat( session.createQuery("select 3%2").getSingleResult(), is(1) );


### PR DESCRIPTION
This is what we talked about in https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/6.2E0.20-.20standardFunction.20vs.20nonStandardFunction

I split it into two commits to record the rename from HqlParser.g4 to HqlParserBase.g4. The second commit then just introduces the grammar extension/override + cleanup of code.