### PR TITLE
HHH-14719 bump apache-derby to 10.14.2.0 fixing CVE-2015-1832 and CVE-2018-1313

### DIFF
--- a/databases/derby/matrix.gradle
+++ b/databases/derby/matrix.gradle
@@ -5,7 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 //databaseProfile {
-	jdbcDependency 'org.apache.derby:derby:10.11.1.1'
+	jdbcDependency 'org.apache.derby:derby:10.14.2.0'
 
 //	testing {
 //		beforeSuite {

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -127,7 +127,7 @@ ext {
             byteman_bmunit:  "org.jboss.byteman:byteman-bmunit:${bytemanVersion}",
             h2:              "com.h2database:h2:${h2Version}",
             hsqldb:          "org.hsqldb:hsqldb:2.3.2",
-            derby:           "org.apache.derby:derby:10.11.1.1",
+            derby:           "org.apache.derby:derby:10.14.2.0",
             postgresql:      'org.postgresql:postgresql:42.2.16',
             mysql:           'mysql:mysql-connector-java:8.0.17',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14719