### PR TITLE
Re-enabled additional tests

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -91,6 +91,7 @@ public class ToOneAttributeMapping
 
 	private final String sqlAliasStem;
 	private final boolean isNullable;
+	private final boolean isIgnoreNotFound;
 	private final boolean unwrapProxy;
 	private final EntityMappingType entityMappingType;
 
@@ -164,6 +165,7 @@ public class ToOneAttributeMapping
 
 		if ( bootValue instanceof ManyToOne ) {
 			final ManyToOne manyToOne = (ManyToOne) bootValue;
+			this.isIgnoreNotFound = ( (ManyToOne) bootValue ).isIgnoreNotFound();
 			if ( manyToOne.isLogicalOneToOne() ) {
 				cardinality = Cardinality.LOGICAL_ONE_TO_ONE;
 			}
@@ -220,8 +222,9 @@ public class ToOneAttributeMapping
 				so in order to recognize the bidirectionality the "primaryKey." is removed from the otherSidePropertyName value.
 		 	*/
 			// todo (6.0): find a better solution for the embeddable part name not in the NavigablePath
+			final OneToOne oneToOne = (OneToOne) bootValue;
 			String bidirectionalAttributeName = StringHelper.subStringNullIfEmpty(
-					( (OneToOne) bootValue ).getMappedByProperty(),
+					oneToOne.getMappedByProperty(),
 					'.'
 			);
 
@@ -234,6 +237,7 @@ public class ToOneAttributeMapping
 			else {
 				this.bidirectionalAttributeName = bidirectionalAttributeName;
 			}
+			isIgnoreNotFound = isNullable();
 		}
 
 		this.navigableRole = navigableRole;
@@ -296,6 +300,7 @@ public class ToOneAttributeMapping
 		this.navigableRole = original.navigableRole;
 		this.sqlAliasStem = original.sqlAliasStem;
 		this.isNullable = original.isNullable;
+		this.isIgnoreNotFound = original.isIgnoreNotFound;
 		this.unwrapProxy = original.unwrapProxy;
 		this.entityMappingType = original.entityMappingType;
 		this.referencedPropertyName = original.referencedPropertyName;
@@ -753,7 +758,6 @@ public class ToOneAttributeMapping
 			return new EntityFetchSelectImpl(
 					fetchParent,
 					this,
-					isNullable,
 					fetchablePath,
 					keyResult,
 					selectByUniqueKey,
@@ -999,6 +1003,10 @@ public class ToOneAttributeMapping
 
 	public boolean isNullable() {
 		return isNullable;
+	}
+
+	public boolean isIgnoreNotFound(){
+		return isIgnoreNotFound;
 	}
 
 	public boolean isUnwrapProxy() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchSelectImpl.java
@@ -24,20 +24,17 @@ import org.hibernate.sql.results.graph.entity.EntityInitializer;
  * @author Andrea Boriero
  */
 public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
-	private final boolean nullable;
 	private final DomainResult result;
 	private final boolean selectByUniqueKey;
 
 	public EntityFetchSelectImpl(
 			FetchParent fetchParent,
 			ToOneAttributeMapping fetchedAttribute,
-			boolean nullable,
 			NavigablePath navigablePath,
 			DomainResult result,
 			boolean selectByUniqueKey,
 			DomainResultCreationState creationState) {
 		super( navigablePath, fetchedAttribute, fetchParent );
-		this.nullable = nullable;
 		this.result = result;
 		this.selectByUniqueKey = selectByUniqueKey;
 	}
@@ -61,23 +58,22 @@ public class EntityFetchSelectImpl extends AbstractNonJoinedEntityFetch {
 
 					EntityPersister entityPersister = getReferencedMappingContainer().getEntityPersister();
 
+					final ToOneAttributeMapping fetchedAttribute = (ToOneAttributeMapping) getFetchedMapping();
 					if ( selectByUniqueKey ) {
 						return new EntitySelectFetchByUniqueKeyInitializer(
 								parentAccess,
-								(ToOneAttributeMapping) getFetchedMapping(),
+								fetchedAttribute,
 								getNavigablePath(),
 								entityPersister,
-								result.createResultAssembler( creationState ),
-								nullable
+								result.createResultAssembler( creationState )
 						);
 					}
 					return new EntitySelectFetchInitializer(
 							parentAccess,
-							(ToOneAttributeMapping) getFetchedMapping(),
+							fetchedAttribute,
 							getNavigablePath(),
 							entityPersister,
-							result.createResultAssembler( creationState ),
-							nullable
+							result.createResultAssembler( creationState )
 					);
 				}
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchByUniqueKeyInitializer.java
@@ -28,9 +28,8 @@ public class EntitySelectFetchByUniqueKeyInitializer extends EntitySelectFetchIn
 			ToOneAttributeMapping fetchedAttribute,
 			NavigablePath fetchedNavigable,
 			EntityPersister concreteDescriptor,
-			DomainResultAssembler identifierAssembler,
-			boolean nullable) {
-		super( parentAccess, fetchedAttribute, fetchedNavigable, concreteDescriptor, identifierAssembler, nullable );
+			DomainResultAssembler identifierAssembler) {
+		super( parentAccess, fetchedAttribute, fetchedNavigable, concreteDescriptor, identifierAssembler );
 		this.fetchedAttribute = fetchedAttribute;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntitySelectFetchInitializer.java
@@ -42,7 +42,6 @@ public class EntitySelectFetchInitializer extends AbstractFetchParentAccess impl
 	private FetchParentAccess parentAccess;
 	private final NavigablePath navigablePath;
 	private final boolean isEnhancedForLazyLoading;
-	private final boolean nullable;
 
 	protected final EntityPersister concreteDescriptor;
 	protected final DomainResultAssembler identifierAssembler;
@@ -55,14 +54,12 @@ public class EntitySelectFetchInitializer extends AbstractFetchParentAccess impl
 			ToOneAttributeMapping referencedModelPart,
 			NavigablePath fetchedNavigable,
 			EntityPersister concreteDescriptor,
-			DomainResultAssembler identifierAssembler,
-			boolean nullable) {
+			DomainResultAssembler identifierAssembler) {
 		this.parentAccess = parentAccess;
 		this.referencedModelPart = referencedModelPart;
 		this.navigablePath = fetchedNavigable;
 		this.concreteDescriptor = concreteDescriptor;
 		this.identifierAssembler = identifierAssembler;
-		this.nullable = nullable;
 		this.isEnhancedForLazyLoading = concreteDescriptor.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading();
 	}
 
@@ -192,7 +189,7 @@ public class EntitySelectFetchInitializer extends AbstractFetchParentAccess impl
 				entityName,
 				entityIdentifier,
 				true,
