### PR TITLE
HHH-14938 Upgrade to MySQL Connector/J 8.0.27

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -125,7 +125,7 @@ ext {
             hsqldb:          "org.hsqldb:hsqldb:2.3.2",
             derby:           "org.apache.derby:derby:10.14.2.0",
             postgresql:      'org.postgresql:postgresql:42.2.16',
-            mysql:           'mysql:mysql-connector-java:8.0.17',
+            mysql:           'mysql:mysql-connector-java:8.0.27',
             mariadb:         'org.mariadb.jdbc:mariadb-java-client:2.2.3',
             cockroachdb:     'org.postgresql:postgresql:42.2.8',
 


### PR DESCRIPTION

Changelog:
 - https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-27.html

Motivation:
 - https://www.oracle.com/security-alerts/cpuoct2021.html#AppendixMSQL