### PR TITLE
HHH-14827 @AttributeOverride at type level does not work when also using orm.xml

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
@@ -1794,9 +1794,10 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 	}
 
 	private AssociationOverrides getAssociationOverrides(ManagedType root, XMLContext.Default defaults) {
-		return root instanceof JaxbEntity
-				? getAssociationOverrides( ( (JaxbEntity) root ).getAssociationOverride(), defaults, true )
-				: null;
+		return getAssociationOverrides(
+				root instanceof JaxbEntity ? ( (JaxbEntity) root ).getAssociationOverride() : Collections.emptyList(),
+				defaults, true
+		);
 	}
 
 	/**
@@ -2742,9 +2743,10 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 	}
 
 	private PrimaryKeyJoinColumns getPrimaryKeyJoinColumns(ManagedType root, XMLContext.Default defaults) {
-		return root instanceof JaxbEntity
-				? getPrimaryKeyJoinColumns( ( (JaxbEntity) root ).getPrimaryKeyJoinColumn(), defaults, true )
-				: null;
+		return getPrimaryKeyJoinColumns(
+				root instanceof JaxbEntity ? ( (JaxbEntity) root ).getPrimaryKeyJoinColumn() : Collections.emptyList(),
+				defaults, true
+		);
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
@@ -1880,9 +1880,10 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 	}
 
 	private AttributeOverrides getAttributeOverrides(ManagedType root, XMLContext.Default defaults) {
-		return root instanceof JaxbEntity
-				? getAttributeOverrides( ( (JaxbEntity) root ).getAttributeOverride(), defaults, true )
-				: null;
+		return getAttributeOverrides(
+				root instanceof JaxbEntity ? ( (JaxbEntity) root ).getAttributeOverride() : Collections.emptyList(),
+				defaults, true
+		);
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/xml/XmlAndAnnotationAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/xml/XmlAndAnnotationAttributeOverrideTest.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpa.test.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.test.util.SchemaUtil;
+import org.junit.Test;
+
+public class XmlAndAnnotationAttributeOverrideTest extends BaseEntityManagerFunctionalTestCase {
+	@Test
+	@TestForIssue(jiraKey = "HHH-14827")
+	public void testDerivedClassAttributeOverriding() {
+		assertThat( SchemaUtil.getColumnNames( entityManagerFactory(), DerivedEntityType.class ) )
+				.contains( "custom_name" )
+				.doesNotContain( "name" );
+	}
+
+	@Test
+	public void testEmbeddedAttributeOverriding() {
+		assertThat( SchemaUtil.getColumnNames( entityManagerFactory(), DerivedEntityType.class ) )
+				.contains( "custom_embeddable_name" )
+				.doesNotContain( "embeddable_name" );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { MappedSuperclassType.class, DerivedEntityType.class, EmbeddableType.class };
+	}
+
+	@Override
+	public String[] getEjb3DD() {
+		return new String[] {
+				// Using an empty orm.xml: the mere presence of an orm.xml used to trigger the bug,
+				// regardless of its content.
+				"org/hibernate/jpa/test/xml/orm-empty.xml"
+		};
+	}
+
+	@MappedSuperclass
+	public static class MappedSuperclassType {
+
+		private String name;
+
+		public MappedSuperclassType() {
+		}
+
+		public MappedSuperclassType(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "derivedentity")
+	@AttributeOverride(name = "name", column = @Column(name = "custom_name"))
+	public static class DerivedEntityType extends MappedSuperclassType {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		@Embedded
+		@AttributeOverride(name = "embeddableName", column = @Column(name = "custom_embeddable_name"))
+		private EmbeddableType embedded;
+
+		public DerivedEntityType() {
+		}
+
+		public DerivedEntityType(String name) {
+			super( name );
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public EmbeddableType getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(EmbeddableType embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddableType {
+		private String embeddableName;
+
+		public String getEmbeddableName() {
+			return embeddableName;
+		}
+
+		public void setEmbeddableName(String embeddableName) {
+			this.embeddableName = embeddableName;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/util/SchemaUtil.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/util/SchemaUtil.java
@@ -6,13 +6,17 @@
  */
 package org.hibernate.test.util;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Table;
+import org.hibernate.persister.entity.AbstractEntityPersister;
 
 /**
  * Check that the Hibernate metamodel contains some database objects
@@ -59,5 +63,19 @@ public abstract class SchemaUtil {
 		}
 
 		return false;
+	}
+
+	public static Set<String> getColumnNames(EntityManagerFactory entityManagerFactory, Class<?> entityType) {
+		Set<String> result = new HashSet<>();
+		AbstractEntityPersister persister = (AbstractEntityPersister) entityManagerFactory
+				.unwrap( SessionFactoryImplementor.class )
+				.getMetamodel().entityPersister( entityType );
+		if ( persister == null ) {
+			return result;
+		}
+		for ( String propertyName : persister.getPropertyNames() ) {
+			Collections.addAll( result, persister.getPropertyColumnNames( propertyName ) );
+		}
+		return result;
 	}
 }

--- a/hibernate-core/src/test/resources/org/hibernate/jpa/test/xml/orm-empty.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/jpa/test/xml/orm-empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
+    version="2.0">
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14827

It turns out this is a bug, caused by [HHH-14529](https://hibernate.atlassian.net/browse/HHH-14529) (the new JAXB implementation of orm.xml parsing). So it only affects 5.6 and 5.5.

The bug probably also affected `@AssociationOverride` and `@PrimaryKeyJoinColumn`; that's fixed in this PR as well.

I created a backport to 5.5 here: #4225 . Please don't forget to merge it as well.