### PR TITLE
HHH-14839 add proxy or injector to lazy association properties of detached entities persisted or merged

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -7,26 +7,44 @@
 package org.hibernate.action.internal;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
+import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.entry.CacheEntry;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.Versioning;
+import org.hibernate.engine.spi.CascadeStyle;
+import org.hibernate.engine.spi.CascadeStyles;
+import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
+import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostCommitInsertEventListener;
 import org.hibernate.event.spi.PostInsertEvent;
 import org.hibernate.event.spi.PostInsertEventListener;
 import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.internal.StatsHelper;
 import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.type.AssociationType;
+import org.hibernate.type.CollectionType;
+import org.hibernate.type.EntityType;
+import org.hibernate.type.Type;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The action for performing an entity insertion, for entities not defined to use IDENTITY generation.
@@ -147,6 +165,159 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 
 		handleNaturalIdPostSaveNotifications( id );
 
+		EntityMetamodel entityMetamodel = getPersister().getEntityMetamodel();
+
+		if (entityMetamodel.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading()) {
+			PersistentAttributeInterceptable interceptable = ((PersistentAttributeInterceptable) instance );
+			PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
+			final BytecodeEnhancementMetadata enhancementMetadata = entityMetamodel.getBytecodeEnhancementMetadata();
+			final LazyAttributesMetadata lazyAttributesMetadata = enhancementMetadata.getLazyAttributesMetadata();
+			if (interceptor == null) {
+				Type[] types = persister.getPropertyTypes();
+				final String[] propertyNames = persister.getPropertyNames();
+				final CascadeStyle[] cascadeStyles = persister.getPropertyCascadeStyles();
+				boolean needsInterceptor = false;
+				Set<String> initializedLazyFields = new HashSet<>();
+				for ( int i = 0; i < types.length; i++) {
+					if(!types[i].isAssociationType()) {
+						continue;
+					}
+					final String propertyName = propertyNames[i];
+					CascadeStyle cascadeStyle = cascadeStyles[i];
+					if(cascadeStyle != CascadeStyles.NONE) {
+						initializedLazyFields.add(propertyName);
+						continue;
+					}
+					Object propertyValue = persister.getPropertyValue(instance, i);
+					if(propertyValue == null) {
+						if(types[i].isCollectionType()) {
+							needsInterceptor = true;
+							continue;
+						}
+					}
+					else {
+						if(propertyValue instanceof PersistentAttributeInterceptable) {
+							PersistentAttributeInterceptable interceptableProperty = ((PersistentAttributeInterceptable) propertyValue );
+							PersistentAttributeInterceptor propertyInterceptor = interceptableProperty.$$_hibernate_getInterceptor();
+							if(propertyInterceptor == null) {
+								needsInterceptor = true;
+								continue;
+							}
+							else {
+								if(lazyAttributesMetadata.isLazyAttribute(propertyName)) {
+									initializedLazyFields.add(propertyName);
+								}
+							}
+						}
+						if(types[i].isCollectionType()) {
+							if(lazyAttributesMetadata.isLazyAttribute(propertyName)) {
+								initializedLazyFields.add(propertyName);
+							}
+							continue;
+						}
+					}
+				}
+				if (needsInterceptor) {
+					persister.getBytecodeEnhancementMetadata().injectEnhancedEntityAsProxyInterceptor(instance, getEntityKey(), session);
+					interceptor = interceptable.$$_hibernate_getInterceptor();
+					for (String propertyName : initializedLazyFields) {
+						interceptor.attributeInitialized(propertyName);
+					}
+				}
+			}
+		}
+		else {
+			if (persister.hasProxy()) {
+				Type[] types = persister.getPropertyTypes();
+				final CascadeStyle[] cascadeStyles = persister.getPropertyCascadeStyles();
+				PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+				for ( int i = 0; i < types.length; i++) {
+					if(!types[i].isAssociationType()) {
+						continue;
+					}
+					
+					final AssociationType type = (AssociationType) types[i];
+					if(type instanceof EntityType) {
+						EntityType entityType = (EntityType) type;
+						if (entityType.isEager(null)) {
+							continue;
+						}
+					}
+
+					CascadeStyle cascadeStyle = cascadeStyles[i];
+					if(cascadeStyle != CascadeStyles.NONE) {
+						continue;
+					}
+					Object propertyValue = persister.getPropertyValue(instance, i);
+
+					if(types[i].isCollectionType()) {
+						final CollectionPersister collectionPersister = session.getFactory().getMetamodel().collectionPersister( ((CollectionType) types[i]).getRole() );
+
+						if ( !collectionPersister.isLazy() ||
+								collectionPersister.getCollectionType().hasHolder() ||
+								collectionPersister.getKeyType().isComponentType() ||
+								(propertyValue instanceof PersistentCollection && Hibernate.isInitialized(propertyValue))) {
+							continue;
+						}
+
+						Object entityId = persister.getIdentifier(instance, session);
+						final CollectionKey collectionKey = new CollectionKey( collectionPersister, entityId );
+						PersistentCollection oldCollection = persistenceContext.getCollection(collectionKey);
+
+						if(oldCollection != null) {
+							if (!Hibernate.isInitialized(oldCollection) && oldCollection == propertyValue) {
+								continue;
+							}
+						}
+
+						PersistentCollection newCollection = ((CollectionType)types[i]).instantiate( session, collectionPersister, entityId );
+						if(propertyValue != null) {
+							Hibernate.initialize(newCollection);
+						}
+						newCollection.setOwner( instance );
+						persistenceContext.addUninitializedCollection( collectionPersister, newCollection, entityId);
+						persister.setPropertyValue(instance, i, newCollection);
+						continue;
+					}
+
+					// by now we know this is not a collection type
+					if(propertyValue == null) {
+						continue;
+					}
+					else {
+						if(propertyValue instanceof HibernateProxy) {
+							continue;
+						}
+						EntityPersister propertyPersister = null;
+						try {
+							propertyPersister = session.getEntityPersister(null, propertyValue);
+						}
+						catch (HibernateException he) {
+							// dynamic map entity will fail to determine type
+							continue;
+						}
+						if(propertyPersister.getRepresentationStrategy().getProxyFactory() == null ||
+								!propertyPersister.canExtractIdOutOfEntity()) {
+							continue;
+						}
+						Object entityId = propertyPersister.getIdentifier(propertyValue, session);
+						Object proxy = null;
+						try {
+							proxy = propertyPersister.createProxy(entityId, session);
+							if(propertyValue != null) {
+								Hibernate.initialize(proxy);
+							}
+						}
+						catch (Exception e) {
+							continue;
+						}
+						final EntityKey keyToLoad = session.generateEntityKey( entityId, propertyPersister );
+						persistenceContext.addProxy(keyToLoad, proxy);
+						persister.setPropertyValue(instance, i, proxy);
+					}
+				}
+			}
+		}
 		postInsert();
 
 		if ( statistics.isStatisticsEnabled() && !veto ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -669,6 +669,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) maybeProxy;
 			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
 			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor ) {
+				( (EnhancementAsProxyLazinessInterceptor) interceptor ).setSession( session );
 				( (EnhancementAsProxyLazinessInterceptor) interceptor ).forceInitialize( maybeProxy, null );
 			}
 			return maybeProxy;

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -13,7 +13,11 @@ import org.hibernate.HibernateException;
 import org.hibernate.ObjectDeletedException;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.WrongClassException;
