### PR TITLE
Support for type coercion for values passed as ids and as query param…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2135,6 +2135,13 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE = "hibernate.jpa.compliance.global_id_generators";
 
 	/**
+	 * @see JpaCompliance#isLoadByIdComplianceEnabled()
+	 *
+	 * @since 6.0
+	 */
+	String JPA_LOAD_BY_ID_COMPLIANCE = "hibernate.jpa.compliance.load_by_id";
+
+	/**
 	 * True/False setting indicating if the value stored in the table used by the {@link javax.persistence.TableGenerator}
 	 * is the last value generated or the next value to be used.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -35,6 +35,8 @@ import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder.Options;
 import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Defines the internal contract shared between {@link org.hibernate.Session} and
@@ -66,7 +68,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  * @author Steve Ebersole
  */
 public interface SharedSessionContractImplementor
-		extends SharedSessionContract, JdbcSessionOwner, Options, LobCreationContext, WrapperOptions, QueryProducerImplementor {
+		extends SharedSessionContract, JdbcSessionOwner, Options, LobCreationContext, WrapperOptions, QueryProducerImplementor, JavaTypeDescriptor.CoercionContext {
 
 	// todo : this is the shared contract between Session and StatelessSession, but it defines methods that StatelessSession does not implement
 	//	(it just throws UnsupportedOperationException).  To me it seems like it is better to properly isolate those methods
@@ -81,6 +83,11 @@ public interface SharedSessionContractImplementor
 	 * Get the creating <tt>SessionFactoryImplementor</tt>
 	 */
 	SessionFactoryImplementor getFactory();
+
+	@Override
+	default TypeConfiguration getTypeConfiguration() {
+		return getFactory().getTypeConfiguration();
+	}
 
 	SessionEventListenerManager getEventListenerManager();
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/JpaComplianceImpl.java
@@ -20,8 +20,9 @@ public class JpaComplianceImpl implements JpaCompliance {
 	private final boolean transactionCompliance;
 	private final boolean closedCompliance;
 	private final boolean cachingCompliance;
+	private final boolean loadByIdCompliance;
 
-	private JpaComplianceImpl(
+	public JpaComplianceImpl(
 			boolean listCompliance,
 			boolean orderByMappingCompliance,
 			boolean proxyCompliance,
@@ -29,7 +30,8 @@ public class JpaComplianceImpl implements JpaCompliance {
 			boolean queryCompliance,
 			boolean transactionCompliance,
 			boolean closedCompliance,
-			boolean cachingCompliance) {
+			boolean cachingCompliance,
+			boolean loadByIdCompliance) {
 		this.queryCompliance = queryCompliance;
 		this.transactionCompliance = transactionCompliance;
 		this.listCompliance = listCompliance;
@@ -38,6 +40,7 @@ public class JpaComplianceImpl implements JpaCompliance {
 		this.cachingCompliance = cachingCompliance;
 		this.globalGeneratorNameScopeCompliance = globalGeneratorNameScopeCompliance;
 		this.orderByMappingCompliance = orderByMappingCompliance;
+		this.loadByIdCompliance = loadByIdCompliance;
 	}
 
 	@Override
@@ -80,6 +83,11 @@ public class JpaComplianceImpl implements JpaCompliance {
 		return orderByMappingCompliance;
 	}
 
+	@Override
+	public boolean isLoadByIdComplianceEnabled() {
+		return loadByIdCompliance;
+	}
+
 	public static class JpaComplianceBuilder {
 		private boolean queryCompliance;
 		private boolean listCompliance;
@@ -89,6 +97,7 @@ public class JpaComplianceImpl implements JpaCompliance {
 		private boolean cachingCompliance;
 		private boolean transactionCompliance;
 		private boolean closedCompliance;
+		private boolean loadByIdCompliance;
 
 		public JpaComplianceBuilder() {
 		}
@@ -133,6 +142,11 @@ public class JpaComplianceImpl implements JpaCompliance {
 			return this;
 		}
 
+		public JpaComplianceBuilder setLoadByIdCompliance(boolean loadByIdCompliance) {
+			this.loadByIdCompliance = loadByIdCompliance;
+			return this;
+		}
+
 		JpaCompliance createJpaCompliance() {
 			return new JpaComplianceImpl(
 					listCompliance,
@@ -142,7 +156,8 @@ public class JpaComplianceImpl implements JpaCompliance {
 					queryCompliance,
 					transactionCompliance,
 					closedCompliance,
-					cachingCompliance
+					cachingCompliance,
+					loadByIdCompliance
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/MutableJpaComplianceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/MutableJpaComplianceImpl.java
@@ -25,6 +25,7 @@ public class MutableJpaComplianceImpl implements MutableJpaCompliance {
 	private boolean transactionCompliance;
 	private boolean closedCompliance;
 	private boolean cachingCompliance;
+	private boolean loadByIdCompliance;
 
 	@SuppressWarnings("ConstantConditions")
 	public MutableJpaComplianceImpl(Map configurationSettings, boolean jpaByDefault) {
@@ -71,6 +72,12 @@ public class MutableJpaComplianceImpl implements MutableJpaCompliance {
 
 		cachingCompliance = ConfigurationHelper.getBoolean(
 				AvailableSettings.JPA_CACHING_COMPLIANCE,
+				configurationSettings,
+				jpaByDefault
+		);
+
+		loadByIdCompliance = ConfigurationHelper.getBoolean(
+				AvailableSettings.JPA_LOAD_BY_ID_COMPLIANCE,
 				configurationSettings,
 				jpaByDefault
 		);
@@ -158,7 +165,15 @@ public class MutableJpaComplianceImpl implements MutableJpaCompliance {
 		this.cachingCompliance = cachingCompliance;
 	}
 
+	@Override
+	public void setLoadByIdCompliance(boolean enabled) {
+		this.loadByIdCompliance = enabled;
+	}
 
+	@Override
+	public boolean isLoadByIdComplianceEnabled() {
+		return loadByIdCompliance;
+	}
 
 	@Override
 	public JpaCompliance immutableCopy() {
@@ -170,7 +185,8 @@ public class MutableJpaComplianceImpl implements MutableJpaCompliance {
 				.setQueryCompliance( queryCompliance )
 				.setTransactionCompliance( transactionCompliance )
 				.setClosedCompliance( closedCompliance )
-				.setCachingCompliance( cachingCompliance );
+				.setCachingCompliance( cachingCompliance )
+				.setLoadByIdCompliance( loadByIdCompliance );
 		return builder.createJpaCompliance();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
@@ -105,4 +105,18 @@ public interface JpaCompliance {
 	 * this enabled, Hibernate will throw a compliance error when a non-attribute-reference is used.
 	 */
 	boolean isJpaOrderByMappingComplianceEnabled();
+
+	/**
+	 * JPA says that the id passed to {@link javax.persistence.EntityManager#getReference} and
+	 * {@link javax.persistence.EntityManager#find} should be the exact expected type, allowing
+	 * no type coercion.
+	 *
+	 * Historically, Hibernate behaved the same way.  Since 6.0 however, Hibernate has the ability to
+	 * coerce the passed type to the expected type.
+	 *
+	 * This setting controls whether such a coercion should be allowed.
+	 *
+	 * @since 6.0
+	 */
+	boolean isLoadByIdComplianceEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/MutableJpaCompliance.java
@@ -26,5 +26,7 @@ public interface MutableJpaCompliance extends JpaCompliance {
 
 	void setGeneratorNameScopeCompliance(boolean generatorScopeCompliance);
 
+	void setLoadByIdCompliance(boolean enabled);
+
 	JpaCompliance immutableCopy();
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/access/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/access/IdentifierLoadAccessImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.event.spi.LoadEventListener;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
@@ -116,7 +117,10 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 		final EventSource eventSource = (EventSource) session;
 		final LoadQueryInfluencers loadQueryInfluencers = session.getLoadQueryInfluencers();
 
-		id = entityPersister.getIdentifierMapping().getJavaTypeDescriptor().coerce( id, this );
+		final JpaCompliance jpaCompliance = session.getFactory().getSessionFactoryOptions().getJpaCompliance();
+		if ( ! jpaCompliance.isLoadByIdComplianceEnabled() ) {
+			id = entityPersister.getIdentifierMapping().getJavaTypeDescriptor().coerce( id, this );
+		}
 
 		if ( this.lockOptions != null ) {
 			LoadEvent event = new LoadEvent( id, entityPersister.getEntityName(), lockOptions, eventSource, loadQueryInfluencers.getReadOnly() );
@@ -158,7 +162,10 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 		final EventSource eventSource = (EventSource) session;
 		final LoadQueryInfluencers loadQueryInfluencers = session.getLoadQueryInfluencers();
 
-		id = entityPersister.getIdentifierMapping().getJavaTypeDescriptor().coerce( id, this );
+		final JpaCompliance jpaCompliance = session.getFactory().getSessionFactoryOptions().getJpaCompliance();
+		if ( ! jpaCompliance.isLoadByIdComplianceEnabled() ) {
+			id = entityPersister.getIdentifierMapping().getJavaTypeDescriptor().coerce( id, this );
+		}
 
 		if ( this.lockOptions != null ) {
 			LoadEvent event = new LoadEvent( id, entityPersister.getEntityName(), lockOptions, eventSource, loadQueryInfluencers.getReadOnly() );

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdLoaderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdLoaderStandard.java
@@ -124,7 +124,7 @@ public class MultiIdLoaderStandard<T> implements MultiIdEntityLoader<T> {
 		final List<Integer> elementPositionsLoadedByBatch = new ArrayList<>();
 
 		for ( int i = 0; i < ids.length; i++ ) {
-			final Object id = ids[i];
+			final Object id = entityDescriptor.getIdentifierMapping().getJavaTypeDescriptor().coerce( ids[i], session );
 			final EntityKey entityKey = new EntityKey( id, entityDescriptor );
 
 			if ( loadOptions.isSessionCheckingEnabled() || loadOptions.isSecondLevelCacheCheckingEnabled() ) {
@@ -175,7 +175,7 @@ public class MultiIdLoaderStandard<T> implements MultiIdEntityLoader<T> {
 
 			// if we did not hit any of the continues above, then we need to batch
 			// load the entity state.
-			idsInBatch.add( ids[i] );
+			idsInBatch.add( id );
 
 			if ( idsInBatch.size() >= maxBatchSize ) {
 				// we've hit the allotted max-batch-size, perform an "intermediate load"
@@ -352,7 +352,7 @@ public class MultiIdLoaderStandard<T> implements MultiIdEntityLoader<T> {
 			final List<Object> nonManagedIds = new ArrayList<>();
 
 			for ( int i = 0; i < ids.length; i++ ) {
-				final Object id = ids[ i ];
+				final Object id = entityDescriptor.getIdentifierMapping().getJavaTypeDescriptor().coerce( ids[ i ], session );
 				final EntityKey entityKey = new EntityKey( id, entityDescriptor );
 
 				LoadEvent loadEvent = new LoadEvent(

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -57,7 +57,6 @@ import org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies;
 import org.hibernate.property.access.spi.Getter;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.query.IllegalQueryOperationException;
-import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.QueryLogging;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBinding.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBinding.java
@@ -54,7 +54,6 @@ public interface QueryParameterBinding<T> {
 
 	/**
 	 * Sets the parameter binding value using the explicit Type.
-	 *
 	 * @param value The bind value
 	 * @param clarifiedType The explicit Type to use
 	 */
@@ -62,7 +61,6 @@ public interface QueryParameterBinding<T> {
 
 	/**
 	 * Sets the parameter binding value using the explicit TemporalType.
-	 *
 	 * @param value The bind value
 	 * @param temporalTypePrecision The temporal type to use
 	 */
@@ -78,14 +76,13 @@ public interface QueryParameterBinding<T> {
 	/**
 	 * Sets the parameter binding values.  The inherent parameter type (if known) is assumed in regards to the
 	 * individual values.
+	 *  @param values The bind values
 	 *
-	 * @param values The bind values
 	 */
 	void setBindValues(Collection<T> values);
 
 	/**
 	 * Sets the parameter binding values using the explicit Type in regards to the individual values.
-	 *
 	 * @param values The bind values
 	 * @param clarifiedType The explicit Type to use
 	 */
@@ -93,8 +90,7 @@ public interface QueryParameterBinding<T> {
 
 	/**Sets the parameter binding value using the explicit TemporalType in regards to the individual values.
 	 *
-	 *
-	 * @param values The bind values
+	 *  @param values The bind values
 	 * @param temporalTypePrecision The temporal type to use
 	 */
 	void setBindValues(Collection<T> values, TemporalType temporalTypePrecision, TypeConfiguration typeConfiguration);

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerTypeDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -82,13 +83,13 @@ public class BigIntegerTypeDescriptor extends AbstractClassTypeDescriptor<BigInt
 		if ( value == null ) {
 			return null;
 		}
-		if ( BigInteger.class.isInstance( value ) ) {
+		if ( value instanceof BigInteger ) {
 			return (BigInteger) value;
 		}
-		if ( BigDecimal.class.isInstance( value ) ) {
+		if ( value instanceof BigDecimal ) {
 			return ( (BigDecimal) value ).toBigIntegerExact();
 		}
-		if ( Number.class.isInstance( value ) ) {
+		if ( value instanceof Number ) {
 			return BigInteger.valueOf( ( (Number) value ).longValue() );
 		}
 		throw unknownWrap( value.getClass() );
@@ -107,5 +108,59 @@ public class BigIntegerTypeDescriptor extends AbstractClassTypeDescriptor<BigInt
 	@Override
 	public int getDefaultSqlScale() {
 		return 0;
+	}
+
+	@Override
+	public <X> BigInteger coerce(X value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof BigInteger ) {
+			return (BigInteger) value;
+		}
+
+		if ( value instanceof Byte ) {
+			return BigInteger.valueOf( ( (byte) value ) );
+		}
+
+		if ( value instanceof Short ) {
+			return BigInteger.valueOf( ( (short) value ) );
+		}
+
+		if ( value instanceof Integer ) {
+			return BigInteger.valueOf( ( (int) value ) );
+		}
+
+		if ( value instanceof Long ) {
+			return BigInteger.valueOf( ( (long) value ) );
+		}
+
+		if ( value instanceof Double ) {
+			return CoercionHelper.toBigInteger( (Double) value );
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toBigInteger( (Float) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toBigInteger( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> BigInteger.valueOf( Long.parseLong( (String) value ) )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Unable to coerce value [%s (%s)] to BigInteger",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteTypeDescriptor.java
@@ -5,6 +5,10 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type.descriptor.java;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Locale;
+
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -66,20 +70,20 @@ public class ByteTypeDescriptor extends AbstractClassTypeDescriptor<Byte> implem
 		if ( value == null ) {
 			return null;
 		}
-		if ( Byte.class.isInstance( value ) ) {
+		if ( value instanceof Byte ) {
 			return (Byte) value;
 		}
-		if ( Number.class.isInstance( value ) ) {
+		if ( value instanceof Number ) {
 			return ( (Number) value ).byteValue();
 		}
-		if ( String.class.isInstance( value ) ) {
+		if ( value instanceof String ) {
 			return Byte.valueOf( ( (String) value ) );
 		}
 		throw unknownWrap( value.getClass() );
 	}
 
 	@Override
-	public Class getPrimitiveClass() {
+	public Class<Byte> getPrimitiveClass() {
 		return byte.class;
 	}
 
@@ -101,5 +105,59 @@ public class ByteTypeDescriptor extends AbstractClassTypeDescriptor<Byte> implem
 	@Override
 	public int getDefaultSqlScale() {
 		return 0;
+	}
+
+	@Override
+	public <X> Byte coerce(X value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Byte ) {
+			return (byte) value;
+		}
+
+		if ( value instanceof Short ) {
+			return CoercionHelper.toByte( (short) value );
+		}
+
+		if ( value instanceof Integer ) {
+			return CoercionHelper.toByte( (Integer) value );
+		}
+
+		if ( value instanceof Long ) {
+			return CoercionHelper.toByte( (Long) value );
+		}
+
+		if ( value instanceof Double ) {
+			return CoercionHelper.toByte( (Double) value );
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toByte( (Float) value );
+		}
+
+		if ( value instanceof BigInteger ) {
+			return CoercionHelper.toByte( (BigInteger) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toByte( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Byte.parseByte( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce value `%s` [%s] as Byte",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CoercionException.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CoercionException.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.type.descriptor.java;
+
+import org.hibernate.HibernateException;
+
+/**
+ * @author Steve Ebersole
+ */
+public class CoercionException extends HibernateException {
+	public CoercionException(String message) {
+		super( message );
+	}
+
+	public CoercionException(String message, Throwable cause) {
+		super( message, cause );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CoercionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CoercionHelper.java
@@ -1,0 +1,399 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.type.descriptor.java;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Locale;
+
+/**
+ * Helper for type coercions.  Mainly used for narrowing coercions which
+ * might lead to under/over-flow problems
+ *
+ * @author Steve Ebersole
+ */
+public class CoercionHelper {
+	private CoercionHelper() {
+		// disallow direct instantiation
+	}
+
+	public static Byte toByte(Short value) {
+		if ( value > Byte.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Short value `%s` to Byte : overflow",
+							value
+					)
+			);
+		}
+
+		if ( value < Byte.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Short value `%s` to Byte : underflow",
+							value
+					)
+			);
+		}
+
+		return value.byteValue();
+	}
+
+	public static Byte toByte(Integer value) {
+		if ( value > Byte.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Integer value `%s` to Byte : overflow",
+							value
+					)
+			);
+		}
+
+		if ( value < Byte.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Integer value `%s` to Byte : underflow",
+							value
+					)
+			);
+		}
+
+		return value.byteValue();
+	}
+
+	public static Byte toByte(Long value) {
+		if ( value > Byte.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Long value `%s` to Byte : overflow",
+							value
+					)
+			);
+		}
+
+		if ( value < Byte.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Long value `%s` to Byte : underflow",
+							value
+					)
+			);
+		}
+
+		return value.byteValue();
+	}
+
+	public static Byte toByte(Double value) {
+		if ( ! isWholeNumber( value ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Double value `%s` to Byte : not a whole number",
+							value
+					)
+			);
+		}
+
+		if ( value > Byte.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Double value `%s` to Byte : overflow",
+							value
+					)
+			);
+		}
+
+		if ( value < Byte.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Double value `%s` to Byte : underflow",
+							value
+					)
+			);
+		}
+
+		return value.byteValue();
+	}
+
+	public static Byte toByte(Float value) {
+		if ( ! isWholeNumber( value ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Float value `%s` to Byte : not a whole number",
+							value
+					)
+			);
+		}
+
+		if ( value > Byte.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Float value `%s` to Byte : overflow",
+							value
+					)
+			);
+		}
+
+		if ( value < Byte.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Float value `%s` to Byte : underflow",
+							value
+					)
+			);
+		}
+
+		return value.byteValue();
+	}
+
+	public static Byte toByte(BigInteger value) {
+		return coerceWrappingError( value::byteValueExact );
+	}
+
+	public static Byte toByte(BigDecimal value) {
+		return coerceWrappingError( value::byteValueExact );
+	}
+
+	public static Short toShort(Byte value) {
+		return value.shortValue();
+	}
+
+	public static Short toShort(Integer value) {
+		if ( value > Short.MAX_VALUE ) {
+			throw new CoercionException( "Cannot coerce Integer value `" + value + "` as Short : overflow" );
+		}
+
+		if ( value < Short.MIN_VALUE ) {
+			throw new CoercionException( "Cannot coerce Integer value `" + value + "` as Short : underflow" );
+		}
+
+		return value.shortValue();
+	}
+
+	public static Short toShort(Long value) {
+		if ( value > Short.MAX_VALUE ) {
+			throw new CoercionException( "Cannot coerce Long value `" + value + "` as Short : overflow" );
+		}
+
+		if ( value < Short.MIN_VALUE ) {
+			throw new CoercionException( "Cannot coerce Long value `" + value + "` as Short : underflow" );
+		}
+
+		return value.shortValue();
+	}
+
+	public static Short toShort(Double doubleValue) {
+		if ( ! isWholeNumber( doubleValue ) ) {
+			throw new CoercionException( "Cannot coerce Double value `" + doubleValue + "` as Short : not a whole number" );
+		}
+		return toShort( doubleValue.longValue() );
+	}
+
+	public static Short toShort(Float floatValue) {
+		if ( ! isWholeNumber( floatValue ) ) {
+			throw new CoercionException( "Cannot coerce Float value `" + floatValue + "` as Short : not a whole number" );
+		}
+		return toShort( floatValue.longValue() );
+	}
+
+	public static Short toShort(BigInteger value) {
+		return coerceWrappingError( value::shortValueExact );
+	}
+
+	public static Short toShort(BigDecimal value) {
+		return coerceWrappingError( value::shortValueExact );
+	}
+
+	public static Integer toInteger(Byte value) {
+		return value.intValue();
+	}
+
+	public static Integer toInteger(Short value) {
+		return value.intValue();
+	}
+
+	public static Integer toInteger(Long value) {
+		return coerceWrappingError( () -> Math.toIntExact( value ) );
+	}
+
+	public static Integer toInteger(Double doubleValue) {
+		if ( ! isWholeNumber( doubleValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Double value `%s` to Integer: not a whole number",
+							doubleValue
+					)
+			);
+		}
+
+		return toInteger( doubleValue.longValue() );
+	}
+
+	public static Integer toInteger(Float floatValue) {
+		if ( ! isWholeNumber( floatValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Float value `%s` to Integer: not a whole number",
+							floatValue
+					)
+			);
+		}
+
+		return toInteger( floatValue.longValue() );
+	}
+
+	public static Integer toInteger(BigInteger value) {
+		return coerceWrappingError( value::intValueExact );
+	}
+
+	public static Integer toInteger(BigDecimal value) {
+		return coerceWrappingError( value::intValueExact );
+	}
+
+	public static Long toLong(Byte value) {
+		return value.longValue();
+	}
+
+	public static Long toLong(Short value) {
+		return value.longValue();
+	}
+
+	public static Long toLong(Integer value) {
+		return value.longValue();
+	}
+
+	public static Long toLong(Double doubleValue) {
+		if ( ! isWholeNumber( doubleValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Double value `%s` as Integer: not a whole number",
+							doubleValue
+					)
+			);
+		}
+		return doubleValue.longValue();
+	}
+
+	public static Long toLong(Float floatValue) {
+		if ( ! isWholeNumber( floatValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Float value `%s` as Integer: not a whole number",
+							floatValue
+					)
+			);
+		}
+		return floatValue.longValue();
+	}
+
+	public static Long toLong(BigInteger value) {
+		return coerceWrappingError( value::longValueExact );
+	}
+
+	public static Long toLong(BigDecimal value) {
+		return coerceWrappingError( value::longValueExact );
+	}
+
+	public static BigInteger toBigInteger(Double doubleValue) {
+		if ( ! isWholeNumber( doubleValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Double value `%s` as BigInteger: not a whole number",
+							doubleValue
+					)
+			);
+		}
+		return BigInteger.valueOf( doubleValue.longValue() );
+	}
+
+	public static BigInteger toBigInteger(Float floatValue) {
+		if ( ! isWholeNumber( floatValue ) ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Unable to coerce Double Float `%s` as BigInteger: not a whole number",
+							floatValue
+					)
+			);
+		}
+		return BigInteger.valueOf( floatValue.longValue() );
+	}
+
+	public static BigInteger toBigInteger(BigDecimal value) {
+		return coerceWrappingError( value::toBigIntegerExact );
+	}
+
+	public static Double toDouble(Float floatValue) {
+		if ( floatValue > (float) Double.MAX_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Float value `%s` to Double : overflow",
+							floatValue
+					)
+			);
+		}
+
+		if ( floatValue < (float) Double.MIN_VALUE ) {
+			throw new CoercionException(
+					String.format(
+							Locale.ROOT,
+							"Cannot coerce Float value `%s` to Double : underflow",
+							floatValue
+					)
+			);
+		}
+
+		return (double) floatValue;
+	}
+
+	public static Double toDouble(BigInteger value) {
+		return coerceWrappingError( value::doubleValue );
+	}
+
+	public static Double toDouble(BigDecimal value) {
+		return coerceWrappingError( value::doubleValue );
+	}
+
+	public static boolean isWholeNumber(double doubleValue) {
+		return doubleValue % 1 == 0;
+	}
+
+	public static boolean isWholeNumber(float floatValue) {
+		return floatValue == ( (float) (long) floatValue );
+	}
+
+	@FunctionalInterface
+	public interface Coercer<T> {
+		T doCoercion();
+	}
+
+	public static <T> T coerceWrappingError(Coercer<T> coercer) {
+		try {
+			return coercer.doCoercion();
+		}
+		catch (ArithmeticException | NumberFormatException e) {
+			throw new CoercionException( "Error coercing value", e );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleTypeDescriptor.java
@@ -9,6 +9,7 @@ package org.hibernate.type.descriptor.java;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
+import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -120,5 +121,59 @@ public class DoubleTypeDescriptor extends AbstractClassTypeDescriptor<Double> im
 		return dialect.getDoublePrecision();
 	}
 
+
+	@Override
+	public <X> Double coerce(X value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Double ) {
+			return ( (Double) value );
+		}
+
+		if ( value instanceof Byte ) {
+			return ( (Byte) value ).doubleValue();
+		}
+
+		if ( value instanceof Short ) {
+			return ( (Short) value ).doubleValue();
+		}
+
+		if ( value instanceof Integer ) {
+			return ( (Integer) value ).doubleValue();
+		}
+
+		if ( value instanceof Long ) {
+			return ( (Long) value ).doubleValue();
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toDouble( (float) value );
+		}
+
+		if ( value instanceof BigInteger ) {
+			return CoercionHelper.toDouble( (BigInteger) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toDouble( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Double.parseDouble( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce value `%s` [%s] as Double",
+						value,
+						value.getClass().getName()
+				)
+		);
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatTypeDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -108,5 +109,59 @@ public class FloatTypeDescriptor extends AbstractClassTypeDescriptor<Float> impl
 		//this is the number of *binary* digits
 		//in a single-precision FP number
 		return dialect.getFloatPrecision();
+	}
+
+	@Override
+	public <X> Float coerce(X value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Float ) {
+			return (Float) value;
+		}
+
+		if ( value instanceof Double ) {
+			return ( (Double) value ).floatValue();
+		}
+
+		if ( value instanceof Byte ) {
+			return ( (Byte) value ).floatValue();
+		}
+
+		if ( value instanceof Short ) {
+			return ( (Short) value ).floatValue();
+		}
+
+		if ( value instanceof Integer ) {
+			return ( (Integer) value ).floatValue();
+		}
+
+		if ( value instanceof Long ) {
+			return ( (Long) value ).floatValue();
+		}
+
+		if ( value instanceof BigInteger ) {
+			return ( (BigInteger) value ).floatValue();
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return ( (BigDecimal) value ).floatValue();
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Float.parseFloat( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce value `%s` [%s] as Float",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerTypeDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -109,5 +110,59 @@ public class IntegerTypeDescriptor extends AbstractClassTypeDescriptor<Integer> 
 	@Override
 	public int getDefaultSqlScale() {
 		return 0;
+	}
+
+	@Override
+	public Integer coerce(Object value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Integer ) {
+			return (int) value;
+		}
+
+		if ( value instanceof Short ) {
+			return CoercionHelper.toInteger( (short) value );
+		}
+
+		if ( value instanceof Byte ) {
+			return CoercionHelper.toInteger( (byte) value );
+		}
+
+		if ( value instanceof Long ) {
+			return CoercionHelper.toInteger( (long) value );
+		}
+
+		if ( value instanceof Double ) {
+			return CoercionHelper.toInteger( (double) value );
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toInteger( (float) value );
+		}
+
+		if ( value instanceof BigInteger ) {
+			return CoercionHelper.toInteger( (BigInteger) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toInteger( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Integer.parseInt( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce vale `%s` [%s] as Integer",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeDescriptor.java
@@ -18,6 +18,7 @@ import org.hibernate.internal.util.compare.ComparableComparator;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeDescriptor;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeDescriptorIndicators;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Descriptor for the Java side of a value mapping.
@@ -178,6 +179,15 @@ public interface JavaTypeDescriptor<T> extends Serializable {
 	 * @return The wrapped value.
 	 */
 	<X> T wrap(X value, WrapperOptions options);
+
+	interface CoercionContext {
+		TypeConfiguration getTypeConfiguration();
+	}
+
+	default <X> T coerce(X value, CoercionContext coercionContext) {
+		//noinspection unchecked
+		return (T) value;
+	}
 
 	/**
 	 * Retrieve the Java type handled here.

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongTypeDescriptor.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -74,16 +75,70 @@ public class LongTypeDescriptor extends AbstractClassTypeDescriptor<Long> implem
 		if ( value == null ) {
 			return null;
 		}
-		if ( Long.class.isInstance( value ) ) {
+		if ( value instanceof Long ) {
 			return (Long) value;
 		}
-		if ( Number.class.isInstance( value ) ) {
+		if ( value instanceof Number ) {
 			return ( (Number) value ).longValue();
 		}
-		else if ( String.class.isInstance( value ) ) {
+		else if ( value instanceof String ) {
 			return Long.valueOf( ( (String) value ) );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public <X> Long coerce(X value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Long ) {
+			return ( (Long) value );
+		}
+
+		if ( value instanceof Byte ) {
+			return CoercionHelper.toLong( (Byte) value );
+		}
+
+		if ( value instanceof Short ) {
+			return CoercionHelper.toLong( (Short) value );
+		}
+
+		if ( value instanceof Integer ) {
+			return CoercionHelper.toLong( (Integer) value );
+		}
+
+		if ( value instanceof Double ) {
+			return CoercionHelper.toLong( (Double) value );
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toLong( (Float) value );
+		}
+
+		if ( value instanceof BigInteger ) {
+			return CoercionHelper.toLong( (BigInteger) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toLong( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Long.parseLong( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce value `%s` [%s] as Long",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortTypeDescriptor.java
@@ -5,6 +5,10 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type.descriptor.java;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Locale;
+
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.Primitive;
@@ -76,7 +80,7 @@ public class ShortTypeDescriptor extends AbstractClassTypeDescriptor<Short> impl
 	}
 
 	@Override
-	public Class getPrimitiveClass() {
+	public Class<Short> getPrimitiveClass() {
 		return short.class;
 	}
 
@@ -98,5 +102,59 @@ public class ShortTypeDescriptor extends AbstractClassTypeDescriptor<Short> impl
 	@Override
 	public int getDefaultSqlScale() {
 		return 0;
+	}
+
+	@Override
+	public Short coerce(Object value, CoercionContext coercionContext) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof Short ) {
+			return (short) value;
+		}
+
+		if ( value instanceof Byte ) {
+			return CoercionHelper.toShort( (Byte) value );
+		}
+
+		if ( value instanceof Integer ) {
+			return CoercionHelper.toShort( (Integer) value );
+		}
+
+		if ( value instanceof Long ) {
+			return CoercionHelper.toShort( (Long) value );
+		}
+
+		if ( value instanceof Double ) {
+			return CoercionHelper.toShort( (Double) value );
+		}
+
+		if ( value instanceof Float ) {
+			return CoercionHelper.toShort( (Float) value );
+		}
+
+		if ( value instanceof BigInteger ) {
+			return CoercionHelper.toShort( (BigInteger) value );
+		}
+
+		if ( value instanceof BigDecimal ) {
+			return CoercionHelper.toShort( (BigDecimal) value );
+		}
+
+		if ( value instanceof String ) {
+			return CoercionHelper.coerceWrappingError(
+					() -> Short.parseShort( (String) value )
+			);
+		}
+
+		throw new CoercionException(
+				String.format(
+						Locale.ROOT,
+						"Cannot coerce value `%s` [%s] as Short",
+						value,
+						value.getClass().getName()
+				)
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/jpa/JpaComplianceStub.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/JpaComplianceStub.java
@@ -53,4 +53,9 @@ public class JpaComplianceStub implements JpaCompliance {
 	public boolean isJpaOrderByMappingComplianceEnabled() {
 		return false;
 	}
+
+	@Override
+	public boolean isLoadByIdComplianceEnabled() {
+		return false;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/emops/GetReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/emops/GetReferenceTest.java
@@ -8,7 +8,6 @@ package org.hibernate.orm.test.jpa.emops;
 
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -17,11 +16,14 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Emmanuel Bernard
  */
 
-@Jpa(annotatedClasses = {
-		Competitor.class,
-		Race.class,
-		Mail.class
-})
+@Jpa(
+		annotatedClasses = {
+				Competitor.class,
+				Race.class,
+				Mail.class
+		},
+		loadByIdComplianceEnabled = true
+)
 public class GetReferenceTest {
 	@Test
 	public void testWrongIdType(EntityManagerFactoryScope scope) {
@@ -40,6 +42,34 @@ public class GetReferenceTest {
 
 					try {
 						entityManager.getReference( Mail.class, 1 );
+						fail("Expected IllegalArgumentException");
+					}
+					catch (IllegalArgumentException e) {
+						//success
+					}
+					catch ( Exception e ) {
+						fail("Wrong exception: " + e );
+					}
+				}
+		);
+	}
+	@Test
+	public void testWrongIdTypeFind(EntityManagerFactoryScope scope) {
+		scope.inEntityManager(
+				entityManager -> {
+					try {
+						entityManager.find( Competitor.class, "30" );
+						fail("Expected IllegalArgumentException");
+					}
+					catch (IllegalArgumentException e) {
+						//success
+					}
+					catch ( Exception e ) {
+						fail("Wrong exception: " + e );
+					}
+
+					try {
+						entityManager.find( Mail.class, 1 );
 						fail("Expected IllegalArgumentException");
 					}
 					catch (IllegalArgumentException e) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/CoercionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/CoercionTests.java
@@ -1,0 +1,313 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.mapping.type.java;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.query.spi.QueryImplementor;
+import org.hibernate.type.descriptor.java.CoercionException;
+import org.hibernate.type.descriptor.java.CoercionHelper;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptorRegistry;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import org.hamcrest.Matchers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for implicit widening coercions
+ *
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = CoercionTests.TheEntity.class )
+@SessionFactory
+public class CoercionTests {
+	final short shortValue = 1;
+	final byte byteValue = 1;
+	final int intValue = 1;
+	final long longValue = 1L;
+	final double doubleValue = 0.5;
+	final float floatValue = 0.5F;
+
+	final long largeLongValue = Integer.MAX_VALUE + 1L;
+	final float largeFloatValue = (float) Double.MAX_VALUE + 1.5F;
+
+	@Test
+	public void testCoercibleDetection(SessionFactoryScope scope) {
+		final TypeConfiguration typeConfiguration = scope.getSessionFactory().getTypeConfiguration();
+		final JavaTypeDescriptorRegistry jtdRegistry = typeConfiguration.getJavaTypeDescriptorRegistry();
+
+		final JavaTypeDescriptor<Integer> integerType = jtdRegistry.resolveDescriptor( Integer.class );
+		final JavaTypeDescriptor<Long> longType = jtdRegistry.resolveDescriptor( Long.class );
+		final JavaTypeDescriptor<Double> doubleType = jtdRegistry.resolveDescriptor( Double.class );
+		final JavaTypeDescriptor<Float> floatType = jtdRegistry.resolveDescriptor( Float.class );
+
+		scope.inTransaction(
+				(session) -> {
+					checkIntegerConversions( integerType, session );
+					checkLongConversions( longType, session );
+
+					checkDoubleConversions( doubleType, session );
+				}
+		);
+	}
+
+	private void checkDoubleConversions(JavaTypeDescriptor<Double> doubleType, SessionImplementor session) {
+		assertThat( doubleType.coerce( (double) 1, session ), Matchers.is( 1.0 ) );
+		assertThat( doubleType.coerce( 1F, session ), Matchers.is( 1.0 ) );
+		assertThat( doubleType.coerce( doubleValue, session ), Matchers.is( doubleValue ) );
+		assertThat( doubleType.coerce( floatValue, session ), Matchers.is( doubleValue ) );
+
+		assertThat( doubleType.coerce( largeFloatValue, session ), Matchers.is( (double) largeFloatValue ) );
+
+		assertThat( doubleType.coerce( shortValue, session ), Matchers.is( 1.0 ) );
+		assertThat( doubleType.coerce( byteValue, session ), Matchers.is( 1.0 ) );
+		assertThat( doubleType.coerce( longValue, session ), Matchers.is( 1.0 ) );
+
+		assertThat( doubleType.coerce( BigInteger.ONE, session ), Matchers.is( 1.0 ) );
+		assertThat( doubleType.coerce( BigDecimal.ONE, session ), Matchers.is( 1.0 ) );
+
+		// negative checks
+	}
+
+	private void checkIntegerConversions(JavaTypeDescriptor<Integer> integerType, SessionImplementor session) {
+		assertThat( integerType.coerce( intValue, session ), Matchers.is( intValue) );
+
+		assertThat( integerType.coerce( shortValue, session ), Matchers.is( intValue) );
+		assertThat( integerType.coerce( byteValue, session ), Matchers.is( intValue) );
+
+		assertThat( integerType.coerce( longValue, session ), Matchers.is( intValue) );
+
+		assertThat( integerType.coerce( (double) 1, session ), Matchers.is( intValue) );
+		assertThat( integerType.coerce( 1F, session ), Matchers.is( intValue) );
+
+		assertThat( integerType.coerce( BigInteger.ONE, session ), Matchers.is( intValue) );
+		assertThat( integerType.coerce( BigDecimal.ONE, session ), Matchers.is( intValue) );
+
+		// negative checks
+		checkDisallowedConversion( () -> integerType.coerce( largeLongValue, session ) );
+		checkDisallowedConversion( () -> integerType.coerce( largeFloatValue, session ) );
+		checkDisallowedConversion( () -> integerType.coerce( doubleValue, session ) );
+		checkDisallowedConversion( () -> integerType.coerce( floatValue, session ) );
+	}
+
+	private void checkLongConversions(JavaTypeDescriptor<Long> longType, SessionImplementor session) {
+		assertThat( longType.coerce( longValue, session ), Matchers.is( longValue ) );
+		assertThat( longType.coerce( largeLongValue, session ), Matchers.is( largeLongValue ) );
+
+		assertThat( longType.coerce( intValue, session ), Matchers.is( longValue ) );
+		assertThat( longType.coerce( shortValue, session ), Matchers.is( longValue ) );
+		assertThat( longType.coerce( byteValue, session ), Matchers.is( longValue ) );
+
+		assertThat( longType.coerce( (double) 1, session ), Matchers.is( longValue ) );
+		assertThat( longType.coerce( 1F, session ), Matchers.is( longValue ) );
+
+		assertThat( longType.coerce( BigInteger.ONE, session ), Matchers.is( longValue ) );
+		assertThat( longType.coerce( BigDecimal.ONE, session ), Matchers.is( longValue ) );
+
+		// negative checks
+		checkDisallowedConversion( () -> longType.coerce( largeFloatValue, session ) );
+		checkDisallowedConversion( () -> longType.coerce( doubleValue, session ) );
+		checkDisallowedConversion( () -> longType.coerce( floatValue, session ) );
+	}
+
+	private void checkDisallowedConversion(CoercionHelper.Coercer callback) {
+		try {
+			callback.doCoercion();
+			fail( "Expecting coercion to fail" );
+		}
+		catch (CoercionException expected) {
+		}
+	}
+
+	@Test
+	public void testLoading(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					session.byId( TheEntity.class ).load( 1L );
+
+					session.byId( TheEntity.class ).load( (byte) 1 );
+					session.byId( TheEntity.class ).load( (short) 1 );
+					session.byId( TheEntity.class ).load( 1 );
+
+					session.byId( TheEntity.class ).load( 1.0 );
+					session.byId( TheEntity.class ).load( 1.0F );
+
+					session.byId( TheEntity.class ).load( BigInteger.ONE );
+					session.byId( TheEntity.class ).load( BigDecimal.ONE );
+				}
+		);
+		scope.inTransaction(
+				(session) -> {
+					session.byId( TheEntity.class ).getReference( 1L );
+					session.byId( TheEntity.class ).getReference( 1 );
+				}
+		);
+	}
+
+	@Test
+	public void testMultiIdLoading(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					session.byMultipleIds( TheEntity.class ).multiLoad( 1L );
+
+					session.byMultipleIds( TheEntity.class ).multiLoad( (byte) 1 );
+					session.byMultipleIds( TheEntity.class ).multiLoad( (short) 1 );
+					session.byMultipleIds( TheEntity.class ).multiLoad( 1 );
+
+					session.byMultipleIds( TheEntity.class ).multiLoad( 1.0 );
+					session.byMultipleIds( TheEntity.class ).multiLoad( 1.0F );
+
+					session.byMultipleIds( TheEntity.class ).multiLoad( BigInteger.ONE );
+					session.byMultipleIds( TheEntity.class ).multiLoad( BigDecimal.ONE );
+				}
+		);
+		scope.inTransaction(
+				(session) -> {
+					session.byMultipleIds( TheEntity.class ).multiLoad( Arrays.asList( 1L ) );
+					session.byMultipleIds( TheEntity.class ).multiLoad( Arrays.asList( 1 ) );
+				}
+		);
+	}
+
+	@Test
+	public void testNaturalIdLoading(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					session.bySimpleNaturalId( TheEntity.class ).load( 1L );
+
+					session.bySimpleNaturalId( TheEntity.class ).load( (byte) 1 );
+					session.bySimpleNaturalId( TheEntity.class ).load( (short) 1 );
+					session.bySimpleNaturalId( TheEntity.class ).load( 1 );
+
+					session.bySimpleNaturalId( TheEntity.class ).load( 1.0 );
+					session.bySimpleNaturalId( TheEntity.class ).load( 1.0F );
+
+					session.bySimpleNaturalId( TheEntity.class ).load( BigInteger.ONE );
+					session.bySimpleNaturalId( TheEntity.class ).load( BigDecimal.ONE );
+				}
+		);
+		scope.inTransaction(
+				(session) -> {
+					session.byMultipleIds( TheEntity.class ).multiLoad( Arrays.asList( 1L ) );
+					session.byMultipleIds( TheEntity.class ).multiLoad( Arrays.asList( 1 ) );
+				}
+		);
+	}
+
+	@Test
+	public void testMultiNaturalIdLoading(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( 1L );
+
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( (byte) 1 );
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( (short) 1 );
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( 1 );
+
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( 1.0 );
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( 1.0F );
+
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( BigInteger.ONE );
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( BigDecimal.ONE );
+				}
+		);
+		scope.inTransaction(
+				(session) -> {
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( Arrays.asList( 1L ) );
+					session.byMultipleNaturalId( TheEntity.class ).enableOrderedReturn( false ).multiLoad( Arrays.asList( 1 ) );
+				}
+		);
+	}
+
+	@Test
+	public void testQueryParameterIntegralWiden(SessionFactoryScope scope) {
+		final String qry = "select e from TheEntity e where e.longId = :id";
+
+		scope.inTransaction(
+				(session) -> {
+					final QueryImplementor query = session.createQuery( qry );
+
+					query.setParameter( "id", 1L ).list();
+
+					query.setParameter( "id", 1 ).list();
+				}
+		);
+	}
+
+	@Test
+	public void testQueryParameterIntegralNarrow(SessionFactoryScope scope) {
+		final String qry = "select e from TheEntity e where e.intValue = ?1";
+
+		scope.inTransaction(
+				(session) -> {
+					final QueryImplementor query = session.createQuery( qry );
+
+					query.setParameter( 1, 1 ).list();
+
+					query.setParameter( 1, 1L ).list();
+				}
+		);
+	}
+
+	@Test
+	public void testQueryParameterFloatingWiden(SessionFactoryScope scope) {
+		final String qry = "select e from TheEntity e where e.floatValue = :p";
+
+		scope.inTransaction(
+				(session) -> {
+					final QueryImplementor query = session.createQuery( qry );
+
+					query.setParameter( "p", 0.5f ).list();
+
+					query.setParameter( "p", 0.5 ).list();
+				}
+		);
+	}
+
+	@Test
+	public void testQueryParameterFloatingNarrow(SessionFactoryScope scope) {
+		final String qry = "select e from TheEntity e where e.doubleValue = :p";
+
+		scope.inTransaction(
+				(session) -> {
+					final QueryImplementor query = session.createQuery( qry );
+
+					query.setParameter( "p", 0.5 ).list();
+
+					query.setParameter( "p", 0.5f ).list();
+				}
+		);
+	}
+
+	@Entity( name = "TheEntity" )
+	@Table( name = "the_entity" )
+	public static class TheEntity {
+		@Id
+		private Long longId;
+		@NaturalId
+		private Long longNaturalId;
+		private Integer intValue;
+		private Float floatValue;
+		private Double doubleValue;
+
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
@@ -48,8 +48,9 @@ import org.jboss.logging.Logger;
  * including argument injection (or see {@link SessionFactoryScopeAware})
  *
  * @author Steve Ebersole
- * @see SessionFactoryScope
+ *
  * @see DomainModelExtension
+ * @see SessionFactoryExtension
  */
 public class EntityManagerFactoryExtension
 		implements TestInstancePostProcessor, AfterAllCallback, TestExecutionExceptionHandler {
@@ -79,8 +80,7 @@ public class EntityManagerFactoryExtension
 				context.getElement().get(),
 				Jpa.class
 		);
-		final Jpa emfAnn = emfAnnWrapper.orElseThrow( () -> new RuntimeException(
-				"Could not locate @EntityManagerFactory" ) );
+		final Jpa emfAnn = emfAnnWrapper.orElseThrow( () -> new RuntimeException( "Could not locate @EntityManagerFactory" ) );
 
 		final PersistenceUnitInfoImpl pui = new PersistenceUnitInfoImpl( emfAnn.persistenceUnitName() );
 
@@ -88,6 +88,17 @@ public class EntityManagerFactoryExtension
 		pui.setCacheMode( emfAnn.sharedCacheMode() );
 		pui.setValidationMode( emfAnn.validationMode() );
 		pui.setExcludeUnlistedClasses( emfAnn.excludeUnlistedClasses() );
+
+		// JpaCompliance
+		pui.getProperties().put( AvailableSettings.JPA_QUERY_COMPLIANCE, emfAnn.queryComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, emfAnn.transactionComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_LIST_COMPLIANCE, emfAnn.listMappingComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_CLOSED_COMPLIANCE, emfAnn.closedComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_PROXY_COMPLIANCE, emfAnn.proxyComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_CACHING_COMPLIANCE, emfAnn.cacheComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE, emfAnn.generatorScopeComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_ORDER_BY_MAPPING_COMPLIANCE, emfAnn.orderByMappingComplianceEnabled() );
+		pui.getProperties().put( AvailableSettings.JPA_LOAD_BY_ID_COMPLIANCE, emfAnn.loadByIdComplianceEnabled() );
 
 		final Setting[] properties = emfAnn.properties();
 		for ( int i = 0; i < properties.length; i++ ) {
@@ -301,8 +312,6 @@ public class EntityManagerFactoryExtension
 		}
 
 		protected javax.persistence.EntityManagerFactory createEntityManagerFactory() {
-
-
 			final EntityManagerFactoryBuilder emfBuilder = Bootstrap.getEntityManagerFactoryBuilder(
 					new PersistenceUnitInfoDescriptor( persistenceUnitInfo ),
 					integrationSettings

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/Jpa.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/Jpa.java
@@ -16,6 +16,8 @@ import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 
+import org.hibernate.jpa.spi.JpaCompliance;
+
 import org.hibernate.testing.orm.domain.DomainModelDescriptor;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.jpa.NonStringValueSettingProvider;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith( FailureExpectedExtension.class )
 public @interface Jpa {
+	String persistenceUnitName() default "test-pu";
 
 	/**
 	 * Used to mimic container integration
@@ -45,8 +48,6 @@ public @interface Jpa {
 	Setting[] integrationSettings() default {};
 
 	Class<? extends NonStringValueSettingProvider>[] nonStringValueSettingProviders() default {};
-
-	String persistenceUnitName() default "test-pu";
 
 	// todo : multiple persistence units?
 
@@ -61,6 +62,51 @@ public @interface Jpa {
 	PersistenceUnitTransactionType transactionType() default PersistenceUnitTransactionType.RESOURCE_LOCAL;
 	SharedCacheMode sharedCacheMode() default SharedCacheMode.UNSPECIFIED;
 	ValidationMode validationMode() default ValidationMode.NONE;
+
+	/**
+	 * @see JpaCompliance#isJpaQueryComplianceEnabled()
+	 */
+	boolean queryComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaTransactionComplianceEnabled()
+	 */
+	boolean transactionComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaClosedComplianceEnabled()
+	 */
+	boolean closedComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaListComplianceEnabled()
+	 */
+	boolean listMappingComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaOrderByMappingComplianceEnabled()
+	 */
+	boolean orderByMappingComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaProxyComplianceEnabled()
+	 */
+	boolean proxyComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isJpaCacheComplianceEnabled()
+	 */
+	boolean cacheComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isGlobalGeneratorScopeEnabled()
+	 */
+	boolean generatorScopeComplianceEnabled() default false;
+
+	/**
+	 * @see JpaCompliance#isLoadByIdComplianceEnabled()
+	 */
+	boolean loadByIdComplianceEnabled() default false;
 
 	boolean excludeUnlistedClasses() default false;
 


### PR DESCRIPTION
Support for type coercion for values passed as ids and as query parameter bindings

- widening coercions
- valid (no over/under flow) narrowing coercions

NOTE : this leads to (1) test failure which explicitly tests for load-by-id type mismatches to fail.  JPA requires this.  Either we should drop load-by-id as part of this work, or cover this under `JpaCompliance`.  