### PR TITLE
wip/6.0 HHH-14642 Critera verifying - tuple

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
@@ -6,17 +6,19 @@
  */
 package org.hibernate.query.sqm.tree.select;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-
+import java.util.Set;
 import javax.persistence.criteria.Selection;
 
 import org.hibernate.query.criteria.JpaCompoundSelection;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.sqm.NodeBuilder;
-import org.hibernate.query.sqm.SqmExpressable;
 import org.hibernate.query.sqm.SemanticQueryWalker;
-import org.hibernate.query.sqm.tree.expression.AbstractSqmExpression;
+import org.hibernate.query.sqm.SqmExpressable;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
+import org.hibernate.query.sqm.tree.expression.AbstractSqmExpression;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 
 /**
@@ -63,10 +65,26 @@ public class SqmJpaCompoundSelection<T>
 			JavaTypeDescriptor<T> javaTypeDescriptor,
 			NodeBuilder criteriaBuilder) {
 		super( null, criteriaBuilder );
+		checkDuplicatedAliases( selectableNodes );
 		this.selectableNodes = selectableNodes;
 		this.javaTypeDescriptor = javaTypeDescriptor;
 
 		setExpressableType( this );
+	}
+
+	private static void checkDuplicatedAliases(Collection<? extends SqmSelectableNode> selectableNodes) {
+		Set<String> aliases = null;
+		for ( SqmSelectableNode selectableNode : selectableNodes ) {
+			final String alias = selectableNode.getAlias();
+			if ( alias != null ) {
+				if ( aliases == null ) {
+					aliases = new HashSet<>();
+				}
+				if ( ! aliases.add( alias ) ) {
+					throw new IllegalArgumentException( "Multi-select expressions defined duplicate alias : " + alias );
+				}
+			}
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -8,7 +8,9 @@ package org.hibernate.query.sqm.tree.select;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.criteria.JpaSelection;
@@ -25,6 +27,7 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpressionContainer<SqmSelection>, JpaSelection<Object> {
 	private boolean distinct;
 	private List<SqmSelection<?>> selections;
+	private Set<String> aliases;
 
 	public SqmSelectClause(
 			boolean distinct,
@@ -40,6 +43,7 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 		super( nodeBuilder );
 		this.distinct = distinct;
 		this.selections = CollectionHelper.arrayList( expectedNumberOfSelections );
+		this.aliases = CollectionHelper.setOfSize( expectedNumberOfSelections );
 	}
 
 	public boolean isDistinct() {
@@ -62,6 +66,11 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 	public void addSelection(SqmSelection selection) {
 		if ( selections == null ) {
 			selections = new ArrayList<>();
+			aliases = new HashSet<>();
+		}
+		final String alias = selection.getAlias();
+		if ( alias != null && ! aliases.add( alias )) {
+			throw new IllegalArgumentException( "Multi-select expressions defined duplicate alias : " + alias );
 		}
 		selections.add( selection );
 	}
@@ -81,6 +90,7 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 	public void setSelection(SqmSelection sqmSelection) {
 		if ( selections != null ) {
 			selections.clear();
+			aliases.clear();
 		}
 
 		addSelection( sqmSelection );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/tuple/TupleCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/tuple/TupleCriteriaTest.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpa.test.criteria.tuple;
+package org.hibernate.orm.test.jpa.criteria.tuple;
 
 import java.util.Date;
 import java.util.List;


### PR DESCRIPTION
another subtask of https://hibernate.atlassian.net/browse/HHH-14642

The fixing is straightforward. Originally we didn't maintain the tuple entry order for we are using Map. Also, the map key is based on nullable alias so if two tuple entries both have no alias, the last one will override the previous one because HashMap accepts null key.