-				nullable
+				referencedModelPart.isNullable() || referencedModelPart.isIgnoreNotFound()
 		);
 
 		if ( EntityLoadingLogger.DEBUG_ENABLED ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/domain/CircularFetchImpl.java
@@ -108,8 +108,7 @@ public class CircularFetchImpl implements BiDirectionalFetch, Association {
 								(ToOneAttributeMapping) referencedModelPart,
 								getReferencedPath(),
 								entityMappingType.getEntityPersister(),
-								resultAssembler,
-								fetchable.isNullable()
+								resultAssembler
 						);
 					}
 					else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerInEmbeddableNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerInEmbeddableNotFoundTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.test.notfound;
+package org.hibernate.orm.test.notfound;
 
 import java.io.Serializable;
 import javax.persistence.CascadeType;
@@ -20,120 +20,116 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12436")
-public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTestCase {
+@TestForIssue(jiraKey = "HHH-12436")
+@DomainModel(
+		annotatedClasses = {
+				OptionalEagerInEmbeddableNotFoundTest.PersonManyToOneJoinIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonManyToOneSelectIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonOneToOneJoinIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonOneToOneSelectIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonMapsIdJoinIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonMapsIdSelectIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonPkjcJoinException.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonPkjcJoinIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonPkjcSelectException.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonPkjcSelectIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonMapsIdColumnJoinIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.PersonMapsIdColumnSelectIgnore.class,
+				OptionalEagerInEmbeddableNotFoundTest.City.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+		@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
+})
+public class OptionalEagerInEmbeddableNotFoundTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				PersonManyToOneJoinIgnore.class,
-				PersonManyToOneSelectIgnore.class,
-				PersonOneToOneJoinIgnore.class,
-				PersonOneToOneSelectIgnore.class,
-				PersonMapsIdJoinIgnore.class,
-				PersonMapsIdSelectIgnore.class,
-				PersonPkjcJoinException.class,
-				PersonPkjcJoinIgnore.class,
-				PersonPkjcSelectException.class,
-				PersonPkjcSelectIgnore.class,
-				PersonMapsIdColumnJoinIgnore.class,
-				PersonMapsIdColumnSelectIgnore.class,
-				City.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
+	@Test
+	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonOneToOneJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testOneToOneJoinIgnore() {
-		setupTest( PersonOneToOneJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonOneToOneJoinIgnore.class, 1L );
+	public void testOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonOneToOneSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testOneToOneSelectIgnore() {
-		setupTest( PersonOneToOneSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonOneToOneSelectIgnore.class, 1L );
+	public void testManyToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonManyToOneJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testManyToOneJoinIgnore() {
-		setupTest( PersonManyToOneJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonManyToOneJoinIgnore.class, 1L );
+	public void testManyToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonManyToOneSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testManyToOneSelectIgnore() {
-		setupTest( PersonManyToOneSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonManyToOneSelectIgnore.class, 1L );
-	}
-
-	@Test
-	public void testPkjcOneToOneJoinException() {
-		setupTest( PersonPkjcJoinException.class, 1L, false );
+	public void testPkjcOneToOneJoinException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinException.class, 1L, false, scope );
 		// optional @OneToOne @PKJC implicitly maps @NotFound(IGNORE)
-		executeIgnoreTest( PersonPkjcJoinException.class, 1L );
+		executeIgnoreTest( PersonPkjcJoinException.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneJoinIgnore() {
-		setupTest( PersonPkjcJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonPkjcJoinIgnore.class, 1L );
+	public void testPkjcOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonPkjcJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectException() {
-		setupTest( PersonPkjcSelectException.class, 1L, false );
+	public void testPkjcOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectException.class, 1L, false, scope );
 		// optional @OneToOne @PKJC implicitly maps @NotFound(IGNORE)
-		executeIgnoreTest( PersonPkjcSelectException.class, 1L );
+		executeIgnoreTest( PersonPkjcSelectException.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectIgnore() {
-		setupTest( PersonPkjcSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonPkjcSelectIgnore.class, 1L );
+	public void testPkjcOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonPkjcSelectIgnore.class, 1L, scope );
 	}
 
 	// @MapsId doesn't work in an embeddable
 
-	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId ) {
-		persistData( clazz, id, isMapsId );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
+		persistData( clazz, id, isMapsId, scope );
+		scope.inTransaction(
+				session -> {
 					Person p = session.find( clazz, id );
 					assertEquals( "New York", p.getCity().getName() );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.createNativeQuery( "delete from City where id = " + id )
-							.executeUpdate();
-				}
+		scope.inTransaction(
+				session ->
+						session.createNativeQuery( "delete from City where id = " + id )
+								.executeUpdate()
 		);
 	}
 
-	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId) {
+	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
 		final Person person;
 		try {
 			person = clazz.newInstance();
@@ -142,8 +138,8 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 			throw new RuntimeException( ex );
 		}
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					City city = new City();
 					city.setId( id );
 					city.setName( "New York" );
@@ -158,24 +154,24 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		);
 	}
 
-	private <T extends Person> void executeIgnoreTest(Class<T> clazz, long id) {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void executeIgnoreTest(Class<T> clazz, long id, SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					checkIgnoreResult( pCheck );
 					pCheck.setName( "Jane Doe" );
 				}
 		);
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					assertEquals( "Jane Doe", pCheck.getName() );
 					checkIgnoreResult( pCheck );
 					pCheck.setCity( null );
 				}
 		);
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					assertEquals( "Jane Doe", pCheck.getName() );
 					checkIgnoreResult( pCheck );
@@ -195,19 +191,21 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		public String getName() {
 			return name;
 		}
+
 		public void setName(String name) {
 			this.name = name;
 		}
 
 		public abstract void setId(Long id);
+
 		public abstract City getCity();
+
 		public abstract void setCity(City city);
 	}
 
 
-
 	@Entity
-	@Table( name = "PersonOneToOneJoinIgnore" )
+	@Table(name = "PersonOneToOneJoinIgnore")
 	public static class PersonOneToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -245,9 +243,9 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		@Embeddable
 		public static class CityInEmbeddable {
 			@OneToOne(cascade = CascadeType.PERSIST)
-			@NotFound( action = NotFoundAction.IGNORE )
+			@NotFound(action = NotFoundAction.IGNORE)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-			@Fetch( FetchMode.JOIN )
+			@Fetch(FetchMode.JOIN)
 			private City city;
 
 			public City getCity() {
@@ -261,7 +259,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectIgnore" )
+	@Table(name = "PersonOneToOneSelectIgnore")
 	public static class PersonOneToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -299,9 +297,9 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		@Embeddable
 		public static class CityInEmbeddable {
 			@OneToOne(cascade = CascadeType.PERSIST)
-			@NotFound( action = NotFoundAction.IGNORE )
+			@NotFound(action = NotFoundAction.IGNORE)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-			@Fetch( FetchMode.SELECT )
+			@Fetch(FetchMode.SELECT)
 			private City city;
 
 			public City getCity() {
@@ -315,7 +313,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneJoinIgnore" )
+	@Table(name = "PersonManyToOneJoinIgnore")
 	public static class PersonManyToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -353,9 +351,9 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		@Embeddable
 		public static class CityInEmbeddable {
 			@ManyToOne(cascade = CascadeType.PERSIST)
-			@NotFound( action = NotFoundAction.IGNORE )
+			@NotFound(action = NotFoundAction.IGNORE)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-			@Fetch( FetchMode.JOIN )
+			@Fetch(FetchMode.JOIN)
 			private City city;
 
 			public City getCity() {
@@ -369,7 +367,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectIgnore" )
+	@Table(name = "PersonManyToOneSelectIgnore")
 	public static class PersonManyToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -407,9 +405,9 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		@Embeddable
 		public static class CityInEmbeddable {
 			@ManyToOne(cascade = CascadeType.PERSIST)
-			@NotFound( action = NotFoundAction.IGNORE )
+			@NotFound(action = NotFoundAction.IGNORE)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-			@Fetch( FetchMode.SELECT )
+			@Fetch(FetchMode.SELECT)
 			private City city;
 
 			public City getCity() {
@@ -423,7 +421,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinException" )
+	@Table(name = "PersonPkjcJoinException")
 	public static class PersonPkjcJoinException extends Person {
 		@Id
 		private Long id;
@@ -462,7 +460,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		public static class CityInEmbeddable {
 			@OneToOne(cascade = CascadeType.PERSIST)
 			@PrimaryKeyJoinColumn
-			@Fetch(FetchMode.JOIN )
+			@Fetch(FetchMode.JOIN)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -477,7 +475,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinIgnore" )
+	@Table(name = "PersonPkjcJoinIgnore")
 	public static class PersonPkjcJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -517,7 +515,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 			@OneToOne(cascade = CascadeType.PERSIST)
 			@PrimaryKeyJoinColumn
 			@NotFound(action = NotFoundAction.IGNORE)
-			@Fetch(FetchMode.JOIN )
+			@Fetch(FetchMode.JOIN)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -532,7 +530,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectException" )
+	@Table(name = "PersonPkjcSelectException")
 	public static class PersonPkjcSelectException extends Person {
 		@Id
 		private Long id;
@@ -571,7 +569,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 		public static class CityInEmbeddable {
 			@OneToOne(cascade = CascadeType.PERSIST)
 			@PrimaryKeyJoinColumn
-			@Fetch(FetchMode.SELECT )
+			@Fetch(FetchMode.SELECT)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -586,7 +584,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectIgnore" )
+	@Table(name = "PersonPkjcSelectIgnore")
 	public static class PersonPkjcSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -626,7 +624,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 			@OneToOne(cascade = CascadeType.PERSIST)
 			@PrimaryKeyJoinColumn
 			@NotFound(action = NotFoundAction.IGNORE)
-			@Fetch(FetchMode.SELECT )
+			@Fetch(FetchMode.SELECT)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -641,7 +639,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinIgnore" )
+	@Table(name = "PersonMapsIdJoinIgnore")
 	public static class PersonMapsIdJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -681,7 +679,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 			@OneToOne
 			@MapsId
 			@NotFound(action = NotFoundAction.IGNORE)
-			@Fetch(FetchMode.JOIN )
+			@Fetch(FetchMode.JOIN)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -696,7 +694,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectIgnore" )
+	@Table(name = "PersonMapsIdSelectIgnore")
 	public static class PersonMapsIdSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -736,7 +734,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 			@OneToOne
 			@MapsId
 			@NotFound(action = NotFoundAction.IGNORE)
-			@Fetch(FetchMode.SELECT )
+			@Fetch(FetchMode.SELECT)
 			@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 			private City city;
 
@@ -751,7 +749,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinIgnore" )
+	@Table(name = "PersonMapsIdColumnJoinIgnore")
 	public static class PersonMapsIdColumnJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -806,7 +804,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectIgnore" )
+	@Table(name = "PersonMapsIdColumnSelectIgnore")
 	public static class PersonMapsIdColumnSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -861,7 +859,7 @@ public class OptionalEagerInEmbeddableNotFoundTest extends BaseCoreFunctionalTes
 	}
 
 	@Entity
-	@Table( name = "City" )
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerInEmbeddableNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerInEmbeddableNotFoundTest.java
@@ -27,6 +27,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,6 +61,31 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 		@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
 })
 public class OptionalEagerInEmbeddableNotFoundTest {
+
+	@AfterEach
+	public void cleanUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from " + PersonManyToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonManyToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectIgnore.class.getName() )
+							.executeUpdate();session.createQuery( "delete from " + PersonMapsIdColumnJoinIgnore.class.getName() )
+							.executeUpdate();session.createQuery( "delete from " + PersonMapsIdColumnSelectIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + City.class.getName() ).executeUpdate();
+				}
+		);
+	}
 
 	@Test
 	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerNotFoundTest.java
@@ -26,6 +26,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,6 +60,33 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 		@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
 })
 public class OptionalEagerNotFoundTest {
+
+	@AfterEach
+	public void cleanUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from " + PersonManyToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonManyToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdColumnJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdColumnSelectIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + City.class.getName() ).executeUpdate();
+				}
+		);
+	}
 
 	@Test
 	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerNotFoundTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.test.notfound;
+package org.hibernate.orm.test.notfound;
 
 import java.io.Serializable;
 import javax.persistence.CascadeType;
@@ -19,142 +19,138 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12436")
-public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
+@TestForIssue(jiraKey = "HHH-12436")
+@DomainModel(
+		annotatedClasses = {
+				OptionalEagerNotFoundTest.PersonManyToOneJoinIgnore.class,
+				OptionalEagerNotFoundTest.PersonManyToOneSelectIgnore.class,
+				OptionalEagerNotFoundTest.PersonOneToOneJoinIgnore.class,
+				OptionalEagerNotFoundTest.PersonOneToOneSelectIgnore.class,
+				OptionalEagerNotFoundTest.PersonMapsIdJoinIgnore.class,
+				OptionalEagerNotFoundTest.PersonMapsIdSelectIgnore.class,
+				OptionalEagerNotFoundTest.PersonPkjcJoinException.class,
+				OptionalEagerNotFoundTest.PersonPkjcJoinIgnore.class,
+				OptionalEagerNotFoundTest.PersonPkjcSelectException.class,
+				OptionalEagerNotFoundTest.PersonPkjcSelectIgnore.class,
+				OptionalEagerNotFoundTest.PersonMapsIdColumnJoinIgnore.class,
+				OptionalEagerNotFoundTest.PersonMapsIdColumnSelectIgnore.class,
+				OptionalEagerNotFoundTest.City.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+		@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
+})
+public class OptionalEagerNotFoundTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				PersonManyToOneJoinIgnore.class,
-				PersonManyToOneSelectIgnore.class,
-				PersonOneToOneJoinIgnore.class,
-				PersonOneToOneSelectIgnore.class,
-				PersonMapsIdJoinIgnore.class,
-				PersonMapsIdSelectIgnore.class,
-				PersonPkjcJoinException.class,
-				PersonPkjcJoinIgnore.class,
-				PersonPkjcSelectException.class,
-				PersonPkjcSelectIgnore.class,
-				PersonMapsIdColumnJoinIgnore.class,
-				PersonMapsIdColumnSelectIgnore.class,
-				City.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
+	@Test
+	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonOneToOneJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testOneToOneJoinIgnore() {
-		setupTest( PersonOneToOneJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonOneToOneJoinIgnore.class, 1L );
+	public void testOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonOneToOneSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testOneToOneSelectIgnore() {
-		setupTest( PersonOneToOneSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonOneToOneSelectIgnore.class, 1L );
+	public void testManyToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonManyToOneJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testManyToOneJoinIgnore() {
-		setupTest( PersonManyToOneJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonManyToOneJoinIgnore.class, 1L );
+	public void testManyToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonManyToOneSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testManyToOneSelectIgnore() {
-		setupTest( PersonManyToOneSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonManyToOneSelectIgnore.class, 1L );
-	}
-
-	@Test
-	public void testPkjcOneToOneJoinException() {
-		setupTest( PersonPkjcJoinException.class, 1L, false );
+	public void testPkjcOneToOneJoinException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinException.class, 1L, false, scope );
 		// optional @OneToOne @PKJC implicitly maps @NotFound(IGNORE)
-		executeIgnoreTest( PersonPkjcJoinException.class, 1L );
+		executeIgnoreTest( PersonPkjcJoinException.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneJoinIgnore() {
-		setupTest( PersonPkjcJoinIgnore.class, 1L, false );
-		executeIgnoreTest( PersonPkjcJoinIgnore.class, 1L );
+	public void testPkjcOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonPkjcJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectException() {
-		setupTest( PersonPkjcSelectException.class, 1L, false );
+	public void testPkjcOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectException.class, 1L, false, scope );
 		// optional @OneToOne @PKJC implicitly maps @NotFound(IGNORE)
-		executeIgnoreTest( PersonPkjcSelectException.class, 1L );
+		executeIgnoreTest( PersonPkjcSelectException.class, 1L, scope );
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectIgnore() {
-		setupTest( PersonPkjcSelectIgnore.class, 1L, false );
-		executeIgnoreTest( PersonPkjcSelectIgnore.class, 1L );
+	public void testPkjcOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectIgnore.class, 1L, false, scope );
+		executeIgnoreTest( PersonPkjcSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testMapsIdOneToOneJoinIgnore() {
-		setupTest( PersonMapsIdJoinIgnore.class, 1L, true );
-		executeIgnoreTest( PersonMapsIdJoinIgnore.class, 1L );
+	public void testMapsIdOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdJoinIgnore.class, 1L, true, scope );
+		executeIgnoreTest( PersonMapsIdJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testMapsIdOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdSelectIgnore.class, 1L, true );
-		executeIgnoreTest( PersonMapsIdSelectIgnore.class, 1L );
+	public void testMapsIdOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdSelectIgnore.class, 1L, true, scope );
+		executeIgnoreTest( PersonMapsIdSelectIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneJoinIgnore() {
-		setupTest( PersonMapsIdColumnJoinIgnore.class, 1L, true );
-		executeIgnoreTest( PersonMapsIdColumnJoinIgnore.class, 1L );
+	public void testMapsIdJoinColumnOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnJoinIgnore.class, 1L, true, scope );
+		executeIgnoreTest( PersonMapsIdColumnJoinIgnore.class, 1L, scope );
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true );
-		executeIgnoreTest( PersonMapsIdColumnSelectIgnore.class, 1L );
+	public void testMapsIdJoinColumnOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true, scope );
+		executeIgnoreTest( PersonMapsIdColumnSelectIgnore.class, 1L, scope );
 	}
 
-	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId ) {
-		persistData( clazz, id, isMapsId );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
+		persistData( clazz, id, isMapsId, scope );
+		scope.inTransaction(
+				session -> {
 					Person p = session.find( clazz, id );
 					assertEquals( "New York", p.getCity().getName() );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.createNativeQuery( "delete from City where id = " + id )
-							.executeUpdate();
-				}
+		scope.inTransaction(
+				session ->
+						session.createNativeQuery( "delete from City where id = " + id )
+								.executeUpdate()
 		);
 	}
 
-	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId) {
+	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
 		final Person person;
 		try {
 			person = clazz.newInstance();
@@ -163,8 +159,8 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 			throw new RuntimeException( ex );
 		}
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					City city = new City();
 					city.setId( id );
 					city.setName( "New York" );
@@ -179,24 +175,24 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		);
 	}
 
-	private <T extends Person> void executeIgnoreTest(Class<T> clazz, long id) {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void executeIgnoreTest(Class<T> clazz, long id, SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					checkResult( pCheck );
 					pCheck.setName( "Jane Doe" );
 				}
 		);
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					assertEquals( "Jane Doe", pCheck.getName() );
 					checkResult( pCheck );
 					pCheck.setCity( null );
 				}
 		);
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( clazz, id );
 					assertEquals( "Jane Doe", pCheck.getName() );
 					checkResult( pCheck );
@@ -216,25 +212,28 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		public String getName() {
 			return name;
 		}
+
 		public void setName(String name) {
 			this.name = name;
 		}
 
 		public abstract void setId(Long id);
+
 		public abstract City getCity();
+
 		public abstract void setCity(City city);
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneJoinIgnore" )
+	@Table(name = "PersonOneToOneJoinIgnore")
 	public static class PersonOneToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -256,15 +255,15 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectIgnore" )
+	@Table(name = "PersonOneToOneSelectIgnore")
 	public static class PersonOneToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -286,15 +285,15 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneJoinIgnore" )
+	@Table(name = "PersonManyToOneJoinIgnore")
 	public static class PersonManyToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
 
 		@ManyToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -316,15 +315,15 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectIgnore" )
+	@Table(name = "PersonManyToOneSelectIgnore")
 	public static class PersonManyToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@ManyToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -346,14 +345,14 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinException" )
+	@Table(name = "PersonPkjcJoinException")
 	public static class PersonPkjcJoinException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -376,7 +375,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinIgnore" )
+	@Table(name = "PersonPkjcJoinIgnore")
 	public static class PersonPkjcJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -384,7 +383,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -407,14 +406,14 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectException" )
+	@Table(name = "PersonPkjcSelectException")
 	public static class PersonPkjcSelectException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -437,7 +436,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectIgnore" )
+	@Table(name = "PersonPkjcSelectIgnore")
 	public static class PersonPkjcSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -445,7 +444,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -468,7 +467,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinIgnore" )
+	@Table(name = "PersonMapsIdJoinIgnore")
 	public static class PersonMapsIdJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -476,7 +475,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		@OneToOne
 		@MapsId
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -499,7 +498,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectIgnore" )
+	@Table(name = "PersonMapsIdSelectIgnore")
 	public static class PersonMapsIdSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -507,7 +506,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 		@OneToOne
 		@MapsId
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -530,7 +529,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinIgnore" )
+	@Table(name = "PersonMapsIdColumnJoinIgnore")
 	public static class PersonMapsIdColumnJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -561,7 +560,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectIgnore" )
+	@Table(name = "PersonMapsIdColumnSelectIgnore")
 	public static class PersonMapsIdColumnSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -592,7 +591,7 @@ public class OptionalEagerNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "City" )
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerRefNonPKNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerRefNonPKNotFoundTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.test.notfound;
+package org.hibernate.orm.test.notfound;
 
 import java.io.Serializable;
 import javax.persistence.CascadeType;
@@ -19,55 +19,55 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12436")
-public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCase {
+@TestForIssue(jiraKey = "HHH-12436")
+@DomainModel(
+		annotatedClasses = {
+				OptionalEagerRefNonPKNotFoundTest.PersonManyToOneJoinIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonManyToOneSelectIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonOneToOneJoinIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonOneToOneSelectIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonMapsIdJoinIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonMapsIdSelectIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonPkjcJoinException.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonPkjcJoinIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonPkjcSelectException.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonPkjcSelectIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonMapsIdColumnJoinIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.PersonMapsIdColumnSelectIgnore.class,
+				OptionalEagerRefNonPKNotFoundTest.City.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
+		}
+)
+public class OptionalEagerRefNonPKNotFoundTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				PersonManyToOneJoinIgnore.class,
-				PersonManyToOneSelectIgnore.class,
-				PersonOneToOneJoinIgnore.class,
-				PersonOneToOneSelectIgnore.class,
-				PersonMapsIdJoinIgnore.class,
-				PersonMapsIdSelectIgnore.class,
-				PersonPkjcJoinException.class,
-				PersonPkjcJoinIgnore.class,
-				PersonPkjcSelectException.class,
-				PersonPkjcSelectIgnore.class,
-				PersonMapsIdColumnJoinIgnore.class,
-				PersonMapsIdColumnSelectIgnore.class,
-				City.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-	}
 
 	@Test
-	public void testOneToOneJoinIgnore() {
-		setupTest( PersonOneToOneJoinIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneJoinIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonOneToOneJoinIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
@@ -75,10 +75,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testOneToOneSelectIgnore() {
-		setupTest( PersonOneToOneSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonOneToOneSelectIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
@@ -86,10 +86,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testManyToOneJoinIgnore() {
-		setupTest( PersonManyToOneJoinIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testManyToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneJoinIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonManyToOneJoinIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
@@ -97,10 +97,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testManyToOneSelectIgnore() {
-		setupTest( PersonManyToOneSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testManyToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonManyToOneSelectIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
@@ -108,10 +108,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testPkjcOneToOneJoinException() {
-		setupTest( PersonPkjcJoinException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneJoinException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcJoinException.class, 1L );
 					// @OneToOne @PrimaryKeyJoinColumn always assumes @NotFound(IGNORE)
 					checkIgnore( pCheck );
@@ -120,10 +120,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testPkjcOneToOneJoinIgnore() {
-		setupTest( PersonPkjcJoinIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcJoinIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcJoinIgnore.class, 1L );
 					// Person is non-null and association is null.
 					checkIgnore( pCheck );
@@ -132,10 +132,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectException() {
-		setupTest( PersonPkjcSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcSelectException.class, 1L );
 					// @OneToOne @PrimaryKeyJoinColumn always assumes @NotFound(IGNORE)
 					checkIgnore( pCheck );
@@ -144,10 +144,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectIgnore() {
-		setupTest( PersonPkjcSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcSelectIgnore.class, 1L );
 					// Person is non-null and association is null.
 					checkIgnore( pCheck );
@@ -156,10 +156,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMapsIdOneToOneJoinIgnore() {
-		setupTest( PersonMapsIdJoinIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdJoinIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdJoinIgnore.class, 1L );
 					// Person is non-null association is null.
 					checkIgnore( pCheck );
@@ -168,10 +168,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMapsIdOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdSelectIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdSelectIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdSelectIgnore.class, 1L );
 					// Person is non-null association is null.
 					checkIgnore( pCheck );
@@ -180,10 +180,10 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneJoinIgnore() {
-		setupTest( PersonMapsIdColumnJoinIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdJoinColumnOneToOneJoinIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnJoinIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdColumnJoinIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
@@ -191,34 +191,33 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdJoinColumnOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdColumnSelectIgnore.class, 1L );
 					checkIgnore( pCheck );
 				}
 		);
 	}
 
-	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId ) {
-		persistData( clazz, id, isMapsId );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
+		persistData( clazz, id, isMapsId, scope );
+		scope.inTransaction(
+				session -> {
 					Person p = session.find( clazz, id );
 					assertEquals( "New York", p.getCity().getName() );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.createNativeQuery( "delete from City where id = " + id )
-							.executeUpdate();
-				}
+		scope.inTransaction(
+				session ->
+						session.createNativeQuery( "delete from City where id = " + id )
+								.executeUpdate()
 		);
 	}
 
-	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId) {
+	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
 		final Person person;
 		try {
 			person = clazz.newInstance();
@@ -227,8 +226,8 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 			throw new RuntimeException( ex );
 		}
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					City city = new City();
 					city.setId( id );
 					city.setName( "New York" );
@@ -259,17 +258,20 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 		public String getName() {
 			return name;
 		}
+
 		public void setName(String name) {
 			this.name = name;
 		}
 
 		public abstract void setId(Long id);
+
 		public abstract City getCity();
+
 		public abstract void setCity(City city);
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneJoinException" )
+	@Table(name = "PersonOneToOneJoinException")
 	public static class PersonOneToOneJoinException extends Person {
 		@Id
 		private Long id;
@@ -280,7 +282,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -302,19 +304,19 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneJoinIgnore" )
+	@Table(name = "PersonOneToOneJoinIgnore")
 	public static class PersonOneToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -336,7 +338,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectException" )
+	@Table(name = "PersonOneToOneSelectException")
 	public static class PersonOneToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -347,7 +349,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -369,19 +371,19 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectIgnore" )
+	@Table(name = "PersonOneToOneSelectIgnore")
 	public static class PersonOneToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -403,7 +405,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneJoinException" )
+	@Table(name = "PersonManyToOneJoinException")
 	public static class PersonManyToOneJoinException extends Person {
 		@Id
 		private Long id;
@@ -414,7 +416,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -436,19 +438,19 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneJoinIgnore" )
+	@Table(name = "PersonManyToOneJoinIgnore")
 	public static class PersonManyToOneJoinIgnore extends Person {
 		@Id
 		private Long id;
 
 		@ManyToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		private City city;
 
 		public Long getId() {
@@ -470,7 +472,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectException" )
+	@Table(name = "PersonManyToOneSelectException")
 	public static class PersonManyToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -481,7 +483,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -503,19 +505,19 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectIgnore" )
+	@Table(name = "PersonManyToOneSelectIgnore")
 	public static class PersonManyToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@ManyToOne(cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
 				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
 		)
-		@Fetch( FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		private City city;
 
 		public Long getId() {
@@ -537,14 +539,14 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinException" )
+	@Table(name = "PersonPkjcJoinException")
 	public static class PersonPkjcJoinException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -571,7 +573,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcJoinIgnore" )
+	@Table(name = "PersonPkjcJoinIgnore")
 	public static class PersonPkjcJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -579,7 +581,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -606,14 +608,14 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectException" )
+	@Table(name = "PersonPkjcSelectException")
 	public static class PersonPkjcSelectException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -640,7 +642,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectIgnore" )
+	@Table(name = "PersonPkjcSelectIgnore")
 	public static class PersonPkjcSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -648,7 +650,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 		@OneToOne(cascade = CascadeType.PERSIST)
 		@PrimaryKeyJoinColumn
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -675,14 +677,14 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinException" )
+	@Table(name = "PersonMapsIdJoinException")
 	public static class PersonMapsIdJoinException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne
 		@MapsId
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -709,7 +711,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinIgnore" )
+	@Table(name = "PersonMapsIdJoinIgnore")
 	public static class PersonMapsIdJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -717,7 +719,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 		@OneToOne
 		@MapsId
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.JOIN )
+		@Fetch(FetchMode.JOIN)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -744,14 +746,14 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectException" )
+	@Table(name = "PersonMapsIdSelectException")
 	public static class PersonMapsIdSelectException extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne
 		@MapsId
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -778,7 +780,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectIgnore" )
+	@Table(name = "PersonMapsIdSelectIgnore")
 	public static class PersonMapsIdSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -786,7 +788,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 		@OneToOne
 		@MapsId
 		@NotFound(action = NotFoundAction.IGNORE)
-		@Fetch(FetchMode.SELECT )
+		@Fetch(FetchMode.SELECT)
 		@JoinColumn(
 				name = "cityName",
 				referencedColumnName = "name",
@@ -813,7 +815,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinException" )
+	@Table(name = "PersonMapsIdColumnJoinException")
 	public static class PersonMapsIdColumnJoinException extends Person {
 		@Id
 		private Long id;
@@ -847,7 +849,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinIgnore" )
+	@Table(name = "PersonMapsIdColumnJoinIgnore")
 	public static class PersonMapsIdColumnJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -882,7 +884,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectException" )
+	@Table(name = "PersonMapsIdColumnSelectException")
 	public static class PersonMapsIdColumnSelectException extends Person {
 		@Id
 		private Long id;
@@ -916,7 +918,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectIgnore" )
+	@Table(name = "PersonMapsIdColumnSelectIgnore")
 	public static class PersonMapsIdColumnSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -951,7 +953,7 @@ public class OptionalEagerRefNonPKNotFoundTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Entity
-	@Table( name = "City" )
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerRefNonPKNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalEagerRefNonPKNotFoundTest.java
@@ -26,6 +26,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,6 +63,30 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 )
 public class OptionalEagerRefNonPKNotFoundTest {
 
+	@AfterEach
+	public void cleanUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from " + PersonManyToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonManyToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneJoinIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcJoinIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectIgnore.class.getName() )
+							.executeUpdate();session.createQuery( "delete from " + PersonMapsIdColumnJoinIgnore.class.getName() )
+							.executeUpdate();session.createQuery( "delete from " + PersonMapsIdColumnSelectIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + City.class.getName() ).executeUpdate();
+				}
+		);
+	}
 
 	@Test
 	public void testOneToOneJoinIgnore(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalLazyNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalLazyNotFoundTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.test.notfound;
+package org.hibernate.orm.test.notfound;
 
 import java.io.Serializable;
 import javax.persistence.CascadeType;
@@ -20,56 +20,55 @@ import org.hibernate.ObjectNotFoundException;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12436")
-public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				PersonManyToOneSelectException.class,
-				PersonManyToOneSelectIgnore.class,
-				PersonOneToOneSelectException.class,
-				PersonOneToOneSelectIgnore.class,
-				PersonMapsIdSelectException.class,
-				PersonMapsIdSelectIgnore.class,
-				PersonPkjcSelectException.class,
-				PersonPkjcSelectIgnore.class,
-				PersonMapsIdColumnSelectIgnore.class,
-				PersonMapsIdColumnSelectException.class,
-				City.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-	}
+@TestForIssue(jiraKey = "HHH-12436")
+@DomainModel(
+		annotatedClasses = {
+				OptionalLazyNotFoundTest.PersonManyToOneSelectException.class,
+				OptionalLazyNotFoundTest.PersonManyToOneSelectIgnore.class,
+				OptionalLazyNotFoundTest.PersonOneToOneSelectException.class,
+				OptionalLazyNotFoundTest.PersonOneToOneSelectIgnore.class,
+				OptionalLazyNotFoundTest.PersonMapsIdSelectException.class,
+				OptionalLazyNotFoundTest.PersonMapsIdSelectIgnore.class,
+				OptionalLazyNotFoundTest.PersonPkjcSelectException.class,
+				OptionalLazyNotFoundTest.PersonPkjcSelectIgnore.class,
+				OptionalLazyNotFoundTest.PersonMapsIdColumnSelectIgnore.class,
+				OptionalLazyNotFoundTest.PersonMapsIdColumnSelectException.class,
+				OptionalLazyNotFoundTest.City.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
+		}
+)
+public class OptionalLazyNotFoundTest {
 
 	@Test
-	public void testOneToOneSelectException() {
-		setupTest( PersonOneToOneSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonOneToOneSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -85,10 +84,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOneToOneSelectIgnore() {
-		setupTest( PersonOneToOneSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonOneToOneSelectIgnore.class, 1L );
 					assertNotNull( pCheck );
 					assertNull( pCheck.getCity() );
@@ -97,10 +96,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testManyToOneSelectException() {
-		setupTest( PersonManyToOneSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testManyToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonManyToOneSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -116,10 +115,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testManyToOneSelectIgnore() {
-		setupTest( PersonManyToOneSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testManyToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonManyToOneSelectIgnore.class, 1L );
 					assertNotNull( pCheck );
 					assertNull( pCheck.getCity() );
@@ -128,10 +127,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectException() {
-		setupTest( PersonPkjcSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcSelectException.class, 1L );
 					assertNotNull( pCheck );
 					// eagerly loaded because @PKJC assumes ignoreNotFound
@@ -152,10 +151,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectIgnore() {
-		setupTest( PersonPkjcSelectIgnore.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectIgnore.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcSelectIgnore.class, 1L );
 					// Person is non-null and association is null.
 					assertNotNull( pCheck );
@@ -165,10 +164,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdOneToOneSelectException() {
-		setupTest( PersonMapsIdSelectException.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdSelectException.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -184,10 +183,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdSelectIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdSelectIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdSelectIgnore.class, 1L );
 					// Person is non-null association is null.
 					assertNotNull( pCheck );
@@ -197,10 +196,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneSelectException() {
-		setupTest( PersonMapsIdColumnSelectException.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdJoinColumnOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnSelectException.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdColumnSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -216,10 +215,10 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneSelectIgnore() {
-		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdJoinColumnOneToOneSelectIgnore(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnSelectIgnore.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdColumnSelectIgnore.class, 1L );
 					// Person should be non-null;association should be null.
 					assertNotNull( pCheck );
@@ -228,24 +227,23 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 		);
 	}
 
-	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId ) {
-		persistData( clazz, id, isMapsId );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
+		persistData( clazz, id, isMapsId, scope );
+		scope.inTransaction(
+				session -> {
 					Person p = session.find( clazz, id );
 					assertEquals( "New York", p.getCity().getName() );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.createNativeQuery( "delete from City where id = " + id )
-							.executeUpdate();
-				}
+		scope.inTransaction(
+				session ->
+						session.createNativeQuery( "delete from City where id = " + id )
+								.executeUpdate()
 		);
 	}
 
-	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId) {
+	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
 		final Person person;
 		try {
 			person = clazz.newInstance();
@@ -254,8 +252,8 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 			throw new RuntimeException( ex );
 		}
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					City city = new City();
 					city.setId( id );
 					city.setName( "New York" );
@@ -277,17 +275,20 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 		public String getName() {
 			return name;
 		}
+
 		public void setName(String name) {
 			this.name = name;
 		}
 
 		public abstract void setId(Long id);
+
 		public abstract City getCity();
+
 		public abstract void setCity(City city);
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectException" )
+	@Table(name = "PersonOneToOneSelectException")
 	public static class PersonOneToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -315,13 +316,13 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectIgnore" )
+	@Table(name = "PersonOneToOneSelectIgnore")
 	public static class PersonOneToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -344,7 +345,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectException" )
+	@Table(name = "PersonManyToOneSelectException")
 	public static class PersonManyToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -372,13 +373,13 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectIgnore" )
+	@Table(name = "PersonManyToOneSelectIgnore")
 	public static class PersonManyToOneSelectIgnore extends Person {
 		@Id
 		private Long id;
 
 		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-		@NotFound( action = NotFoundAction.IGNORE )
+		@NotFound(action = NotFoundAction.IGNORE)
 		@JoinColumn(foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 		private City city;
 
@@ -401,7 +402,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectException" )
+	@Table(name = "PersonPkjcSelectException")
 	public static class PersonPkjcSelectException extends Person {
 		@Id
 		private Long id;
@@ -430,7 +431,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectIgnore" )
+	@Table(name = "PersonPkjcSelectIgnore")
 	public static class PersonPkjcSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -460,7 +461,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinException" )
+	@Table(name = "PersonMapsIdJoinException")
 	public static class PersonMapsIdJoinException extends Person {
 		@Id
 		private Long id;
@@ -489,7 +490,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinIgnore" )
+	@Table(name = "PersonMapsIdJoinIgnore")
 	public static class PersonMapsIdJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -519,7 +520,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectException" )
+	@Table(name = "PersonMapsIdSelectException")
 	public static class PersonMapsIdSelectException extends Person {
 		@Id
 		private Long id;
@@ -548,7 +549,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectIgnore" )
+	@Table(name = "PersonMapsIdSelectIgnore")
 	public static class PersonMapsIdSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -578,7 +579,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinException" )
+	@Table(name = "PersonMapsIdColumnJoinException")
 	public static class PersonMapsIdColumnJoinException extends Person {
 		@Id
 		private Long id;
@@ -607,7 +608,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinIgnore" )
+	@Table(name = "PersonMapsIdColumnJoinIgnore")
 	public static class PersonMapsIdColumnJoinIgnore extends Person {
 		@Id
 		private Long id;
@@ -637,7 +638,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectExcept" )
+	@Table(name = "PersonMapsIdColumnSelectExcept")
 	public static class PersonMapsIdColumnSelectException extends Person {
 		@Id
 		private Long id;
@@ -666,7 +667,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectIgnore" )
+	@Table(name = "PersonMapsIdColumnSelectIgnore")
 	public static class PersonMapsIdColumnSelectIgnore extends Person {
 		@Id
 		private Long id;
@@ -696,7 +697,7 @@ public class OptionalLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "City" )
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalLazyNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/OptionalLazyNotFoundTest.java
@@ -27,6 +27,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,6 +64,29 @@ import static org.junit.jupiter.api.Assertions.fail;
 		}
 )
 public class OptionalLazyNotFoundTest {
+
+	@AfterEach
+	public void cleanUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from " + PersonManyToOneSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonManyToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectIgnore.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdColumnSelectIgnore.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdColumnSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + City.class.getName() ).executeUpdate();
+				}
+		);
+	}
 
 	@Test
 	public void testOneToOneSelectException(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/RequiredLazyNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/RequiredLazyNotFoundTest.java
@@ -1,4 +1,4 @@
-package org.hibernate.test.notfound;
+package org.hibernate.orm.test.notfound;
 
 import java.io.Serializable;
 import javax.persistence.CascadeType;
@@ -17,54 +17,49 @@ import javax.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.ObjectNotFoundException;
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12436")
-public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				PersonManyToOneSelectException.class,
-				PersonOneToOneSelectException.class,
-				PersonMapsIdSelectException.class,
-				PersonPkjcSelectException.class,
-				PersonMapsIdColumnSelectException.class,
-				City.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( AvailableSettings.SHOW_SQL, Boolean.TRUE.toString() );
-		configuration.setProperty( AvailableSettings.FORMAT_SQL, Boolean.TRUE.toString() );
-	}
+@TestForIssue(jiraKey = "HHH-12436")
+@DomainModel(
+		annotatedClasses = {
+				RequiredLazyNotFoundTest.PersonManyToOneSelectException.class,
+				RequiredLazyNotFoundTest.PersonOneToOneSelectException.class,
+				RequiredLazyNotFoundTest.PersonMapsIdSelectException.class,
+				RequiredLazyNotFoundTest.PersonPkjcSelectException.class,
+				RequiredLazyNotFoundTest.PersonMapsIdColumnSelectException.class,
+				RequiredLazyNotFoundTest.City.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true")
+		}
+)
+public class RequiredLazyNotFoundTest {
 
 	@Test
-	public void testOneToOneSelectException() {
-		setupTest( PersonOneToOneSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonOneToOneSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonOneToOneSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -80,10 +75,10 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testManyToOneSelectException() {
-		setupTest( PersonManyToOneSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testManyToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonManyToOneSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonManyToOneSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -99,10 +94,10 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testPkjcOneToOneSelectException() {
-		setupTest( PersonPkjcSelectException.class, 1L, false );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testPkjcOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonPkjcSelectException.class, 1L, false, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonPkjcSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -118,10 +113,10 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdOneToOneSelectException() {
-		setupTest( PersonMapsIdSelectException.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdSelectException.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -137,10 +132,10 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testMapsIdJoinColumnOneToOneSelectException() {
-		setupTest( PersonMapsIdColumnSelectException.class, 1L, true );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void testMapsIdJoinColumnOneToOneSelectException(SessionFactoryScope scope) {
+		setupTest( PersonMapsIdColumnSelectException.class, 1L, true, scope );
+		scope.inTransaction(
+				session -> {
 					Person pCheck = session.find( PersonMapsIdColumnSelectException.class, 1L );
 					assertNotNull( pCheck );
 					assertFalse( Hibernate.isInitialized( pCheck.getCity() ) );
@@ -155,24 +150,23 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 		);
 	}
 
-	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId ) {
-		persistData( clazz, id, isMapsId );
-		doInHibernate(
-				this::sessionFactory, session -> {
+	private <T extends Person> void setupTest(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
+		persistData( clazz, id, isMapsId, scope );
+		scope.inTransaction(
+				session -> {
 					Person p = session.find( clazz, id );
 					assertEquals( "New York", p.getCity().getName() );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.createNativeQuery( "delete from City where id = " + id )
-							.executeUpdate();
-				}
+		scope.inTransaction(
+				session ->
+						session.createNativeQuery( "delete from City where id = " + id )
+								.executeUpdate()
 		);
 	}
 
-	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId) {
+	private <T extends Person> void persistData(Class<T> clazz, long id, boolean isMapsId, SessionFactoryScope scope) {
 		final Person person;
 		try {
 			person = clazz.newInstance();
@@ -181,8 +175,8 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 			throw new RuntimeException( ex );
 		}
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction(
+				session -> {
 					City city = new City();
 					city.setId( id );
 					city.setName( "New York" );
@@ -204,17 +198,20 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 		public String getName() {
 			return name;
 		}
+
 		public void setName(String name) {
 			this.name = name;
 		}
 
 		public abstract void setId(Long id);
+
 		public abstract City getCity();
+
 		public abstract void setCity(City city);
 	}
 
 	@Entity
-	@Table( name = "PersonOneToOneSelectException" )
+	@Table(name = "PersonOneToOneSelectException")
 	public static class PersonOneToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -242,7 +239,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonManyToOneSelectException" )
+	@Table(name = "PersonManyToOneSelectException")
 	public static class PersonManyToOneSelectException extends Person {
 		@Id
 		private Long id;
@@ -270,7 +267,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonPkjcSelectException" )
+	@Table(name = "PersonPkjcSelectException")
 	public static class PersonPkjcSelectException extends Person {
 		@Id
 		private Long id;
@@ -299,7 +296,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdJoinException" )
+	@Table(name = "PersonMapsIdJoinException")
 	public static class PersonMapsIdJoinException extends Person {
 		@Id
 		private Long id;
@@ -328,7 +325,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdSelectException" )
+	@Table(name = "PersonMapsIdSelectException")
 	public static class PersonMapsIdSelectException extends Person {
 		@Id
 		private Long id;
@@ -357,7 +354,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnJoinException" )
+	@Table(name = "PersonMapsIdColumnJoinException")
 	public static class PersonMapsIdColumnJoinException extends Person {
 		@Id
 		private Long id;
@@ -386,7 +383,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "PersonMapsIdColumnSelectExcept" )
+	@Table(name = "PersonMapsIdColumnSelectExcept")
 	public static class PersonMapsIdColumnSelectException extends Person {
 		@Id
 		private Long id;
@@ -415,7 +412,7 @@ public class RequiredLazyNotFoundTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	@Table( name = "City" )
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/RequiredLazyNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/RequiredLazyNotFoundTest.java
@@ -25,6 +25,7 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +55,23 @@ import static org.junit.jupiter.api.Assertions.fail;
 		}
 )
 public class RequiredLazyNotFoundTest {
+
+	@AfterEach
+	public void cleanUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from " + PersonManyToOneSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonOneToOneSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdSelectException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonPkjcSelectException.class.getName() ).executeUpdate();
+					session.createQuery( "delete from " + PersonMapsIdColumnSelectException.class.getName() )
+							.executeUpdate();
+					session.createQuery( "delete from " + City.class.getName() ).executeUpdate();
+				}
+		);
+	}
 
 	@Test
 	public void testOneToOneSelectException(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/test/notfound/ToDeleteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/notfound/ToDeleteTest.java
@@ -1,0 +1,106 @@
+package org.hibernate.test.notfound;
+
+import javax.persistence.ConstraintMode;
+import javax.persistence.Entity;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@DomainModel(
+		annotatedClasses = {
+				ToDeleteTest.Task.class,
+				ToDeleteTest.Employee.class,
+				ToDeleteTest.Location.class
+		}
+)
+@SessionFactory
+public class ToDeleteTest {
+	@Test
+	public void testExistingProxyWithNonExistingAssociation(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final Employee employee = new Employee();
+					employee.id = 1;
+					session.persist( employee );
+
+					final Task task = new Task();
+					task.id = 2;
+					task.employee = employee;
+					session.persist( task );
+
+					session.flush();
+
+					session.createNativeQuery( "update Employee set locationId = 3 where id = 1" )
+							.executeUpdate();
+				} );
+
+		try {
+			scope.inTransaction(
+					session -> {
+						session.load( Employee.class, 1 );
+						session.createQuery( "from Task", Task.class ).getSingleResult();
+					} );
+			fail( "EntityNotFoundException should have been thrown because Task.employee.location is not found " +
+						  "and is not mapped with @NotFound(IGNORE)" );
+		}
+		catch (EntityNotFoundException expected) {
+		}
+	}
+
+	@Entity(name = "Task")
+	public static class Task {
+
+		@Id
+		private int id;
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@JoinColumn(
+				name = "employeeId",
+				foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+		)
+		@NotFound(action = NotFoundAction.IGNORE)
+		private Employee employee;
+
+	}
+
+	@Entity(name = "Employee")
+	public static class Employee {
+		@Id
+		private int id;
+
+		private String name;
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@JoinColumn(name = "locationId", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+		private Location location;
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+	}
+
+	@Entity(name = "Location")
+	public static class Location {
+		@Id
+		private int id;
+
+		private String description;
+	}
+}


### PR DESCRIPTION
Fix load toOne association not referencing a PK with `FetchMode.SELECT`
Fix throw `EntityNotFoundException` when an association not mapped with  `NotFound(IGNORE)`