### PR TITLE
remove left-behind method createSQLQuery() from StatelessSession

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
@@ -8,9 +8,6 @@ package org.hibernate;
 
 import java.io.Closeable;
 
-import org.hibernate.annotations.Remove;
-import org.hibernate.query.NativeQuery;
-
 /**
  * A command-oriented API for performing bulk operations against a database.
  * <p/>
@@ -155,9 +152,4 @@ public interface StatelessSession extends SharedSessionContract, AutoCloseable, 
 	 * @param lockMode The LockMode to be applied.
 	 */
 	void refresh(String entityName, Object entity, LockMode lockMode);
-
-	@Remove
-	default <T> NativeQuery<T> createSQLQuery(String queryString) {
-		return createNativeQuery( queryString );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionTest.java
@@ -83,7 +83,7 @@ public class StatelessSessionTest {
 						assertEquals( "Blahs", doc2.getName() );
 						assertEquals( doc.getText(), doc2.getText() );
 
-						doc2 = (Document) statelessSession.createSQLQuery( "select * from Document" )
+						doc2 = (Document) statelessSession.createNativeQuery( "select * from Document" )
 								.addEntity( Document.class )
 								.uniqueResult();
 						assertEquals( "Blahs", doc2.getName() );


### PR DESCRIPTION
It was already annotated `@Remove`.