### PR TITLE
wip/6.0 HHH-14642 verify Criteria - add DerbyConcatFunction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -11,6 +11,7 @@ import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.CommonFunctionFactory;
+import org.hibernate.dialect.function.DerbyConcatFunction;
 import org.hibernate.dialect.function.DerbyLpadFunction;
 import org.hibernate.dialect.function.DerbyRpadFunction;
 import org.hibernate.dialect.function.IndividualLeastGreatestEmulation;
@@ -209,6 +210,7 @@ public class DerbyDialect extends Dialect {
 		//no way I can see to pad with anything other than spaces
 		queryEngine.getSqmFunctionRegistry().register( "lpad", new DerbyLpadFunction() );
 		queryEngine.getSqmFunctionRegistry().register( "rpad", new DerbyRpadFunction() );
+		queryEngine.getSqmFunctionRegistry().register( "concat", new DerbyConcatFunction() );
 		queryEngine.getSqmFunctionRegistry().register( "least", new IndividualLeastGreatestEmulation( true ) );
 		queryEngine.getSqmFunctionRegistry().register( "greatest", new IndividualLeastGreatestEmulation( false ) );
 		queryEngine.getSqmFunctionRegistry().register( "overlay", new InsertSubstringOverlayEmulation( true ) );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/DerbyConcatFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/DerbyConcatFunction.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect.function;
+
+import java.util.List;
+
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.query.sqm.sql.internal.SqmParameterInterpretation;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * @author Nathan Xu
+ */
+public class DerbyConcatFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
+
+	public DerbyConcatFunction() {
+		super(
+				"concat",
+				StandardArgumentsValidators.min( 1 ),
+				StandardFunctionReturnTypeResolvers.invariant( StandardBasicTypes.STRING )
+		);
+	}
+
+	@Override
+	public void render(
+			SqlAppender sqlAppender,
+			List<SqlAstNode> arguments,
+			SqlAstTranslator<?> walker) {
+		assert arguments.size() > 0;
+
+		boolean hasJdbcParameter = false;
+		for (SqlAstNode argument : arguments) {
+			if ( argument instanceof SqmParameterInterpretation || argument instanceof JdbcParameter ) {
+				hasJdbcParameter = true;
+				break;
+			}
+		}
+
+		if ( hasJdbcParameter ) {
+			sqlAppender.appendSql( "varchar" );
+		}
+		else {
+			if ( arguments.size() == 1 ) {
+				walker.render( arguments.get( 0 ), SqlAstNodeRenderingMode.DEFAULT );
+				return;
+			}
+		}
+
+		sqlAppender.appendSql( "( ");
+		for ( int i = 0; i < arguments.size(); i++ ) {
+			if ( i > 0 ) {
+				sqlAppender.appendSql( " || " );
+			}
+			renderOperand( arguments.get( i ), sqlAppender, walker, hasJdbcParameter );
+		}
+		sqlAppender.appendSql( " )" );
+	}
+
+	private void renderOperand(SqlAstNode operand, SqlAppender sqlAppender, SqlAstTranslator<?> walker, boolean castRequired) {
+		if ( castRequired ) {
+			sqlAppender.appendSql( "cast" );
+		}
+		sqlAppender.appendSql( "( " );
+		walker.render( operand, SqlAstNodeRenderingMode.DEFAULT );
+		if ( castRequired ) {
+			sqlAppender.appendSql( " as varchar(32672)" );
+		}
+		sqlAppender.appendSql( " )" );
+	}
+
+	@Override
+	public String getArgumentListSignature() {
+		return "(arg0[ ,arg1[ ,arg2[...]]])";
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/jpa/ParameterCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/jpa/ParameterCollector.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 import org.hibernate.query.sqm.spi.BaseSemanticQueryWalker;
 import org.hibernate.query.sqm.tree.SqmStatement;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
+import org.hibernate.query.sqm.tree.expression.SqmFunction;
 import org.hibernate.query.sqm.tree.expression.SqmJpaCriteriaParameterWrapper;
 import org.hibernate.query.sqm.tree.expression.SqmNamedParameter;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
@@ -79,6 +80,25 @@ public class ParameterCollector extends BaseSemanticQueryWalker {
 						expression.nodeBuilder()
 				)
 		);
+	}
+
+	@Override
+	public Object visitFunction(SqmFunction sqmFunction) {
+		for ( Object argument : sqmFunction.getArguments() ) {
+			if ( argument instanceof SqmFunction) {
+				visitFunction( (SqmFunction) argument );
+			}
+			else if ( argument instanceof JpaCriteriaParameter ) {
+				visitJpaCriteriaParameter( (JpaCriteriaParameter<?>) argument );
+			}
+			else if ( argument instanceof SqmPositionalParameter ) {
+				visitPositionalParameterExpression( (SqmPositionalParameter) argument );
+			}
+			else if ( argument instanceof SqmNamedParameter ) {
+				visitNamedParameterExpression( ( SqmNamedParameter ) argument );
+			}
+		}
+		return sqmFunction;
 	}
 
 	private SqmParameter<?> visitParameter(SqmParameter<?> param) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/DerbyConcatFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/DerbyConcatFunctionTest.java
