### PR TITLE
HHH-14921 + HHH-14922 Definition of the default catalog/schema on session factory creation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -2197,8 +2197,6 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		// for now we only handle id generators as ExportableProducers
 
 		final Dialect dialect = getDatabase().getJdbcEnvironment().getDialect();
-		final String defaultCatalog = extractName( getDatabase().getDefaultNamespace().getName().getCatalog(), dialect );
-		final String defaultSchema = extractName( getDatabase().getDefaultNamespace().getName().getSchema(), dialect );
 
 		for ( PersistentClass entityBinding : entityBindingMap.values() ) {
 			if ( entityBinding.isInherited() ) {
@@ -2208,8 +2206,6 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 			handleIdentifierValueBinding(
 					entityBinding.getIdentifier(),
 					dialect,
-					defaultCatalog,
-					defaultSchema,
 					(RootClass) entityBinding
 			);
 		}
@@ -2222,8 +2218,6 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 			handleIdentifierValueBinding(
 					( (IdentifierCollection) collection ).getIdentifier(),
 					dialect,
-					defaultCatalog,
-					defaultSchema,
 					null
 			);
 		}
@@ -2232,8 +2226,6 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 	private void handleIdentifierValueBinding(
 			KeyValue identifierValueBinding,
 			Dialect dialect,
-			String defaultCatalog,
-			String defaultSchema,
 			RootClass entityBinding) {
 		// todo : store this result (back into the entity or into the KeyValue, maybe?)
 		// 		This process of instantiating the id-generator is called multiple times.
@@ -2243,8 +2235,6 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 			final IdentifierGenerator ig = identifierValueBinding.createIdentifierGenerator(
 					getIdentifierGeneratorFactory(),
 					dialect,
-					defaultCatalog,
-					defaultSchema,
 					entityBinding
 			);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -45,7 +45,6 @@ import org.hibernate.boot.model.naming.ImplicitIndexNameSource;
 import org.hibernate.boot.model.naming.ImplicitUniqueKeyNameSource;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Database;
-import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedTableName;
 import org.hibernate.boot.model.source.internal.ImplicitColumnNamingSecondPass;
@@ -2249,9 +2248,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 					entityBinding
 			);
 
