### PR TITLE
HHH-13999 Support SQL Server 2016

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
@@ -480,7 +480,7 @@ public enum Database {
 	SQLSERVER {
 		@Override
 		public Class<? extends Dialect> latestDialect() {
-			return SQLServer2012Dialect.class;
+			return SQLServer2016Dialect.class;
 		}
 
 		@Override
@@ -501,16 +501,20 @@ public enum Database {
 						return new SQLServer2008Dialect();
 					}
 					case 11:
-					case 12:
-					case 13: {
+					case 12: {
 						return new SQLServer2012Dialect();
+					}
+					case 13:
+					case 14:
+					case 15: {
+						return new SQLServer2016Dialect();
 					}
 					default: {
 						if ( majorVersion < 8 ) {
 							return new SQLServerDialect();
 						}
 						else {
-							// assume `majorVersion > 13`
+							// assume `majorVersion > 15`
 							return latestDialectInstance( this );
 						}
 					}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+/**
+ * Microsoft SQL Server 2016 Dialect
+ */
+public class SQLServer2016Dialect extends SQLServer2012Dialect {
+
+	@Override
+	public boolean supportsIfExistsBeforeTableName() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsIfExistsBeforeConstraintName() {
+		return true;
+	}
+
+	@Override
+	public String getDropSequenceString(String sequenceName) {
+		return "drop sequence if exists " + sequenceName;
+	}
+
+	@Override
+	public String[] getDropSchemaCommand(String schemaName) {
+		return new String[] {"drop schema if exists " + schemaName};
+	}
+}


### PR DESCRIPTION
SQL Server 2016 (13.x) and later support the `if exists` clause for most `drop` DDL statements. The new `SQLServer2016Dialect` dialect accounts for this and offers the advantage that no error messages get logged when using `hibernate.hbm2ddl.auto=create-drop`.