### PR TITLE
Only apply --add-opens to compiler JVM options when using JDK9+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 # Keep all these properties in sync unless you know what you are doing!
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-# Needs add-opens because of https://github.com/gradle/gradle/issues/15538
-toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.javadoc.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.launcher.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -137,6 +137,8 @@ else {
 			options.compilerArgs << gradle.ext.javaVersions.main.release.toString()
 		} else {
 			options.release = gradle.ext.javaVersions.main.release.asInt()
+			// Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+			options.forkOptions.jvmArgs.addAll( ["--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"] )
 		}
 	}
 	tasks.compileTestJava.configure {
@@ -147,6 +149,8 @@ else {
 			options.compilerArgs << gradle.ext.javaVersions.test.release.toString()
 		} else {
 			options.release = gradle.ext.javaVersions.test.release.asInt()
+			// Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+			options.forkOptions.jvmArgs.addAll( ["--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"] )
 		}
 	}
 


### PR DESCRIPTION
Without this, I simply cannot run this locally:

```
./gradlew clean :hibernate-integrationtest-java-modules:test -Ptest.jdk.version=11 -Porg.gradle.java.installations.paths=$HOME/tools/java/jdk1.8,$HOME/tools/java/jdk11
```

It fails when the (JDK8) compiler encounters the `--add-opens` option, which is normal because that option isn't supported in JDK8:

```
> Task :hibernate-core:compileJava FAILED
Compiling with '/home/yrodiere/tools/java/jdk8u222-b10'
Unrecognized option: --add-opens
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

FAILURE: Build failed with an exception.
```

For some reason we don't get this failure on CI; I have no idea why. Regardless, it seems to me that there is a problem and it should be fixed.