### PR TITLE
wip/6.0 HHH-14642 fix a misuse of IdentityHashMap

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/DomainParameterXref.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/DomainParameterXref.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.hibernate.HibernateException;
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.internal.QueryParameterNamedImpl;
 import org.hibernate.query.internal.QueryParameterPositionalImpl;
 import org.hibernate.query.spi.QueryParameterImplementor;
@@ -87,9 +86,7 @@ public class DomainParameterXref {
 		final Map<QueryParameterImplementor<?>, List<SqmParameter>> sqmParamsByQueryParam = new IdentityHashMap<>();
 
 		final int sqmParamCount = parameterResolutions.getSqmParameters().size();
-		final Map<SqmParameter, QueryParameterImplementor<?>> queryParamBySqmParam = new IdentityHashMap<>(
-				CollectionHelper.determineProperSizing( sqmParamCount )
-		);
+		final Map<SqmParameter, QueryParameterImplementor<?>> queryParamBySqmParam = new IdentityHashMap<>( sqmParamCount );
 
 		for ( SqmParameter<?> sqmParameter : parameterResolutions.getSqmParameters() ) {
 			if ( sqmParameter instanceof JpaCriteriaParameter ) {


### PR DESCRIPTION
Just found this error during criteria verifying. Usually for HashMap or HashSet with expected element size, the below is a surprising common error:
```
Map<String, String> map = new HashMap<>( expectedSize );
``` 
for HashMap or HashSet's load factor is never 1 so it will end up with growing unnecessarily and time consuming, thus defeating the purpose of such size specification endeavour in the first place.

There are tons of such misuse in our codebase, but it is not the scope of this PR (I even created a PR to fix the error in ANTLR (see https://github.com/antlr/antlr4/pull/2938). I believe the misuse is a performance drain for it is used so often everywhere. Off course CollectionHelper has provided util methods for both HashMap and HashSet, but they are not used as often as expected.

But there are two noticeable exceptions in JDK. For both IdentityHashMap and ConcurrentHashMap we can finally cease to worry about load factor and its implication. This PR simply aims to fix this.