-			if ( ig instanceof ExportableProducer ) {
-				( (ExportableProducer) ig ).registerExportables( getDatabase() );
-			}
+			ig.registerExportables( getDatabase() );
 		}
 		catch (MappingException e) {
 			// ignore this for now.  The reasoning being "non-reflective" binding as needed

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -499,17 +499,12 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		public MappingDefaultsImpl(StandardServiceRegistry serviceRegistry) {
 			final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );
 
-			this.implicitSchemaName = configService.getSetting(
-					AvailableSettings.DEFAULT_SCHEMA,
-					StandardConverters.STRING,
-					null
-			);
-
-			this.implicitCatalogName = configService.getSetting(
-					AvailableSettings.DEFAULT_CATALOG,
-					StandardConverters.STRING,
-					null
-			);
+			// AvailableSettings.DEFAULT_SCHEMA and AvailableSettings.DEFAULT_CATALOG
+			// are taken into account later, at runtime, when rendering table/sequence names.
+			// These fields are exclusively about mapping defaults,
+			// overridden in XML mappings or through setters in MetadataBuilder.
+			this.implicitSchemaName = null;
+			this.implicitCatalogName = null;
 
 			this.implicitlyQuoteIdentifiers = configService.getSetting(
 					AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS,

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -82,7 +82,9 @@ import static org.hibernate.cfg.AvailableSettings.CONVENTIONAL_JAVA_CONSTANTS;
 import static org.hibernate.cfg.AvailableSettings.CRITERIA_LITERAL_HANDLING_MODE;
 import static org.hibernate.cfg.AvailableSettings.CUSTOM_ENTITY_DIRTINESS_STRATEGY;
 import static org.hibernate.cfg.AvailableSettings.DEFAULT_BATCH_FETCH_SIZE;
+import static org.hibernate.cfg.AvailableSettings.DEFAULT_CATALOG;
 import static org.hibernate.cfg.AvailableSettings.DEFAULT_ENTITY_MODE;
+import static org.hibernate.cfg.AvailableSettings.DEFAULT_SCHEMA;
 import static org.hibernate.cfg.AvailableSettings.DELAY_ENTITY_LOADER_CREATIONS;
 import static org.hibernate.cfg.AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS;
 import static org.hibernate.cfg.AvailableSettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH;
@@ -242,6 +244,12 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean queryParametersValidationEnabled;
 	private LiteralHandlingMode criteriaLiteralHandlingMode;
 	private ImmutableEntityUpdateQueryHandlingMode immutableEntityUpdateQueryHandlingMode;
+	// These two settings cannot be modified from the builder,
+	// in order to maintain consistency.
+	// Indeed, other components (the schema tools) also make use of these settings,
+	// and THOSE do not have access to session factory options.
+	private final String defaultCatalog;
+	private final String defaultSchema;
 
 	private Map<String, SQLFunction> sqlFunctions;
 
@@ -530,6 +538,9 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.immutableEntityUpdateQueryHandlingMode = ImmutableEntityUpdateQueryHandlingMode.interpret(
 				configurationSettings.get( IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE )
 		);
+
+		this.defaultCatalog = ConfigurationHelper.getString( DEFAULT_CATALOG, configurationSettings );
+		this.defaultSchema = ConfigurationHelper.getString( DEFAULT_SCHEMA, configurationSettings );
 
 		this.inClauseParameterPaddingEnabled =  ConfigurationHelper.getBoolean(
 				IN_CLAUSE_PARAMETER_PADDING,
@@ -1048,6 +1059,16 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	@Override
+	public String getDefaultCatalog() {
+		return defaultCatalog;
+	}
+
+	@Override
+	public String getDefaultSchema() {
+		return defaultSchema;
+	}
+
+	@Override
 	public boolean jdbcStyleParamsZeroBased() {
 		return this.jdbcStyleParamsZeroBased;
 	}
@@ -1091,7 +1112,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	public boolean isOmitJoinOfSuperclassTablesEnabled() {
 		return omitJoinOfSuperclassTablesEnabled;
 	}
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// In-flight mutation access

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AbstractAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AbstractAuxiliaryDatabaseObject.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.hibernate.dialect.Dialect;
 
 /**
- * Convenience base class for {@link org.hibernate.mapping.AuxiliaryDatabaseObject}s.
+ * Convenience base class for {@link AuxiliaryDatabaseObject}s.
  * <p/>
  * This implementation performs dialect scoping checks strictly based on
  * dialect name comparisons.  Custom implementations might want to do

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AuxiliaryDatabaseObject.java
@@ -42,11 +42,37 @@ public interface AuxiliaryDatabaseObject extends Exportable, Serializable {
 	/**
 	 * Gets the SQL strings for creating the database object.
 	 *
-	 * @param dialect The dialect for which to generate the SQL creation strings
+	 * @param context A context to help generate the SQL creation strings
 	 *
 	 * @return the SQL strings for creating the database object.
 	 */
-	public String[] sqlCreateStrings(Dialect dialect);
+	default String[] sqlCreateStrings(SqlStringGenerationContext context) {
+		return sqlCreateStrings( context.getDialect() );
+	}
+
+	/**
+	 * Gets the SQL strings for creating the database object.
+	 *
+	 * @param dialect The dialect for which to generate the SQL creation strings
+	 *
+	 * @return the SQL strings for creating the database object.
+	 * @deprecated Implement {@link #sqlCreateStrings(SqlStringGenerationContext)} instead.
+	 */
+	@Deprecated
+	default String[] sqlCreateStrings(Dialect dialect) {
+		throw new IllegalStateException( this + " does not implement sqlCreateStrings(...)" );
+	}
+
+	/**
+	 * Gets the SQL strings for dropping the database object.
+	 *
+	 * @param context A context to help generate the SQL drop strings
+	 *
+	 * @return the SQL strings for dropping the database object.
+	 */
+	default String[] sqlDropStrings(SqlStringGenerationContext context) {
+		return sqlDropStrings( context.getDialect() );
+	}
 
 	/**
 	 * Gets the SQL strings for dropping the database object.
@@ -54,8 +80,12 @@ public interface AuxiliaryDatabaseObject extends Exportable, Serializable {
 	 * @param dialect The dialect for which to generate the SQL drop strings
 	 *
 	 * @return the SQL strings for dropping the database object.
+	 * @deprecated Implement {@link #sqlDropStrings(SqlStringGenerationContext)} instead.
 	 */
-	public String[] sqlDropStrings(Dialect dialect);
+	@Deprecated
+	default String[] sqlDropStrings(Dialect dialect) {
+		throw new IllegalStateException( this + " does not implement sqlDropStrings(...)" );
+	}
 
 	/**
 	 * Additional, optional interface for AuxiliaryDatabaseObject that want to allow

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/QualifiedName.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/QualifiedName.java
@@ -31,8 +31,8 @@ public interface QualifiedName {
 	 * Returns a String-form of the qualified name.
 	 * <p/>
 	 * Depending on intention, may not be appropriate.  May want
-	 * {@link org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter#format}
-	 * instead.  See {@link org.hibernate.engine.jdbc.env.spi.JdbcEnvironment#getQualifiedObjectNameFormatter}
+	 * {@link SqlStringGenerationContext#format}
+	 * instead.
 	 *
 	 * @return The string form
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.relational;
 
+import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 
@@ -26,6 +27,22 @@ public interface SqlStringGenerationContext {
 	 * Note that the Identifiers returned from this helper already account for auto-quoting.
 	 */
 	IdentifierHelper getIdentifierHelper();
+
+	/**
+	 * @return The default catalog, used for table/sequence names that do not explicitly mention a catalog.
+	 * May be {@code null}.
+	 * This default is generally applied automatically by the {@link #format(QualifiedName) format methods},
+	 * but in some cases it can be useful to access it directly.
+	 */
+	Identifier getDefaultCatalog();
+
+	/**
+	 * @return The default schema, used for table/sequence names that do not explicitly mention a schema.
+	 * May be {@code null}.
+	 * This default is generally applied automatically by the {@link #format(QualifiedName) format methods},
+	 * but in some cases it can be useful to access it directly.
+	 */
+	Identifier getDefaultSchema();
 
 	/**
 	 * Render a formatted a table name

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.model.relational;
+
+import org.hibernate.dialect.Dialect;
+
+/**
+ * A context provided to methods responsible for generating SQL strings on startup.
+ */
+public interface SqlStringGenerationContext {
+
+	/**
+	 * @return The database dialect, to generate SQL fragments that are specific to each vendor.
+	 */
+	Dialect getDialect();
+
+	/**
+	 * Render a formatted a table name
+	 *
+	 * @param qualifiedName The table name
+	 *
+	 * @return The formatted name,
+	 */
+	String format(QualifiedTableName qualifiedName);
+
+	/**
+	 * Render a formatted sequence name
+	 *
+	 * @param qualifiedName The sequence name
+	 *
+	 * @return The formatted name
+	 */
+	String format(QualifiedSequenceName qualifiedName);
+
+	/**
+	 * Render a formatted non-table and non-sequence qualified name
+	 *
+	 * @param qualifiedName The name
+	 *
+	 * @return The formatted name
+	 */
+	String format(QualifiedName qualifiedName);
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -37,12 +37,24 @@ public interface SqlStringGenerationContext {
 	Identifier getDefaultCatalog();
 
 	/**
+	 * @param explicitCatalogOrNull An explicitly configured catalog, or {@code null}.
+	 * @return The given identifier if non-{@code null}, or the default catalog otherwise.
+	 */
+	Identifier catalogWithDefault(Identifier explicitCatalogOrNull);
+
+	/**
 	 * @return The default schema, used for table/sequence names that do not explicitly mention a schema.
 	 * May be {@code null}.
 	 * This default is generally applied automatically by the {@link #format(QualifiedName) format methods},
 	 * but in some cases it can be useful to access it directly.
 	 */
 	Identifier getDefaultSchema();
+
+	/**
+	 * @param explicitSchemaOrNull An explicitly configured schema, or {@code null}.
+	 * @return The given identifier if non-{@code null}, or the default schema otherwise.
+	 */
+	Identifier schemaWithDefault(Identifier explicitSchemaOrNull);
 
 	/**
 	 * Render a formatted a table name

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.relational;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 
 /**
  * A context provided to methods responsible for generating SQL strings on startup.
@@ -14,9 +15,17 @@ import org.hibernate.dialect.Dialect;
 public interface SqlStringGenerationContext {
 
 	/**
-	 * @return The database dialect, to generate SQL fragments that are specific to each vendor.
+	 * @return The database dialect of the current JDBC environment,
+	 * to generate SQL fragments that are specific to each vendor.
 	 */
 	Dialect getDialect();
+
+	/**
+	 * @return The helper for dealing with identifiers in the current JDBC environment.
+	 * <p>
+	 * Note that the Identifiers returned from this helper already account for auto-quoting.
+	 */
+	IdentifierHelper getIdentifierHelper();
 
 	/**
 	 * Render a formatted a table name
@@ -44,5 +53,14 @@ public interface SqlStringGenerationContext {
 	 * @return The formatted name
 	 */
 	String format(QualifiedName qualifiedName);
+
+	/**
+	 * Render a formatted sequence name, without the catalog (even the default one).
+	 *
+	 * @param qualifiedName The sequence name
+	 *
+	 * @return The formatted name
+	 */
+	String formatWithoutCatalog(QualifiedSequenceName qualifiedName);
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.model.relational.internal;
+
+import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.boot.model.relational.QualifiedSequenceName;
+import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter;
+
+public class SqlStringGenerationContextImpl
+		implements SqlStringGenerationContext {
+
+	public static SqlStringGenerationContext forTests(JdbcEnvironment jdbcEnvironment) {
+		return new SqlStringGenerationContextImpl( jdbcEnvironment );
+	}
+
+	private final Dialect dialect;
+	private final QualifiedObjectNameFormatter qualifiedObjectNameFormatter;
+
+	public SqlStringGenerationContextImpl(JdbcEnvironment jdbcEnvironment) {
+		this.dialect = jdbcEnvironment.getDialect();
+		this.qualifiedObjectNameFormatter = jdbcEnvironment.getQualifiedObjectNameFormatter();
+	}
+
+	@Override
+	public Dialect getDialect() {
+		return dialect;
+	}
+
+	@Override
+	public String format(QualifiedTableName qualifiedName) {
+		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+	}
+
+	@Override
+	public String format(QualifiedSequenceName qualifiedName) {
+		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+	}
+
+	@Override
+	public String format(QualifiedName qualifiedName) {
+		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -41,8 +41,8 @@ public class SqlStringGenerationContextImpl
 	/**
 	 * @param jdbcEnvironment The JDBC environment, to extract the dialect, identifier helper, etc.
 	 * @param database The database metadata, to retrieve the implicit namespace name configured through XML mapping.
-	 * @param defaultCatalog The default catalog to use, unless an implicit catalog was configured through XML mapping.
-	 * @param defaultSchema The default schema to use, unless an implicit schema was configured through XML mapping.
+	 * @param defaultCatalog The default catalog to use; if {@code null}, will use the implicit catalog that was configured through XML mapping.
+	 * @param defaultSchema The default schema to use; if {@code null}, will use the implicit schema that was configured through XML mapping.
 	 * @return An {@link SqlStringGenerationContext}.
 	 */
 	public static SqlStringGenerationContext fromExplicit(JdbcEnvironment jdbcEnvironment,
@@ -52,15 +52,17 @@ public class SqlStringGenerationContextImpl
 		NameQualifierSupport nameQualifierSupport = jdbcEnvironment.getNameQualifierSupport();
 		Identifier actualDefaultCatalog = null;
 		if ( nameQualifierSupport.supportsCatalogs() ) {
-			actualDefaultCatalog = implicitNamespaceName.getCatalog() != null
-					? implicitNamespaceName.getCatalog()
-					: identifierHelper.toIdentifier( defaultCatalog );
+			actualDefaultCatalog = identifierHelper.toIdentifier( defaultCatalog );
+			if ( actualDefaultCatalog == null ) {
+				actualDefaultCatalog = implicitNamespaceName.getCatalog();
+			}
 		}
 		Identifier actualDefaultSchema = null;
 		if ( nameQualifierSupport.supportsSchemas() ) {
-			actualDefaultSchema = implicitNamespaceName.getSchema() != null
-					? implicitNamespaceName.getSchema()
-					: identifierHelper.toIdentifier( defaultSchema );
+			actualDefaultSchema = identifierHelper.toIdentifier( defaultSchema );
+			if ( defaultSchema == null ) {
+				actualDefaultSchema = implicitNamespaceName.getSchema();
+			}
 		}
 		return new SqlStringGenerationContextImpl( jdbcEnvironment, actualDefaultCatalog, actualDefaultSchema );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -6,31 +6,90 @@
  */
 package org.hibernate.boot.model.relational.internal;
 
+import java.util.Map;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.QualifiedTableName;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter;
 
 public class SqlStringGenerationContextImpl
 		implements SqlStringGenerationContext {
 
+	/**
+	 * @param jdbcEnvironment The JDBC environment, to extract the dialect, identifier helper, etc.
+	 * @param database The database metadata, to retrieve the implicit namespace name configured through XML mapping.
+	 * @param configurationMap The configuration map, holding settings such as {@link AvailableSettings#DEFAULT_SCHEMA}.
+	 * @return An {@link SqlStringGenerationContext}.
+	 */
+	public static SqlStringGenerationContext fromConfigurationMap(JdbcEnvironment jdbcEnvironment,
+			Database database, Map<String, Object> configurationMap) {
+		String defaultCatalog = (String) configurationMap.get( AvailableSettings.DEFAULT_CATALOG );
+		String defaultSchema = (String) configurationMap.get( AvailableSettings.DEFAULT_SCHEMA );
+		return fromExplicit( jdbcEnvironment, database, defaultCatalog, defaultSchema );
+	}
+
+	/**
+	 * @param jdbcEnvironment The JDBC environment, to extract the dialect, identifier helper, etc.
+	 * @param database The database metadata, to retrieve the implicit namespace name configured through XML mapping.
+	 * @param defaultCatalog The default catalog to use, unless an implicit catalog was configured through XML mapping.
+	 * @param defaultSchema The default schema to use, unless an implicit schema was configured through XML mapping.
+	 * @return An {@link SqlStringGenerationContext}.
+	 */
+	public static SqlStringGenerationContext fromExplicit(JdbcEnvironment jdbcEnvironment,
+			Database database, String defaultCatalog, String defaultSchema) {
+		Namespace.Name implicitNamespaceName = database.getDefaultNamespace().getPhysicalName();
+		IdentifierHelper identifierHelper = jdbcEnvironment.getIdentifierHelper();
+		NameQualifierSupport nameQualifierSupport = jdbcEnvironment.getNameQualifierSupport();
+		Identifier actualDefaultCatalog = null;
+		if ( nameQualifierSupport.supportsCatalogs() ) {
+			actualDefaultCatalog = implicitNamespaceName.getCatalog() != null
+					? implicitNamespaceName.getCatalog()
+					: identifierHelper.toIdentifier( defaultCatalog );
+		}
+		Identifier actualDefaultSchema = null;
+		if ( nameQualifierSupport.supportsSchemas() ) {
+			actualDefaultSchema = implicitNamespaceName.getSchema() != null
+					? implicitNamespaceName.getSchema()
+					: identifierHelper.toIdentifier( defaultSchema );
+		}
+		return new SqlStringGenerationContextImpl( jdbcEnvironment, actualDefaultCatalog, actualDefaultSchema );
+	}
+
 	public static SqlStringGenerationContext forTests(JdbcEnvironment jdbcEnvironment) {
-		return new SqlStringGenerationContextImpl( jdbcEnvironment );
+		return forTests( jdbcEnvironment, null, null );
+	}
+
+	public static SqlStringGenerationContext forTests(JdbcEnvironment jdbcEnvironment,
+			String defaultCatalog, String defaultSchema) {
+		IdentifierHelper identifierHelper = jdbcEnvironment.getIdentifierHelper();
+		return new SqlStringGenerationContextImpl( jdbcEnvironment,
+				identifierHelper.toIdentifier( defaultCatalog ), identifierHelper.toIdentifier( defaultSchema ) );
 	}
 
 	private final Dialect dialect;
 	private final IdentifierHelper identifierHelper;
 	private final QualifiedObjectNameFormatter qualifiedObjectNameFormatter;
+	private final Identifier defaultCatalog;
+	private final Identifier defaultSchema;
 
 	@SuppressWarnings("deprecation")
-	public SqlStringGenerationContextImpl(JdbcEnvironment jdbcEnvironment) {
+	private SqlStringGenerationContextImpl(JdbcEnvironment jdbcEnvironment,
+			Identifier defaultCatalog, Identifier defaultSchema) {
 		this.dialect = jdbcEnvironment.getDialect();
 		this.identifierHelper = jdbcEnvironment.getIdentifierHelper();
 		this.qualifiedObjectNameFormatter = jdbcEnvironment.getQualifiedObjectNameFormatter();
+		this.defaultCatalog = defaultCatalog;
+		this.defaultSchema = defaultSchema;
 	}
 
 	@Override
@@ -44,18 +103,59 @@ public class SqlStringGenerationContextImpl
 	}
 
 	@Override
+	public Identifier getDefaultCatalog() {
+		return defaultCatalog;
+	}
+
+	@Override
+	public Identifier getDefaultSchema() {
+		return defaultSchema;
+	}
+
+	@Override
 	public String format(QualifiedTableName qualifiedName) {
-		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+		return qualifiedObjectNameFormatter.format( withDefaults( qualifiedName ), dialect );
 	}
 
 	@Override
 	public String format(QualifiedSequenceName qualifiedName) {
-		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+		return qualifiedObjectNameFormatter.format( withDefaults( qualifiedName ), dialect );
 	}
 
 	@Override
 	public String format(QualifiedName qualifiedName) {
-		return qualifiedObjectNameFormatter.format( qualifiedName, dialect );
+		return qualifiedObjectNameFormatter.format( withDefaults( qualifiedName ), dialect );
+	}
+
+	private QualifiedTableName withDefaults(QualifiedTableName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedTableName( withDefault( name.getCatalogName(), defaultCatalog ),
+					withDefault( name.getSchemaName(), defaultSchema ), name.getTableName() );
+		}
+		return name;
+	}
+
+	private QualifiedSequenceName withDefaults(QualifiedSequenceName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedSequenceName( withDefault( name.getCatalogName(), defaultCatalog ),
+					withDefault( name.getSchemaName(), defaultSchema ), name.getSequenceName() );
+		}
+		return name;
+	}
+
+	private QualifiedName withDefaults(QualifiedName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedSequenceName( withDefault( name.getCatalogName(), defaultCatalog ),
+					withDefault( name.getSchemaName(), defaultSchema ), name.getObjectName() );
+		}
+		return name;
+	}
+
+	private static Identifier withDefault(Identifier value, Identifier defaultValue) {
+		return value != null ? value : defaultValue;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -47,7 +47,7 @@ public class SqlStringGenerationContextImpl
 	 */
 	public static SqlStringGenerationContext fromExplicit(JdbcEnvironment jdbcEnvironment,
 			Database database, String defaultCatalog, String defaultSchema) {
-		Namespace.Name implicitNamespaceName = database.getDefaultNamespace().getPhysicalName();
+		Namespace.Name implicitNamespaceName = database.getPhysicalImplicitNamespaceName();
 		IdentifierHelper identifierHelper = jdbcEnvironment.getIdentifierHelper();
 		NameQualifierSupport nameQualifierSupport = jdbcEnvironment.getNameQualifierSupport();
 		Identifier actualDefaultCatalog = null;
@@ -108,8 +108,45 @@ public class SqlStringGenerationContextImpl
 	}
 
 	@Override
+	public Identifier catalogWithDefault(Identifier explicitCatalogOrNull) {
+		return explicitCatalogOrNull != null ? explicitCatalogOrNull : defaultCatalog;
+	}
+
+	@Override
 	public Identifier getDefaultSchema() {
 		return defaultSchema;
+	}
+
+	@Override
+	public Identifier schemaWithDefault(Identifier explicitSchemaOrNull) {
+		return explicitSchemaOrNull != null ? explicitSchemaOrNull : defaultSchema;
+	}
+
+	private QualifiedTableName withDefaults(QualifiedTableName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedTableName( catalogWithDefault( name.getCatalogName() ),
+					schemaWithDefault( name.getSchemaName() ), name.getTableName() );
+		}
+		return name;
+	}
+
+	private QualifiedSequenceName withDefaults(QualifiedSequenceName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedSequenceName( catalogWithDefault( name.getCatalogName() ),
+					schemaWithDefault( name.getSchemaName() ), name.getSequenceName() );
+		}
+		return name;
+	}
+
+	private QualifiedName withDefaults(QualifiedName name) {
+		if ( name.getCatalogName() == null && defaultCatalog != null
+				|| name.getSchemaName() == null && defaultSchema != null ) {
+			return new QualifiedSequenceName( catalogWithDefault( name.getCatalogName() ),
+					schemaWithDefault( name.getSchemaName() ), name.getObjectName() );
+		}
+		return name;
 	}
 
 	@Override
@@ -125,37 +162,6 @@ public class SqlStringGenerationContextImpl
 	@Override
 	public String format(QualifiedName qualifiedName) {
 		return qualifiedObjectNameFormatter.format( withDefaults( qualifiedName ), dialect );
-	}
-
-	private QualifiedTableName withDefaults(QualifiedTableName name) {
-		if ( name.getCatalogName() == null && defaultCatalog != null
-				|| name.getSchemaName() == null && defaultSchema != null ) {
-			return new QualifiedTableName( withDefault( name.getCatalogName(), defaultCatalog ),
-					withDefault( name.getSchemaName(), defaultSchema ), name.getTableName() );
-		}
-		return name;
-	}
-
-	private QualifiedSequenceName withDefaults(QualifiedSequenceName name) {
-		if ( name.getCatalogName() == null && defaultCatalog != null
-				|| name.getSchemaName() == null && defaultSchema != null ) {
-			return new QualifiedSequenceName( withDefault( name.getCatalogName(), defaultCatalog ),
-					withDefault( name.getSchemaName(), defaultSchema ), name.getSequenceName() );
-		}
-		return name;
-	}
-
-	private QualifiedName withDefaults(QualifiedName name) {
-		if ( name.getCatalogName() == null && defaultCatalog != null
-				|| name.getSchemaName() == null && defaultSchema != null ) {
-			return new QualifiedSequenceName( withDefault( name.getCatalogName(), defaultCatalog ),
-					withDefault( name.getSchemaName(), defaultSchema ), name.getObjectName() );
-		}
-		return name;
-	}
-
-	private static Identifier withDefault(Identifier value, Identifier defaultValue) {
-		return value != null ? value : defaultValue;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -804,15 +804,6 @@ public class ModelBinder {
 			// YUCK!  but cannot think of a clean way to do this given the string-config based scheme
 			params.put( PersistentIdentifierGenerator.IDENTIFIER_NORMALIZER, objectNameNormalizer);
 
-			String implicitSchemaName = metadataBuildingContext.getMappingDefaults().getImplicitSchemaName();
-			if ( implicitSchemaName != null ) {
-				params.setProperty( PersistentIdentifierGenerator.SCHEMA, implicitSchemaName );
-			}
-			String implicitCatalogName = metadataBuildingContext.getMappingDefaults().getImplicitCatalogName();
-			if ( implicitCatalogName != null ) {
-				params.setProperty( PersistentIdentifierGenerator.CATALOG, implicitCatalogName );
-			}
-
 			params.putAll( generator.getParameters() );
 
 			identifierValue.setIdentifierGeneratorProperties( params );
@@ -2966,7 +2957,7 @@ public class ModelBinder {
 			return database.toIdentifier( tableSpecSource.getExplicitSchemaName() );
 		}
 		else {
-			return database.toIdentifier( metadataBuildingContext.getMappingDefaults().getImplicitSchemaName() );
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -804,17 +804,13 @@ public class ModelBinder {
 			// YUCK!  but cannot think of a clean way to do this given the string-config based scheme
 			params.put( PersistentIdentifierGenerator.IDENTIFIER_NORMALIZER, objectNameNormalizer);
 
-			if ( database.getDefaultNamespace().getPhysicalName().getSchema() != null ) {
-				params.setProperty(
-						PersistentIdentifierGenerator.SCHEMA,
-						database.getDefaultNamespace().getPhysicalName().getSchema().render( database.getDialect() )
-				);
+			String implicitSchemaName = metadataBuildingContext.getMappingDefaults().getImplicitSchemaName();
+			if ( implicitSchemaName != null ) {
+				params.setProperty( PersistentIdentifierGenerator.SCHEMA, implicitSchemaName );
 			}
-			if ( database.getDefaultNamespace().getPhysicalName().getCatalog() != null ) {
-				params.setProperty(
-						PersistentIdentifierGenerator.CATALOG,
-						database.getDefaultNamespace().getPhysicalName().getCatalog().render( database.getDialect() )
-				);
+			String implicitCatalogName = metadataBuildingContext.getMappingDefaults().getImplicitCatalogName();
+			if ( implicitCatalogName != null ) {
+				params.setProperty( PersistentIdentifierGenerator.CATALOG, implicitCatalogName );
 			}
 
 			params.putAll( generator.getParameters() );
@@ -2961,7 +2957,7 @@ public class ModelBinder {
 			return database.toIdentifier( tableSpecSource.getExplicitCatalogName() );
 		}
 		else {
-			return database.getDefaultNamespace().getName().getCatalog();
+			return database.toIdentifier( metadataBuildingContext.getMappingDefaults().getImplicitCatalogName() );
 		}
 	}
 
@@ -2970,7 +2966,7 @@ public class ModelBinder {
 			return database.toIdentifier( tableSpecSource.getExplicitSchemaName() );
 		}
 		else {
-			return database.getDefaultNamespace().getName().getSchema();
+			return database.toIdentifier( metadataBuildingContext.getMappingDefaults().getImplicitSchemaName() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/MetadataSourceProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/MetadataSourceProcessor.java
@@ -47,7 +47,7 @@ public interface MetadataSourceProcessor {
 	void processNamedQueries();
 
 	/**
-	 * Process all {@link org.hibernate.mapping.AuxiliaryDatabaseObject} definitions.
+	 * Process all {@link org.hibernate.boot.model.relational.AuxiliaryDatabaseObject} definitions.
 	 * <p/>
 	 * This step has no prerequisites.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -424,6 +424,16 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public String getDefaultCatalog() {
+		return delegate.getDefaultCatalog();
+	}
+
+	@Override
+	public String getDefaultSchema() {
+		return delegate.getDefaultSchema();
+	}
+
+	@Override
 	public boolean inClauseParameterPaddingEnabled() {
 		return delegate.inClauseParameterPaddingEnabled();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -293,6 +293,26 @@ public interface SessionFactoryOptions {
 		return ImmutableEntityUpdateQueryHandlingMode.WARNING;
 	}
 
+	/**
+	 * The default catalog to use in generated SQL when a catalog wasn't specified in the mapping,
+	 * neither explicitly nor implicitly (see the concept of implicit catalog in XML mapping).
+	 *
+	 * @return The default catalog to use.
+	 */
+	default String getDefaultCatalog() {
+		return null;
+	}
+
+	/**
+	 * The default schema to use in generated SQL when a catalog wasn't specified in the mapping,
+	 * neither explicitly nor implicitly (see the concept of implicit schema in XML mapping).
+	 *
+	 * @return The default schema to use.
+	 */
+	default String getDefaultSchema() {
+		return null;
+	}
+
 	default boolean inClauseParameterPaddingEnabled() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -149,7 +149,6 @@ import org.hibernate.cfg.annotations.TableBinder;
 import org.hibernate.cfg.internal.NullableDiscriminatorColumnSecondPass;
 import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.engine.spi.FilterDefinition;
-import org.hibernate.id.PersistentIdentifierGenerator;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.jpa.event.internal.CallbackDefinitionResolverLegacyImpl;
@@ -466,20 +465,6 @@ public final class AnnotationBinder {
 		}
 
 		IdentifierGeneratorDefinition.Builder definitionBuilder = new IdentifierGeneratorDefinition.Builder();
-
-		if ( context.getMappingDefaults().getImplicitSchemaName() != null ) {
-			definitionBuilder.addParam(
-					PersistentIdentifierGenerator.SCHEMA,
-					context.getMappingDefaults().getImplicitSchemaName()
-			);
-		}
-
-		if ( context.getMappingDefaults().getImplicitCatalogName() != null ) {
-			definitionBuilder.addParam(
-					PersistentIdentifierGenerator.CATALOG,
-					context.getMappingDefaults().getImplicitCatalogName()
-			);
-		}
 
 		if ( generatorAnn instanceof TableGenerator ) {
 			context.getBuildingOptions().getIdGenerationTypeInterpreter().interpretTableGenerator(

--- a/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
@@ -525,15 +525,6 @@ public class BinderHelper {
 				PersistentIdentifierGenerator.TABLE, table.getName()
 		);
 
-		final String implicitCatalogName = buildingContext.getBuildingOptions().getMappingDefaults().getImplicitCatalogName();
-		if ( implicitCatalogName != null ) {
-			params.put( PersistentIdentifierGenerator.CATALOG, implicitCatalogName );
-		}
-		final String implicitSchemaName = buildingContext.getBuildingOptions().getMappingDefaults().getImplicitSchemaName();
-		if ( implicitSchemaName != null ) {
-			params.put( PersistentIdentifierGenerator.SCHEMA, implicitSchemaName );
-		}
-
 		if ( id.getColumnSpan() == 1 ) {
 			params.setProperty(
 					PersistentIdentifierGenerator.PK,

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
@@ -50,8 +50,8 @@ public final class Settings {
 	public Settings(SessionFactoryOptions sessionFactoryOptions, Metadata metadata) {
 		this(
 				sessionFactoryOptions,
-				extractName( metadata.getDatabase().getDefaultNamespace().getName().getCatalog() ),
-				extractName( metadata.getDatabase().getDefaultNamespace().getName().getSchema() )
+				extractName( metadata.getDatabase().getPhysicalImplicitNamespaceName().getCatalog() ),
+				extractName( metadata.getDatabase().getPhysicalImplicitNamespaceName().getSchema() )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
@@ -61,8 +61,8 @@ public final class Settings {
 
 	public Settings(SessionFactoryOptions sessionFactoryOptions, String defaultCatalogName, String defaultSchemaName) {
 		this.sessionFactoryOptions = sessionFactoryOptions;
-		this.defaultCatalogName = defaultCatalogName != null ? defaultCatalogName : sessionFactoryOptions.getDefaultCatalog();
-		this.defaultSchemaName = defaultSchemaName != null ? defaultSchemaName : sessionFactoryOptions.getDefaultSchema();
+		this.defaultCatalogName = sessionFactoryOptions.getDefaultCatalog() != null ? sessionFactoryOptions.getDefaultCatalog() : defaultCatalogName;
+		this.defaultSchemaName = sessionFactoryOptions.getDefaultSchema() != null ? sessionFactoryOptions.getDefaultSchema() : defaultSchemaName;
 
 		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "SessionFactory name : %s", sessionFactoryOptions.getSessionFactoryName() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Settings.java
@@ -61,8 +61,8 @@ public final class Settings {
 
 	public Settings(SessionFactoryOptions sessionFactoryOptions, String defaultCatalogName, String defaultSchemaName) {
 		this.sessionFactoryOptions = sessionFactoryOptions;
-		this.defaultCatalogName = defaultCatalogName;
-		this.defaultSchemaName = defaultSchemaName;
+		this.defaultCatalogName = defaultCatalogName != null ? defaultCatalogName : sessionFactoryOptions.getDefaultCatalog();
+		this.defaultSchemaName = defaultSchemaName != null ? defaultSchemaName : sessionFactoryOptions.getDefaultSchema();
 
 		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "SessionFactory name : %s", sessionFactoryOptions.getSessionFactoryName() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
@@ -477,10 +477,10 @@ public class TableBinder {
 			String subselect,
 			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref) {
 		schema = BinderHelper.isEmptyOrNullAnnotationValue( schema )
-				? buildingContext.getBuildingOptions().getMappingDefaults().getImplicitSchemaName()
+				? null
 				: schema;
 		catalog = BinderHelper.isEmptyOrNullAnnotationValue( catalog )
-				? buildingContext.getBuildingOptions().getMappingDefaults().getImplicitCatalogName()
+				? null
 				: catalog;
 
 		final Table table;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/TableBinder.java
@@ -477,10 +477,10 @@ public class TableBinder {
 			String subselect,
 			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref) {
 		schema = BinderHelper.isEmptyOrNullAnnotationValue( schema )
-				? extract( buildingContext.getMetadataCollector().getDatabase().getDefaultNamespace().getPhysicalName().getSchema() )
+				? buildingContext.getBuildingOptions().getMappingDefaults().getImplicitSchemaName()
 				: schema;
 		catalog = BinderHelper.isEmptyOrNullAnnotationValue( catalog )
-				? extract( buildingContext.getMetadataCollector().getDatabase().getDefaultNamespace().getPhysicalName().getCatalog() )
+				? buildingContext.getBuildingOptions().getMappingDefaults().getImplicitCatalogName()
 				: catalog;
 
 		final Table table;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenAnnotationReader.java
@@ -407,7 +407,9 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 	 */
 	private void initAnnotations() {
 		if ( annotations == null ) {
-			XMLContext.Default defaults = xmlContext.getDefault( className );
+			// We don't want the global catalog and schema here: they are applied much later,
+			// when SQL gets rendered.
+			XMLContext.Default defaults = xmlContext.getDefaultWithoutGlobalCatalogAndSchema( className );
 			if ( className != null && propertyName == null ) {
 				//is a class
 				ManagedType managedTypeOverride = xmlContext.getManagedTypeOverride( className );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/JPAXMLOverriddenMetadataProvider.java
@@ -94,7 +94,7 @@ public final class JPAXMLOverriddenMetadataProvider implements MetadataProvider 
 		else {
 			if ( defaults == null ) {
 				defaults = new HashMap<>();
-				XMLContext.Default xmlDefaults = xmlContext.getDefault( null );
+				XMLContext.Default xmlDefaults = xmlContext.getDefaultWithGlobalCatalogAndSchema();
 
 				defaults.put( "schema", xmlDefaults.getSchema() );
 				defaults.put( "catalog", xmlDefaults.getCatalog() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/XMLContext.java
@@ -124,12 +124,12 @@ public class XMLContext implements Serializable {
 			managedTypeOverride.put( className, element );
 			Default mergedDefaults = new Default();
 			// Apply entity mapping defaults
-			mergedDefaults.override( defaults );
+			mergedDefaults.overrideWithCatalogAndSchema( defaults );
 			// ... then apply entity settings
 			Default fileDefaults = new Default();
 			fileDefaults.setMetadataComplete( element.isMetadataComplete() );
 			fileDefaults.setAccess( element.getAccess() );
-			mergedDefaults.override( fileDefaults );
+			mergedDefaults.overrideWithCatalogAndSchema( fileDefaults );
 			// ... and we get the merged defaults for that entity
 			defaultsOverride.put( className, mergedDefaults );
 
@@ -196,13 +196,19 @@ public class XMLContext implements Serializable {
 		return buildSafeClassName( className, defaults.getPackageName() );
 	}
 
-	public Default getDefault(String className) {
+	public Default getDefaultWithoutGlobalCatalogAndSchema(String className) {
 		Default xmlDefault = new Default();
-		xmlDefault.override( globalDefaults );
+		xmlDefault.overrideWithoutCatalogAndSchema( globalDefaults );
 		if ( className != null ) {
 			Default entityMappingOverriding = defaultsOverride.get( className );
-			xmlDefault.override( entityMappingOverriding );
+			xmlDefault.overrideWithCatalogAndSchema( entityMappingOverriding );
 		}
+		return xmlDefault;
+	}
+
+	public Default getDefaultWithGlobalCatalogAndSchema() {
+		Default xmlDefault = new Default();
+		xmlDefault.overrideWithCatalogAndSchema( globalDefaults );
 		return xmlDefault;
 	}
 
@@ -292,19 +298,25 @@ public class XMLContext implements Serializable {
 			this.cascadePersist = cascadePersist;
 		}
 
-		public void override(Default globalDefault) {
+		public void overrideWithCatalogAndSchema(Default override) {
+			overrideWithoutCatalogAndSchema( override );
+			if ( override != null ) {
+				if ( override.getSchema() != null ) {
+					schema = override.getSchema();
+				}
+				if ( override.getCatalog() != null ) {
+					catalog = override.getCatalog();
+				}
+			}
+		}
+
+		public void overrideWithoutCatalogAndSchema(Default globalDefault) {
 			if ( globalDefault != null ) {
 				if ( globalDefault.getAccess() != null ) {
 					access = globalDefault.getAccess();
 				}
 				if ( globalDefault.getPackageName() != null ) {
 					packageName = globalDefault.getPackageName();
-				}
-				if ( globalDefault.getSchema() != null ) {
-					schema = globalDefault.getSchema();
-				}
-				if ( globalDefault.getCatalog() != null ) {
-					catalog = globalDefault.getCatalog();
 				}
 				if ( globalDefault.getDelimitedIdentifier() != null ) {
 					delimitedIdentifier = globalDefault.getDelimitedIdentifier();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -40,8 +40,10 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
 import org.hibernate.ScrollMode;
+import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.function.AnsiTrimFunction;
 import org.hibernate.dialect.function.NoArgSQLFunction;
@@ -728,14 +730,16 @@ public abstract class AbstractHANADialect extends Dialect {
 	private final StandardTableExporter hanaTableExporter = new StandardTableExporter( this ) {
 
 		@Override
-		public String[] getSqlCreateStrings(org.hibernate.mapping.Table table, org.hibernate.boot.Metadata metadata) {
-			String[] sqlCreateStrings = super.getSqlCreateStrings( table, metadata );
+		public String[] getSqlCreateStrings(Table table, Metadata metadata,
+				SqlStringGenerationContext context) {
+			String[] sqlCreateStrings = super.getSqlCreateStrings( table, metadata, context );
 			return quoteTypeIfNecessary( table, sqlCreateStrings, getCreateTableString() );
 		}
 
 		@Override
-		public String[] getSqlDropStrings(Table table, org.hibernate.boot.Metadata metadata) {
-			String[] sqlDropStrings = super.getSqlDropStrings( table, metadata );
+		public String[] getSqlDropStrings(Table table, Metadata metadata,
+				SqlStringGenerationContext context) {
+			String[] sqlDropStrings = super.getSqlDropStrings( table, metadata, context );
 			return quoteTypeIfNecessary( table, sqlDropStrings, "drop table" );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2012Dialect.java
@@ -9,9 +9,9 @@ package org.hibernate.dialect;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.SQLServer2012LimitHandler;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.tool.schema.internal.StandardSequenceExporter;
 import org.hibernate.tool.schema.spi.Exporter;
 
@@ -118,14 +118,12 @@ public class SQLServer2012Dialect extends SQLServer2008Dialect {
 		}
 
 		@Override
-		protected String getFormattedSequenceName(QualifiedSequenceName name, Metadata metadata) {
-			if ( name.getCatalogName() != null ) {
-				// SQL Server does not allow the catalog in the sequence name.
-				// See https://docs.microsoft.com/en-us/sql/t-sql/statements/create-sequence-transact-sql?view=sql-server-ver15&viewFallbackFrom=sql-server-ver12
-				// Keeping the catalog in the name does not break on ORM, but it fails using Vert.X for Reactive.
-				name = new QualifiedSequenceName( null, name.getSchemaName(), name.getObjectName() );
-			}
-			return super.getFormattedSequenceName( name, metadata );
+		protected String getFormattedSequenceName(QualifiedSequenceName name, Metadata metadata,
+				SqlStringGenerationContext context) {
+			// SQL Server does not allow the catalog in the sequence name.
+			// See https://docs.microsoft.com/en-us/sql/t-sql/statements/create-sequence-transact-sql?view=sql-server-ver15&viewFallbackFrom=sql-server-ver12
+			// Keeping the catalog in the name does not break on ORM, but it fails using Vert.X for Reactive.
+			return context.formatWithoutCatalog( name );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Teradata14Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Teradata14Dialect.java
@@ -17,6 +17,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.QualifiedNameImpl;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
@@ -214,22 +215,19 @@ public class Teradata14Dialect extends TeradataDialect {
 		}
 
 		@Override
-		public String[] getSqlCreateStrings(Index index, Metadata metadata) {
+		public String[] getSqlCreateStrings(Index index, Metadata metadata,
+				SqlStringGenerationContext context) {
 			final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-			final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-					index.getTable().getQualifiedTableName(),
-					jdbcEnvironment.getDialect()
-			);
+			final String tableName = context.format( index.getTable().getQualifiedTableName() );
 
 			final String indexNameForCreation;
 			if ( getDialect().qualifyIndexName() ) {
-				indexNameForCreation = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
+				indexNameForCreation = context.format(
 						new QualifiedNameImpl(
 								index.getTable().getQualifiedTableName().getCatalogName(),
 								index.getTable().getQualifiedTableName().getSchemaName(),
 								jdbcEnvironment.getIdentifierHelper().toIdentifier( index.getName() )
-						),
-						jdbcEnvironment.getDialect()
+						)
 				);
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/identity/GetGeneratedKeysDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/identity/GetGeneratedKeysDelegate.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.IdentifierGeneratorHelper;
@@ -37,7 +38,7 @@ public class GetGeneratedKeysDelegate
 	}
 
 	@Override
-	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert() {
+	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
 		IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( dialect );
 		insert.addIdentityColumn( persister.getRootTableKeyColumnNames()[0] );
 		return insert;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/DB2UniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/DB2UniqueDelegate.java
@@ -9,6 +9,7 @@ package org.hibernate.dialect.unique;
 import java.util.Iterator;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.UniqueKey;
 
@@ -29,10 +30,11 @@ public class DB2UniqueDelegate extends DefaultUniqueDelegate {
 	}
 
 	@Override
-	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
+	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context) {
 		if ( hasNullable( uniqueKey ) ) {
 			return org.hibernate.mapping.Index.buildSqlCreateIndexString(
-					dialect,
+					context,
 					uniqueKey.getName(),
 					uniqueKey.getTable(),
 					uniqueKey.columnIterator(),
@@ -42,23 +44,21 @@ public class DB2UniqueDelegate extends DefaultUniqueDelegate {
 			);
 		}
 		else {
-			return super.getAlterTableToAddUniqueKeyCommand( uniqueKey, metadata );
+			return super.getAlterTableToAddUniqueKeyCommand( uniqueKey, metadata, context );
 		}
 	}
 	
 	@Override
-	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
+	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context) {
 		if ( hasNullable( uniqueKey ) ) {
 			return org.hibernate.mapping.Index.buildSqlDropIndexString(
 					uniqueKey.getName(),
-					metadata.getDatabase().getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-							uniqueKey.getTable().getQualifiedTableName(),
-							metadata.getDatabase().getJdbcEnvironment().getDialect()
-					)
+					context.format( uniqueKey.getTable().getQualifiedTableName() )
 			);
 		}
 		else {
-			return super.getAlterTableToDropUniqueKeyCommand( uniqueKey, metadata );
+			return super.getAlterTableToDropUniqueKeyCommand( uniqueKey, metadata, context );
 		}
 	}
 	

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/DefaultUniqueDelegate.java
@@ -9,8 +9,10 @@ package org.hibernate.dialect.unique;
 import java.util.Iterator;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 
 /**
@@ -34,23 +36,21 @@ public class DefaultUniqueDelegate implements UniqueDelegate {
 	// legacy model ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
-	public String getColumnDefinitionUniquenessFragment(org.hibernate.mapping.Column column) {
+	public String getColumnDefinitionUniquenessFragment(Column column,
+			SqlStringGenerationContext context) {
 		return "";
 	}
 
 	@Override
-	public String getTableCreationUniqueConstraintsFragment(org.hibernate.mapping.Table table) {
+	public String getTableCreationUniqueConstraintsFragment(Table table,
+			SqlStringGenerationContext context) {
 		return "";
 	}
 
 	@Override
-	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-
-		final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				uniqueKey.getTable().getQualifiedTableName(),
-				dialect
-		);
+	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context) {
+		final String tableName = context.format( uniqueKey.getTable().getQualifiedTableName() );
 
 		final String constraintName = dialect.quote( uniqueKey.getName() );
 		return dialect.getAlterTableString( tableName )
@@ -76,13 +76,9 @@ public class DefaultUniqueDelegate implements UniqueDelegate {
 	}
 
 	@Override
-	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-
-		final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				uniqueKey.getTable().getQualifiedTableName(),
-				dialect
-		);
+	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context) {
+		final String tableName = context.format( uniqueKey.getTable().getQualifiedTableName() );
 
 		final StringBuilder buf = new StringBuilder( dialect.getAlterTableString(tableName) );
 		buf.append( getDropUnique() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/InformixUniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/InformixUniqueDelegate.java
@@ -7,6 +7,7 @@
 package org.hibernate.dialect.unique;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.UniqueKey;
 
@@ -24,13 +25,11 @@ public class InformixUniqueDelegate extends DefaultUniqueDelegate {
 	// legacy model ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
-	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata) {
+	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context) {
 		// Do this here, rather than allowing UniqueKey/Constraint to do it.
 		// We need full, simplified control over whether or not it happens.
-		final String tableName = metadata.getDatabase().getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-				uniqueKey.getTable().getQualifiedTableName(),
-				metadata.getDatabase().getJdbcEnvironment().getDialect()
-		);
+		final String tableName = context.format( uniqueKey.getTable().getQualifiedTableName() );
 		final String constraintName = dialect.quote( uniqueKey.getName() );
 		return dialect.getAlterTableString( tableName )
 				+ " add constraint " + uniqueConstraintSql( uniqueKey ) + " constraint " + constraintName;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
@@ -7,6 +7,9 @@
 package org.hibernate.dialect.unique;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 
 /**
@@ -38,11 +41,11 @@ public interface UniqueDelegate {
 	 * This is intended for dialects which do not support unique constraints
 	 * 
 	 * @param column The column to which to apply the unique
-	 *
+	 * @param context A context for SQL string generation
 	 * @return The fragment (usually "unique"), empty string indicates the uniqueness will be indicated using a
 	 * different approach
 	 */
-	public String getColumnDefinitionUniquenessFragment(org.hibernate.mapping.Column column);
+	public String getColumnDefinitionUniquenessFragment(Column column, SqlStringGenerationContext context);
 
 	/**
 	 * Get the fragment that can be used to apply unique constraints as part of table creation.  The implementation
@@ -53,30 +56,32 @@ public interface UniqueDelegate {
 	 * Intended for Dialects which support unique constraint definitions, but just not in separate ALTER statements.
 	 *
 	 * @param table The table for which to generate the unique constraints fragment
-	 *
+	 * @param context A context for SQL string generation
 	 * @return The fragment, typically in the form {@code ", unique(col1, col2), unique( col20)"}.  NOTE: The leading
 	 * comma is important!
 	 */
-	public String getTableCreationUniqueConstraintsFragment(org.hibernate.mapping.Table table);
+	public String getTableCreationUniqueConstraintsFragment(Table table, SqlStringGenerationContext context);
 
 	/**
 	 * Get the SQL ALTER TABLE command to be used to create the given UniqueKey.
 	 *
 	 * @param uniqueKey The UniqueKey instance.  Contains all information about the columns
 	 * @param metadata Access to the bootstrap mapping information
-	 *
+	 * @param context A context for SQL string generation
 	 * @return The ALTER TABLE command
 	 */
-	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata);
+	public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context);
 
 	/**
 	 * Get the SQL ALTER TABLE command to be used to drop the given UniqueKey.
 	 *
 	 * @param uniqueKey The UniqueKey instance.  Contains all information about the columns
 	 * @param metadata Access to the bootstrap mapping information
-	 *
+	 * @param context A context for SQL string generation
 	 * @return The ALTER TABLE command
 	 */
-	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata);
+	public String getAlterTableToDropUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata,
+			SqlStringGenerationContext context);
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
@@ -55,7 +55,9 @@ public interface JdbcEnvironment extends Service {
 	 * Obtain support for formatting qualified object names.
 	 *
 	 * @return Qualified name support.
+	 * @deprecated Use a provided {@link org.hibernate.boot.model.relational.SqlStringGenerationContext} instead.
 	 */
+	@Deprecated
 	QualifiedObjectNameFormatter getQualifiedObjectNameFormatter();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -30,6 +30,7 @@ import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatelessSession;
 import org.hibernate.StatelessSessionBuilder;
 import org.hibernate.TypeHelper;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.cfg.Settings;
@@ -242,6 +243,11 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public JdbcServices getJdbcServices() {
 		return delegate.getJdbcServices();
+	}
+
+	@Override
+	public SqlStringGenerationContext getSqlStringGenerationContext() {
+		return delegate.getSqlStringGenerationContext();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -21,6 +21,7 @@ import org.hibernate.Metamodel;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.cfg.Settings;
@@ -297,6 +298,8 @@ public interface SessionFactoryImplementor extends Mapping, SessionFactory, Quer
 	default Dialect getDialect() {
 		return getJdbcServices().getDialect();
 	}
+
+	SqlStringGenerationContext getSqlStringGenerationContext();
 
 	/**
 	 * Retrieves the SQLExceptionConverter in effect for this SessionFactory.

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/HqlSqlWalker.java
@@ -897,7 +897,7 @@ public class HqlSqlWalker extends HqlSqlBaseWalker implements ErrorReporter, Par
 			}
 
 			final String fragment = capableGenerator.determineBulkInsertionIdentifierGenerationSelectFragment(
-					sessionFactoryHelper.getFactory().getDialect()
+					sessionFactoryHelper.getFactory().getSqlStringGenerationContext()
 			);
 			if ( fragment != null ) {
 				// we got a fragment from the generator, so alter the sql tree...

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/MultiTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/MultiTableBulkIdStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.hql.spi.id;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -27,16 +28,18 @@ public interface MultiTableBulkIdStrategy {
 	 *     <li>Adding tables to the passed Mappings, to be picked by by "schema management tools"</li>
 	 *     <li>Manually creating the tables immediately through the passed JDBC Connection access</li>
 	 * </ul>
-	 *  @param jdbcServices The JdbcService object
+	 * @param jdbcServices The JdbcService object
 	 * @param connectionAccess Access to the JDBC Connection
 	 * @param metadata Access to the O/RM mapping information
 	 * @param sessionFactoryOptions
+	 * @param sqlStringGenerationContext
 	 */
 	void prepare(
 			JdbcServices jdbcServices,
 			JdbcConnectionAccess connectionAccess,
 			MetadataImplementor metadata,
-			SessionFactoryOptions sessionFactoryOptions);
+			SessionFactoryOptions sessionFactoryOptions,
+			SqlStringGenerationContext sqlStringGenerationContext);
 
 	/**
 	 * Release the strategy.   Called as the SessionFactory is being shut down.

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/cte/AbstractCteValuesListBulkIdHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/cte/AbstractCteValuesListBulkIdHandler.java
@@ -72,13 +72,12 @@ public abstract class AbstractCteValuesListBulkIdHandler extends
 				"HT_" + StringHelper.unquote( persister.getTableName(), jdbcEnvironment.getDialect() )
 		).render();
 
-		return jdbcEnvironment.getQualifiedObjectNameFormatter().format(
+		return persister.getFactory().getSqlStringGenerationContext().format(
 				new QualifiedTableName(
 						Identifier.toIdentifier( catalog ),
 						Identifier.toIdentifier( schema ),
 						Identifier.toIdentifier( qualifiedTableName )
-				),
-				jdbcEnvironment.getDialect()
+				)
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/cte/CteValuesListBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/cte/CteValuesListBulkIdStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.hql.spi.id.cte;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -55,7 +56,8 @@ public class CteValuesListBulkIdStrategy
 			JdbcServices jdbcServices,
 			JdbcConnectionAccess jdbcConnectionAccess,
 			MetadataImplementor metadataImplementor,
-			SessionFactoryOptions sessionFactoryOptions) {
+			SessionFactoryOptions sessionFactoryOptions,
+			SqlStringGenerationContext sqlStringGenerationContext) {
 		// nothing to do
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/global/GlobalTemporaryTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/global/GlobalTemporaryTableBulkIdStrategy.java
@@ -8,6 +8,7 @@ package org.hibernate.hql.spi.id.global;
 
 import java.sql.PreparedStatement;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -104,16 +105,14 @@ public class GlobalTemporaryTableBulkIdStrategy
 			Table idTable,
 			JdbcServices jdbcServices,
 			MetadataImplementor metadata,
-			PreparationContextImpl context) {
-		context.creationStatements.add( buildIdTableCreateStatement( idTable, jdbcServices, metadata ) );
+			PreparationContextImpl context,
+			SqlStringGenerationContext sqlStringGenerationContext) {
+		context.creationStatements.add( buildIdTableCreateStatement( idTable, metadata, sqlStringGenerationContext ) );
 		if ( dropIdTables ) {
-			context.dropStatements.add( buildIdTableDropStatement( idTable, jdbcServices ) );
+			context.dropStatements.add( buildIdTableDropStatement( idTable, sqlStringGenerationContext ) );
 		}
 
-		final String renderedName = jdbcServices.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-				idTable.getQualifiedTableName(),
-				jdbcServices.getJdbcEnvironment().getDialect()
-		);
+		final String renderedName = sqlStringGenerationContext.format( idTable.getQualifiedTableName() );
 
 		return new IdTableInfoImpl( renderedName );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsInClauseBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsInClauseBulkIdStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.hql.spi.id.inline;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -43,7 +44,8 @@ public class InlineIdsInClauseBulkIdStrategy
 			JdbcServices jdbcServices,
 			JdbcConnectionAccess jdbcConnectionAccess,
 			MetadataImplementor metadataImplementor,
-			SessionFactoryOptions sessionFactoryOptions) {
+			SessionFactoryOptions sessionFactoryOptions,
+			SqlStringGenerationContext sqlStringGenerationContext) {
 		// nothing to do
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsOrClauseBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsOrClauseBulkIdStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.hql.spi.id.inline;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -45,7 +46,8 @@ public class InlineIdsOrClauseBulkIdStrategy
 			JdbcServices jdbcServices,
 			JdbcConnectionAccess jdbcConnectionAccess,
 			MetadataImplementor metadataImplementor,
-			SessionFactoryOptions sessionFactoryOptions) {
+			SessionFactoryOptions sessionFactoryOptions,
+			SqlStringGenerationContext sqlStringGenerationContext) {
 		// nothing to do
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsSubSelectValueListBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/inline/InlineIdsSubSelectValueListBulkIdStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.hql.spi.id.inline;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -48,7 +49,8 @@ public class InlineIdsSubSelectValueListBulkIdStrategy
 			JdbcServices jdbcServices,
 			JdbcConnectionAccess jdbcConnectionAccess,
 			MetadataImplementor metadataImplementor,
-			SessionFactoryOptions sessionFactoryOptions) {
+			SessionFactoryOptions sessionFactoryOptions,
+			SqlStringGenerationContext sqlStringGenerationContext) {
 		// nothing to do
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/local/LocalTemporaryTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/local/LocalTemporaryTableBulkIdStrategy.java
@@ -7,6 +7,7 @@
 package org.hibernate.hql.spi.id.local;
 
 import org.hibernate.boot.TempTableDdlTransactionHandling;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -111,17 +112,15 @@ public class LocalTemporaryTableBulkIdStrategy
 			Table idTable,
 			JdbcServices jdbcServices,
 			MetadataImplementor metadata,
-			PreparationContextImpl context) {
-		String dropStatement = buildIdTableDropStatement( idTable, jdbcServices );
+			PreparationContextImpl context,
+			SqlStringGenerationContext sqlStringGenerationContext) {
+		String dropStatement = buildIdTableDropStatement( idTable, sqlStringGenerationContext );
 		if ( dropIdTables ) {
 			context.dropStatements.add( dropStatement );
 		}
 		return new IdTableInfoImpl(
-				jdbcServices.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-						idTable.getQualifiedTableName(),
-						jdbcServices.getJdbcEnvironment().getDialect()
-				),
-				buildIdTableCreateStatement( idTable, jdbcServices, metadata ),
+				sqlStringGenerationContext.format( idTable.getQualifiedTableName() ),
+				buildIdTableCreateStatement( idTable, metadata, sqlStringGenerationContext ),
 				dropStatement
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/hql/spi/id/persistent/PersistentTableBulkIdStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/spi/id/persistent/PersistentTableBulkIdStrategy.java
@@ -10,6 +10,7 @@ import java.sql.Types;
 
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.boot.spi.MetadataImplementor;
@@ -124,15 +125,15 @@ public class PersistentTableBulkIdStrategy
 			Table idTable,
 			JdbcServices jdbcServices,
 			MetadataImplementor metadata,
-			PreparationContextImpl context) {
-		final String renderedName = jdbcServices.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-				idTable.getQualifiedTableName(),
-				jdbcServices.getJdbcEnvironment().getDialect()
-		);
+			PreparationContextImpl context,
+			SqlStringGenerationContext sqlStringGenerationContext) {
+		final String renderedName = sqlStringGenerationContext.format( idTable.getQualifiedTableName() );
 
-		context.creationStatements.add( buildIdTableCreateStatement( idTable, jdbcServices, metadata ) );
+		context.creationStatements.add( buildIdTableCreateStatement( idTable, metadata,
+				sqlStringGenerationContext
+		) );
 		if ( dropIdTables ) {
-			context.dropStatements.add( buildIdTableDropStatement( idTable, jdbcServices ) );
+			context.dropStatements.add( buildIdTableDropStatement( idTable, sqlStringGenerationContext ) );
 		}
 
 		return new IdTableInfoImpl( renderedName );

--- a/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
@@ -8,6 +8,7 @@ package org.hibernate.id;
 
 import java.io.Serializable;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -29,7 +30,7 @@ public abstract class AbstractPostInsertGenerator
 	}
 
 	@Override
-	public String determineBulkInsertionIdentifierGenerationSelectFragment(Dialect dialect) {
+	public String determineBulkInsertionIdentifierGenerationSelectFragment(SqlStringGenerationContext context) {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/Assigned.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/Assigned.java
@@ -23,7 +23,7 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  */
-public class Assigned implements IdentifierGenerator, Configurable {
+public class Assigned implements IdentifierGenerator {
 	private String entityName;
 
 	public Serializable generate(SharedSessionContractImplementor session, Object obj) throws HibernateException {

--- a/hibernate-core/src/main/java/org/hibernate/id/BulkInsertionCapableIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/BulkInsertionCapableIdentifierGenerator.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.id;
 
-import org.hibernate.dialect.Dialect;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 
 /**
  * Specialized contract for {@link IdentifierGenerator} implementations capable of being used in conjunction
@@ -32,5 +32,5 @@ public interface BulkInsertionCapableIdentifierGenerator extends IdentifierGener
 	 *
 	 * @return The identifier value generation fragment (SQL).  {@code null} indicates that no fragment is needed.
 	 */
-	public String determineBulkInsertionIdentifierGenerationSelectFragment(Dialect dialect);
+	public String determineBulkInsertionIdentifierGenerationSelectFragment(SqlStringGenerationContext context);
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/CompositeNestedGeneratedValueGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/CompositeNestedGeneratedValueGenerator.java
@@ -9,11 +9,15 @@ package org.hibernate.id;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.ExportableProducer;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.Type;
 
 /**
  * For composite identifiers, defines a number of "nested" generations that
@@ -67,6 +71,16 @@ public class CompositeNestedGeneratedValueGenerator implements IdentifierGenerat
 	 * determined {@link GenerationContextLocator#locateGenerationContext context}
 	 */
 	public interface GenerationPlan extends ExportableProducer {
+
+		/**
+		 * Initializes this instance, in particular pre-generates SQL as necessary.
+		 * <p>
+		 * This method is called after {@link #registerExportables(Database)}, before first use.
+		 *
+		 * @param context A context to help generate SQL strings
+		 */
+		void initialize(SqlStringGenerationContext context);
+
 		/**
 		 * Execute the value generation.
 		 *
@@ -104,6 +118,13 @@ public class CompositeNestedGeneratedValueGenerator implements IdentifierGenerat
 	public void registerExportables(Database database) {
 		for (GenerationPlan plan : generationPlans) {
 			plan.registerExportables( database );
+		}
+	}
+
+	@Override
+	public void initialize(SqlStringGenerationContext context) {
+		for (GenerationPlan plan : generationPlans) {
+			plan.initialize( context );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/Configurable.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/Configurable.java
@@ -15,11 +15,14 @@ import org.hibernate.type.Type;
 /**
  * An {@link IdentifierGenerator} that supports "configuration".
  *
+ * @deprecated All methods are already defined in {@link IdentifierGenerator}.
+ * Just implement {@link IdentifierGenerator}.
  * @see IdentifierGenerator
  *
  * @author Gavin King
  * @author Steve Ebersole
  */
+@Deprecated
 public interface Configurable {
 	/**
 	 * Configure this instance, given the value of parameters

--- a/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
@@ -34,7 +34,7 @@ import static org.hibernate.internal.CoreLogging.messageLogger;
  *
  * @author Gavin King
  */
-public class ForeignGenerator implements IdentifierGenerator, Configurable {
+public class ForeignGenerator implements IdentifierGenerator {
 	private static final CoreMessageLogger LOG = messageLogger( ForeignGenerator.class );
 
 	private String entityName;

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
@@ -14,6 +14,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.ExportableProducer;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
@@ -77,6 +78,16 @@ public interface IdentifierGenerator extends Configurable, ExportableProducer {
 	 */
 	@Override
 	default void registerExportables(Database database) {
+	}
+
+	/**
+	 * Initializes this instance, in particular pre-generates SQL as necessary.
+	 * <p>
+	 * This method is called after {@link #registerExportables(Database)}, before first use.
+	 *
+	 * @param context A context to help generate SQL strings
+	 */
+	default void initialize(SqlStringGenerationContext context) {
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
@@ -7,10 +7,16 @@
 package org.hibernate.id;
 
 import java.io.Serializable;
+import java.util.Properties;
 import javax.persistence.GeneratedValue;
 
 import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.Type;
 
 /**
  * The general contract between a class that generates unique
@@ -29,9 +35,8 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  * @author Gavin King
  *
  * @see PersistentIdentifierGenerator
- * @see Configurable
  */
-public interface IdentifierGenerator {
+public interface IdentifierGenerator extends Configurable, ExportableProducer {
 	/**
 	 * The configuration parameter holding the entity name
 	 */
@@ -47,6 +52,32 @@ public interface IdentifierGenerator {
 	 * {@link IdentifierGenerator} as it is configured.
 	 */
 	String GENERATOR_NAME = "GENERATOR_NAME";
+
+	/**
+	 * Configure this instance, given the value of parameters
+	 * specified by the user as <tt>&lt;param&gt;</tt> elements.
+	 * <p>
+	 * This method is called just once, following instantiation, and before {@link #registerExportables(Database)}.
+	 *
+	 * @param type The id property type descriptor
+	 * @param params param values, keyed by parameter name
+	 * @param serviceRegistry Access to service that may be needed.
+	 * @throws MappingException If configuration fails.
+	 */
+	@Override
+	default void configure(Type type, Properties params, ServiceRegistry serviceRegistry) throws MappingException {
+	}
+
+	/**
+	 * Register database objects used by this identifier generator, e.g. sequences, tables, etc.
+	 * <p>
+	 * This method is called just once, after {@link #configure(Type, Properties, ServiceRegistry)}.
+	 *
+	 * @param database The database instance
+	 */
+	@Override
+	default void registerExportables(Database database) {
+	}
 
 	/**
 	 * Generate a new identifier.

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentityGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentityGenerator.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.insert.AbstractReturningDelegate;
@@ -67,7 +68,7 @@ public class IdentityGenerator extends AbstractPostInsertGenerator {
 		}
 
 		@Override
-		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert() {
+		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
 			InsertSelectIdentityInsert insert = new InsertSelectIdentityInsert( dialect );
 			insert.addIdentityColumn( persister.getRootTableKeyColumnNames()[0] );
 			return insert;
@@ -120,7 +121,7 @@ public class IdentityGenerator extends AbstractPostInsertGenerator {
 		}
 
 		@Override
-		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert() {
+		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
 			IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( dialect );
 			insert.addIdentityColumn( persister.getRootTableKeyColumnNames()[0] );
 			return insert;

--- a/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
@@ -38,7 +38,7 @@ import org.hibernate.type.Type;
  * @author Steve Ebersole
  * @author Brett Meyer
  */
-public class IncrementGenerator implements IdentifierGenerator, Configurable {
+public class IncrementGenerator implements IdentifierGenerator {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( IncrementGenerator.class );
 
 	private Class returnClass;

--- a/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
@@ -54,6 +54,14 @@ public class IncrementGenerator implements IdentifierGenerator {
 
 	private IntegralDataTypeHolder previousValueHolder;
 
+	/**
+	 * @deprecated Exposed for tests only.
+	 */
+	@Deprecated
+	public String[] getAllSqlForTests() {
+		return new String[] { sql };
+	}
+
 	@Override
 	public synchronized Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
 		if ( sql != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
@@ -10,11 +10,17 @@ import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ObjectNameNormalizer;
+import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
@@ -42,6 +48,8 @@ public class IncrementGenerator implements IdentifierGenerator {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( IncrementGenerator.class );
 
 	private Class returnClass;
+	private String column;
+	private List<QualifiedTableName> physicalTableNames;
 	private String sql;
 
 	private IntegralDataTypeHolder previousValueHolder;
@@ -62,17 +70,13 @@ public class IncrementGenerator implements IdentifierGenerator {
 		final ObjectNameNormalizer normalizer =
 				(ObjectNameNormalizer) params.get( PersistentIdentifierGenerator.IDENTIFIER_NORMALIZER );
 
-		String column = params.getProperty( "column" );
+		column = params.getProperty( "column" );
 		if ( column == null ) {
 			column = params.getProperty( PersistentIdentifierGenerator.PK );
 		}
 		column = normalizer.normalizeIdentifierQuoting( column ).render( jdbcEnvironment.getDialect() );
 
-		String tableList = params.getProperty( "tables" );
-		if ( tableList == null ) {
-			tableList = params.getProperty( PersistentIdentifierGenerator.TABLES );
-		}
-		String[] tables = StringHelper.split( ", ", tableList );
+		IdentifierHelper identifierHelper = jdbcEnvironment.getIdentifierHelper();
 
 		final String schema = normalizer.toDatabaseIdentifierText(
 				params.getProperty( PersistentIdentifierGenerator.SCHEMA )
@@ -81,23 +85,40 @@ public class IncrementGenerator implements IdentifierGenerator {
 				params.getProperty( PersistentIdentifierGenerator.CATALOG )
 		);
 
+		String tableList = params.getProperty( "tables" );
+		if ( tableList == null ) {
+			tableList = params.getProperty( PersistentIdentifierGenerator.TABLES );
+		}
+		physicalTableNames = new ArrayList<>();
+		for ( String tableName : StringHelper.split( ", ", tableList ) ) {
+			physicalTableNames.add( new QualifiedTableName( identifierHelper.toIdentifier( catalog ),
+					identifierHelper.toIdentifier( schema ), identifierHelper.toIdentifier( tableName ) ) );
+		}
+	}
+
+	@Override
+	public void initialize(SqlStringGenerationContext context) {
 		StringBuilder buf = new StringBuilder();
-		for ( int i = 0; i < tables.length; i++ ) {
-			final String tableName = normalizer.toDatabaseIdentifierText( tables[i] );
-			if ( tables.length > 1 ) {
+		for ( int i = 0; i < physicalTableNames.size(); i++ ) {
+			final String tableName = context.format( physicalTableNames.get( i ) );
+			if ( physicalTableNames.size() > 1 ) {
 				buf.append( "select max(" ).append( column ).append( ") as mx from " );
 			}
-			buf.append( Table.qualify( catalog, schema, tableName ) );
-			if ( i < tables.length - 1 ) {
+			buf.append( tableName );
+			if ( i < physicalTableNames.size() - 1 ) {
 				buf.append( " union " );
 			}
 		}
-		if ( tables.length > 1 ) {
+		String maxColumn;
+		if ( physicalTableNames.size() > 1 ) {
 			buf.insert( 0, "( " ).append( " ) ids_" );
-			column = "ids_.mx";
+			maxColumn = "ids_.mx";
+		}
+		else {
+			maxColumn = column;
 		}
 
-		sql = "select max(" + column + ") from " + buf.toString();
+		sql = "select max(" + maxColumn + ") from " + buf.toString();
 	}
 
 	private void initializePreviousValueHolder(SharedSessionContractImplementor session) {

--- a/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
@@ -375,7 +375,4 @@ public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenera
 
 	}
 
-	public Object generatorKey() {
-		return tableName;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
@@ -14,7 +14,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Properties;
 
-import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.naming.Identifier;
@@ -22,7 +21,6 @@ import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.QualifiedNameParser;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -375,20 +373,6 @@ public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenera
 
 
 
-	}
-
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return new String[] {
-				dialect.getCreateTableString()
-						+ ' ' + tableName + " ( "
-						+ segmentColumnName + ' ' + dialect.getTypeName( Types.VARCHAR, keySize, 0, 0 ) + ",  "
-						+ valueColumnName + ' ' + dialect.getTypeName( Types.INTEGER )
-						+ " )" + dialect.getTableTypeString()
-		};
-	}
-
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return new String[] {dialect.getDropTableString( tableName )};
 	}
 
 	public Object generatorKey() {

--- a/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
@@ -78,7 +78,7 @@ import org.hibernate.type.Type;
  * @deprecated Use {@link org.hibernate.id.enhanced.TableGenerator} instead.
  */
 @Deprecated
-public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenerator, Configurable {
+public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenerator {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( MultipleHiLoPerTableGenerator.class );
 
 	public static final String ID_TABLE = "table";
@@ -253,6 +253,7 @@ public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenera
 		}
 	}
 
+	@Override
 	@SuppressWarnings({"StatementWithEmptyBody", "deprecation"})
 	public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) throws MappingException {
 		returnClass = type.getReturnedClass();

--- a/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
@@ -58,12 +58,4 @@ public interface PersistentIdentifierGenerator extends IdentifierGenerator {
 	 * The key under which to find the {@link org.hibernate.boot.model.naming.ObjectNameNormalizer} in the config param map.
 	 */
 	String IDENTIFIER_NORMALIZER = "identifier_normalizer";
-
-	/**
-	 * Return a key unique to the underlying database objects. Prevents us from
-	 * trying to create/remove them multiple times.
-	 *
-	 * @return Object an identifying key for this generator
-	 */
-	Object generatorKey();
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
@@ -6,23 +6,25 @@
  */
 package org.hibernate.id;
 
+import java.util.Properties;
+
 import org.hibernate.HibernateException;
-import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.Type;
 
 /**
  * An <tt>IdentifierGenerator</tt> that requires creation of database objects.
  * <br><br>
- * All <tt>PersistentIdentifierGenerator</tt>s that also implement
- * <tt>Configurable</tt> have access to a special mapping parameter: schema
+ * All <tt>PersistentIdentifierGenerator</tt>s have access to a special mapping parameter
+ * in their {@link #configure(Type, Properties, ServiceRegistry)} method: schema
  *
  * @author Gavin King
  * @author Steve Ebersole
  *
  * @see IdentifierGenerator
- * @see Configurable
  */
-public interface PersistentIdentifierGenerator extends IdentifierGenerator, ExportableProducer {
+public interface PersistentIdentifierGenerator extends IdentifierGenerator {
 
 	/**
 	 * The configuration parameter holding the schema name

--- a/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
@@ -60,32 +60,6 @@ public interface PersistentIdentifierGenerator extends IdentifierGenerator {
 	String IDENTIFIER_NORMALIZER = "identifier_normalizer";
 
 	/**
-	 * The SQL required to create the underlying database objects.
-	 *
-	 * @param dialect The dialect against which to generate the create command(s)
-	 *
-	 * @return The create command(s)
-	 *
-	 * @throws HibernateException problem creating the create command(s)
-	 * @deprecated Utilize the ExportableProducer contract instead
-	 */
-	@Deprecated
-	String[] sqlCreateStrings(Dialect dialect) throws HibernateException;
-
-	/**
-	 * The SQL required to remove the underlying database objects.
-	 *
-	 * @param dialect The dialect against which to generate the drop command(s)
-	 *
-	 * @return The drop command(s)
-	 *
-	 * @throws HibernateException problem creating the drop command(s)
-	 * @deprecated Utilize the ExportableProducer contract instead
-	 */
-	@Deprecated
-	String[] sqlDropStrings(Dialect dialect) throws HibernateException;
-
-	/**
 	 * Return a key unique to the underlying database objects. Prevents us from
 	 * trying to create/remove them multiple times.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/id/PostInsertIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PostInsertIdentifierGenerator.java
@@ -7,6 +7,7 @@
 package org.hibernate.id;
 
 import org.hibernate.HibernateException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.id.insert.InsertGeneratedIdentifierDelegate;
 

--- a/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
@@ -31,7 +31,7 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  */
-public class SelectGenerator extends AbstractPostInsertGenerator implements Configurable {
+public class SelectGenerator extends AbstractPostInsertGenerator {
 	private String uniqueKeyPropertyName;
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.insert.AbstractSelectingDelegate;
@@ -39,6 +40,7 @@ public class SelectGenerator extends AbstractPostInsertGenerator {
 		uniqueKeyPropertyName = params.getProperty( "key" );
 	}
 
+	@Override
 	public InsertGeneratedIdentifierDelegate getInsertGeneratedIdentifierDelegate(
 			PostInsertIdentityPersister persister,
 			Dialect dialect,
@@ -102,7 +104,8 @@ public class SelectGenerator extends AbstractPostInsertGenerator {
 			idType = persister.getIdentifierType();
 		}
 
-		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert() {
+		@Override
+		public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
 			return new IdentifierGeneratingInsert( dialect );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
@@ -73,10 +73,6 @@ public class SequenceGenerator
 		return identifierType;
 	}
 
-	public Object generatorKey() {
-		return getSequenceName();
-	}
-
 	public String getSequenceName() {
 		return sequenceName;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
@@ -45,7 +45,7 @@ import org.jboss.logging.Logger;
  */
 @Deprecated
 public class SequenceGenerator
-		implements PersistentIdentifierGenerator, BulkInsertionCapableIdentifierGenerator, Configurable {
+		implements PersistentIdentifierGenerator, BulkInsertionCapableIdentifierGenerator {
 
 	private static final Logger LOG = Logger.getLogger( SequenceGenerator.class.getName() );
 

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
@@ -75,6 +75,14 @@ public class SequenceGenerator
 		return physicalSequenceName;
 	}
 
+	/**
+	 * @deprecated Exposed for tests only.
+	 */
+	@Deprecated
+	public String[] getAllSqlForTests() {
+		return new String[] { sql };
+	}
+
 	@Override
 	@SuppressWarnings("StatementWithEmptyBody")
 	public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SequenceGenerator.java
@@ -145,17 +145,6 @@ public class SequenceGenerator
 	}
 
 	@Override
-	@SuppressWarnings( {"deprecation"})
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return dialect.getCreateSequenceStrings( sequenceName, 1, 1 );
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return dialect.getDropSequenceStrings( sequenceName );
-	}
-
-	@Override
 	public boolean supportsBulkInsertionIdentifierGeneration() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
@@ -39,7 +39,7 @@ import org.hibernate.type.descriptor.java.UUIDTypeDescriptor;
  *
  * @author Steve Ebersole
  */
-public class UUIDGenerator implements IdentifierGenerator, Configurable {
+public class UUIDGenerator implements IdentifierGenerator {
 	public static final String UUID_GEN_STRATEGY = "uuid_gen_strategy";
 	public static final String UUID_GEN_STRATEGY_CLASS = "uuid_gen_strategy_class";
 

--- a/hibernate-core/src/main/java/org/hibernate/id/UUIDHexGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/UUIDHexGenerator.java
@@ -29,7 +29,7 @@ import org.hibernate.type.Type;
  *
  * @author Gavin King
  */
-public class UUIDHexGenerator extends AbstractUUIDGenerator implements Configurable {
+public class UUIDHexGenerator extends AbstractUUIDGenerator {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( UUIDHexGenerator.class );
 
 	private static boolean WARNED;

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
@@ -7,7 +7,6 @@
 package org.hibernate.id.enhanced;
 
 import org.hibernate.boot.model.relational.ExportableProducer;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -57,20 +56,6 @@ public interface DatabaseStructure extends ExportableProducer {
 	 * @param optimizer The optimizer being applied to the generator.
 	 */
 	void prepare(Optimizer optimizer);
-
-	/**
-	 * Commands needed to create the underlying structures.
-	 * @param dialect The database dialect being used.
-	 * @return The creation commands.
-	 */
-	String[] sqlCreateStrings(Dialect dialect);
-
-	/**
-	 * Commands needed to drop the underlying structures.
-	 * @param dialect The database dialect being used.
-	 * @return The drop commands.
-	 */
-	String[] sqlDropStrings(Dialect dialect);
 
 	/**
 	 * Is the structure physically a sequence?

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.id.enhanced;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.ExportableProducer;
+import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -17,10 +20,14 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  */
 public interface DatabaseStructure extends ExportableProducer {
 	/**
-	 * The name of the database structure (table or sequence).
+	 * The physical name of the database structure (table or sequence).
+	 * <p>
+	 * Only available after {@link #registerExportables(Database)}
+	 * has been called.
+	 *
 	 * @return The structure name.
 	 */
-	String getName();
+	QualifiedName getPhysicalName();
 
 	/**
 	 * How many times has this structure been accessed through this reference?
@@ -54,8 +61,45 @@ public interface DatabaseStructure extends ExportableProducer {
 	 * but before first use.
 	 *
 	 * @param optimizer The optimizer being applied to the generator.
+	 *
+	 * @deprecated Use {@link #configure(Optimizer)} instead.
 	 */
-	void prepare(Optimizer optimizer);
+	@Deprecated
+	default void prepare(Optimizer optimizer) {
+	}
+
+	/**
+	 * Configures this structure with the given arguments.
+	 * <p>
+	 * Called just after instantiation, before {@link #initialize(SqlStringGenerationContext)}
+	 *
+	 * @param optimizer The optimizer being applied to the generator.
+	 */
+	default void configure(Optimizer optimizer) {
+		prepare( optimizer );
+	}
+
+	/**
+	 * Register database objects involved in this structure, e.g. sequences, tables, etc.
+	 * <p>
+	 * This method is called just once, after {@link #configure(Optimizer)},
+	 * but before {@link #initialize(SqlStringGenerationContext)}.
+	 *
+	 * @param database The database instance
+	 */
+	@Override
+	void registerExportables(Database database);
+
+	/**
+	 * Initializes this structure, in particular pre-generates SQL as necessary.
+	 * <p>
+	 * This method is called just once, after {@link #registerExportables(Database)},
+	 * before first use.
+	 *
+	 * @param context A context to help generate SQL strings
+	 */
+	default void initialize(SqlStringGenerationContext context) {
+	}
 
 	/**
 	 * Is the structure physically a sequence?

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/DatabaseStructure.java
@@ -107,4 +107,12 @@ public interface DatabaseStructure extends ExportableProducer {
 	 * @return {@code true} if the actual database structure is a sequence; {@code false} otherwise.
 	 */
 	boolean isPhysicalSequence();
+
+	/**
+	 * @deprecated Exposed for tests only.
+	 */
+	@Deprecated
+	public default String[] getAllSqlForTests() {
+		return new String[] { };
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
@@ -11,12 +11,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.hibernate.AssertionFailure;
-import org.hibernate.HibernateException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.Sequence;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.IdentifierGeneratorHelper;
@@ -142,16 +140,6 @@ public class SequenceStructure implements DatabaseStructure {
 	public void registerExportables(Database database) {
 		buildSequence( database );
 		this.sql = database.getJdbcEnvironment().getDialect().getSequenceNextValString( sequenceName );
-	}
-
-	@Override
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return dialect.getCreateSequenceStrings( sequenceName, initialValue, getSourceIncrementSize() );
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return dialect.getDropSequenceStrings( sequenceName );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
@@ -79,6 +79,11 @@ public class SequenceStructure implements DatabaseStructure {
 	}
 
 	@Override
+	public String[] getAllSqlForTests() {
+		return new String[] { sql };
+	}
+
+	@Override
 	public AccessCallback buildCallback(final SharedSessionContractImplementor session) {
 		if ( sql == null ) {
 			throw new AssertionFailure( "SequenceStyleGenerator's SequenceStructure was not properly initialized" );

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -24,7 +24,6 @@ import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.BulkInsertionCapableIdentifierGenerator;
-import org.hibernate.id.Configurable;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.PersistentIdentifierGenerator;
 import org.hibernate.id.SequenceMismatchStrategy;
@@ -101,7 +100,7 @@ import org.jboss.logging.Logger;
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 public class SequenceStyleGenerator
-		implements PersistentIdentifierGenerator, BulkInsertionCapableIdentifierGenerator, Configurable {
+		implements PersistentIdentifierGenerator, BulkInsertionCapableIdentifierGenerator {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
 			CoreMessageLogger.class,

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -16,6 +16,7 @@ import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.QualifiedNameParser;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -297,7 +298,17 @@ public class SequenceStyleGenerator
 				incrementSize,
 				ConfigurationHelper.getInt( INITIAL_PARAM, params, -1 )
 		);
-		this.databaseStructure.prepare( optimizer );
+		this.databaseStructure.configure( optimizer );
+	}
+
+	@Override
+	public void registerExportables(Database database) {
+		databaseStructure.registerExportables( database );
+	}
+
+	@Override
+	public void initialize(SqlStringGenerationContext context) {
+		this.databaseStructure.initialize( context );
 	}
 
 	/**
@@ -535,13 +546,8 @@ public class SequenceStyleGenerator
 	}
 
 	@Override
-	public String determineBulkInsertionIdentifierGenerationSelectFragment(Dialect dialect) {
-		return dialect.getSelectSequenceNextValString( getDatabaseStructure().getName() );
-	}
-
-	@Override
-	public void registerExportables(Database database) {
-		databaseStructure.registerExportables( database );
+	public String determineBulkInsertionIdentifierGenerationSelectFragment(SqlStringGenerationContext context) {
+		return context.getDialect().getSelectSequenceNextValString( context.format( getDatabaseStructure().getPhysicalName() ) );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -12,7 +12,6 @@ import java.util.Properties;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
-import org.hibernate.boot.SchemaAutoTooling;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedName;
@@ -530,16 +529,6 @@ public class SequenceStyleGenerator
 	@Override
 	public Object generatorKey() {
 		return databaseStructure.getName();
-	}
-
-	@Override
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return databaseStructure.sqlCreateStrings( dialect );
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return databaseStructure.sqlDropStrings( dialect );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -523,15 +523,6 @@ public class SequenceStyleGenerator
 		return optimizer.generate( databaseStructure.buildCallback( session ) );
 	}
 
-
-	// PersistentIdentifierGenerator implementation ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-	@Override
-	public Object generatorKey() {
-		return databaseStructure.getName();
-	}
-
-
 	// BulkInsertionCapableIdentifierGenerator implementation ~~~~~~~~~~~~~~~~~
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -36,7 +36,6 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.id.Configurable;
 import org.hibernate.id.ExportableColumn;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.IdentifierGeneratorHelper;
@@ -129,7 +128,7 @@ import org.jboss.logging.Logger;
  *
  * @author Steve Ebersole
  */
-public class TableGenerator implements PersistentIdentifierGenerator, Configurable {
+public class TableGenerator implements PersistentIdentifierGenerator {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
 			CoreMessageLogger.class,
 			TableGenerator.class.getName()

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -248,11 +248,6 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 	private Optimizer optimizer;
 	private long accessCount;
 
-	@Override
-	public Object generatorKey() {
-		return qualifiedTableName.render();
-	}
-
 	/**
 	 * Type mapping for the identifier.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -350,6 +350,14 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 		return accessCount;
 	}
 
+	/**
+	 * @deprecated Exposed for tests only.
+	 */
+	@Deprecated
+	public String[] getAllSqlForTests() {
+		return new String[] { selectQuery, insertQuery, updateQuery };
+	}
+
 	@Override
 	public void configure(Type type, Properties params, ServiceRegistry serviceRegistry) throws MappingException {
 		storeLastUsedValue = serviceRegistry.getService( ConfigurationService.class )

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -25,6 +25,7 @@ import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.QualifiedNameParser;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -231,7 +232,7 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 	private Type identifierType;
 
 	private QualifiedName qualifiedTableName;
-	private String renderedTableName;
+	private QualifiedName physicalTableName;
 
 	private String segmentColumnName;
 	private String segmentValue;
@@ -518,30 +519,31 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 	}
 
 	@SuppressWarnings({"unchecked", "WeakerAccess"})
-	protected String buildSelectQuery(Dialect dialect) {
+	protected String buildSelectQuery(String formattedPhysicalTableName, SqlStringGenerationContext context) {
 		final String alias = "tbl";
 		final String query = "select " + StringHelper.qualify( alias, valueColumnName ) +
-				" from " + renderedTableName + ' ' + alias +
+				" from " + formattedPhysicalTableName + ' ' + alias +
 				" where " + StringHelper.qualify( alias, segmentColumnName ) + "=?";
 		final LockOptions lockOptions = new LockOptions( LockMode.PESSIMISTIC_WRITE );
 		lockOptions.setAliasSpecificLockMode( alias, LockMode.PESSIMISTIC_WRITE );
 		final Map updateTargetColumnsMap = Collections.singletonMap( alias, new String[] { valueColumnName } );
-		return dialect.applyLocksToSql( query, lockOptions, updateTargetColumnsMap );
+		return context.getDialect().applyLocksToSql( query, lockOptions, updateTargetColumnsMap );
 	}
 
 	@SuppressWarnings("WeakerAccess")
-	protected String buildUpdateQuery() {
-		return "update " + renderedTableName +
+	protected String buildUpdateQuery(String formattedPhysicalTableName, SqlStringGenerationContext context) {
+		return "update " + formattedPhysicalTableName +
 				" set " + valueColumnName + "=? " +
 				" where " + valueColumnName + "=? and " + segmentColumnName + "=?";
 	}
 
 	@SuppressWarnings("WeakerAccess")
-	protected String buildInsertQuery() {
-		return "insert into " + renderedTableName + " (" + segmentColumnName + ", " + valueColumnName + ") " + " values (?,?)";
+	protected String buildInsertQuery(String formattedPhysicalTableName, SqlStringGenerationContext context) {
+		return "insert into " + formattedPhysicalTableName + " (" + segmentColumnName + ", " + valueColumnName + ") " + " values (?,?)";
 	}
 
-	protected InitCommand generateInsertInitCommand() {
+	protected InitCommand generateInsertInitCommand(SqlStringGenerationContext context) {
+		String renderedTableName = context.format( physicalTableName );
 		int value = initialValue;
 		if ( storeLastUsedValue ) {
 			value = initialValue - 1;
@@ -639,7 +641,7 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 												rows = executeUpdate( updatePS, statsCollector );
 											}
 											catch (SQLException e) {
-												LOG.unableToUpdateQueryHiValue( renderedTableName, e );
+												LOG.unableToUpdateQueryHiValue( physicalTableName.render(), e );
 												throw e;
 											}
 										}
@@ -740,14 +742,15 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 		}
 
 		// allow physical naming strategies a chance to kick in
-		this.renderedTableName = database.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-				table.getQualifiedTableName(),
-				dialect
-		);
-		table.addInitCommand( generateInsertInitCommand() );
+		this.physicalTableName = table.getQualifiedTableName();
+		table.addInitCommand( this::generateInsertInitCommand );
+	}
 
-		this.selectQuery = buildSelectQuery( dialect );
-		this.updateQuery = buildUpdateQuery();
-		this.insertQuery = buildInsertQuery();
+	@Override
+	public void initialize(SqlStringGenerationContext context) {
+		String formattedPhysicalTableName = context.format( physicalTableName );
+		this.selectQuery = buildSelectQuery( formattedPhysicalTableName, context );
+		this.updateQuery = buildUpdateQuery( formattedPhysicalTableName, context );
+		this.insertQuery = buildInsertQuery( formattedPhysicalTableName, context );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
@@ -706,21 +705,6 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 		finally {
 			statsCollector.jdbcExecuteStatementEnd();
 		}
-	}
-
-	@Override
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return new String[] {
-				dialect.getCreateTableString() + ' ' + renderedTableName + " ( "
-						+ segmentColumnName + ' ' + dialect.getTypeName( Types.VARCHAR, segmentValueLength, 0, 0 ) + " not null "
-						+ ", " + valueColumnName + ' ' + dialect.getTypeName( Types.BIGINT )
-						+ ", primary key ( " + segmentColumnName + " ) )" + dialect.getTableTypeString()
-		};
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return new String[] { dialect.getDropTableString( renderedTableName ) };
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -99,6 +99,11 @@ public class TableStructure implements DatabaseStructure {
 	}
 
 	@Override
+	public String[] getAllSqlForTests() {
+		return new String[] { selectQuery, updateQuery };
+	}
+
+	@Override
 	public void prepare(Optimizer optimizer) {
 		applyIncrementSizeToSourceValues = optimizer.applyIncrementSizeToSourceValues();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -10,10 +10,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Types;
 
 import org.hibernate.AssertionFailure;
-import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Database;
@@ -218,19 +216,6 @@ public class TableStructure implements DatabaseStructure {
 		finally {
 			statsCollector.jdbcExecuteStatementEnd();
 		}
-	}
-
-	@Override
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		return new String[] {
-				dialect.getCreateTableString() + " " + tableNameText + " ( " + valueColumnNameText + " " + dialect.getTypeName( Types.BIGINT ) + " )",
-				"insert into " + tableNameText + " values ( " + initialValue + " )"
-		};
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		return new String[] { dialect.getDropTableString( tableNameText ) };
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/DefaultIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/DefaultIdentifierGeneratorFactory.java
@@ -19,7 +19,6 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.id.Assigned;
-import org.hibernate.id.Configurable;
 import org.hibernate.id.ForeignGenerator;
 import org.hibernate.id.GUIDGenerator;
 import org.hibernate.id.IdentifierGenerator;
@@ -140,9 +139,7 @@ public class DefaultIdentifierGeneratorFactory
 						FallbackBeanInstanceProducer.INSTANCE
 				).getBeanInstance();
 			}
-			if ( identifierGenerator instanceof Configurable ) {
-				( ( Configurable ) identifierGenerator ).configure( type, config, serviceRegistry );
-			}
+			identifierGenerator.configure( type, config, serviceRegistry );
 			return identifierGenerator;
 		}
 		catch ( Exception e ) {

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/InsertGeneratedIdentifierDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/InsertGeneratedIdentifierDelegate.java
@@ -8,6 +8,7 @@ package org.hibernate.id.insert;
 
 import java.io.Serializable;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -25,9 +26,10 @@ public interface InsertGeneratedIdentifierDelegate {
 	 * Build a {@link org.hibernate.sql.Insert} specific to the delegate's mode
 	 * of handling generated key values.
 	 *
+	 * @param context A context to help generate SQL strings
 	 * @return The insert object.
 	 */
-	IdentifierGeneratingInsert prepareIdentifierGeneratingInsert();
+	IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context);
 
 	/**
 	 * Perform the indicated insert SQL statement and determine the identifier value

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterConfiguration.java
@@ -59,7 +59,7 @@ public class FilterConfiguration {
 		}
 		else if ( persistentClass != null ) {
 			String table = persistentClass.getTable().getQualifiedName(
-					factory.getDialect(),
+					factory.getSqlStringGenerationContext(),
 					factory.getSettings().getDefaultCatalogName(),
 					factory.getSettings().getDefaultSchemaName()
 			);

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterConfiguration.java
@@ -59,9 +59,7 @@ public class FilterConfiguration {
 		}
 		else if ( persistentClass != null ) {
 			String table = persistentClass.getTable().getQualifiedName(
-					factory.getSqlStringGenerationContext(),
-					factory.getSettings().getDefaultCatalogName(),
-					factory.getSettings().getDefaultSchemaName()
+					factory.getSqlStringGenerationContext()
 			);
 			return Collections.singletonMap( null, table );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -325,7 +325,8 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 					jdbcServices,
 					buildLocalConnectionAccess(),
 					metadata,
-					sessionFactoryOptions
+					sessionFactoryOptions,
+					sqlStringGenerationContext
 			);
 
 			SchemaManagementToolCoordinator.process(

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -233,10 +233,11 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		this.uuid = options.getUuid();
 
 		jdbcServices = serviceRegistry.getService( JdbcServices.class );
-		sqlStringGenerationContext = new SqlStringGenerationContextImpl( jdbcServices.getJdbcEnvironment() );
+
+		ConfigurationService configurationService = serviceRegistry.getService( ConfigurationService.class );
 
 		this.properties = new HashMap<>();
-		this.properties.putAll( serviceRegistry.getService( ConfigurationService.class ).getSettings() );
+		this.properties.putAll( configurationService.getSettings() );
 		if ( !properties.containsKey( AvailableSettings.JPA_VALIDATION_FACTORY )
 				&& !properties.containsKey( AvailableSettings.JAKARTA_JPA_VALIDATION_FACTORY ) ) {
 			if ( getSessionFactoryOptions().getValidatorFactoryReference() != null ) {
@@ -253,6 +254,10 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 
 		maskOutSensitiveInformation(this.properties);
 		logIfEmptyCompositesEnabled( this.properties );
+
+		sqlStringGenerationContext = SqlStringGenerationContextImpl.fromExplicit(
+				jdbcServices.getJdbcEnvironment(), metadata.getDatabase(),
+				options.getDefaultCatalog(), options.getDefaultSchema() );
 
 		this.sqlFunctionRegistry = new SQLFunctionRegistry( jdbcServices.getJdbcEnvironment().getDialect(), options.getCustomSqlFunctionMap() );
 		this.cacheAccess = this.serviceRegistry.getService( CacheImplementor.class );
@@ -301,8 +306,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 				IdentifierGenerator generator = model.getIdentifier().createIdentifierGenerator(
 						metadata.getIdentifierGeneratorFactory(),
 						jdbcServices.getJdbcEnvironment().getDialect(),
-						settings.getDefaultCatalogName(),
-						settings.getDefaultSchemaName(),
 						(RootClass) model
 				);
 				generator.initialize( sqlStringGenerationContext );

--- a/hibernate-core/src/main/java/org/hibernate/loader/custom/sql/SQLQueryParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/custom/sql/SQLQueryParser.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.hibernate.QueryException;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.query.spi.ParameterParser;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.param.ParameterBinder;
@@ -85,6 +87,8 @@ public class SQLQueryParser {
 		StringBuilder result = new StringBuilder( sqlQuery.length() + 20 );
 		int left, right;
 
+		SqlStringGenerationContext sqlStringGenerationContext = factory.getSqlStringGenerationContext();
+
 		// replace {....} with corresponding column aliases
 		for ( int curr = 0; curr < sqlQuery.length(); curr = right + 1 ) {
 			if ( ( left = sqlQuery.indexOf( '{', curr ) ) < 0 ) {
@@ -107,30 +111,30 @@ public class SQLQueryParser {
 			if ( isPlaceholder ) {
 				// Domain replacement
 				if ( DOMAIN_PLACEHOLDER.equals( aliasPath ) ) {
-					final String catalogName = factory.getSettings().getDefaultCatalogName();
+					final Identifier catalogName = sqlStringGenerationContext.getDefaultCatalog();
 					if ( catalogName != null ) {
-						result.append( catalogName );
+						result.append( catalogName.render( sqlStringGenerationContext.getDialect() ) );
 						result.append( "." );
 					}
-					final String schemaName = factory.getSettings().getDefaultSchemaName();
+					final Identifier schemaName = sqlStringGenerationContext.getDefaultSchema();
 					if ( schemaName != null ) {
-						result.append( schemaName );
+						result.append( schemaName.render( sqlStringGenerationContext.getDialect() ) );
 						result.append( "." );
 					}
 				}
 				// Schema replacement
 				else if ( SCHEMA_PLACEHOLDER.equals( aliasPath ) ) {
-					final String schemaName = factory.getSettings().getDefaultSchemaName();
+					final Identifier schemaName = sqlStringGenerationContext.getDefaultSchema();
 					if ( schemaName != null ) {
-						result.append(schemaName);
+						result.append( schemaName.render( sqlStringGenerationContext.getDialect() ) );
 						result.append(".");
 					}
 				}
 				// Catalog replacement
 				else if ( CATALOG_PLACEHOLDER.equals( aliasPath ) ) {
-					final String catalogName = factory.getSettings().getDefaultCatalogName();
+					final Identifier catalogName = sqlStringGenerationContext.getDefaultCatalog();
 					if ( catalogName != null ) {
-						result.append( catalogName );
+						result.append( catalogName.render( sqlStringGenerationContext.getDialect() ) );
 						result.append( "." );
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/AuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/AuxiliaryDatabaseObject.java
@@ -15,7 +15,10 @@ import org.hibernate.dialect.Dialect;
  * creating/dropping the schema.
  *
  * @author Steve Ebersole
+ *
+ * @deprecated Use {@link org.hibernate.boot.model.relational.AuxiliaryDatabaseObject} instead.
  */
+@Deprecated
 public interface AuxiliaryDatabaseObject extends RelationalModel, Serializable {
 	/**
 	 * Add the given dialect name to the scope of dialects to which

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import org.hibernate.EntityMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
-import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -512,9 +511,7 @@ public class Component extends SimpleValue implements MetaAttributable {
 
 		@Override
 		public void registerExportables(Database database) {
-			if ( ExportableProducer.class.isInstance( subGenerator ) ) {
-				( (ExportableProducer) subGenerator ).registerExportables( database );
-			}
+			subGenerator.registerExportables( database );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.hibernate.EntityMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -512,6 +513,11 @@ public class Component extends SimpleValue implements MetaAttributable {
 		@Override
 		public void registerExportables(Database database) {
 			subGenerator.registerExportables( database );
+		}
+
+		@Override
+		public void initialize(SqlStringGenerationContext context) {
+			subGenerator.initialize( context );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.model.relational.Exportable;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
@@ -179,9 +180,12 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		return true;
 	}
 
-	public String sqlDropString(Dialect dialect, String defaultCatalog, String defaultSchema) {
+	@Override
+	public String sqlDropString(SqlStringGenerationContext context,
+			String defaultCatalog, String defaultSchema) {
+		Dialect dialect = context.getDialect();
 		if ( isGenerated( dialect ) ) {
-			final String tableName = getTable().getQualifiedName( dialect, defaultCatalog, defaultSchema );
+			final String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
 			return String.format(
 					Locale.ROOT,
 					"%s evictData constraint %s",
@@ -194,14 +198,17 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		}
 	}
 
-	public String sqlCreateString(Dialect dialect, Mapping p, String defaultCatalog, String defaultSchema) {
+	@Override
+	public String sqlCreateString(Mapping p, SqlStringGenerationContext context, String defaultCatalog,
+			String defaultSchema) {
+		Dialect dialect = context.getDialect();
 		if ( isGenerated( dialect ) ) {
 			// Certain dialects (ex: HANA) don't support FKs as expected, but other constraints can still be created.
 			// If that's the case, hasAlterTable() will be true, but getAddForeignKeyConstraintString will return
 			// empty string.  Prevent blank "alter table" statements.
-			String constraintString = sqlConstraintString( dialect, getName(), defaultCatalog, defaultSchema );
+			String constraintString = sqlConstraintString( context, getName(), defaultCatalog, defaultSchema );
 			if ( !StringHelper.isEmpty( constraintString ) ) {
-				final String tableName = getTable().getQualifiedName( dialect, defaultCatalog, defaultSchema );
+				final String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
 				return dialect.getAlterTableString( tableName ) + " " + constraintString;
 			}
 		}
@@ -213,7 +220,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 	}
 
 	public abstract String sqlConstraintString(
-			Dialect d,
+			SqlStringGenerationContext context,
 			String constraintName,
 			String defaultCatalog,
 			String defaultSchema);

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -185,7 +185,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 			String defaultCatalog, String defaultSchema) {
 		Dialect dialect = context.getDialect();
 		if ( isGenerated( dialect ) ) {
-			final String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
+			final String tableName = getTable().getQualifiedName( context );
 			return String.format(
 					Locale.ROOT,
 					"%s evictData constraint %s",
@@ -208,7 +208,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 			// empty string.  Prevent blank "alter table" statements.
 			String constraintString = sqlConstraintString( context, getName(), defaultCatalog, defaultSchema );
 			if ( !StringHelper.isEmpty( constraintString ) ) {
-				final String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
+				final String tableName = getTable().getQualifiedName( context );
 				return dialect.getAlterTableString( tableName ) + " " + constraintString;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -90,9 +90,7 @@ public class ForeignKey extends Constraint {
 						constraintName,
 						columnNames,
 						referencedTable.getQualifiedName(
-								context,
-								defaultCatalog,
-								defaultSchema
+								context
 						),
 						referencedColumnNames,
 						isReferenceToPrimaryKey()
@@ -179,7 +177,7 @@ public class ForeignKey extends Constraint {
 	public String sqlDropString(SqlStringGenerationContext context,
 			String defaultCatalog, String defaultSchema) {
 		Dialect dialect = context.getDialect();
-		String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
+		String tableName = getTable().getQualifiedName( context );
 		final StringBuilder buf = new StringBuilder( dialect.getAlterTableString( tableName ) );
 		buf.append( dialect.getDropForeignKeyString() );
 		if ( dialect.supportsIfExistsBeforeConstraintName() ) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.util.StringHelper;
 
@@ -54,11 +55,13 @@ public class ForeignKey extends Constraint {
 		}
 	}
 
+	@Override
 	public String sqlConstraintString(
-			Dialect dialect,
+			SqlStringGenerationContext context,
 			String constraintName,
 			String defaultCatalog,
 			String defaultSchema) {
+		Dialect dialect = context.getDialect();
 		String[] columnNames = new String[getColumnSpan()];
 		String[] referencedColumnNames = new String[getColumnSpan()];
 
@@ -87,7 +90,7 @@ public class ForeignKey extends Constraint {
 						constraintName,
 						columnNames,
 						referencedTable.getQualifiedName(
-								dialect,
+								context,
 								defaultCatalog,
 								defaultSchema
 						),
@@ -172,8 +175,11 @@ public class ForeignKey extends Constraint {
 		this.keyDefinition = keyDefinition;
 	}
 	
-	public String sqlDropString(Dialect dialect, String defaultCatalog, String defaultSchema) {
-		String tableName = getTable().getQualifiedName( dialect, defaultCatalog, defaultSchema );
+	@Override
+	public String sqlDropString(SqlStringGenerationContext context,
+			String defaultCatalog, String defaultSchema) {
+		Dialect dialect = context.getDialect();
+		String tableName = getTable().getQualifiedName( context, defaultCatalog, defaultSchema );
 		final StringBuilder buf = new StringBuilder( dialect.getAlterTableString( tableName ) );
 		buf.append( dialect.getDropForeignKeyString() );
 		if ( dialect.supportsIfExistsBeforeConstraintName() ) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
@@ -55,7 +55,7 @@ public class Index implements RelationalModel, Exportable, Serializable {
 			String name,
 			String defaultCatalog,
 			String defaultSchema) {
-		return buildSqlDropIndexString( name, table.getQualifiedName( context, defaultCatalog, defaultSchema ) );
+		return buildSqlDropIndexString( name, table.getQualifiedName( context ) );
 	}
 
 	public static String buildSqlDropIndexString(
@@ -76,7 +76,7 @@ public class Index implements RelationalModel, Exportable, Serializable {
 		return buildSqlCreateIndexString(
 				context.getDialect(),
 				name,
-				table.getQualifiedName( context, defaultCatalog, defaultSchema ),
+				table.getQualifiedName( context ),
 				columns,
 				columnOrderMap,
 				unique
@@ -151,7 +151,7 @@ public class Index implements RelationalModel, Exportable, Serializable {
 		Dialect dialect = context.getDialect();
 		return "drop index " +
 				StringHelper.qualify(
-						table.getQualifiedName( context, defaultCatalog, defaultSchema ),
+						table.getQualifiedName( context ),
 						getQuotedName( dialect )
 				);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Index.java
@@ -16,8 +16,8 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Exportable;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
 
@@ -32,10 +32,13 @@ public class Index implements RelationalModel, Exportable, Serializable {
 	private java.util.Map<Column, String> columnOrderMap = new HashMap<Column, String>(  );
 	private Identifier name;
 
-	public String sqlCreateString(Dialect dialect, Mapping mapping, String defaultCatalog, String defaultSchema)
+	@Override
+	public String sqlCreateString(Mapping mapping, SqlStringGenerationContext context, String defaultCatalog,
+			String defaultSchema)
 			throws HibernateException {
+		Dialect dialect = context.getDialect();
 		return buildSqlCreateIndexString(
-				dialect,
+				context,
 				getQuotedName( dialect ),
 				getTable(),
 				getColumnIterator(),
@@ -47,12 +50,12 @@ public class Index implements RelationalModel, Exportable, Serializable {
 	}
 
 	public static String buildSqlDropIndexString(
-			Dialect dialect,
+			SqlStringGenerationContext context,
 			Table table,
 			String name,
 			String defaultCatalog,
 			String defaultSchema) {
-		return buildSqlDropIndexString( name, table.getQualifiedName( dialect, defaultCatalog, defaultSchema ) );
+		return buildSqlDropIndexString( name, table.getQualifiedName( context, defaultCatalog, defaultSchema ) );
 	}
 
 	public static String buildSqlDropIndexString(
@@ -62,7 +65,7 @@ public class Index implements RelationalModel, Exportable, Serializable {
 	}
 
 	public static String buildSqlCreateIndexString(
-			Dialect dialect,
+			SqlStringGenerationContext context,
 			String name,
 			Table table,
 			Iterator<Column> columns,
@@ -71,9 +74,9 @@ public class Index implements RelationalModel, Exportable, Serializable {
 			String defaultCatalog,
 			String defaultSchema) {
 		return buildSqlCreateIndexString(
-				dialect,
+				context.getDialect(),
 				name,
-				table.getQualifiedName( dialect, defaultCatalog, defaultSchema ),
+				table.getQualifiedName( context, defaultCatalog, defaultSchema ),
 				columns,
 				columnOrderMap,
 				unique
@@ -109,42 +112,17 @@ public class Index implements RelationalModel, Exportable, Serializable {
 	}
 
 	public static String buildSqlCreateIndexString(
-			Dialect dialect,
-			String name,
-			Table table,
-			Iterator<Column> columns,
-			boolean unique,
-			String defaultCatalog,
-			String defaultSchema) {
-		return buildSqlCreateIndexString(
-				dialect,
-				name,
-				table,
-				columns,
-				Collections.EMPTY_MAP,
-				unique,
-				defaultCatalog,
-				defaultSchema
-		);
-	}
-
-	public static String buildSqlCreateIndexString(
-			Dialect dialect,
+			SqlStringGenerationContext context,
 			String name,
 			Table table,
 			Iterator<Column> columns,
 			java.util.Map<Column, String> columnOrderMap,
 			boolean unique,
 			Metadata metadata) {
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-
-		final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				table.getQualifiedTableName(),
-				dialect
-		);
+		final String tableName = context.format( table.getQualifiedTableName() );
 
 		return buildSqlCreateIndexString(
-				dialect,
+				context.getDialect(),
 				name,
 				tableName,
 				columns,
@@ -168,10 +146,12 @@ public class Index implements RelationalModel, Exportable, Serializable {
 	}
 
 	@Override
-	public String sqlDropString(Dialect dialect, String defaultCatalog, String defaultSchema) {
+	public String sqlDropString(SqlStringGenerationContext context,
+			String defaultCatalog, String defaultSchema) {
+		Dialect dialect = context.getDialect();
 		return "drop index " +
 				StringHelper.qualify(
-						table.getQualifiedName( dialect, defaultCatalog, defaultSchema ),
+						table.getQualifiedName( context, defaultCatalog, defaultSchema ),
 						getQuotedName( dialect )
 				);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
@@ -18,11 +18,21 @@ import org.hibernate.id.factory.IdentifierGeneratorFactory;
  */
 public interface KeyValue extends Value {
 
+	/**
+	 * @deprecated Use {@link #createIdentifierGenerator(IdentifierGeneratorFactory, Dialect, RootClass)}
+	 * instead.
+	 */
+	@Deprecated
 	public IdentifierGenerator createIdentifierGenerator(
 			IdentifierGeneratorFactory identifierGeneratorFactory,
 			Dialect dialect,
 			String defaultCatalog,
 			String defaultSchema,
+			RootClass rootClass) throws MappingException;
+
+	IdentifierGenerator createIdentifierGenerator(
+			IdentifierGeneratorFactory identifierGeneratorFactory,
+			Dialect dialect,
 			RootClass rootClass) throws MappingException;
 
 	public boolean isIdentityColumn(IdentifierGeneratorFactory identifierGeneratorFactory, Dialect dialect);

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
@@ -7,6 +7,7 @@
 package org.hibernate.mapping;
 import java.util.Iterator;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.util.StringHelper;
 
@@ -69,7 +70,9 @@ public class PrimaryKey extends Constraint {
 		return buf.append(')').toString();
 	}
 
-	public String sqlConstraintString(Dialect dialect, String constraintName, String defaultCatalog, String defaultSchema) {
+	@Override
+	public String sqlConstraintString(SqlStringGenerationContext context, String constraintName, String defaultCatalog, String defaultSchema) {
+		Dialect dialect = context.getDialect();
 		StringBuilder buf = new StringBuilder(
 			dialect.getAddPrimaryKeyConstraintString(constraintName)
 		).append('(');

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RelationalModel.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RelationalModel.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.mapping;
 import org.hibernate.HibernateException;
-import org.hibernate.dialect.Dialect;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.Mapping;
 
 /**
@@ -17,6 +17,6 @@ import org.hibernate.engine.spi.Mapping;
  */
 @Deprecated
 public interface RelationalModel {
-	String sqlCreateString(Dialect dialect, Mapping p, String defaultCatalog, String defaultSchema) throws HibernateException;
-	String sqlDropString(Dialect dialect, String defaultCatalog, String defaultSchema);
+	String sqlCreateString(Mapping p, SqlStringGenerationContext context, String defaultCatalog, String defaultSchema) throws HibernateException;
+	String sqlDropString(SqlStringGenerationContext context, String defaultCatalog, String defaultSchema);
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -52,13 +52,9 @@ import org.hibernate.type.descriptor.JdbcTypeNameMapper;
 import org.hibernate.type.descriptor.converter.AttributeConverterSqlTypeDescriptorAdapter;
 import org.hibernate.type.descriptor.converter.AttributeConverterTypeAdapter;
 import org.hibernate.type.descriptor.java.BasicJavaDescriptor;
-import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
-import org.hibernate.type.descriptor.spi.JdbcRecommendedSqlTypeMappingContext;
-import org.hibernate.type.descriptor.sql.JdbcTypeJavaClassMappings;
 import org.hibernate.type.descriptor.sql.LobTypeMappings;
 import org.hibernate.type.descriptor.sql.NationalizedTypeMappings;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
-import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.DynamicParameterizedType;
 
 /**
@@ -279,6 +275,14 @@ public class SimpleValue implements KeyValue {
 	@Override
 	public IdentifierGenerator createIdentifierGenerator(
 			IdentifierGeneratorFactory identifierGeneratorFactory,
+			Dialect dialect,
+			RootClass rootClass) throws MappingException {
+		return createIdentifierGenerator( identifierGeneratorFactory, dialect, null, null, rootClass );
+	}
+
+	@Override
+	public IdentifierGenerator createIdentifierGenerator(
+			IdentifierGeneratorFactory identifierGeneratorFactory,
 			Dialect dialect, 
 			String defaultCatalog, 
 			String defaultSchema, 
@@ -289,18 +293,17 @@ public class SimpleValue implements KeyValue {
 		}
 
 		Properties params = new Properties();
-		
-		//if the hibernate-mapping did not specify a schema/catalog, use the defaults
-		//specified by properties - but note that if the schema/catalog were specified
-		//in hibernate-mapping, or as params, they will already be initialized and
-		//will override the values set here (they are in identifierGeneratorProperties)
+
+		// This is for backwards compatibility only;
+		// when this method is called by Hibernate ORM, defaultSchema and defaultCatalog are always
+		// null, and defaults are handled later.
 		if ( defaultSchema!=null ) {
 			params.setProperty(PersistentIdentifierGenerator.SCHEMA, defaultSchema);
 		}
 		if ( defaultCatalog!=null ) {
 			params.setProperty(PersistentIdentifierGenerator.CATALOG, defaultCatalog);
 		}
-		
+
 		//pass the entity-name, if not a collection-id
 		if (rootClass!=null) {
 			params.setProperty( IdentifierGenerator.ENTITY_NAME, rootClass.getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
@@ -25,6 +26,7 @@ import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.env.spi.QualifiedObjectNameFormatter;
@@ -67,7 +69,7 @@ public class Table implements RelationalModel, Serializable, Exportable {
 	private boolean hasDenormalizedTables;
 	private String comment;
 
-	private List<InitCommand> initCommands;
+	private List<Function<SqlStringGenerationContext, InitCommand>> initCommandProducers;
 
 	public Table() {
 	}
@@ -897,18 +899,30 @@ public class Table implements RelationalModel, Serializable, Exportable {
 		}
 	}
 
+	/**
+	 * @deprecated Use {@link #addInitCommand(Function)} instead.
+	 */
+	@Deprecated
 	public void addInitCommand(InitCommand command) {
-		if ( initCommands == null ) {
-			initCommands = new ArrayList<>();
-		}
-		initCommands.add( command );
+		addInitCommand( ignored -> command );
 	}
 
-	public List<InitCommand> getInitCommands() {
-		if ( initCommands == null ) {
+	public void addInitCommand(Function<SqlStringGenerationContext, InitCommand> commandProducer) {
+		if ( initCommandProducers == null ) {
+			initCommandProducers = new ArrayList<>();
+		}
+		initCommandProducers.add( commandProducer );
+	}
+
+	public List<InitCommand> getInitCommands(SqlStringGenerationContext context) {
+		if ( initCommandProducers == null ) {
 			return Collections.emptyList();
 		}
 		else {
+			List<InitCommand> initCommands = new ArrayList<>();
+			for ( Function<SqlStringGenerationContext, InitCommand> producer : initCommandProducers ) {
+				initCommands.add( producer.apply( context ) );
+			}
 			return Collections.unmodifiableList( initCommands );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
@@ -9,6 +9,7 @@ package org.hibernate.mapping;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.StringHelper;
@@ -23,7 +24,7 @@ public class UniqueKey extends Constraint {
 
 	@Override
 	public String sqlConstraintString(
-			Dialect dialect,
+			SqlStringGenerationContext context,
 			String constraintName,
 			String defaultCatalog,
 			String defaultSchema) {
@@ -34,9 +35,8 @@ public class UniqueKey extends Constraint {
 
 	@Override
 	public String sqlCreateString(
-			Dialect dialect,
 			Mapping p,
-			String defaultCatalog,
+			SqlStringGenerationContext context, String defaultCatalog,
 			String defaultSchema) {
 		return null;
 //		return dialect.getUniqueDelegate().getAlterTableToAddUniqueKeyCommand(
@@ -46,8 +46,7 @@ public class UniqueKey extends Constraint {
 
 	@Override
 	public String sqlDropString(
-			Dialect dialect,
-			String defaultCatalog,
+			SqlStringGenerationContext context, String defaultCatalog,
 			String defaultSchema) {
 		return null;
 //		return dialect.getUniqueDelegate().getAlterTableToDropUniqueKeyCommand(

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -240,7 +240,6 @@ public abstract class AbstractCollectionPersister
 			PersisterCreationContext creationContext) throws MappingException, CacheException {
 
 		final Database database = creationContext.getMetadata().getDatabase();
-		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
 
 		this.factory = creationContext.getSessionFactory();
 		this.cacheAccessStrategy = cacheAccessStrategy;
@@ -272,7 +271,7 @@ public abstract class AbstractCollectionPersister
 		isArray = collectionBinding.isArray();
 		subselectLoadable = collectionBinding.isSubselectLoadable();
 
-		qualifiedTableName = determineTableName( table, jdbcEnvironment );
+		qualifiedTableName = determineTableName( table );
 
 		int spacesSize = 1 + collectionBinding.getSynchronizedTables().size();
 		spaces = new String[spacesSize];
@@ -615,15 +614,12 @@ public abstract class AbstractCollectionPersister
 		initCollectionPropertyMap();
 	}
 
-	protected String determineTableName(Table table, JdbcEnvironment jdbcEnvironment) {
+	protected String determineTableName(Table table) {
 		if ( table.getSubselect() != null ) {
 			return "( " + table.getSubselect() + " )";
 		}
 
-		return jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				table.getQualifiedTableName(),
-				jdbcEnvironment.getDialect()
-		);
+		return factory.getSqlStringGenerationContext().format( table.getQualifiedTableName() );
 	}
 
 	private class ColumnMapperImpl implements ColumnMapper {

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -454,8 +454,6 @@ public abstract class AbstractCollectionPersister
 			identifierGenerator = idColl.getIdentifier().createIdentifierGenerator(
 					creationContext.getMetadata().getIdentifierGeneratorFactory(),
 					factory.getDialect(),
-					factory.getSettings().getDefaultCatalogName(),
-					factory.getSettings().getDefaultSchemaName(),
 					null
 					);
 			identifierGenerator.initialize( creationContext.getSessionFactory().getSqlStringGenerationContext() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -459,6 +459,7 @@ public abstract class AbstractCollectionPersister
 					factory.getSettings().getDefaultSchemaName(),
 					null
 					);
+			identifierGenerator.initialize( creationContext.getSessionFactory().getSqlStringGenerationContext() );
 		}
 		else {
 			identifierType = null;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -37,6 +37,7 @@ import org.hibernate.QueryException;
 import org.hibernate.Session;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.StaleStateException;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
@@ -2957,8 +2958,8 @@ public abstract class AbstractEntityPersister
 	 *
 	 * @return The insert SQL statement string
 	 */
-	public String generateIdentityInsertString(boolean[] includeProperty) {
-		Insert insert = identityDelegate.prepareIdentifierGeneratingInsert();
+	public String generateIdentityInsertString(SqlStringGenerationContext context, boolean[] includeProperty) {
+		Insert insert = identityDelegate.prepareIdentifierGeneratingInsert( context );
 		insert.setTableName( getTableName( 0 ) );
 
 		// add normal properties except lobs
@@ -4396,7 +4397,7 @@ public abstract class AbstractEntityPersister
 			identityDelegate = ( (PostInsertIdentifierGenerator) getIdentifierGenerator() )
 					.getInsertGeneratedIdentifierDelegate( this, getFactory().getDialect(), useGetGeneratedKeys() );
 			sqlIdentityInsertString = customSQLInsert[0] == null
-					? generateIdentityInsertString( getPropertyInsertability() )
+					? generateIdentityInsertString( factory.getSqlStringGenerationContext(), getPropertyInsertability() )
 					: substituteBrackets( customSQLInsert[0] );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5045,6 +5045,14 @@ public abstract class AbstractEntityPersister
 		return entityMetamodel.getIdentifierProperty().getIdentifierGenerator();
 	}
 
+	/**
+	 * @deprecated Exposed for tests only
+	 */
+	@Deprecated
+	public InsertGeneratedIdentifierDelegate getIdentityDelegate() {
+		return identityDelegate;
+	}
+
 	public String getRootEntityName() {
 		return entityMetamodel.getRootName();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -66,7 +66,6 @@ import org.hibernate.engine.internal.MutableEntityEntryFactory;
 import org.hibernate.engine.internal.StatefulPersistenceContext;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.CachedNaturalIdValueSource;
@@ -5803,15 +5802,12 @@ public abstract class AbstractEntityPersister
 		return 0;
 	}
 
-	protected String determineTableName(Table table, JdbcEnvironment jdbcEnvironment) {
+	protected String determineTableName(Table table) {
 		if ( table.getSubselect() != null ) {
 			return "( " + table.getSubselect() + " )";
 		}
 
-		return jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				table.getQualifiedTableName(),
-				jdbcEnvironment.getDialect()
-		);
+		return factory.getSqlStringGenerationContext().format( table.getQualifiedTableName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -13,7 +13,6 @@ import org.hibernate.QueryException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
@@ -439,9 +438,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		while ( iter.hasNext() ) {
 			Property prop = (Property) iter.next();
 			String tabname = prop.getValue().getTable().getQualifiedName(
-					factory.getSqlStringGenerationContext(),
-					factory.getSettings().getDefaultCatalogName(),
-					factory.getSettings().getDefaultSchemaName()
+					factory.getSqlStringGenerationContext()
 			);
 			propertyTableNumbers[i] = getTableId( tabname, this.tableNames );
 			naturalOrderPropertyTableNumbers[i] = getTableId( tabname, naturalOrderTableNames );
@@ -461,9 +458,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			Property prop = (Property) iter.next();
 			Table tab = prop.getValue().getTable();
 			String tabname = tab.getQualifiedName(
-					factory.getSqlStringGenerationContext(),
-					factory.getSettings().getDefaultCatalogName(),
-					factory.getSettings().getDefaultSchemaName()
+					factory.getSqlStringGenerationContext()
 			);
 			Integer tabnum = getTableId( tabname, subclassTableNameClosure );
 			propTableNumbers.add( tabnum );
@@ -497,9 +492,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			notNullColumnTableNumbers = new int[subclassSpan];
 			final int id = getTableId(
 					persistentClass.getTable().getQualifiedName(
-							factory.getSqlStringGenerationContext(),
-							factory.getSettings().getDefaultCatalogName(),
-							factory.getSettings().getDefaultSchemaName()
+							factory.getSqlStringGenerationContext()
 					),
 					subclassTableNameClosure
 			);
@@ -551,9 +544,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 					discriminatorValues[k] = discriminatorValue.toString();
 					int id = getTableId(
 							sc.getTable().getQualifiedName(
-									factory.getSqlStringGenerationContext(),
-									factory.getSettings().getDefaultCatalogName(),
-									factory.getSettings().getDefaultSchemaName()
+									factory.getSqlStringGenerationContext()
 							),
 							subclassTableNameClosure
 					);
@@ -676,9 +667,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			SessionFactoryImplementor factory) {
 
 		final String tableName = persistentClass.getTable().getQualifiedName(
-				factory.getSqlStringGenerationContext(),
-				factory.getSettings().getDefaultCatalogName(),
-				factory.getSettings().getDefaultSchemaName()
+				factory.getSqlStringGenerationContext()
 		);
 
 		associateSubclassNamesToSubclassTableIndex( tableName, classNames, mapping );
@@ -687,9 +676,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		while ( itr.hasNext() ) {
 			final Join join = (Join) itr.next();
 			final String secondaryTableName = join.getTable().getQualifiedName(
-					factory.getSqlStringGenerationContext(),
-					factory.getSettings().getDefaultCatalogName(),
-					factory.getSettings().getDefaultSchemaName()
+					factory.getSqlStringGenerationContext()
 			);
 			associateSubclassNamesToSubclassTableIndex( secondaryTableName, classNames, mapping );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -136,7 +136,6 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		final SessionFactoryImplementor factory = creationContext.getSessionFactory();
 		final Database database = creationContext.getMetadata().getDatabase();
-		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
 
 		// DISCRIMINATOR
 
@@ -215,7 +214,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		while ( tItr.hasNext() ) {
 			final Table table = (Table) tItr.next();
 			final KeyValue key = (KeyValue) kItr.next();
-			final String tableName = determineTableName( table, jdbcEnvironment );
+			final String tableName = determineTableName( table );
 			tableNames.add( tableName );
 			String[] keyCols = new String[idColumnSpan];
 			String[] keyColReaders = new String[idColumnSpan];
@@ -248,7 +247,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			isInverseTable[tableIndex] = join.isInverse();
 
 			Table table = join.getTable();
-			final String tableName = determineTableName( table, jdbcEnvironment );
+			final String tableName = determineTableName( table );
 			tableNames.add( tableName );
 
 			KeyValue key = join.getKey();
@@ -294,7 +293,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			isLazies.add( Boolean.FALSE );
 			isInverses.add( Boolean.FALSE );
 			isNullables.add( Boolean.FALSE );
-			final String tableName = determineTableName( tab, jdbcEnvironment );
+			final String tableName = determineTableName( tab );
 			subclassTableNames.add( tableName );
 			String[] key = new String[idColumnSpan];
 			Iterator cItr = tab.getPrimaryKey().getColumnIterator();
@@ -316,7 +315,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			isNullables.add( join.isOptional() );
 			isLazies.add( join.isLazy() );
 
-			String joinTableName = determineTableName( joinTable, jdbcEnvironment );
+			String joinTableName = determineTableName( joinTable );
 			subclassTableNames.add( joinTableName );
 			String[] key = new String[idColumnSpan];
 			Iterator citer = joinTable.getPrimaryKey().getColumnIterator();
@@ -440,7 +439,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		while ( iter.hasNext() ) {
 			Property prop = (Property) iter.next();
 			String tabname = prop.getValue().getTable().getQualifiedName(
-					factory.getDialect(),
+					factory.getSqlStringGenerationContext(),
 					factory.getSettings().getDefaultCatalogName(),
 					factory.getSettings().getDefaultSchemaName()
 			);
@@ -462,7 +461,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			Property prop = (Property) iter.next();
 			Table tab = prop.getValue().getTable();
 			String tabname = tab.getQualifiedName(
-					factory.getDialect(),
+					factory.getSqlStringGenerationContext(),
 					factory.getSettings().getDefaultCatalogName(),
 					factory.getSettings().getDefaultSchemaName()
 			);
@@ -498,7 +497,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			notNullColumnTableNumbers = new int[subclassSpan];
 			final int id = getTableId(
 					persistentClass.getTable().getQualifiedName(
-							factory.getDialect(),
+							factory.getSqlStringGenerationContext(),
 							factory.getSettings().getDefaultCatalogName(),
 							factory.getSettings().getDefaultSchemaName()
 					),
@@ -552,7 +551,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 					discriminatorValues[k] = discriminatorValue.toString();
 					int id = getTableId(
 							sc.getTable().getQualifiedName(
-									factory.getDialect(),
+									factory.getSqlStringGenerationContext(),
 									factory.getSettings().getDefaultCatalogName(),
 									factory.getSettings().getDefaultSchemaName()
 							),
@@ -677,7 +676,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			SessionFactoryImplementor factory) {
 
 		final String tableName = persistentClass.getTable().getQualifiedName(
-				factory.getDialect(),
+				factory.getSqlStringGenerationContext(),
 				factory.getSettings().getDefaultCatalogName(),
 				factory.getSettings().getDefaultSchemaName()
 		);
@@ -688,7 +687,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		while ( itr.hasNext() ) {
 			final Join join = (Join) itr.next();
 			final String secondaryTableName = join.getTable().getQualifiedName(
-					factory.getDialect(),
+					factory.getSqlStringGenerationContext(),
 					factory.getSettings().getDefaultCatalogName(),
 					factory.getSettings().getDefaultSchemaName()
 			);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -128,7 +128,6 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		final SessionFactoryImplementor factory = creationContext.getSessionFactory();
 
 		final Database database = creationContext.getMetadata().getDatabase();
-		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
 
 		// CLASS + TABLE
 
@@ -138,7 +137,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		isNullableTable = new boolean[joinSpan];
 		keyColumnNames = new String[joinSpan][];
 		final Table table = persistentClass.getRootTable();
-		qualifiedTableNames[0] = determineTableName( table, jdbcEnvironment );
+		qualifiedTableNames[0] = determineTableName( table );
 
 		isInverseTable[0] = false;
 		isNullableTable[0] = false;
@@ -178,7 +177,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		int j = 1;
 		while ( joinIter.hasNext() ) {
 			Join join = (Join) joinIter.next();
-			qualifiedTableNames[j] = determineTableName( join.getTable(), jdbcEnvironment );
+			qualifiedTableNames[j] = determineTableName( join.getTable() );
 			isInverseTable[j] = join.isInverse();
 			isNullableTable[j] = join.isOptional();
 			cascadeDeleteEnabled[j] = join.getKey().isCascadeDeleteEnabled() &&
@@ -255,7 +254,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			isDeferreds.add( isDeferred );
 			hasDeferred |= isDeferred;
 
-			String joinTableName = determineTableName( join.getTable(), jdbcEnvironment );
+			String joinTableName = determineTableName( join.getTable() );
 			subclassTables.add( joinTableName );
 
 			Iterator iter = join.getKey().getColumnIterator();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -25,7 +25,6 @@ import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.cfg.Settings;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -367,9 +366,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 
 		if ( !model.hasSubclasses() ) {
 			return model.getTable().getQualifiedName(
-					sqlStringGenerationContext,
-					settings.getDefaultCatalogName(),
-					settings.getDefaultSchemaName()
+					sqlStringGenerationContext
 			);
 		}
 
@@ -415,9 +412,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 				buf.append( " from " )
 						.append(
 								table.getQualifiedName(
-										sqlStringGenerationContext,
-										settings.getDefaultCatalogName(),
-										settings.getDefaultSchemaName()
+										sqlStringGenerationContext
 								)
 						);
 				buf.append( " union " );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -20,6 +20,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.cfg.Settings;
@@ -85,11 +86,10 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 
 		final SessionFactoryImplementor factory = creationContext.getSessionFactory();
 		final Database database = creationContext.getMetadata().getDatabase();
-		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
 
 		// TABLE
 
-		tableName = determineTableName( persistentClass.getTable(), jdbcEnvironment );
+		tableName = determineTableName( persistentClass.getTable() );
 
 		//Custom SQL
 
@@ -168,7 +168,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		HashSet<String> subclassTables = new HashSet();
 		Iterator<Table> subclassTableIter = persistentClass.getSubclassTableClosureIterator();
 		while ( subclassTableIter.hasNext() ) {
-			subclassTables.add( determineTableName( subclassTableIter.next(), jdbcEnvironment ) );
+			subclassTables.add( determineTableName( subclassTableIter.next() ) );
 		}
 		subclassSpaces = ArrayHelper.toStringArray( subclassTables );
 
@@ -182,7 +182,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			while ( tableIter.hasNext() ) {
 				Table tab = tableIter.next();
 				if ( !tab.isAbstractUnionTable() ) {
-					final String tableName = determineTableName( tab, jdbcEnvironment );
+					final String tableName = determineTableName( tab );
 					tableNames.add( tableName );
 					String[] key = new String[idColumnSpan];
 					Iterator<Column> citer = tab.getPrimaryKey().getColumnIterator();
@@ -363,10 +363,11 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 
 		Dialect dialect = getFactory().getDialect();
 		Settings settings = getFactory().getSettings();
+		SqlStringGenerationContext sqlStringGenerationContext = getFactory().getSqlStringGenerationContext();
 
 		if ( !model.hasSubclasses() ) {
 			return model.getTable().getQualifiedName(
-					dialect,
+					sqlStringGenerationContext,
 					settings.getDefaultCatalogName(),
 					settings.getDefaultSchemaName()
 			);
@@ -414,7 +415,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 				buf.append( " from " )
 						.append(
 								table.getQualifiedName(
-										dialect,
+										sqlStringGenerationContext,
 										settings.getDefaultCatalogName(),
 										settings.getDefaultSchemaName()
 								)

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.service.ServiceRegistry;
@@ -39,16 +40,15 @@ public class DatabaseInformationImpl
 	public DatabaseInformationImpl(
 			ServiceRegistry serviceRegistry,
 			JdbcEnvironment jdbcEnvironment,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			DdlTransactionIsolator ddlTransactionIsolator,
-			Namespace.Name defaultNamespace,
 			SchemaManagementTool tool) throws SQLException {
 		this.jdbcEnvironment = jdbcEnvironment;
 		this.extractionContext = tool.getExtractionTool().createExtractionContext(
 				serviceRegistry,
 				jdbcEnvironment,
+				sqlStringGenerationContext,
 				ddlTransactionIsolator,
-				defaultNamespace.getCatalog(),
-				defaultNamespace.getSchema(),
 				this
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
@@ -32,6 +32,7 @@ import org.hibernate.tool.schema.spi.SchemaManagementTool;
 public class DatabaseInformationImpl
 		implements DatabaseInformation, ExtractionContext.DatabaseObjectAccess {
 	private final JdbcEnvironment jdbcEnvironment;
+	private final SqlStringGenerationContext sqlStringGenerationContext;
 	private final ExtractionContext extractionContext;
 	private final InformationExtractor extractor;
 
@@ -44,6 +45,7 @@ public class DatabaseInformationImpl
 			DdlTransactionIsolator ddlTransactionIsolator,
 			SchemaManagementTool tool) throws SQLException {
 		this.jdbcEnvironment = jdbcEnvironment;
+		this.sqlStringGenerationContext = sqlStringGenerationContext;
 		this.extractionContext = tool.getExtractionTool().createExtractionContext(
 				serviceRegistry,
 				jdbcEnvironment,
@@ -78,12 +80,13 @@ public class DatabaseInformationImpl
 
 	@Override
 	public boolean catalogExists(Identifier catalog) {
-		return extractor.catalogExists( catalog );
+		return extractor.catalogExists( sqlStringGenerationContext.catalogWithDefault( catalog ) );
 	}
 
 	@Override
 	public boolean schemaExists(Namespace.Name namespace) {
-		return extractor.schemaExists( namespace.getCatalog(), namespace.getSchema() );
+		return extractor.schemaExists( sqlStringGenerationContext.catalogWithDefault( namespace.getCatalog() ),
+				sqlStringGenerationContext.schemaWithDefault( namespace.getSchema() ) );
 	}
 
 	@Override
@@ -108,15 +111,16 @@ public class DatabaseInformationImpl
 		}
 
 		return extractor.getTable(
-				tableName.getCatalogName(),
-				tableName.getSchemaName(),
+				sqlStringGenerationContext.catalogWithDefault( tableName.getCatalogName() ),
+				sqlStringGenerationContext.schemaWithDefault( tableName.getSchemaName() ),
 				tableName.getTableName()
 		);
 	}
 
 	@Override
 	public NameSpaceTablesInformation getTablesInformation(Namespace namespace) {
-		return extractor.getTables( namespace.getPhysicalName().getCatalog(), namespace.getPhysicalName().getSchema() );
+		return extractor.getTables( sqlStringGenerationContext.catalogWithDefault( namespace.getPhysicalName().getCatalog() ),
+				sqlStringGenerationContext.schemaWithDefault( namespace.getPhysicalName().getSchema() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/ExtractionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/ExtractionContextImpl.java
@@ -11,6 +11,8 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.service.ServiceRegistry;
@@ -22,6 +24,7 @@ import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 public class ExtractionContextImpl implements ExtractionContext {
 	private final ServiceRegistry serviceRegistry;
 	private final JdbcEnvironment jdbcEnvironment;
+	private final SqlStringGenerationContext sqlStringGenerationContext;
 	private final JdbcConnectionAccess jdbcConnectionAccess;
 	private final DatabaseObjectAccess registeredTableAccess;
 	private final Identifier defaultCatalogName;
@@ -39,6 +42,7 @@ public class ExtractionContextImpl implements ExtractionContext {
 			Identifier defaultSchemaName) {
 		this.serviceRegistry = serviceRegistry;
 		this.jdbcEnvironment = jdbcEnvironment;
+		this.sqlStringGenerationContext = new SqlStringGenerationContextImpl( jdbcEnvironment );
 		this.jdbcConnectionAccess = jdbcConnectionAccess;
 		this.registeredTableAccess = registeredTableAccess;
 		this.defaultCatalogName = defaultCatalogName;
@@ -53,6 +57,11 @@ public class ExtractionContextImpl implements ExtractionContext {
 	@Override
 	public JdbcEnvironment getJdbcEnvironment() {
 		return jdbcEnvironment;
+	}
+
+	@Override
+	public SqlStringGenerationContext getSqlStringGenerationContext() {
+		return sqlStringGenerationContext;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/ExtractionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/ExtractionContextImpl.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
-import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.service.ServiceRegistry;
@@ -27,8 +26,6 @@ public class ExtractionContextImpl implements ExtractionContext {
 	private final SqlStringGenerationContext sqlStringGenerationContext;
 	private final JdbcConnectionAccess jdbcConnectionAccess;
 	private final DatabaseObjectAccess registeredTableAccess;
-	private final Identifier defaultCatalogName;
-	private final Identifier defaultSchemaName;
 
 	private Connection jdbcConnection;
 	private DatabaseMetaData jdbcDatabaseMetaData;
@@ -36,17 +33,14 @@ public class ExtractionContextImpl implements ExtractionContext {
 	public ExtractionContextImpl(
 			ServiceRegistry serviceRegistry,
 			JdbcEnvironment jdbcEnvironment,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			JdbcConnectionAccess jdbcConnectionAccess,
-			DatabaseObjectAccess registeredTableAccess,
-			Identifier defaultCatalogName,
-			Identifier defaultSchemaName) {
+			DatabaseObjectAccess registeredTableAccess) {
 		this.serviceRegistry = serviceRegistry;
 		this.jdbcEnvironment = jdbcEnvironment;
-		this.sqlStringGenerationContext = new SqlStringGenerationContextImpl( jdbcEnvironment );
+		this.sqlStringGenerationContext = sqlStringGenerationContext;
 		this.jdbcConnectionAccess = jdbcConnectionAccess;
 		this.registeredTableAccess = registeredTableAccess;
-		this.defaultCatalogName = defaultCatalogName;
-		this.defaultSchemaName = defaultSchemaName;
 	}
 
 	@Override
@@ -92,12 +86,12 @@ public class ExtractionContextImpl implements ExtractionContext {
 
 	@Override
 	public Identifier getDefaultCatalog() {
-		return defaultCatalogName;
+		return sqlStringGenerationContext.getDefaultCatalog();
 	}
 
 	@Override
 	public Identifier getDefaultSchema() {
-		return defaultSchemaName;
+		return sqlStringGenerationContext.getDefaultSchema();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -137,11 +137,10 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl extends AbstractInform
 		final ExtractionContext extractionContext = getExtractionContext();
 		// We use this dummy query to retrieve the table information through the ResultSetMetaData
 		// This is significantly better than to use the DatabaseMetaData especially on Oracle with synonyms enable
-		final String tableName = extractionContext.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
+		final String tableName = extractionContext.getSqlStringGenerationContext().format(
 				// The name comes from the database, so the case is correct
 				// But we quote here to avoid issues with reserved words
-				tableInformation.getName().quote(),
-				extractionContext.getJdbcEnvironment().getDialect()
+				tableInformation.getName().quote()
 		);
 
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
@@ -16,6 +16,7 @@ import org.hibernate.Incubating;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.service.ServiceRegistry;
 
@@ -30,6 +31,7 @@ import org.hibernate.service.ServiceRegistry;
 public interface ExtractionContext {
 	ServiceRegistry getServiceRegistry();
 	JdbcEnvironment getJdbcEnvironment();
+	SqlStringGenerationContext getSqlStringGenerationContext();
 	Connection getJdbcConnection();
 	DatabaseMetaData getJdbcDatabaseMetaData();
 
@@ -80,6 +82,11 @@ public interface ExtractionContext {
 
 		@Override
 		public JdbcEnvironment getJdbcEnvironment() {
+			return null;
+		}
+
+		@Override
+		public SqlStringGenerationContext getSqlStringGenerationContext() {
 			return null;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
@@ -13,7 +13,10 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
@@ -54,13 +57,18 @@ public abstract class AbstractSchemaValidator implements SchemaValidator {
 
 	@Override
 	public void doValidation(Metadata metadata, ExecutionOptions options) {
+		SqlStringGenerationContext sqlStringGenerationContext = SqlStringGenerationContextImpl.fromConfigurationMap(
+				tool.getServiceRegistry().getService( JdbcEnvironment.class ),
+				metadata.getDatabase(),
+				options.getConfigurationValues()
+		);
 		final JdbcContext jdbcContext = tool.resolveJdbcContext( options.getConfigurationValues() );
 
 		final DdlTransactionIsolator isolator = tool.getDdlTransactionIsolator( jdbcContext );
 		final DatabaseInformation databaseInformation = Helper.buildDatabaseInformation(
 				tool.getServiceRegistry(),
 				isolator,
-				metadata.getDatabase().getDefaultNamespace().getName(),
+				sqlStringGenerationContext,
 				tool
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/GroupedSchemaMigratorImpl.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.Table;
@@ -46,7 +47,9 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 			boolean tryToCreateCatalogs,
 			boolean tryToCreateSchemas,
 			Set<Identifier> exportedCatalogs,
-			Namespace namespace, GenerationTarget[] targets) {
+			Namespace namespace,
+			SqlStringGenerationContext sqlStringGenerationContext,
+			GenerationTarget[] targets) {
 		final NameSpaceTablesInformation tablesInformation =
 				new NameSpaceTablesInformation( metadata.getDatabase().getJdbcEnvironment().getIdentifierHelper() );
 
@@ -68,11 +71,12 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 					checkExportIdentifier( table, exportIdentifiers );
 					final TableInformation tableInformation = tables.getTableInformation( table );
 					if ( tableInformation == null ) {
-						createTable( table, dialect, metadata, formatter, options, targets );
+						createTable( table, dialect, metadata, formatter, options, sqlStringGenerationContext, targets );
 					}
 					else if ( tableInformation.isPhysicalTable() ) {
 						tablesInformation.addTableInformation( tableInformation );
-						migrateTable( table, tableInformation, dialect, metadata, formatter, options, targets );
+						migrateTable( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
 					}
 				}
 			}
@@ -81,8 +85,10 @@ public class GroupedSchemaMigratorImpl extends AbstractSchemaMigrator {
 				if ( schemaFilter.includeTable( table ) && table.isPhysicalTable() ) {
 					final TableInformation tableInformation = tablesInformation.getTableInformation( table );
 					if ( tableInformation == null || tableInformation.isPhysicalTable() ) {
-						applyIndexes( table, tableInformation, dialect, metadata, formatter, options, targets );
-						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options, targets );
+						applyIndexes( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
+						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
 					}
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
@@ -14,7 +14,7 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
@@ -176,15 +176,15 @@ public class Helper {
 	public static DatabaseInformation buildDatabaseInformation(
 			ServiceRegistry serviceRegistry,
 			DdlTransactionIsolator ddlTransactionIsolator,
-			Namespace.Name defaultNamespace,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			SchemaManagementTool tool) {
 		final JdbcEnvironment jdbcEnvironment = serviceRegistry.getService( JdbcEnvironment.class );
 		try {
 			return new DatabaseInformationImpl(
 					serviceRegistry,
 					jdbcEnvironment,
+					sqlStringGenerationContext,
 					ddlTransactionIsolator,
-					defaultNamespace,
 					tool
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -10,6 +10,7 @@ import java.sql.Connection;
 import java.util.Map;
 
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
@@ -375,16 +376,14 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		public ExtractionContext createExtractionContext(
 				ServiceRegistry serviceRegistry,
 				JdbcEnvironment jdbcEnvironment,
+				SqlStringGenerationContext sqlStringGenerationContext,
 				DdlTransactionIsolator ddlTransactionIsolator,
-				Identifier defaultCatalog,
-				Identifier defaultSchema,
 				ExtractionContext.DatabaseObjectAccess databaseObjectAccess) {
 			return new ImprovedExtractionContextImpl(
 					serviceRegistry,
 					jdbcEnvironment,
+					sqlStringGenerationContext,
 					ddlTransactionIsolator,
-					defaultCatalog,
-					defaultSchema,
 					databaseObjectAccess
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/IndividuallySchemaMigratorImpl.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.Table;
@@ -47,6 +48,7 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 			boolean tryToCreateSchemas,
 			Set<Identifier> exportedCatalogs,
 			Namespace namespace,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			GenerationTarget[] targets) {
 		final NameSpaceTablesInformation tablesInformation =
 				new NameSpaceTablesInformation( metadata.getDatabase().getJdbcEnvironment().getIdentifierHelper() );
@@ -68,11 +70,12 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 					checkExportIdentifier( table, exportIdentifiers );
 					final TableInformation tableInformation = existingDatabase.getTableInformation( table.getQualifiedTableName() );
 					if ( tableInformation == null ) {
-						createTable( table, dialect, metadata, formatter, options, targets );
+						createTable( table, dialect, metadata, formatter, options, sqlStringGenerationContext, targets );
 					}
 					else if ( tableInformation.isPhysicalTable() ) {
 						tablesInformation.addTableInformation( tableInformation );
-						migrateTable( table, tableInformation, dialect, metadata, formatter, options, targets );
+						migrateTable( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
 					}
 				}
 			}
@@ -81,8 +84,10 @@ public class IndividuallySchemaMigratorImpl extends AbstractSchemaMigrator {
 				if ( schemaFilter.includeTable( table ) && table.isPhysicalTable() ) {
 					final TableInformation tableInformation = tablesInformation.getTableInformation( table );
 					if ( tableInformation == null || tableInformation.isPhysicalTable() ) {
-						applyIndexes( table, tableInformation, dialect, metadata, formatter, options, targets );
-						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options, targets );
+						applyIndexes( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
+						applyUniqueKeys( table, tableInformation, dialect, metadata, formatter, options,
+								sqlStringGenerationContext, targets );
 					}
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -23,6 +23,8 @@ import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
@@ -216,6 +218,8 @@ public class SchemaCreatorImpl implements SchemaCreator {
 		}
 
 		final Database database = metadata.getDatabase();
+		SqlStringGenerationContext sqlStringGenerationContext =
+				new SqlStringGenerationContextImpl( database.getJdbcEnvironment() );
 
 		final Set<String> exportIdentifiers = new HashSet<String>( 50 );
 
@@ -265,7 +269,8 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				applySqlStrings(
 						dialect.getAuxiliaryDatabaseObjectExporter().getSqlCreateStrings(
 								auxiliaryDatabaseObject,
-								metadata
+								metadata,
+								sqlStringGenerationContext
 						),
 						formatter,
 						options,
@@ -290,7 +295,8 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				applySqlStrings(
 						dialect.getSequenceExporter().getSqlCreateStrings(
 								sequence,
-								metadata
+								metadata,
+								sqlStringGenerationContext
 						),
 //						dialect.getCreateSequenceStrings(
 //								jdbcEnvironment.getQualifiedObjectNameFormatter().format( sequence.getName(), dialect ),
@@ -313,7 +319,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 				checkExportIdentifier( table, exportIdentifiers );
 				applySqlStrings(
-						dialect.getTableExporter().getSqlCreateStrings( table, metadata ),
+						dialect.getTableExporter().getSqlCreateStrings( table, metadata, sqlStringGenerationContext ),
 						formatter,
 						options,
 						targets
@@ -334,7 +340,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 					final Index index = (Index) indexItr.next();
 					checkExportIdentifier( index, exportIdentifiers );
 					applySqlStrings(
-							dialect.getIndexExporter().getSqlCreateStrings( index, metadata ),
+							dialect.getIndexExporter().getSqlCreateStrings( index, metadata,
+									sqlStringGenerationContext
+							),
 							formatter,
 							options,
 							targets
@@ -347,7 +355,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 					final UniqueKey uniqueKey = (UniqueKey) ukItr.next();
 					checkExportIdentifier( uniqueKey, exportIdentifiers );
 					applySqlStrings(
-							dialect.getUniqueKeyExporter().getSqlCreateStrings( uniqueKey, metadata ),
+							dialect.getUniqueKeyExporter().getSqlCreateStrings( uniqueKey, metadata,
+									sqlStringGenerationContext
+							),
 							formatter,
 							options,
 							targets
@@ -373,7 +383,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				while ( fkItr.hasNext() ) {
 					final ForeignKey foreignKey = (ForeignKey) fkItr.next();
 					applySqlStrings(
-							dialect.getForeignKeyExporter().getSqlCreateStrings( foreignKey, metadata ),
+							dialect.getForeignKeyExporter().getSqlCreateStrings( foreignKey, metadata,
+									sqlStringGenerationContext
+							),
 							formatter,
 							options,
 							targets
@@ -388,7 +400,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 					&& !auxiliaryDatabaseObject.beforeTablesOnCreation() ) {
 				checkExportIdentifier( auxiliaryDatabaseObject, exportIdentifiers );
 				applySqlStrings(
-						dialect.getAuxiliaryDatabaseObjectExporter().getSqlCreateStrings( auxiliaryDatabaseObject, metadata ),
+						dialect.getAuxiliaryDatabaseObjectExporter().getSqlCreateStrings( auxiliaryDatabaseObject, metadata,
+								sqlStringGenerationContext
+						),
 						formatter,
 						options,
 						targets

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -218,8 +218,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 		}
 
 		final Database database = metadata.getDatabase();
-		SqlStringGenerationContext sqlStringGenerationContext =
-				new SqlStringGenerationContextImpl( database.getJdbcEnvironment() );
+		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
+		SqlStringGenerationContext sqlStringGenerationContext = SqlStringGenerationContextImpl.fromConfigurationMap(
+				jdbcEnvironment, database, options.getConfigurationValues() );
 
 		final Set<String> exportIdentifiers = new HashSet<String>( 50 );
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -235,7 +235,8 @@ public class SchemaCreatorImpl implements SchemaCreator {
 
 				if ( tryToCreateCatalogs ) {
 					final Identifier catalogLogicalName = namespace.getName().getCatalog();
-					final Identifier catalogPhysicalName = namespace.getPhysicalName().getCatalog();
+					final Identifier catalogPhysicalName =
+							sqlStringGenerationContext.catalogWithDefault( namespace.getPhysicalName().getCatalog() );
 
 					if ( catalogPhysicalName != null && !exportedCatalogs.contains( catalogLogicalName ) ) {
 						applySqlStrings(
@@ -248,9 +249,11 @@ public class SchemaCreatorImpl implements SchemaCreator {
 					}
 				}
 
-				if ( tryToCreateSchemas && namespace.getPhysicalName().getSchema() != null ) {
+				final Identifier schemaPhysicalName =
+						sqlStringGenerationContext.schemaWithDefault( namespace.getPhysicalName().getSchema() );
+				if ( tryToCreateSchemas && schemaPhysicalName != null ) {
 					applySqlStrings(
-							dialect.getCreateSchemaCommand( namespace.getPhysicalName().getSchema().render( dialect ) ),
+							dialect.getCreateSchemaCommand( schemaPhysicalName.render( dialect ) ),
 							formatter,
 							options,
 							targets

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -22,6 +22,8 @@ import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -187,7 +189,8 @@ public class SchemaDropperImpl implements SchemaDropper {
 			Formatter formatter,
 			GenerationTarget... targets) {
 		final Database database = metadata.getDatabase();
-		final JdbcEnvironment jdbcEnvironment = database.getJdbcEnvironment();
+		SqlStringGenerationContext sqlStringGenerationContext =
+				new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() );
 
 		boolean tryToDropCatalogs = false;
 		boolean tryToDropSchemas = false;
@@ -259,7 +262,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			}
 
 			applySqlStrings(
-					auxiliaryDatabaseObject.sqlDropStrings( jdbcEnvironment.getDialect() ),
+					auxiliaryDatabaseObject.sqlDropStrings( sqlStringGenerationContext ),
 					formatter,
 					options,
 					targets

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -189,8 +189,8 @@ public class SchemaDropperImpl implements SchemaDropper {
 			Formatter formatter,
 			GenerationTarget... targets) {
 		final Database database = metadata.getDatabase();
-		SqlStringGenerationContext sqlStringGenerationContext =
-				new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() );
+		SqlStringGenerationContext sqlStringGenerationContext = SqlStringGenerationContextImpl.fromConfigurationMap(
+				metadata.getDatabase().getJdbcEnvironment(), database, options.getConfigurationValues());
 
 		boolean tryToDropCatalogs = false;
 		boolean tryToDropSchemas = false;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -216,7 +216,9 @@ public class SchemaDropperImpl implements SchemaDropper {
 			}
 
 			applySqlStrings(
-					dialect.getAuxiliaryDatabaseObjectExporter().getSqlDropStrings( auxiliaryDatabaseObject, metadata ),
+					dialect.getAuxiliaryDatabaseObjectExporter().getSqlDropStrings( auxiliaryDatabaseObject, metadata,
+							sqlStringGenerationContext
+					),
 					formatter,
 					options,
 					targets
@@ -230,7 +232,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			}
 
 			// we need to drop all constraints/indexes prior to dropping the tables
-			applyConstraintDropping( namespace, metadata, formatter, options, targets );
+			applyConstraintDropping( namespace, metadata, formatter, options, sqlStringGenerationContext, targets );
 
 			// now it's safe to drop the tables
 			for ( Table table : namespace.getTables() ) {
@@ -241,7 +243,9 @@ public class SchemaDropperImpl implements SchemaDropper {
 					continue;
 				}
 				checkExportIdentifier( table, exportIdentifiers );
-				applySqlStrings( dialect.getTableExporter().getSqlDropStrings( table, metadata ), formatter, options,targets );
+				applySqlStrings( dialect.getTableExporter().getSqlDropStrings( table, metadata,
+						sqlStringGenerationContext
+				), formatter, options,targets );
 			}
 
 			for ( Sequence sequence : namespace.getSequences() ) {
@@ -249,7 +253,9 @@ public class SchemaDropperImpl implements SchemaDropper {
 					continue;
 				}
 				checkExportIdentifier( sequence, exportIdentifiers );
-				applySqlStrings( dialect.getSequenceExporter().getSqlDropStrings( sequence, metadata ), formatter, options, targets );
+				applySqlStrings( dialect.getSequenceExporter().getSqlDropStrings( sequence, metadata,
+						sqlStringGenerationContext
+				), formatter, options, targets );
 			}
 		}
 
@@ -313,6 +319,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			Metadata metadata,
 			Formatter formatter,
 			ExecutionOptions options,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			GenerationTarget... targets) {
 		final Dialect dialect = metadata.getDatabase().getJdbcEnvironment().getDialect();
 
@@ -332,7 +339,9 @@ public class SchemaDropperImpl implements SchemaDropper {
 			while ( fks.hasNext() ) {
 				final ForeignKey foreignKey = (ForeignKey) fks.next();
 				applySqlStrings(
-						dialect.getForeignKeyExporter().getSqlDropStrings( foreignKey, metadata ),
+						dialect.getForeignKeyExporter().getSqlDropStrings( foreignKey, metadata,
+								sqlStringGenerationContext
+						),
 						formatter,
 						options,
 						targets

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardAuxiliaryDatabaseObjectExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardAuxiliaryDatabaseObjectExporter.java
@@ -8,6 +8,7 @@ package org.hibernate.tool.schema.internal;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.tool.schema.spi.Exporter;
 
@@ -23,11 +24,11 @@ public class StandardAuxiliaryDatabaseObjectExporter implements Exporter<Auxilia
 
 	@Override
 	public String[] getSqlCreateStrings(AuxiliaryDatabaseObject object, Metadata metadata) {
-		return object.sqlCreateStrings( dialect );
+		return object.sqlCreateStrings( new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() ) );
 	}
 
 	@Override
 	public String[] getSqlDropStrings(AuxiliaryDatabaseObject object, Metadata metadata) {
-		return object.sqlDropStrings( dialect );
+		return object.sqlDropStrings( new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardAuxiliaryDatabaseObjectExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardAuxiliaryDatabaseObjectExporter.java
@@ -8,7 +8,7 @@ package org.hibernate.tool.schema.internal;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
-import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.tool.schema.spi.Exporter;
 
@@ -23,12 +23,14 @@ public class StandardAuxiliaryDatabaseObjectExporter implements Exporter<Auxilia
 	}
 
 	@Override
-	public String[] getSqlCreateStrings(AuxiliaryDatabaseObject object, Metadata metadata) {
-		return object.sqlCreateStrings( new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() ) );
+	public String[] getSqlCreateStrings(AuxiliaryDatabaseObject object, Metadata metadata,
+			SqlStringGenerationContext context) {
+		return object.sqlCreateStrings( context );
 	}
 
 	@Override
-	public String[] getSqlDropStrings(AuxiliaryDatabaseObject object, Metadata metadata) {
-		return object.sqlDropStrings( new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() ) );
+	public String[] getSqlDropStrings(AuxiliaryDatabaseObject object, Metadata metadata,
+			SqlStringGenerationContext context) {
+		return object.sqlDropStrings( context );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardForeignKeyExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardForeignKeyExporter.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.mapping.Column;
@@ -31,7 +32,7 @@ public class StandardForeignKeyExporter implements Exporter<ForeignKey> {
 	}
 
 	@Override
-	public String[] getSqlCreateStrings(ForeignKey foreignKey, Metadata metadata) {
+	public String[] getSqlCreateStrings(ForeignKey foreignKey, Metadata metadata, SqlStringGenerationContext context) {
 		if ( !dialect.hasAlterTable() ) {
 			return NO_COMMANDS;
 		}
@@ -90,15 +91,8 @@ public class StandardForeignKeyExporter implements Exporter<ForeignKey> {
 			i++;
 		}
 
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-		final String sourceTableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				foreignKey.getTable().getQualifiedTableName(),
-				dialect
-		);
-		final String targetTableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				foreignKey.getReferencedTable().getQualifiedTableName(),
-				dialect
-		);
+		final String sourceTableName = context.format( foreignKey.getTable().getQualifiedTableName() );
+		final String targetTableName = context.format( foreignKey.getReferencedTable().getQualifiedTableName() );
 
 		final StringBuilder buffer = new StringBuilder( dialect.getAlterTableString( sourceTableName ) )
 				.append(
@@ -126,7 +120,7 @@ public class StandardForeignKeyExporter implements Exporter<ForeignKey> {
 	}
 
 	@Override
-	public String[] getSqlDropStrings(ForeignKey foreignKey, Metadata metadata) {
+	public String[] getSqlDropStrings(ForeignKey foreignKey, Metadata metadata, SqlStringGenerationContext context) {
 		if ( !dialect.hasAlterTable() ) {
 			return NO_COMMANDS;
 		}
@@ -139,11 +133,7 @@ public class StandardForeignKeyExporter implements Exporter<ForeignKey> {
 			return NO_COMMANDS;
 		}
 
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-		final String sourceTableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				foreignKey.getTable().getQualifiedTableName(),
-				dialect
-		);
+		final String sourceTableName = context.format( foreignKey.getTable().getQualifiedTableName() );
 		return new String[] {
 				getSqlDropStrings( sourceTableName, foreignKey, dialect )
 		};

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardIndexExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardIndexExporter.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.QualifiedNameImpl;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.internal.util.StringHelper;
@@ -29,22 +30,18 @@ public class StandardIndexExporter implements Exporter<Index> {
 	}
 
 	@Override
-	public String[] getSqlCreateStrings(Index index, Metadata metadata) {
+	public String[] getSqlCreateStrings(Index index, Metadata metadata, SqlStringGenerationContext context) {
 		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-		final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				index.getTable().getQualifiedTableName(),
-				dialect
-		);
+		final String tableName = context.format( index.getTable().getQualifiedTableName() );
 
 		final String indexNameForCreation;
 		if ( dialect.qualifyIndexName() ) {
-			indexNameForCreation = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
+			indexNameForCreation = context.format(
 					new QualifiedNameImpl(
 							index.getTable().getQualifiedTableName().getCatalogName(),
 							index.getTable().getQualifiedTableName().getSchemaName(),
 							jdbcEnvironment.getIdentifierHelper().toIdentifier( index.getQuotedName( dialect ) )
-					),
-					jdbcEnvironment.getDialect()
+					)
 			);
 		}
 		else {
@@ -78,16 +75,12 @@ public class StandardIndexExporter implements Exporter<Index> {
 	}
 
 	@Override
-	public String[] getSqlDropStrings(Index index, Metadata metadata) {
+	public String[] getSqlDropStrings(Index index, Metadata metadata, SqlStringGenerationContext context) {
 		if ( !dialect.dropConstraints() ) {
 			return NO_COMMANDS;
 		}
 
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-		final String tableName = jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				index.getTable().getQualifiedTableName(),
-				dialect
-		);
+		final String tableName = context.format( index.getTable().getQualifiedTableName() );
 
 		final String indexNameForCreation;
 		if ( dialect.qualifyIndexName() ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardSequenceExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardSequenceExporter.java
@@ -9,8 +9,8 @@ package org.hibernate.tool.schema.internal;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.tool.schema.spi.Exporter;
 
 /**
@@ -24,26 +24,23 @@ public class StandardSequenceExporter implements Exporter<Sequence> {
 	}
 
 	@Override
-	public String[] getSqlCreateStrings(Sequence sequence, Metadata metadata) {
+	public String[] getSqlCreateStrings(Sequence sequence, Metadata metadata, SqlStringGenerationContext context) {
 		return dialect.getCreateSequenceStrings(
-				getFormattedSequenceName( sequence.getName(), metadata ),
+				getFormattedSequenceName( sequence.getName(), metadata, context ),
 				sequence.getInitialValue(),
 				sequence.getIncrementSize()
 		);
 	}
 
 	@Override
-	public String[] getSqlDropStrings(Sequence sequence, Metadata metadata) {
+	public String[] getSqlDropStrings(Sequence sequence, Metadata metadata, SqlStringGenerationContext context) {
 		return dialect.getDropSequenceStrings(
-				getFormattedSequenceName( sequence.getName(), metadata )
+				getFormattedSequenceName( sequence.getName(), metadata, context )
 		);
 	}
 
-	protected String getFormattedSequenceName(QualifiedSequenceName name, Metadata metadata) {
-		final JdbcEnvironment jdbcEnvironment = metadata.getDatabase().getJdbcEnvironment();
-		return jdbcEnvironment.getQualifiedObjectNameFormatter().format(
-				name,
-				jdbcEnvironment.getDialect()
-		);
+	protected String getFormattedSequenceName(QualifiedSequenceName name, Metadata metadata,
+			SqlStringGenerationContext context) {
+		return context.format( name );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -16,6 +16,8 @@ import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.InitCommand;
 import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.boot.model.relational.QualifiedNameParser;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.mapping.Column;
@@ -152,7 +154,9 @@ public class StandardTableExporter implements Exporter<Table> {
 
 		applyComments( table, tableName, sqlStrings );
 
-		applyInitCommands( table, sqlStrings );
+		SqlStringGenerationContext context =
+				new SqlStringGenerationContextImpl( metadata.getDatabase().getJdbcEnvironment() );
+		applyInitCommands( table, sqlStrings, context );
 
 		return sqlStrings.toArray( new String[ sqlStrings.size() ] );
 	}
@@ -173,8 +177,8 @@ public class StandardTableExporter implements Exporter<Table> {
 		}
 	}
 
-	protected void applyInitCommands(Table table, List<String> sqlStrings) {
-		for ( InitCommand initCommand : table.getInitCommands() ) {
+	protected void applyInitCommands(Table table, List<String> sqlStrings, SqlStringGenerationContext context) {
+		for ( InitCommand initCommand : table.getInitCommands( context ) ) {
 			Collections.addAll( sqlStrings, initCommand.getInitCommands() );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardUniqueKeyExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardUniqueKeyExporter.java
@@ -7,6 +7,7 @@
 package org.hibernate.tool.schema.internal;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.UniqueKey;
@@ -26,21 +27,25 @@ public class StandardUniqueKeyExporter implements Exporter<Constraint> {
 	}
 
 	@Override
-	public String[] getSqlCreateStrings(Constraint constraint, Metadata metadata) {
+	public String[] getSqlCreateStrings(Constraint constraint, Metadata metadata,
+			SqlStringGenerationContext context) {
 		return new String[] {
 				dialect.getUniqueDelegate().getAlterTableToAddUniqueKeyCommand(
 						(UniqueKey) constraint,
-						metadata
+						metadata,
+						context
 				)
 		};
 	}
 
 	@Override
-	public String[] getSqlDropStrings(Constraint constraint, Metadata metadata) {
+	public String[] getSqlDropStrings(Constraint constraint, Metadata metadata,
+			SqlStringGenerationContext context) {
 		return new String[] {
 				dialect.getUniqueDelegate().getAlterTableToDropUniqueKeyCommand(
 						(UniqueKey) constraint,
-						metadata
+						metadata,
+						context
 				)
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ImprovedExtractionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ImprovedExtractionContextImpl.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
-import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.service.ServiceRegistry;
@@ -26,8 +25,6 @@ public class ImprovedExtractionContextImpl implements ExtractionContext {
 	private final JdbcEnvironment jdbcEnvironment;
 	private final SqlStringGenerationContext sqlStringGenerationContext;
 	private final DdlTransactionIsolator ddlTransactionIsolator;
-	private final Identifier defaultCatalog;
-	private final Identifier defaultSchema;
 
 	private final DatabaseObjectAccess databaseObjectAccess;
 
@@ -36,16 +33,13 @@ public class ImprovedExtractionContextImpl implements ExtractionContext {
 	public ImprovedExtractionContextImpl(
 			ServiceRegistry serviceRegistry,
 			JdbcEnvironment jdbcEnvironment,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			DdlTransactionIsolator ddlTransactionIsolator,
-			Identifier defaultCatalog,
-			Identifier defaultSchema,
 			DatabaseObjectAccess databaseObjectAccess) {
 		this.serviceRegistry = serviceRegistry;
 		this.jdbcEnvironment = jdbcEnvironment;
-		this.sqlStringGenerationContext = new SqlStringGenerationContextImpl( jdbcEnvironment );
+		this.sqlStringGenerationContext = sqlStringGenerationContext;
 		this.ddlTransactionIsolator = ddlTransactionIsolator;
-		this.defaultCatalog = defaultCatalog;
-		this.defaultSchema = defaultSchema;
 		this.databaseObjectAccess = databaseObjectAccess;
 	}
 
@@ -87,12 +81,12 @@ public class ImprovedExtractionContextImpl implements ExtractionContext {
 
 	@Override
 	public Identifier getDefaultCatalog() {
-		return defaultCatalog;
+		return sqlStringGenerationContext.getDefaultCatalog();
 	}
 
 	@Override
 	public Identifier getDefaultSchema() {
-		return defaultSchema;
+		return sqlStringGenerationContext.getDefaultSchema();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ImprovedExtractionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/exec/ImprovedExtractionContextImpl.java
@@ -11,6 +11,8 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.service.ServiceRegistry;
@@ -22,6 +24,7 @@ import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 public class ImprovedExtractionContextImpl implements ExtractionContext {
 	private final ServiceRegistry serviceRegistry;
 	private final JdbcEnvironment jdbcEnvironment;
+	private final SqlStringGenerationContext sqlStringGenerationContext;
 	private final DdlTransactionIsolator ddlTransactionIsolator;
 	private final Identifier defaultCatalog;
 	private final Identifier defaultSchema;
@@ -39,6 +42,7 @@ public class ImprovedExtractionContextImpl implements ExtractionContext {
 			DatabaseObjectAccess databaseObjectAccess) {
 		this.serviceRegistry = serviceRegistry;
 		this.jdbcEnvironment = jdbcEnvironment;
+		this.sqlStringGenerationContext = new SqlStringGenerationContextImpl( jdbcEnvironment );
 		this.ddlTransactionIsolator = ddlTransactionIsolator;
 		this.defaultCatalog = defaultCatalog;
 		this.defaultSchema = defaultSchema;
@@ -53,6 +57,11 @@ public class ImprovedExtractionContextImpl implements ExtractionContext {
 	@Override
 	public JdbcEnvironment getJdbcEnvironment() {
 		return jdbcEnvironment;
+	}
+
+	@Override
+	public SqlStringGenerationContext getSqlStringGenerationContext() {
+		return sqlStringGenerationContext;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
@@ -9,6 +9,7 @@ package org.hibernate.tool.schema.spi;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.relational.Exportable;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 
 /**
  * Defines a contract for exporting of database objects (tables, sequences, etc) for use in SQL {@code CREATE} and

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/Exporter.java
@@ -27,12 +27,12 @@ public interface Exporter<T extends Exportable> {
 	 *
 	 * @return The commands needed for creation scripting.
 	 */
-	String[] getSqlCreateStrings(T exportable, Metadata metadata);
+	String[] getSqlCreateStrings(T exportable, Metadata metadata, SqlStringGenerationContext context);
 
 	/**
 	 * Get the commands needed for dropping.
 	 *
 	 * @return The commands needed for drop scripting.
 	 */
-	String[] getSqlDropStrings(T exportable, Metadata metadata);
+	String[] getSqlDropStrings(T exportable, Metadata metadata, SqlStringGenerationContext context);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ExtractionTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ExtractionTool.java
@@ -8,6 +8,7 @@ package org.hibernate.tool.schema.spi;
 
 import org.hibernate.Incubating;
 import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.service.ServiceRegistry;
@@ -26,9 +27,8 @@ public interface ExtractionTool {
 	ExtractionContext createExtractionContext(
 			ServiceRegistry serviceRegistry,
 			JdbcEnvironment jdbcEnvironment,
+			SqlStringGenerationContext sqlStringGenerationContext,
 			DdlTransactionIsolator ddlTransactionIsolator,
-			Identifier defaultCatalog,
-			Identifier defaultSchema,
 			ExtractionContext.DatabaseObjectAccess databaseObjectAccess);
 
 	InformationExtractor createInformationExtractor(ExtractionContext extractionContext);

--- a/hibernate-core/src/test/java/org/hibernate/id/SequenceHiLoGeneratorNoIncrementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/SequenceHiLoGeneratorNoIncrementTest.java
@@ -76,6 +76,7 @@ public class SequenceHiLoGeneratorNoIncrementTest extends BaseUnitTestCase {
 		generator.registerExportables( metadata.getDatabase() );
 
 		sessionFactory = (SessionFactoryImplementor) metadata.buildSessionFactory();
+		generator.initialize( sessionFactory.getSqlStringGenerationContext() );
 		sequenceValueExtractor = new SequenceValueExtractor( sessionFactory.getDialect(), TEST_SEQUENCE );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/id/SequenceHiLoGeneratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/SequenceHiLoGeneratorTest.java
@@ -71,6 +71,7 @@ public class SequenceHiLoGeneratorTest extends BaseUnitTestCase {
 		generator.registerExportables( metadata.getDatabase() );
 
 		sessionFactory = (SessionFactoryImplementor) metadata.buildSessionFactory();
+		generator.initialize( sessionFactory.getSqlStringGenerationContext() );
 		sequenceValueExtractor = new SequenceValueExtractor( sessionFactory.getDialect(), TEST_SEQUENCE );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/id/SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncrementSizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncrementSizeTest.java
@@ -74,6 +74,7 @@ public class SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncreme
 		generator.registerExportables( metadata.getDatabase() );
 
 		sessionFactory = (SessionFactoryImplementor) metadata.buildSessionFactory();
+		generator.initialize( sessionFactory.getSqlStringGenerationContext() );
 		sequenceValueExtractor = new SequenceValueExtractor( sessionFactory.getDialect(), TEST_SEQUENCE );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/id/enhanced/SequenceStyleConfigUnitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/id/enhanced/SequenceStyleConfigUnitTest.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import org.hibernate.MappingException;
 import org.hibernate.boot.internal.MetadataBuilderImpl;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
@@ -45,13 +46,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
 
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( NoopOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 	}
 
@@ -76,13 +78,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
 
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( TableStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( NoopOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 	}
 
@@ -103,13 +106,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
 
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( TableStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 
 		// for dialects which do support pooled sequences, we default to pooled+sequence
@@ -121,13 +125,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 	}
 
@@ -146,13 +151,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( TableStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 	}
 
@@ -169,13 +175,14 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( TableStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( NoopOptimizer.class, generator.getOptimizer().getClass() );
-			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, generator.getDatabaseStructure().getName() );
+			assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+					generator.getDatabaseStructure().getPhysicalName().render() );
 		}
 	}
 
@@ -193,9 +200,9 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			props.setProperty( SequenceStyleGenerator.INCREMENT_PARAM, "20" );
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( NoopOptimizer.class, generator.getOptimizer().getClass() );
@@ -208,9 +215,8 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			props.setProperty( SequenceStyleGenerator.INCREMENT_PARAM, "20" );
 			generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( HiLoOptimizer.class, generator.getOptimizer().getClass() );
 			assertEquals( 20, generator.getOptimizer().getIncrementSize() );
@@ -222,9 +228,8 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			props.setProperty( SequenceStyleGenerator.INCREMENT_PARAM, "20" );
 			generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 			// because the dialect reports to not support pooled seqyences, the expectation is that we will
 			// use a table for the backing structure...
 			assertClassAssignability( TableStructure.class, generator.getDatabaseStructure().getClass() );
@@ -243,27 +248,25 @@ public class SequenceStyleConfigUnitTest extends BaseUnitTestCase {
 			props.setProperty( SequenceStyleGenerator.INCREMENT_PARAM, "20" );
 			SequenceStyleGenerator generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			Database database = new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) );
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledOptimizer.class, generator.getOptimizer().getClass() );
 
 			props.setProperty( Environment.PREFER_POOLED_VALUES_LO, "true" );
 			generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledLoOptimizer.class, generator.getOptimizer().getClass() );
 
 			props.setProperty( Environment.PREFERRED_POOLED_OPTIMIZER, StandardOptimizerDescriptor.POOLED_LOTL.getExternalName() );
 			generator = new SequenceStyleGenerator();
 			generator.configure( StandardBasicTypes.LONG, props, serviceRegistry );
-			generator.registerExportables(
-					new Database( new MetadataBuilderImpl.MetadataBuildingOptionsImpl( serviceRegistry ) )
-			);
+			generator.registerExportables( database );
+			generator.initialize( SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() ) );
 			assertClassAssignability( SequenceStructure.class, generator.getDatabaseStructure().getClass() );
 			assertClassAssignability( PooledLoThreadLocalOptimizer.class, generator.getOptimizer().getClass() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/jpa/PersistenceUnitOverridesTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/jpa/PersistenceUnitOverridesTests.java
@@ -18,6 +18,7 @@ import javax.persistence.spi.PersistenceProvider;
 import javax.persistence.spi.PersistenceUnitInfo;
 import javax.sql.DataSource;
 
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.access.AccessType;
@@ -519,7 +520,8 @@ public class PersistenceUnitOverridesTests extends BaseUnitTestCase {
 				JdbcServices jdbcServices,
 				JdbcConnectionAccess connectionAccess,
 				MetadataImplementor metadata,
-				SessionFactoryOptions sessionFactoryOptions) {
+				SessionFactoryOptions sessionFactoryOptions,
+				SqlStringGenerationContext sqlStringGenerationContext) {
 
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/id/generationmappings/NewGeneratorMappingsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/id/generationmappings/NewGeneratorMappingsTest.java
@@ -66,7 +66,8 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 		IdentifierGenerator generator = persister.getIdentifierGenerator();
 		assertTrue( SequenceStyleGenerator.class.isInstance( generator ) );
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
-		assertEquals( MinimalSequenceEntity.SEQ_NAME, seqGenerator.getDatabaseStructure().getName() );
+		assertEquals( MinimalSequenceEntity.SEQ_NAME,
+				seqGenerator.getDatabaseStructure().getPhysicalName().render() );
 		// 1 is the annotation default
 		assertEquals( 1, seqGenerator.getDatabaseStructure().getInitialValue() );
 		// 50 is the annotation default
@@ -91,7 +92,8 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 		IdentifierGenerator generator = persister.getIdentifierGenerator();
 		assertTrue( SequenceStyleGenerator.class.isInstance( generator ) );
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
-		assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME, seqGenerator.getDatabaseStructure().getName() );
+		assertEquals( SequenceStyleGenerator.DEF_SEQUENCE_NAME,
+				seqGenerator.getDatabaseStructure().getPhysicalName().render() );
 		assertEquals( SequenceStyleGenerator.DEFAULT_INITIAL_VALUE, seqGenerator.getDatabaseStructure().getInitialValue() );
 		assertEquals( SequenceStyleGenerator.DEFAULT_INCREMENT_SIZE, seqGenerator.getDatabaseStructure().getIncrementSize() );
 	}
@@ -123,7 +125,7 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
 		assertEquals(
 				StringHelper.unqualifyEntityName( DedicatedSequenceEntity1.class.getName() ) + DedicatedSequenceEntity1.SEQUENCE_SUFFIX,
-				seqGenerator.getDatabaseStructure().getName()
+				seqGenerator.getDatabaseStructure().getPhysicalName().render()
 		);
 
 		// Checking second entity.
@@ -133,7 +135,7 @@ public class NewGeneratorMappingsTest extends BaseCoreFunctionalTestCase {
 		seqGenerator = (SequenceStyleGenerator) generator;
 		assertEquals(
 				DedicatedSequenceEntity2.ENTITY_NAME + DedicatedSequenceEntity1.SEQUENCE_SUFFIX,
-				seqGenerator.getDatabaseStructure().getName()
+				seqGenerator.getDatabaseStructure().getPhysicalName().render()
 		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
@@ -55,7 +55,7 @@ public class HibernateSequenceTest extends BaseCoreFunctionalTestCase {
 		Assert.assertTrue( SequenceStyleGenerator.class.isInstance( generator ) );
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
 		Assert.assertEquals(
-				Table.qualify( null, SCHEMA_NAME, SequenceStyleGenerator.DEF_SEQUENCE_NAME ),
+				SCHEMA_NAME + "." + SequenceStyleGenerator.DEF_SEQUENCE_NAME,
 				seqGenerator.getDatabaseStructure().getPhysicalName().render()
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
@@ -57,7 +56,7 @@ public class HibernateSequenceTest extends BaseCoreFunctionalTestCase {
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
 		Assert.assertEquals(
 				Table.qualify( null, SCHEMA_NAME, SequenceStyleGenerator.DEF_SEQUENCE_NAME ),
-				seqGenerator.getDatabaseStructure().getName()
+				seqGenerator.getDatabaseStructure().getPhysicalName().render()
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/id/sequences/HibernateSequenceTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.id.IdentifierGenerator;
@@ -54,9 +55,10 @@ public class HibernateSequenceTest extends BaseCoreFunctionalTestCase {
 		IdentifierGenerator generator = persister.getIdentifierGenerator();
 		Assert.assertTrue( SequenceStyleGenerator.class.isInstance( generator ) );
 		SequenceStyleGenerator seqGenerator = (SequenceStyleGenerator) generator;
+		SqlStringGenerationContext sqlStringGenerationContext = sessionFactory().getSqlStringGenerationContext();
 		Assert.assertEquals(
 				SCHEMA_NAME + "." + SequenceStyleGenerator.DEF_SEQUENCE_NAME,
-				seqGenerator.getDatabaseStructure().getPhysicalName().render()
+				sqlStringGenerationContext.format( seqGenerator.getDatabaseStructure().getPhysicalName() )
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
@@ -64,7 +64,9 @@ public class JPAXMLOverriddenAnnotationReaderTest extends BaseUnitTestCase {
 		);
 		assertNotNull( reader.getAnnotation( Table.class ) );
 		assertEquals( "@Table not overridden", "tbl_admin", reader.getAnnotation( Table.class ).name() );
-		assertEquals( "Default schema not overridden", "myschema", reader.getAnnotation( Table.class ).schema() );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
+		assertEquals( "Default schema overridden too soon", "", reader.getAnnotation( Table.class ).schema() );
 		assertEquals(
 				"Proper @Table.uniqueConstraints", 2,
 				reader.getAnnotation( Table.class ).uniqueConstraints()[0].columnNames().length
@@ -88,7 +90,9 @@ public class JPAXMLOverriddenAnnotationReaderTest extends BaseUnitTestCase {
 		assertEquals( "default fails", 50, reader.getAnnotation( SequenceGenerator.class ).allocationSize() );
 		assertNotNull( "TableOverriding not working", reader.getAnnotation( TableGenerator.class ) );
 		assertEquals( "wrong tble name", "tablehilo", reader.getAnnotation( TableGenerator.class ).table() );
-		assertEquals( "no schema overriding", "myschema", reader.getAnnotation( TableGenerator.class ).schema() );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
+		assertEquals( "Default schema overridden too soon", "", reader.getAnnotation( TableGenerator.class ).schema() );
 
 		reader = new JPAXMLOverriddenAnnotationReader( Match.class, context, bootstrapContext );
 		assertNotNull( reader.getAnnotation( Table.class ) );
@@ -98,10 +102,14 @@ public class JPAXMLOverriddenAnnotationReaderTest extends BaseUnitTestCase {
 		assertEquals(
 				"Java annotation not taken into account", "matchschema", reader.getAnnotation( Table.class ).schema()
 		);
-		assertEquals( "Overriding not taken into account", "mycatalog", reader.getAnnotation( Table.class ).catalog() );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
+		assertEquals( "Default catalog overridden too soon", "", reader.getAnnotation( Table.class ).catalog() );
 		assertNotNull( "SecondaryTable swallowed", reader.getAnnotation( SecondaryTables.class ) );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
 		assertEquals(
-				"Default schema not taken into account", "myschema",
+				"Default schema not taken into account", "",
 				reader.getAnnotation( SecondaryTables.class ).value()[0].schema()
 		);
 		assertNotNull( reader.getAnnotation( Inheritance.class ) );
@@ -194,15 +202,14 @@ public class JPAXMLOverriddenAnnotationReaderTest extends BaseUnitTestCase {
 		assertEquals(
 				"Metadata complete should ignore java annotations", "", reader.getAnnotation( Entity.class ).name()
 		);
-		assertNotNull( reader.getAnnotation( Table.class ) );
-		assertEquals( "@Table should not be used", "", reader.getAnnotation( Table.class ).name() );
-		assertEquals( "Default schema not overriden", "myschema", reader.getAnnotation( Table.class ).schema() );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
+		assertNull( "Default schema overridden too soon", reader.getAnnotation( Table.class ) );
 
 		reader = new JPAXMLOverriddenAnnotationReader( Match.class, context, bootstrapContext );
-		assertNotNull( reader.getAnnotation( Table.class ) );
-		assertEquals( "@Table should not be used", "", reader.getAnnotation( Table.class ).name() );
-		assertEquals( "Overriding not taken into account", "myschema", reader.getAnnotation( Table.class ).schema() );
-		assertEquals( "Overriding not taken into account", "mycatalog", reader.getAnnotation( Table.class ).catalog() );
+		// The default schema is assigned later, when we generate SQL.
+		// See DefaultCatalogAndSchemaTest.
+		assertNull( "Default schema overridden too soon", reader.getAnnotation( Table.class ) );
 		assertNull( "Ignore Java annotation", reader.getAnnotation( SecondaryTable.class ) );
 		assertNull( "Ignore Java annotation", reader.getAnnotation( SecondaryTables.class ) );
 		assertNull( "Ignore Java annotation", reader.getAnnotation( Inheritance.class ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -42,6 +42,9 @@ import org.hibernate.annotations.SQLUpdate;
 import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.internal.MetadataImpl;
+import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
+import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -97,38 +100,53 @@ public class DefaultCatalogAndSchemaTest {
 	private static final String CUSTOM_DELETE_SQL_PART_2 = ", {h-domain}";
 	private static final String CUSTOM_DELETE_SQL_PART_3 = " WHERE id = ?";
 
-	@Parameterized.Parameters(name = "configuredXmlMappingPath = {0}, configuredDefaultCatalog = {1}, configuredDefaultSchema = {2}")
+	enum SettingsMode {
+		// "Standard" way of providing settings, though configuration properties:
+		// both metadata and session factory receive the same settings
+		METADATA_SERVICE_REGISTRY,
+		// An alternative way of providing settings so that they are applied late,
+		// when the session factory is created.
+		// This mode is used by frameworks relying on build-time initialization of the application,
+		// like Quarkus and its "static init".
+		SESSION_FACTORY_SERVICE_REGISTRY
+	}
+
+	@Parameterized.Parameters(name = "settingsMode = {0}, configuredXmlMappingPath = {1}, configuredDefaultCatalog = {2}, configuredDefaultSchema = {3}")
 	public static List<Object[]> params() {
 		List<Object[]> params = new ArrayList<>();
-		for ( String defaultCatalog : Arrays.asList( null, "someDefaultCatalog" ) ) {
-			for ( String defaultSchema : Arrays.asList( null, "someDefaultSchema" ) ) {
-				params.add( new Object[] { null, defaultCatalog, defaultSchema,
-						// The default catalog/schema should be used when
-						// there is no implicit catalog/schema defined in the mapping.
-						defaultCatalog, defaultSchema } );
+		for ( SettingsMode mode : SettingsMode.values() ) {
+			for ( String defaultCatalog : Arrays.asList( null, "someDefaultCatalog" ) ) {
+				for ( String defaultSchema : Arrays.asList( null, "someDefaultSchema" ) ) {
+					params.add( new Object[] { mode, null, defaultCatalog, defaultSchema,
+							// The default catalog/schema should be used when
+							// there is no implicit catalog/schema defined in the mapping.
+							defaultCatalog, defaultSchema  } );
+				}
 			}
+			params.add( new Object[] { mode, "implicit-global-catalog-and-schema.orm.xml",
+					null, null,
+					"someImplicitCatalog", "someImplicitSchema"  } );
+			// HHH-14922: Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
+//			params.add( new Object[] { mode, "implicit-global-catalog-and-schema.orm.xml",
+//					"someDefaultCatalog", "someDefaultSchema",
+//					// The implicit catalog/schema defined in the mapping should take precedence
+//					// over the default catalog/schema defined in settings.
+//					"someImplicitCatalog", "someImplicitSchema"  } );
 		}
-		params.add( new Object[] { "implicit-global-catalog-and-schema.orm.xml",
-				null, null,
-				"someImplicitCatalog", "someImplicitSchema" } );
-		// HHH-14922: Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
-//		params.add( new Object[] { "implicit-global-catalog-and-schema.orm.xml",
-//				"someDefaultCatalog", "someDefaultSchema",
-//				// The implicit catalog/schema defined in the mapping should take precedence
-//				// over the default catalog/schema defined in settings.
-//				"someImplicitCatalog", "someImplicitSchema" } );
 		return params;
 	}
 
 	@Parameterized.Parameter
-	public String configuredXmlMappingPath;
+	public SettingsMode settingsMode;
 	@Parameterized.Parameter(1)
-	public String configuredDefaultCatalog;
+	public String configuredXmlMappingPath;
 	@Parameterized.Parameter(2)
-	public String configuredDefaultSchema;
+	public String configuredDefaultCatalog;
 	@Parameterized.Parameter(3)
-	public String expectedDefaultCatalog;
+	public String configuredDefaultSchema;
 	@Parameterized.Parameter(4)
+	public String expectedDefaultCatalog;
+	@Parameterized.Parameter(5)
 	public String expectedDefaultSchema;
 
 	private boolean dbSupportsCatalogs;
@@ -170,7 +188,17 @@ public class DefaultCatalogAndSchemaTest {
 				EntityWithExplicitQualifiersWithLegacySequenceGenerator.class
 		);
 
-		StandardServiceRegistry serviceRegistry = createStandardServiceRegistry( configuredDefaultCatalog, configuredDefaultSchema );
+		StandardServiceRegistry serviceRegistry;
+		switch ( settingsMode ) {
+			case METADATA_SERVICE_REGISTRY:
+				serviceRegistry = createStandardServiceRegistry( configuredDefaultCatalog, configuredDefaultSchema );
+				break;
+			case SESSION_FACTORY_SERVICE_REGISTRY:
+				serviceRegistry = createStandardServiceRegistry( null, null );
+				break;
+			default:
+				throw new IllegalStateException( "Unknown settings mode: " + settingsMode );
+		}
 
 		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.orm.xml" ) );
@@ -185,7 +213,19 @@ public class DefaultCatalogAndSchemaTest {
 		final MetadataBuilder metadataBuilder = metadataSources.getMetadataBuilder();
 		metadata = (MetadataImplementor) metadataBuilder.build();
 
-		SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+		SessionFactoryBuilder sfb;
+		switch ( settingsMode ) {
+			case METADATA_SERVICE_REGISTRY:
+				sfb = metadata.getSessionFactoryBuilder();
+				break;
+			case SESSION_FACTORY_SERVICE_REGISTRY:
+				serviceRegistry = createStandardServiceRegistry( configuredDefaultCatalog, configuredDefaultSchema );
+				sfb = new SessionFactoryBuilderImpl( metadata, new SessionFactoryOptionsBuilder( serviceRegistry,
+						((MetadataImpl) metadata).getBootstrapContext() ) );
+				break;
+			default:
+				throw new IllegalStateException( "Unknown settings mode: " + settingsMode );
+		}
 
 		sessionFactory = (SessionFactoryImplementor) sfb.build();
 		toClose.add( sessionFactory );

--- a/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -1,0 +1,1190 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.boot.database.qualfiedTableNaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.persistence.Basic;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
+
+import org.hibernate.MappingException;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLInsert;
+import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.SQLServer2012Dialect;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.hql.spi.id.global.GlobalTemporaryTableBulkIdStrategy;
+import org.hibernate.hql.spi.id.local.LocalTemporaryTableBulkIdStrategy;
+import org.hibernate.id.IdentifierGenerator;
+import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.exec.ScriptTargetOutputToWriter;
+import org.hibernate.tool.schema.spi.DelayedDropRegistryNotAvailableImpl;
+import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
+import org.hibernate.tool.schema.spi.ScriptTargetOutput;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
+
+import org.hibernate.testing.AfterClassOnce;
+import org.hibernate.testing.BeforeClassOnce;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(CustomParameterized.class)
+@TestForIssue(jiraKey = "HHH-14921")
+public class DefaultCatalogAndSchemaTest {
+
+	private static final String SQL_QUOTE_CHARACTER_CLASS = "([`\"]|\\[|\\])";
+
+	private static final String EXPLICIT_CATALOG = "someExplicitCatalog";
+	private static final String EXPLICIT_SCHEMA = "someExplicitSchema";
+
+	// Yes this is invalid SQL, and in most cases it simply wouldn't work because of missing columns,
+	// but in this case we don't care: we just want to check catalog/schema substitution.
+	private static final String CUSTOM_INSERT_SQL_PART_1 = "insert into {h-catalog}{h-schema}";
+	private static final String CUSTOM_INSERT_SQL_PART_2 = ", {h-domain}";
+	private static final String CUSTOM_INSERT_SQL_PART_3 = " VALUES(basic = ?)";
+	private static final String CUSTOM_UPDATE_SQL_PART_1 = "update {h-catalog}{h-schema}";
+	private static final String CUSTOM_UPDATE_SQL_PART_2 = ", {h-domain}";
+	private static final String CUSTOM_UPDATE_SQL_PART_3 = " SET basic = ?";
+	private static final String CUSTOM_DELETE_SQL_PART_1 = "delete from {h-catalog}{h-schema}";
+	private static final String CUSTOM_DELETE_SQL_PART_2 = ", {h-domain}";
+	private static final String CUSTOM_DELETE_SQL_PART_3 = " WHERE id = ?";
+
+	@Parameterized.Parameters(name = "configuredXmlMappingPath = {0}, configuredDefaultCatalog = {1}, configuredDefaultSchema = {2}")
+	public static List<Object[]> params() {
+		List<Object[]> params = new ArrayList<>();
+		for ( String defaultCatalog : Arrays.asList( null, "someDefaultCatalog" ) ) {
+			for ( String defaultSchema : Arrays.asList( null, "someDefaultSchema" ) ) {
+				params.add( new Object[] { null, defaultCatalog, defaultSchema,
+						// The default catalog/schema should be used when
+						// there is no implicit catalog/schema defined in the mapping.
+						defaultCatalog, defaultSchema } );
+			}
+		}
+		params.add( new Object[] { "implicit-global-catalog-and-schema.orm.xml",
+				null, null,
+				"someImplicitCatalog", "someImplicitSchema" } );
+		// HHH-14922: Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
+//		params.add( new Object[] { "implicit-global-catalog-and-schema.orm.xml",
+//				"someDefaultCatalog", "someDefaultSchema",
+//				// The implicit catalog/schema defined in the mapping should take precedence
+//				// over the default catalog/schema defined in settings.
+//				"someImplicitCatalog", "someImplicitSchema" } );
+		return params;
+	}
+
+	@Parameterized.Parameter
+	public String configuredXmlMappingPath;
+	@Parameterized.Parameter(1)
+	public String configuredDefaultCatalog;
+	@Parameterized.Parameter(2)
+	public String configuredDefaultSchema;
+	@Parameterized.Parameter(3)
+	public String expectedDefaultCatalog;
+	@Parameterized.Parameter(4)
+	public String expectedDefaultSchema;
+
+	private boolean dbSupportsCatalogs;
+	private boolean dbSupportsSchemas;
+
+	private MetadataImplementor metadata;
+	private final List<AutoCloseable> toClose = new ArrayList<>();
+	private SessionFactoryImplementor sessionFactory;
+
+	@BeforeClassOnce
+	public void initSessionFactory() {
+		List<Class<?>> annotatedClasses = Arrays.asList(
+				EntityWithDefaultQualifiers.class,
+				EntityWithExplicitQualifiers.class,
+				EntityWithJoinedInheritanceWithDefaultQualifiers.class,
+				EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.class,
+				EntityWithJoinedInheritanceWithExplicitQualifiers.class,
+				EntityWithJoinedInheritanceWithExplicitQualifiersSubclass.class,
+				EntityWithTablePerClassInheritanceWithDefaultQualifiers.class,
+				EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass.class,
+				EntityWithTablePerClassInheritanceWithExplicitQualifiers.class,
+				EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass.class,
+				EntityWithDefaultQualifiersWithCustomSql.class,
+				EntityWithDefaultQualifiersWithIdentityGenerator.class,
+				EntityWithExplicitQualifiersWithIdentityGenerator.class,
+				EntityWithDefaultQualifiersWithTableGenerator.class,
+				EntityWithExplicitQualifiersWithTableGenerator.class,
+				EntityWithDefaultQualifiersWithSequenceGenerator.class,
+				EntityWithExplicitQualifiersWithSequenceGenerator.class,
+				EntityWithDefaultQualifiersWithSeqHiLoGenerator.class,
+				EntityWithExplicitQualifiersWithSeqHiLoGenerator.class,
+				EntityWithDefaultQualifiersWithIncrementGenerator.class,
+				EntityWithExplicitQualifiersWithIncrementGenerator.class,
+				EntityWithDefaultQualifiersWithSequenceIdentityGenerator.class,
+				EntityWithExplicitQualifiersWithSequenceIdentityGenerator.class,
+				EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.class,
+				EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.class,
+				EntityWithDefaultQualifiersWithLegacySequenceGenerator.class,
+				EntityWithExplicitQualifiersWithLegacySequenceGenerator.class
+		);
+
+		StandardServiceRegistry serviceRegistry = createStandardServiceRegistry( configuredDefaultCatalog, configuredDefaultSchema );
+
+		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.orm.xml" ) );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.hbm.xml" ) );
+		if ( configuredXmlMappingPath != null ) {
+			metadataSources.addInputStream( getClass().getResourceAsStream( configuredXmlMappingPath ) );
+		}
+		for ( Class<?> annotatedClass : annotatedClasses ) {
+			metadataSources.addAnnotatedClass( annotatedClass );
+		}
+
+		final MetadataBuilder metadataBuilder = metadataSources.getMetadataBuilder();
+		metadata = (MetadataImplementor) metadataBuilder.build();
+
+		SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+
+		sessionFactory = (SessionFactoryImplementor) sfb.build();
+		toClose.add( sessionFactory );
+
+		NameQualifierSupport nameQualifierSupport = sessionFactory.getJdbcServices().getJdbcEnvironment()
+				.getNameQualifierSupport();
+		dbSupportsCatalogs = nameQualifierSupport.supportsCatalogs();
+		dbSupportsSchemas = nameQualifierSupport.supportsSchemas();
+	}
+
+	@AfterClassOnce
+	public void cleanup() throws Throwable {
+		Throwable thrown = null;
+		Collections.reverse( toClose );
+		for ( AutoCloseable closeable : toClose ) {
+			try {
+				closeable.close();
+			}
+			catch (Throwable t) {
+				if ( thrown == null ) {
+					thrown = t;
+				}
+				else {
+					thrown.addSuppressed( t );
+				}
+			}
+		}
+		if ( thrown != null ) {
+			throw thrown;
+		}
+	}
+
+	private StandardServiceRegistry createStandardServiceRegistry(String defaultCatalog, String defaultSchema) {
+		final BootstrapServiceRegistryBuilder bsrb = new BootstrapServiceRegistryBuilder();
+		bsrb.applyClassLoader( getClass().getClassLoader() );
+		// by default we do not share the BootstrapServiceRegistry nor the StandardServiceRegistry,
+		// so we want the BootstrapServiceRegistry to be automatically closed when the
+		// StandardServiceRegistry is closed.
+		bsrb.enableAutoClose();
+
+		final BootstrapServiceRegistry bsr = bsrb.build();
+
+		final Map<String, Object> settings = new HashMap<>();
+		settings.put( GlobalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		settings.put( LocalTemporaryTableBulkIdStrategy.DROP_ID_TABLES, "true" );
+		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
+			settings.put(
+					AvailableSettings.CONNECTION_PROVIDER,
+					SharedDriverManagerConnectionProviderImpl.getInstance()
+			);
+		}
+		if ( defaultCatalog != null ) {
+			settings.put( AvailableSettings.DEFAULT_CATALOG, defaultCatalog );
+		}
+		if ( defaultSchema != null ) {
+			settings.put( AvailableSettings.DEFAULT_SCHEMA, defaultSchema );
+		}
+
+		final StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder( bsr );
+		ssrb.applySettings( settings );
+		StandardServiceRegistry registry = ssrb.build();
+		toClose.add( registry );
+		return registry;
+	}
+
+	@Test
+	public void createSchema_fromSessionFactory() {
+		String script = generateScriptFromSessionFactory( "create" );
+		verifyDDLQualifiers( script );
+	}
+
+	@Test
+	public void dropSchema_fromSessionFactory() {
+		String script = generateScriptFromSessionFactory( "drop" );
+		verifyDDLQualifiers( script );
+	}
+
+	@Test
+	public void createSchema_fromMetadata() {
+		String script = generateScriptFromMetadata( SchemaExport.Action.CREATE );
+		verifyDDLQualifiers( script );
+	}
+
+	@Test
+	public void dropSchema_fromMetadata() {
+		String script = generateScriptFromMetadata( SchemaExport.Action.DROP );
+		verifyDDLQualifiers( script );
+	}
+
+	@Test
+	public void entityPersister() {
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiers.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiers.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithOrmXmlImplicitFileLevelQualifiers.class, expectedImplicitFileLevelQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithHbmXmlImplicitFileLevelQualifiers.class, expectedImplicitFileLevelQualifier() );
+
+		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithDefaultQualifiers.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithExplicitQualifiers.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithExplicitQualifiersSubclass.class, expectedExplicitQualifier() );
+
+		verifyEntityPersisterQualifiers( EntityWithTablePerClassInheritanceWithDefaultQualifiers.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithTablePerClassInheritanceWithExplicitQualifiers.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass.class, expectedExplicitQualifier() );
+
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithCustomSql.class, expectedDefaultQualifier() );
+
+
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithIdentityGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithIdentityGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithTableGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithTableGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithSequenceGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithSequenceGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithSeqHiLoGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithSeqHiLoGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithIncrementGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithIncrementGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithSequenceIdentityGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithSequenceIdentityGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.class, expectedExplicitQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithDefaultQualifiersWithLegacySequenceGenerator.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiersWithLegacySequenceGenerator.class, expectedExplicitQualifier() );
+	}
+
+	private void verifyEntityPersisterQualifiers(Class<?> entityClass, ExpectedQualifier expectedQualifier) {
+		// The hbm.xml mapping unfortunately sets the native entity name on top of the JPA entity name,
+		// so many methods that allow retrieving the entity persister or entity metamodel from the entity class no longer work,
+		// because these methods generally assume the native entity name is the FQCN.
+		// Thus we use custom code.
+		AbstractEntityPersister persister = (AbstractEntityPersister) sessionFactory.getMetamodel().entityPersisters()
+				.values().stream()
+				.filter( p -> p.getMappedClass().equals( entityClass ) )
+				.findFirst()
+				.orElseThrow( () -> new IllegalStateException( "Cannot find persister for " + entityClass ) );
+		String jpaEntityName = sessionFactory.getMetamodel().getEntities().stream()
+				.filter( p -> p.getBindableJavaType().equals( entityClass ) )
+				.findFirst()
+				.orElseThrow( () -> new IllegalStateException( "Cannot find entity metamodel for " + entityClass ) )
+				.getName();
+
+		// Table names are what's used for Query, in particular.
+		verifyOnlyQualifier( persister.getTableName(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+		// Here, to simplify assertions, we assume all derived entity types have:
+		// - an entity name prefixed with the name of their super entity type
+		// - the same explicit catalog and schema, if any, as their super entity type
+		verifyOnlyQualifier( persister.getTableNames(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+
+		// This will include SQL generated by ID generators in some cases, which will be validated here
+		// because ID generators table/sequence names are prefixed with the owning entity name.
+		verifyOnlyQualifier( persister.getSQLInsertStrings(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+		if ( persister.isIdentifierAssignedByInsert() ) {
+			verifyOnlyQualifier( persister.getSQLIdentityInsertString(), SqlType.RUNTIME,
+					jpaEntityName, expectedQualifier );
+		}
+		try {
+			verifyOnlyQualifierOptional( persister.getIdentitySelectString(), SqlType.RUNTIME,
+					jpaEntityName, expectedQualifier );
+		}
+		catch (MappingException e) {
+			if ( e.getMessage().contains( "does not support identity key generation" ) ) {
+				// For some reason Oracle12cIdentityColumnSupport#supportsInsertSelectIdentity() returns true,
+				// but getIdentitySelectString is not implemented, resulting in runtime exceptions.
+				// Whatever, we'll just ignore this for now.
+			}
+			else {
+				throw e;
+			}
+		}
+
+		verifyOnlyQualifier( persister.getSQLUpdateStrings(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+		verifyOnlyQualifier( persister.getSQLLazyUpdateStrings(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+
+		verifyOnlyQualifier( persister.getSQLDeleteStrings(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+
+		verifyOnlyQualifier( persister.getSQLSnapshotSelectString(), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+
+		// This is used in the "select" id generator in particular.
+		verifyOnlyQualifierOptional( persister.getSelectByUniqueKeyString( "basic" ), SqlType.RUNTIME,
+				jpaEntityName, expectedQualifier );
+	}
+
+	@Test
+	public void tableGenerator() {
+		org.hibernate.id.enhanced.TableGenerator generator = idGenerator(
+				org.hibernate.id.enhanced.TableGenerator.class,
+						EntityWithDefaultQualifiersWithTableGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithTableGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.enhanced.TableGenerator.class,
+				EntityWithExplicitQualifiersWithTableGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithTableGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void enhancedTableGenerator() {
+		org.hibernate.id.enhanced.TableGenerator generator = idGenerator(
+				org.hibernate.id.enhanced.TableGenerator.class,
+				EntityWithDefaultQualifiersWithTableGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithTableGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.enhanced.TableGenerator.class,
+				EntityWithExplicitQualifiersWithTableGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithTableGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void sequenceGenerator() {
+		org.hibernate.id.enhanced.SequenceStyleGenerator generator = idGenerator(
+				org.hibernate.id.enhanced.SequenceStyleGenerator.class,
+				EntityWithDefaultQualifiersWithSequenceGenerator.class );
+		verifyOnlyQualifier( generator.getDatabaseStructure().getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithSequenceGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.enhanced.SequenceStyleGenerator.class,
+				EntityWithExplicitQualifiersWithSequenceGenerator.class );
+		verifyOnlyQualifier( generator.getDatabaseStructure().getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithSequenceGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void enhancedSequenceGenerator() {
+		org.hibernate.id.enhanced.SequenceStyleGenerator generator = idGenerator(
+				org.hibernate.id.enhanced.SequenceStyleGenerator.class,
+				EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.class );
+		verifyOnlyQualifier( generator.getDatabaseStructure().getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.enhanced.SequenceStyleGenerator.class,
+				EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.class );
+		verifyOnlyQualifier( generator.getDatabaseStructure().getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void legacySequenceGenerator() {
+		org.hibernate.id.SequenceGenerator generator = idGenerator( org.hibernate.id.SequenceGenerator.class,
+				EntityWithDefaultQualifiersWithLegacySequenceGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithLegacySequenceGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.SequenceGenerator.class,
+				EntityWithExplicitQualifiersWithLegacySequenceGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithLegacySequenceGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void seqHiLoGenerator() {
+		org.hibernate.id.SequenceHiLoGenerator generator = idGenerator( org.hibernate.id.SequenceHiLoGenerator.class,
+				EntityWithDefaultQualifiersWithSeqHiLoGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithSeqHiLoGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.SequenceHiLoGenerator.class,
+				EntityWithExplicitQualifiersWithSeqHiLoGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithSeqHiLoGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void incrementGenerator() {
+		org.hibernate.id.IncrementGenerator generator = idGenerator( org.hibernate.id.IncrementGenerator.class,
+				EntityWithDefaultQualifiersWithIncrementGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithIncrementGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.IncrementGenerator.class,
+				EntityWithExplicitQualifiersWithIncrementGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithIncrementGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	@Test
+	public void sequenceIdentityGenerator() {
+		org.hibernate.id.SequenceIdentityGenerator generator = idGenerator( org.hibernate.id.SequenceIdentityGenerator.class,
+				EntityWithDefaultQualifiersWithSequenceIdentityGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithDefaultQualifiersWithSequenceIdentityGenerator.NAME, expectedDefaultQualifier() );
+
+		generator = idGenerator( org.hibernate.id.SequenceIdentityGenerator.class,
+				EntityWithExplicitQualifiersWithSequenceIdentityGenerator.class );
+		verifyOnlyQualifier( generator.getAllSqlForTests(), SqlType.RUNTIME,
+				EntityWithExplicitQualifiersWithSequenceIdentityGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	private <T extends IdentifierGenerator> T idGenerator(Class<T> expectedType, Class<?> entityClass) {
+		AbstractEntityPersister persister = (AbstractEntityPersister)
+				sessionFactory.getMetamodel().entityPersister( entityClass );
+		return expectedType.cast( persister.getIdentifierGenerator() );
+	}
+
+	private void verifyDDLQualifiers(String sql) {
+		// Here, to simplify assertions, we assume:
+		// - that all entity types have a table name identical to the entity name
+		// - that all association tables have a name prefixed with the name of their owning entity type
+		// - that all association tables have the same explicit catalog and schema, if any, as their owning entity type
+		// - that all ID generator tables/sequences have a name prefixed with the name of their owning entity type
+
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiers.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiers.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithOrmXmlImplicitFileLevelQualifiers.NAME, expectedImplicitFileLevelQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithHbmXmlImplicitFileLevelQualifiers.NAME, expectedImplicitFileLevelQualifier() );
+
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithDefaultQualifiers.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithExplicitQualifiers.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithExplicitQualifiersSubclass.NAME, expectedExplicitQualifier() );
+
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithTablePerClassInheritanceWithDefaultQualifiers.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithTablePerClassInheritanceWithExplicitQualifiers.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass.NAME, expectedExplicitQualifier() );
+
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithCustomSql.NAME, expectedDefaultQualifier() );
+
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithIdentityGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithIdentityGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithTableGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithTableGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithSequenceGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithSequenceGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithSeqHiLoGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithSeqHiLoGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithIncrementGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithIncrementGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithSequenceIdentityGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithSequenceIdentityGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.NAME, expectedExplicitQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithLegacySequenceGenerator.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithLegacySequenceGenerator.NAME, expectedExplicitQualifier() );
+	}
+
+	private enum SqlType {
+		DDL,
+		RUNTIME
+	}
+
+	private void verifyOnlyQualifier(String[] sql, SqlType sqlType, String name, ExpectedQualifier expectedQualifier) {
+		verifyOnlyQualifier( String.join( "\n", sql ), sqlType, name, expectedQualifier );
+	}
+
+	private void verifyOnlyQualifierOptional(String sql, SqlType sqlType, String name, ExpectedQualifier expectedQualifier) {
+		verifyOnlyQualifier( sql, sqlType, name, expectedQualifier, true );
+	}
+
+	private void verifyOnlyQualifier(String sql, SqlType sqlType, String name, ExpectedQualifier expectedQualifier) {
+		verifyOnlyQualifier( sql, sqlType, name, expectedQualifier, false );
+	}
+
+	private void verifyOnlyQualifier(String sql, SqlType sqlType, String name, ExpectedQualifier expectedQualifier, boolean optional) {
+		String patternStringForTableName = SQL_QUOTE_CHARACTER_CLASS + "?" + Pattern.quote( name ) + "(?!\\w*_seq)" + SQL_QUOTE_CHARACTER_CLASS + "?";
+		String patternStringForSequenceName = SQL_QUOTE_CHARACTER_CLASS + "?" + Pattern.quote( name ) + "\\w*_seq" + SQL_QUOTE_CHARACTER_CLASS + "?";
+
+		ExpectedQualifier expectedQualifierForTables = expectedQualifier;
+		ExpectedQualifier expectedQualifierForSequences;
+		if ( SqlType.DDL == sqlType && sessionFactory.getJdbcServices().getDialect() instanceof SQLServer2012Dialect ) {
+			// SQL Server does not allow the catalog in the sequence name when creating the sequence,
+			// so we need different patterns for sequence names and table names.
+			// See org.hibernate.dialect.SQLServer2012Dialect.SqlServerSequenceExporter.getFormattedSequenceName
+			expectedQualifierForSequences = new ExpectedQualifier( null, expectedQualifier.schema );
+		}
+		else {
+			expectedQualifierForSequences = expectedQualifier;
+		}
+
+		if ( !optional ) {
+			// Check that we find the name at least once with the proper qualifier, be it a table or a sequence.
+			// While not strictly necessary, this ensures our patterns are not completely wrong.
+			assertThat( sql )
+					.containsPattern(
+							"(" + expectedQualifierForTables.patternStringForNameWithThisQualifier( patternStringForTableName )
+									+ ")|("
+									+ expectedQualifierForSequences.patternStringForNameWithThisQualifier( patternStringForSequenceName )
+									+ ")" );
+		}
+
+		// Check that we don't find any name with an incorrect qualifier
+		assertThat( sql.split( System.getProperty( "line.separator" ) ) )
+				.allSatisfy( line -> assertThat( line )
+						.doesNotContainPattern( expectedQualifierForTables
+								.patternStringForNameWithDifferentQualifier( patternStringForTableName ) )
+						.doesNotContainPattern( expectedQualifierForSequences
+								.patternStringForNameWithDifferentQualifier( patternStringForSequenceName ) ) );
+	}
+
+	private ExpectedQualifier expectedDefaultQualifier() {
+		return expectedQualifier( expectedDefaultCatalog, expectedDefaultSchema );
+	}
+
+	private ExpectedQualifier expectedExplicitQualifier() {
+		return expectedQualifier( EXPLICIT_CATALOG, EXPLICIT_SCHEMA );
+	}
+
+	private ExpectedQualifier expectedImplicitFileLevelQualifier() {
+		return expectedQualifier( "someImplicitFileLevelCatalog", "someImplicitFileLevelSchema" );
+	}
+
+	private ExpectedQualifier expectedQualifier(String catalog, String schema) {
+		return new ExpectedQualifier(
+				dbSupportsCatalogs ? catalog : null,
+				dbSupportsSchemas ? schema : null
+		);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private String generateScriptFromSessionFactory(String action) {
+		ServiceRegistryImplementor serviceRegistry = sessionFactory.getServiceRegistry();
+		Map<String, Object> settings = new HashMap<>(
+				serviceRegistry.getService( ConfigurationService.class ).getSettings()
+		);
+		StringWriter writer = new StringWriter();
+		settings.put( AvailableSettings.HBM2DDL_SCRIPTS_ACTION, action );
+		settings.put( AvailableSettings.HBM2DDL_SCRIPTS_CREATE_TARGET, writer );
+		settings.put( AvailableSettings.HBM2DDL_SCRIPTS_DROP_TARGET, writer );
+
+		SchemaManagementToolCoordinator.process(
+				metadata, serviceRegistry, settings, DelayedDropRegistryNotAvailableImpl.INSTANCE );
+		return writer.toString();
+	}
+
+	// This is precisely how scripts are generated for the Quarkus DevUI
+	// Don't change this code except to match changes in
+	// https://github.com/quarkusio/quarkus/blob/d07ecb23bfba38ee48868635e155c4b513ce6af9/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/devconsole/HibernateOrmDevConsoleInfoSupplier.java#L61-L92
+	private String generateScriptFromMetadata(SchemaExport.Action action) {
+		ServiceRegistryImplementor sessionFactoryServiceRegistry = sessionFactory.getServiceRegistry();
+		SchemaExport schemaExport = new SchemaExport();
+		schemaExport.setFormat( true );
+		schemaExport.setDelimiter( ";" );
+		StringWriter writer = new StringWriter();
+		schemaExport.doExecution( action, false, metadata, sessionFactoryServiceRegistry,
+				new TargetDescriptor() {
+					@Override
+					public EnumSet<TargetType> getTargetTypes() {
+						return EnumSet.of( TargetType.SCRIPT );
+					}
+
+					@Override
+					public ScriptTargetOutput getScriptTargetOutput() {
+						return new ScriptTargetOutputToWriter( writer ) {
+							@Override
+							public void accept(String command) {
+								super.accept( command );
+							}
+						};
+					}
+				}
+		);
+		return writer.toString();
+	}
+
+	private static class ExpectedQualifier {
+		private final String catalog;
+		private final String schema;
+
+		private ExpectedQualifier(String catalog, String schema) {
+			this.catalog = catalog;
+			this.schema = schema;
+		}
+
+		String patternStringForNameWithThisQualifier(String patternStringForName) {
+			if ( catalog == null && schema == null ) {
+				// Look for unqualified names
+				return "(?<!\\.)" + patternStringForName;
+			}
+			else {
+				// Look for a qualified name with this exact qualifier
+				return "(?<!\\.)" + patternStringForQualifier() + patternStringForName;
+			}
+		}
+
+		String patternStringForNameWithDifferentQualifier(String patternStringForName) {
+			if ( catalog == null && schema == null ) {
+				// Look for a qualified name with any qualifier
+				return "\\." + patternStringForName;
+			}
+			else {
+				// Look for a qualified name with a different qualifier
+				// ignoring content of string literals (preceded with a single-quote)
+				return "(?<!" + patternStringForQualifier() + "|')" + patternStringForName;
+			}
+		}
+
+		private String patternStringForQualifier() {
+			return ( catalog != null ? Pattern.quote( catalog + "." ) : "" )
+					+ ( schema != null ? Pattern.quote( schema + "." ) : "" );
+		}
+	}
+
+	@Entity(name = EntityWithDefaultQualifiers.NAME)
+	public static class EntityWithDefaultQualifiers {
+		public static final String NAME = "EntityWithDefaultQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiers.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiers {
+		public static final String NAME = "EntityWithExplicitQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	public static class EntityWithOrmXmlImplicitFileLevelQualifiers {
+		public static final String NAME = "EntityWithOrmXmlImplicitFileLevelQualifiers";
+		private Long id;
+		private String basic;
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		private List<String> elementCollection;
+	}
+
+	public static class EntityWithHbmXmlImplicitFileLevelQualifiers {
+		public static final String NAME = "EntityWithHbmXmlImplicitFileLevelQualifiers";
+		private Long id;
+		private String basic;
+	}
+
+	@Entity(name = EntityWithJoinedInheritanceWithDefaultQualifiers.NAME)
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class EntityWithJoinedInheritanceWithDefaultQualifiers {
+		public static final String NAME = "EntityWithJoinedInheritanceWithDefaultQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.NAME)
+	public static class EntityWithJoinedInheritanceWithDefaultQualifiersSubclass
+			extends EntityWithJoinedInheritanceWithDefaultQualifiers {
+		public static final String NAME = "EntityWithJoinedInheritanceWithDefaultQualifiersSubclass";
+		@Basic
+		private String basic2;
+	}
+
+	@Entity(name = EntityWithJoinedInheritanceWithExplicitQualifiers.NAME)
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithJoinedInheritanceWithExplicitQualifiers {
+		public static final String NAME = "EntityWithJoinedInheritanceWithExplicitQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithJoinedInheritanceWithExplicitQualifiersSubclass.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithJoinedInheritanceWithExplicitQualifiersSubclass
+			extends EntityWithJoinedInheritanceWithExplicitQualifiers {
+		public static final String NAME = "EntityWithJoinedInheritanceWithExplicitQualifiersSubclass";
+		@Basic
+		private String basic2;
+	}
+
+	@Entity(name = EntityWithTablePerClassInheritanceWithDefaultQualifiers.NAME)
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static class EntityWithTablePerClassInheritanceWithDefaultQualifiers {
+		public static final String NAME = "EntityWithTablePerClassInheritanceWithDefaultQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass.NAME)
+	public static class EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass
+			extends EntityWithTablePerClassInheritanceWithDefaultQualifiers {
+		public static final String NAME = "EntityWithTablePerClassInheritanceWithDefaultQualifiersSubclass";
+		@Basic
+		private String basic2;
+	}
+
+	@Entity(name = EntityWithTablePerClassInheritanceWithExplicitQualifiers.NAME)
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithTablePerClassInheritanceWithExplicitQualifiers {
+		public static final String NAME = "EntityWithTablePerClassInheritanceWithExplicitQualifiers";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection", catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA,
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass
+			extends EntityWithTablePerClassInheritanceWithExplicitQualifiers {
+		public static final String NAME = "EntityWithTablePerClassInheritanceWithExplicitQualifiersSubclass";
+		@Basic
+		private String basic2;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithCustomSql.NAME)
+	@SQLInsert(sql = CUSTOM_INSERT_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_INSERT_SQL_PART_2
+			+ EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_INSERT_SQL_PART_3)
+	@SQLUpdate(sql = CUSTOM_UPDATE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_UPDATE_SQL_PART_2
+			+ EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_UPDATE_SQL_PART_3)
+	@SQLDelete(sql = CUSTOM_DELETE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_DELETE_SQL_PART_2
+			+ EntityWithDefaultQualifiersWithCustomSql.NAME + CUSTOM_DELETE_SQL_PART_3)
+	public static class EntityWithDefaultQualifiersWithCustomSql {
+		public static final String NAME = "EntityWithDefaultQualifiersWithCustomSql";
+		@Id
+		private Long id;
+		@Basic
+		private String basic;
+		@OneToMany
+		@JoinTable(name = NAME + "_oneToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_oneToMany"))
+		@SQLInsert(sql = CUSTOM_INSERT_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_INSERT_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_INSERT_SQL_PART_3)
+		@SQLUpdate(sql = CUSTOM_UPDATE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_UPDATE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_UPDATE_SQL_PART_3)
+		@SQLDelete(sql = CUSTOM_DELETE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_DELETE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_oneToMany" + CUSTOM_DELETE_SQL_PART_3)
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		@OneToMany
+		@JoinTable(name = NAME + "_manyToMany",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				inverseJoinColumns = @JoinColumn(name = "inverse"),
+				foreignKey = @ForeignKey(name = "FK_manyToMany"))
+		@SQLInsert(sql = CUSTOM_INSERT_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_INSERT_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_INSERT_SQL_PART_3)
+		@SQLUpdate(sql = CUSTOM_UPDATE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_UPDATE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_UPDATE_SQL_PART_3)
+		@SQLDelete(sql = CUSTOM_DELETE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_DELETE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_manyToMany" + CUSTOM_DELETE_SQL_PART_3)
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		@ElementCollection
+		@JoinTable(name = NAME + "_elementCollection",
+				// Custom names to avoid false positive in assertions
+				joinColumns = @JoinColumn(name = "forward"),
+				foreignKey = @ForeignKey(name = "FK_elementCollection"))
+		@SQLInsert(sql = CUSTOM_INSERT_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_INSERT_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_INSERT_SQL_PART_3)
+		@SQLUpdate(sql = CUSTOM_UPDATE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_UPDATE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_UPDATE_SQL_PART_3)
+		@SQLDelete(sql = CUSTOM_DELETE_SQL_PART_1 + EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_DELETE_SQL_PART_2
+				+ EntityWithDefaultQualifiersWithCustomSql.NAME + "_elementCollection" + CUSTOM_DELETE_SQL_PART_3)
+		private List<String> elementCollection;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithIdentityGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithIdentityGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithIdentityGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithIdentityGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithIdentityGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithIdentityGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithSequenceGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithSequenceGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithSequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@SequenceGenerator(name = NAME + "_generator", sequenceName = NAME + "_seq")
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithSequenceGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithSequenceGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithSequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@SequenceGenerator(name = NAME + "_generator", sequenceName = NAME + "_seq",
+				catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+
+	@Entity(name = EntityWithDefaultQualifiersWithTableGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithTableGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithTableGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@TableGenerator(name = NAME + "_generator", table = NAME + "_tableseq")
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithTableGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithTableGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithTableGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@TableGenerator(name = NAME + "_generator", table = NAME + "_tableseq",
+				catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithSeqHiLoGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithSeqHiLoGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithSeqHiLoGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "org.hibernate.id.SequenceHiLoGenerator", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq"),
+				@Parameter(name = "max_lo", value = "5")
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithSeqHiLoGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithSeqHiLoGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithSeqHiLoGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "org.hibernate.id.SequenceHiLoGenerator", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq"),
+				@Parameter(name = "max_lo", value = "5"),
+				@Parameter(name = "catalog", value = EXPLICIT_CATALOG),
+				@Parameter(name = "schema", value = EXPLICIT_SCHEMA)
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithIncrementGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithIncrementGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithIncrementGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "increment")
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithIncrementGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithIncrementGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithIncrementGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "increment", parameters = {
+				@Parameter(name = "catalog", value = EXPLICIT_CATALOG),
+				@Parameter(name = "schema", value = EXPLICIT_SCHEMA)
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithSequenceIdentityGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithSequenceIdentityGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithSequenceIdentityGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "sequence-identity", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq")
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithSequenceIdentityGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithSequenceIdentityGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithSequenceIdentityGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "sequence-identity", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq"),
+				@Parameter(name = "catalog", value = EXPLICIT_CATALOG),
+				@Parameter(name = "schema", value = EXPLICIT_SCHEMA)
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithEnhancedSequenceGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithEnhancedSequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "enhanced-sequence", parameters = {
+				@Parameter(name = "sequence_name", value = NAME + "_seq")
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithEnhancedSequenceGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithEnhancedSequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "enhanced-sequence", parameters = {
+				@Parameter(name = "sequence_name", value = NAME + "_seq"),
+				@Parameter(name = "catalog", value = EXPLICIT_CATALOG),
+				@Parameter(name = "schema", value = EXPLICIT_SCHEMA)
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+
+	@Entity(name = EntityWithDefaultQualifiersWithLegacySequenceGenerator.NAME)
+	public static class EntityWithDefaultQualifiersWithLegacySequenceGenerator {
+		public static final String NAME = "EntityWithDefaultQualifiersWithLegacySequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "org.hibernate.id.SequenceGenerator", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq")
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+	@Entity(name = EntityWithExplicitQualifiersWithLegacySequenceGenerator.NAME)
+	@Table(catalog = EXPLICIT_CATALOG, schema = EXPLICIT_SCHEMA)
+	public static class EntityWithExplicitQualifiersWithLegacySequenceGenerator {
+		public static final String NAME = "EntityWithExplicitQualifiersWithLegacySequenceGenerator";
+		@Id
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = NAME + "_generator")
+		@GenericGenerator(name = NAME + "_generator", strategy = "org.hibernate.id.SequenceGenerator", parameters = {
+				@Parameter(name = "sequence", value = NAME + "_seq"),
+				@Parameter(name = "catalog", value = EXPLICIT_CATALOG),
+				@Parameter(name = "schema", value = EXPLICIT_SCHEMA)
+		})
+		private Long id;
+		@Basic
+		private String basic;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -80,7 +80,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(CustomParameterized.class)
-@TestForIssue(jiraKey = "HHH-14921")
+@TestForIssue(jiraKey = { "HHH-14921", "HHH-14922" })
 public class DefaultCatalogAndSchemaTest {
 
 	private static final String SQL_QUOTE_CHARACTER_CLASS = "([`\"]|\\[|\\])";
@@ -127,11 +127,11 @@ public class DefaultCatalogAndSchemaTest {
 					null, null,
 					"someImplicitCatalog", "someImplicitSchema"  } );
 			// HHH-14922: Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
-//			params.add( new Object[] { mode, "implicit-global-catalog-and-schema.orm.xml",
-//					"someDefaultCatalog", "someDefaultSchema",
-//					// The implicit catalog/schema defined in the mapping should take precedence
-//					// over the default catalog/schema defined in settings.
-//					"someImplicitCatalog", "someImplicitSchema"  } );
+			params.add( new Object[] { mode, "implicit-global-catalog-and-schema.orm.xml",
+					"someDefaultCatalog", "someDefaultSchema",
+					// The implicit catalog/schema defined in the mapping should take precedence
+					// over the default catalog/schema defined in settings.
+					"someImplicitCatalog", "someImplicitSchema"  } );
 		}
 		return params;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -129,9 +129,9 @@ public class DefaultCatalogAndSchemaTest {
 			// HHH-14922: Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
 			params.add( new Object[] { mode, "implicit-global-catalog-and-schema.orm.xml",
 					"someDefaultCatalog", "someDefaultSchema",
-					// The implicit catalog/schema defined in the mapping should take precedence
-					// over the default catalog/schema defined in settings.
-					"someImplicitCatalog", "someImplicitSchema"  } );
+					// The default catalog/schema should replace the
+					// implicit catalog/schema defined in the mapping.
+					"someDefaultCatalog", "someDefaultSchema"  } );
 		}
 		return params;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/hbm/uk/UniqueDelegateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hbm/uk/UniqueDelegateTest.java
@@ -8,6 +8,7 @@ package org.hibernate.test.hbm.uk;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
@@ -103,29 +104,33 @@ public class UniqueDelegateTest extends BaseUnitTestCase {
 		}
 
 		@Override
-		public String getColumnDefinitionUniquenessFragment(Column column) {
+		public String getColumnDefinitionUniquenessFragment(Column column,
+				SqlStringGenerationContext context) {
 			getColumnDefinitionUniquenessFragmentCallCount++;
-			return super.getColumnDefinitionUniquenessFragment( column );
+			return super.getColumnDefinitionUniquenessFragment( column, context );
 		}
 
 		@Override
-		public String getTableCreationUniqueConstraintsFragment(Table table) {
+		public String getTableCreationUniqueConstraintsFragment(Table table,
+				SqlStringGenerationContext context) {
 			getTableCreationUniqueConstraintsFragmentCallCount++;
-			return super.getTableCreationUniqueConstraintsFragment( table );
+			return super.getTableCreationUniqueConstraintsFragment( table, context );
 		}
 
 		@Override
 		public String getAlterTableToAddUniqueKeyCommand(
-				UniqueKey uniqueKey, Metadata metadata) {
+				UniqueKey uniqueKey, Metadata metadata,
+				SqlStringGenerationContext context) {
 			getAlterTableToAddUniqueKeyCommandCallCount++;
-			return super.getAlterTableToAddUniqueKeyCommand( uniqueKey, metadata );
+			return super.getAlterTableToAddUniqueKeyCommand( uniqueKey, metadata, context );
 		}
 
 		@Override
 		public String getAlterTableToDropUniqueKeyCommand(
-				UniqueKey uniqueKey, Metadata metadata) {
+				UniqueKey uniqueKey, Metadata metadata,
+				SqlStringGenerationContext context) {
 			getAlterTableToDropUniqueKeyCommandCallCount++;
-			return super.getAlterTableToDropUniqueKeyCommand( uniqueKey, metadata );
+			return super.getAlterTableToDropUniqueKeyCommand( uniqueKey, metadata, context );
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/auto/NewGeneratorsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/auto/NewGeneratorsTests.java
@@ -70,9 +70,9 @@ public class NewGeneratorsTests extends BaseUnitTestCase {
 		final DatabaseStructure databaseStructure = generator.getDatabaseStructure();
 
 		// HHH-14491 - what we want to happen
-		assertThat( databaseStructure.getName(), is( "Entity1_SEQ" ) );
+		assertThat( databaseStructure.getPhysicalName().render(), is( "Entity1_SEQ" ) );
 		// or this depending on the discussion (Jira) about using entity name v. table name as the base
-		assertThat( databaseStructure.getName(), is( "tbl_1_SEQ" ) );
+		assertThat( databaseStructure.getPhysicalName().render(), is( "tbl_1_SEQ" ) );
 
 		// HHH-14491 - this is what we want to have happen
 		assertThat( databaseStructure.getIncrementSize(), is( 50 ) );

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/sequence/BasicSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/sequence/BasicSequenceTest.java
@@ -64,7 +64,8 @@ public class BasicSequenceTest extends BaseCoreFunctionalTestCase {
 		EntityPersister persister = sessionFactory().getEntityPersister( overriddenEntityName );
 		assertClassAssignability( SequenceStyleGenerator.class, persister.getIdentifierGenerator().getClass() );
 		SequenceStyleGenerator generator = (SequenceStyleGenerator) persister.getIdentifierGenerator();
-		assertEquals( overriddenEntityName + SequenceStyleGenerator.DEF_SEQUENCE_SUFFIX, generator.getDatabaseStructure().getName() );
+		assertEquals( overriddenEntityName + SequenceStyleGenerator.DEF_SEQUENCE_SUFFIX,
+				generator.getDatabaseStructure().getPhysicalName().getObjectName().getText() );
 
 		Session s = openSession();
 		s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/sequence/HiLoSequenceMismatchStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/sequence/HiLoSequenceMismatchStrategyTest.java
@@ -16,6 +16,7 @@ import javax.persistence.Id;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.boot.model.relational.QualifiedName;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
@@ -93,8 +94,8 @@ public class HiLoSequenceMismatchStrategyTest extends BaseCoreFunctionalTestCase
 		SequenceStyleGenerator generator = (SequenceStyleGenerator) persister.getIdentifierGenerator();
 		assertClassAssignability( HiLoOptimizer.class, generator.getOptimizer().getClass() );
 
-		String sequenceName = generator.getDatabaseStructure().getName();
-		Assert.assertEquals( this.sequenceName, sequenceName );
+		QualifiedName sequenceName = generator.getDatabaseStructure().getPhysicalName();
+		Assert.assertEquals( this.sequenceName, sequenceName.render() );
 
 		int incrementSize = generator.getOptimizer().getIncrementSize();
 		Assert.assertNotEquals( 1, incrementSize );

--- a/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/Db2GenerationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/idgen/enhanced/table/Db2GenerationTest.java
@@ -10,6 +10,9 @@ import java.util.Properties;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
@@ -52,8 +55,13 @@ public class Db2GenerationTest extends BaseUnitTestCase {
 
 			assertEquals( 1, metadata.getDatabase().getDefaultNamespace().getTables().size() );
 
-			final Table table = metadata.getDatabase().getDefaultNamespace().getTables().iterator().next();
-			final String[] createCommands = new DB2Dialect().getTableExporter().getSqlCreateStrings( table, metadata );
+			Database database = metadata.getDatabase();
+			final Table table = database.getDefaultNamespace().getTables().iterator().next();
+			SqlStringGenerationContext sqlStringGenerationContext =
+					SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
+			final String[] createCommands = new DB2Dialect().getTableExporter().getSqlCreateStrings( table, metadata,
+					sqlStringGenerationContext
+			);
 			assertContains( "sequence_name varchar(255) not null", createCommands[0] );
 		}
 		finally {
@@ -88,8 +96,13 @@ public class Db2GenerationTest extends BaseUnitTestCase {
 
 			assertEquals( 1, metadata.getDatabase().getDefaultNamespace().getTables().size() );
 
-			final Table table = metadata.getDatabase().getDefaultNamespace().getTables().iterator().next();
-			final String[] createCommands = new DB2Dialect().getTableExporter().getSqlCreateStrings( table, metadata );
+			Database database = metadata.getDatabase();
+			final Table table = database.getDefaultNamespace().getTables().iterator().next();
+			SqlStringGenerationContext sqlStringGenerationContext =
+					SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
+			final String[] createCommands = new DB2Dialect().getTableExporter().getSqlCreateStrings( table, metadata,
+					sqlStringGenerationContext
+			);
 			assertContains( "sequence_name varchar(255) not null", createCommands[0] );
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/GeneratedValueTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/jpa/compliance/tck2_2/GeneratedValueTests.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
@@ -61,13 +62,13 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final SequenceStyleGenerator sequenceStyleGenerator = assertTyping(
 					SequenceStyleGenerator.class,
 					generator
 			);
-
-			assertThat( sequenceStyleGenerator.getDatabaseStructure().getName(), is( "my_real_db_sequence" ) );
+			assertThat( sequenceStyleGenerator.getDatabaseStructure().getPhysicalName().render(), is( "my_real_db_sequence" ) );
 
 			// all the JPA defaults since they were not defined
 			assertThat( sequenceStyleGenerator.getDatabaseStructure().getInitialValue(), is( 100 ) );
@@ -91,6 +92,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final SequenceStyleGenerator sequenceStyleGenerator = assertTyping(
 					SequenceStyleGenerator.class,
@@ -99,7 +101,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 
 			// PREFER_GENERATOR_NAME_AS_DEFAULT_SEQUENCE_NAME == false indicates that the legacy
 			// 		default (hibernate_sequence) should be used
-			assertThat( sequenceStyleGenerator.getDatabaseStructure().getName(), is( "hibernate_sequence" ) );
+			assertThat( sequenceStyleGenerator.getDatabaseStructure().getPhysicalName().render(), is( "hibernate_sequence" ) );
 
 			// the JPA defaults since they were not defined
 			assertThat( sequenceStyleGenerator.getDatabaseStructure().getInitialValue(), is( 1 ) );
@@ -121,6 +123,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final SequenceStyleGenerator sequenceStyleGenerator = assertTyping(
 					SequenceStyleGenerator.class,
@@ -129,7 +132,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 
 			// PREFER_GENERATOR_NAME_AS_DEFAULT_SEQUENCE_NAME == true (the default) indicates that the generator-name
 			//		should be used as the default instead.
-			assertThat( sequenceStyleGenerator.getDatabaseStructure().getName(), is( "my_db_sequence" ) );
+			assertThat( sequenceStyleGenerator.getDatabaseStructure().getPhysicalName().render(), is( "my_db_sequence" ) );
 
 			// the JPA defaults since they were not defined
 			assertThat( sequenceStyleGenerator.getDatabaseStructure().getInitialValue(), is( 1 ) );
@@ -153,10 +156,11 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 				null,
 				(RootClass) entityMapping
 		);
+		generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 		final SequenceStyleGenerator sequenceStyleGenerator = assertTyping( SequenceStyleGenerator.class, generator );
 		// all the JPA defaults since they were not defined
-		assertThat( sequenceStyleGenerator.getDatabaseStructure().getName(), is( SequenceStyleGenerator.DEF_SEQUENCE_NAME ) );
+		assertThat( sequenceStyleGenerator.getDatabaseStructure().getPhysicalName().render(), is( SequenceStyleGenerator.DEF_SEQUENCE_NAME ) );
 		assertThat( sequenceStyleGenerator.getDatabaseStructure().getInitialValue(), is( 100 ) );
 		assertThat( sequenceStyleGenerator.getDatabaseStructure().getIncrementSize(), is( 500 ) );
 	}
@@ -177,13 +181,14 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final SequenceStyleGenerator sequenceStyleGenerator = assertTyping(
 					SequenceStyleGenerator.class,
 					generator
 			);
 			// all the JPA defaults since they were not defined
-			assertThat( sequenceStyleGenerator.getDatabaseStructure().getName(), is( "my_db_sequence" ) );
+			assertThat( sequenceStyleGenerator.getDatabaseStructure().getPhysicalName().render(), is( "my_db_sequence" ) );
 			assertThat( sequenceStyleGenerator.getDatabaseStructure().getInitialValue(), is( 100 ) );
 			assertThat( sequenceStyleGenerator.getDatabaseStructure().getIncrementSize(), is( 500 ) );
 
@@ -215,6 +220,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final TableGenerator tableGenerator = assertTyping( TableGenerator.class, generator );
 
@@ -240,6 +246,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final TableGenerator tableGenerator = assertTyping( TableGenerator.class, generator );
 
@@ -265,6 +272,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			final TableGenerator tableGenerator = assertTyping( TableGenerator.class, generator );
 
@@ -292,6 +300,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			assertTyping( IncrementGenerator.class, generator );
 		}
@@ -311,6 +320,7 @@ public class GeneratedValueTests extends BaseUnitTestCase {
 					null,
 					(RootClass) entityMapping
 			);
+			generator.initialize( SqlStringGenerationContextImpl.forTests( bootModel.getDatabase().getJdbcEnvironment() ) );
 
 			assertTyping( IncrementGenerator.class, generator );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/schematools/TestExtraPhysicalTableTypes.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schematools/TestExtraPhysicalTableTypes.java
@@ -11,13 +11,14 @@ import java.sql.SQLException;
 
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.extract.internal.DatabaseInformationImpl;
@@ -25,7 +26,6 @@ import org.hibernate.tool.schema.extract.internal.ExtractionContextImpl;
 import org.hibernate.tool.schema.extract.internal.InformationExtractorJdbcDatabaseMetaDataImpl;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
-import org.hibernate.tool.schema.internal.exec.ImprovedExtractionContextImpl;
 import org.hibernate.tool.schema.internal.exec.JdbcContext;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
 
@@ -121,21 +121,23 @@ public class TestExtraPhysicalTableTypes {
 			throws SQLException {
 		Database database = metadata.getDatabase();
 
+		SqlStringGenerationContext sqlStringGenerationContext =
+				SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
+
 		DatabaseInformation dbInfo = new DatabaseInformationImpl(
 				ssr,
 				database.getJdbcEnvironment(),
+				sqlStringGenerationContext,
 				ddlTransactionIsolator,
-				database.getDefaultNamespace().getName(),
 				database.getServiceRegistry().getService( SchemaManagementTool.class )
 		);
 
 		ExtractionContextImpl extractionContext = new ExtractionContextImpl(
 				ssr,
 				database.getJdbcEnvironment(),
+				sqlStringGenerationContext,
 				ssr.getService( JdbcServices.class ).getBootstrapJdbcConnectionAccess(),
-				(ExtractionContext.DatabaseObjectAccess) dbInfo,
-				database.getDefaultNamespace().getPhysicalName().getCatalog(),
-				database.getDefaultNamespace().getPhysicalName().getSchema()
+				(ExtractionContext.DatabaseObjectAccess) dbInfo
 
 		);
 		return new InformationExtractorJdbcDatabaseMetaDataImplTest(

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateTableBackedSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateTableBackedSequenceTest.java
@@ -16,6 +16,8 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
@@ -34,7 +36,6 @@ import org.hibernate.tool.schema.spi.TargetDescriptor;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -77,7 +78,8 @@ public class SchemaUpdateTableBackedSequenceTest extends BaseUnitTestCase {
 		// lets make sure the InitCommand is there
 		assertEquals( 1, database.getDefaultNamespace().getTables().size() );
 		Table table = database.getDefaultNamespace().getTables().iterator().next();
-		assertEquals( 1, table.getInitCommands().size() );
+		SqlStringGenerationContext context = SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
+		assertEquals( 1, table.getInitCommands( context ).size() );
 
 		final TargetImpl target = new TargetImpl();
 

--- a/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateTableBackedSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/schemaupdate/SchemaUpdateTableBackedSequenceTest.java
@@ -78,7 +78,7 @@ public class SchemaUpdateTableBackedSequenceTest extends BaseUnitTestCase {
 		// lets make sure the InitCommand is there
 		assertEquals( 1, database.getDefaultNamespace().getTables().size() );
 		Table table = database.getDefaultNamespace().getTables().iterator().next();
-		SqlStringGenerationContext context = SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
+		SqlStringGenerationContext context = SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment(), null, null );
 		assertEquals( 1, table.getInitCommands( context ).size() );
 
 		final TargetImpl target = new TargetImpl();

--- a/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tool/schema/internal/CheckForExistingForeignKeyTest.java
@@ -12,6 +12,7 @@ import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.Namespace.Name;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.internal.Formatter;
@@ -53,10 +54,14 @@ public class CheckForExistingForeignKeyTest {
 		 * Needed implementation. Not used in test.
 		 */
 		@Override
-		protected NameSpaceTablesInformation performTablesMigration(Metadata metadata, DatabaseInformation existingDatabase, ExecutionOptions options,
+		protected NameSpaceTablesInformation performTablesMigration(Metadata metadata,
+				DatabaseInformation existingDatabase, ExecutionOptions options,
 				Dialect dialect,
-				Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs, boolean tryToCreateSchemas,
-				Set<Identifier> exportedCatalogs, Namespace namespace, GenerationTarget[] targets) {
+				Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs,
+				boolean tryToCreateSchemas,
+				Set<Identifier> exportedCatalogs, Namespace namespace,
+				SqlStringGenerationContext sqlStringGenerationContext,
+				GenerationTarget[] targets) {
 			return null;
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/tool/schema/internal/AbstractSchemaMigratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/tool/schema/internal/AbstractSchemaMigratorTest.java
@@ -14,6 +14,7 @@ import org.hibernate.boot.model.TruthValue;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.testing.TestForIssue;
@@ -44,7 +45,12 @@ public class AbstractSchemaMigratorTest {
     public void testForeignKeyPreExistenceDetectionIgnoresCaseForTableAndColumnName() {
         final AbstractSchemaMigrator schemaMigrator = new AbstractSchemaMigrator(null, null) {
             @Override
-            protected NameSpaceTablesInformation performTablesMigration(Metadata metadata, DatabaseInformation existingDatabase, ExecutionOptions options, Dialect dialect, Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs, boolean tryToCreateSchemas, Set<Identifier> exportedCatalogs, Namespace namespace, GenerationTarget[] targets) { return null; }
+            protected NameSpaceTablesInformation performTablesMigration(Metadata metadata,
+					DatabaseInformation existingDatabase, ExecutionOptions options, Dialect dialect,
+					Formatter formatter, Set<String> exportIdentifiers, boolean tryToCreateCatalogs,
+					boolean tryToCreateSchemas, Set<Identifier> exportedCatalogs, Namespace namespace,
+					SqlStringGenerationContext sqlStringGenerationContext,
+					GenerationTarget[] targets) { return null; }
         };
 
         final TableInformation existingTableInformation = mock(TableInformation.class);

--- a/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.test.boot.database.qualfiedTableNaming"
+				   catalog="someImplicitFileLevelCatalog" schema="someImplicitFileLevelSchema" default-access="field">
+	<class name="DefaultCatalogAndSchemaTest$EntityWithHbmXmlImplicitFileLevelQualifiers" entity-name="EntityWithHbmXmlImplicitFileLevelQualifiers">
+		<id name="id" />
+		<property name="basic" />
+	</class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.orm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
+                 http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+				 version="2.1">
+	<package>org.hibernate.test.boot.database.qualfiedTableNaming</package>
+	<schema>someImplicitFileLevelSchema</schema>
+	<catalog>someImplicitFileLevelCatalog</catalog>
+	<entity class="DefaultCatalogAndSchemaTest$EntityWithOrmXmlImplicitFileLevelQualifiers" name="EntityWithOrmXmlImplicitFileLevelQualifiers"
+			access="FIELD">
+		<attributes>
+			<id name="id"/>
+			<basic name="basic"/>
+			<one-to-many name="oneToMany">
+				<join-table name="EntityWithOrmXmlImplicitFileLevelQualifiers_oneToMany">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_oneToMany" />
+					<inverse-join-column name="inverse" />
+				</join-table>
+			</one-to-many>
+			<many-to-many name="manyToMany">
+				<join-table name="EntityWithOrmXmlImplicitFileLevelQualifiers_manyToMany">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_oneToMany" />
+					<inverse-join-column name="inverse" />
+				</join-table>
+			</many-to-many>
+			<element-collection name="elementCollection">
+				<collection-table name="EntityWithOrmXmlImplicitFileLevelQualifiers_elementCollection">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_elementCollection" />
+				</collection-table>
+			</element-collection>
+		</attributes>
+	</entity>
+</entity-mappings>

--- a/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-global-catalog-and-schema.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/implicit-global-catalog-and-schema.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
+                 http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+				 version="2.1">
+	<persistence-unit-metadata>
+		<persistence-unit-defaults>
+			<schema>someImplicitSchema</schema>
+			<catalog>someImplicitCatalog</catalog>
+		</persistence-unit-defaults>
+	</persistence-unit-metadata>
+</entity-mappings>

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     testCompile( project( ':hibernate-testing' ) )
     testCompile( project( path: ':hibernate-core', configuration: 'tests' ) )
+    testCompile( libraries.assertj )
 }
 
 sourceSets {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/enhanced/OrderedSequenceStructure.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/enhanced/OrderedSequenceStructure.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.envers.enhanced;
 
-import org.hibernate.HibernateException;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedName;
@@ -34,18 +33,6 @@ public class OrderedSequenceStructure extends SequenceStructure {
 			Class numberType) {
 		super( jdbcEnvironment, qualifiedSequenceName, initialValue, incrementSize, numberType );
 		this.sequenceObject = new OrderedSequence();
-	}
-
-	@Override
-	public String[] sqlCreateStrings(Dialect dialect) throws HibernateException {
-		// delegate to auxiliary object
-		return sequenceObject.sqlCreateStrings( dialect );
-	}
-
-	@Override
-	public String[] sqlDropStrings(Dialect dialect) throws HibernateException {
-		// delegate to auxiliary object
-		return sequenceObject.sqlDropStrings( dialect );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/enhanced/OrderedSequenceStructure.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/enhanced/OrderedSequenceStructure.java
@@ -9,6 +9,7 @@ package org.hibernate.envers.enhanced;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
@@ -38,16 +39,13 @@ public class OrderedSequenceStructure extends SequenceStructure {
 	@Override
 	protected void buildSequence(Database database) {
 		database.addAuxiliaryDatabaseObject( sequenceObject );
-		this.sequenceName = database.getJdbcEnvironment().getQualifiedObjectNameFormatter().format(
-				getQualifiedName(),
-				database.getJdbcEnvironment().getDialect()
-		);
+		this.physicalSequenceName = getQualifiedName();
 	}
 
 	private class OrderedSequence implements AuxiliaryDatabaseObject {
 		@Override
 		public String getExportIdentifier() {
-			return getName();
+			return getQualifiedName().render();
 		}
 
 		@Override
@@ -63,9 +61,10 @@ public class OrderedSequenceStructure extends SequenceStructure {
 		}
 
 		@Override
-		public String[] sqlCreateStrings(Dialect dialect) {
+		public String[] sqlCreateStrings(SqlStringGenerationContext context) {
+			Dialect dialect = context.getDialect();
 			final String[] createStrings = dialect.getCreateSequenceStrings(
-					getName(),
+					context.format( getPhysicalName() ),
 					getInitialValue(),
 					getSourceIncrementSize()
 			);
@@ -80,8 +79,9 @@ public class OrderedSequenceStructure extends SequenceStructure {
 		}
 
 		@Override
-		public String[] sqlDropStrings(Dialect dialect) {
-			return dialect.getDropSequenceStrings( getName() );
+		public String[] sqlDropStrings(SqlStringGenerationContext context) {
+			Dialect dialect = context.getDialect();
+			return dialect.getDropSequenceStrings( context.format( getPhysicalName() ) );
 		}
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/MonotonicRevisionNumberTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/MonotonicRevisionNumberTest.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.envers.enhanced.OrderedSequenceGenerator;
 import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
@@ -43,11 +45,13 @@ public class MonotonicRevisionNumberTest extends BaseEnversFunctionalTestCase {
 		Assert.assertTrue( OrderedSequenceGenerator.class.isInstance( generator ) );
 
 		Database database = metadata().getDatabase();
+		SqlStringGenerationContext sqlStringGenerationContext =
+				SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
 		Optional<AuxiliaryDatabaseObject> sequenceOptional = database.getAuxiliaryDatabaseObjects().stream()
 				.filter( o -> "REVISION_GENERATOR".equals( o.getExportIdentifier() ) )
 				.findFirst();
 		assertThat( sequenceOptional ).isPresent();
-		String[] sqlCreateStrings = sequenceOptional.get().sqlCreateStrings( database.getDialect() );
+		String[] sqlCreateStrings = sequenceOptional.get().sqlCreateStrings( sqlStringGenerationContext );
 		Assert.assertTrue(
 				"Oracle sequence needs to be ordered in RAC environment.",
 				sqlCreateStrings[0].toLowerCase().endsWith( " order" )

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/MonotonicRevisionNumberTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/reventity/MonotonicRevisionNumberTest.java
@@ -6,6 +6,12 @@
  */
 package org.hibernate.envers.test.integration.reventity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.envers.enhanced.OrderedSequenceGenerator;
 import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
@@ -35,10 +41,16 @@ public class MonotonicRevisionNumberTest extends BaseEnversFunctionalTestCase {
 		EntityPersister persister = sessionFactory().getEntityPersister( SequenceIdRevisionEntity.class.getName() );
 		IdentifierGenerator generator = persister.getIdentifierGenerator();
 		Assert.assertTrue( OrderedSequenceGenerator.class.isInstance( generator ) );
-		OrderedSequenceGenerator seqGenerator = (OrderedSequenceGenerator) generator;
+
+		Database database = metadata().getDatabase();
+		Optional<AuxiliaryDatabaseObject> sequenceOptional = database.getAuxiliaryDatabaseObjects().stream()
+				.filter( o -> "REVISION_GENERATOR".equals( o.getExportIdentifier() ) )
+				.findFirst();
+		assertThat( sequenceOptional ).isPresent();
+		String[] sqlCreateStrings = sequenceOptional.get().sqlCreateStrings( database.getDialect() );
 		Assert.assertTrue(
 				"Oracle sequence needs to be ordered in RAC environment.",
-				seqGenerator.sqlCreateStrings( getDialect() )[0].toLowerCase().endsWith( " order" )
+				sqlCreateStrings[0].toLowerCase().endsWith( " order" )
 		);
 	}
 }


### PR DESCRIPTION
* [HHH-14922](https://hibernate.atlassian.net/browse/HHH-14922): Inconsistent precedence of orm.xml implicit catalog/schema over "default_catalog"/"default_schema"
* [HHH-14921](https://hibernate.atlassian.net/browse/HHH-14921): Definition of the default catalog/schema on session factory creation

This should allow us to change the catalog/schema in "runtime" settings in Quarkus: https://github.com/quarkusio/quarkus/issues/19660

I am currently working on porting this to the 6.0 branch. It's going to take some time, considering the size of this patch.