### PR TITLE
Remove 'statementInspectorClass' from @Jpa

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryCommentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryCommentTest.java
@@ -25,6 +25,7 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.jdbc.DefaultSQLStatementInspectorSettingProvider;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialect;
@@ -48,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 		settingProviders = {
 				@SettingProvider(
 						settingName = AvailableSettings.STATEMENT_INSPECTOR,
-						provider = NamedQueryCommentTest.StatementInspectorSettingProvider.class
+						provider = DefaultSQLStatementInspectorSettingProvider.class
 				)
 		}
 )
@@ -61,6 +62,9 @@ public class NamedQueryCommentTest {
 
 	@BeforeAll
 	public void setUp(EntityManagerFactoryScope scope) {
+
+		statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
+
 		scope.inTransaction(
 				entityManager -> {
 					for ( String title : GAME_TITLES ) {
@@ -292,11 +296,4 @@ public class NamedQueryCommentTest {
 		}
 	}
 
-	public static class StatementInspectorSettingProvider implements SettingProvider.Provider<StatementInspector> {
-		@Override
-		public StatementInspector getSetting() {
-			statementInspector = new SQLStatementInspector();
-			return statementInspector;
-		}
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetoone/OneToOneMapsIdJoinColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetoone/OneToOneMapsIdJoinColumnTest.java
@@ -8,15 +8,14 @@ package org.hibernate.orm.test.mapping.onetoone;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 
+import org.hibernate.testing.orm.jdbc.DefaultSQLStatementInspectorSettingProvider;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -37,18 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 		settingProviders = {
 				@SettingProvider(
 						settingName = AvailableSettings.STATEMENT_INSPECTOR,
-						provider = OneToOneMapsIdJoinColumnTest.SQLStatementInspectorProvider.class
+						provider = DefaultSQLStatementInspectorSettingProvider.class
 				)
 		}
 )
 public class OneToOneMapsIdJoinColumnTest {
-
-	public static class SQLStatementInspectorProvider implements SettingProvider.Provider<Class> {
-		@Override
-		public Class getSetting() {
-			return SQLStatementInspector.class;
-		}
-	}
 
 	@BeforeEach
 	public void setUp(EntityManagerFactoryScope scope) {
@@ -67,7 +59,7 @@ public class OneToOneMapsIdJoinColumnTest {
 
 	@Test
 	public void testLifecycle(EntityManagerFactoryScope scope) {
-		SQLStatementInspector statementInspector = getSqlStatementInspector( scope );
+		SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 
 		statementInspector.clear();
 		scope.inTransaction( entityManager -> {
@@ -83,12 +75,6 @@ public class OneToOneMapsIdJoinColumnTest {
 			assertSame( details.getPerson(), person );
 			statementInspector.assertExecutedCount( 0 );
 		} );
-	}
-
-	private SQLStatementInspector getSqlStatementInspector(EntityManagerFactoryScope scope) {
-		EntityManagerFactory entityManagerFactory = scope.getEntityManagerFactory();
-		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		return (SQLStatementInspector) sessionFactory.getSessionFactoryOptions().getStatementInspector();
 	}
 
 	@Entity(name = "Person")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingCriteriaTest.java
@@ -13,9 +13,11 @@ import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.jdbc.DefaultSQLStatementInspectorSettingProvider;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +32,6 @@ import jakarta.persistence.criteria.Root;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 /**
  * @author Vlad Mihalcea
  */
@@ -41,7 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 				@Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true"),
 				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
 		},
-		statementInspectorClass = SQLStatementInspector.class
+		settingProviders = {
+				@SettingProvider(
+						settingName = AvailableSettings.STATEMENT_INSPECTOR,
+						provider = DefaultSQLStatementInspectorSettingProvider.class
+				)
+		}
 )
 public class InClauseParameterPaddingCriteriaTest {
 
@@ -56,7 +62,7 @@ public class InClauseParameterPaddingCriteriaTest {
 
 	@Test
 	public void testInClauseParameterPadding(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction( entityManager -> {
@@ -80,7 +86,7 @@ public class InClauseParameterPaddingCriteriaTest {
 
 	@Test
 	public void testInClauseParameterPaddingForExpressions(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction( entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingTest.java
@@ -12,9 +12,11 @@ import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.jdbc.DefaultSQLStatementInspectorSettingProvider;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,8 +36,12 @@ import static org.junit.Assert.assertTrue;
 				@Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true"),
 				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true")
 		},
-		statementInspectorClass = SQLStatementInspector.class
-
+		settingProviders = {
+				@SettingProvider(
+						settingName = AvailableSettings.STATEMENT_INSPECTOR,
+						provider = DefaultSQLStatementInspectorSettingProvider.class
+				)
+		}
 )
 public class InClauseParameterPaddingTest {
 
@@ -70,7 +76,7 @@ public class InClauseParameterPaddingTest {
 			EntityManagerFactoryScope scope,
 			String expectedInClause,
 			Integer... ids) {
-		final SQLStatementInspector sqlStatementInterceptor = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector sqlStatementInterceptor = scope.getStatementInspector( SQLStatementInspector.class );
 		sqlStatementInterceptor.clear();
 
 		scope.inTransaction( entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
@@ -14,6 +14,7 @@ import org.hibernate.dialect.H2Dialect;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.jdbc.DefaultSQLStatementInspectorSettingProvider;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialect;
@@ -43,12 +44,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 						settingName = AvailableSettings.DIALECT,
 						provider = MaxInExpressionParameterPaddingTest.DialectProvider.class
 				),
-		},
-		statementInspectorClass = SQLStatementInspector.class
+				@SettingProvider(
+						settingName = AvailableSettings.STATEMENT_INSPECTOR,
+						provider = DefaultSQLStatementInspectorSettingProvider.class
+				)
+		}
 )
 public class MaxInExpressionParameterPaddingTest {
 
-	public static  class DialectProvider implements SettingProvider.Provider<String> {
+	public static class DialectProvider implements SettingProvider.Provider<String> {
 		@Override
 		public String getSetting() {
 			return MaxInExpressionParameterPaddingTest.MaxCountInExpressionH2Dialect.class.getName();
@@ -72,7 +76,7 @@ public class MaxInExpressionParameterPaddingTest {
 
 	@Test
 	public void testInClauseParameterPadding(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction( entityManager ->
@@ -94,7 +98,7 @@ public class MaxInExpressionParameterPaddingTest {
 	@TestForIssue(jiraKey = "HHH-14109")
 	@Test
 	public void testInClauseParameterPaddingToLimit(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction(
@@ -119,7 +123,7 @@ public class MaxInExpressionParameterPaddingTest {
 
 	@Test
 	public void testInClauseParameterSplittingAfterLimit(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction(
@@ -145,7 +149,7 @@ public class MaxInExpressionParameterPaddingTest {
 
 	@Test
 	public void testInClauseParameterSplittingAfterLimit2(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction(
@@ -171,7 +175,7 @@ public class MaxInExpressionParameterPaddingTest {
 
 	@Test
 	public void testInClauseParameterSplittingAfterLimit3(EntityManagerFactoryScope scope) {
-		final SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getStatementInspector();
+		final SQLStatementInspector statementInspector = scope.getStatementInspector( SQLStatementInspector.class );
 		statementInspector.clear();
 
 		scope.inTransaction(

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/jdbc/DefaultSQLStatementInspectorSettingProvider.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/jdbc/DefaultSQLStatementInspectorSettingProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.testing.orm.jdbc;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.SettingProvider;
+
+public class DefaultSQLStatementInspectorSettingProvider implements SettingProvider.Provider<SQLStatementInspector> {
+
+	@Override
+	public SQLStatementInspector getSetting() {
+		return new SQLStatementInspector();
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/AbstractEntityManagerFactoryScope.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/AbstractEntityManagerFactoryScope.java
@@ -50,6 +50,12 @@ abstract class AbstractEntityManagerFactoryScope implements EntityManagerFactory
 	}
 
 	@Override
+	public <T extends StatementInspector> T getStatementInspector(Class<T> type) {
+		//noinspection unchecked
+		return (T) getStatementInspector();
+	}
+
+	@Override
 	public void close() {
 		if ( !active ) {
 			return;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
@@ -99,9 +99,6 @@ public class EntityManagerFactoryExtension
 		pui.getProperties().put( AvailableSettings.JPA_ID_GENERATOR_GLOBAL_SCOPE_COMPLIANCE, emfAnn.generatorScopeComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_ORDER_BY_MAPPING_COMPLIANCE, emfAnn.orderByMappingComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_LOAD_BY_ID_COMPLIANCE, emfAnn.loadByIdComplianceEnabled() );
-		if ( !emfAnn.statementInspectorClass().equals( StatementInspector.class ) ) {
-			pui.getProperties().put( AvailableSettings.STATEMENT_INSPECTOR, emfAnn.statementInspectorClass() );
-		}
 
 		final Setting[] properties = emfAnn.properties();
 		for ( int i = 0; i < properties.length; i++ ) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryScope.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryScope.java
@@ -19,7 +19,9 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 public interface EntityManagerFactoryScope {
 	EntityManagerFactory getEntityManagerFactory();
 	void releaseEntityManagerFactory();
+
 	StatementInspector getStatementInspector();
+	<T extends StatementInspector> T getStatementInspector(Class<T> type);
 
 	void inEntityManager(Consumer<EntityManager> action);
 	void inTransaction(Consumer<EntityManager> action);

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/Jpa.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/Jpa.java
@@ -108,8 +108,6 @@ public @interface Jpa {
 	 */
 	boolean loadByIdComplianceEnabled() default false;
 
-	Class<? extends StatementInspector> statementInspectorClass() default StatementInspector.class;
-
 	boolean excludeUnlistedClasses() default false;
 
 	StandardDomainModel[] standardModels() default {};


### PR DESCRIPTION
Change 'provider' attribute in @SettingProvider to ' providerClass'
Remove 'statementInspectorClass' from @Jpa and refactor its usage to use a @SettingProvider

Signed-off-by: Jan Schatteman <jschatte@redhat.com>