@@ -1,0 +1,63 @@
+package org.hibernate.orm.test.jpa.criteria.basic;
+
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.jpa.test.metamodel.Product;
+import org.hibernate.orm.test.jpa.criteria.AbstractCriteriaTest;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Nathan Xu
+ */
+public class DerbyConcatFunctionTest extends AbstractCriteriaTest {
+
+	@Test
+	void testConcatWithAllLiteralArgs(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			CriteriaBuilder cb = em.getCriteriaBuilder();
+			CriteriaQuery<Product> criteria = cb.createQuery( Product.class );
+			Root<Product> root = criteria.from( Product.class );
+
+			criteria.select( root ).where( cb.equal( root.get( "name" ), cb.concat( cb.literal( "prefix" ), cb.literal( "suffix" ) ) ) );
+
+			em.createQuery( criteria ).getResultList();
+		} );
+	}
+
+	@Test
+	void testConcatWithAllParameterArgs(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			CriteriaBuilder cb = em.getCriteriaBuilder();
+			CriteriaQuery<Product> criteria = cb.createQuery( Product.class );
+			Root<Product> root = criteria.from( Product.class );
+
+			ParameterExpression<String> prefixParam = cb.parameter( String.class );
+			ParameterExpression<String> suffixParam = cb.parameter( String.class );
+			criteria.select( root ).where( cb.equal( root.get( "name" ), cb.concat( prefixParam, suffixParam ) ) );
+
+			TypedQuery<Product> query = em.createQuery( criteria );
+			query.setParameter( prefixParam, "prefix" ).setParameter( suffixParam, "suffix" ).getResultList();
+		} );
+	}
+
+	@Test
+	void testConcatWithMixedTypeArgs(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			CriteriaBuilder cb = em.getCriteriaBuilder();
+			CriteriaQuery<Product> criteria = cb.createQuery( Product.class );
+			Root<Product> root = criteria.from( Product.class );
+
+			ParameterExpression<String> prefixParam = cb.parameter( String.class );
+			criteria.select( root ).where( cb.equal( root.get( "name" ), cb.concat( prefixParam, cb.literal( "suffix" ) ) ) );
+			TypedQuery<Product> query = em.createQuery( criteria );
+			query.setParameter( prefixParam, "prefix" ).getResultList();
+		} );
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14642

The missing of Derby specific 'concat' function was found during migration of ConcatTests during Critera verifying, however, the migration of that testing class requires the completion of https://github.com/hibernate/hibernate-orm/pull/4018.

However, another existing FunctionTests#testConcatFunction() would test this for Derby dialect.