### PR TITLE
proposed solution to "long varchar" problem

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
@@ -67,13 +67,14 @@ public class CUBRIDDialect extends Dialect {
 		//'timestamp' has a very limited range
 		//'datetime' does not support explicit precision
 		//(always 3, millisecond precision)
-		registerColumnType(Types.TIMESTAMP, "datetime");
-		registerColumnType(Types.TIMESTAMP, "datetimetz");
+		registerColumnType(Types.TIMESTAMP, "datetime" );
+		registerColumnType(Types.TIMESTAMP, "datetimetz" );
 
 		//CUBRID has no 'binary' nor 'varbinary', but 'bit' is
-		//intended to be used for binary data
-		registerColumnType( Types.BINARY, "bit($l)");
-		registerColumnType( Types.VARBINARY, "bit varying($l)");
+		//intended to be used for binary data (unfortunately the
+		//length parameter is measured in bits, not bytes)
+		registerColumnType( Types.BINARY, "bit($l)" );
+		registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "bit varying($l)" );
 
 		getDefaultProperties().setProperty( Environment.USE_STREAMS_FOR_BINARY, "true" );
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
@@ -113,6 +114,17 @@ public class CUBRIDDialect extends Dialect {
 	public CUBRIDDialect(DialectResolutionInfo info) {
 		this();
 		registerKeywords( info );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 1_073_741_823;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		//note that the length of BIT VARYING in CUBRID is actually in bits
+		return 1_073_741_823;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
@@ -141,23 +141,12 @@ public class FirebirdDialect extends Dialect {
 		else {
 			registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp with time zone" );
 		}
-		// Single byte character sets can be 32_765 characters, but assume use of UTF8
-		registerColumnType( Types.VARCHAR, 8_191, "varchar($l)" );
+
 		registerColumnType( Types.VARCHAR, "blob sub_type text" );
 
 		if ( getVersion().isBefore( 4, 0 ) ) {
-			registerColumnType( Types.BINARY, 32_767, "char($l) character set octets" );
-		}
-		else {
-			registerColumnType( Types.BINARY, 32_767, "binary($l)" );
-		}
-		registerColumnType( Types.BINARY, "blob sub_type binary" );
-
-		if ( getVersion().isBefore( 4, 0 ) ) {
-			registerColumnType( Types.VARBINARY, 32_765, "varchar($l) character set octets" );
-		}
-		else {
-			registerColumnType( Types.VARBINARY, 32_765, "varbinary($l)" );
+			registerColumnType( Types.BINARY, "char($l) character set octets" );
+			registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "varchar($l) character set octets" );
 		}
 		registerColumnType( Types.VARBINARY, "blob sub_type binary" );
 
@@ -166,6 +155,18 @@ public class FirebirdDialect extends Dialect {
 		registerColumnType( Types.NCLOB, "blob sub_type text" ); // Firebird doesn't have NCLOB, but Jaybird emulates NCLOB support
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, NO_BATCH );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		// Single byte character sets can be 32_765
+		// characters, but assume use of UTF8
+		return 8_191;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		return 32_756;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -107,7 +107,7 @@ public class InformixDialect extends Dialect {
 		registerColumnType( Types.VARBINARY, "byte" );
 
 		registerColumnType( Types.VARCHAR, 255, "varchar($l)" );
-		registerColumnType( Types.VARCHAR, 32_739, "lvarchar($l)" );
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "lvarchar($l)" );
 		registerColumnType( Types.VARCHAR, "text" );
 
 		uniqueDelegate = new InformixUniqueDelegate( this );
@@ -118,6 +118,18 @@ public class InformixDialect extends Dialect {
 				//version 11 and above, parameters are supported
 				//but I have not tested this at all!
 				: new SkipFirstLimitHandler( getVersion().isSameOrAfter( 11 ) );
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		//there's no varbinary type, only byte
+		return -1;
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		//the maximum length of an lvarchar
+		return 32_739;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
@@ -119,10 +119,8 @@ public class IngresDialect extends Dialect {
 
 		registerColumnType( Types.NUMERIC, "decimal($p, $s)" ); //Ingres has no 'numeric' type
 
-		final int maxStringLength = 32_000;
-
-		registerColumnType( Types.BINARY, maxStringLength, "byte($l)" );
-		registerColumnType( Types.VARBINARY, maxStringLength, "varbyte($l)" );
+		registerColumnType( Types.BINARY, "byte($l)" );
+		registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "varbyte($l)" );
 		//note: 'long byte' is a  synonym for 'blob'
 		registerColumnType( Types.VARBINARY, "long byte($l)" );
 
@@ -130,13 +128,13 @@ public class IngresDialect extends Dialect {
 		//      here? I think Ingres char/varchar types don't
 		//      support Unicode. Copy what AbstractHANADialect
 		//      does with a Hibernate property to config this.
-		registerColumnType( Types.CHAR, maxStringLength, "char($l)" );
-		registerColumnType( Types.VARCHAR, maxStringLength, "varchar($l)" );
+		registerColumnType( Types.CHAR, "char($l)" );
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "varchar($l)" );
 		//note: 'long varchar' is a synonym for 'clob'
 		registerColumnType( Types.VARCHAR, "long varchar($l)" );
 
-		registerColumnType( Types.NCHAR, maxStringLength, "nchar($l)" );
-		registerColumnType( Types.NVARCHAR, maxStringLength, "nvarchar($l)" );
+		registerColumnType( Types.NCHAR, "nchar($l)" );
+		registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "nvarchar($l)" );
 		//note: 'long nvarchar' is a synonym for 'nclob'
 		registerColumnType( Types.NVARCHAR, "long nvarchar($l)" );
 
@@ -178,6 +176,20 @@ public class IngresDialect extends Dialect {
 	@Override
 	public DatabaseVersion getVersion() {
 		return version;
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		// the maximum possible (configurable) value for
+		// both varchar and varbyte
+		return 32_000;
+	}
+
+	@Override
+	public int getMaxNVarcharLength() {
+		// the maximum possible (configurable) value for
+		// nvarchar
+		return 16_000;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MaxDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MaxDBDialect.java
@@ -69,6 +69,12 @@ public class MaxDBDialect extends Dialect {
 	}
 
 	@Override
+	public int getMaxVarbinaryLength() {
+		// there's no varbinary type
+		return -1;
+	}
+
+	@Override
 	public JdbcType resolveSqlTypeDescriptor(
 			String columnTypeName,
 			int jdbcTypeCode,

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
@@ -106,22 +106,28 @@ public class RDMSOS2200Dialect extends Dialect {
 		registerColumnType( Types.BLOB, "blob($l)" );
 
 		//no 'binary' nor 'varbinary' so use 'blob'
-		registerColumnType( Types.BINARY, "blob($l)");
-		registerColumnType( Types.VARBINARY, "blob($l)");
+		registerColumnType( Types.BINARY, "blob($l)" );
+		registerColumnType( Types.VARBINARY, "blob($l)" );
 
 		//'varchar' is not supported in RDMS for OS 2200
 		//(but it is for other flavors of RDMS)
 		//'character' means ASCII by default, 'unicode(n)'
 		//means 'character(n) character set "UCS-2"'
-		registerColumnType( Types.CHAR, "unicode($l)");
-		registerColumnType( Types.VARCHAR, "unicode($l)");
+		registerColumnType( Types.CHAR, "unicode($l)" );
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "unicode($l)" );
 
-		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp($p)");
+		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp($p)" );
 	}
 
 	public RDMSOS2200Dialect(DialectResolutionInfo info) {
 		this();
 		registerKeywords( info );
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		//no varbinary type
+		return -1;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -112,6 +112,12 @@ public class SQLiteDialect extends Dialect {
 		uniqueDelegate = new SQLiteUniqueDelegate( this );
 	}
 
+	@Override
+	public int getMaxVarbinaryLength() {
+		//no varbinary type
+		return -1;
+	}
+
 	private static class SQLiteUniqueDelegate extends DefaultUniqueDelegate {
 		public SQLiteUniqueDelegate(Dialect dialect) {
 			super( dialect );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -109,7 +109,6 @@ public class SQLiteDialect extends Dialect {
 
 		registerColumnType( Types.BINARY, "blob" );
 		registerColumnType( Types.VARBINARY, "blob" );
-		registerColumnType( Types.LONGVARBINARY, "blob" );
 		uniqueDelegate = new SQLiteUniqueDelegate( this );
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
@@ -55,20 +55,16 @@ public class SybaseAnywhereDialect extends SybaseDialect {
 		registerColumnType( Types.TIMESTAMP, "timestamp" );
 		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp with time zone" );
 
-		final int maxStringLength = 32_767;
-
-		registerColumnType( Types.CHAR, maxStringLength, "char($l)" );
-		registerColumnType( Types.VARCHAR, maxStringLength, "varchar($l)" );
 		registerColumnType( Types.VARCHAR, "long varchar)" );
-
-		registerColumnType( Types.NCHAR, maxStringLength, "nchar($l)" );
-		registerColumnType( Types.NVARCHAR, maxStringLength, "nvarchar($l)" );
 		registerColumnType( Types.NVARCHAR, "long nvarchar)" );
 
 		//note: 'binary' is actually a synonym for 'varbinary'
-		registerColumnType( Types.BINARY, maxStringLength, "binary($l)" );
-		registerColumnType( Types.VARBINARY, maxStringLength, "varbinary($l)" );
 		registerColumnType( Types.VARBINARY, "long binary)" );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 32_767;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
@@ -93,7 +93,7 @@ public class TeradataDialect extends Dialect {
 		registerColumnType( Types.TINYINT, "byteint" );
 
 		registerColumnType( Types.BINARY, "byte($l)" );
-		registerColumnType( Types.VARBINARY, "varbyte($l)" );
+		registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "varbyte($l)" );
 
 		if ( getVersion().isBefore( 13 ) ) {
 			registerColumnType( Types.BIGINT, "numeric(19,0)" );
@@ -127,6 +127,17 @@ public class TeradataDialect extends Dialect {
 			getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
 		}
 
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		//for the unicode server character set
+		return 32_000;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		return 64_000;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
@@ -73,28 +73,28 @@ public class TimesTenDialect extends Dialect {
 		//      TypeMode=0
 		registerColumnType( Types.BOOLEAN, "tt_tinyint" );
 
-		registerColumnType(Types.TINYINT, "tt_tinyint");
-		registerColumnType(Types.SMALLINT, "tt_smallint");
-		registerColumnType(Types.INTEGER, "tt_integer");
-		registerColumnType(Types.BIGINT, "tt_bigint");
+		registerColumnType( Types.TINYINT, "tt_tinyint" );
+		registerColumnType( Types.SMALLINT, "tt_smallint" );
+		registerColumnType( Types.INTEGER, "tt_integer" );
+		registerColumnType( Types.BIGINT, "tt_bigint" );
 
 		//note that 'binary_float'/'binary_double' might
 		//be better mappings for Java Float/Double
 
 		//'numeric'/'decimal' are synonyms for 'number'
-		registerColumnType(Types.NUMERIC, "number($p,$s)");
-		registerColumnType(Types.DECIMAL, "number($p,$s)" );
+		registerColumnType( Types.NUMERIC, "number($p,$s)" );
+		registerColumnType( Types.DECIMAL, "number($p,$s)" );
 
-		registerColumnType( Types.VARCHAR, "varchar2($l)" );
-		registerColumnType( Types.NVARCHAR, "nvarchar2($l)" );
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "varchar2($l)" );
+		registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "nvarchar2($l)" );
 
 		//do not use 'date' because it's a datetime
-		registerColumnType(Types.DATE, "tt_date");
+		registerColumnType( Types.DATE, "tt_date" );
 		//'time' and 'tt_time' are synonyms
-		registerColumnType(Types.TIME, "tt_time");
+		registerColumnType( Types.TIME, "tt_time" );
 		//`timestamp` has more precision than `tt_timestamp`
 //		registerColumnType(Types.TIMESTAMP, "tt_timestamp");
-		registerColumnType(Types.TIMESTAMP_WITH_TIMEZONE, "timestamp($p)");
+		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp($p)" );
 
 		getDefaultProperties().setProperty( Environment.USE_STREAMS_FOR_BINARY, "true" );
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );

--- a/hibernate-core/src/main/java/org/hibernate/Length.java
+++ b/hibernate-core/src/main/java/org/hibernate/Length.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate;
+
+/**
+ * Defines a list of useful constant values that may be used
+ * to specify long column lengths in the JPA
+ * {@link jakarta.persistence.Column} annotation.
+ * <p>
+ * For example, {@code @Column(length=LONG16)} would specify
+ * that Hibernate should generate DDL with a column type
+ * capable of holding strings with 16-bit lengths.
+ *
+ * @see jakarta.persistence.Column#length()
+ *
+ * @author Gavin King
+ */
+public final class Length {
+	/**
+	 * The default length for a column in JPA.
+	 *
+	 * @see jakarta.persistence.Column#length()
+	 * @see org.hibernate.type.descriptor.java.JavaType#getDefaultSqlLength
+	 */
+	public static final int DEFAULT = 255;
+	/**
+	 * Used to select a variable-length SQL type large
+	 * enough to contain values of maximum length 32600.
+	 * This arbitrary-looking number was chosen because
+	 * some databases support variable-length types
+	 * right up to a limit that is just slightly below
+	 * 32767. (For some, the limit is 32672 characters.)
+	 * <p>
+	 * This is also the default length for a column
+	 * declared using
+	 * {@code @JdbcTypeCode(Types.LONGVARCHAR)} or
+	 * {@code @JdbcTypeCode(Types.LONGVARBINARY)}.
+	 *
+	 * @see org.hibernate.type.descriptor.java.JavaType#getLongSqlLength
+	 */
+	public static final int LONG = 32_600;
+	/**
+	 * The maximum length that fits in 16 bits.
+	 * Used to select a variable-length SQL type large
+	 * enough to contain values of maximum length 32767.
+	 */
+	public static final int LONG16 = Short.MAX_VALUE;
+	/**
+	 * The maximum length of a Java string, that is,
+	 * the maximum length that fits in 32 bits.
+	 * Used to select a variable-length SQL type large
+	 * enough to contain any Java string.
+	 */
+	public static final int LONG32 = Integer.MAX_VALUE;
+	/**
+	 * The default length for a LOB column.
+	 *
+	 * @see org.hibernate.dialect.Dialect#getDefaultLobLength
+	 */
+	public static final int LOB_DEFAULT = 1_048_576;
+
+	private Length() {}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -95,20 +95,23 @@ public class CockroachDialect extends Dialect {
 
 		registerColumnType( Types.TINYINT, "smallint" ); //no tinyint
 
+		//use 'string' instead of 'varchar'
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "string($l)");
+		registerColumnType( Types.VARCHAR, "string");
+
 		//no binary/varbinary
 		registerColumnType( Types.VARBINARY, "bytes" );
 		registerColumnType( Types.BINARY, "bytes" );
 
 		//no clob
-		registerColumnType( Types.LONGVARCHAR, "string" );
 		registerColumnType( Types.CLOB, "string" );
 
 		//no nchar/nvarchar
 		registerColumnType( Types.NCHAR, "string($l)" );
-		registerColumnType( Types.NVARCHAR, "string($l)" );
+		registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "string($l)" );
+		registerColumnType( Types.NVARCHAR, "string");
 
 		//no nclob
-		registerColumnType( Types.LONGNVARCHAR, "string" );
 		registerColumnType( Types.NCLOB, "string" );
 
 		registerColumnType( SqlTypes.UUID, "uuid" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -101,14 +101,16 @@ public class DB2Dialect extends Dialect {
 		registerColumnType( Types.NUMERIC, "decimal($p,$s)" );
 
 		if ( getVersion().isBefore( 11 ) ) {
-			registerColumnType( Types.BINARY, "varchar($l) for bit data" ); //should use 'binary' since version 11
 			registerColumnType( Types.BINARY, 254, "char($l) for bit data" ); //should use 'binary' since version 11
-			registerColumnType( Types.VARBINARY, "varchar($l) for bit data" ); //should use 'varbinary' since version 11
+			registerColumnType( Types.BINARY, "varchar($l) for bit data" ); //should use 'binary' since version 11
+
+			registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "varchar($l) for bit data" ); //should use 'varbinary' since version 11
 
 			//prior to DB2 11, the 'boolean' type existed,
 			//but was not allowed as a column type
 			registerColumnType( Types.BOOLEAN, "smallint" );
 		}
+		registerColumnType( Types.VARBINARY, "blob($l)" );
 
 		registerColumnType( Types.BLOB, "blob($l)" );
 		registerColumnType( Types.CLOB, "clob($l)" );
@@ -117,7 +119,8 @@ public class DB2Dialect extends Dialect {
 		registerColumnType( Types.TIME_WITH_TIMEZONE, "time" );
 
 		// The long varchar data type was deprecated in DB2 and shouldn't be used anymore
-		registerColumnType( Types.LONGVARCHAR, "clob($l)" );
+		registerColumnType( Types.VARCHAR, "clob($l)" );
+		registerColumnType( Types.NVARCHAR, "nclob($l)" );
 
 		//not keywords, at least not in DB2 11,
 		//but perhaps they were in older versions?
@@ -141,6 +144,11 @@ public class DB2Dialect extends Dialect {
 
 	protected UniqueDelegate createUniqueDelegate() {
 		return new DB2UniqueDelegate( this );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 32_672;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -120,10 +120,11 @@ public class DerbyDialect extends Dialect {
 		registerColumnType( Types.NUMERIC, "decimal($p,$s)" );
 
 		registerColumnType( Types.BINARY, 254, "char($l) for bit data" );
-		registerColumnType( Types.BINARY, 32672, "varchar($l) for bit data" );
+		registerColumnType( Types.BINARY, getMaxVarbinaryLength(), "varchar($l) for bit data" );
 		registerColumnType( Types.BINARY, "long varchar for bit data" );
-		registerColumnType( Types.VARBINARY, 32672, "varchar($l) for bit data" );
-		registerColumnType( Types.VARBINARY, "long varchar for bit data" );
+		registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "varchar($l) for bit data" );
+		registerColumnType( Types.VARBINARY, 32_700,"long varchar for bit data" );
+		registerColumnType( Types.VARBINARY, "blob($l)" );
 
 		registerColumnType( Types.BLOB, "blob($l)" );
 		registerColumnType( Types.CLOB, "clob($l)" );
@@ -131,7 +132,8 @@ public class DerbyDialect extends Dialect {
 		registerColumnType( Types.TIMESTAMP, "timestamp" );
 		registerColumnType( Types.TIMESTAMP_WITH_TIMEZONE, "timestamp" );
 
-		registerColumnType( Types.LONGVARCHAR, "long varchar" );
+		registerColumnType( Types.VARCHAR, 32_700, "long varchar" );
+		registerColumnType( Types.VARCHAR, "clob($l)" );
 
 		registerDerbyKeywords();
 
@@ -140,6 +142,11 @@ public class DerbyDialect extends Dialect {
 				: new DerbyLimitHandler( getVersion().isSameOrAfter( 10, 6 ) );
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, NO_BATCH );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 32_672;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -128,7 +128,12 @@ public class H2Dialect extends Dialect {
 		// http://code.google.com/p/h2database/issues/detail?id=235
 		getDefaultProperties().setProperty( AvailableSettings.NON_CONTEXTUAL_LOB_CREATION, "true" );
 
+		registerColumnType( Types.VARCHAR, "varchar" );
+		registerColumnType( Types.NVARCHAR, "varchar" );
+		registerColumnType( Types.VARBINARY, "varbinary" );
+
 		registerColumnType( SqlTypes.ARRAY, "array" );
+
 		if ( version.isSameOrAfter( 1, 4, 32 ) ) {
 			this.sequenceInformationExtractor = version.isSameOrAfter( 1, 4, 201 )
 					? SequenceInformationExtractorLegacyImpl.INSTANCE
@@ -238,6 +243,11 @@ public class H2Dialect extends Dialect {
 			CommonFunctionFactory.format_formatdatetime( queryEngine );
 		}
 		CommonFunctionFactory.rownum( queryEngine );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 1_048_576;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
@@ -47,12 +47,10 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 	public HANAColumnStoreDialect(DatabaseVersion version) {
 		super( version );
 		if ( version.isSameOrAfter( 4 ) ) {
-			registerColumnType( Types.CHAR, "nvarchar(1)" );
-			registerColumnType( Types.VARCHAR, 5000, "nvarchar($l)" );
-			registerColumnType( Types.LONGVARCHAR, 5000, "nvarchar($l)" );
+			registerColumnType( Types.CHAR, "nvarchar($l)" );
+			registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "nvarchar($l)" );
 
 			// for longer values map to clob/nclob
-			registerColumnType( Types.LONGVARCHAR, "nclob" );
 			registerColumnType( Types.VARCHAR, "nclob" );
 			registerColumnType( Types.CLOB, "nclob" );
 
@@ -67,6 +65,11 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 			// register additional keywords
 			registerHanaCloudKeywords();
 		}
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 5000;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -60,10 +60,6 @@ public class MariaDBDialect extends MySQLDialect {
 		this.version = version;
 	}
 
-	protected int getMaxVarcharLen() {
-		return getMySQLVersion().isBefore( 5 ) ? 255 : 65_534;
-	}
-
 	@Override
 	public DatabaseVersion getVersion() {
 		return version;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -200,6 +200,19 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public int getMaxVarcharLength() {
+		//with MAX_STRING_SIZE=EXTENDED, changes to 32_767
+		//TODO: provide a way to change this without a custom Dialect
+		return 4000;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		//with MAX_STRING_SIZE=EXTENDED, changes to 32_767
+		return 2000;
+	}
+
+	@Override
 	public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
 		return new StandardSqlAstTranslatorFactory() {
 			@Override
@@ -525,16 +538,17 @@ public class OracleDialect extends Dialect {
 
 	protected void registerCharacterTypeMappings() {
 		if ( getVersion().isBefore( 9 ) ) {
-			registerColumnType( Types.VARCHAR, 4000, "varchar2($l)" );
+			registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "varchar2($l)" );
 			registerColumnType( Types.VARCHAR, "clob" );
 		}
 		else {
 			registerColumnType( Types.CHAR, "char($l char)" );
-			registerColumnType( Types.VARCHAR, 4000, "varchar2($l char)" );
+			registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "varchar2($l char)" );
 			registerColumnType( Types.VARCHAR, "clob" );
-			registerColumnType( Types.NVARCHAR, 4000, "nvarchar2($l)" );
+			registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "nvarchar2($l)" );
 			registerColumnType( Types.NVARCHAR, "nclob" );
 		}
+		//note: the 'long' type is deprecated
 	}
 
 	protected void registerNumericTypeMappings() {
@@ -576,10 +590,10 @@ public class OracleDialect extends Dialect {
 	}
 
 	protected void registerBinaryTypeMappings() {
-		registerColumnType( Types.BINARY, 2000, "raw($l)" );
+		registerColumnType( Types.BINARY, getMaxVarbinaryLength(), "raw($l)" );
 		registerColumnType( Types.BINARY, "blob" );
 
-		registerColumnType( Types.VARBINARY, 2000, "raw($l)" );
+		registerColumnType( Types.VARBINARY, getMaxVarbinaryLength(), "raw($l)" );
 		registerColumnType( Types.VARBINARY, "blob" );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -132,13 +132,13 @@ public class PostgreSQLDialect extends Dialect {
 
 		//there are no nchar/nvarchar types in Postgres
 		registerColumnType( Types.NCHAR, "char($l)" );
-		registerColumnType( Types.NVARCHAR, "varchar($l)" );
+		registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "varchar($l)" );
+		registerColumnType( Types.NVARCHAR, "text" );
 
-		//since there's no real difference between
-		//TEXT and VARCHAR, except for the length limit,
-		//we can just use 'text' for the "long" types
-		registerColumnType( Types.LONGVARCHAR, "text" );
-		registerColumnType( Types.LONGNVARCHAR, "text" );
+		// since there's no real difference between TEXT and VARCHAR,
+		// except for the length limit, we can just use 'text' for the
+		// "long" string types
+		registerColumnType( Types.VARCHAR, "text" );
 
 		registerColumnType( SqlTypes.INET, "inet" );
 		registerColumnType( SqlTypes.INTERVAL_SECOND, "interval second($s)" );
@@ -161,6 +161,17 @@ public class PostgreSQLDialect extends Dialect {
 
 		getDefaultProperties().setProperty( Environment.STATEMENT_BATCH_SIZE, DEFAULT_BATCH_SIZE );
 		getDefaultProperties().setProperty( Environment.NON_CONTEXTUAL_LOB_CREATION, "true" );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 10_485_760;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		//postgres has no varbinary-like type
+		return 0;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -66,7 +66,6 @@ import java.util.TimeZone;
 
 import jakarta.persistence.TemporalType;
 
-import static java.util.regex.Pattern.compile;
 import static org.hibernate.query.TemporalUnit.NANOSECOND;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsDate;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTime;
@@ -113,13 +112,10 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 			exporter = new SqlServerSequenceExporter( this );
 		}
 
-		registerColumnType( Types.VARCHAR, 8000, "varchar($l)" );
-		registerColumnType( Types.NVARCHAR, 4000, "nvarchar($l)" );
-		registerColumnType( Types.VARBINARY, 8000, "varbinary($l)" );
-
 		if ( getVersion().isBefore( 9 ) ) {
 			registerColumnType( Types.VARBINARY, "image" );
 			registerColumnType( Types.VARCHAR, "text" );
+			registerColumnType( Types.NVARCHAR, "text" );
 		}
 		else {
 
@@ -144,6 +140,16 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 		registerKeyword( "top" );
 		registerKeyword( "key" );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 8000;
+	}
+
+	@Override
+	public int getMaxNVarcharLength() {
+		return 4000;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -92,17 +92,20 @@ public class SpannerDialect extends Dialect {
 		//there is no time type of any kind
 		registerColumnType( Types.TIME, "timestamp" );
 
-		final int stringMaxLength = 2_621_440;
-		final int bytesMaxLength = 10_485_760;
+		registerColumnType( Types.CHAR, getMaxVarcharLength(), "string($l)" );
+		registerColumnType( Types.CHAR, "string(max)" );
+		registerColumnType( Types.VARCHAR, getMaxVarcharLength(), "string($l)" );
+		registerColumnType( Types.VARCHAR, "string(max)" );
 
-		registerColumnType( Types.CHAR, stringMaxLength, "string($l)" );
-		registerColumnType( Types.VARCHAR, stringMaxLength, "string($l)" );
+		registerColumnType( Types.NCHAR, getMaxNVarcharLength(), "string($l)" );
+		registerColumnType( Types.NCHAR, "string(max)" );
+		registerColumnType( Types.NVARCHAR, getMaxNVarcharLength(), "string($l)" );
+		registerColumnType( Types.NVARCHAR, "string(max)" );
 
-		registerColumnType( Types.NCHAR, stringMaxLength, "string($l)" );
-		registerColumnType( Types.NVARCHAR, stringMaxLength, "string($l)" );
-
-		registerColumnType( Types.BINARY, bytesMaxLength, "bytes($l)" );
-		registerColumnType( Types.VARBINARY, bytesMaxLength, "bytes($l)" );
+		registerColumnType( Types.BINARY, getMaxBytesLength(), "bytes($l)" );
+		registerColumnType( Types.BINARY, "bytes(max)" );
+		registerColumnType( Types.VARBINARY, getMaxBytesLength(), "bytes($l)" );
+		registerColumnType( Types.VARBINARY, "bytes(max)" );
 
 		registerColumnType( Types.CLOB, "string(max)" );
 		registerColumnType( Types.NCLOB, "string(max)" );
@@ -112,6 +115,17 @@ public class SpannerDialect extends Dialect {
 	public SpannerDialect(DialectResolutionInfo info) {
 		this();
 		registerKeywords( info );
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		//max is equivalent to 2_621_440
+		return 2_621_440;
+	}
+
+	public int getMaxBytesLength() {
+		//max is equivalent to 10_485_760
+		return 10_485_760;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
@@ -99,12 +99,8 @@ public class SybaseASEDialect extends SybaseDialect {
 			}
 		}
 
-		// the maximum length of a VARCHAR or VARBINARY
-		// depends on the page size, and also on the
-		// version of Sybase ASE, and can be quite small,
-		// so use 'image' and 'text' as the "long" types
-		registerColumnType( Types.LONGVARBINARY, "image" );
-		registerColumnType( Types.LONGVARCHAR, "text" );
+		registerColumnType( Types.VARBINARY, "image" );
+		registerColumnType( Types.VARCHAR, "text" );
 
 		registerSybaseKeywords();
 		sizeStrategy = new SizeStrategyImpl() {
@@ -125,6 +121,17 @@ public class SybaseASEDialect extends SybaseDialect {
 				return super.resolveSize( jdbcType, javaType, precision, scale, length );
 			}
 		};
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		// the maximum length of a VARCHAR or VARBINARY
+		// column depends on the page size and ASE version
+		// and is actually a limit on the whole row length,
+		// not the individual column length -- anyway, the
+		// largest possible page size is 16k, so that's a
+		// hard upper limit
+		return 16_384;
 	}
 
 	private static boolean isAnsiNull(DatabaseMetaData databaseMetaData) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/Size.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/Size.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.engine.jdbc;
 
+import org.hibernate.Length;
+
 import java.io.Serializable;
 
 /**
@@ -35,9 +37,9 @@ public class Size implements Serializable {
 		}
 	}
 
-	public static final long DEFAULT_LENGTH = 255;
-	public static final long LONG_LENGTH = 65_535;
-	public static final long DEFAULT_LOB_LENGTH = 1_048_576;
+	public static final long DEFAULT_LENGTH = Length.DEFAULT;
+	public static final long LONG_LENGTH = Length.LONG;
+	public static final long DEFAULT_LOB_LENGTH = Length.LOB_DEFAULT;
 	public static final int DEFAULT_PRECISION = 19;
 	public static final int DEFAULT_SCALE = 2;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/length/LengthTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/length/LengthTest.java
@@ -1,0 +1,25 @@
+package org.hibernate.orm.test.length;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+@SessionFactory
+@DomainModel(annotatedClasses = WithLongStrings.class)
+public class LengthTest {
+    @Test
+    public void testLength(SessionFactoryScope scope) {
+        WithLongStrings strings = new WithLongStrings();
+        strings.long16 = "hello world ".repeat(2700);
+        strings.long32 = "hello world ".repeat(20000);
+        scope.inTransaction(s->s.persist(strings));
+        scope.inTransaction(s-> {
+            WithLongStrings strs = s.find(WithLongStrings.class, strings.id);
+            assertEquals(strs.long16, strings.long16);
+            assertEquals(strs.long32, strings.long32);
+        });
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/length/WithLongStrings.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/length/WithLongStrings.java
@@ -1,0 +1,21 @@
+package org.hibernate.orm.test.length;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static org.hibernate.Length.*;
+
+@Entity
+public class WithLongStrings {
+    @Id
+    @GeneratedValue
+    public int id;
+
+    @Column(length = LONG16)
+    public String long16;
+
+    @Column(length = LONG32)
+    public String long32;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ImageMappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ImageMappings.hbm.xml
@@ -16,7 +16,7 @@
 			<generator class="increment"/>
 		</id>
 
-		<property name="longByteArray" column="LONG_BYTE_ARRAY" type="image" length="15000"/>
+		<property name="longByteArray" column="LONG_BYTE_ARRAY" type="image" length="17000"/>
     </class>
 
 </hibernate-mapping>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/GeneratedUuidTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/GeneratedUuidTests.java
@@ -53,7 +53,7 @@ public class GeneratedUuidTests {
 
 		// then changing
 		final GeneratedUuidEntity merged = scope.fromTransaction( (session) -> {
-			return (GeneratedUuidEntity) session.merge( created );
+			return session.merge( created );
 		} );
 
 		assertThat( merged ).isNotNull();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/LongVarcharValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/LongVarcharValidationTest.java
@@ -53,7 +53,8 @@ public class LongVarcharValidationTest implements ExecutionOptions {
 	@Parameterized.Parameters
 	public static Collection<String> parameters() {
 		return Arrays.asList(
-				new String[] {JdbcMetadaAccessStrategy.GROUPED.toString(), JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()}
+				JdbcMetadaAccessStrategy.GROUPED.toString(),
+				JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/NumericValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/NumericValidationTest.java
@@ -52,10 +52,8 @@ public class NumericValidationTest implements ExecutionOptions {
 	@Parameterized.Parameters
 	public static Collection<String> parameters() {
 		return Arrays.asList(
-				new String[] {
-						JdbcMetadaAccessStrategy.GROUPED.toString(),
-						JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
-				}
+				JdbcMetadaAccessStrategy.GROUPED.toString(),
+				JdbcMetadaAccessStrategy.INDIVIDUALLY.toString()
 		);
 	}
 


### PR DESCRIPTION
I'm really very happy with this, it just makes sense:

- it makes the supported dialects more graceful and much more consistent in their handling of long column lengths
- it makes it easy for people already using JPA's `@Column` or even Hibernate Validators `@Size` annotation
- it nicely distinguishes between 16-bit "long" (MySQL `text`) and really damn 32-bit "long"
- it has an incredibly minimal impact
