### PR TITLE
Update DB2 dialect with bind parameters limit

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -51,6 +51,8 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
  */
 public class DB2Dialect extends Dialect {
 
+	private static final int BIND_PARAMETERS_NUMBER_LIMIT = 32_767;	
+	
 	private static final AbstractLimitHandler LIMIT_HANDLER = new AbstractLimitHandler() {
 		@Override
 		public String processSql(String sql, RowSelection selection) {
@@ -596,4 +598,9 @@ public class DB2Dialect extends Dialect {
 	public boolean supportsPartitionBy() {
 		return true;
 	}
+	
+	@Override
+	public int getInExpressionCountLimit() {
+		return BIND_PARAMETERS_NUMBER_LIMIT;
+	}	
 }


### PR DESCRIPTION
Provide allowed parameters limit for DB2 queries based on official documentation: https://www.ibm.com/docs/en/db2/11.5?topic=sql-xml-limits