### PR TITLE
HHH-14567 Filters are ignored if enabled after query creation but before execution

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryImpl.java
@@ -92,7 +92,9 @@ public class QueryImpl<R> extends AbstractProducedQuery<R> implements Query<R> {
 		if ( queryPlan != null ) {
 			queryParameters.setQueryPlan( queryPlan );
 		}
-		else if ( hql.equals( getQueryString() ) ) {
+		else if ( hql.equals( getQueryString() )
+				&& getQueryPlan().getEnabledFilterNames()
+						.equals( getProducer().getLoadQueryInfluencers().getEnabledFilters().values() ) ) {
 			queryParameters.setQueryPlan( getQueryPlan() );
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/Salesperson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/Salesperson.java
@@ -24,6 +24,13 @@ public class Salesperson {
 	private Department department;
 	private Set orders = new HashSet();
 
+	@Override
+	public String toString() {
+		return "Salesperson#" + id + "{"
+				+ ", name='" + name + '\'' +
+				'}';
+	}
+
 	public Long getId() {
 		return id;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14567

No need to backport, as the optimization that causes the bug was not backported.