### PR TITLE
HHH-14887 forking of the compilation process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ nexusPublishing {
 }
 
 allprojects {
+	tasks.withType(Test).configureEach {
+        	forkEvery = 100
+        }
+
 	repositories {
 		mavenCentral()
 		//Allow loading additional dependencies from a local path;


### PR DESCRIPTION
According to [Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options), Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones.
one option is to fork a new test VM after a certain number of tests have run. So our recommendation is to configure "forkEvery" and we give a specific value of 100

