### PR TITLE
Fix incorrect additional joins being generated when non-fetch joining and selecting a plural association

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/Account.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/Account.java
@@ -4,7 +4,6 @@ import javax.persistence.DiscriminatorColumn;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
@@ -12,29 +11,27 @@ import javax.persistence.ManyToOne;
 @DiscriminatorColumn(name = "account_type")
 abstract class Account {
 
+    @Id
+    private Integer id;
+    private double amount;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Client client;
+
     Account() {}
 
-    Account(Client client) {
+    Account(Integer id, Client client) {
+        this.id = id;
         this.client = client;
         amount = 0.0;
         rate = 12.0;
     }
 
-    @Id @GeneratedValue
-    private Long id;
-
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Client client;
-
     public Client getClient() {
         return client;
     }
-
-    private double amount;
 
     public double getAmount() {
         return amount;
@@ -64,8 +61,8 @@ class DebitAccount extends Account {
     public DebitAccount() {
     }
 
-    public DebitAccount(Client client) {
-        super(client);
+    public DebitAccount(Integer id, Client client) {
+        super( id, client );
     }
 
     @Override
@@ -81,8 +78,8 @@ class CreditAccount extends Account {
     public CreditAccount() {
     }
 
-    public CreditAccount(Client client) {
-        super(client);
+    public CreditAccount(Integer id, Client client) {
+        super( id, client );
     }
 
     @Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/Client.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/Client.java
@@ -12,18 +12,10 @@ import java.util.Set;
 @Entity
 class Client {
 
-    @Id @GeneratedValue
-    private Long id;
-
-    public Long getId() {
-        return id;
-    }
+    @Id
+    private Integer id;
 
     private String name;
-
-    public String getName() {
-        return name;
-    }
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "client", fetch = FetchType.LAZY)
     private Set<DebitAccount> debitAccounts = new HashSet<>();
@@ -33,8 +25,17 @@ class Client {
 
     Client() {}
 
-    Client(String name) {
+    Client(Integer id, String name) {
+        this.id = id;
         this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public Set<CreditAccount> getCreditAccounts() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/DiscriminatedCollectionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/DiscriminatedCollectionTests.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.discriminatedcollections;
 
+import java.util.List;
 import javax.persistence.criteria.JoinType;
 
 import org.hibernate.query.criteria.JpaCriteriaQuery;
@@ -13,8 +14,11 @@ import org.hibernate.query.criteria.JpaCriteriaQuery;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -23,29 +27,45 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * @author Gavin King
  */
 @DomainModel(
-		annotatedClasses = {
-				Client.class, Account.class, DebitAccount.class, CreditAccount.class
-		}
+		annotatedClasses = { Client.class, Account.class, DebitAccount.class, CreditAccount.class }
 )
 @SessionFactory
-public class TempTest {
+public class DiscriminatedCollectionTests {
+
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final Client c = new Client( 1, "Gavin" );
+			final DebitAccount da = new DebitAccount( 1, c );
+			final CreditAccount ca = new CreditAccount( 2, c );
+			c.getDebitAccounts().add( da );
+			c.getCreditAccounts().add( ca );
+
+			session.persist( c );
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.remove( session.load( Client.class, 1 ) );
+		} );
+	}
+
+	@Test
+	public void testHqlNonFetchJoins(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final String queryString = "select c, da from Client c inner join c.debitAccounts da";
+			final List<Object[]> clients = session.createQuery( queryString, Object[].class ).getResultList();
+			assertThat( clients ).hasSize( 1 );
+		} );
+	}
 
 	@Test
 	public void test(SessionFactoryScope scope) {
-		Client c = new Client( "Gavin" );
-		DebitAccount da = new DebitAccount( c );
-		CreditAccount ca = new CreditAccount( c );
-		c.getDebitAccounts().add( da );
-		c.getCreditAccounts().add( ca );
-
-		scope.inTransaction(
-				session ->
-						session.persist( c )
-		);
-
 		scope.inSession(
 				session -> {
-					Client client = session.find( Client.class, c.getId() );
+					Client client = session.find( Client.class, 1 );
 					assertEquals( 1, client.getDebitAccounts().size() );
 					assertEquals( 1, client.getCreditAccounts().size() );
 					assertNotEquals(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/PluralAttributeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/PluralAttributeTests.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.hql;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.domain.StandardDomainModel;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel( standardModels = StandardDomainModel.GAMBIT )
+@SessionFactory
+public class PluralAttributeTests {
+	@Test
+	public void testJoinAndSelectElementSets(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			session.createQuery( "select e, s from EntityOfSets e join e.setOfBasics s" ).list();
+		} );
+
+		assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+		assertThat( statementInspector.getNumberOfJoins( 0 ) ).isEqualTo( 1 );
+	}
+
+	@Test
+	public void testJoinAndSelectOneToManySets(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			session.createQuery( "select e, s from EntityOfSets e join e.setOfOneToMany s" ).list();
+		} );
+
+		assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+		// should be 2 because the association specifies a collection-table
+		assertThat( statementInspector.getNumberOfJoins( 0 ) ).isEqualTo( 2 );
+	}
+}

--- a/hibernate-core/src/test/resources/log4j2.properties
+++ b/hibernate-core/src/test/resources/log4j2.properties
@@ -24,6 +24,12 @@ appender.ddl.layout.pattern=%d{ABSOLUTE} %5p %c:%L - %m%n
 rootLogger.level=info
 rootLogger.appenderRef.stdout.ref=STDOUT
 
+logger.sqm-tree.name=org.hibernate.orm.query.sqm.ast
+logger.sqm-tree.level=trace
+
+logger.sql-tree.name=org.hibernate.orm.sql.ast.tree
+logger.sql-tree.level=trace
+
 logger.graph.name=org.hibernate.orm.graph
 logger.graph.level=debug
 


### PR DESCRIPTION
This first commit is just tests illustrating the problem until we can all discuss the better design approach to fix this - either we stop implicitly "converting" the collection selection as its {element} path or later better handle the "mismatched" NavigablePaths in terms of resolving TableGroups

