### PR TITLE
HHH-14679 - Deprecate ResultSetWrapper and friends

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -1273,6 +1273,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.scrollableResultSetsEnabled = enabled;
 	}
 
+	@Deprecated
 	public void enableResultSetWrappingSupport(boolean enabled) {
 		this.wrapResultSetsEnabled = enabled;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -219,6 +219,10 @@ public interface SessionFactoryOptions {
 
 	boolean isScrollableResultSetsEnabled();
 
+	/**
+	 * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
+	 */
+	@Deprecated
 	boolean isWrapResultSetsEnabled();
 
 	boolean isGetGeneratedKeysEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1114,7 +1114,10 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	/**
 	 * Enable wrapping of JDBC result sets in order to speed up column name lookups for
 	 * broken JDBC drivers
+	 *
+	 * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
 	 */
+	@Deprecated
 	String WRAP_RESULT_SETS = "hibernate.jdbc.wrap_result_sets";
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ColumnNameCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ColumnNameCache.java
@@ -13,8 +13,11 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Cache of column-name -> column-index resolutions
  *
+ * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
+ *
  * @author Steve Ebersole
  */
+@Deprecated
 public final class ColumnNameCache {
 	private static final float LOAD_FACTOR = .75f;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ResultSetWrapperProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/ResultSetWrapperProxy.java
@@ -27,9 +27,12 @@ import org.hibernate.service.ServiceRegistry;
  * A proxy for a ResultSet delegate, responsible for locally caching the columnName-to-columnIndex resolution that
  * has been found to be inefficient in a few vendor's drivers (i.e., Oracle and Postgres).
  *
+ * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
+ *
  * @author Steve Ebersole
  * @author Gail Badner
  */
+@Deprecated
 public class ResultSetWrapperProxy implements InvocationHandler {
 	private static final CoreMessageLogger LOG = messageLogger( ResultSetWrapperProxy.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetWrapperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetWrapperImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.engine.jdbc.internal;
 
 import java.sql.ResultSet;
 
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.engine.jdbc.ColumnNameCache;
 import org.hibernate.engine.jdbc.ResultSetWrapperProxy;
 import org.hibernate.engine.jdbc.spi.ResultSetWrapper;
@@ -18,9 +17,12 @@ import org.hibernate.service.ServiceRegistry;
  * Standard Hibernate implementation for wrapping a {@link ResultSet} in a
  " column name cache" wrapper.
  *
+ * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
+ *
  * @author Steve Ebersole
  * @author Gail Badner
  */
+@Deprecated
 public class ResultSetWrapperImpl implements ResultSetWrapper {
 	private final ServiceRegistry serviceRegistry;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/ResultSetWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/ResultSetWrapper.java
@@ -13,8 +13,11 @@ import org.hibernate.engine.jdbc.ColumnNameCache;
 /**
  * Contract for wrapping a {@link ResultSet} in a "column name cache" wrapper.
  *
+ * @deprecated (since 5.5) Scheduled for removal in 6.0 as ResultSet wrapping is no longer needed
+ *
  * @author Gail Badner
  */
+@Deprecated
 public interface ResultSetWrapper {
 	/**
 	 * Wrap a result set in a "column name cache" wrapper.


### PR DESCRIPTION
Deprecate ResultSet wrapping related to performance of reading from ResultSet by name in preparation for removing those contracts from 6.0