### PR TITLE
TimePropertyTest fails on MySQL 8.0 with a ComparisonFailure

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -10,7 +10,7 @@
 ext {
 
     junitVersion = '4.12'
-    h2Version = '1.4.196'
+    h2Version = '1.4.197'
     bytemanVersion = '4.0.3' //Compatible with JDK10
     jnpVersion = '5.0.6.CR1'
 

--- a/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/temporal/TimePropertyTest.java
@@ -41,6 +41,7 @@ public class TimePropertyTest extends BaseCoreFunctionalTestCase {
 		// See javadoc for java.sql.Time: 'The date components should be set to the "zero epoch" value of January 1, 1970 and should not be accessed'
 		// Other dates can potentially lead to errors in JDBC drivers, in particular MySQL ConnectorJ 8.x.
 		calendar.set( 1970, Calendar.JANUARY, 1 );
+		calendar.set( Calendar.MILLISECOND, 0 );
 		eOrig.tAsDate = new Time( calendar.getTimeInMillis() );
 
 		Session s = openSession();


### PR DESCRIPTION
Issue: TimePropertyTest fails on MySQL 8.0 with a ComparisonFailure

(we will deliver Hibernate 5.3.x throughout the whole EAP 7.4.x lifecycle - therefore fixing it in 5.3.x branch)