### PR TITLE
HHH-14891 update JTS package name in user guide

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/basic_types.adoc
@@ -87,7 +87,7 @@ Internally Hibernate uses a registry of basic types when it needs to resolve a s
 [cols="<.^,<.^,<.^,<.^",options="header",]
 |=================================================================================================
 |Hibernate type (org.hibernate.spatial package) |JDBC type |Java type |BasicTypeRegistry key(s)
-|JTSGeometryType |depends on the dialect | com.vividsolutions.jts.geom.Geometry |jts_geometry, and the class names of Geometry and its subclasses
+|JTSGeometryType |depends on the dialect | org.locationtech.jts.geom.Geometry |jts_geometry, and the class names of Geometry and its subclasses
 |GeolatteGeometryType |depends on the dialect | org.geolatte.geom.Geometry |geolatte_geometry, and the class names of Geometry and its subclasses
 |=================================================================================================
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14891

Since v1.5, JTS core library has changed its package name from "com.vividsolutions.jts" to "org.locationtech.jts" (see https://github.com/locationtech/jts/blob/master/MIGRATION.md#jts-115). We did update the package name in “Spatial” chapter but it seems we overlooked the “Hibernate Spatial Basic Types” table 3 in “Domain Model” chapter.
