### PR TITLE
Backport to 5.4: Only apply --add-opens to compiler JVM options when using JDK9+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 # Keep all these properties in sync unless you know what you are doing!
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-# Needs add-opens because of https://github.com/gradle/gradle/issues/15538
-toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.javadoc.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.launcher.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -137,6 +137,8 @@ else {
 			options.compilerArgs << gradle.ext.javaVersions.main.release.toString()
 		} else {
 			options.release = gradle.ext.javaVersions.main.release.asInt()
+			// Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+			options.forkOptions.jvmArgs.addAll( ["--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"] )
 		}
 	}
 	tasks.compileTestJava.configure {
@@ -147,6 +149,8 @@ else {
 			options.compilerArgs << gradle.ext.javaVersions.test.release.toString()
 		} else {
 			options.release = gradle.ext.javaVersions.test.release.asInt()
+			// Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+			options.forkOptions.jvmArgs.addAll( ["--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"] )
 		}
 	}
 


### PR DESCRIPTION
Running CI before I backport this...