+import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
+import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributesMetadata;
+import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.engine.internal.Cascade;
 import org.hibernate.engine.internal.CascadePoint;
 import org.hibernate.engine.spi.CascadingAction;
@@ -39,6 +43,7 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.type.ForeignKeyDirection;
 import org.hibernate.type.TypeHelper;
 
@@ -455,6 +460,25 @@ public class DefaultMergeEventListener extends AbstractSaveEventListener impleme
 				target,
 				copyCache
 		);
+		EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
+		final boolean enhancedForLazyLoading = PersistentAttributeInterceptable.class.isAssignableFrom( entity.getClass() );
+
+		if(enhancedForLazyLoading) {
+			final BytecodeEnhancementMetadata enhancementMetadata = entityMetamodel.getBytecodeEnhancementMetadata();
+			final LazyAttributesMetadata lazyAttributesMetadata = enhancementMetadata.getLazyAttributesMetadata();
+			final BytecodeLazyAttributeInterceptor interceptor = enhancementMetadata.extractLazyInterceptor(entity);
+			if (interceptor == null) {
+				final int span = entityMetamodel.getPropertySpan();
+				final String[] propertyNames = entityMetamodel.getPropertyNames();
+
+				for ( int j = 0; j < span; j++ ) {
+					final String propertyName = propertyNames[j];
+					if(lazyAttributesMetadata.isLazyAttribute( propertyName ) && copiedValues[j] == null) {
+						copiedValues[j] = LazyPropertyInitializer.UNFETCHED_PROPERTY;
+					}
+				}
+			}
+		}
 
 		persister.setPropertyValues( target, copiedValues );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -676,7 +676,12 @@ public abstract class CollectionType extends AbstractType implements Association
 			final Object owner,
 			final Map copyCache) throws HibernateException {
 		if ( original == null ) {
-			return null;
+			if(target instanceof PersistentCollection) {
+				return target;
+			}
+			else {
+				return null;
+			}
 		}
 		if ( !Hibernate.isInitialized( original ) ) {
 			if ( ( (PersistentCollection) original ).hasQueuedOperations() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lazyload/LazyLoadingIndexing1Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lazyload/LazyLoadingIndexing1Test.java
@@ -1,0 +1,799 @@
+package org.hibernate.orm.test.lazyload;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+@TestForIssue(jiraKey = "HHH-14839")
+public class LazyLoadingIndexing1Test extends BaseEntityManagerFunctionalTestCase {
+
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{
+                BusinessEntity.class,
+                SalesOrder.class,
+                SalesOrderDetail.class,
+                Item.class,
+                ItemVendorInfo.class,
+                SerialNumber.class,
+                Vendor.class,
+                Manufacturer.class,
+                ItemText.class,
+                PurchaseOrder.class,
+                PurchaseOrderDetail.class
+        };
+    }
+
+    @Test
+    public void testLazyLoadingAfterDetachedPersistOrMerge() {
+
+        // add vendor, manufacturer, and item
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Vendor vendor = new Vendor(1L, "Distributor");
+            entityManager.persist(vendor);
+
+            Manufacturer manufacturer = new Manufacturer(1L, "Manufacturer");
+            entityManager.persist(manufacturer);
+
+            Item item = new Item(1L, "New Item");
+            item.setManufacturer(manufacturer);
+            entityManager.persist(item);
+        });
+
+        // add item vendor info with all ToOne references detached
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Manufacturer manufacturer = new Manufacturer(1L);
+            Vendor vendor = new Vendor(1L);
+            Item item = new Item(1L);
+            item.setManufacturer(manufacturer);
+
+            ItemVendorInfo itemVendorInfo = new ItemVendorInfo(1L, item, vendor, new BigDecimal("2000"));
+            entityManager.persist(itemVendorInfo);
+            entityManager.flush();
+
+            assertThat(itemVendorInfo.getItem().getManufacturer().getName()).matches("Manufacturer");
+            assertThat(itemVendorInfo.getItem().getManufacturer().getItems()).hasSize(1);
+
+            verifyReachableByIndexing(itemVendorInfo.getItem(), itemVendorInfo.getVendor(), 1, 1);
+
+        });
+
+        // update detached item
+        {
+            Item detachedItem;
+
+            detachedItem = doInJPA(this::entityManagerFactory, entityManager -> {
+                return entityManager.find(Item.class, 1L);
+            });
+
+            assertProxyState(detachedItem);
+
+            doInJPA(this::entityManagerFactory, entityManager -> {
+
+                Manufacturer manufacturer = new Manufacturer(1L);  // simulate detached manufacturer
+
+                Item i = new Item(1L);
+                i.setManufacturer(manufacturer);
+                i.setName("Item 1 New Name");
+                i.setVersion(detachedItem.getVersion());
+
+                int version = i.getVersion();
+                i = entityManager.merge(i);
+                entityManager.flush();
+
+                assertThat(i.getVendorInfos()).hasSize(1);
+
+                manufacturer = i.getManufacturer();
+                assertThat(manufacturer.getName()).matches("Manufacturer");
+                assertThat(manufacturer.getItems()).hasSize(1);
+
+                assertThat(i.getVersion()).isEqualTo(version + 1);
+
+                entityManager.refresh(i);
+
+                assertThat(i.getName()).matches("Item 1 New Name");
+                assertThat(i.getVersion()).isEqualTo(version + 1);
+
+            });
+
+        }
+
+        // add another item with vendor info, and make sure information from previous transaction is still there
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Manufacturer manufacturer1 = entityManager.find(Manufacturer.class, 1L);
+            Item item2 = new Item(2L, "New Item 2");
+            item2.setManufacturer(manufacturer1);
+            item2.setVersion(0);
+
+            entityManager.persist(item2);
+
+            Vendor vendor1 = entityManager.find(Vendor.class, 1L);
+            ItemVendorInfo itemVendorInfo2 = new ItemVendorInfo(2L, item2, vendor1, new BigDecimal("2000"));
+            entityManager.persist(itemVendorInfo2);
+            entityManager.flush();
+
+            verifyReachableByIndexing(item2, itemVendorInfo2.getVendor(), 1, 2);
+        });
+
+
+        // also check manufacturer --> items is accumulating
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Manufacturer manufacturer1 = new Manufacturer(1L);
+            Item item3 = new Item(3L, "New Item 3");
+            item3.setManufacturer(manufacturer1);
+            item3.setVersion(0);
+
+            entityManager.persist(item3);
+
+            Vendor vendor1 = new Vendor(1L);
+            ItemVendorInfo itemVendorInfo3 = new ItemVendorInfo(3L, item3, vendor1, new BigDecimal("2000"));
+            entityManager.persist(itemVendorInfo3);
+            entityManager.flush();
+
+            Set<ItemVendorInfo> vi = item3.getVendorInfos();
+            assertThat(vi).hasSize(1);
+
+            assertThat(item3.getManufacturer().getName()).matches("Manufacturer");
+            assertThat(item3.getManufacturer().getItems()).hasSize(3);
+
+            verifyReachableByIndexing(item3, itemVendorInfo3.getVendor(), 1, 3);
+
+        });
+
+        // test ToMany on the other side of a ToOne
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            SalesOrder salesOrder = new SalesOrder(1L);
+            entityManager.persist(salesOrder);
+
+            Item Item1 = new Item(1L);
+            Item1.setVersion(1);
+
+            SalesOrderDetail salesOrderDetail = new SalesOrderDetail(1L, salesOrder, Item1);
+            entityManager.persist(salesOrderDetail);
+            entityManager.flush();
+
+            assertThat(salesOrderDetail.getItem().getSalesOrderDetails()).hasSize(1);
+
+        });
+
+        // test ToMany --> ToOne from entity persisted
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            SalesOrderDetail salesOrderDetail = new SalesOrderDetail(1L);
+
+            SerialNumber serialNumber = new SerialNumber(1L, "1", salesOrderDetail);
+            entityManager.persist(serialNumber);
+            entityManager.flush();
+
+            assertNotNull(serialNumber.getSalesOrderDetail().getSalesOrder());
+        });
+
+
+        // test ToMany --> ToOne from entity removed
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            SerialNumber serialNumber = entityManager.find(SerialNumber.class, 1L);
+            entityManager.remove(serialNumber);
+            assertNotNull(serialNumber.getSalesOrderDetail().getSalesOrder());
+        });
+
+
+        // test ToOne --> ToMany from entity persisted
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Item Item1 = new Item(1L);
+            Item1.setVersion(1);
+
+            Vendor vendor1 = new Vendor(1L);
+
+            ItemVendorInfo itemVendorInfo4 = new ItemVendorInfo(4L, Item1, vendor1, new BigDecimal("2000"));
+            entityManager.persist(itemVendorInfo4);
+            entityManager.flush();
+
+            Set<ItemVendorInfo> vi = itemVendorInfo4.getItem().getVendorInfos();
+            assertThat(vi).hasSize(2);
+
+        });
+
+        // add an entity to remove in the next test, check reachability
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Item item10 = new Item(10L);
+            entityManager.persist(item10);
+            entityManager.flush();
+
+            Vendor vendor1 = new Vendor(1L);
+
+            ItemVendorInfo itemVendorInfo5 = new ItemVendorInfo(5L, item10, vendor1, new BigDecimal("2000"));
+            entityManager.persist(itemVendorInfo5);
+            entityManager.flush();
+
+            verifyReachableByIndexing(itemVendorInfo5.getItem(), itemVendorInfo5.getVendor(), 1, 5);
+
+        });
+
+        // remove entity and check reachability
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            ItemVendorInfo itemVendorInfo5 = entityManager.find(ItemVendorInfo.class, 5L);
+            entityManager.remove(itemVendorInfo5);
+            entityManager.flush();
+
+            verifyReachableByIndexing(itemVendorInfo5.getItem(), itemVendorInfo5.getVendor(), 0, 4);
+        });
+
+
+        // add an item to merge in the next test
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            Item i = new Item(11L);
+            entityManager.persist(i);
+        });
+
+        // check merged values after a refresh
+        doInJPA(this::entityManagerFactory, entityManager -> {
+
+            Item i = new Item(11L);
+
+            Manufacturer manufacturer = new Manufacturer(1L);
+            i.setManufacturer(manufacturer); // simulate detached manufacturer
+            i.setName("Item 11 Test update with lazy init collection");
+            i = entityManager.merge(i);
+            entityManager.flush();
+
+            entityManager.refresh(i);
+            assertThat(i.getName()).isEqualTo("Item 11 Test update with lazy init collection");
+        });
+
+        // test that Cascade DETACH does not inhibit indexing for serial number in purchase order entity
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            PurchaseOrder po = new PurchaseOrder(1L);
+            entityManager.persist(po);
+
+            PurchaseOrderDetail purchaseOrderDetail = new PurchaseOrderDetail(1L, po, new Item(1L));
+            entityManager.persist(purchaseOrderDetail);
+        });
+
+        // make sure serial number remains reachable from po after persist/flush
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            PurchaseOrderDetail purchaseOrderDetail = new PurchaseOrderDetail(1L);
+            purchaseOrderDetail.setPo(new PurchaseOrder(1L));
+            SerialNumber serialNumber = new SerialNumber(1L);
+            serialNumber.setPurchaseOrderDetail(purchaseOrderDetail);
+            serialNumber.setSerialNumber("ABCDEFG");
+            entityManager.persist(serialNumber);
+            entityManager.flush();
+
+            assertThat(serialNumber.getPurchaseOrderDetail().getPo().getPoDetails()).hasSize(1);
+        });
+
+        // make sure serial number remains reachable from po after merge/flush
+        doInJPA(this::entityManagerFactory, entityManager -> {
+            PurchaseOrder po = entityManager.find(PurchaseOrder.class, 1L);
+            po.setPoDescription("New Description");
+            entityManager.merge(po);
+            entityManager.flush();
+
+            assertThat(po.getPoDetails()).hasSize(1);
+
+            for (PurchaseOrderDetail pod : po.getPoDetails()) {
+                assertThat(pod.getSerialNumbers()).hasSize(1);
+            }
+        });
+    }
+
+    private void verifyReachableByIndexing(Item item, Vendor vendor, int infoByItemSize, int infoByVendorSize) {
+        assertThat(item.getVendorInfos()).hasSize(infoByItemSize);
+        assertThat(vendor.getItemVendorInfos()).hasSize(infoByVendorSize);
+
+        if (item.getVendorInfos().size() > 0) {
+            ItemVendorInfo vendorInfo = (ItemVendorInfo) item.getVendorInfos().toArray()[0];
+            assertThat(vendorInfo.getVendor().getId()).isEqualTo(vendor.getId());
+        }
+    }
+
+    protected void assertProxyState(Item item) {
+        try {
+            item.getManufacturer().getName();
+            fail("Should throw LazyInitializationException!");
+        } catch (LazyInitializationException expected) {
+
+        }
+
+        try {
+            item.getVendorInfos().size();
+            fail("Should throw LazyInitializationException!");
+        } catch (LazyInitializationException expected) {
+
+        }
+    }
+
+    @MappedSuperclass
+    public static class BusinessEntity {
+
+        private Long id;
+        private int version;
+
+        public BusinessEntity() {
+            version = 0;
+        }
+
+        public BusinessEntity(Long id) {
+            this.id = id;
+            version = 0;
+        }
+
+        @Id
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        @Version
+        public int getVersion() {
+            return version;
+        }
+
+        public void setVersion(int version) {
+            this.version = version;
+        }
+    }
+
+    @Entity
+    public static class SalesOrder extends BusinessEntity {
+
+        public SalesOrder() {
+        }
+
+        public SalesOrder(Long id) {
+            super(id);
+        }
+
+        private Set<SalesOrderDetail> salesOrderDetails;
+
+        @OneToMany(mappedBy = "salesOrder")
+        public Set<SalesOrderDetail> getSalesOrderDetails() {
+            return this.salesOrderDetails;
+        }
+
+        public void setSalesOrderDetails(Set<SalesOrderDetail> SalesOrderDetails) {
+            this.salesOrderDetails = SalesOrderDetails;
+        }
+
+    }
+
+    @Entity
+    public static class SalesOrderDetail extends BusinessEntity {
+
+        Item item;
+        SalesOrder salesOrder;
+
+        public SalesOrderDetail() {
+
+        }
+
+        public SalesOrderDetail(Long id) {
+            super(id);
+        }
+
+        public SalesOrderDetail(Long id, SalesOrder salesOrder, Item item) {
+            super(id);
+            this.salesOrder = salesOrder;
+            this.item = item;
+        }
+
+        private Set<SerialNumber> serialNumbers;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public SalesOrder getSalesOrder() {
+            return this.salesOrder;
+        }
+
+        public void setSalesOrder(SalesOrder salesOrder) {
+            this.salesOrder = salesOrder;
+        }
+
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public Item getItem() {
+            return item;
+        }
+
+        public void setItem(Item item) {
+            this.item = item;
+        }
+
+        @OneToMany(mappedBy = "salesOrderDetail")
+        public Set<SerialNumber> getSerialNumbers() {
+            return serialNumbers;
+        }
+
+        public void setSerialNumbers(Set<SerialNumber> serialNumbers) {
+            this.serialNumbers = serialNumbers;
+        }
+
+    }
+
+    @Entity
+    public static class Item extends BusinessEntity {
+
+        private String name;
+        private Manufacturer manufacturer;
+        private Set<ItemVendorInfo> vendorInfos;
+
+        protected Item() {
+        }
+
+        public Item(Long id, String name) {
+            super(id);
+            this.name = name;
+        }
+
+        public Item(long id) {
+            super(id);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @OneToMany(mappedBy = "item", targetEntity = ItemVendorInfo.class)
+        public Set<ItemVendorInfo> getVendorInfos() {
+            return this.vendorInfos;
+        }
+
+        public void setVendorInfos(Set<ItemVendorInfo> vendorInfo) {
+            this.vendorInfos = vendorInfo;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public Manufacturer getManufacturer() {
+            return manufacturer;
+        }
+
+        public void setManufacturer(Manufacturer manufacturer) {
+            this.manufacturer = manufacturer;
+        }
+
+        private Set<SalesOrderDetail> salesOrderDetails;
+
+        @OneToMany(mappedBy = "item")
+        public Set<SalesOrderDetail> getSalesOrderDetails() {
+            return salesOrderDetails;
+        }
+
+        private Set<ItemText> itemTexts;
+
+        public void setSalesOrderDetails(Set<SalesOrderDetail> salesOrderDetails) {
+            this.salesOrderDetails = salesOrderDetails;
+        }
+
+        @OneToMany(mappedBy = "item")
+        public Set<ItemText> getItemTexts() {
+            return this.itemTexts;
+        }
+
+        public void setItemTexts(Set<ItemText> itemTexts) {
+            this.itemTexts = itemTexts;
+        }
+    }
+
+
+    @Entity
+    public static class ItemVendorInfo extends BusinessEntity {
+
+        private Item item;
+        private Vendor vendor;
+        private BigDecimal cost;
+
+        protected ItemVendorInfo() {
+        }
+
+        public ItemVendorInfo(Long id, Item item, Vendor vendor, BigDecimal cost) {
+            super(id);
+            this.item = item;
+            this.vendor = vendor;
+            this.cost = cost;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(nullable = false)
+        public Item getItem() {
+            return item;
+        }
+
+        public void setItem(Item item) {
+            this.item = item;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(nullable = false)
+        public Vendor getVendor() {
+            return this.vendor;
+        }
+
+        public void setVendor(Vendor Vendor) {
+            this.vendor = Vendor;
+        }
+
+        public BigDecimal getCost() {
+            return cost;
+        }
+
+        public void setCost(BigDecimal cost) {
+            this.cost = cost;
+        }
+    }
+
+    @Entity
+    public static class SerialNumber extends BusinessEntity {
+        private Item item;
+        private String serialNumber;
+        private SalesOrderDetail salesOrderDetail;
+        private PurchaseOrderDetail purchaseOrderDetail;
+
+        public SerialNumber() {
+
+        }
+
+        public SerialNumber(Long id) {
+            super(id);
+        }
+
+        public SerialNumber(Long id, String serialNumber, SalesOrderDetail salesOrderDetail) {
+            super(id);
+            this.serialNumber = serialNumber;
+            this.salesOrderDetail = salesOrderDetail;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public Item getItem() {
+            return item;
+        }
+
+        public void setItem(Item item) {
+            this.item = item;
+        }
+
+        public String getSerialNumber() {
+            return serialNumber;
+        }
+
+        public void setSerialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public SalesOrderDetail getSalesOrderDetail() {
+            return salesOrderDetail;
+        }
+
+        public void setSalesOrderDetail(SalesOrderDetail salesOrderDetail) {
+            this.salesOrderDetail = salesOrderDetail;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public PurchaseOrderDetail getPurchaseOrderDetail() {
+            return purchaseOrderDetail;
+        }
+
+        public void setPurchaseOrderDetail(PurchaseOrderDetail purchaseOrderDetail) {
+            this.purchaseOrderDetail = purchaseOrderDetail;
+        }
+    }
+
+    @Entity
+    public static class Vendor extends BusinessEntity {
+
+        private String name;
+        private Set<ItemVendorInfo> itemVendorInfos;
+
+        protected Vendor() {
+        }
+
+        public Vendor(Long id, String name) {
+            super(id);
+            this.name = name;
+        }
+
+        public Vendor(long id) {
+            super(id);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @OneToMany(mappedBy = "vendor")
+        public Set<ItemVendorInfo> getItemVendorInfos() {
+            return itemVendorInfos;
+        }
+
+        public void setItemVendorInfos(Set<ItemVendorInfo> itemVendorInfos) {
+            this.itemVendorInfos = itemVendorInfos;
+        }
+
+    }
+
+    @Entity
+    public static class Manufacturer extends BusinessEntity {
+
+        private String name;
+
+        public Manufacturer() {
+
+        }
+
+        public Manufacturer(Long id, String name) {
+            super(id);
+            this.name = name;
+        }
+
+        public Manufacturer(long id) {
+            super(id);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        private Set<Item> items;
+
+        @OneToMany(mappedBy = "manufacturer")
+        public Set<Item> getItems() {
+            return items;
+        }
+
+        public void setItems(Set<Item> items) {
+            this.items = items;
+        }
+    }
+
+    @Entity
+    public static class ItemText extends BusinessEntity {
+        private Item item;
+
+        public ItemText() {
+        }
+
+        public ItemText(long id) {
+            super(id);
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "PARENT_ID")
+        public Item getItem() {
+            return this.item;
+        }
+
+        public void setItem(Item item) {
+            this.item = item;
+        }
+
+    }
+
+    @Entity
+    public static class PurchaseOrder extends BusinessEntity {
+        public PurchaseOrder() {
+
+        }
+
+        public PurchaseOrder(long id) {
+            super(id);
+        }
+
+        private String poDescription;
+        private Set<PurchaseOrderDetail> poDetails;
+
+        public String getPoDescription() {
+            return poDescription;
+        }
+
+        public void setPoDescription(String poDescription) {
+            this.poDescription = poDescription;
+        }
+
+        @OneToMany(mappedBy = "po")
+        @Cascade({org.hibernate.annotations.CascadeType.DETACH})
+        public Set<PurchaseOrderDetail> getPoDetails() {
+            return poDetails;
+        }
+
+        public void setPoDetails(Set<PurchaseOrderDetail> poDetails) {
+            this.poDetails = poDetails;
+        }
+    }
+
+    @Entity
+    public static class PurchaseOrderDetail extends BusinessEntity {
+        private PurchaseOrder po;
+        private Item item;
+        private String vendorRmaNumber;
+        private Set<SerialNumber> serialNumbers;
+
+        public PurchaseOrderDetail() {
+
+        }
+
+        public PurchaseOrderDetail(long id) {
+            super(id);
+        }
+
+        public PurchaseOrderDetail(Long id, PurchaseOrder po, Item item) {
+            super(id);
+            this.po = po;
+            this.item = item;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public Item getItem() {
+            return item;
+        }
+
+        public void setItem(Item item) {
+            this.item = item;
+        }
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public PurchaseOrder getPo() {
+            return this.po;
+        }
+
+        public void setPo(PurchaseOrder Po) {
+            this.po = Po;
+        }
+
+
+        @OneToMany(mappedBy = "purchaseOrderDetail")
+        public Set<SerialNumber> getSerialNumbers() {
+            return serialNumbers;
+        }
+
+        public void setSerialNumbers(Set<SerialNumber> serialNumbers) {
+            this.serialNumbers = serialNumbers;
+        }
+
+        public String getVendorRmaNumber() {
+            return vendorRmaNumber;
+        }
+
+        public void setVendorRmaNumber(String vendorRmaNumber) {
+            this.vendorRmaNumber = vendorRmaNumber;
+        }
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lazyload/LazyLoadingIndexing2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lazyload/LazyLoadingIndexing2Test.java
@@ -1,0 +1,11 @@
+package org.hibernate.orm.test.lazyload;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.junit.runner.RunWith;
+
+@TestForIssue(jiraKey = "HHH-14839")
+@RunWith(BytecodeEnhancerRunner.class)
+public class LazyLoadingIndexing2Test extends LazyLoadingIndexing1Test {
+
+}


### PR DESCRIPTION
This allows entities to be fully traversed after a flush by hibernate search v6

https://hibernate.atlassian.net/browse/HHH-14839