### PR TITLE
Backporting  HHH-13077 and HHH-14567 to 5.4

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -638,11 +638,11 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		throw getExceptionConverter().convert( new IllegalArgumentException( "No query defined for that name [" + name + "]" ) );
 	}
 
-	protected QueryImplementor createQuery(NamedQueryDefinition queryDefinition) {
+	protected QueryImpl createQuery(NamedQueryDefinition queryDefinition) {
 		String queryString = queryDefinition.getQueryString();
 		final QueryImpl query = new QueryImpl(
 				this,
-				getQueryPlan( queryString, false ).getParameterMetadata(),
+				getQueryPlan( queryString, false ),
 				queryString
 		);
 		applyQuerySettingsAndHints( query );
@@ -714,7 +714,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@Override
-	public QueryImplementor createQuery(String queryString) {
+	public QueryImpl createQuery(String queryString) {
 		checkOpen();
 		pulseTransactionCoordinator();
 		delayedAfterCompletion();
@@ -722,7 +722,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		try {
 			final QueryImpl query = new QueryImpl(
 					this,
-					getQueryPlan( queryString, false ).getParameterMetadata(),
+					getQueryPlan( queryString, false ),
 					queryString
 			);
 			applyQuerySettingsAndHints( query );
@@ -822,7 +822,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 		try {
 			// do the translation
-			final QueryImplementor<T> query = createQuery( queryString );
+			final QueryImpl<T> query = createQuery( queryString );
 			resultClassChecking( resultClass, query );
 			return query;
 		}
@@ -832,13 +832,10 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@SuppressWarnings({"unchecked", "WeakerAccess", "StatementWithEmptyBody"})
-	protected void resultClassChecking(Class resultClass, org.hibernate.Query hqlQuery) {
+	protected void resultClassChecking(Class resultClass, QueryImpl hqlQuery) {
 		// make sure the query is a select -> HHH-7192
-		final HQLQueryPlan queryPlan = getFactory().getQueryPlanCache().getHQLQueryPlan(
-				hqlQuery.getQueryString(),
-				false,
-				getLoadQueryInfluencers().getEnabledFilters()
-		);
+		HQLQueryPlan queryPlan = hqlQuery.getQueryPlan();
+
 		if ( queryPlan.getTranslators()[0].isManipulationStatement() ) {
 			throw new IllegalArgumentException( "Update/delete queries cannot be typed" );
 		}
@@ -914,7 +911,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@SuppressWarnings({"WeakerAccess", "unchecked"})
 	protected <T> QueryImplementor<T> createQuery(NamedQueryDefinition namedQueryDefinition, Class<T> resultType) {
-		final QueryImplementor query = createQuery( namedQueryDefinition );
+		final QueryImpl query = createQuery( namedQueryDefinition );
 		if ( resultType != null ) {
 			resultClassChecking( resultType, query );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1523,7 +1523,7 @@ public class SessionImpl
 		queryParameters.validateParameters();
 
 		HQLQueryPlan plan = queryParameters.getQueryPlan();
-		if ( plan == null ) {
+		if ( plan == null || !plan.isShallow() ) {
 			plan = getQueryPlan( query, true );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -67,7 +67,7 @@ import org.hibernate.type.Type;
  * @author Steve Ebersole
  * @author Gavin King
  */
-@SuppressWarnings("UnusedDeclaration")
+@SuppressWarnings("UnusedDeclaratiqon")
 public interface Query<R> extends TypedQuery<R>, org.hibernate.Query<R>, CommonQueryContract {
 	/**
 	 * Get the QueryProducer this Query originates from.

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -1434,8 +1434,8 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 			);
 		}
 
-	QueryParameters queryParameters = new QueryParameters(
-			getQueryParameterBindings(),
+		QueryParameters queryParameters = new QueryParameters(
+				getQueryParameterBindings(),
 				getLockOptions(),
 				queryOptions,
 				true,
@@ -1450,11 +1450,22 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 				optionalId,
 				resultTransformer
 		);
-		queryParameters.setQueryPlan( entityGraphHintedQueryPlan );
+
+		appendQueryPlanToQueryParameters( hql, queryParameters, entityGraphHintedQueryPlan );
+
 		if ( passDistinctThrough != null ) {
 			queryParameters.setPassDistinctThrough( passDistinctThrough );
 		}
 		return queryParameters;
+	}
+
+	protected void appendQueryPlanToQueryParameters(
+			String hql,
+			QueryParameters queryParameters,
+			HQLQueryPlan queryPlan) {
+		if ( queryPlan != null ) {
+			queryParameters.setQueryPlan( queryPlan );
+		}
 	}
 
 	public QueryParameters getQueryParameters() {
@@ -1732,7 +1743,7 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 				: defaultType;
 	}
 
-	private boolean isSelect() {
+	protected boolean isSelect() {
 		return getProducer().getFactory().getQueryPlanCache()
 				.getHQLQueryPlan( getQueryString(), false, Collections.<String, Filter>emptyMap() )
 				.isSelect();

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryImpl.java
@@ -92,7 +92,9 @@ public class QueryImpl<R> extends AbstractProducedQuery<R> implements Query<R> {
 		if ( queryPlan != null ) {
 			queryParameters.setQueryPlan( queryPlan );
 		}
-		else if ( hql.equals( getQueryString() ) ) {
+		else if ( hql.equals( getQueryString() )
+				&& getQueryPlan().getEnabledFilterNames()
+						.equals( getProducer().getLoadQueryInfluencers().getEnabledFilters().values() ) ) {
 			queryParameters.setQueryPlan( getQueryPlan() );
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/filter/Salesperson.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/filter/Salesperson.java
@@ -24,6 +24,13 @@ public class Salesperson {
 	private Department department;
 	private Set orders = new HashSet();
 
+	@Override
+	public String toString() {
+		return "Salesperson#" + id + "{"
+				+ ", name='" + name + '\'' +
+				'}';
+	}
+
 	public Long getId() {
 		return id;
 	}


### PR DESCRIPTION
Backporting these changes from 5.5 will make it possible for Hibernate Reactive to work with 5.4 and 5.5.
Is it possible to apply these changes?

Backports: [HHH-13077](https://hibernate.atlassian.net/browse/HHH-13077) and [HHH-14567](https://hibernate.atlassian.net/browse/HHH-14567).

For Hibernate Reactive only HHH-13077 is required but the other commits fix a regression in Quarkus.