### PR TITLE
Fix a bug that has existed for more than 15 years. 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -94,7 +94,7 @@ public class Column implements Selectable, Serializable, Cloneable {
 	 */
 	public String getQuotedName() {
 		return safeInterning(
-				quoted ?
+				!quoted ?
 				"`" + name + "`" :
 				name
 		);
@@ -102,7 +102,7 @@ public class Column implements Selectable, Serializable, Cloneable {
 
 	public String getQuotedName(Dialect d) {
 		return safeInterning(
-				quoted ?
+				!quoted ?
 				d.openQuote() + name + d.closeQuote() :
 				name
 		);


### PR DESCRIPTION
Fix a bug that has existed for more than 15 years. When column names use database reserved words, such as when using `groups` as column names under mysql8, the generated SQL script cannot be executed in the database because the column names are not quoted