### PR TITLE
TestCase for HHH-14944 Detach removes NaturalIdCrossRef in 2nd level cache too. 

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/caching/SecondLevelCacheTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/caching/SecondLevelCacheTest.java
@@ -22,24 +22,28 @@ import org.hibernate.CacheMode;
 import org.hibernate.Session;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.jpa.QueryHints;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.stat.CacheRegionStatistics;
 import org.hibernate.stat.Statistics;
 
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 
 /**
  * @author Vlad Mihalcea
  */
-@Ignore
-//@FailureExpected( jiraKey = "HHH-12146", message = "No idea why those changes cause this to fail, especially in the way it does" )
+//@FailureExpected( jiraKey = "HHH-12146", message = "fixed in 5.3.0.Beta1" )
 public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 
     @Override
@@ -74,6 +78,7 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 			log.info( "Jpa load by id" );
 			//tag::caching-entity-jpa-example[]
 			Person person = entityManager.find( Person.class, 1L );
+			assertNotNull(person);
 			//end::caching-entity-jpa-example[]
 		});
 
@@ -82,6 +87,7 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 			Session session = entityManager.unwrap( Session.class );
 			//tag::caching-entity-native-example[]
 			Person person = session.get( Person.class, 1L );
+			assertNotNull(person);
 			//end::caching-entity-native-example[]
 		});
 
@@ -251,8 +257,84 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 		});
 	}
 
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-14944") // "worked in Hibernate 5.4
+	public void testCacheVerifyHits() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			entityManager.persist( new Person() );
+			Person aPerson= new Person();
+			aPerson.setName( "John Doe" );
+			aPerson.setCode( "unique-code" );
+			entityManager.persist( aPerson );
+			Session session = entityManager.unwrap(Session.class);
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			sfi.getStatistics().clear();
+			return aPerson;
+		});
+
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			log.info("Native load by natural-id, generate first hit");
+
+			Session session = entityManager.unwrap(Session.class);
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			//tag::caching-entity-natural-id-example[]
+			Person person = session
+					.byNaturalId(Person.class)
+					.using("code", "unique-code")
+					.load();
+
+			assertNotNull(person);
+			log.info("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			log.info("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertEquals(1, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(1, sfi.getStatistics().getSecondLevelCacheHitCount());
+			//end::caching-entity-natural-id-example[]
+		});
+
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			log.info("Native load by natural-id, generate second hit");
+
+			Session session = entityManager.unwrap(Session.class);
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			//tag::caching-entity-natural-id-example[]
+			Person person = session.bySimpleNaturalId(Person.class).load("unique-code");
+			assertNotNull(person);
+
+			// resolve in persistence context (first level cache)
+			session.bySimpleNaturalId(Person.class).load("unique-code");
+			log.info("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			log.info("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertEquals(2, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(2, sfi.getStatistics().getSecondLevelCacheHitCount());
+
+			session.clear();
+			//  persistence context (first level cache) empty, should resolve from second level cache
+			log.info("Native load by natural-id, generate third hit");
+			person = session.bySimpleNaturalId(Person.class).load("unique-code");
+			log.info("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			log.info("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertNotNull(person);
+			assertEquals(3, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(3, sfi.getStatistics().getSecondLevelCacheHitCount());
+
+			//Remove the entity from the persistence context
+			Long id = person.getId();
+
+			entityManager.detach(person); // Still it should resolve from second level cache
+
+			log.info("Native load by natural-id, generate 4. hit");
+			person = session.bySimpleNaturalId(Person.class).load("unique-code");
+			log.info("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals("we expected now 4 hits" , 4, sfi.getStatistics().getNaturalIdCacheHitCount()); // fails
+			assertNotNull(person);
+			//end::caching-entity-natural-id-example[]
+		});
+	}
+
 	//tag::caching-entity-natural-id-mapping-example[]
 	@Entity(name = "Person")
+	@NaturalIdCache
 	@Cacheable
 	@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     public static class Person {
@@ -296,6 +378,7 @@ public class SecondLevelCacheTest extends BaseEntityManagerFunctionalTestCase {
 		public void setCode(String code) {
 			this.code = code;
 		}
+
 	//tag::caching-entity-natural-id-mapping-example[]
 	}
 	//end::caching-entity-natural-id-mapping-example[]


### PR DESCRIPTION
Bug/Regression.
Detaching entity removes NaturalIdCrossReference in second level cache
too. Should operate on first level cache only.