### PR TITLE
HHH-14667 Reduce amount of Database metadata details being loaded during bootstrap

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -275,7 +275,7 @@ Please report your mapping that causes the problem to us so we can examine the d
 +
 The default value is `false` which means Hibernate will use an algorithm to determine if the insert can be delayed or if the insert should be performed immediately.
 
-`*hibernate.id.sequence.increment_size_mismatch_strategy*` (e.g. `LOG`, `FIX` or `EXCEPTION` (default value))::
+`*hibernate.id.sequence.increment_size_mismatch_strategy*` (e.g. `LOG`, `FIX`, `NONE` or `EXCEPTION` (default value))::
 This setting defines the `org.hibernate.id.SequenceMismatchStrategy` used when
 Hibernate detects a mismatch between a sequence configuration in an entity mapping
 and its database sequence object counterpart.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2423,8 +2423,9 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	 * and its database sequence object counterpart.
 	 * </p>
 	 * Possible values are {@link org.hibernate.id.SequenceMismatchStrategy#EXCEPTION},
-	 * {@link org.hibernate.id.SequenceMismatchStrategy#LOG}, and
-	 * {@link org.hibernate.id.SequenceMismatchStrategy#FIX}.
+	 * {@link org.hibernate.id.SequenceMismatchStrategy#LOG},
+	 * {@link org.hibernate.id.SequenceMismatchStrategy#FIX}
+	 * and {@link org.hibernate.id.SequenceMismatchStrategy#NONE}.
 	 * </p>
 	 * The default value is given by the {@link org.hibernate.id.SequenceMismatchStrategy#EXCEPTION},
 	 * meaning that an Exception is thrown when detecting such a conflict.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
@@ -40,7 +40,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	private final boolean supportsDataDefinitionInTransaction;
 	private final boolean doesDataDefinitionCauseTransactionCommit;
 	private final SQLStateType sqlStateType;
-	private final boolean lobLocatorUpdateCopy;
 
 	private final Set<String> extraKeywords;
 	private final List<SequenceInformation> sequenceInformationList;
@@ -58,7 +57,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			boolean supportsDataDefinitionInTransaction,
 			boolean doesDataDefinitionCauseTransactionCommit,
 			SQLStateType sqlStateType,
-			boolean lobLocatorUpdateCopy,
 			List<SequenceInformation> sequenceInformationList) {
 		this.jdbcEnvironment = jdbcEnvironment;
 
@@ -77,7 +75,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 		this.supportsDataDefinitionInTransaction = supportsDataDefinitionInTransaction;
 		this.doesDataDefinitionCauseTransactionCommit = doesDataDefinitionCauseTransactionCommit;
 		this.sqlStateType = sqlStateType;
-		this.lobLocatorUpdateCopy = lobLocatorUpdateCopy;
 		this.sequenceInformationList = sequenceInformationList;
 	}
 
@@ -132,11 +129,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	}
 
 	@Override
-	public boolean doesLobLocatorUpdateCopy() {
-		return lobLocatorUpdateCopy;
-	}
-
-	@Override
 	public String getConnectionCatalogName() {
 		return connectionCatalogName;
 	}
@@ -167,7 +159,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 		private boolean supportsDataDefinitionInTransaction;
 		private boolean doesDataDefinitionCauseTransactionCommit;
 		private SQLStateType sqlStateType;
-		private boolean lobLocatorUpdateCopy;
 		private List<SequenceInformation> sequenceInformationList = Collections.emptyList();
 
 		public Builder(JdbcEnvironment jdbcEnvironment) {
@@ -186,7 +177,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			doesDataDefinitionCauseTransactionCommit = databaseMetaData.dataDefinitionCausesTransactionCommit();
 			extraKeywords = parseKeywords( databaseMetaData.getSQLKeywords() );
 			sqlStateType = SQLStateType.interpretReportedSQLStateType( databaseMetaData.getSQLStateType() );
-			lobLocatorUpdateCopy = databaseMetaData.locatorsUpdateCopy();
 			return this;
 		}
 
@@ -262,11 +252,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			return this;
 		}
 
-		public Builder setLobLocatorUpdateCopy(boolean lobLocatorUpdateCopy) {
-			this.lobLocatorUpdateCopy = lobLocatorUpdateCopy;
-			return this;
-		}
-
 		public Builder setSequenceInformationList(List<SequenceInformation> sequenceInformationList) {
 			this.sequenceInformationList = sequenceInformationList;
 			return this;
@@ -286,7 +271,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 					supportsDataDefinitionInTransaction,
 					doesDataDefinitionCauseTransactionCommit,
 					sqlStateType,
-					lobLocatorUpdateCopy,
 					sequenceInformationList
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
@@ -10,7 +10,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -41,14 +40,12 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	private final boolean doesDataDefinitionCauseTransactionCommit;
 	private final SQLStateType sqlStateType;
 
-	private final Set<String> extraKeywords;
 	private final List<SequenceInformation> sequenceInformationList;
 
 	private ExtractedDatabaseMetaDataImpl(
 			JdbcEnvironment jdbcEnvironment,
 			String connectionCatalogName,
 			String connectionSchemaName,
-			Set<String> extraKeywords,
 			boolean supportsRefCursors,
 			boolean supportsNamedParameters,
 			boolean supportsScrollableResults,
@@ -59,14 +56,8 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			SQLStateType sqlStateType,
 			List<SequenceInformation> sequenceInformationList) {
 		this.jdbcEnvironment = jdbcEnvironment;
-
 		this.connectionCatalogName = connectionCatalogName;
 		this.connectionSchemaName = connectionSchemaName;
-
-		this.extraKeywords = extraKeywords != null
-				? extraKeywords
-				: Collections.<String>emptySet();
-
 		this.supportsRefCursors = supportsRefCursors;
 		this.supportsNamedParameters = supportsNamedParameters;
 		this.supportsScrollableResults = supportsScrollableResults;
@@ -119,11 +110,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	}
 
 	@Override
-	public Set<String> getExtraKeywords() {
-		return extraKeywords;
-	}
-
-	@Override
 	public SQLStateType getSqlStateType() {
 		return sqlStateType;
 	}
@@ -149,8 +135,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 		private String connectionSchemaName;
 		private String connectionCatalogName;
 
-		private Set<String> extraKeywords;
-
 		private boolean supportsRefCursors;
 		private boolean supportsNamedParameters;
 		private boolean supportsScrollableResults;
@@ -175,7 +159,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			supportsBatchUpdates = databaseMetaData.supportsBatchUpdates();
 			supportsDataDefinitionInTransaction = !databaseMetaData.dataDefinitionIgnoredInTransactions();
 			doesDataDefinitionCauseTransactionCommit = databaseMetaData.dataDefinitionCausesTransactionCommit();
-			extraKeywords = parseKeywords( databaseMetaData.getSQLKeywords() );
 			sqlStateType = SQLStateType.interpretReportedSQLStateType( databaseMetaData.getSQLStateType() );
 			return this;
 		}
@@ -191,24 +174,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 
 		public Builder setConnectionCatalogName(String connectionCatalogName) {
 			this.connectionCatalogName = connectionCatalogName;
-			return this;
-		}
-
-		public Builder setExtraKeywords(Set<String> extraKeywords) {
-			if ( this.extraKeywords == null ) {
-				this.extraKeywords = extraKeywords;
-			}
-			else {
-				this.extraKeywords.addAll( extraKeywords );
-			}
-			return this;
-		}
-
-		public Builder addExtraKeyword(String keyword) {
-			if ( this.extraKeywords == null ) {
-				this.extraKeywords = new HashSet<String>();
-			}
-			this.extraKeywords.add( keyword );
 			return this;
 		}
 
@@ -262,7 +227,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 					jdbcEnvironment,
 					connectionCatalogName,
 					connectionSchemaName,
-					extraKeywords,
 					supportsRefCursors,
 					supportsNamedParameters,
 					supportsScrollableResults,

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/ExtractedDatabaseMetaDataImpl.java
@@ -9,10 +9,8 @@ package org.hibernate.engine.jdbc.env.internal;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -21,8 +19,6 @@ import org.hibernate.engine.jdbc.cursor.internal.StandardRefCursorSupport;
 import org.hibernate.engine.jdbc.env.spi.ExtractedDatabaseMetaData;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.env.spi.SQLStateType;
-import org.hibernate.engine.jdbc.spi.TypeInfo;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.tool.schema.extract.spi.SequenceInformation;
 
 /**
@@ -47,7 +43,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	private final boolean lobLocatorUpdateCopy;
 
 	private final Set<String> extraKeywords;
-	private final LinkedHashSet<TypeInfo> typeInfoSet;
 	private final List<SequenceInformation> sequenceInformationList;
 
 	private ExtractedDatabaseMetaDataImpl(
@@ -55,7 +50,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			String connectionCatalogName,
 			String connectionSchemaName,
 			Set<String> extraKeywords,
-			LinkedHashSet<TypeInfo> typeInfoSet,
 			boolean supportsRefCursors,
 			boolean supportsNamedParameters,
 			boolean supportsScrollableResults,
@@ -74,9 +68,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 		this.extraKeywords = extraKeywords != null
 				? extraKeywords
 				: Collections.<String>emptySet();
-		this.typeInfoSet = typeInfoSet != null
-				? typeInfoSet
-				: new LinkedHashSet<TypeInfo>();
 
 		this.supportsRefCursors = supportsRefCursors;
 		this.supportsNamedParameters = supportsNamedParameters;
@@ -156,11 +147,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 	}
 
 	@Override
-	public LinkedHashSet<TypeInfo> getTypeInfoSet() {
-		return typeInfoSet;
-	}
-
-	@Override
 	public List<SequenceInformation> getSequenceInformationList() {
 		return sequenceInformationList;
 	}
@@ -172,7 +158,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 		private String connectionCatalogName;
 
 		private Set<String> extraKeywords;
-		private LinkedHashSet<TypeInfo> typeInfoSet;
 
 		private boolean supportsRefCursors;
 		private boolean supportsNamedParameters;
@@ -202,8 +187,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 			extraKeywords = parseKeywords( databaseMetaData.getSQLKeywords() );
 			sqlStateType = SQLStateType.interpretReportedSQLStateType( databaseMetaData.getSQLStateType() );
 			lobLocatorUpdateCopy = databaseMetaData.locatorsUpdateCopy();
-			typeInfoSet = new LinkedHashSet<TypeInfo>();
-			typeInfoSet.addAll( TypeInfo.extractTypeInfo( databaseMetaData ) );
 			return this;
 		}
 
@@ -236,24 +219,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 				this.extraKeywords = new HashSet<String>();
 			}
 			this.extraKeywords.add( keyword );
-			return this;
-		}
-
-		public Builder setTypeInfoSet(LinkedHashSet<TypeInfo> typeInfoSet) {
-			if ( this.typeInfoSet == null ) {
-				this.typeInfoSet = typeInfoSet;
-			}
-			else {
-				this.typeInfoSet.addAll( typeInfoSet );
-			}
-			return this;
-		}
-
-		public Builder addTypeInfo(TypeInfo typeInfo) {
-			if ( this.typeInfoSet == null ) {
-				this.typeInfoSet = new LinkedHashSet<TypeInfo>();
-			}
-			typeInfoSet.add( typeInfo );
 			return this;
 		}
 
@@ -313,7 +278,6 @@ public class ExtractedDatabaseMetaDataImpl implements ExtractedDatabaseMetaData 
 					connectionCatalogName,
 					connectionSchemaName,
 					extraKeywords,
-					typeInfoSet,
 					supportsRefCursors,
 					supportsNamedParameters,
 					supportsScrollableResults,

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -9,12 +9,8 @@ package org.hibernate.engine.jdbc.env.internal;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -288,7 +284,7 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	private String determineCurrentSchemaName(
 			DatabaseMetaData databaseMetaData,
 			ServiceRegistry serviceRegistry,
-			Dialect dialect) throws SQLException {
+			Dialect dialect) {
 		final SchemaNameResolver schemaNameResolver;
 
 		final Object setting = serviceRegistry.getService( ConfigurationService.class ).getSettings().get(
@@ -321,14 +317,6 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 		// todo : vary this based on extractedMetaDataSupport.getSqlStateType()
 		sqlExceptionConverter.addDelegate( new SQLStateConversionDelegate( dialect ) );
 		return new SqlExceptionHelper( sqlExceptionConverter, logWarnings );
-	}
-
-	private Set<String> buildMergedReservedWords(Dialect dialect, DatabaseMetaData dbmd) throws SQLException {
-		Set<String> reservedWords = new HashSet<String>();
-		reservedWords.addAll( dialect.getKeywords() );
-		// todo : do we need to explicitly handle SQL:2003 keywords?
-		reservedWords.addAll( Arrays.asList( dbmd.getSQLKeywords().split( "," ) ) );
-		return reservedWords;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -60,7 +60,6 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	private final QualifiedObjectNameFormatter qualifiedObjectNameFormatter;
 	private final LobCreatorBuilderImpl lobCreatorBuilder;
 
-	private final LinkedHashSet<TypeInfo> typeInfoSet = new LinkedHashSet<TypeInfo>();
 	private final NameQualifierSupport nameQualifierSupport;
 
 	/**
@@ -277,8 +276,6 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 				databaseMetaData
 		);
 
-		this.typeInfoSet.addAll( TypeInfo.extractTypeInfo( databaseMetaData ) );
-
 		this.lobCreatorBuilder = LobCreatorBuilderImpl.makeLobCreatorBuilder(
 				dialect,
 				cfgService.getSettings(),
@@ -379,14 +376,9 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 		return lobCreatorBuilder;
 	}
 
-	@Override
 	public TypeInfo getTypeInfoForJdbcCode(int jdbcTypeCode) {
-		for ( TypeInfo typeInfo : typeInfoSet ) {
-			if ( typeInfo.getJdbcTypeCode() == jdbcTypeCode ) {
-				return typeInfo;
-			}
-		}
-		return null;
+		throw new UnsupportedOperationException( "Support for getting TypeInfo from jdbcTypeCode has been disabled as it wasn't used." +
+													" Use org.hibernate.engine.jdbc.spi.TypeInfo.extractTypeInfo as alternative, or report an issue and explain." );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -114,7 +114,8 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 					return new JdbcEnvironmentImpl(
 							registry,
 							dialect,
-							dbmd
+							dbmd,
+							jdbcConnectionAccess
 					);
 				}
 				catch (SQLException e) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
@@ -128,15 +128,6 @@ public interface ExtractedDatabaseMetaData {
 	SQLStateType getSqlStateType();
 
 	/**
-	 * Did the driver report that updates to a LOB locator affect a copy of the LOB?
-	 *
-	 * @return True if updates to the state of a LOB locator update only a copy.
-	 *
-	 * @see java.sql.DatabaseMetaData#locatorsUpdateCopy()
-	 */
-	boolean doesLobLocatorUpdateCopy();
-
-	/**
 	 * Retrieve the list of {@code SequenceInformation} objects which describe the underlying database sequences.
 	 *
 	 * @return {@code SequenceInformation} objects.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
@@ -46,15 +46,6 @@ public interface ExtractedDatabaseMetaData {
 	String getConnectionSchemaName();
 
 	/**
-	 * Get the list of extra keywords (beyond standard SQL92 keywords) reported by the driver.
-	 *
-	 * @return The extra keywords used by this database.
-	 *
-	 * @see java.sql.DatabaseMetaData#getSQLKeywords()
-	 */
-	Set<String> getExtraKeywords();
-
-	/**
 	 * Does the driver report supporting named parameters?
 	 *
 	 * @return {@code true} indicates the driver reported true; {@code false} indicates the driver reported false

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/ExtractedDatabaseMetaData.java
@@ -46,15 +46,6 @@ public interface ExtractedDatabaseMetaData {
 	String getConnectionSchemaName();
 
 	/**
-	 * Set of type info reported by the driver.
-	 *
-	 * @return The type information obtained from the driver.
-	 *
-	 * @see java.sql.DatabaseMetaData#getTypeInfo()
-	 */
-	LinkedHashSet<TypeInfo> getTypeInfoSet();
-
-	/**
 	 * Get the list of extra keywords (beyond standard SQL92 keywords) reported by the driver.
 	 *
 	 * @return The extra keywords used by this database.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/IdentifierHelperBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/IdentifierHelperBuilder.java
@@ -61,6 +61,10 @@ public class IdentifierHelperBuilder {
 			return;
 		}
 
+		//Important optimisation: skip loading all keywords from the DB when autoQuoteKeywords is disabled
+		if ( autoQuoteKeywords == false ) {
+			return;
+		}
 		this.reservedWords.addAll( parseKeywords( metaData.getSQLKeywords() ) );
 	}
 
@@ -176,6 +180,10 @@ public class IdentifierHelperBuilder {
 	}
 
 	public void applyReservedWords(Set<String> words) {
+		//No use when autoQuoteKeywords is disabled
+		if ( autoQuoteKeywords == false ) {
+			return;
+		}
 		this.reservedWords.addAll( words );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
@@ -9,7 +9,6 @@ package org.hibernate.engine.jdbc.env.spi;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
-import org.hibernate.engine.jdbc.spi.TypeInfo;
 import org.hibernate.service.Service;
 
 /**
@@ -89,12 +88,4 @@ public interface JdbcEnvironment extends Service {
 	 */
 	LobCreatorBuilder getLobCreatorBuilder();
 
-	/**
-	 * Find type information for the type identified by the given "JDBC type code".
-	 *
-	 * @param jdbcTypeCode The JDBC type code.
-	 *
-	 * @return The corresponding type info.
-	 */
-	TypeInfo getTypeInfoForJdbcCode(int jdbcTypeCode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceMismatchStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceMismatchStrategy.java
@@ -32,7 +32,13 @@ public enum SequenceMismatchStrategy {
 	 * When detecting a mismatch, Hibernate tries to fix it by overriding the entity sequence mapping using the one
 	 * found in the database.
 	 */
-	FIX;
+	FIX,
+
+	/**
+	 * Don't perform any check. This is useful to speedup bootstrap as it won't query the sequences on the DB,
+	 * at cost of not validating the sequences.
+	 */
+	NONE;
 
 	/**
 	 * Interpret the configured SequenceMismatchStrategy value.

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.boot.SchemaAutoTooling;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedName;
@@ -242,18 +243,19 @@ public class SequenceStyleGenerator
 
 		final boolean isPooledOptimizer = OptimizerFactory.isPooledOptimizer( optimizationStrategy );
 
-		if ( isPooledOptimizer && isPhysicalSequence( jdbcEnvironment, forceTableUse ) ) {
+
+		SequenceMismatchStrategy sequenceMismatchStrategy = configurationService.getSetting(
+				AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY,
+				SequenceMismatchStrategy::interpret,
+				SequenceMismatchStrategy.EXCEPTION
+		);
+
+		if ( sequenceMismatchStrategy != SequenceMismatchStrategy.NONE && isPooledOptimizer && isPhysicalSequence( jdbcEnvironment, forceTableUse ) ) {
 			String databaseSequenceName = sequenceName.getObjectName().getText();
 			Long databaseIncrementValue = getSequenceIncrementValue( jdbcEnvironment, databaseSequenceName );
 
 			if ( databaseIncrementValue != null && !databaseIncrementValue.equals( (long) incrementSize ) ) {
 				int dbIncrementValue = databaseIncrementValue.intValue();
-
-				SequenceMismatchStrategy sequenceMismatchStrategy = configurationService.getSetting(
-						AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY,
-						SequenceMismatchStrategy::interpret,
-						SequenceMismatchStrategy.EXCEPTION
-				);
 
 				switch ( sequenceMismatchStrategy ) {
 					case EXCEPTION:

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/env/internal/SkipLoadingSequenceInformationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/env/internal/SkipLoadingSequenceInformationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.jdbc.env.internal;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.id.SequenceMismatchStrategy;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * Verifies that setting {@code AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY} to {@code none}
+ * is going to skip loading the sequence information from the database.
+ */
+@TestForIssue( jiraKey = "HHH-14667")
+public class SkipLoadingSequenceInformationTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.SEQUENCE_INCREMENT_SIZE_MISMATCH_STRATEGY, SequenceMismatchStrategy.NONE.name() );
+		configuration.setProperty( Environment.DIALECT, VetoingDialect.class.getName() );
+	}
+
+	@Entity(name="seqentity")
+	static class SequencingEntity {
+		@Id
+		@GenericGenerator(name = "pooledoptimizer", strategy = "enhanced-sequence",
+				parameters = {
+						@org.hibernate.annotations.Parameter(name = "optimizer", value = "pooled"),
+						@org.hibernate.annotations.Parameter(name = "initial_value", value = "1"),
+						@org.hibernate.annotations.Parameter(name = "increment_size", value = "2")
+				}
+		)
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "pooledoptimizer")
+		Integer id;
+		String name;
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{SequencingEntity.class};
+	}
+
+	@Test
+	public void test() {
+		// If it's able to boot, we're good.
+	}
+
+	public static class VetoingDialect extends H2Dialect {
+		@Override
+		public SequenceInformationExtractor getSequenceInformationExtractor() {
+			throw new IllegalStateException("Should really not invoke this method in this setup");
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/NoDatabaseMetaDataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/NoDatabaseMetaDataTest.java
@@ -38,7 +38,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 
 		assertNull( extractedDatabaseMetaData.getConnectionCatalogName() );
 		assertNull( extractedDatabaseMetaData.getConnectionSchemaName() );
-		assertTrue( extractedDatabaseMetaData.getExtraKeywords().isEmpty() );
 		assertFalse( extractedDatabaseMetaData.supportsNamedParameters() );
 		assertFalse( extractedDatabaseMetaData.supportsRefCursors() );
 		assertFalse( extractedDatabaseMetaData.supportsScrollableResults() );
@@ -63,7 +62,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 
 		assertNull( extractedDatabaseMetaData.getConnectionCatalogName() );
 		assertNull( extractedDatabaseMetaData.getConnectionSchemaName() );
-		assertTrue( extractedDatabaseMetaData.getExtraKeywords().isEmpty() );
 		assertTrue( extractedDatabaseMetaData.supportsNamedParameters() );
 		assertFalse( extractedDatabaseMetaData.supportsRefCursors() );
 		assertFalse( extractedDatabaseMetaData.supportsScrollableResults() );

--- a/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/NoDatabaseMetaDataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jdbc/env/NoDatabaseMetaDataTest.java
@@ -38,7 +38,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 
 		assertNull( extractedDatabaseMetaData.getConnectionCatalogName() );
 		assertNull( extractedDatabaseMetaData.getConnectionSchemaName() );
-		assertTrue( extractedDatabaseMetaData.getTypeInfoSet().isEmpty() );
 		assertTrue( extractedDatabaseMetaData.getExtraKeywords().isEmpty() );
 		assertFalse( extractedDatabaseMetaData.supportsNamedParameters() );
 		assertFalse( extractedDatabaseMetaData.supportsRefCursors() );
@@ -48,7 +47,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 		assertFalse( extractedDatabaseMetaData.supportsDataDefinitionInTransaction() );
 		assertFalse( extractedDatabaseMetaData.doesDataDefinitionCauseTransactionCommit() );
 		assertNull( extractedDatabaseMetaData.getSqlStateType() );
-		assertFalse( extractedDatabaseMetaData.doesLobLocatorUpdateCopy() );
 
 		StandardServiceRegistryBuilder.destroy( serviceRegistry );
 	}
@@ -65,7 +63,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 
 		assertNull( extractedDatabaseMetaData.getConnectionCatalogName() );
 		assertNull( extractedDatabaseMetaData.getConnectionSchemaName() );
-		assertTrue( extractedDatabaseMetaData.getTypeInfoSet().isEmpty() );
 		assertTrue( extractedDatabaseMetaData.getExtraKeywords().isEmpty() );
 		assertTrue( extractedDatabaseMetaData.supportsNamedParameters() );
 		assertFalse( extractedDatabaseMetaData.supportsRefCursors() );
@@ -75,7 +72,6 @@ public class NoDatabaseMetaDataTest extends BaseUnitTestCase {
 		assertFalse( extractedDatabaseMetaData.supportsDataDefinitionInTransaction() );
 		assertFalse( extractedDatabaseMetaData.doesDataDefinitionCauseTransactionCommit() );
 		assertNull( extractedDatabaseMetaData.getSqlStateType() );
-		assertFalse( extractedDatabaseMetaData.doesLobLocatorUpdateCopy() );
 
 		StandardServiceRegistryBuilder.destroy( serviceRegistry );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/schemafilter/SequenceFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemafilter/SequenceFilterTest.java
@@ -62,6 +62,7 @@ public class SequenceFilterTest extends BaseUnitTestCase {
 		Map settings = new HashMap();
 		settings.putAll( Environment.getProperties() );
 		settings.put( AvailableSettings.DIALECT, H2Dialect.class.getName() );
+		settings.put( "hibernate.temp.use_jdbc_metadata_defaults", "false" );
 		settings.put( AvailableSettings.FORMAT_SQL, false );
 
 		this.serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( settings );

--- a/hibernate-core/src/test/java/org/hibernate/test/schemafilter/SequenceFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemafilter/SequenceFilterTest.java
@@ -6,19 +6,16 @@
  */
 package org.hibernate.test.schemafilter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
@@ -34,16 +31,17 @@ import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.internal.SchemaDropperImpl;
 import org.hibernate.tool.schema.spi.SchemaFilter;
 
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.ServiceRegistryBuilder;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.hibernate.testing.DialectChecks;
-import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.ServiceRegistryBuilder;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 
 import static org.hibernate.test.schemafilter.RecordingTarget.Category.SEQUENCE_CREATE;
 import static org.hibernate.test.schemafilter.RecordingTarget.Category.SEQUENCE_DROP;
@@ -52,7 +50,7 @@ import static org.hibernate.test.schemafilter.RecordingTarget.Category.SEQUENCE_
  * @author Andrea Boriero
  */
 @TestForIssue(jiraKey = "HHH-10937")
-@RequiresDialectFeature(value = {DialectChecks.SupportSchemaCreation.class})
+@RequiresDialect(H2Dialect.class)
 public class SequenceFilterTest extends BaseUnitTestCase {
 	private StandardServiceRegistryImpl serviceRegistry;
 	private Metadata metadata;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/BasicTestingJdbcServiceImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/BasicTestingJdbcServiceImpl.java
@@ -58,10 +58,11 @@ public class BasicTestingJdbcServiceImpl implements JdbcServices, ServiceRegistr
 		dialect = ConnectionProviderBuilder.getCorrespondingDialect();
 		connectionProvider = ConnectionProviderBuilder.buildConnectionProvider( allowAggressiveRelease );
 		sqlStatementLogger = new SqlStatementLogger( true, false, false );
+		this.jdbcConnectionAccess = new JdbcConnectionAccessImpl( connectionProvider );
 
 		Connection jdbcConnection = connectionProvider.getConnection();
 		try {
-			jdbcEnvironment = new JdbcEnvironmentImpl( jdbcConnection.getMetaData(), dialect );
+			jdbcEnvironment = new JdbcEnvironmentImpl( jdbcConnection.getMetaData(), dialect, jdbcConnectionAccess );
 		}
 		finally {
 			try {
@@ -71,7 +72,6 @@ public class BasicTestingJdbcServiceImpl implements JdbcServices, ServiceRegistr
 			}
 		}
 
-		this.jdbcConnectionAccess = new JdbcConnectionAccessImpl( connectionProvider );
 	}
 
 	public void release() {


### PR DESCRIPTION
This PR attempts to minimize the number of queries we need to run on bootstrap to fech database metadata and schema information, so to improve bootstrap times as apparently when having very large databases the time was getting out of hand (multiple minutes).

It turns out that some minor queries we did run were not used for any purpose; these were the simplest one to fix, simply by deleting them.

Loading the Sequences information was also reported as being very time consuming, and only useful for certain combinations of mappings - such as

- you need to have sequences
- you need to be using them
- they need to be mapped with a pooled optimizer
- not emulated via tables

If all these conditions are true, and only in this case, we would have good use for this metadata so to validate the configured increment sizes of the pooled optimisers.

So one aspect of the patch is to make the operation of loading Sequence(s) details lazy, only t riggered in the above conditions.
In addition, a new property was introduced which allows people to skip the validation of the increment sizes; while this option is fairly dangerous, the check is redundant when using schema validation as this operation would also validate the same. 
