### PR TITLE
HHH-14659 "join fetch" on mapped-by association is ignored when using bytecode enhancement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3127,13 +3127,15 @@ public abstract class AbstractEntityPersister
 	 * without resolving associations or collections. Question: should
 	 * this really be here, or should it be sent back to Loader?
 	 */
+	@Override
 	public Object[] hydrate(
 			final ResultSet rs,
 			final Serializable id,
 			final Object object,
 			final Loadable rootLoadable,
 			final String[][] suffixedPropertyColumns,
-			final boolean allProperties,
+			final boolean forceEager,
+			final boolean[] propertiesForceEager,
 			final SharedSessionContractImplementor session) throws SQLException, HibernateException {
 
 		if ( LOG.isTraceEnabled() ) {
@@ -3195,7 +3197,7 @@ public abstract class AbstractEntityPersister
 				if ( !propertySelectable[i] ) {
 					values[i] = PropertyAccessStrategyBackRefImpl.UNKNOWN;
 				}
-				else if ( allProperties || !laziness[i] ) {
+				else if ( forceEager || !laziness[i] || propertiesForceEager != null && propertiesForceEager[i] ) {
 					//decide which ResultSet to get the property value from:
 					final boolean propertyIsDeferred = hasDeferred &&
 							rootPersister.isSubclassPropertyDeferred( propNames[i], propSubclassNames[i] );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/Loadable.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/Loadable.java
@@ -83,13 +83,28 @@ public interface Loadable extends EntityPersister {
 	/**
 	 * Retrieve property values from one row of a result set
 	 */
+	default Object[] hydrate(
+			ResultSet rs,
+			Serializable id,
+			Object object,
+			Loadable rootLoadable,
+			String[][] suffixedPropertyColumns,
+			boolean forceEager,
+			SharedSessionContractImplementor session) throws SQLException, HibernateException {
+		return hydrate( rs, id, object, rootLoadable, suffixedPropertyColumns, forceEager, null, session );
+	}
+
+	/**
+	 * Retrieve property values from one row of a result set
+	 */
 	Object[] hydrate(
 			ResultSet rs,
 			Serializable id,
 			Object object,
 			Loadable rootLoadable,
 			String[][] suffixedPropertyColumns,
-			boolean allProperties,
+			boolean forceEager,
+			boolean[] propertiesForceEager,
 			SharedSessionContractImplementor session) throws SQLException, HibernateException;
 
 	boolean isAbstract();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/manytoone/ManyToOneExplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/manytoone/ManyToOneExplicitOptionTests.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -22,11 +23,13 @@ import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +40,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.annotations.LazyToOneOption.NO_PROXY;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Baseline test for uni-directional to-one, using an explicit @LazyToOne(NO_PROXY)
@@ -64,17 +68,6 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 
 	@Test
 	public void testOwnerIsProxy() {
-		inTransaction(
-				(session) -> {
-					final Customer customer = new Customer( 1, "Acme Brick" );
-					session.persist( customer );
-					final Order order = new Order( 1, customer, BigDecimal.ONE );
-					session.persist( order );
-				}
-		);
-
-		sqlStatementInterceptor.clear();
-
 		final EntityPersister orderDescriptor = sessionFactory().getMetamodel().entityPersister( Order.class );
 		final BytecodeEnhancementMetadata orderEnhancementMetadata = orderDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( orderEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
@@ -125,6 +118,40 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		Order order = fromTransaction( (session) -> {
+			final Order result = session.createQuery(
+							"select o from Order o join fetch o.customer",
+							Order.class )
+					.uniqueResult();
+			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			return result;
+		} );
+
+		// The "join fetch" should have already initialized the property,
+		// so that the getter can safely be called outside of a session.
+		assertTrue( Hibernate.isPropertyInitialized( order, "customer" ) );
+		// The "join fetch" should have already initialized the associated entity.
+		Customer customer = order.getCustomer();
+		assertTrue( Hibernate.isInitialized( customer ) );
+		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+	}
+
+	@Before
+	public void createTestData() {
+		inTransaction(
+				(session) -> {
+					final Customer customer = new Customer( 1, "Acme Brick" );
+					session.persist( customer );
+					final Order order = new Order( 1, customer, BigDecimal.ONE );
+					session.persist( order );
+				}
+		);
+		sqlStatementInterceptor.clear();
 	}
 
 	@After

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneAllowProxyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneAllowProxyTests.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.hibernate.Hibernate;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
@@ -20,6 +21,7 @@ import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
@@ -35,6 +37,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -60,8 +63,6 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 
 	@Test
 	public void testOwnerIsProxy() {
-		sqlStatementInterceptor.clear();
-
 		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMetamodel().entityPersister( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
@@ -113,6 +114,27 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 		);
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		SupplementalInfo info = fromTransaction( (session) -> {
+			final SupplementalInfo result = session.createQuery(
+							"select s from SupplementalInfo s join fetch s.customer",
+							SupplementalInfo.class )
+					.uniqueResult();
+			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			return result;
+		} );
+
+		// The "join fetch" should have already initialized the property,
+		// so that the getter can safely be called outside of a session.
+		assertTrue( Hibernate.isPropertyInitialized( info, "customer" ) );
+		// The "join fetch" should have already initialized the associated entity.
+		Customer customer = info.getCustomer();
+		assertTrue( Hibernate.isInitialized( customer ) );
+		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+	}
+
 	@Before
 	public void createTestData() {
 		inTransaction(
@@ -123,6 +145,7 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 					session.persist( supplementalInfo );
 				}
 		);
+		sqlStatementInterceptor.clear();
 	}
 
 	@After

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/JoinFetchedOneToOneAllowProxyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/JoinFetchedOneToOneAllowProxyTests.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -18,6 +19,7 @@ import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
@@ -31,6 +33,7 @@ import static javax.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.annotations.FetchMode.JOIN;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -56,8 +59,6 @@ public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctio
 
 	@Test
 	public void testOwnerIsProxy() {
-		sqlStatementInterceptor.clear();
-
 		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMetamodel().entityPersister( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
@@ -94,6 +95,27 @@ public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctio
 		);
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		SupplementalInfo info = fromTransaction( (session) -> {
+			final SupplementalInfo result = session.createQuery(
+							"select s from SupplementalInfo s join fetch s.customer",
+							SupplementalInfo.class )
+					.uniqueResult();
+			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			return result;
+		} );
+
+		// The "join fetch" should have already initialized the property,
+		// so that the getter can safely be called outside of a session.
+		assertTrue( Hibernate.isPropertyInitialized( info, "customer" ) );
+		// The "join fetch" should have already initialized the associated entity.
+		Customer customer = info.getCustomer();
+		assertTrue( Hibernate.isInitialized( customer ) );
+		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+	}
+
 	@Before
 	public void createTestData() {
 		inTransaction(
@@ -104,6 +126,7 @@ public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctio
 					session.persist( supplementalInfo );
 				}
 		);
+		sqlStatementInterceptor.clear();
 	}
 
 	@After

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/JoinFetchedPolymorphicToOneTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/JoinFetchedPolymorphicToOneTests.java
@@ -20,6 +20,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
@@ -68,6 +69,21 @@ public class JoinFetchedPolymorphicToOneTests extends BaseNonConfigCoreFunctiona
 					customer.getName();
 					// customer base fetch state should also have been loaded above
 					assertThat( sqlStatementInterceptor.getQueryCount(), is( 1 ) );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		inTransaction(
+				(session) -> {
+					final Order order = session.createQuery( "select o from Order o join fetch o.customer", Order.class )
+							.uniqueResult();
+
+					assertTrue( Hibernate.isPropertyInitialized( order, "customer" ) );
+					Customer customer = order.getCustomer();
+					assertTrue( Hibernate.isInitialized( customer ) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/PolymorphicToOneExplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/PolymorphicToOneExplicitOptionTests.java
@@ -22,6 +22,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
@@ -36,6 +37,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -96,6 +98,21 @@ public class PolymorphicToOneExplicitOptionTests extends BaseNonConfigCoreFuncti
 					// but again that is not the case
 					expectedCount++;
 					assertThat( sqlStatementInterceptor.getQueryCount(), is( expectedCount ) );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		inTransaction(
+				(session) -> {
+					final Order order = session.createQuery( "select o from Order o join fetch o.customer", Order.class )
+							.uniqueResult();
+
+					assertTrue( Hibernate.isPropertyInitialized( order, "customer" ) );
+					Customer customer = order.getCustomer();
+					assertTrue( Hibernate.isInitialized( customer ) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/PolymorphicToOneImplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/polymorphic/PolymorphicToOneImplicitOptionTests.java
@@ -20,6 +20,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
@@ -34,6 +35,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steve Ebersole
@@ -68,6 +70,21 @@ public class PolymorphicToOneImplicitOptionTests extends BaseNonConfigCoreFuncti
 
 					customer.getName();
 					assertThat( sqlStatementInterceptor.getQueryCount(), is( 2 ) );
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14659")
+	public void testQueryJoinFetch() {
+		inTransaction(
+				(session) -> {
+					final Order order = session.createQuery( "select o from Order o join fetch o.customer", Order.class )
+							.uniqueResult();
+
+					assertTrue( Hibernate.isPropertyInitialized( order, "customer" ) );
+					Customer customer = order.getCustomer();
+					assertTrue( Hibernate.isInitialized( customer ) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/join/HHH3949Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/join/HHH3949Test.java
@@ -23,6 +23,7 @@ import javax.persistence.Table;
 import java.util.List;
 
 import static org.hibernate.Hibernate.isInitialized;
+import static org.hibernate.Hibernate.isPropertyInitialized;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -131,6 +132,11 @@ public class HHH3949Test extends BaseCoreFunctionalTestCase {
         for ( Person person : persons ) {
             assertTrue( isInitialized( person ) );
             if ( shouldHaveVehicle( person ) ) {
+                // We used a "join fetch", so the vehicle must be initialized
+                // before we even call the getter
+                // (which could trigger lazy initialization if the join fetch didn't work).
+                assertTrue( isPropertyInitialized( person, "vehicle" ) );
+
                 assertNotNull( person.getVehicle() );
                 assertTrue( isInitialized( person.getVehicle() ) );
                 assertNotNull( person.getVehicle().getDriver() );
@@ -146,6 +152,11 @@ public class HHH3949Test extends BaseCoreFunctionalTestCase {
         }
         for ( Vehicle vehicle : vehicles ) {
             if ( shouldHaveDriver( vehicle ) ) {
+                // We used a "join fetch", so the drover must be initialized
+                // before we even call the getter
+                // (which could trigger lazy initialization if the join fetch didn't work).
+                assertTrue( isPropertyInitialized( vehicle, "driver" ) );
+
                 assertNotNull( vehicle.getDriver() );
                 assertNotNull( vehicle.getDriver().getVehicle() );
             }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14659

This is not a great fix. But it should work. All the code related to loaders, and especially lazy/eager fetching, is being rewritten in ORM 6, and for good reasons. With that in mind, I think investing more in this fix would be a waste of time.

Here's an explanation of the problem, if someone wants more information:

For mapped-by associations, we generate the correct SQL and fetch the associated entities correctly, and we even add them to the session. But when we decide which value to assign to the corresponding property, we assume that since the property is lazy,  we didn't retrieve it. Which is wrong when `join fetch` is being used.

This behavior was most likely implemented when fixing [HHH-13134](https://hibernate.atlassian.net/browse/HHH-13134) as a way to avoid unnecessary queries for lazy associations. In most cases it's a good thing, but here it's causing us to ignore a `join fetch`.

To be more precise,  when the problem occurs, the `laziness` local variable in `org.hibernate.persister.entity.AbstractEntityPersister#hydrate` (`org/hibernate/persister/entity/AbstractEntityPersister.java:3191`) is `true` for the property representing the association, which causes the `hydrate` method to consider the property "unfetched", even though the associated entity is being loaded.

When the association is not `mapped-by`, the property does get set because `laziness` in this method is `false`, so we set the value to the ID of the non-owning entity, and later another method will retrieve the associated entity from the persistence context and set the property value (in `org.hibernate.engine.internal.TwoPhaseLoad#initializeEntityEntryLoadedState`, which will indirectly call `org.hibernate.type.EntityType#loadByUniqueKey`).