### PR TITLE
[HHH-14937] SybaseASE15 supports schemas and catalogs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASE15Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASE15Dialect.java
@@ -12,6 +12,7 @@ import org.hibernate.dialect.function.AnsiTrimEmulationFunction;
 import org.hibernate.dialect.function.NoArgSQLFunction;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.function.VarArgsSQLFunction;
+import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 import org.hibernate.type.descriptor.sql.TinyIntTypeDescriptor;
@@ -435,5 +436,10 @@ public class SybaseASE15Dialect extends SybaseDialect {
 	@Override
 	public boolean supportsPartitionBy() {
 		return false;
+	}
+
+	@Override
+	public NameQualifierSupport getNameQualifierSupport() {
+		return NameQualifierSupport.BOTH;
 	}
 }


### PR DESCRIPTION
As stated in https://hibernate.atlassian.net/browse/HHH-14937 our code breaks with the update to 5.6.0 due to [this commit](https://github.com/hibernate/hibernate-orm/commit/8cecdd3f43796c134688d99b6387d59600e75738)

The PR adds the support for schemas again. This is supported since ASE 15.5, see [documentation](https://infocenter.sybase.com/help/topic/com.sybase.infocenter.dc36272.1550/html/commands/X48762.htm?resultof=%22%73%63%68%65%6d%61%22%20).