### PR TITLE
cleanup lots of warnings, especially generics-related

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -88,7 +88,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.TableOwner;
 import org.hibernate.mapping.Value;
 
-import org.hibernate.tuple.Tuplizer;
+import org.hibernate.persister.entity.EntityPersister;
 import org.jboss.logging.Logger;
 
 import static org.hibernate.cfg.BinderHelper.toAliasEntityMap;
@@ -305,7 +305,7 @@ public class EntityBinder {
 		//set persister if needed
 		Persister persisterAnn = annotatedClass.getAnnotation( Persister.class );
 		if ( persisterAnn != null ) {
-			Class persister = persisterAnn.impl();
+			Class<? extends EntityPersister> persister = (Class<? extends EntityPersister>) persisterAnn.impl();
 			persistentClass.setEntityPersisterClass( persister );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.event.internal;
 
-import java.io.Serializable;
 import java.util.Arrays;
 
 import org.hibernate.AssertionFailure;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -75,33 +75,33 @@ public final class ArrayHelper {
 		return array;
 	}
 
-	public static String[] toStringArray(Collection coll) {
-		return (String[]) coll.toArray( new String[coll.size()] );
+	public static String[] toStringArray(Collection<String> coll) {
+		return coll.toArray( EMPTY_STRING_ARRAY );
 	}
 
-	public static String[][] to2DStringArray(Collection coll) {
-		return (String[][]) coll.toArray( new String[coll.size()][] );
+	public static String[][] to2DStringArray(Collection<String[]> coll) {
+		return coll.toArray( new String[0][] );
 	}
 
-	public static int[][] to2DIntArray(Collection coll) {
-		return (int[][]) coll.toArray( new int[coll.size()][] );
+	public static int[][] to2DIntArray(Collection<int[]> coll) {
+		return coll.toArray( new int[0][] );
 	}
 
-	public static Type[] toTypeArray(Collection coll) {
-		return (Type[]) coll.toArray( new Type[coll.size()] );
+	public static Type[] toTypeArray(Collection<Type> coll) {
+		return coll.toArray( EMPTY_TYPE_ARRAY );
 	}
 
-	public static int[] toIntArray(Collection coll) {
-		Iterator iter = coll.iterator();
+	public static int[] toIntArray(Collection<Integer> coll) {
+		Iterator<Integer> iter = coll.iterator();
 		int[] arr = new int[coll.size()];
 		int i = 0;
 		while ( iter.hasNext() ) {
-			arr[i++] = (Integer) iter.next();
+			arr[i++] = iter.next();
 		}
 		return arr;
 	}
 
-	public static boolean[] toBooleanArray(Collection coll) {
+	public static boolean[] toBooleanArray(Collection<Boolean> coll) {
 		Iterator iter = coll.iterator();
 		boolean[] arr = new boolean[coll.size()];
 		int i = 0;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
@@ -19,18 +19,18 @@ import java.util.List;
  * @author Steve Ebersole
  */
 public class JoinedIterator<T> implements Iterator<T> {
-	private Iterator<T>[] wrappedIterators;
+	private final Iterator<? extends T>[] wrappedIterators;
 
 	private int currentIteratorIndex;
-	private Iterator<T> currentIterator;
-	private Iterator<T> lastUsedIterator;
+	private Iterator<? extends T> currentIterator;
+	private Iterator<? extends T> lastUsedIterator;
 
 	@SuppressWarnings("unchecked")
 	public JoinedIterator(List<Iterator<T>> wrappedIterators) {
-		this( wrappedIterators.toArray( new Iterator[ wrappedIterators.size() ]) );
+		this( wrappedIterators.toArray(new Iterator[0]) );
 	}
 
-	public JoinedIterator(Iterator<T>... iteratorsToWrap) {
+	public JoinedIterator(Iterator<? extends T>... iteratorsToWrap) {
 		if( iteratorsToWrap == null ) {
 			throw new NullPointerException( "Iterators to join were null" );
 		}
@@ -58,7 +58,7 @@ public class JoinedIterator<T> implements Iterator<T> {
 	protected void updateCurrentIterator() {
 		if ( currentIterator == null ) {
 			if( wrappedIterators.length == 0  ) {
-				currentIterator = Collections.<T>emptyList().iterator();
+				currentIterator = Collections.emptyIterator();
 			}
 			else {
 				currentIterator = wrappedIterators[0];

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -29,7 +29,6 @@ import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
-import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
@@ -61,7 +60,6 @@ class DatabaseSnapshotExecutor {
 	private static final Logger log = Logger.getLogger( DatabaseSnapshotExecutor.class );
 
 	private final EntityMappingType entityDescriptor;
-	private final SessionFactoryImplementor sessionFactory;
 
 	private final JdbcSelect jdbcSelect;
 	private final List<JdbcParameter> jdbcParameters;
@@ -70,7 +68,6 @@ class DatabaseSnapshotExecutor {
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
-		this.sessionFactory = sessionFactory;
 		this.jdbcParameters = new ArrayList<>(
 				entityDescriptor.getIdentifierMapping().getJdbcTypeCount()
 		);
@@ -170,7 +167,7 @@ class DatabaseSnapshotExecutor {
 						// TODO: Instead use a delayed collection result? Or will we remove this when redesigning this
 						//noinspection unchecked
 						domainResults.add(
-								new BasicResult<Object>(
+								new BasicResult(
 										0,
 										null,
 										contributorMapping.getJavaTypeDescriptor()

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Filterable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Filterable.java
@@ -7,6 +7,8 @@
 package org.hibernate.mapping;
 
 
+import org.hibernate.internal.FilterConfiguration;
+
 /**
  * Defines mapping elements to which filters may be applied.
  *
@@ -15,5 +17,5 @@ package org.hibernate.mapping;
 public interface Filterable {
 	public void addFilter(String name, String condition, boolean autoAliasInjection, java.util.Map<String,String> aliasTableMap, java.util.Map<String,String> aliasEntityMap);
 
-	public java.util.List getFilters();
+	public java.util.List<FilterConfiguration> getFilters();
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -20,8 +20,8 @@ public class Join implements AttributeContainer, Serializable {
 
 	private static final Alias PK_ALIAS = new Alias(15, "PK");
 
-	private ArrayList properties = new ArrayList();
-	private ArrayList declaredProperties = new ArrayList();
+	private final ArrayList<Property> properties = new ArrayList<>();
+	private final ArrayList<Property> declaredProperties = new ArrayList<>();
 	private Table table;
 	private KeyValue key;
 	private PersistentClass persistentClass;
@@ -52,14 +52,14 @@ public class Join implements AttributeContainer, Serializable {
 		prop.setPersistentClass( getPersistentClass() );
 	}
 
-	public Iterator getDeclaredPropertyIterator() {
+	public Iterator<Property> getDeclaredPropertyIterator() {
 		return declaredProperties.iterator();
 	}
 
 	public boolean containsProperty(Property prop) {
 		return properties.contains(prop);
 	}
-	public Iterator getPropertyIterator() {
+	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
 	}
 
@@ -176,10 +176,9 @@ public class Join implements AttributeContainer, Serializable {
 	}
 
 	public boolean isLazy() {
-		Iterator iter = getPropertyIterator();
+		Iterator<Property> iter = getPropertyIterator();
 		while ( iter.hasNext() ) {
-			Property prop = (Property) iter.next();
-			if ( !prop.isLazy() ) {
+			if ( !iter.next().isLazy() ) {
 				return false;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
@@ -52,7 +52,7 @@ public class JoinedSubclass extends Subclass implements TableOwner {
 		}
 	}
 
-	public Iterator getReferenceablePropertyIterator() {
+	public Iterator<Property> getReferenceablePropertyIterator() {
 		return getPropertyIterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -18,6 +18,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.SingletonIterator;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * The root class of an inheritance hierarchy
@@ -44,7 +45,7 @@ public class RootClass extends PersistentClass implements TableOwner {
 	private boolean mutable = true;
 	private boolean embeddedIdentifier;
 	private boolean explicitPolymorphism;
-	private Class entityPersisterClass;
+	private Class<? extends EntityPersister> entityPersisterClass;
 	private boolean forceDiscriminator;
 	private String where;
 	private Table table;
@@ -125,18 +126,18 @@ public class RootClass extends PersistentClass implements TableOwner {
 	}
 
 	@Override
-	public Iterator getPropertyClosureIterator() {
+	public Iterator<Property> getPropertyClosureIterator() {
 		return getPropertyIterator();
 	}
 
 	@Override
-	public Iterator getTableClosureIterator() {
-		return new SingletonIterator( getTable() );
+	public Iterator<Table> getTableClosureIterator() {
+		return new SingletonIterator<>( getTable() );
 	}
 
 	@Override
-	public Iterator getKeyClosureIterator() {
-		return new SingletonIterator( getKey() );
+	public Iterator<KeyValue> getKeyClosureIterator() {
+		return new SingletonIterator<>( getKey() );
 	}
 
 	@Override
@@ -184,7 +185,7 @@ public class RootClass extends PersistentClass implements TableOwner {
 	}
 
 	@Override
-	public Class getEntityPersisterClass() {
+	public Class<? extends EntityPersister> getEntityPersisterClass() {
 		return entityPersisterClass;
 	}
 
@@ -194,7 +195,7 @@ public class RootClass extends PersistentClass implements TableOwner {
 	}
 
 	@Override
-	public void setEntityPersisterClass(Class persister) {
+	public void setEntityPersisterClass(Class<? extends EntityPersister> persister) {
 		this.entityPersisterClass = persister;
 	}
 
@@ -333,7 +334,7 @@ public class RootClass extends PersistentClass implements TableOwner {
 	}
 
 	@Override
-	public java.util.Set getSynchronizedTables() {
+	public java.util.Set<String> getSynchronizedTables() {
 		return synchronizedTables;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -23,14 +23,14 @@ public class SingleTableSubclass extends Subclass {
 	}
 
 	@SuppressWarnings("unchecked")
-	protected Iterator getNonDuplicatedPropertyIterator() {
-		return new JoinedIterator(
+	protected Iterator<Property> getNonDuplicatedPropertyIterator() {
+		return new JoinedIterator<>(
 				getSuperclass().getUnjoinedPropertyIterator(),
 				getUnjoinedPropertyIterator()
 		);
 	}
 
-	protected Iterator getDiscriminatorColumnIterator() {
+	protected Iterator<Selectable> getDiscriminatorColumnIterator() {
 		if ( isDiscriminatorInsertable() && !getDiscriminator().hasFormula() ) {
 			return getDiscriminator().getColumnIterator();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -15,8 +15,10 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.EntityMode;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.engine.OptimisticLockStyle;
+import org.hibernate.internal.FilterConfiguration;
 import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.internal.util.collections.SingletonIterator;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * A subclass in a table-per-class-hierarchy mapping
@@ -24,7 +26,7 @@ import org.hibernate.internal.util.collections.SingletonIterator;
  */
 public class Subclass extends PersistentClass {
 	private PersistentClass superclass;
-	private Class classPersisterClass;
+	private Class<? extends EntityPersister> classPersisterClass;
 	private final int subclassId;
 
 	public Subclass(PersistentClass superclass, MetadataBuildingContext metadataBuildingContext) {
@@ -100,22 +102,22 @@ public class Subclass extends PersistentClass {
 		getSuperclass().addSubclassJoin(j);
 	}
 
-	public Iterator getPropertyClosureIterator() {
-		return new JoinedIterator(
+	public Iterator<Property> getPropertyClosureIterator() {
+		return new JoinedIterator<>(
 				getSuperclass().getPropertyClosureIterator(),
 				getPropertyIterator()
 			);
 	}
-	public Iterator getTableClosureIterator() {
-		return new JoinedIterator(
+	public Iterator<Table> getTableClosureIterator() {
+		return new JoinedIterator<>(
 				getSuperclass().getTableClosureIterator(),
-				new SingletonIterator( getTable() )
+				new SingletonIterator<>( getTable() )
 			);
 	}
-	public Iterator getKeyClosureIterator() {
-		return new JoinedIterator(
+	public Iterator<KeyValue> getKeyClosureIterator() {
+		return new JoinedIterator<>(
 				getSuperclass().getKeyClosureIterator(),
-				new SingletonIterator( getKey() )
+				new SingletonIterator<>( getKey() )
 			);
 	}
 	protected void addSubclassProperty(Property p) {
@@ -146,7 +148,7 @@ public class Subclass extends PersistentClass {
 	public boolean hasEmbeddedIdentifier() {
 		return getSuperclass().hasEmbeddedIdentifier();
 	}
-	public Class getEntityPersisterClass() {
+	public Class<? extends EntityPersister> getEntityPersisterClass() {
 		if (classPersisterClass==null) {
 			return getSuperclass().getEntityPersisterClass();
 		}
@@ -186,7 +188,7 @@ public class Subclass extends PersistentClass {
 		getKey().createForeignKeyOfEntity( getSuperclass().getEntityName() );
 	}
 
-	public void setEntityPersisterClass(Class classPersisterClass) {
+	public void setEntityPersisterClass(Class<? extends EntityPersister> classPersisterClass) {
 		this.classPersisterClass = classPersisterClass;
 	}
 
@@ -198,8 +200,8 @@ public class Subclass extends PersistentClass {
 		return getSuperclass().getPropertyClosureSpan() + super.getPropertyClosureSpan();
 	}
 
-	public Iterator getJoinClosureIterator() {
-		return new JoinedIterator(
+	public Iterator<Join> getJoinClosureIterator() {
+		return new JoinedIterator<>(
 			getSuperclass().getJoinClosureIterator(),
 			super.getJoinClosureIterator()
 		);
@@ -225,8 +227,8 @@ public class Subclass extends PersistentClass {
 		return getSuperclass().isDiscriminatorInsertable();
 	}
 
-	public java.util.Set getSynchronizedTables() {
-		HashSet result = new HashSet();
+	public java.util.Set<String> getSynchronizedTables() {
+		HashSet<String> result = new HashSet<>();
 		result.addAll(synchronizedTables);
 		result.addAll( getSuperclass().getSynchronizedTables() );
 		return result;
@@ -236,8 +238,8 @@ public class Subclass extends PersistentClass {
 		return mv.accept(this);
 	}
 
-	public java.util.List getFilters() {
-		java.util.List filters = new ArrayList(super.getFilters());
+	public java.util.List<FilterConfiguration> getFilters() {
+		java.util.List<FilterConfiguration> filters = new ArrayList<>(super.getFilters());
 		filters.addAll(getSuperclass().getFilters());
 		return filters;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
@@ -32,11 +32,11 @@ public class UnionSubclass extends Subclass implements TableOwner {
 		getSuperclass().addSubclassTable(table);
 	}
 
-	public java.util.Set getSynchronizedTables() {
+	public java.util.Set<String> getSynchronizedTables() {
 		return synchronizedTables;
 	}
 	
-	protected Iterator getNonDuplicatedPropertyIterator() {
+	protected Iterator<Property> getNonDuplicatedPropertyIterator() {
 		return getPropertyClosureIterator();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityDiscriminatorMapping.java
@@ -30,7 +30,7 @@ public interface EntityDiscriminatorMapping extends VirtualModelPart, BasicValue
 	}
 
 	@Override
-	default JavaTypeDescriptor getJavaTypeDescriptor() {
+	default JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityMappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityMappingType.java
@@ -79,7 +79,7 @@ public interface EntityMappingType extends ManagedMappingType, EntityValuedModel
 	}
 
 	@Override
-	default JavaTypeDescriptor getJavaTypeDescriptor() {
+	default JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getMappedJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ManagedMappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ManagedMappingType.java
@@ -22,7 +22,7 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
  */
 public interface ManagedMappingType extends MappingType, FetchableContainer {
 	@Override
-	default JavaTypeDescriptor getJavaTypeDescriptor() {
+	default JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getMappedJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingType.java
@@ -14,5 +14,5 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
  * @author Steve Ebersole
  */
 public interface MappingType {
-	JavaTypeDescriptor getMappedJavaTypeDescriptor();
+	JavaTypeDescriptor<?> getMappedJavaTypeDescriptor();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ModelPart.java
@@ -32,7 +32,7 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 public interface ModelPart extends MappingModelExpressable {
 	MappingType getPartMappingType();
 
-	JavaTypeDescriptor getJavaTypeDescriptor();
+	JavaTypeDescriptor<?> getJavaTypeDescriptor();
 
 	String getPartName();
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractAttributeMapping.java
@@ -42,8 +42,7 @@ public abstract class AbstractAttributeMapping implements AttributeMapping {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getMappedType().getMappedJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEntityDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEntityDiscriminatorMapping.java
@@ -36,14 +36,14 @@ public abstract class AbstractEntityDiscriminatorMapping implements EntityDiscri
 	private final String mappedColumnExpression;
 	private final boolean isFormula;
 
-	private final BasicType mappingType;
+	private final BasicType<?> mappingType;
 
 	public AbstractEntityDiscriminatorMapping(
 			EntityPersister entityDescriptor,
 			String tableExpression,
 			String mappedColumnExpression,
 			boolean isFormula,
-			BasicType mappingType) {
+			BasicType<?> mappingType) {
 		this.entityDescriptor = entityDescriptor;
 		this.tableExpression = tableExpression;
 		this.mappedColumnExpression = mappedColumnExpression;
@@ -146,7 +146,7 @@ public abstract class AbstractEntityDiscriminatorMapping implements EntityDiscri
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getMappedType().getMappedJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicEntityIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicEntityIdentifierMappingImpl.java
@@ -17,7 +17,6 @@ import org.hibernate.mapping.IndexedConsumer;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
-import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.SelectionConsumer;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -59,7 +58,7 @@ public class BasicEntityIdentifierMappingImpl implements BasicEntityIdentifierMa
 	private final String rootTable;
 	private final String pkColumnName;
 
-	private final BasicType idType;
+	private final BasicType<?> idType;
 
 	private final SessionFactoryImplementor sessionFactory;
 
@@ -68,7 +67,7 @@ public class BasicEntityIdentifierMappingImpl implements BasicEntityIdentifierMa
 			String attributeName,
 			String rootTable,
 			String pkColumnName,
-			BasicType idType,
+			BasicType<?> idType,
 			MappingModelCreationProcess creationProcess) {
 		assert attributeName != null;
 		this.attributeName = attributeName;
@@ -162,7 +161,7 @@ public class BasicEntityIdentifierMappingImpl implements BasicEntityIdentifierMa
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getMappedType().getMappedJavaTypeDescriptor();
 	}
 
@@ -179,7 +178,6 @@ public class BasicEntityIdentifierMappingImpl implements BasicEntityIdentifierMa
 			DomainResultCreationState creationState) {
 		final SqlSelection sqlSelection = resolveSqlSelection( navigablePath, tableGroup, creationState );
 
-		//noinspection unchecked
 		return new BasicResult(
 				sqlSelection.getValuesArrayPosition(),
 				resultVariable,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
@@ -110,7 +110,7 @@ public class BasicValuedCollectionPart
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return selectionMapping.getJdbcMapping().getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedSingularAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedSingularAttributeMapping.java
@@ -112,7 +112,7 @@ public class BasicValuedSingularAttributeMapping
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return domainTypeDescriptor;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationMapping.java
@@ -458,7 +458,7 @@ public class DiscriminatedAssociationMapping implements MappingType, FetchOption
 		@Override
 		public JavaTypeDescriptor<T> getAssembledJavaTypeDescriptor() {
 			//noinspection unchecked
-			return fetchedPart.getJavaTypeDescriptor();
+			return (JavaTypeDescriptor<T>) fetchedPart.getJavaTypeDescriptor();
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
@@ -341,7 +341,7 @@ public class EmbeddedForeignKeyDescriptor implements ForeignKeyDescriptor, Model
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return mappingType.getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityCollectionPart.java
@@ -107,7 +107,7 @@ public class EntityCollectionPart
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return getEntityMappingType().getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityDiscriminatorMappingImpl.java
@@ -32,7 +32,7 @@ public class EntityDiscriminatorMappingImpl extends AbstractEntityDiscriminatorM
 			String tableExpression,
 			String mappedColumnExpression,
 			boolean isFormula,
-			BasicType mappingType) {
+			BasicType<?> mappingType) {
 		super( entityDescriptor, tableExpression, mappedColumnExpression, isFormula, mappingType );
 		this.navigableRole = entityDescriptor.getNavigableRole().append( EntityDiscriminatorMapping.ROLE_NAME );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
@@ -55,7 +55,7 @@ public class EntityRowIdMappingImpl implements EntityRowIdMapping, SelectionMapp
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return JavaObjectType.INSTANCE.getJavaTypeDescriptor();
 	}
 
@@ -106,7 +106,7 @@ public class EntityRowIdMappingImpl implements EntityRowIdMapping, SelectionMapp
 				sqlAstCreationState.getCreationContext().getDomainModel().getTypeConfiguration()
 		);
 
-		return new BasicResult<T>(
+		return new BasicResult(
 				sqlSelection.getValuesArrayPosition(),
 				resultVariable,
 				getJavaTypeDescriptor(),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
@@ -109,7 +109,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return versionBasicType.getJavaTypeDescriptor();
 	}
 
@@ -190,8 +190,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 			DomainResultCreationState creationState) {
 		final SqlSelection sqlSelection = resolveSqlSelection( tableGroup, creationState );
 
-		//noinspection unchecked
-		return new BasicResult<>(
+		return new BasicResult(
 				sqlSelection.getValuesArrayPosition(),
 				resultVariable,
 				getJavaTypeDescriptor(),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/JoinedSubclassDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/JoinedSubclassDiscriminatorMappingImpl.java
@@ -38,7 +38,7 @@ public class JoinedSubclassDiscriminatorMappingImpl extends AbstractEntityDiscri
 			boolean isFormula,
 			CaseSearchedExpression caseSearchedExpression,
 			List<ColumnReference> columnReferences,
-			BasicType mappingType) {
+			BasicType<?> mappingType) {
 		super( entityDescriptor, tableExpression, mappedColumnExpression, isFormula, mappingType );
 
 		this.navigableRole = entityDescriptor.getNavigableRole().append( EntityDiscriminatorMapping.ROLE_NAME );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -161,7 +161,7 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping {
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return attribute.getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -364,7 +364,7 @@ public interface EntityPersister
 	 *
 	 * @return The type of the version property; or null, if not versioned.
 	 */
-	VersionType getVersionType();
+	VersionType<?> getVersionType();
 
 	/**
 	 * If {@link #isVersioned()}, then what is the index of the property
@@ -433,7 +433,7 @@ public interface EntityPersister
 	 */
 	boolean hasLazyProperties();
 
-	default NaturalIdLoader getNaturalIdLoader() {
+	default NaturalIdLoader<?> getNaturalIdLoader() {
 		throw new UnsupportedOperationException(
 				"EntityPersister implementation `" + getClass().getName() + "` does not support `NaturalIdLoader`"
 		);
@@ -447,7 +447,6 @@ public interface EntityPersister
 
 	/**
 	 * Load the id for the entity based on the natural id.
-	 * @return
 	 */
 	Object loadEntityIdByNaturalId(
 			Object[] naturalIdValues,
@@ -763,7 +762,7 @@ public interface EntityPersister
 	/**
 	 * The persistent class, or null
 	 */
-	Class getMappedClass();
+	Class<?> getMappedClass();
 
 	/**
 	 * Does the class implement the {@link org.hibernate.classic.Lifecycle} interface.
@@ -774,7 +773,7 @@ public interface EntityPersister
 	 * Get the proxy interface that instances of <em>this</em> concrete class will be
 	 * cast to (optional operation).
 	 */
-	Class getConcreteProxyClass();
+	Class<?> getConcreteProxyClass();
 
 	/**
 	 * Set the given values to the mapped properties of the given object

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/AbstractLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/AbstractLiteral.java
@@ -69,8 +69,7 @@ public abstract class AbstractLiteral<T>
 						.getTypeConfiguration()
 		);
 
-		//noinspection unchecked
-		return new BasicResult<>(
+		return new BasicResult(
 				sqlSelection.getValuesArrayPosition(),
 				resultVariable,
 				type.getMappedType().getMappedJavaTypeDescriptor()

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
@@ -73,8 +73,7 @@ public class QueryLiteral<T> implements Literal, DomainResultProducer<T> {
 						.getTypeConfiguration()
 		);
 
-		//noinspection unchecked
-		return new BasicResult<>(
+		return new BasicResult(
 				sqlSelection.getValuesArrayPosition(),
 				resultVariable,
 				type.getMappedType().getMappedJavaTypeDescriptor()

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularBiDirectionalFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularBiDirectionalFetchImpl.java
@@ -135,7 +135,7 @@ public class CircularBiDirectionalFetchImpl implements BiDirectionalFetch, Assoc
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return fetchable.getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -172,7 +172,7 @@ public class CircularFetchImpl implements BiDirectionalFetch, Association {
 	}
 
 	@Override
-	public JavaTypeDescriptor getJavaTypeDescriptor() {
+	public JavaTypeDescriptor<?> getJavaTypeDescriptor() {
 		return fetchable.getJavaTypeDescriptor();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -123,7 +123,7 @@ public class EntityMetamodel implements Serializable {
 	private final boolean explicitPolymorphism;
 	private final boolean inherited;
 	private final boolean hasSubclasses;
-	private final Set subclassEntityNames;
+	private final Set<String> subclassEntityNames;
 	private final Map<Class,String> entityNameByInheritenceClassMap;
 
 	private final BytecodeEnhancementMetadata bytecodeEnhancementMetadata;
@@ -154,7 +154,6 @@ public class EntityMetamodel implements Serializable {
 			if ( identifierMapperComponent != null ) {
 				nonAggregatedCidMapper = (CompositeType) identifierMapperComponent.getType();
 				idAttributeNames = new HashSet<>( );
-				//noinspection unchecked
 				final Iterator<Property> propertyItr = identifierMapperComponent.getPropertyIterator();
 				while ( propertyItr.hasNext() ) {
 					idAttributeNames.add( propertyItr.next().getName() );
@@ -205,7 +204,7 @@ public class EntityMetamodel implements Serializable {
 		boolean foundPostUpdateGeneratedValues = false;
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-		Iterator iter = persistentClass.getPropertyClosureIterator();
+		Iterator<Property> props = persistentClass.getPropertyClosureIterator();
 		int i = 0;
 		int tempVersionProperty = NO_VERSION_INDX;
 		boolean foundCascade = false;
@@ -214,8 +213,8 @@ public class EntityMetamodel implements Serializable {
 		boolean foundNonIdentifierPropertyNamedId = false;
 		boolean foundUpdateableNaturalIdProperty = false;
 
-		while ( iter.hasNext() ) {
-			Property prop = ( Property ) iter.next();
+		while ( props.hasNext() ) {
+			Property prop = props.next();
 
 			if ( prop == persistentClass.getVersion() ) {
 				tempVersionProperty = i;
@@ -404,7 +403,7 @@ public class EntityMetamodel implements Serializable {
 		hasCollections = foundCollection;
 		mutablePropertiesIndexes = mutableIndexes;
 
-		iter = persistentClass.getSubclassIterator();
+		Iterator iter = persistentClass.getSubclassIterator();
 		final Set<String> subclassEntityNamesLocal = new HashSet<>();
 		while ( iter.hasNext() ) {
 			subclassEntityNamesLocal.add( ( (PersistentClass) iter.next() ).getEntityName() );
@@ -803,7 +802,7 @@ public class EntityMetamodel implements Serializable {
 		return hasImmutableNaturalId;
 	}
 
-	public Set getSubclassEntityNames() {
+	public Set<String> getSubclassEntityNames() {
 		return subclassEntityNames;
 	}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/PersistentClassGraphDefiner.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/PersistentClassGraphDefiner.java
@@ -38,27 +38,24 @@ public class PersistentClassGraphDefiner implements GraphDefiner<PersistentClass
 		return metadata.getEntityBinding( entityName );
 	}
 
-	@SuppressWarnings({"unchecked"})
-	private void addNeighbours(List<PersistentClass> neighbours, Iterator<PersistentClass> subclassIterator) {
+	private void addNeighbours(List<PersistentClass> neighbours, Iterator<? extends PersistentClass> subclassIterator) {
 		while ( subclassIterator.hasNext() ) {
 			final PersistentClass subclass = subclassIterator.next();
 			neighbours.add( subclass );
-			addNeighbours( neighbours, (Iterator<PersistentClass>) subclass.getSubclassIterator() );
+			addNeighbours( neighbours, subclass.getSubclassIterator() );
 		}
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked"})
 	public List<PersistentClass> getNeighbours(PersistentClass pc) {
 		final List<PersistentClass> neighbours = new ArrayList<>();
 
-		addNeighbours( neighbours, (Iterator<PersistentClass>) pc.getSubclassIterator() );
+		addNeighbours( neighbours, pc.getSubclassIterator() );
 
 		return neighbours;
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked"})
 	public List<PersistentClass> getValues() {
 		return Tools.collectionToList( metadata.getEntityBindings() );
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMetadataGenerator.java
@@ -70,6 +70,7 @@ import org.hibernate.envers.internal.tools.Tools;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.IndexedCollection;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.OneToMany;
 import org.hibernate.mapping.PersistentClass;
@@ -1012,9 +1013,8 @@ public final class CollectionMetadataGenerator {
 		return null;
 	}
 
-	@SuppressWarnings({"unchecked"})
 	private String searchMappedByKey(PersistentClass referencedClass, Collection collectionValue) {
-		final Iterator<Value> assocIdClassProps = referencedClass.getKeyClosureIterator();
+		final Iterator<KeyValue> assocIdClassProps = referencedClass.getKeyClosureIterator();
 		while ( assocIdClassProps.hasNext() ) {
 			final Value value = assocIdClassProps.next();
 			// make sure its a 'Component' because IdClass is registered as this type.


### PR DESCRIPTION
This mainly focusses on the `EntityPersister`s, but touches some other code as well.