### PR TITLE
Use a proxy based Stream decorator to support close on terminal

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/AbstractProducedQuery.java
@@ -78,12 +78,12 @@ import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.Query;
 import org.hibernate.query.QueryParameter;
+import org.hibernate.query.spi.CloseOnTerminalDecorator;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryParameterBinding;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.spi.QueryParameterListBinding;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
-import org.hibernate.query.spi.StreamDecorator;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
@@ -1599,9 +1599,8 @@ public abstract class AbstractProducedQuery<R> implements QueryImplementor<R> {
 		final ScrollableResultsIterator<R> iterator = new ScrollableResultsIterator<>( scrollableResults );
 		final Spliterator<R> spliterator = Spliterators.spliteratorUnknownSize( iterator, Spliterator.NONNULL );
 
-		return new StreamDecorator<>(
-				StreamSupport.stream( spliterator, false ),
-				iterator::close
+		return CloseOnTerminalDecorator.decorate(
+				StreamSupport.stream( spliterator, false ).onClose( iterator::close )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
@@ -64,7 +64,7 @@ public class CloseOnTerminalDecorator implements InvocationHandler {
 			}
 		}
 
-		if ( !terminal ) {
+		if ( result != null && !terminal ) {
 			if ( delegate == result ) {
 				result = proxy;
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
@@ -1,0 +1,113 @@
+package org.hibernate.query.spi;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.stream.*;
+
+public class CloseOnTerminalDecorator implements InvocationHandler {
+
+	private final BaseStream<?, ?> delegate;
+
+	private CloseOnTerminalDecorator(
+			BaseStream<?, ?> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		boolean terminal;
+
+		switch ( method.getName() ) {
+			case "equals":
+				// Only consider equal when proxies are identical.
+				return proxy == args[0];
+			case "hashCode":
+				// Use hashCode of proxy.
+				return System.identityHashCode( proxy );
+			case "toString":
+				return "CloseOnTerminal{" + delegate + "}";
+
+			case "forEach":
+			case "forEachOrdered":
+			case "toArray":
+			case "reduce":
+			case "collect":
+			case "sum":
+			case "min":
+			case "max":
+			case "count":
+			case "average":
+			case "summaryStatistics":
+			case "anyMatch":
+			case "allMatch":
+			case "noneMatch":
+			case "findFirst":
+			case "findAny":
+				terminal = true;
+				break;
+			default:
+				terminal = false;
+				break;
+		}
+
+		Object result;
+		try {
+			result = method.invoke( delegate, args );
+		} catch (InvocationTargetException e) {
+			throw e.getTargetException();
+		} finally {
+			// Close on terminal
+			if ( terminal ) {
+				delegate.close();
+			}
+		}
+
+		if ( !terminal ) {
+			if ( delegate == result ) {
+				result = proxy;
+
+			} else if ( result instanceof Stream ) {
+				result = decorate( (Stream<?>) result );
+
+			} else if ( result instanceof IntStream ) {
+				result = decorate( (IntStream) result );
+
+			} else if ( result instanceof LongStream ) {
+				result = decorate( (LongStream) result );
+
+			} else if ( result instanceof DoubleStream ) {
+				result = decorate( (DoubleStream) result );
+			}
+		}
+
+		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Stream<T> decorate(Stream<T> delegate) {
+		return decorate( delegate, Stream.class );
+	}
+
+	public static IntStream decorate(IntStream delegate) {
+		return decorate( delegate, IntStream.class );
+	}
+
+	public static LongStream decorate(LongStream delegate) {
+		return decorate( delegate, LongStream.class );
+	}
+
+	public static DoubleStream decorate(DoubleStream delegate) {
+		return decorate( delegate, DoubleStream.class );
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T, S extends BaseStream<T, ?>> S decorate(S delegate, Class<S> type) {
+		return (S) Proxy.newProxyInstance(
+				CloseOnTerminalDecorator.class.getClassLoader(),
+				new Class<?>[] { type },
+				new CloseOnTerminalDecorator( delegate )
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
@@ -85,28 +85,43 @@ public class CloseOnTerminalDecorator implements InvocationHandler {
 		return result;
 	}
 
+	private static final Class<?>[] STREAM = new Class<?>[] { Stream.class };
+
 	@SuppressWarnings("unchecked")
 	public static <T> Stream<T> decorate(Stream<T> delegate) {
-		return decorate( delegate, Stream.class );
+		return (Stream<T>) Proxy.newProxyInstance(
+				CloseOnTerminalDecorator.class.getClassLoader(),
+				STREAM,
+				new CloseOnTerminalDecorator( delegate )
+		);
 	}
+
+	private static final Class<?>[] INT_STREAM = new Class<?>[] { IntStream.class };
 
 	public static IntStream decorate(IntStream delegate) {
-		return decorate( delegate, IntStream.class );
+		return (IntStream) Proxy.newProxyInstance(
+				CloseOnTerminalDecorator.class.getClassLoader(),
+				INT_STREAM,
+				new CloseOnTerminalDecorator( delegate )
+		);
 	}
+
+	private static final Class<?>[] LONG_STREAM = new Class<?>[] { LongStream.class };
 
 	public static LongStream decorate(LongStream delegate) {
-		return decorate( delegate, LongStream.class );
+		return (LongStream) Proxy.newProxyInstance(
+				CloseOnTerminalDecorator.class.getClassLoader(),
+				LONG_STREAM,
+				new CloseOnTerminalDecorator( delegate )
+		);
 	}
+
+	private static final Class<?>[] DOUBLE_STREAM = new Class<?>[] { DoubleStream.class };
 
 	public static DoubleStream decorate(DoubleStream delegate) {
-		return decorate( delegate, DoubleStream.class );
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T, S extends BaseStream<T, ?>> S decorate(S delegate, Class<S> type) {
-		return (S) Proxy.newProxyInstance(
+		return (DoubleStream) Proxy.newProxyInstance(
 				CloseOnTerminalDecorator.class.getClassLoader(),
-				new Class<?>[] { type },
+				DOUBLE_STREAM,
 				new CloseOnTerminalDecorator( delegate )
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/CloseOnTerminalDecorator.java
@@ -45,6 +45,7 @@ public class CloseOnTerminalDecorator implements InvocationHandler {
 			case "noneMatch":
 			case "findFirst":
 			case "findAny":
+			case "toList":
 				terminal = true;
 				break;
 			default:

--- a/hibernate-core/src/test/java/org/hibernate/query/spi/CloseOnTerminalDecoratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/query/spi/CloseOnTerminalDecoratorTest.java
@@ -1,0 +1,87 @@
+package org.hibernate.query.spi;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloseOnTerminalDecoratorTest extends BaseUnitTestCase {
+
+    @Test
+    public void test() {
+        testTerminal( DoubleStream::close );
+
+        testTerminal( stream -> stream.forEach( d -> {} ));
+        testTerminal( stream -> stream.forEachOrdered( d -> {} ));
+
+        testTerminal( DoubleStream::toArray );
+        testTerminal( stream -> stream.reduce( 0.0, Double::sum ) );
+        testTerminal( stream -> stream.collect( ArrayList::new, ArrayList::add, ArrayList::addAll ));
+
+        testTerminal( DoubleStream::sum );
+        testTerminal( DoubleStream::min );
+        testTerminal( DoubleStream::max );
+        testTerminal( DoubleStream::count );
+        testTerminal( DoubleStream::average );
+        testTerminal( DoubleStream::summaryStatistics );
+
+        testTerminal( stream -> stream.anyMatch( d -> d > 0 ) );
+        testTerminal( stream -> stream.allMatch( d -> d > 0 ) );
+        testTerminal( stream -> stream.noneMatch( d -> d > 0 ) );
+
+        testTerminal( DoubleStream::findFirst );
+        testTerminal( DoubleStream::findAny );
+
+        // For exception in terminal operation
+        testTerminal( stream -> stream.peek( d -> {
+            throw new IllegalStateException();
+        }).count(), e -> assertThat( e ).isInstanceOf( IllegalStateException.class ) );
+    }
+
+    private void testTerminal(Consumer<DoubleStream> terminal) {
+        testTerminal( terminal, e -> {} );
+    }
+
+    private void testTerminal(Consumer<DoubleStream> terminal, Consumer<Exception> exceptionHandler) {
+        AtomicInteger counter1 = new AtomicInteger();
+        AtomicInteger counter2 = new AtomicInteger();
+        AtomicInteger counter3 = new AtomicInteger();
+        AtomicInteger counter4 = new AtomicInteger();
+        AtomicInteger counter5 = new AtomicInteger();
+        AtomicInteger counter6 = new AtomicInteger();
+
+        Stream<Integer> stream = Stream.of( 1, 2, 3 )
+                .onClose( counter1::incrementAndGet );
+
+        DoubleStream decoratedStream = CloseOnTerminalDecorator.decorate( stream )
+                .onClose( counter2::incrementAndGet )
+                .map( i -> i * 2 )
+                .onClose( counter3::incrementAndGet )
+                .mapToInt( Integer::intValue )
+                .onClose( counter4::incrementAndGet )
+                .asLongStream()
+                .onClose( counter5::incrementAndGet )
+                .asDoubleStream()
+                .onClose( counter6::incrementAndGet );
+
+        try {
+            terminal.accept( decoratedStream );
+        } catch ( Exception e ) {
+            exceptionHandler.accept( e );
+        }
+
+        assertThat( counter1 ).hasValue( 1 );
+        assertThat( counter2 ).hasValue( 1 );
+        assertThat( counter3 ).hasValue( 1 );
+        assertThat( counter4 ).hasValue( 1 );
+        assertThat( counter5 ).hasValue( 1 );
+        assertThat( counter6 ).hasValue( 1 );
+    }
+
+}


### PR DESCRIPTION
For #4011, here provide a redesign for `Stream` decorator that supports close on terminal.

Inspired by https://rmannibucau.metawerx.net/post/java-stream-decorator.

@NathanQingyangXu @vladmihalcea