### PR TITLE
wip/6.0 HHH 14605 Handling for BLOB, CLOB and NCLOB relative to JavaTypeDescriptor `#isString` and `#isBinary`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeDescriptor.java
@@ -60,7 +60,6 @@ public interface JdbcTypeDescriptor extends Serializable {
 	 */
 	boolean canBeRemapped();
 
-	@SuppressWarnings("unchecked")
 	default <T> BasicJavaDescriptor<T> getJdbcRecommendedJavaTypeMapping(TypeConfiguration typeConfiguration) {
 		// match legacy behavior
 		return (BasicJavaDescriptor<T>) typeConfiguration.getJavaTypeDescriptorRegistry().getDescriptor(
@@ -129,6 +128,7 @@ public interface JdbcTypeDescriptor extends Serializable {
 			case Types.BINARY:
 			case Types.VARBINARY:
 			case Types.LONGVARBINARY:
+			case Types.BLOB:
 				return true;
 		}
 		return false;
@@ -142,6 +142,8 @@ public interface JdbcTypeDescriptor extends Serializable {
 			case Types.NVARCHAR:
 			case Types.LONGVARCHAR:
 			case Types.LONGNVARCHAR:
+			case Types.CLOB:
+			case Types.NCLOB:
 				return true;
 		}
 		return false;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14605

Given we have discussed about this, especially we have confirmed with Beikov, we can go ahead to fix it right away. See the discussion in https://github.com/hibernate/hibernate-orm/pull/3974.