### PR TITLE
HHH-14139 BasicBinder Trace Logging Causes Duplicated Message

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -92,7 +92,7 @@ ext {
             jakarta_cdi:            'jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0',
 
             // logging
-            logging:        'org.jboss.logging:jboss-logging:3.4.1.Final',
+            logging:        'org.jboss.logging:jboss-logging:3.4.2.Final',
             logging_annotations: 'org.jboss.logging:jboss-logging-annotations:2.1.0.Final',
             logging_processor:  'org.jboss.logging:jboss-logging-processor:2.1.0.Final',
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14139

The bug is as follows. Suppose one string BasicBinder field contains the "{}" string, the corresponding logging statement would end up as below:
```
binding parameter [2] as [VARCHAR] - [binding parameter [2] as [VARCHAR] - [{}]]
```
not expected statement as:
```
binding parameter [2] as [VARCHAR] - [{}]
```
The root cause is a bug which was fixed by me in jboss-logging:3.4.2.Final: https://issues.redhat.com/browse/JBLOGGING-147?_sscc=t.

This is the only bug fixed in the new version of jboss-logging: https://github.com/jboss-logging/jboss-logging/releases/tag/3.4.2.Final. After we bump our dependency fomr 3.4.1 to it, the issue would be gone automatically.

This bug is only reproducible in SL4J logging framework (as common in Spring Boot project), but not reproducible in our Hibernate testing framework which is based on jboss logging framework.

It is hard to reproduce this bug in our existing Hibernate logging framework but it is pretty easy to reproduce it externally as per the comment https://hibernate.atlassian.net/browse/HHH-14139?focusedCommentId=107034.

Let me know whether I need to reproduce this bug in our testing code (we need to introduce SLF4J and maybe logback Logger dependencies, which might seem overkill). In theory it would be possible but I am not sure whether it is worthwhile or not.
 