### PR TITLE
HHH-14557 Connection leaked on rollback with mode DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -270,7 +270,8 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 	public void afterTransaction() {
 		transactionTimeOutInstant = -1;
 		if ( getConnectionReleaseMode() == ConnectionReleaseMode.AFTER_STATEMENT ||
-				getConnectionReleaseMode() == ConnectionReleaseMode.AFTER_TRANSACTION ) {
+				getConnectionReleaseMode() == ConnectionReleaseMode.AFTER_TRANSACTION ||
+				getConnectionReleaseMode() == ConnectionReleaseMode.BEFORE_TRANSACTION_COMPLETION ) {
 			this.logicalConnection.afterTransaction();
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/LogicalConnectionManagedImpl.java
@@ -167,8 +167,10 @@ public class LogicalConnectionManagedImpl extends AbstractLogicalConnectionImple
 		super.afterTransaction();
 
 		if ( connectionHandlingMode.getReleaseMode() != ConnectionReleaseMode.ON_CLOSE ) {
-			// NOTE : we check for !ON_CLOSE here (rather than AFTER_TRANSACTION) to also catch AFTER_STATEMENT cases
-			// that were circumvented due to held resources
+			// NOTE : we check for !ON_CLOSE here (rather than AFTER_TRANSACTION) to also catch:
+			// - AFTER_STATEMENT cases that were circumvented due to held resources
+			// - BEFORE_TRANSACTION_COMPLETION cases that were circumvented because a rollback occurred
+			//   (we don't get a beforeTransactionCompletion event on rollback).
 			log.debug( "Initiating JDBC connection release from afterTransaction" );
 			releaseConnection();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/connections/BeforeCompletionReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/connections/BeforeCompletionReleaseTest.java
@@ -110,11 +110,11 @@ public class BeforeCompletionReleaseTest extends BaseEntityManagerFunctionalTest
     @Test
     @TestForIssue(jiraKey = {"HHH-13976", "HHH-14326"})
     public void testResourcesReleasedThenConnectionClosedThenCommit() throws SQLException, XAException {
-        XAResource transactionSpy = mock( XAResource.class );
-        Connection[] connectionSpies = new Connection[1];
-        Statement statementMock = Mockito.mock( Statement.class );
-
         try (SessionImplementor s = (SessionImplementor) openSession()) {
+            XAResource transactionSpy = mock( XAResource.class );
+            Connection[] connectionSpies = new Connection[1];
+            Statement statementMock = Mockito.mock( Statement.class );
+
             TransactionUtil2.inTransaction( s, session -> {
                 spyOnTransaction( transactionSpy );
 
@@ -126,16 +126,18 @@ public class BeforeCompletionReleaseTest extends BaseEntityManagerFunctionalTest
                 logicalConnection.getResourceRegistry().register( statementMock, true );
                 connectionSpies[0] = logicalConnection.getPhysicalConnection();
             } );
+
+            // Note: all this must happen BEFORE the session is closed;
+            // it's particularly important when reusing the session.
+
+            Connection connectionSpy = connectionSpies[0];
+
+            // Must close the resources, then the connection, then commit
+            InOrder inOrder = inOrder( statementMock, connectionSpy, transactionSpy );
+            inOrder.verify( statementMock ).close();
+            inOrder.verify( connectionSpy ).close();
+            inOrder.verify( transactionSpy ).commit( any(), anyBoolean() );
         }
-
-        Connection connectionSpy = connectionSpies[0];
-
-        // Must close the resources, then the connection, then commit
-        InOrder inOrder = inOrder( statementMock, connectionSpy, transactionSpy );
-        inOrder.verify( statementMock ).close();
-        inOrder.verify( connectionSpy ).close();
-        inOrder.verify( transactionSpy ).commit( any(), anyBoolean() );
-        Mockito.reset( connectionSpy );
     }
 
     private void spyOnTransaction(XAResource xaResource) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14557

Turns out we don't have a "before transaction completion" event in the case of rollbacks, so we need to rely on the "after transaction completion" event to do some more cleanup, even when using `DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION`.

Related: https://issues.redhat.com/browse/AG-168