### PR TITLE
fix the signature of Session.merge()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -479,7 +479,7 @@ public interface Session extends SharedSessionContract, EntityManager, AutoClose
 	 *
 	 * @return an updated persistent instance
 	 */
-	Object merge(Object object);
+	<T> T merge(T object);
 
 	/**
 	 * Copy the state of the given object onto the persistent object with the same
@@ -497,7 +497,7 @@ public interface Session extends SharedSessionContract, EntityManager, AutoClose
 	 *
 	 * @return an updated persistent instance
 	 */
-	Object merge(String entityName, Object object);
+	<T> T merge(String entityName, T object);
 
 	/**
 	 * Make a transient instance persistent. This operation cascades to associated

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -789,15 +789,15 @@ public class SessionImpl
 	// merge() operations ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
-	public Object merge(String entityName, Object object) throws HibernateException {
+	public <T> T merge(String entityName, T object) throws HibernateException {
 		checkOpen();
-		return fireMerge( new MergeEvent( entityName, object, this ) );
+		return (T) fireMerge( new MergeEvent( entityName, object, this ) );
 	}
 
 	@Override
-	public Object merge(Object object) throws HibernateException {
+	public <T> T merge(T object) throws HibernateException {
 		checkOpen();
-		return fireMerge( new MergeEvent( null, object, this ));
+		return (T) fireMerge( new MergeEvent( null, object, this ));
 	}
 
 	@Override


### PR DESCRIPTION
Previously `Session.merge()` erased the generic type parameter inherited from the supertype, obligating the client code to perform a typecast.

See https://github.com/hibernate/hibernate-orm/discussions/4391