### PR TITLE
HHH-14837 : Re-enable hibernate-jcache module.

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -29,7 +29,7 @@ dependencies {
 	testImplementation project(':hibernate-testing')
 	testImplementation project(':hibernate-envers')
 	testImplementation project(':hibernate-spatial')
-//	testImplementation project( ':hibernate-jcache' )
+	testImplementation project(':hibernate-jcache')
 	testImplementation project( path: ':hibernate-core', configuration: 'tests' )
 
 	testImplementation 'org.apache.commons:commons-lang3:3.4'
@@ -39,7 +39,11 @@ dependencies {
 	testImplementation libraries.mockito_inline
 
 	testRuntimeOnly libraries.wildfly_transaction_client
-	testRuntimeOnly libraries.ehcache3
+	testRuntimeOnly(libraries.ehcache3) {
+		capabilities {
+			requireCapability 'org.ehcache.modules:ehcache-xml-jakarta'
+		}
+	}
 }
 
 

--- a/documentation/src/test/java/org/hibernate/userguide/caching/FirstLevelCacheTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/caching/FirstLevelCacheTest.java
@@ -8,8 +8,10 @@ package org.hibernate.userguide.caching;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
 import org.junit.Test;
@@ -31,6 +33,13 @@ public class FirstLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
     protected Class<?>[] getAnnotatedClasses() {
         return new Class<?>[] { Person.class };
     }
+
+	@Override
+	@SuppressWarnings( "unchecked" )
+	protected void addConfigOptions(Map options) {
+		options.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, Boolean.TRUE.toString());
+		options.put(AvailableSettings.CACHE_REGION_FACTORY, "jcache");
+	}
 
     @Test
     public void testCache() {

--- a/documentation/src/test/java/org/hibernate/userguide/caching/NonStrictReadWriteCacheTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/caching/NonStrictReadWriteCacheTest.java
@@ -11,10 +11,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cache.jcache.JCacheHelper;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
 import org.junit.Test;
 
 import jakarta.persistence.Cacheable;
@@ -27,29 +27,30 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Version;
 
+import javax.cache.configuration.MutableConfiguration;
+
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
 
 /**
  * @author Vlad Mihalcea
  */
-@FailureExpected( jiraKey = "", message = "Relies on hibernate-jcache + JCache + Ehcache - Ehcache uses JAXB and has not been updated to use Jakarta" )
 public class NonStrictReadWriteCacheTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
 	public void buildEntityManagerFactory() {
-//		JCacheHelper.locateStandardCacheManager().createCache(
-//				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Person",
-//				new MutableConfiguration<>()
-//		);
-//		JCacheHelper.locateStandardCacheManager().createCache(
-//				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Phone",
-//				new MutableConfiguration<>()
-//		);
-//		JCacheHelper.locateStandardCacheManager().createCache(
-//				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Person.phones",
-//				new MutableConfiguration<>()
-//		);
+		JCacheHelper.locateStandardCacheManager().createCache(
+				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Person",
+				new MutableConfiguration<>()
+		);
+		JCacheHelper.locateStandardCacheManager().createCache(
+				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Phone",
+				new MutableConfiguration<>()
+		);
+		JCacheHelper.locateStandardCacheManager().createCache(
+				"hibernate.test.org.hibernate.userguide.caching.NonStrictReadWriteCacheTest$Person.phones",
+				new MutableConfiguration<>()
+		);
 
 		super.buildEntityManagerFactory();
 	}

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/identifier/CacheableNaturalIdTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/identifier/CacheableNaturalIdTest.java
@@ -11,14 +11,16 @@ import java.util.Map;
 import org.hibernate.Session;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.NaturalIdCache;
+import org.hibernate.cache.jcache.JCacheHelper;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.FailureExpected;
 import org.junit.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+
+import javax.cache.configuration.MutableConfiguration;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
@@ -26,15 +28,14 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Vlad Mihalcea
  */
-@FailureExpected( jiraKey = "", message = "Relies on hibernate-jcache + JCache + Ehcache - Ehcache uses JAXB and has not been updated to use Jakarta" )
 public class CacheableNaturalIdTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
 	public void buildEntityManagerFactory() {
-//		JCacheHelper.locateStandardCacheManager().createCache( "default-update-timestamps-region", new MutableConfiguration<>() );
-//		JCacheHelper.locateStandardCacheManager().createCache( "default-query-results-region", new MutableConfiguration<>() );
-//		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.userguide.mapping.identifier.CacheableNaturalIdTest$Book##NaturalId", new MutableConfiguration<>() );
-////		JCacheHelper.locateStandardCacheManager().createCache( "", new MutableConfiguration<>() );
+		JCacheHelper.locateStandardCacheManager().createCache( "default-update-timestamps-region", new MutableConfiguration<>() );
+		JCacheHelper.locateStandardCacheManager().createCache( "default-query-results-region", new MutableConfiguration<>() );
+		JCacheHelper.locateStandardCacheManager().createCache( "org.hibernate.userguide.mapping.identifier.CacheableNaturalIdTest$Book##NaturalId", new MutableConfiguration<>() );
+//		JCacheHelper.locateStandardCacheManager().createCache( "", new MutableConfiguration<>() );
 
 		super.buildEntityManagerFactory();
 	}

--- a/documentation/src/test/java/org/hibernate/userguide/pc/MultiLoadIdTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/pc/MultiLoadIdTest.java
@@ -43,6 +43,8 @@ public class MultiLoadIdTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override
 	protected void addMappings(Map settings) {
+		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
+		settings.put( AvailableSettings.CACHE_REGION_FACTORY, "jcache" );
 		settings.put( AvailableSettings.GENERATE_STATISTICS, Boolean.TRUE.toString() );
 		sqlStatementInterceptor = new SQLStatementInterceptor( settings );
 	}

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -176,7 +176,7 @@ ext {
 
             c3p0:            "com.mchange:c3p0:0.9.5.5",
             ehcache:         "net.sf.ehcache:ehcache:2.10.6",
-            ehcache3:        "org.ehcache:ehcache:3.8.1",
+            ehcache3:        "org.ehcache:ehcache:3.10.0-alpha0",
             jcache:          "javax.cache:cache-api:1.0.0",
             proxool:         "proxool:proxool:0.8.3",
             hikaricp:        "com.zaxxer:HikariCP:3.2.0",

--- a/hibernate-jcache/hibernate-jcache.gradle
+++ b/hibernate-jcache/hibernate-jcache.gradle
@@ -4,12 +4,16 @@ apply from: rootProject.file( 'gradle/published-java-module.gradle' )
 
 
 dependencies {
-    implementation project( ':hibernate-core' )
-    implementation libraries.jcache
+    api project( ':hibernate-core' )
+    api libraries.jcache
 
     testImplementation project( ':hibernate-testing' )
     testImplementation libraries.mockito
     testImplementation libraries.mockito_inline
 
-    testRuntimeOnly libraries.ehcache3
+    testRuntimeOnly(libraries.ehcache3) {
+        capabilities {
+            requireCapability 'org.ehcache.modules:ehcache-xml-jakarta'
+        }
+    }
 }

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/InsertedDataTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/InsertedDataTest.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.orm.test.jcache;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheTransactionalCacheConcurrencyStrategyTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheTransactionalCacheConcurrencyStrategyTest.java
@@ -9,13 +9,14 @@ package org.hibernate.orm.test.jcache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/RefreshUpdatedDataTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/RefreshUpdatedDataTest.java
@@ -8,12 +8,12 @@ package org.hibernate.orm.test.jcache;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Version;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.boot.Metadata;

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
@@ -31,6 +31,7 @@ import org.hibernate.orm.test.jcache.domain.VersionedItem;
 import org.hibernate.orm.test.jcache.domain.Event;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.testing.orm.junit.DialectContext;
 import org.hibernate.tool.schema.Action;
 
 import static org.hibernate.cache.jcache.JCacheHelper.locateStandardCacheManager;
@@ -121,7 +122,7 @@ public class TestHelper {
 				.applySetting( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP )
 				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
 
-		if ( H2Dialect.class.equals( Dialect.getDialect().getClass() ) ) {
+		if ( H2Dialect.class.equals( DialectContext.getDialect().getClass() ) ) {
 			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc" );
 		}
 		return ssrb;

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/domain/EventManager.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/domain/EventManager.java
@@ -12,8 +12,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 
 import org.hibernate.query.Query;
 import org.hibernate.Session;

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/domain/Product.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/domain/Product.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.orm.test.jcache.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 /**
  * @author Vlad Mihalcea

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -130,8 +130,8 @@ dependencies {
     vibur project( ':hibernate-vibur' )
     javadocSources project( path: ':hibernate-vibur', configuration: 'javadocSources' )
 
-//    jcache project( ':hibernate-jcache' )
-//    javadocSources project( path: ':hibernate-jcache', configuration: 'javadocSources' )
+    jcache project( ':hibernate-jcache' )
+    javadocSources project( path: ':hibernate-jcache', configuration: 'javadocSources' )
 
     jpamodelgen project( ':hibernate-jpamodelgen' )
     javadocSources project( path: ':hibernate-jpamodelgen', configuration: 'javadocSources' )

--- a/settings.gradle
+++ b/settings.gradle
@@ -125,7 +125,7 @@ include 'hibernate-hikaricp'
 include 'hibernate-vibur'
 include 'hibernate-agroal'
 
-//include 'hibernate-jcache'
+include 'hibernate-jcache'
 
 include 'hibernate-micrometer'
 include 'hibernate-graalvm'


### PR DESCRIPTION
Hey @sebersole. My PR against ehcache3 is an enormous ball of Gradle goo, so its still waiting on some poor soul to have the courage to review it. In order to expedite things I've instead cut an informal release with the proposed changes as `3.10.0-alpha0`. This PR is my first cut at re-enabling the `hibernate-jcache` module using that release. I made a cursory attempt at the archaeology required but I probably missed some code that should have been reinstated/uncommented.

Since the proposal for Ehcache 3 is to use Gradle capabilities and feature variants to handle this split it doesn't quite play perfectly with the way Hibernate's build system abstracts its dependencies. Currently I just left the version in `gradle/libraries.gradle` and the capability requirement in the couple of `build.gradle` files. If that's objectionable I imagine more work could be done to clean that split up.