### PR TITLE
HHH-14888 Running the Compiler as a separate process to shorten the build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ nexusPublishing {
 }
 
 allprojects {
+	tasks.withType(JavaCompile).configureEach {
+        	options.fork = true
+    	}
 	repositories {
 		mavenCentral()
 		//Allow loading additional dependencies from a local path;


### PR DESCRIPTION
[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon),We found that the project had over 1000 Java and Groovy files, so running the Compiler as a separate process shortened the build time of this project