### PR TITLE
HHH-14553: test case for byte-enhanced runner persisting Long ID entity failing with IAE

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/persist/HHH_14553/Ship.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/persist/HHH_14553/Ship.java
@@ -1,0 +1,86 @@
+package org.hibernate.test.bytecode.enhancement.persist.HHH_14553;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "\"Ships\"")
+public class Ship
+{
+    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Basic(optional = false)
+    @Column
+    private String name;
+
+//    @Basic(fetch = FetchType.LAZY)
+//    @Column
+//    @Lob
+//    private byte[] thumbnail;
+//
+//    @Basic(fetch = FetchType.LAZY)
+//    @Column(name = "full_image")
+//    @Lob
+//    private byte[] fullImage;
+
+    public Ship()
+    {
+    }
+
+    public Ship(String name)
+    {
+        this(null, name);
+    }
+
+    public Ship(Long id, String name)
+    {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId()
+    {
+        return id;
+    }
+
+    public void setId(Long id)
+    {
+        this.id = id;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+//    public byte[] getThumbnail()
+//    {
+//        return thumbnail;
+//    }
+//
+//    public void setThumbnail(byte[] thumbnail)
+//    {
+//        this.thumbnail = thumbnail;
+//    }
+//
+//    public byte[] getFullImage()
+//    {
+//        return fullImage;
+//    }
+//
+//    public void setFullImage(byte[] fullImage)
+//    {
+//        this.fullImage = fullImage;
+//    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/persist/HHH_14553/SimpleLongIdEntityPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/persist/HHH_14553/SimpleLongIdEntityPersistTest.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.bytecode.enhancement.persist.HHH_14553;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+/**
+ * @author Karsten Wutzke
+ */
+@TestForIssue( jiraKey = "HHH-14553")
+@RunWith( BytecodeEnhancerRunner.class ) // <-- without this, persist works
+public class SimpleLongIdEntityPersistTest extends BaseEntityManagerFunctionalTestCase {
+
+    @Override
+    public Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{Ship.class};
+    }
+
+    @Override
+    protected void addConfigOptions(Map options) {
+        options.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, "false" );
+        options.put( AvailableSettings.SHOW_SQL, "true" );
+        options.put( AvailableSettings.FORMAT_SQL, "true" );
+    }
+
+    @Before
+    public void prepare() {
+        doInJPA( this::entityManagerFactory, em -> {
+            Ship entity = new Ship(1L, "Titanic");
+            em.persist( entity );
+        });
+    }
+
+    /**
+     * Use --debug to see the SQL being run + the sysouts.
+     */
+    @Test
+    public void test() {
+        doInJPA( this::entityManagerFactory, em -> {
+            Ship entity = em.find( Ship.class, 1L );
+
+            Assert.assertNotNull("Ship not found!", entity);
+        } );
+    }
+}


### PR DESCRIPTION
Test case for https://hibernate.atlassian.net/browse/HHH-14553

We're currently stuck on a big project using a Java EE 7 environment and we won't be able to switch to Java EE 8 anytime soon. It would be very nice to get this fixed, also given this doesn't happen on the current Hibernate main branch, the fix must somehow be present in 5.3 and/or 5.4.