### PR TITLE
Improve SemanticQueryBuilder performance and fix a few generics related issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,8 @@ stage('Configure') {
 		buildEnv('8', 'mssql'),
 		buildEnv('8', 'sybase'),
 		buildEnv('8', 'hana', 'HANA'),
-		buildEnv('8', 'edb')
+		// Disable EDB for now as the image is not available anymore
+// 		buildEnv('8', 'edb')
 	];
 
 	helper.configure {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CastStrEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CastStrEmulation.java
@@ -37,7 +37,7 @@ public class CastStrEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CoalesceIfnullEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CoalesceIfnullEmulation.java
@@ -31,7 +31,7 @@ public class CoalesceIfnullEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -1479,7 +1479,7 @@ public class CommonFunctionFactory {
 		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder("sum")
 				.setReturnTypeResolver( new FunctionReturnTypeResolver() {
 					@Override
-					public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
+					public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<? extends SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
 						final AllowableFunctionReturnType<?> argType = StandardFunctionReturnTypeResolvers.extractArgumentType(
 								arguments,
 								1

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
@@ -48,7 +48,7 @@ public class ExtractFunction
 
 	@Override
 	protected <T> SelfRenderingSqmFunction generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/FieldFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/FieldFunction.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.SqlTupleContainer;
 import org.hibernate.type.StandardBasicTypes;
 
@@ -36,9 +37,9 @@ public class FieldFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 			sqlAppender.appendSql( ", " );
 
 			final SqlAstNode argument = sqlAstArguments.get( i );
-			if ( argument instanceof SqlTupleContainer ) {
-				final List<? extends Expression> expressions = ( (SqlTupleContainer) argument ).getSqlTuple()
-						.getExpressions();
+			final SqlTuple sqlTuple = SqlTupleContainer.getSqlTuple( argument );
+			if ( sqlTuple != null ) {
+				final List<? extends Expression> expressions = sqlTuple.getExpressions();
 				for ( int j = 0; j < expressions.size(); j++ ) {
 					if ( j != 0 ) {
 						sqlAppender.appendSql( ", " );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/InsertSubstringOverlayEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/InsertSubstringOverlayEmulation.java
@@ -51,7 +51,7 @@ public class InsertSubstringOverlayEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/LocatePositionEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/LocatePositionEmulation.java
@@ -34,7 +34,7 @@ public class LocatePositionEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/LpadRpadPadEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/LpadRpadPadEmulation.java
@@ -38,7 +38,7 @@ public class LpadRpadPadEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/NvlCoalesceEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/NvlCoalesceEmulation.java
@@ -41,7 +41,7 @@ public class NvlCoalesceEmulation
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/PluralPersistentAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/PluralPersistentAttribute.java
@@ -21,16 +21,16 @@ import org.hibernate.query.sqm.SqmPathSource;
  *
  * @author Steve Ebersole
  */
-public interface PluralPersistentAttribute<D,C,E>
-		extends PersistentAttribute<D,C>, SqmPathSource<E>, SqmJoinable, PluralAttribute<D,C,E> {
+public interface PluralPersistentAttribute<D, C, E>
+		extends PersistentAttribute<D, C>, SqmPathSource<E>, SqmJoinable, PluralAttribute<D, C, E> {
 	@Override
 	ManagedDomainType<D> getDeclaringType();
 
 	CollectionClassification getCollectionClassification();
 
-	SqmPathSource getElementPathSource();
+	SqmPathSource<E> getElementPathSource();
 
-	default SqmPathSource getIndexPathSource() {
+	default SqmPathSource<?> getIndexPathSource() {
 		throw new NotIndexedCollectionException(
 				"Plural attribute [" +  getPathName() + "] is not indexed (list / map)"
 		);
@@ -42,7 +42,7 @@ public interface PluralPersistentAttribute<D,C,E>
 	@Override
 	SimpleDomainType<E> getValueGraphType();
 
-	default SimpleDomainType<E> getKeyGraphType() {
+	default SimpleDomainType<?> getKeyGraphType() {
 		throw new NotIndexedCollectionException(
 				"Plural attribute [" +  getPathName() + "] is not indexed (list / map)"
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -29,9 +29,9 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
  * @author Emmanuel Bernard
  * @author Steve Ebersole
  */
-public abstract class AbstractPluralAttribute<D,C,E>
-		extends AbstractAttribute<D,C,E>
-		implements PluralPersistentAttribute<D,C,E>, Serializable {
+public abstract class AbstractPluralAttribute<D, C, E>
+		extends AbstractAttribute<D, C, E>
+		implements PluralPersistentAttribute<D, C, E>, Serializable {
 
 	private final CollectionClassification classification;
 	private final SqmPathSource<E> elementPathSource;
@@ -101,7 +101,7 @@ public abstract class AbstractPluralAttribute<D,C,E>
 	}
 
 	@Override
-	public SimpleDomainType getKeyGraphType() {
+	public SimpleDomainType<?> getKeyGraphType() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -28,7 +28,7 @@ class ListAttributeImpl<X, E> extends AbstractPluralAttribute<X, List<E>, E> imp
 		super( builder, metadataContext );
 
 		//noinspection unchecked
-		this.indexPathSource = (SqmPathSource) SqmMappingModelHelper.resolveSqmKeyPathSource(
+		this.indexPathSource = (SqmPathSource<Integer>) SqmMappingModelHelper.resolveSqmKeyPathSource(
 				getName(),
 				builder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -47,12 +47,12 @@ class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K, V>, V>
 	}
 
 	@Override
-	public SqmPathSource getKeyPathSource() {
+	public SqmPathSource<K> getKeyPathSource() {
 		return keyPathSource;
 	}
 
 	@Override
-	public SqmPathSource getIndexPathSource() {
+	public SqmPathSource<K> getIndexPathSource() {
 		return getKeyPathSource();
 	}
 
@@ -62,7 +62,7 @@ class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K, V>, V>
 	}
 
 	@Override
-	public SimpleDomainType getKeyGraphType() {
+	public SimpleDomainType<K> getKeyGraphType() {
 		return getKeyType();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/HibernateCriteriaBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/HibernateCriteriaBuilder.java
@@ -258,7 +258,7 @@ public interface HibernateCriteriaBuilder extends CriteriaBuilder {
 
 	@Override
 	<T> JpaExpression<T> literal(T value);
-	<T> SqmExpression<T> literal(T value, SqmExpression<T> typeInferenceSource);
+	<T> SqmExpression<T> literal(T value, SqmExpression<? extends T> typeInferenceSource);
 
 	<T> List<? extends JpaExpression<T>> literals(T[] values);
 
@@ -368,7 +368,7 @@ public interface HibernateCriteriaBuilder extends CriteriaBuilder {
 
 	<T> SqmExpression<T> value(T value);
 
-	<T> SqmExpression<T> value(T value, SqmExpression<T> typeInferenceSource);
+	<T> SqmExpression<T> value(T value, SqmExpression<? extends T> typeInferenceSource);
 
 	<V, C extends Collection<V>> JpaExpression<Collection<V>> values(C collection);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
@@ -80,13 +80,13 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 	}
 
 
-	public static List<SqlAstNode> resolveSqlAstArguments(List<SqmTypedNode<?>> sqmArguments, SqmToSqlAstConverter walker) {
+	public static List<SqlAstNode> resolveSqlAstArguments(List<? extends SqmTypedNode<?>> sqmArguments, SqmToSqlAstConverter walker) {
 		if ( sqmArguments == null || sqmArguments.isEmpty() ) {
 			return emptyList();
 		}
 
 		final ArrayList<SqlAstNode> sqlAstArguments = new ArrayList<>();
-		for ( SqmTypedNode sqmArgument : sqmArguments ) {
+		for ( SqmTypedNode<?> sqmArgument : sqmArguments ) {
 			sqlAstArguments.add( toSqlAstNode( ((SqmVisitableNode) sqmArgument).accept( walker ), walker ) );
 		}
 		return sqlAstArguments;
@@ -94,7 +94,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 
 	@Override
 	public final <T> SelfRenderingSqmFunction<T> generateSqmExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
@@ -110,7 +110,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 
 	@Override
 	public final <T> SelfRenderingSqmFunction<T> generateAggregateSqmExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			SqmPredicate filter,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
@@ -135,7 +135,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 	 * @param impliedResultType the function return type as inferred from its usage
 	 */
 	protected abstract <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration);
@@ -149,7 +149,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 	 * @param impliedResultType the function return type as inferred from its usage
 	 */
 	protected <T> SelfRenderingSqmAggregateFunction<T> generateSqmAggregateFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			SqmPredicate filter,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmSelfRenderingFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmSelfRenderingFunctionDescriptor.java
@@ -40,7 +40,7 @@ public abstract class AbstractSqmSelfRenderingFunctionDescriptor
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
@@ -60,7 +60,7 @@ public abstract class AbstractSqmSelfRenderingFunctionDescriptor
 
 	@Override
 	public <T> SelfRenderingSqmAggregateFunction<T> generateSqmAggregateFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			SqmPredicate filter,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/JdbcEscapeFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/JdbcEscapeFunctionDescriptor.java
@@ -32,7 +32,7 @@ public class JdbcEscapeFunctionDescriptor
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/MultipatternSqmFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/MultipatternSqmFunctionDescriptor.java
@@ -69,7 +69,7 @@ public class MultipatternSqmFunctionDescriptor extends AbstractSqmFunctionDescri
 
 	@Override
 	protected <T> SelfRenderingSqmFunction<T> generateSqmFunctionExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmAggregateFunction.java
@@ -29,7 +29,7 @@ public class SelfRenderingSqmAggregateFunction<T> extends SelfRenderingSqmFuncti
 	public SelfRenderingSqmAggregateFunction(
 			SqmFunctionDescriptor descriptor,
 			FunctionRenderingSupport renderingSupport,
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			SqmPredicate filter,
 			AllowableFunctionReturnType<T> impliedResultType,
 			FunctionReturnTypeResolver returnTypeResolver,
@@ -57,7 +57,7 @@ public class SelfRenderingSqmAggregateFunction<T> extends SelfRenderingSqmFuncti
 
 	@Override
 	public void appendHqlString(StringBuilder sb) {
-		final List<SqmTypedNode<?>> arguments = getArguments();
+		final List<? extends SqmTypedNode<?>> arguments = getArguments();
 		sb.append( getFunctionName() );
 		sb.append( '(' );
 		int i = 1;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
@@ -40,7 +40,7 @@ public class SelfRenderingSqmFunction<T> extends SqmFunction<T> {
 	public SelfRenderingSqmFunction(
 			SqmFunctionDescriptor descriptor,
 			FunctionRenderingSupport renderingSupport,
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			FunctionReturnTypeResolver returnTypeResolver,
 			NodeBuilder nodeBuilder,
@@ -55,7 +55,7 @@ public class SelfRenderingSqmFunction<T> extends SqmFunction<T> {
 		return renderingSupport;
 	}
 
-	protected static List<SqlAstNode> resolveSqlAstArguments(List<SqmTypedNode<?>> sqmArguments, SqmToSqlAstConverter walker) {
+	protected static List<SqlAstNode> resolveSqlAstArguments(List<? extends SqmTypedNode<?>> sqmArguments, SqmToSqlAstConverter walker) {
 		if ( sqmArguments == null || sqmArguments.isEmpty() ) {
 			return emptyList();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SqmFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SqmFunctionDescriptor.java
@@ -41,7 +41,7 @@ public interface SqmFunctionDescriptor {
 	 * portable between databases.
 	 */
 	<T> SelfRenderingSqmFunction<T> generateSqmExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration);
@@ -51,7 +51,7 @@ public interface SqmFunctionDescriptor {
 	 * but also accepts a filter predicate. This method is intended for aggregate functions.
 	 */
 	default <T> SelfRenderingSqmFunction<T> generateAggregateSqmExpression(
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			SqmPredicate filter,
 			AllowableFunctionReturnType<T> impliedResultType,
 			QueryEngine queryEngine,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -136,7 +136,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 
 		// NOTE : if we get here, a result-type of some kind (other than Object[].class) was specified
 
-		final List<SqmSelection> selections = sqm.getQueryPart().getFirstQuerySpec().getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = sqm.getQueryPart().getFirstQuerySpec().getSelectClause().getSelections();
 		if ( Tuple.class.isAssignableFrom( resultType ) ) {
 			// resultType is Tuple..
 			if ( queryOptions.getTupleTransformer() == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -244,7 +244,7 @@ public class QuerySqmImpl<R>
 			SessionFactoryImplementor factory) {
 		if ( queryPart instanceof SqmQuerySpec<?> ) {
 			final SqmQuerySpec<R> sqmQuerySpec = (SqmQuerySpec<R>) queryPart;
-			final List<SqmSelection> sqmSelections = sqmQuerySpec.getSelectClause().getSelections();
+			final List<SqmSelection<?>> sqmSelections = sqmQuerySpec.getSelectClause().getSelections();
 
 			// make sure there is at least one root
 			final List<SqmRoot<?>> sqmRoots = sqmQuerySpec.getFromClause().getRoots();
@@ -281,7 +281,7 @@ public class QuerySqmImpl<R>
 			return;
 		}
 
-		final List<SqmSelection> selections = querySpec.getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = querySpec.getSelectClause().getSelections();
 
 		if ( resultClass.isArray() ) {
 			// todo (6.0) : implement

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -714,8 +714,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	public SqmExpression<Number> quot(Number x, Expression<? extends Number> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.QUOT,
-				value( x, (SqmExpression) y ),
-				(SqmExpression) y
+				value( x, (SqmExpression<? extends Number>) y ),
+				(SqmExpression<? extends Number>) y
 		);
 	}
 
@@ -723,34 +723,31 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	public SqmExpression<Integer> mod(Expression<Integer> x, Expression<Integer> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MODULO,
-				(SqmExpression<?>) x,
-				(SqmExpression<?>) y
+				(SqmExpression<Integer>) x,
+				(SqmExpression<Integer>) y
 		);
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public SqmExpression<Integer> mod(Expression<Integer> x, Integer y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MODULO,
-				(SqmExpression) x,
-				value( y, (SqmExpression) x )
+				(SqmExpression<Integer>) x,
+				value( y, (SqmExpression<Integer>) x )
 		);
 	}
 
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public SqmExpression<Integer> mod(Integer x, Expression<Integer> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MODULO,
-				value( x, (SqmExpression) y ),
-				(SqmExpression) y
+				value( x, (SqmExpression<Integer>) y ),
+				(SqmExpression<Integer>) y
 		);
 	}
 
 	@Override
 	public SqmExpression<Double> sqrt(Expression<? extends Number> x) {
-		//noinspection unchecked
 		return getFunctionDescriptor("sqrt").generateSqmExpression(
 				(SqmTypedNode<?>) x,
 				null,
@@ -760,37 +757,31 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<Long> toLong(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asLong();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<Integer> toInteger(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asInteger();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<Float> toFloat(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asFloat();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<Double> toDouble(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asDouble();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<BigDecimal> toBigDecimal(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asBigDecimal();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public SqmExpression<BigInteger> toBigInteger(Expression<? extends Number> number) {
 		return ( (SqmExpression<?>) number ).asBigInteger();
 	}
@@ -801,7 +792,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
-	public <T> SqmLiteral<T> literal(T value, SqmExpression<T> typeInferenceSource) {
+	public <T> SqmLiteral<T> literal(T value, SqmExpression<? extends T> typeInferenceSource) {
 		if ( value == null ) {
 			return new SqmLiteralNull<>( this );
 		}
@@ -812,10 +803,11 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	private static <T> SqmExpressable<T> resolveInferredType(
 			T value,
-			SqmExpression<T> typeInferenceSource,
+			SqmExpression<? extends T> typeInferenceSource,
 			TypeConfiguration typeConfiguration) {
 		if ( typeInferenceSource != null ) {
-			return typeInferenceSource.getNodeType();
+			//noinspection unchecked
+			return (SqmExpressable<T>) typeInferenceSource.getNodeType();
 		}
 
 		if ( value == null ) {
@@ -903,13 +895,13 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public <T> JpaCriteriaParameter<T> parameter(Class<T> paramClass, String name) {
-
 		if ( Collection.class.isAssignableFrom( paramClass ) ) {
 			// a Collection-valued, multi-valued parameter
-			return new JpaCriteriaParameter(
+			return new JpaCriteriaParameter<>(
 					name,
-					new MultiValueParameterType<>( Collection.class ),
+					new MultiValueParameterType<T>( (Class<T>) Collection.class ),
 					true,
 					this
 			);
@@ -917,9 +909,9 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 		if ( paramClass.isArray() ) {
 			// an array-valued, multi-valued parameter
-			return new JpaCriteriaParameter(
+			return new JpaCriteriaParameter<>(
 					name,
-					new MultiValueParameterType( Object[].class ),
+					new MultiValueParameterType<T>( (Class<T>) Object[].class ),
 					true,
 					this
 			);
@@ -936,8 +928,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmExpression<String> concat(Expression<String> x, Expression<String> y) {
-		final SqmExpression xSqmExpression = (SqmExpression) x;
-		final SqmExpression ySqmExpression = (SqmExpression) y;
+		final SqmExpression<String> xSqmExpression = (SqmExpression<String>) x;
+		final SqmExpression<String> ySqmExpression = (SqmExpression<String>) y;
 		//noinspection unchecked
 		return getFunctionDescriptor( "concat" ).generateSqmExpression(
 				asList( xSqmExpression, ySqmExpression ),
@@ -952,10 +944,10 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "unchecked" })
 	public SqmExpression<String> concat(Expression<String> x, String y) {
-		final SqmExpression xSqmExpression = (SqmExpression) x;
-		final SqmExpression ySqmExpression = value( y, xSqmExpression );
+		final SqmExpression<String> xSqmExpression = (SqmExpression<String>) x;
+		final SqmExpression<String> ySqmExpression = value( y, xSqmExpression );
 
 		return getFunctionDescriptor( "concat" ).generateSqmExpression(
 				asList( xSqmExpression, ySqmExpression ),
@@ -970,10 +962,10 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "unchecked" })
 	public SqmExpression<String> concat(String x, Expression<String> y) {
-		final SqmExpression ySqmExpression = (SqmExpression) y;
-		final SqmExpression xSqmExpression = value( x, ySqmExpression );
+		final SqmExpression<String> ySqmExpression = (SqmExpression<String>) y;
+		final SqmExpression<String> xSqmExpression = value( x, ySqmExpression );
 
 		return getFunctionDescriptor( "concat" ).generateSqmExpression(
 				asList( xSqmExpression, ySqmExpression ),
@@ -988,10 +980,10 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "unchecked" })
 	public SqmExpression<String> concat(String x, String y) {
-		final SqmExpression xSqmExpression = value( x );
-		final SqmExpression ySqmExpression = value( y, xSqmExpression );
+		final SqmExpression<String> xSqmExpression = value( x );
+		final SqmExpression<String> ySqmExpression = value( y, xSqmExpression );
 
 		return getFunctionDescriptor( "concat" ).generateSqmExpression(
 				asList( xSqmExpression, ySqmExpression ),
@@ -1008,19 +1000,22 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	@Override
 	public SqmFunction<String> substring(Expression<String> source, Expression<Integer> from) {
 		return createSubstringNode(
-				(SqmExpression) source,
-				(SqmExpression) from,
+				(SqmExpression<String>) source,
+				(SqmExpression<Integer>) from,
 				null
 		);
 	}
 
-	private SqmFunction<String> createSubstringNode(SqmExpression source, SqmExpression from, SqmExpression len) {
-		final AllowableFunctionReturnType resultType = (AllowableFunctionReturnType)  QueryHelper.highestPrecedenceType2(
+	private SqmFunction<String> createSubstringNode(
+			SqmExpression<String> source,
+			SqmExpression<Integer> from,
+			SqmExpression<Integer> len) {
+		//noinspection unchecked
+		final AllowableFunctionReturnType<String> resultType = (AllowableFunctionReturnType<String>) QueryHelper.highestPrecedenceType2(
 				source.getNodeType(),
 				StandardBasicTypes.STRING
 		);
 
-		//noinspection unchecked
 		return getFunctionDescriptor( "substring" ).generateSqmExpression(
 				len==null ? asList( source, from ) : asList( source, from, len ),
 				resultType,
@@ -1032,7 +1027,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	@Override
 	public SqmFunction<String> substring(Expression<String> source, int from) {
 		return createSubstringNode(
-				(SqmExpression) source,
+				(SqmExpression<String>) source,
 				value( from ),
 				null
 		);
@@ -1041,16 +1036,16 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	@Override
 	public SqmFunction<String> substring(Expression<String> source, Expression<Integer> from, Expression<Integer> len) {
 		return createSubstringNode(
-				(SqmExpression) source,
-				(SqmExpression) from,
-				(SqmExpression) len
+				(SqmExpression<String>) source,
+				(SqmExpression<Integer>) from,
+				(SqmExpression<Integer>) len
 		);
 	}
 
 	@Override
 	public SqmFunction<String> substring(Expression<String> source, int from, int len) {
 		return createSubstringNode(
-				(SqmExpression) source,
+				(SqmExpression<String>) source,
 				value( from ),
 				value( len )
 		);
@@ -1058,10 +1053,13 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<String> trim(Expression<String> source) {
-		return createTrimNode( null, null, (SqmExpression) source );
+		return createTrimNode( null, null, (SqmExpression<String>) source );
 	}
 
-	private SqmFunction<String> createTrimNode(TrimSpec trimSpecification, SqmExpression trimCharacter, SqmExpression source) {
+	private SqmFunction<String> createTrimNode(
+			TrimSpec trimSpecification,
+			SqmExpression<Character> trimCharacter,
+			SqmExpression<String> source) {
 
 		final ArrayList<SqmTypedNode<?>> arguments = new ArrayList<>();
 
@@ -1088,7 +1086,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<String> trim(Trimspec ts, Expression<String> source) {
-		return createTrimNode( convertTrimSpec( ts ), null, (SqmExpression) source );
+		return createTrimNode( convertTrimSpec( ts ), null, (SqmExpression<String>) source );
 	}
 
 	private static TrimSpec convertTrimSpec(Trimspec jpaTs) {
@@ -1113,35 +1111,34 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<String> trim(Expression<Character> trimChar, Expression<String> source) {
-		return createTrimNode( null, (SqmExpression) trimChar, (SqmExpression) source );
+		return createTrimNode( null, (SqmExpression<Character>) trimChar, (SqmExpression<String>) source );
 	}
 
 	@Override
 	public SqmFunction<String> trim(Trimspec ts, Expression<Character> trimChar, Expression<String> source) {
-		return createTrimNode( convertTrimSpec( ts ), (SqmExpression) trimChar, (SqmExpression) source );
+		return createTrimNode( convertTrimSpec( ts ), (SqmExpression<Character>) trimChar, (SqmExpression<String>) source );
 	}
 
 	@Override
 	public SqmFunction<String> trim(char trimChar, Expression<String> source) {
-		return createTrimNode( null, literal( trimChar ), (SqmExpression) source );
+		return createTrimNode( null, literal( trimChar ), (SqmExpression<String>) source );
 	}
 
 	@Override
 	public SqmFunction<String> trim(Trimspec ts, char trimChar, Expression<String> source) {
-		return createTrimNode( convertTrimSpec( ts ), literal( trimChar ), (SqmExpression) source );
+		return createTrimNode( convertTrimSpec( ts ), literal( trimChar ), (SqmExpression<String>) source );
 	}
 
 	@Override
 	public SqmFunction<String> lower(Expression<String> x) {
-
-		final AllowableFunctionReturnType type = (AllowableFunctionReturnType)  highestPrecedenceType(
-				((SqmExpression) x).getNodeType(),
+		//noinspection unchecked
+		final AllowableFunctionReturnType<String> type = (AllowableFunctionReturnType<String>) highestPrecedenceType(
+				((SqmExpression<String>) x).getNodeType(),
 				StandardBasicTypes.STRING
 		);
 
-		//noinspection unchecked
 		return getFunctionDescriptor( "lower" ).generateSqmExpression(
-				(SqmExpression) x,
+				(SqmExpression<String>) x,
 				type,
 				getQueryEngine(),
 				getJpaMetamodel().getTypeConfiguration()
@@ -1150,14 +1147,14 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<String> upper(Expression<String> x) {
-		final AllowableFunctionReturnType type = (AllowableFunctionReturnType) highestPrecedenceType(
-				((SqmExpression) x).getNodeType(),
+		//noinspection unchecked
+		final AllowableFunctionReturnType<String> type = (AllowableFunctionReturnType<String>) highestPrecedenceType(
+				((SqmExpression<String>) x).getNodeType(),
 				StandardBasicTypes.STRING
 		);
 
-		//noinspection unchecked
 		return getFunctionDescriptor( "upper" ).generateSqmExpression(
-				(SqmExpression) x,
+				(SqmExpression<String>) x,
 				type,
 				getQueryEngine(),
 				getJpaMetamodel().getTypeConfiguration()
@@ -1166,13 +1163,9 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<Integer> length(Expression<String> argument) {
-		//noinspection unchecked
 		return getFunctionDescriptor( "length" ).generateSqmExpression(
-				(SqmExpression) argument,
-				(AllowableFunctionReturnType) highestPrecedenceType(
-						((SqmExpression) argument).getNodeType(),
-						StandardBasicTypes.INTEGER
-				),
+				(SqmExpression<String>) argument,
+				StandardBasicTypes.INTEGER,
 				getQueryEngine(),
 				getJpaMetamodel().getTypeConfiguration()
 		);
@@ -1191,11 +1184,6 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 			SqmExpression<String> source,
 			SqmExpression<String> pattern,
 			SqmExpression<Integer> startPosition) {
-		final AllowableFunctionReturnType type = (AllowableFunctionReturnType) highestPrecedenceType(
-				source.getNodeType(),
-				StandardBasicTypes.INTEGER
-		);
-
 		final List<SqmTypedNode<?>> arguments;
 		if ( startPosition == null ) {
 			arguments = asList(
@@ -1206,14 +1194,14 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 		else {
 			arguments = asList(
 					source,
-					pattern
+					pattern,
+					startPosition
 			);
 		}
 
-		//noinspection unchecked
 		return getFunctionDescriptor("locate").generateSqmExpression(
 				arguments,
-				type,
+				StandardBasicTypes.INTEGER,
 				getQueryEngine(),
 				getJpaMetamodel().getTypeConfiguration()
 		);
@@ -1251,7 +1239,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 		//noinspection unchecked
 		return getFunctionDescriptor("current_date")
 				.generateSqmExpression(
-						(AllowableFunctionReturnType) StandardBasicTypes.DATE,
+						(AllowableFunctionReturnType<Date>) (AllowableFunctionReturnType<?>) StandardBasicTypes.DATE,
 						queryEngine,
 						getJpaMetamodel().getTypeConfiguration()
 				);
@@ -1262,7 +1250,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 		//noinspection unchecked
 		return getFunctionDescriptor("current_timestamp")
 				.generateSqmExpression(
-						(AllowableFunctionReturnType) StandardBasicTypes.TIMESTAMP,
+						(AllowableFunctionReturnType<Timestamp>) (AllowableFunctionReturnType<?>) StandardBasicTypes.TIMESTAMP,
 						queryEngine,
 						getJpaMetamodel().getTypeConfiguration()
 				);
@@ -1273,7 +1261,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 		//noinspection unchecked
 		return getFunctionDescriptor("current_time")
 				.generateSqmExpression(
-						(AllowableFunctionReturnType) StandardBasicTypes.TIME,
+						(AllowableFunctionReturnType<Time>) (AllowableFunctionReturnType<?>) StandardBasicTypes.TIME,
 						queryEngine,
 						getJpaMetamodel().getTypeConfiguration()
 				);
@@ -1281,7 +1269,6 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	@Override
 	public SqmFunction<Instant> currentInstant() {
-		//noinspection unchecked
 		return getFunctionDescriptor("current_timestamp")
 				.generateSqmExpression(
 						StandardBasicTypes.INSTANT,
@@ -1297,9 +1284,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 			throw new SemanticException( "Could not resolve function named `" + name + "`" );
 		}
 
-		//noinspection unchecked
 		return functionTemplate.generateSqmExpression(
-				(List) expressionList( args ),
+				expressionList( args ),
 				getTypeConfiguration().getBasicTypeForJavaType( type ),
 				getQueryEngine(),
 				getJpaMetamodel().getTypeConfiguration()
@@ -1359,7 +1345,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 	 * Creates an expression for the value with the given "type inference" information
 	 */
 	@Override
-	public <T> SqmExpression<T> value(T value, SqmExpression<T> typeInferenceSource) {
+	public <T> SqmExpression<T> value(T value, SqmExpression<? extends T> typeInferenceSource) {
 		if ( typeInferenceSource == null ) {
 			return value( value );
 		}
@@ -1377,7 +1363,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 
 	private static <T> AllowableParameterType<T> resolveInferredParameterType(
 			T value,
-			SqmExpression<T> typeInferenceSource,
+			SqmExpression<? extends T> typeInferenceSource,
 			TypeConfiguration typeConfiguration) {
 		if ( typeInferenceSource != null ) {
 			if ( typeInferenceSource instanceof AllowableParameterType ) {
@@ -1386,6 +1372,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext {
 			}
 
 			if ( typeInferenceSource.getNodeType() instanceof AllowableParameterType ) {
+				//noinspection unchecked
 				return (AllowableParameterType<T>) typeInferenceSource.getNodeType();
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
@@ -17,7 +17,7 @@ public interface ArgumentsValidator {
 	/**
 	 * The main (functional) operation defining validation
 	 */
-	void validate(List<SqmTypedNode<?>> arguments);
+	void validate(List<? extends SqmTypedNode<?>> arguments);
 
 	default String getSignature() {
 		return "( ... )";

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionReturnTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionReturnTypeResolver.java
@@ -34,7 +34,7 @@ public interface FunctionReturnTypeResolver {
 	 */
 	AllowableFunctionReturnType<?> resolveFunctionReturnType(
 			AllowableFunctionReturnType<?> impliedType,
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			TypeConfiguration typeConfiguration);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
@@ -28,7 +28,7 @@ public final class StandardArgumentsValidators {
 	 */
 	public static final ArgumentsValidator NONE = new ArgumentsValidator() {
 		@Override
-		public void validate(List<SqmTypedNode<?>> arguments) {}
+		public void validate(List<? extends SqmTypedNode<?>> arguments) {}
 
 		@Override
 		public String getSignature() {
@@ -41,7 +41,7 @@ public final class StandardArgumentsValidators {
 	 */
 	public static final ArgumentsValidator NO_ARGS = new ArgumentsValidator() {
 		@Override
-		public void validate(List<SqmTypedNode<?>> arguments) {
+		public void validate(List<? extends SqmTypedNode<?>> arguments) {
 			if (!arguments.isEmpty()) {
 				throw new QueryException("Expecting no arguments, but found " + arguments.size());
 			}
@@ -59,7 +59,7 @@ public final class StandardArgumentsValidators {
 		}
 		return new ArgumentsValidator() {
 			@Override
-			public void validate(List<SqmTypedNode<?>> arguments) {
+			public void validate(List<? extends SqmTypedNode<?>> arguments) {
 				if (arguments.size() < minNumOfArgs) {
 					throw new QueryException(
 							String.format(
@@ -92,7 +92,7 @@ public final class StandardArgumentsValidators {
 	public static ArgumentsValidator exactly(int number) {
 		return new ArgumentsValidator() {
 			@Override
-			public void validate(List<SqmTypedNode<?>> arguments) {
+			public void validate(List<? extends SqmTypedNode<?>> arguments) {
 				if (arguments.size() != number) {
 					throw new QueryException(
 							String.format(
@@ -127,7 +127,7 @@ public final class StandardArgumentsValidators {
 	public static ArgumentsValidator max(int maxNumOfArgs) {
 		return new ArgumentsValidator() {
 			@Override
-			public void validate(List<SqmTypedNode<?>> arguments) {
+			public void validate(List<? extends SqmTypedNode<?>> arguments) {
 				if (arguments.size() > maxNumOfArgs) {
 					throw new QueryException(
 							String.format(
@@ -158,7 +158,7 @@ public final class StandardArgumentsValidators {
 	public static ArgumentsValidator between(int minNumOfArgs, int maxNumOfArgs) {
 		return new ArgumentsValidator() {
 			@Override
-			public void validate(List<SqmTypedNode<?>> arguments) {
+			public void validate(List<? extends SqmTypedNode<?>> arguments) {
 				if (arguments.size() < minNumOfArgs || arguments.size() > maxNumOfArgs) {
 					throw new QueryException(
 							String.format(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -47,7 +47,7 @@ public class StandardFunctionReturnTypeResolvers {
 			@Override
 			public AllowableFunctionReturnType<?> resolveFunctionReturnType(
 					AllowableFunctionReturnType<?> impliedType,
-					List<SqmTypedNode<?>> arguments,
+					List<? extends SqmTypedNode<?>> arguments,
 					TypeConfiguration typeConfiguration) {
 				return isAssignableTo( invariantType, impliedType )
 						? impliedType : invariantType;
@@ -68,7 +68,7 @@ public class StandardFunctionReturnTypeResolvers {
 	public static FunctionReturnTypeResolver useArgType(int argPosition) {
 		return new FunctionReturnTypeResolver() {
 			@Override
-			public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
+			public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<? extends SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
 				AllowableFunctionReturnType<?> argType = extractArgumentType( arguments, argPosition );
 				return isAssignableTo( argType, impliedType ) ? impliedType : argType;
 			}
@@ -101,7 +101,7 @@ public class StandardFunctionReturnTypeResolvers {
 			}
 
 			@Override
-			public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
+			public AllowableFunctionReturnType<?> resolveFunctionReturnType(AllowableFunctionReturnType<?> impliedType, List<? extends SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
 				for (SqmTypedNode<?> arg: arguments) {
 					if (arg!=null && arg.getNodeType() instanceof AllowableFunctionReturnType) {
 						AllowableFunctionReturnType<?> argType = (AllowableFunctionReturnType<?>) arg.getNodeType();
@@ -200,8 +200,10 @@ public class StandardFunctionReturnTypeResolvers {
 		return false;
 	}
 
-	public static AllowableFunctionReturnType<?> extractArgumentType(List<SqmTypedNode<?>> arguments, int position) {
-		final SqmTypedNode<?> specifiedArgument = arguments.get( position-1 );
+	public static AllowableFunctionReturnType<?> extractArgumentType(
+			List<? extends SqmTypedNode<?>> arguments,
+			int position) {
+		final SqmTypedNode<?> specifiedArgument = arguments.get( position - 1 );
 		final SqmExpressable<?> specifiedArgType = specifiedArgument.getNodeType();
 		if ( !(specifiedArgType instanceof AllowableFunctionReturnType) ) {
 			throw new QueryException(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -1717,11 +1717,11 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 	private boolean selectClauseContains(SqmFrom<?, ?> from) {
 		final SqmQuerySpec<?> sqmQuerySpec = (SqmQuerySpec<?>) currentSqmQueryPart;
-		final List<SqmSelection> selections = sqmQuerySpec.getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = sqmQuerySpec.getSelectClause().getSelections();
 		if ( selections.isEmpty() && from instanceof SqmRoot<?> ) {
 			return true;
 		}
-		for ( SqmSelection selection : selections ) {
+		for ( SqmSelection<?> selection : selections ) {
 			if ( selection.getSelectableNode() == from ) {
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxIndexPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMaxIndexPath.java
@@ -32,11 +32,11 @@ public class SqmMaxIndexPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 
 		if ( getPluralAttribute() instanceof ListPersistentAttribute ) {
 			//noinspection unchecked
-			this.indexPathSource = getPluralAttribute().getIndexPathSource();
+			this.indexPathSource = (SqmPathSource<T>) getPluralAttribute().getIndexPathSource();
 		}
 		else if ( getPluralAttribute() instanceof MapPersistentAttribute ) {
 			//noinspection unchecked
-			this.indexPathSource = ( (MapPersistentAttribute) getPluralAttribute() ).getKeyPathSource();
+			this.indexPathSource = ( (MapPersistentAttribute<?, ?, ?>) getPluralAttribute() ).getKeyPathSource();
 		}
 		else {
 			throw new UnsupportedOperationException( "Plural attribute [" + getPluralAttribute() + "] is not indexed" );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinIndexPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMinIndexPath.java
@@ -32,11 +32,11 @@ public class SqmMinIndexPath<T> extends AbstractSqmSpecificPluralPartPath<T> {
 
 		if ( getPluralAttribute() instanceof ListPersistentAttribute ) {
 			//noinspection unchecked
-			this.indexPathSource = getPluralAttribute().getIndexPathSource();
+			this.indexPathSource = (SqmPathSource<T>) getPluralAttribute().getIndexPathSource();
 		}
 		else if ( getPluralAttribute() instanceof MapPersistentAttribute ) {
 			//noinspection unchecked
-			this.indexPathSource = ( (MapPersistentAttribute) getPluralAttribute() ).getKeyPathSource();
+			this.indexPathSource = ( (MapPersistentAttribute<?, ?, ?>) getPluralAttribute() ).getKeyPathSource();
 		}
 		else {
 			throw new UnsupportedOperationException( "Plural attribute [" + getPluralAttribute() + "] is not indexed" );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
@@ -25,7 +25,7 @@ import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
 public class SqmCaseSearched<R>
 		extends AbstractSqmExpression<R>
 		implements JpaSearchedCase<R>, DomainResultProducer<R> {
-	private List<WhenFragment<R>> whenFragments = new ArrayList<>();
+	private final List<WhenFragment<R>> whenFragments;
 	private SqmExpression<R> otherwise;
 
 	public SqmCaseSearched(NodeBuilder nodeBuilder) {
@@ -34,6 +34,12 @@ public class SqmCaseSearched<R>
 
 	public SqmCaseSearched(SqmExpressable<R> inherentType, NodeBuilder nodeBuilder) {
 		super( inherentType, nodeBuilder );
+		this.whenFragments = new ArrayList<>();
+	}
+
+	public SqmCaseSearched(SqmExpressable<R> inherentType, int estimateWhenSize, NodeBuilder nodeBuilder) {
+		super( inherentType, nodeBuilder );
+		this.whenFragments = new ArrayList<>( estimateWhenSize );
 	}
 
 	public List<WhenFragment<R>> getWhenFragments() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSimple.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSimple.java
@@ -22,11 +22,11 @@ import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
 /**
  * @author Steve Ebersole
  */
-public class SqmCaseSimple<T,R>
+public class SqmCaseSimple<T, R>
 		extends AbstractSqmExpression<R>
-		implements JpaSimpleCase<T,R>, DomainResultProducer<R> {
+		implements JpaSimpleCase<T, R>, DomainResultProducer<R> {
 	private final SqmExpression<T> fixture;
-	private List<WhenFragment<T,R>> whenFragments = new ArrayList<>();
+	private final List<WhenFragment<T, R>> whenFragments;
 	private SqmExpression<R> otherwise;
 
 	public SqmCaseSimple(SqmExpression<T> fixture, NodeBuilder nodeBuilder) {
@@ -35,6 +35,13 @@ public class SqmCaseSimple<T,R>
 
 	public SqmCaseSimple(SqmExpression<T> fixture, SqmExpressable<R> inherentType, NodeBuilder nodeBuilder) {
 		super( inherentType, nodeBuilder );
+		this.whenFragments = new ArrayList<>( );
+		this.fixture = fixture;
+	}
+
+	public SqmCaseSimple(SqmExpression<T> fixture, SqmExpressable<R> inherentType, int estimateWhenSize, NodeBuilder nodeBuilder) {
+		super( inherentType, nodeBuilder );
+		this.whenFragments = new ArrayList<>( estimateWhenSize );
 		this.fixture = fixture;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExtractUnit.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExtractUnit.java
@@ -20,7 +20,7 @@ import org.hibernate.query.sqm.tree.SqmVisitableNode;
  */
 public class SqmExtractUnit<T> extends AbstractSqmNode implements SqmTypedNode<T>, SqmVisitableNode {
 	private final TemporalUnit unit;
-	private final AllowableFunctionReturnType type;
+	private final AllowableFunctionReturnType<T> type;
 
 	public SqmExtractUnit(TemporalUnit unit, AllowableFunctionReturnType<T> type, NodeBuilder nodeBuilder) {
 		super( nodeBuilder );
@@ -32,7 +32,7 @@ public class SqmExtractUnit<T> extends AbstractSqmNode implements SqmTypedNode<T
 		return unit;
 	}
 
-	public AllowableFunctionReturnType getType() {
+	public AllowableFunctionReturnType<T> getType() {
 		return type;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
@@ -35,13 +35,13 @@ public abstract class SqmFunction<T> extends AbstractSqmExpression<T>
 	private final String functionName;
 	private final SqmFunctionDescriptor functionDescriptor;
 
-	private final List<SqmTypedNode<?>> arguments;
+	private final List<? extends SqmTypedNode<?>> arguments;
 
 	public SqmFunction(
 			String functionName,
 			SqmFunctionDescriptor functionDescriptor,
 			SqmExpressable<T> type,
-			List<SqmTypedNode<?>> arguments,
+			List<? extends SqmTypedNode<?>> arguments,
 			NodeBuilder criteriaBuilder) {
 		super( type, criteriaBuilder );
 		this.functionName = functionName;
@@ -58,7 +58,7 @@ public abstract class SqmFunction<T> extends AbstractSqmExpression<T>
 		return functionName;
 	}
 
-	public List<SqmTypedNode<?>> getArguments() {
+	public List<? extends SqmTypedNode<?>> getArguments() {
 		return arguments;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTrimSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTrimSpecification.java
@@ -20,7 +20,7 @@ import org.hibernate.query.sqm.tree.SqmVisitableNode;
  *
  * @author Steve Ebersole
  */
-public class SqmTrimSpecification extends AbstractSqmNode implements SqmTypedNode, SqmVisitableNode {
+public class SqmTrimSpecification extends AbstractSqmNode implements SqmTypedNode<Void>, SqmVisitableNode {
 	private final TrimSpec specification;
 
 	public SqmTrimSpecification(TrimSpec specification, NodeBuilder nodeBuilder) {
@@ -43,7 +43,7 @@ public class SqmTrimSpecification extends AbstractSqmNode implements SqmTypedNod
 	}
 
 	@Override
-	public SqmExpressable getNodeType() {
+	public SqmExpressable<Void> getNodeType() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInListPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInListPredicate.java
@@ -40,7 +40,7 @@ public class SqmInListPredicate<T> extends AbstractNegatableSqmPredicate impleme
 
 	public SqmInListPredicate(
 			SqmExpression<T> testExpression,
-			List<SqmExpression<T>> listExpressions,
+			List<? extends SqmExpression<T>> listExpressions,
 			NodeBuilder nodeBuilder) {
 		this( testExpression, listExpressions, false, nodeBuilder );
 	}
@@ -48,13 +48,14 @@ public class SqmInListPredicate<T> extends AbstractNegatableSqmPredicate impleme
 	@SuppressWarnings("WeakerAccess")
 	public SqmInListPredicate(
 			SqmExpression<T> testExpression,
-			List<SqmExpression<T>> listExpressions,
+			List<? extends SqmExpression<T>> listExpressions,
 			boolean negated,
 			NodeBuilder nodeBuilder) {
 		super( negated, nodeBuilder );
 		this.testExpression = testExpression;
-		this.listExpressions = listExpressions;
-		for ( SqmExpression listExpression : listExpressions ) {
+		//noinspection unchecked
+		this.listExpressions = (List<SqmExpression<T>>) listExpressions;
+		for ( SqmExpression<T> listExpression : listExpressions ) {
 			implyListElementType( listExpression );
 		}
 
@@ -87,30 +88,30 @@ public class SqmInListPredicate<T> extends AbstractNegatableSqmPredicate impleme
 	}
 
 	@Override
-	public SqmInPredicate<T> value(Expression value) {
+	public SqmInPredicate<T> value(Expression<? extends T> value) {
+		//noinspection unchecked
 		addExpression( (SqmExpression<T>) value );
 		return this;
 	}
 
 	@Override
-	public SqmInPredicate<T> value(JpaExpression value) {
-		addExpression( (SqmExpression) value );
+	public SqmInPredicate<T> value(JpaExpression<? extends T> value) {
+		//noinspection unchecked
+		addExpression( (SqmExpression<T>) value );
 		return this;
 	}
 
-	public List<SqmExpression<T>> getListExpressions() {
+	public List<? extends SqmExpression<T>> getListExpressions() {
 		return listExpressions;
 	}
 
-	public <X> void addExpression(SqmExpression<X> expression) {
+	public void addExpression(SqmExpression<T> expression) {
 		implyListElementType( expression );
 
-		//noinspection unchecked
-		listExpressions.add( (SqmExpression<T>) expression );
+		listExpressions.add( expression );
 	}
 
-	private void implyListElementType(SqmExpression expression) {
-		//noinspection unchecked
+	private void implyListElementType(SqmExpression<?> expression) {
 		expression.applyInferableType(
 				QueryHelper.highestPrecedenceType2(
 						getTestExpression().getNodeType(),

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInSubQueryPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInSubQueryPredicate.java
@@ -79,7 +79,7 @@ public class SqmInSubQueryPredicate<T> extends AbstractNegatableSqmPredicate imp
 	}
 
 	@Override
-	public SqmInPredicate<T> value(JpaExpression value) {
+	public SqmInPredicate<T> value(JpaExpression<? extends T> value) {
 		throw new UnsupportedOperationException(  );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmAliasedExpressionContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmAliasedExpressionContainer.java
@@ -11,7 +11,7 @@ import org.hibernate.query.sqm.tree.expression.SqmExpression;
 /**
  * @author Steve Ebersole
  */
-public interface SqmAliasedExpressionContainer<T extends SqmAliasedNode> {
+public interface SqmAliasedExpressionContainer<T extends SqmAliasedNode<?>> {
 	T add(SqmExpression<?> expression, String alias);
 	void add(T aliasExpression);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmOrderByClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmOrderByClause.java
@@ -23,6 +23,10 @@ public class SqmOrderByClause {
 	public SqmOrderByClause() {
 	}
 
+	public SqmOrderByClause(int estimateSize) {
+		this.sortSpecifications = new ArrayList<>( estimateSize );
+	}
+
 	public boolean hasPositionalSortItem() {
 		return hasPositionalSortItem;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQueryGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQueryGroup.java
@@ -116,7 +116,7 @@ public class SqmQueryGroup<T> extends SqmQueryPart<T> implements JpaQueryGroup<T
 	}
 
 	private void validateQueryGroupFetchStructure(SqmQuerySpec<?> firstQuerySpec) {
-		final List<SqmSelection> firstSelections = firstQuerySpec.getSelectClause().getSelections();
+		final List<SqmSelection<?>> firstSelections = firstQuerySpec.getSelectClause().getSelections();
 		final int firstSelectionSize = firstSelections.size();
 		for ( int i = 0; i < queryParts.size(); i++ ) {
 			final SqmQueryPart<T> queryPart = queryParts.get( i );
@@ -125,12 +125,12 @@ public class SqmQueryGroup<T> extends SqmQueryPart<T> implements JpaQueryGroup<T
 			}
 			else {
 				final SqmQuerySpec<?> querySpec = (SqmQuerySpec<?>) queryPart;
-				final List<SqmSelection> selections = querySpec.getSelectClause().getSelections();
+				final List<SqmSelection<?>> selections = querySpec.getSelectClause().getSelections();
 				if ( firstSelectionSize != selections.size() ) {
 					throw new SemanticException( "All query parts in a query group must have the same arity!" );
 				}
 				for ( int j = 0; j < firstSelectionSize; j++ ) {
-					final SqmSelection firstSqmSelection = firstSelections.get( j );
+					final SqmSelection<?> firstSqmSelection = firstSelections.get( j );
 					final JavaTypeDescriptor<?> firstJavaTypeDescriptor = firstSqmSelection.getNodeJavaTypeDescriptor();
 					if ( firstJavaTypeDescriptor != selections.get( j ).getNodeJavaTypeDescriptor() ) {
 						throw new SemanticException(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -340,7 +340,7 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 			if ( selectClause.isDistinct() ) {
 				sb.append( "distinct " );
 			}
-			final List<SqmSelection> selections = selectClause.getSelections();
+			final List<SqmSelection<?>> selections = selectClause.getSelections();
 			selections.get( 0 ).appendHqlString( sb );
 			for ( int i = 1; i < selections.size(); i++ ) {
 				sb.append( ", " );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -22,7 +22,7 @@ import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
  *
  * @author Steve Ebersole
  */
-public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpressionContainer<SqmSelection>, JpaSelection<Object> {
+public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpressionContainer<SqmSelection<?>>, JpaSelection<Object> {
 	private boolean distinct;
 	private List<SqmSelection<?>> selections;
 
@@ -50,7 +50,7 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 		this.distinct = distinct;
 	}
 
-	public List<SqmSelection> getSelections() {
+	public List<SqmSelection<?>> getSelections() {
 		if ( selections == null ) {
 			return Collections.emptyList();
 		}
@@ -59,7 +59,7 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 		}
 	}
 
-	public void addSelection(SqmSelection selection) {
+	public void addSelection(SqmSelection<?> selection) {
 		if ( selections == null ) {
 			selections = new ArrayList<>();
 		}
@@ -67,18 +67,18 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 	}
 
 	@Override
-	public SqmSelection add(SqmExpression<?> expression, String alias) {
-		final SqmSelection selection = new SqmSelection<>( expression, alias, nodeBuilder()  );
+	public SqmSelection<?> add(SqmExpression<?> expression, String alias) {
+		final SqmSelection<?> selection = new SqmSelection<>( expression, alias, nodeBuilder()  );
 		addSelection( selection );
 		return selection;
 	}
 
 	@Override
-	public void add(SqmSelection aliasExpression) {
+	public void add(SqmSelection<?> aliasExpression) {
 		addSelection( aliasExpression );
 	}
 
-	public void setSelection(SqmSelection sqmSelection) {
+	public void setSelection(SqmSelection<?> sqmSelection) {
 		if ( selections != null ) {
 			selections.clear();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlTupleContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/SqlTupleContainer.java
@@ -6,9 +6,18 @@
  */
 package org.hibernate.sql.ast.tree.expression;
 
+import org.hibernate.sql.ast.tree.SqlAstNode;
+
 /**
  * @author Steve Ebersole
  */
 public interface SqlTupleContainer {
 	SqlTuple getSqlTuple();
+
+	static SqlTuple getSqlTuple(SqlAstNode expression) {
+		if ( expression instanceof SqlTupleContainer ) {
+			return ( (SqlTupleContainer) expression ).getSqlTuple();
+		}
+		return null;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AliasCollisionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AliasCollisionTest.java
@@ -93,7 +93,7 @@ public class AliasCollisionTest extends BaseSqmUnitTest {
 
 		final SqmQuerySpec<?> querySpec = sqm.getQuerySpec();
 
-		final List<SqmSelection> selections = querySpec.getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = querySpec.getSelectClause().getSelections();
 		assertThat( selections, hasSize( 1 ) );
 		assertThat( selections.get( 0 ).getAlias(), nullValue() );
 
@@ -122,7 +122,7 @@ public class AliasCollisionTest extends BaseSqmUnitTest {
 
 		final SqmQuerySpec<?> querySpec = sqm.getQuerySpec();
 
-		final List<SqmSelection> selections = querySpec.getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = querySpec.getSelectClause().getSelections();
 		assertThat( selections, hasSize( 1 ) );
 		assertThat( selections.get( 0 ).getAlias(), nullValue() );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
@@ -59,7 +59,7 @@ public class AttributePathTests extends BaseSqmUnitTest {
 //		assertPropertyPath( space.getRoot(), "com.acme.Something(s)" );
 //		assertPropertyPath( space.getJoins().get( 0 ), "com.acme.Something(s).entity" );
 
-		final List<SqmSelection> selections = statement.getQuerySpec().getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = statement.getQuerySpec().getSelectClause().getSelections();
 		assertThat( selections.size(), is(2) );
 
 		// expression paths
@@ -136,7 +136,7 @@ public class AttributePathTests extends BaseSqmUnitTest {
 	@Test
 	public void testManyToOneReference() {
 		final SqmSelectStatement<?> sqm = interpretSelect( "select s.mate from Person s" );
-		final List<SqmSelection> selections = sqm.getQuerySpec().getSelectClause().getSelections();
+		final List<SqmSelection<?>> selections = sqm.getQuerySpec().getSelectClause().getSelections();
 		assertThat( selections.size(), is( 1 ) );
 		final SqmSelection<?> selection = selections.get( 0 );
 		final SqmSelectableNode<?> selectableNode = selection.getSelectableNode();

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/ASTParserLoadingTest.java
@@ -331,7 +331,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 					Query<?> query = session.createQuery( "select a.class from Animal a where a.class = Dog" );
 					query.list();
 					SqmSelectStatement<?> sqmStatement = (SqmSelectStatement<?>) query.unwrap( QuerySqmImpl.class ).getSqmStatement();
-					List<SqmSelection> selections = sqmStatement.getQuerySpec().getSelectClause().getSelections();
+					List<SqmSelection<?>> selections = sqmStatement.getQuerySpec().getSelectClause().getSelections();
 					assertEquals( 1, selections.size() );
 					SqmSelection<?> typeSelection = selections.get( 0 );
 					// always integer for joined
@@ -2627,7 +2627,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 
 		Query<?> q = s.createQuery( "select a.bodyWeight as abw, a.description from Animal a" );
 		SqmSelectStatement<?> sqmStatement = (SqmSelectStatement<?>) q.unwrap( QuerySqmImpl.class ).getSqmStatement();
-		List<SqmSelection> selections = sqmStatement.getQuerySpec().getSelectClause().getSelections();
+		List<SqmSelection<?>> selections = sqmStatement.getQuerySpec().getSelectClause().getSelections();
 		assertThat( selections.size(), is( 2 ) );
 		assertThat( selections.get( 0 ).getAlias(), is( "abw" ) );
 		assertThat( selections.get( 1 ).getAlias(), nullValue() );


### PR DESCRIPTION
The methods to access sub-contexts in the ANTLR visitors always search through the list of children. In case of variable arity grammar rules i.e. when the method returns a list of contexts, it always materializes a new list on every access which is quite wasteful. This PR aims to get rid of these calls and rely on the grammar structure to find the sub-contexts at the indexes where they should be according to the rule structure of the grammar.