### PR TITLE
HHH-14826 - Regression: OneToOne fields are always null if parent is loaded from L2 cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -215,11 +215,19 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	public Object assemble(Serializable oid, SharedSessionContractImplementor session, Object owner) throws HibernateException {
+
+		if ( oid == null ) {
+			if ( uniqueKeyPropertyName != null ) {
+				return resolve( session.getContextEntityIdentifier( owner ), session, owner );
+			}
+			return null;
+		}
+
 		//the owner of the association is not the owner of the id
 		Serializable id = ( Serializable ) getIdentifierType( session ).assemble( oid, session, null );
 
 		if ( id == null ) {
-			return resolve( session.getContextEntityIdentifier(owner), session, owner );
+			return null;
 		}
 
 		return resolveIdentifier( id, session );

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -219,7 +219,7 @@ public class OneToOneType extends EntityType {
 		Serializable id = ( Serializable ) getIdentifierType( session ).assemble( oid, session, null );
 
 		if ( id == null ) {
-			return null;
+			return resolve( session.getContextEntityIdentifier(owner), session, owner );
 		}
 
 		return resolveIdentifier( id, session );

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/cache/OneToOneCacheEnableSelectingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/cache/OneToOneCacheEnableSelectingTest.java
@@ -1,0 +1,158 @@
+package org.hibernate.test.onetoone.cache;
+
+import java.util.concurrent.atomic.AtomicLong;
+import javax.persistence.Cacheable;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Version;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@TestForIssue( jiraKey = "HHH-14826")
+public class OneToOneCacheEnableSelectingTest extends BaseCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Product.class,
+				ProductConfig.class
+		};
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
+		configuration.setProperty(AvailableSettings.JPA_SHARED_CACHE_MODE, "ENABLE_SELECTIVE");
+		configuration.setProperty(AvailableSettings.GENERATE_STATISTICS, "true");
+	}
+
+	@Test
+	public void testFieldShouldNotBeNull() {
+		final AtomicLong pid = new AtomicLong();
+
+		// create Product
+		inTransaction(s -> {
+			Product product = new Product();
+			s.persist(product);
+			pid.set(product.getId());
+		});
+
+		// create ProductConfig and associate with a Product
+		inTransaction(s -> {
+			Product product = s.find(Product.class, pid.get());
+			ProductConfig config = new ProductConfig();
+			config.setProduct(product);
+			s.persist(config);
+		});
+
+		assertTrue(sessionFactory().getCache().containsEntity(Product.class, pid.get()));
+
+		sessionFactory().getStatistics().clear();
+
+		// now fetch the Product again
+		inTransaction(s -> {
+			Product product = s.find(Product.class, pid.get());
+
+			// should have been from cache
+			assertNotEquals (0, sessionFactory().getStatistics().getSecondLevelCacheHitCount());
+
+			// this should not fail
+			assertNotNull("one-to-one field should not be null", product.getConfig());
+		});
+	}
+
+	@Entity(name = "Product")
+	@Cacheable
+	public static class Product {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Version
+		private Integer version;
+
+		@OneToOne(mappedBy = "product", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+		private ProductConfig config;
+
+		public Product() {}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Integer getVersion() {
+			return version;
+		}
+
+		public void setVersion(Integer version) {
+			this.version = version;
+		}
+
+		public ProductConfig getConfig() {
+			return config;
+		}
+
+		public void setConfig(ProductConfig config) {
+			this.config = config;
+		}
+	}
+
+	@Entity(name = "ProductConfig")
+	@Cacheable
+	public static class ProductConfig {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Version
+		private Integer version;
+
+		@OneToOne(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+		private Product product;
+
+		public ProductConfig() {}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Integer getVersion() {
+			return version;
+		}
+
+		public void setVersion(Integer version) {
+			this.version = version;
+		}
+
+		public Product getProduct() {
+			return product;
+		}
+
+		public void setProduct(Product product) {
+			this.product = product;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/onetoone/cache/OneToOneCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/onetoone/cache/OneToOneCacheTest.java
@@ -1,15 +1,11 @@
 package org.hibernate.test.onetoone.cache;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -21,8 +17,6 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
-import javax.persistence.*;
-
 public class OneToOneCacheTest extends BaseCoreFunctionalTestCase {
 	@Override
 	public String[] getMappings() {
@@ -33,17 +27,8 @@ public class OneToOneCacheTest extends BaseCoreFunctionalTestCase {
     }
     
 	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Product.class,
-				ProductConfig.class
-		};
-	}
-
-	@Override
 	protected void configure(Configuration configuration) {
 		configuration.setProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
-		configuration.setProperty(AvailableSettings.JPA_SHARED_CACHE_MODE, "ENABLE_SELECTIVE");
 		configuration.setProperty(AvailableSettings.GENERATE_STATISTICS, "true");
     }
 
@@ -131,122 +116,5 @@ public class OneToOneCacheTest extends BaseCoreFunctionalTestCase {
 	@Test
 	public void OneToOneCacheByRef() throws Exception {
 		OneToOneTest(PersonByRef.class, DetailsByRef.class);
-	}
-
-	@Test
-	public void testFieldShouldNotBeNull2() {
-		final AtomicLong pid = new AtomicLong();
-
-		// create Product
-		inTransaction(s -> {
-			Product product = new Product();
-			s.persist(product);
-			pid.set(product.getId());
-		});
-
-		// create ProductConfig and associate with a Product
-		inTransaction(s -> {
-			Product product = s.find(Product.class, pid.get());
-			ProductConfig config = new ProductConfig();
-			config.setProduct(product);
-			s.persist(config);
-		});
-
-		assertTrue(sessionFactory().getCache().containsEntity(Product.class, pid.get()));
-
-		sessionFactory().getStatistics().clear();
-
-		// now fetch the Product again
-		inTransaction(s -> {
-			Product product = s.find(Product.class, pid.get());
-
-			// should have been from cache
-			assertNotEquals (0, sessionFactory().getStatistics().getSecondLevelCacheHitCount());
-
-			// this should not fail
-			assertNotNull("one-to-one field should not be null", product.getConfig());
-		});
-	}
-
-	@Entity(name = "Product")
-	@Cacheable
-	public static class Product {
-
-		@Id
-		@GeneratedValue
-		private Long id;
-
-		@Version
-		private Integer version;
-
-		@OneToOne(mappedBy = "product", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
-		private ProductConfig config;
-
-		public Product() {}
-
-		public Long getId() {
-			return id;
-		}
-
-		public void setId(Long id) {
-			this.id = id;
-		}
-
-		public Integer getVersion() {
-			return version;
-		}
-
-		public void setVersion(Integer version) {
-			this.version = version;
-		}
-
-		public ProductConfig getConfig() {
-			return config;
-		}
-
-		public void setConfig(ProductConfig config) {
-			this.config = config;
-		}
-	}
-
-	@Entity(name = "ProductConfig")
-	@Cacheable
-	public static class ProductConfig {
-
-		@Id
-		@GeneratedValue
-		private Long id;
-
-		@Version
-		private Integer version;
-
-		@OneToOne(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
-		private Product product;
-
-		public ProductConfig() {}
-
-		public Long getId() {
-			return id;
-		}
-
-		public void setId(Long id) {
-			this.id = id;
-		}
-
-		public Integer getVersion() {
-			return version;
-		}
-
-		public void setVersion(Integer version) {
-			this.version = version;
-		}
-
-		public Product getProduct() {
-			return product;
-		}
-
-		public void setProduct(Product product) {
-			this.product = product;
-		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14826