### PR TITLE
HHH-14543: fix gap error when there is an empty binding

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -634,20 +634,15 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 					//		1) create a new ordinal parameter at a synthetic position of maxOrdinalPosition + 1
 					//		2) expand the queryString to include each new ordinal param in place of the original
 					//		3) create a new ordinal binding for just that single value under the synthetic position
-					// for the first item, we reuse the original parameter to avoid gaps in the positions
-					if ( i == 0 ) {
-						syntheticParam = sourceParam;
-					}
-					else {
-						int syntheticPosition = ++maxOrdinalPosition;
-						syntheticParam = new OrdinalParameterDescriptor(
-								syntheticPosition,
-								syntheticPosition - jdbcStyleOrdinalCountBase,
-								sourceParam.getHibernateType(),
-								sourceParam.getSourceLocations()
-						);
-					}
-
+					// There is no strong demand, we must reuse the original ordinal parameters, so we just start
+					// from (maxOrdinalPosition + 1).
+					int syntheticPosition = ++maxOrdinalPosition;
+					syntheticParam = new OrdinalParameterDescriptor(
+									syntheticPosition,
+									syntheticPosition - jdbcStyleOrdinalCountBase,
+									sourceParam.getHibernateType(),
+									sourceParam.getSourceLocations()
+					);
 					expansionList.append( "?" ).append( syntheticParam.getPosition() );
 				}
 

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh14543/Category.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh14543/Category.java
@@ -1,0 +1,15 @@
+package org.hibernate.query.hhh14543;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity(name = "Category")
+@Table(name = "Category")
+public class Category implements Serializable {
+  @Id
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn
+  private CategorySet categorySet;
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh14543/CategorySet.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh14543/CategorySet.java
@@ -1,0 +1,19 @@
+package org.hibernate.query.hhh14543;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Set;
+
+@Entity(name = "CategorySet")
+@Table(name = "CategorySet")
+public class CategorySet implements Serializable {
+  @Id
+  private Long id;
+
+  @ManyToMany
+  @JoinTable
+  private Set<Network> networks;
+
+  @OneToMany(mappedBy = "categorySet")
+  private Set<Category> categories;
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh14543/HHH14543Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh14543/HHH14543Test.java
@@ -1,0 +1,65 @@
+package org.hibernate.query.hhh14543;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+@TestForIssue(jiraKey = "HHH-14543")
+public class HHH14543Test extends BaseEntityManagerFunctionalTestCase{
+
+  @Override
+  protected Class<?>[] getAnnotatedClasses() {
+    return new Class<?>[] {
+            Category.class,
+            Network.class,
+            CategorySet.class
+    };
+  }
+
+  // Entities are auto-discovered, so just add them anywhere on class-path
+  // Add your tests, using standard JUnit.
+  @Test
+  public void ordinal132Test_working() {
+    doInJPA(this::entityManagerFactory, entityManager -> {
+      entityManager.createQuery("SELECT c FROM Category c "
+              + "JOIN c.categorySet s "
+              + "JOIN s.networks n "
+              + "WHERE c.id IN ?1 AND (n IS EMPTY or n.id IN ?2)")
+              .setParameter(1, Arrays.asList(2L, 4L))
+              .setParameter(2, Collections.emptySet())
+              .getResultList();
+    });
+  }
+
+  @Test
+  public void ordinal123Test_working() {
+    doInJPA(this::entityManagerFactory, entityManager -> {
+      entityManager.createQuery("SELECT c FROM Category c "
+              + "JOIN c.categorySet s "
+              + "JOIN s.networks n "
+              + "WHERE c.id IN ?2 AND (n IS EMPTY or n.id IN ?1)")
+              .setParameter(2, Arrays.asList(2L, 4L))
+              .setParameter(1, Collections.emptySet())
+              .getResultList();
+    });
+  }
+
+  @Test
+  public void ordinal1324Test_working() {
+    doInJPA(this::entityManagerFactory, entityManager -> {
+      entityManager.createQuery("SELECT c FROM Category c "
+              + "JOIN c.categorySet s "
+              + "JOIN s.networks n "
+              + "WHERE c.id IN ?1 AND (n IS EMPTY or n.id IN ?2)")
+              .setParameter(2, Arrays.asList(2L, 4L))
+              .setParameter(1, Arrays.asList(1L, 3L))
+              .getResultList();
+    });
+  }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/query/hhh14543/Network.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/hhh14543/Network.java
@@ -1,0 +1,18 @@
+package org.hibernate.query.hhh14543;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.util.Set;
+
+@Entity(name = "Network")
+@Table(name = "Network")
+public class Network implements Serializable {
+  @Id
+  private Long id;
+
+  @ManyToMany(mappedBy = "networks")
+  private Set<CategorySet> categorySets;
+}


### PR DESCRIPTION
in below case, if the binding variable is (1, [2,3]) (2, [])
```
WHERE c.id IN ?1 AND (n IS EMPTY or n.id IN ?2)
```
then the generated sql will be 
```
WHERE c.id IN (?1, ?3) AND (n IS EMPTY or n.id IN ())
```
if we don't reuse original ordinal parameter, we just get,
which I think is an easy solution
```
WHERE c.id IN (?3, ?4) AND (n IS EMPTY or n.id IN ())
```
(sorry for my poor English)