### PR TITLE
HHH-14948 Adapt contributed patch to 6.0 branch

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/MetamodelBoundedCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/MetamodelBoundedCacheTest.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.hql;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.hibernate.metamodel.model.domain.internal.JpaMetamodelImpl;
+import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetamodelBoundedCacheTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14948")
+	public void testMemoryConsumptionOfFailedImportsCache() throws NoSuchFieldException, IllegalAccessException {
+		MappingMetamodel mappingMetamodel = sessionFactory().getMetamodel();
+
+		MappingMetamodelImpl mImpl = (MappingMetamodelImpl) mappingMetamodel;
+		final JpaMetamodel jpaMetamodel = mImpl.getJpaMetamodel();
+
+		for ( int i = 0; i < 1001; i++ ) {
+			jpaMetamodel.qualifyImportableName( "nonexistend" + i );
+		}
+
+		Field field = JpaMetamodelImpl.class.getDeclaredField( "nameToImportMap" );
+		field.setAccessible( true );
+
+		//noinspection unchecked
+		Map<String, String> imports = (Map<String, String>) field.get( jpaMetamodel );
+
+		// VERY hard-coded, but considering the possibility of a regression of a memory-related issue,
+		// it should be worth it
+		assertEquals( 1000, imports.size() );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Employee.class };
+	}
+
+	@Entity( name = "Employee" )
+	@Table( name= "tabEmployees" )
+	public class Employee {
+		@Id
+		private long id;
+		private String name;
+
+		public Employee() {
+
+		}
+
+		public Employee(long id, String strName) {
+			this();
+			this.name = strName;
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String strName) {
+			this.name = strName;
+		}
+
+	}
+}

--- a/hibernate-core/src/test_legacy/org/hibernate/test/hql/QuerySplitterTest.java
+++ b/hibernate-core/src/test_legacy/org/hibernate/test/hql/QuerySplitterTest.java
@@ -13,6 +13,12 @@ import jakarta.persistence.Table;
 
 import org.hibernate.query.hql.internal.QuerySplitter;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.hibernate.metamodel.internal.MetamodelImpl;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
@@ -46,6 +52,29 @@ public class QuerySplitterTest extends BaseNonConfigCoreFunctionalTestCase {
 				"from org.hibernate.test.hql.QuerySplitterTest$Employee where name = 'He is the, Employee Number 1'",
 				results[0]
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-14948")
+	public void testMemoryConsumptionOfFailedImportsCache() throws NoSuchFieldException, IllegalAccessException {
+
+		IntStream.range( 0, 1001 )
+				.forEach( i -> QuerySplitter.concreteQueries(
+						"from Employee e join e.company" + i,
+						sessionFactory()
+				) );
+
+		MetamodelImpl metamodel = (MetamodelImpl) sessionFactory().getMetamodel();
+
+		Field field = MetamodelImpl.class.getDeclaredField( "imports" );
+		field.setAccessible( true );
+
+		//noinspection unchecked
+		Map<String, String> imports = (Map<String, String>) field.get( metamodel );
+
+		// VERY hard-coded, but considering the possibility of a regression of a memory-related issue,
+		// it should be worth it
+		assertEquals( 1000, imports.size() );
 	}
 
 	@Test


### PR DESCRIPTION
This particular test is disabled as it's located in `test_legacy` .. it's also not compiling but it's a 1:1 port of the contribution already applied on 5.6 so I'd first align these to not forget.

I'll try to conver the test soon with @dreab8 