### PR TITLE
HHH-14657 Use the compile instead of runtime classpath

### DIFF
--- a/tooling/hibernate-gradle-plugin/src/main/groovy/org/hibernate/orm/tooling/gradle/EnhancementHelper.java
+++ b/tooling/hibernate-gradle-plugin/src/main/groovy/org/hibernate/orm/tooling/gradle/EnhancementHelper.java
@@ -37,7 +37,7 @@ import org.hibernate.cfg.Environment;
  */
 public class EnhancementHelper {
 	static void enhance(SourceSet sourceSet, EnhanceExtension options, Project project) {
-		final ClassLoader classLoader = toClassLoader( sourceSet.getRuntimeClasspath() );
+		final ClassLoader classLoader = toClassLoader( sourceSet.getCompileClasspath(), sourceSet.getOutput().getClassesDirs() );
 
 		final EnhancementContext enhancementContext = new DefaultEnhancementContext() {
 			@Override
@@ -96,14 +96,16 @@ public class EnhancementHelper {
 		}
 	}
 
-	public static ClassLoader toClassLoader(FileCollection runtimeClasspath) {
+	public static ClassLoader toClassLoader(FileCollection... classpaths) {
 		List<URL> urls = new ArrayList<>();
-		for ( File file : runtimeClasspath ) {
-			try {
-				urls.add( file.toURI().toURL() );
-			}
-			catch (MalformedURLException e) {
-				throw new GradleException( "Unable to resolve classpath entry to URL : " + file.getAbsolutePath(), e );
+		for ( FileCollection classpath : classpaths ) {
+			for ( File file : classpath ) {
+				try {
+					urls.add( file.toURI().toURL() );
+				}
+				catch (MalformedURLException e) {
+					throw new GradleException( "Unable to resolve classpath entry to URL : " + file.getAbsolutePath(), e );
+				}
 			}
 		}
 		return new URLClassLoader( urls.toArray( new URL[0] ), Enhancer.class.getClassLoader() );

--- a/tooling/hibernate-gradle-plugin/src/main/groovy/org/hibernate/orm/tooling/gradle/EnhancementHelper.java
+++ b/tooling/hibernate-gradle-plugin/src/main/groovy/org/hibernate/orm/tooling/gradle/EnhancementHelper.java
@@ -37,6 +37,11 @@ import org.hibernate.cfg.Environment;
  */
 public class EnhancementHelper {
 	static void enhance(SourceSet sourceSet, EnhanceExtension options, Project project) {
+		// The compile classpath contains the jar dependencies and
+		// the output directories with the compiled classes of project dependencies in a multi-project build.
+		// The classes directories contain the compiled classes of this project.
+		// The runtime classpath cannot be used for this purpose
+		// because it contains the jars of project dependencies which are not yet built.
 		final ClassLoader classLoader = toClassLoader( sourceSet.getCompileClasspath(), sourceSet.getOutput().getClassesDirs() );
 
 		final EnhancementContext enhancementContext = new DefaultEnhancementContext() {


### PR DESCRIPTION
The runtime classpath contains the dependencies as jars that are not yet built when the plugin needs them. So use the compile classpath plus the compiled classes of the current project.