### PR TITLE
HHH-14948 - Reduce the size of the imports cache in the metamodel

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
@@ -632,7 +632,13 @@ public class MetamodelImpl implements MetamodelImplementor, Serializable {
 				return className;
 			}
 			catch ( ClassLoadingException cnfe ) {
-				imports.put( className, INVALID_IMPORT );
+				// This check doesn't necessarily mean that the map can't exceed 1000 elements because
+				// new entries might be added _while_ performing the check (making it 1000+ since size() isn't
+				// synchronized). Regardless, this would pass as "good enough" to prevent the map from growing
+				// above a certain threshold, thus, avoiding memory issues.
+				if ( imports.size() < 1_000 ) {
+					imports.put( className, INVALID_IMPORT );
+				}
 				return null;
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/QuerySplitterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/QuerySplitterTest.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.test.hql;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.stream.IntStream;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.hql.internal.QuerySplitter;
+import org.hibernate.metamodel.internal.MetamodelImpl;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
@@ -45,6 +49,29 @@ public class QuerySplitterTest extends BaseNonConfigCoreFunctionalTestCase {
 				"from org.hibernate.test.hql.QuerySplitterTest$Employee where name = 'He is the, Employee Number 1'",
 				results[0]
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14948")
+	public void testMemoryConsumptionOfFailedImportsCache() throws NoSuchFieldException, IllegalAccessException {
+
+		IntStream.range( 0, 1001 )
+				.forEach( i -> QuerySplitter.concreteQueries(
+						"from Employee e join e.company" + i,
+						sessionFactory()
+				) );
+
+		MetamodelImpl metamodel = (MetamodelImpl) sessionFactory().getMetamodel();
+
+		Field field = MetamodelImpl.class.getDeclaredField( "imports" );
+		field.setAccessible( true );
+
+		//noinspection unchecked
+		Map<String, String> imports = (Map<String, String>) field.get( metamodel );
+
+		// VERY hard-coded, but considering the possibility of a regression of a memory-related issue,
+		// it should be worth it
+		assertEquals( 1000, imports.size() );
 	}
 
 	@Test


### PR DESCRIPTION
Corresponding task: [HHH-14948](https://hibernate.atlassian.net/browse/HHH-14948)

The original change from [HHH-12485](https://hibernate.atlassian.net/browse/HHH-12485) introduced memory issues (as described in the corresponding task). As such, I am requesting that it is reverted.

I have also added a test to illustrate the issue as is the requirement for bugfix tasks. That said, I don't particularly like using reflection in the way I have so I don't mind dropping the test altogether or accepting advice from more experienced Hibernate developers on how I could perform the test better.