### PR TITLE
HHH-14762 Testsuite: Assert.notNull must not be used on primitive types

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyBasicProxyFactoryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyBasicProxyFactoryTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.hibernate.bytecode.internal.bytebuddy.BasicProxyFactoryImpl;
 import org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState;
@@ -27,7 +28,7 @@ public class ByteBuddyBasicProxyFactoryTest {
 		Object entityProxy = BASIC_PROXY_FACTORY.getProxy();
 
 		assertTrue( entityProxy.equals( entityProxy ) );
-		assertNotNull( entityProxy.hashCode() );
+		assertNotEquals(0, entityProxy.hashCode() );
 
 		Object otherEntityProxy = BASIC_PROXY_FACTORY.getProxy();
 		assertFalse( entityProxy.equals( otherEntityProxy ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
@@ -278,7 +278,7 @@ public class JPAXMLOverriddenAnnotationReaderTest extends BaseUnitTestCase {
 
 		field = BusTripPk.class.getDeclaredField( "busDriver" );
 		reader = new JPAXMLOverriddenAnnotationReader( field, context, BootstrapContextImpl.INSTANCE );
-		assertNotNull( reader.isAnnotationPresent( Basic.class ) );
+		assertTrue( reader.isAnnotationPresent( Basic.class ) );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/metadata/StaticMetadataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/metadata/StaticMetadataTest.java
@@ -66,7 +66,7 @@ public class StaticMetadataTest {
 
 		// Cat (hierarchy)
 		assertNotNull( Cat_.id );
-		assertNotNull( Cat_.id.isId() );
+		assertTrue( Cat_.id.isId() );
 		assertEquals( Animal.class, Cat_.id.getJavaMember().getDeclaringClass() );
 		assertNotNull( Cat_.nickname );
 

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/BasicTypeColumnDefinitionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/basic/BasicTypeColumnDefinitionTest.java
@@ -61,8 +61,8 @@ public class BasicTypeColumnDefinitionTest extends BaseEnversJPAFunctionalTestCa
 	@Priority(10)
 	public void testMetadataBindings() {
 		final Long expectedDefaultLength = new Long( DEFAULT_LENGTH );
-		final Long expectedDefaultPrecision = new Long( DEFAULT_PRECISION );
-		final Long expectedDefaultScale = new Long( DEFAULT_SCALE );
+		final Integer expectedDefaultPrecision = Integer.valueOf( DEFAULT_PRECISION );
+		final Integer expectedDefaultScale = Integer.valueOf( DEFAULT_SCALE );
 
 		final Table auditTable = metadata().getEntityBinding( BasicTypeContainer.class.getName() + "_AUD" ).getTable();
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/mappedsuperclass/EmbeddableWithDeclaredDataTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/mappedsuperclass/EmbeddableWithDeclaredDataTest.java
@@ -72,6 +72,6 @@ public class EmbeddableWithDeclaredDataTest extends BaseEnversJPAFunctionalTestC
 		// only value.codeArt should be audited because it is the only audited field in EmbeddableWithDeclaredData;
 		// fields in AbstractEmbeddable should not be audited.
 		Assert.assertEquals( entityLoaded.getValue().getCodeart(), entityRev1.getValue().getCodeart() );
-		Assert.assertNull( entityRev1.getValue().getCode() );
+		Assert.assertEquals(0, entityRev1.getValue().getCode() );
 	}
 }


### PR DESCRIPTION
Fix https://hibernate.atlassian.net/browse/HHH-14762