### PR TITLE
make logFlushResults() protected for the benefit of HR

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -104,8 +104,8 @@ public abstract class AbstractFlushingEventListener implements JpaBootstrapSensi
 		logFlushResults( event );
 	}
 
-	@SuppressWarnings( value = {"unchecked"} )
-	private void logFlushResults(FlushEvent event) {
+	@SuppressWarnings("unchecked")
+	protected void logFlushResults(FlushEvent event) {
 		if ( !LOG.isDebugEnabled() ) {
 			return;
 		}


### PR DESCRIPTION
A very minor change so HR can call  `logFlushResults()`.