### PR TITLE
HHH-14620 Do not initialize collections just to take a snapshot of their size

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionLoadingTest.java
@@ -91,7 +91,6 @@ public class LazyCollectionLoadingTest extends BaseCoreFunctionalTestCase {
             Parent parent = s.load( Parent.class, parentID );
             assertThat( parent, notNullValue() );
             assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
-            assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
             assertFalse( isPropertyInitialized( parent, "children" ) );
             checkDirtyTracking( parent );
 
@@ -116,7 +115,6 @@ public class LazyCollectionLoadingTest extends BaseCoreFunctionalTestCase {
             // find will not return a proxy, which is exactly what we want here.
             Parent parent = s.find( Parent.class, parentID );
             assertThat( parent, notNullValue() );
-            assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
             assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
             assertFalse( isPropertyInitialized( parent, "children" ) );
             checkDirtyTracking( parent );
@@ -144,7 +142,6 @@ public class LazyCollectionLoadingTest extends BaseCoreFunctionalTestCase {
         doInHibernate( this::sessionFactory, s -> {
             parent = s.load( Parent.class, parentID );
             assertThat( parent, notNullValue() );
-            assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
             assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
             assertFalse( isPropertyInitialized( parent, "children" ) );
         } );

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/LazyCollectionLoadingTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.Hibernate.isInitialized;
 import static org.hibernate.Hibernate.isPropertyInitialized;
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.checkDirtyTracking;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
@@ -101,7 +102,40 @@ public class LazyCollectionLoadingTest extends BaseCoreFunctionalTestCase {
             checkDirtyTracking( parent );
 
             assertThat( children1, sameInstance( children2 ) );
+
+            assertFalse( isInitialized( children1 ) );
             assertThat( children1.size(), equalTo( CHILDREN_SIZE ) );
+            assertTrue( isInitialized( children1 ) );
+        } );
+    }
+
+    @Test
+    @TestForIssue( jiraKey = "HHH-14620" )
+    public void testTransaction_noProxy() {
+        doInHibernate( this::sessionFactory, s -> {
+            // find will not return a proxy, which is exactly what we want here.
+            Parent parent = s.find( Parent.class, parentID );
+            assertThat( parent, notNullValue() );
+            assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
+            assertThat( parent, not( instanceOf( HibernateProxy.class ) ) );
+            assertFalse( isPropertyInitialized( parent, "children" ) );
+            checkDirtyTracking( parent );
+
+            List<Child> children1 = parent.children;
+            List<Child> children2 = parent.children;
+
+            assertTrue( isPropertyInitialized( parent, "children" ) );
+            checkDirtyTracking( parent );
+
+            assertThat( children1, sameInstance( children2 ) );
+
+            // This check is important: a bug used to cause the collection to be initialized
+            // during the call to parent.children above.
+            // Note the same problem would occur if we were using getters:
+            // we only need extended enhancement to be enabled.
+            assertFalse( isInitialized( children1 ) );
+            assertThat( children1.size(), equalTo( CHILDREN_SIZE ) );
+            assertTrue( isInitialized( children1 ) );
         } );
     }
 
@@ -122,7 +156,10 @@ public class LazyCollectionLoadingTest extends BaseCoreFunctionalTestCase {
 
         checkDirtyTracking( parent );
         assertThat( children1, sameInstance( children2 ) );
+
+        assertFalse( isInitialized( children1 ) );
         assertThat( children1.size(), equalTo( CHILDREN_SIZE ) );
+        assertTrue( isInitialized( children1 ) );
     }
 
     // --- //

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/ondemandload/OnDemandLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/ondemandload/OnDemandLoadTest.java
@@ -119,16 +119,17 @@ public class OnDemandLoadTest extends BaseCoreFunctionalTestCase {
             store.getInventories().size();
             assertTrue( isPropertyInitialized( store, "inventories" ) );
 
-            // the extra Session is the temp Session needed to perform the init
-            assertEquals( 2, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 1, sessionFactory().getStatistics().getSessionCloseCount() );
+            // the extra Sessions are the temp Sessions needed to perform the init:
+            // first the entity, then the collection (since it's lazy)
+            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
 
             // clear Session again.  The collection should still be recognized as initialized from above
             s.clear();
             assertNotNull( store );
             assertTrue( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 1, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
 
             // lets clear the Session again and this time reload the Store
             s.clear();
@@ -138,21 +139,22 @@ public class OnDemandLoadTest extends BaseCoreFunctionalTestCase {
 
             // collection should be back to uninitialized since we have a new entity instance
             assertFalse( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 1, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
             store.getInventories().size();
             assertTrue( isPropertyInitialized( store, "inventories" ) );
 
-            // the extra Session is the temp Session needed to perform the init
-            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+            // the extra Sessions are the temp Sessions needed to perform the init:
+            // first the entity, then the collection (since it's lazy)
+            assertEquals( 5, sessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 4, sessionFactory().getStatistics().getSessionCloseCount() );
 
             // clear Session again.  The collection should still be recognized as initialized from above
             s.clear();
             assertNotNull( store );
             assertTrue( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 5, sessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 4, sessionFactory().getStatistics().getSessionCloseCount() );
         } );
     }
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14620

As far as I can tell this is safe enough for dirty tracking:

* The collection tracker will return a size of -1 for that collection
* Which is exactly the behavior we currently get after
  `$$_hibernane_clearDirtyCollectionNames` is called if a collection has
  been "retrieved" (getter called) but was not initialized.
* This will mainly prevent some optimizations because we will no longer
  be able to tell whether a collection is "dirty" or not.

I think we should be able to restore those optimizations: for
`PersistentCollection` instances, we would store the "initial" size
inside the collection itself upon initialization,
and we would compare THAT size to the current size in implementations
of `$$_hibernate_areCollectionFieldsDirty` (see
`org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates`).

Alternatively we could store the `CollectionTracker` inside the
`PersistentCollection` so that the collection can update the tracker
upon initialization.

However, that's outside the scope of this bug, that would require
significant testing, and that may cause conflicts with ORM 6, so I won't
do it here.

Relates to https://github.com/quarkusio/quarkus/issues/17291, which will be fixed after we release and upgrade the ORM dependency in Quarkus.
