### PR TITLE
HHH-14970 make use of new Java language features from v8 to v11

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.cache.spi;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,20 +27,18 @@ public abstract class AbstractRegionFactory implements RegionFactory {
 	/**
 	 * Legacy names that used to be the default for the query results region.
 	 */
-	public static final List<String> LEGACY_QUERY_RESULTS_REGION_UNQUALIFIED_NAMES =
-			Collections.unmodifiableList( Arrays.asList(
-					"org.hibernate.cache.spi.QueryResultsRegion",
-					"org.hibernate.cache.internal.StandardQueryCache"
-			) );
+	public static final List<String> LEGACY_QUERY_RESULTS_REGION_UNQUALIFIED_NAMES = List.of(
+			"org.hibernate.cache.spi.QueryResultsRegion",
+			"org.hibernate.cache.internal.StandardQueryCache"
+	);
 
 	/**
 	 * Legacy names that used to be the default for the update timestamps region.
 	 */
-	public static final List<String> LEGACY_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAMES =
-			Collections.unmodifiableList( Arrays.asList(
-					"org.hibernate.cache.spi.TimestampsRegion",
-					"org.hibernate.cache.spi.UpdateTimestampsCache"
-			) );
+	public static final List<String> LEGACY_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAMES = List.of(
+			"org.hibernate.cache.spi.TimestampsRegion",
+			"org.hibernate.cache.spi.UpdateTimestampsCache"
+	);
 
 	private Exception startingException;
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
@@ -78,20 +78,16 @@ public class BinderHelper {
 	private BinderHelper() {
 	}
 
-	static {
-		Set<String> primitiveNames = new HashSet<>();
-		primitiveNames.add( byte.class.getName() );
-		primitiveNames.add( short.class.getName() );
-		primitiveNames.add( int.class.getName() );
-		primitiveNames.add( long.class.getName() );
-		primitiveNames.add( float.class.getName() );
-		primitiveNames.add( double.class.getName() );
-		primitiveNames.add( char.class.getName() );
-		primitiveNames.add( boolean.class.getName() );
-		PRIMITIVE_NAMES = Collections.unmodifiableSet( primitiveNames );
-	}
-
-	public static final Set<String> PRIMITIVE_NAMES;
+	public static final Set<String> PRIMITIVE_NAMES = Set.of(
+			byte.class.getName(),
+			short.class.getName(),
+			int.class.getName(),
+			long.class.getName(),
+			float.class.getName(),
+			double.class.getName(),
+			char.class.getName(),
+			boolean.class.getName()
+	);
 
 	/**
 	 * create a property copy reusing the same value

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.cfg.annotations;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -113,7 +111,6 @@ import jakarta.persistence.MapKey;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.OneToMany;
 
-import static jakarta.persistence.AccessType.FIELD;
 import static jakarta.persistence.AccessType.PROPERTY;
 import static org.hibernate.cfg.BinderHelper.toAliasEntityMap;
 import static org.hibernate.cfg.BinderHelper.toAliasTableMap;
@@ -128,13 +125,14 @@ import static org.hibernate.cfg.BinderHelper.toAliasTableMap;
 public abstract class CollectionBinder {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, CollectionBinder.class.getName());
 
-	private static final List<Class<?>> INFERRED_CLASS_PRIORITY = Collections.unmodifiableList( Arrays.asList(
+	private static final List<Class<?>> INFERRED_CLASS_PRIORITY = List.of(
 			List.class,
 			java.util.SortedSet.class,
 			java.util.Set.class,
 			java.util.SortedMap.class,
 			Map.class,
-			java.util.Collection.class) );
+			java.util.Collection.class
+	);
 
 	private MetadataBuildingContext buildingContext;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
@@ -11,7 +11,6 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -78,24 +77,16 @@ public class ConnectionProviderInitiator implements StandardServiceInitiator<Con
 
 	// mapping from legacy connection provider name to actual
 	// connection provider that will be used
-	private static final Map<String,String> LEGACY_CONNECTION_PROVIDER_MAPPING;
+	private static final Map<String,String> LEGACY_CONNECTION_PROVIDER_MAPPING = Map.of(
+			"org.hibernate.connection.DatasourceConnectionProvider",
+			DatasourceConnectionProviderImpl.class.getName(),
 
-	static {
-		LEGACY_CONNECTION_PROVIDER_MAPPING = CollectionHelper.mapOfSize( 5 );
+			"org.hibernate.connection.DriverManagerConnectionProvider",
+			DriverManagerConnectionProviderImpl.class.getName(),
 
-		LEGACY_CONNECTION_PROVIDER_MAPPING.put(
-				"org.hibernate.connection.DatasourceConnectionProvider",
-				DatasourceConnectionProviderImpl.class.getName()
-		);
-		LEGACY_CONNECTION_PROVIDER_MAPPING.put(
-				"org.hibernate.connection.DriverManagerConnectionProvider",
-				DriverManagerConnectionProviderImpl.class.getName()
-		);
-		LEGACY_CONNECTION_PROVIDER_MAPPING.put(
-				"org.hibernate.connection.UserSuppliedConnectionProvider",
-				UserSuppliedConnectionProviderImpl.class.getName()
-		);
-	}
+			"org.hibernate.connection.UserSuppliedConnectionProvider",
+			UserSuppliedConnectionProviderImpl.class.getName()
+	);
 
 	@Override
 	public Class<ConnectionProvider> getServiceInitiated() {
@@ -448,13 +439,10 @@ public class ConnectionProviderInitiator implements StandardServiceInitiator<Con
 	// Connection properties (map value) that automatically need set if the
 	// Hibernate property (map key) is available. Makes the assumption that
 	// both settings use the same value type.
-	private static final Map<String, String> CONDITIONAL_PROPERTIES;
-
-	static {
-		CONDITIONAL_PROPERTIES = new HashMap<>();
-		// Oracle requires that includeSynonyms=true in order for getColumns to work using a table synonym name.
-		CONDITIONAL_PROPERTIES.put( AvailableSettings.ENABLE_SYNONYMS, "includeSynonyms" );
-	}
+	private static final Map<String, String> CONDITIONAL_PROPERTIES = Map.of(
+			// Oracle requires that includeSynonyms=true in order for getColumns to work using a table synonym name.
+			AvailableSettings.ENABLE_SYNONYMS, "includeSynonyms"
+	);
 
 	public static Integer extractIsolation(Map settings) {
 		return interpretIsolation( settings.get( AvailableSettings.ISOLATION ) );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.engine.jdbc.internal;
 
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Set;
@@ -22,49 +21,24 @@ import org.hibernate.internal.util.StringHelper;
  */
 public class BasicFormatterImpl implements Formatter {
 
-	private static final Set<String> BEGIN_CLAUSES = new HashSet<>();
-	private static final Set<String> END_CLAUSES = new HashSet<>();
-	private static final Set<String> LOGICAL = new HashSet<>();
-	private static final Set<String> QUANTIFIERS = new HashSet<>();
-	private static final Set<String> DML = new HashSet<>();
-	private static final Set<String> MISC = new HashSet<>();
-
-	static {
-		BEGIN_CLAUSES.add( "left" );
-		BEGIN_CLAUSES.add( "right" );
-		BEGIN_CLAUSES.add( "inner" );
-		BEGIN_CLAUSES.add( "outer" );
-		BEGIN_CLAUSES.add( "group" );
-		BEGIN_CLAUSES.add( "order" );
-
-		END_CLAUSES.add( "where" );
-		END_CLAUSES.add( "set" );
-		END_CLAUSES.add( "having" );
-		END_CLAUSES.add( "from" );
-		END_CLAUSES.add( "by" );
-		END_CLAUSES.add( "join" );
-		END_CLAUSES.add( "into" );
-		END_CLAUSES.add( "union" );
-
-		LOGICAL.add( "and" );
-		LOGICAL.add( "or" );
-		LOGICAL.add( "when" );
-		LOGICAL.add( "else" );
-		LOGICAL.add( "end" );
-
-		QUANTIFIERS.add( "in" );
-		QUANTIFIERS.add( "all" );
-		QUANTIFIERS.add( "exists" );
-		QUANTIFIERS.add( "some" );
-		QUANTIFIERS.add( "any" );
-
-		DML.add( "insert" );
-		DML.add( "update" );
-		DML.add( "delete" );
-
-		MISC.add( "select" );
-		MISC.add( "on" );
-	}
+	private static final Set<String> BEGIN_CLAUSES = Set.of(
+			"left",	"right", "inner", "outer", "group", "order"
+	);
+	private static final Set<String> END_CLAUSES = Set.of(
+			"where", "set", "having", "from", "by", "join", "into", "union"
+	);
+	private static final Set<String> LOGICAL = Set.of(
+			"and", "or", "when", "else", "end"
+	);
+	private static final Set<String> QUANTIFIERS = Set.of(
+			"in", "all", "exists", "some", "any"
+	);
+	private static final Set<String> DML = Set.of(
+			"insert", "update", "delete"
+	);
+	private static final Set<String> MISC = Set.of(
+			"select", "on"
+	);
 
 	private static final String INDENT_STRING = "    ";
 	private static final String INITIAL = System.lineSeparator() + INDENT_STRING;

--- a/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
@@ -7,9 +7,6 @@
 package org.hibernate.exception.internal;
 
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.hibernate.JDBCException;
@@ -40,8 +37,7 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 
 	private static final Set<String> SQL_GRAMMAR_CATEGORIES = buildGrammarCategories();
 	private static Set<String> buildGrammarCategories() {
-		HashSet<String> categories = new HashSet<>(
-				Arrays.asList(
+		return Set.of(
 						"07", 	// "dynamic SQL error"
 						"20",
 						"2A", 	// "direct SQL syntax error or access rule violation"
@@ -49,41 +45,31 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 						"42",	// "syntax error or access rule violation"
 						"65",	// Oracle specific as far as I can tell
 						"S0"	// MySQL specific as far as I can tell
-				)
 		);
-		return Collections.unmodifiableSet( categories );
 	}
 
 	private static final Set DATA_CATEGORIES = buildDataCategories();
 	private static Set<String> buildDataCategories() {
-		HashSet<String> categories = new HashSet<>(
-				Arrays.asList(
-						"21",	// "cardinality violation"
-						"22"	// "data exception"
-				)
+		return Set.of(
+				"21",	// "cardinality violation"
+				"22"	// "data exception"
 		);
-		return Collections.unmodifiableSet( categories );
 	}
 
 	private static final Set INTEGRITY_VIOLATION_CATEGORIES = buildContraintCategories();
 	private static Set<String> buildContraintCategories() {
-		HashSet<String> categories = new HashSet<>(
-				Arrays.asList(
-						"23",	// "integrity constraint violation"
-						"27",	// "triggered data change violation"
-						"44"	// "with check option violation"
-				)
+		return Set.of(
+				"23",	// "integrity constraint violation"
+				"27",	// "triggered data change violation"
+				"44"	// "with check option violation"
 		);
-		return Collections.unmodifiableSet( categories );
 	}
 
 	private static final Set CONNECTION_CATEGORIES = buildConnectionCategories();
 	private static Set<String> buildConnectionCategories() {
-		HashSet<String> categories = new HashSet<>();
-		categories.add(
+		return Set.of(
 				"08"	// "connection exception"
 		);
-		return Collections.unmodifiableSet( categories );
 	}
 
 	public SQLStateConversionDelegate(ConversionContext conversionContext) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.StringTokenizer;
 
 import org.hibernate.boot.model.source.internal.hbm.CommaSeparatedStringHelper;
@@ -542,20 +541,7 @@ public final class StringHelper {
 	}
 
 	public static boolean isBlank(String string) {
-		//TODO use Java 11's more efficient String#isBlank - currently we still require Java 8 compatibility
-		if ( string == null || string.isEmpty() ) {
-			return true;
-		}
-		else {
-			//Else: we need to check all characters, preferably without using String#trim() so to
-			//not allocate temporary strings
-			for ( int i = 0; i < string.length(); i++ ) {
-				if ( ! Character.isWhitespace( string.charAt( i ) ) ) {
-					return false;
-				}
-			}
-			return true;
-		}
+		return string == null || string.isBlank();
 	}
 
 	/**


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14970

Mainly focused on the following two new Java language features introduced from v8 to v11 (I referred to https://ondro.inginea.eu/index.php/new-features-in-java-versions-since-java-8/):

- new String's methods in JDK 11 (e.g. String#isBlank());

- new Collection factory methods in JDK 9 (i.e., List.of(), Map.of(), Set.of()); 

Demonstrably `List.of()` is better than `Arrays.asList()` even in immutability context (see https://stackoverflow.com/questions/46579074/what-is-the-difference-between-list-of-and-arrays-aslist, e.g.), but given the latter has been an established pattern, it won't be touched upon. This PR mainly focused on easy migration so it is easy to review and verify. 