### PR TITLE
HHH-14936 JdbcConnectionContext in hibernate-testing throws NPE when user/password are not provided in configuration

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/JdbcConnectionContext.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cleaner/JdbcConnectionContext.java
@@ -38,8 +38,12 @@ public final class JdbcConnectionContext {
 			password = connectionProperties.getProperty(
 					AvailableSettings.PASS );
 			Properties p = new Properties();
-			p.put( "user", user );
-			p.put( "password", password );
+			if ( user != null ) {
+				p.put( "user", user );
+			}
+			if ( password != null ) {
+				p.put( "password", password );
+			}
 			properties = p;
 		}
 		catch (Exception e) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14936
