### PR TITLE
Make TableReference an interface with various sub-classes

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -10,8 +10,8 @@
 ext {
 
     junitVersion = '4.13.2'
-    junitVintageVersion = '5.7.1'
-    junit5Version = '5.7.1'
+    junitVintageVersion = '5.8.2'
+    junit5Version = '5.8.2'
 
     h2Version = '1.4.197'
     bytemanVersion = '4.0.16' //Compatible with JDK16

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
@@ -702,6 +702,11 @@ public class FirebirdDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 4, 0 );
+	}
+
+	@Override
 	public String translateExtractField(TemporalUnit unit) {
 		switch ( unit ) {
 			case DAY_OF_MONTH: return "day";

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -342,6 +342,16 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsWindowFunctions() {
+		return getVersion().isSameOrAfter( 12, 10 );
+	}
+
+	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 12, 10 );
+	}
+
+	@Override
 	public ViolatedConstraintNameExtractor getViolatedConstraintNameExtractor() {
 		return EXTRACTOR;
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixSqmToSqlAstConverter.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixSqmToSqlAstConverter.java
@@ -18,8 +18,8 @@ import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 
 /**
@@ -54,7 +54,7 @@ public class InformixSqmToSqlAstConverter<T extends Statement> extends BaseSqmTo
 								null,
 								null,
 								null,
-								new TableReference(
+								new NamedTableReference(
 										"(select 1)",
 										"dummy_(x)",
 										false,

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
@@ -500,7 +500,11 @@ public class IngresDialect extends Dialect {
 		return false;
 	}
 
-	// Informational metadata ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	@Override
+	public boolean supportsWindowFunctions() {
+		return getVersion().isSameOrAfter( 10, 2 );
+	}
+// Informational metadata ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
 	public boolean doesReadCommittedCauseWritersToBlockReaders() {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresSqmToSqlAstConverter.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresSqmToSqlAstConverter.java
@@ -18,8 +18,8 @@ import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 
 /**
@@ -54,7 +54,7 @@ public class IngresSqmToSqlAstConverter<T extends Statement> extends BaseSqmToSq
 								null,
 								null,
 								null,
-								new TableReference(
+								new NamedTableReference(
 										"(select 1)",
 										"dummy_(x)",
 										false,

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteSqlAstTranslator.java
@@ -16,6 +16,7 @@ import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.Every;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -90,6 +91,11 @@ public class SQLiteSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 		else {
 			super.visitQuerySpec( querySpec );
 		}
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+		emulateQueryPartTableReferenceColumnAliasing( tableReference );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
@@ -30,7 +30,7 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import static org.hibernate.type.SqlTypes.*;
 
 /**
- * SQL Dialect for Sybase Anywhere
+ * SQL Dialect for Sybase/SQL Anywhere
  * (Tested on ASA 8.x)
  */
 public class SybaseAnywhereDialect extends SybaseDialect {
@@ -133,6 +133,16 @@ public class SybaseAnywhereDialect extends SybaseDialect {
 	@Override
 	public boolean dropConstraints() {
 		return false;
+	}
+
+	@Override
+	public boolean supportsWindowFunctions() {
+		return getVersion().isSameOrAfter( 12 );
+	}
+
+	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 10 );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereSqlAstTranslator.java
@@ -23,7 +23,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.Summarization;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectClause;
@@ -93,8 +93,8 @@ public class SybaseAnywhereSqlAstTranslator<T extends JdbcOperation> extends Abs
 	}
 
 	@Override
-	protected boolean renderTableReference(TableReference tableReference, LockMode lockMode) {
-		super.renderTableReference( tableReference, lockMode );
+	protected boolean renderNamedTableReference(NamedTableReference tableReference, LockMode lockMode) {
+		super.renderNamedTableReference( tableReference, lockMode );
 		if ( getDialect().getVersion().isBefore( 10 ) ) {
 			if ( LockMode.READ.lessThan( lockMode ) ) {
 				appendSql( " holdlock" );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
@@ -380,6 +380,11 @@ public class TeradataDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsWindowFunctions() {
+		return getVersion().isSameOrAfter( 16, 10 );
+	}
+
+	@Override
 	public String getSelectClauseNullString(int sqlType) {
 		String v = "null";
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenSqlAstTranslator.java
@@ -21,6 +21,9 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.from.TableGroupJoin;
+import org.hibernate.sql.ast.tree.predicate.Junction;
+import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -56,12 +59,34 @@ public class TimesTenSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	}
 
 	@Override
-	protected void renderJoinType(SqlAstJoinType joinType) {
-		if ( joinType == SqlAstJoinType.CROSS ) {
+	protected void renderTableGroupJoin(TableGroupJoin tableGroupJoin, List<TableGroupJoin> tableGroupJoinCollector) {
+		if ( tableGroupJoin.getJoinType() == SqlAstJoinType.CROSS ) {
 			appendSql( ", " );
 		}
 		else {
-			super.renderJoinType( joinType );
+			appendSql( WHITESPACE );
+			appendSql( tableGroupJoin.getJoinType().getText() );
+			appendSql( "join " );
+		}
+
+		final Predicate predicate;
+		if ( tableGroupJoin.isLateral() ) {
+			append( "lateral " );
+			if ( tableGroupJoin.getPredicate() == null ) {
+				predicate = new Junction( Junction.Nature.CONJUNCTION );
+			}
+			else {
+				predicate = tableGroupJoin.getPredicate();
+			}
+		}
+		else {
+			predicate = tableGroupJoin.getPredicate();
+		}
+		if ( predicate != null && !predicate.isEmpty() ) {
+			renderTableGroup( tableGroupJoin.getJoinedGroup(), predicate, tableGroupJoinCollector );
+		}
+		else {
+			renderTableGroup( tableGroupJoin.getJoinedGroup(), tableGroupJoinCollector );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -673,6 +673,11 @@ public class CockroachDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 20, 1 );
+	}
+
+	@Override
 	public boolean supportsNoWait() {
 		return getVersion().isSameOrAfter( 20, 1 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -672,6 +672,11 @@ public class DB2Dialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 9, 1 );
+	}
+
+	@Override
 	public void appendDatetimeFormat(SqlAppender appender, String format) {
 		//DB2 does not need nor support FM
 		appender.appendSql( OracleDialect.datetimeFormat( format, false, false ).result() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -100,6 +100,11 @@ public class DB2iDialect extends DB2Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getIVersion().isSameOrAfter( 7, 1 );
+	}
+
+	@Override
 	public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
 		return new StandardSqlAstTranslatorFactory() {
 			@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -42,7 +42,7 @@ public class DB2zDialect extends DB2Dialect {
 	}
 
 	public DB2zDialect() {
-		this( DatabaseVersion.make(7) );
+		this( DatabaseVersion.make( 7 ) );
 	}
 
 	public DB2zDialect(DatabaseVersion version) {
@@ -53,7 +53,7 @@ public class DB2zDialect extends DB2Dialect {
 	@Override
 	protected String columnType(int jdbcTypeCode) {
 		// See https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/wnew/src/tpc/db2z_10_timestamptimezone.html
-		if ( jdbcTypeCode==TIMESTAMP_WITH_TIMEZONE &&  version.isAfter(10) ) {
+		if ( jdbcTypeCode==TIMESTAMP_WITH_TIMEZONE && version.isAfter(10) ) {
 			return "timestamp with time zone";
 		}
 		return super.columnType(jdbcTypeCode);
@@ -92,6 +92,11 @@ public class DB2zDialect extends DB2Dialect {
 
 	@Override
 	public boolean supportsSkipLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsLateral() {
 		return true;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+
+import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
@@ -50,4 +57,24 @@ public class DB2zSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 		renderComparisonStandard( lhs, operator, rhs );
 	}
 
+	@Override
+	protected boolean renderPrimaryTableReference(TableGroup tableGroup, LockMode lockMode) {
+		final TableReference tableReference = tableGroup.getPrimaryTableReference();
+		if ( tableReference instanceof NamedTableReference ) {
+			return renderNamedTableReference( (NamedTableReference) tableReference, lockMode );
+		}
+		// DB2 z/OS we need the "table" qualifier for table valued functions or lateral sub-queries
+		append( "table " );
+		tableReference.accept( this );
+		return false;
+	}
+
+	@Override
+	public void visitFunctionTableReference(FunctionTableReference tableReference) {
+		// For the table qualifier we need parenthesis on DB2 z/OS
+		append( OPEN_PARENTHESIS );
+		tableReference.getFunctionExpression().accept( this );
+		append( CLOSE_PARENTHESIS );
+		renderDerivedTableReference( tableReference );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3495,6 +3495,16 @@ public abstract class Dialect implements ConversionContext {
 		return false;
 	}
 
+	/**
+	 * Does this dialect support the SQL lateral keyword or a proprietary alternative=
+	 *
+	 * @return {@code true} if the underlying database supports lateral,
+	 * {@code false} otherwise.  The default is {@code false}.
+	 */
+	public boolean supportsLateral() {
+		return false;
+	}
+
 	public CallableStatementSupport getCallableStatementSupport() {
 		// most databases do not support returning cursors (ref_cursor)...
 		return StandardCallableStatementSupport.NO_REF_CURSOR_INSTANCE;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANACloudColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANACloudColumnStoreDialect.java
@@ -6,11 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.Types;
-
-import org.hibernate.query.spi.QueryEngine;
-import org.hibernate.type.StandardBasicTypes;
-
 /**
  * An SQL dialect for the SAP HANA Cloud column store.
  * <p>
@@ -30,7 +25,29 @@ import org.hibernate.type.StandardBasicTypes;
 public class HANACloudColumnStoreDialect extends HANAColumnStoreDialect {
 
 	public HANACloudColumnStoreDialect() {
+		// No idea how the versioning scheme is here, but since this is deprecated anyway, keep it as is
 		super( DatabaseVersion.make( 4 ) );
+	}
+
+	@Override
+	public boolean supportsLateral() {
+		// Couldn't find a reference since when this is supported
+		return true;
+	}
+
+	@Override
+	protected boolean supportsAsciiStringTypes() {
+		return getVersion().isBefore( 4 );
+	}
+
+	@Override
+	protected Boolean useUnicodeStringTypesDefault() {
+		return getVersion().isSameOrAfter( 4 );
+	}
+
+	@Override
+	public boolean isUseUnicodeStringTypes() {
+		return getVersion().isSameOrAfter( 4 ) || super.isUseUnicodeStringTypes();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
@@ -35,13 +35,15 @@ import org.hibernate.type.StandardBasicTypes;
  * @author <a href="mailto:jonathan.bregler@sap.com">Jonathan Bregler</a>
  */
 public class HANAColumnStoreDialect extends AbstractHANADialect {
+
 	public HANAColumnStoreDialect(DialectResolutionInfo info) {
-		this( info.makeCopy() );
+		this( AbstractHANADialect.createVersion( info ) );
 		registerKeywords( info );
 	}
 	
 	public HANAColumnStoreDialect() {
-		this( DatabaseVersion.make( 3, 0 ) );
+		// SAP HANA 1.0 SP12 is the default
+		this( DatabaseVersion.make( 1, 0, 120 ) );
 	}
 
 	public HANAColumnStoreDialect(DatabaseVersion version) {
@@ -172,17 +174,11 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 
 	@Override
 	protected boolean supportsAsciiStringTypes() {
-		return getVersion().isBefore( 4 );
+		return true;
 	}
 
 	@Override
 	protected Boolean useUnicodeStringTypesDefault() {
-		return getVersion().isSameOrAfter( 4 );
-	}
-
-	@Override
-	public boolean isUseUnicodeStringTypes() {
-		return getVersion().isSameOrAfter( 4 )
-				|| super.isUseUnicodeStringTypes();
+		return true;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANARowStoreDialect.java
@@ -32,13 +32,14 @@ import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
  */
 public class HANARowStoreDialect extends AbstractHANADialect {
 
-	public HANARowStoreDialect() {
-		super( DatabaseVersion.make( 3, 0 ));
+	public HANARowStoreDialect(DialectResolutionInfo info) {
+		this( AbstractHANADialect.createVersion( info ) );
+		registerKeywords( info );
 	}
 
-	public HANARowStoreDialect(DialectResolutionInfo info) {
-		this( info.makeCopy() );
-		registerKeywords( info );
+	public HANARowStoreDialect() {
+		// SAP HANA 1.0 SPS12 R0 is the default
+		this( DatabaseVersion.make( 1, 0, 120 ) );
 	}
 
 	public HANARowStoreDialect(DatabaseVersion version) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -721,6 +721,11 @@ public class HSQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 2, 6, 1 );
+	}
+
+	@Override
 	public boolean requiresFloatCastingOfIntegerDivision() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -33,6 +33,8 @@ import org.hibernate.type.StandardBasicTypes;
  * @author Gavin King
  */
 public class MariaDBDialect extends MySQLDialect {
+	private static final DatabaseVersion VERSION5 = DatabaseVersion.make( 5 );
+	private static final DatabaseVersion VERSION57 = DatabaseVersion.make( 5, 7 );
 
 	public MariaDBDialect() {
 		this( DatabaseVersion.make( 5 ) );
@@ -49,8 +51,8 @@ public class MariaDBDialect extends MySQLDialect {
 	@Override
 	public DatabaseVersion getMySQLVersion() {
 		return getVersion().isBefore( 5, 3 )
-				? DatabaseVersion.make( 5 )
-				: DatabaseVersion.make( 5, 7 );
+				? VERSION5
+				: VERSION57;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBSqlAstTranslator.java
@@ -14,6 +14,7 @@ import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -69,6 +70,11 @@ public class MariaDBSqlAstTranslator<T extends JdbcOperation> extends AbstractSq
 		else {
 			super.visitQuerySpec( querySpec );
 		}
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+		emulateQueryPartTableReferenceColumnAliasing( tableReference );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -1180,6 +1180,11 @@ public class MySQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getMySQLVersion().isSameOrAfter( 8, 14 );
+	}
+
+	@Override
 	public boolean supportsSkipLocked() {
 		return getMySQLVersion().isSameOrAfter( 8 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
@@ -14,6 +14,8 @@ import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -69,6 +71,21 @@ public class MySQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 		}
 		else {
 			super.visitQuerySpec( querySpec );
+		}
+	}
+
+	@Override
+	public void visitValuesTableReference(ValuesTableReference tableReference) {
+		emulateValuesTableReferenceColumnAliasing( tableReference );
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+		if ( getDialect().getVersion().isSameOrAfter( 8 ) ) {
+			super.visitQueryPartTableReference( tableReference );
+		}
+		else {
+			emulateQueryPartTableReferenceColumnAliasing( tableReference );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1062,6 +1062,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 12, 1 );
+	}
+
+	@Override
 	public boolean supportsNoWait() {
 		return getVersion().isSameOrAfter( 9 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
@@ -247,10 +247,10 @@ public class OracleSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 	}
 
 	@Override
-	protected void renderValuesTableReference(ValuesTableReference tableReference) {
+	public void visitValuesTableReference(ValuesTableReference tableReference) {
 		final List<Values> valuesList = tableReference.getValuesList();
 		if ( valuesList.size() < 2 ) {
-			super.renderValuesTableReference( tableReference );
+			super.visitValuesTableReference( tableReference );
 		}
 		else {
 			append( '(' );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -1007,6 +1007,11 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 9, 3 );
+	}
+
+	@Override
 	public boolean supportsFetchClause(FetchClauseType type) {
 		switch ( type ) {
 			case ROWS_ONLY:

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -563,6 +563,11 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
+	public boolean supportsLateral() {
+		return getVersion().isSameOrAfter( 9 );
+	}
+
+	@Override
 	public boolean supportsFetchClause(FetchClauseType type) {
 		return getVersion().isSameOrAfter( 11 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerSqlAstTranslator.java
@@ -22,7 +22,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.Summarization;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableReference;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -45,7 +45,7 @@ public class SQLServerSqlAstTranslator<T extends JdbcOperation> extends Abstract
 	}
 
 	@Override
-	protected boolean renderTableReference(TableReference tableReference, LockMode lockMode) {
+	protected boolean renderNamedTableReference(NamedTableReference tableReference, LockMode lockMode) {
 		final String tableExpression = tableReference.getTableExpression();
 		if ( tableReference instanceof UnionTableReference && lockMode != LockMode.NONE && tableExpression.charAt( 0 ) == '(' ) {
 			// SQL Server requires to push down the lock hint to the actual table names
@@ -72,7 +72,7 @@ public class SQLServerSqlAstTranslator<T extends JdbcOperation> extends Abstract
 			}
 		}
 		else {
-			super.renderTableReference( tableReference, lockMode );
+			super.renderNamedTableReference( tableReference, lockMode );
 			renderLockHint( lockMode );
 		}
 		// Just always return true because SQL Server doesn't support the FOR UPDATE clause

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
@@ -25,8 +25,8 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableReference;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
@@ -98,8 +98,8 @@ public class SybaseASESqlAstTranslator<T extends JdbcOperation> extends Abstract
 	}
 
 	@Override
-	protected boolean renderTableReference(TableReference tableReference, LockMode lockMode) {
-		super.renderTableReference( tableReference, lockMode );
+	protected boolean renderNamedTableReference(NamedTableReference tableReference, LockMode lockMode) {
+		super.renderNamedTableReference( tableReference, lockMode );
 		if ( getDialect().getVersion().isBefore( 15, 7 ) ) {
 			if ( LockMode.READ.lessThan( lockMode ) ) {
 				appendSql( " holdlock" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
@@ -23,7 +23,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
 import org.hibernate.sql.ast.tree.expression.Summarization;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.exec.spi.JdbcOperation;
@@ -92,8 +92,8 @@ public class SybaseSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 	}
 
 	@Override
-	protected boolean renderTableReference(TableReference tableReference, LockMode lockMode) {
-		super.renderTableReference( tableReference, lockMode );
+	protected boolean renderNamedTableReference(NamedTableReference tableReference, LockMode lockMode) {
+		super.renderNamedTableReference( tableReference, lockMode );
 		if ( LockMode.READ.lessThan( lockMode ) ) {
 			appendSql( " holdlock" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqmToSqlAstConverter.java
@@ -18,8 +18,8 @@ import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 
 /**
@@ -54,7 +54,7 @@ public class SybaseSqmToSqlAstConverter<T extends Statement> extends BaseSqmToSq
 								null,
 								null,
 								null,
-								new TableReference(
+								new NamedTableReference(
 										"(select 1)",
 										"dummy_(x)",
 										false,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TiDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TiDBDialect.java
@@ -28,6 +28,8 @@ import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
  */
 public class TiDBDialect extends MySQLDialect {
 
+	private static final DatabaseVersion VERSION57 = DatabaseVersion.make( 5, 7 );
+
 	public TiDBDialect() {
 		this( DatabaseVersion.make(5, 4) );
 	}
@@ -45,7 +47,7 @@ public class TiDBDialect extends MySQLDialect {
 	@Override
 	public DatabaseVersion getMySQLVersion() {
 		// For simplicity’s sake, configure MySQL 5.7 compatibility
-		return DatabaseVersion.make( 5, 7 );
+		return VERSION57;
 	}
 
 	private void registerKeywords() {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractCompositeIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractCompositeIdentifierMapping.java
@@ -226,7 +226,7 @@ public abstract class AbstractCompositeIdentifierMapping
 		final TableReference defaultTableReference = tableGroup.resolveTableReference( navigablePath, getContainingTableExpression() );
 		getEmbeddableTypeDescriptor().forEachSelectable(
 				(columnIndex, selection) -> {
-					final TableReference tableReference = selection.getContainingTableExpression().equals( defaultTableReference.getTableExpression() )
+					final TableReference tableReference = defaultTableReference.resolveTableReference( selection.getContainingTableExpression() ) != null
 							? defaultTableReference
 							: tableGroup.resolveTableReference( navigablePath, selection.getContainingTableExpression() );
 					final Expression columnReference = sqlAstCreationState.getSqlExpressionResolver()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedAttributeMapping.java
@@ -279,7 +279,7 @@ public class EmbeddedAttributeMapping
 		final TableReference defaultTableReference = tableGroup.resolveTableReference( navigablePath, getContainingTableExpression() );
 		getEmbeddableTypeDescriptor().forEachSelectable(
 				(columnIndex, selection) -> {
-					final TableReference tableReference = selection.getContainingTableExpression().equals( defaultTableReference.getTableExpression() )
+					final TableReference tableReference = defaultTableReference.resolveTableReference( selection.getContainingTableExpression() ) != null
 							? defaultTableReference
 							: tableGroup.resolveTableReference( navigablePath, selection.getContainingTableExpression() );
 					final Expression columnReference = sqlAstCreationState.getSqlExpressionResolver().resolveSqlExpression(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
@@ -406,14 +406,16 @@ public class EmbeddedForeignKeyDescriptor implements ForeignKeyDescriptor {
 	}
 
 	protected TableReference getTableReference(TableGroup lhs, TableGroup tableGroup, String table) {
-		if ( lhs.getPrimaryTableReference().getTableExpression().equals( table ) ) {
-			return lhs.getPrimaryTableReference();
+		TableReference tableReference = lhs.getPrimaryTableReference().resolveTableReference( table );
+		if ( tableReference != null ) {
+			return tableReference;
 		}
-		else if ( tableGroup.getPrimaryTableReference().getTableExpression().equals( table ) ) {
-			return tableGroup.getPrimaryTableReference();
+		tableReference = tableGroup.getPrimaryTableReference().resolveTableReference( table );
+		if ( tableReference != null ) {
+			return tableReference;
 		}
 
-		final TableReference tableReference = lhs.resolveTableReference(
+		tableReference = lhs.resolveTableReference(
 				lhs.getNavigablePath().append( getNavigableRole().getNavigableName() ),
 				table
 		);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
@@ -20,7 +20,6 @@ import org.hibernate.metamodel.internal.AbstractCompositeIdentifierMapping;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
-import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
@@ -175,13 +174,9 @@ public class NonAggregatedIdentifierMappingImpl extends AbstractCompositeIdentif
 				offset += attributeMapping.forEachSelectable(
 						offset,
 						(columnIndex, selection) -> {
-							final TableReference tableReference = selection.getContainingTableExpression().equals(
-									defaultTableReference.getTableExpression() )
+							final TableReference tableReference = defaultTableReference.resolveTableReference( selection.getContainingTableExpression() ) != null
 									? defaultTableReference
-									: tableGroup.resolveTableReference(
-									navigablePath,
-									selection.getContainingTableExpression()
-							);
+									: tableGroup.resolveTableReference( navigablePath, selection.getContainingTableExpression() );
 							final Expression columnReference = sqlAstCreationState.getSqlExpressionResolver()
 									.resolveSqlExpression(
 											SqlExpressionResolver.createColumnReferenceKey(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -51,6 +51,7 @@ import org.hibernate.sql.ast.spi.SqlAstCreationState;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.from.CollectionTableGroup;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableGroupJoinProducer;
@@ -663,7 +664,7 @@ public class PluralAttributeMappingImpl
 		assert !getCollectionDescriptor().isOneToMany();
 
 		final String collectionTableName = ( (Joinable) collectionDescriptor ).getTableName();
-		final TableReference collectionTableReference = new TableReference(
+		final TableReference collectionTableReference = new NamedTableReference(
 				collectionTableName,
 				sqlAliasBase.generateNewAlias(),
 				true,

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -2028,7 +2028,7 @@ public abstract class AbstractCollectionPersister
 			alias = tableReference.getIdentificationVariable();
 		}
 		else {
-			alias = tableReference.getTableExpression();
+			alias = tableReference.getTableId();
 		}
 
 		applyWhereRestriction( alias, querySpec, tableGroupJoin );
@@ -2202,7 +2202,7 @@ public abstract class AbstractCollectionPersister
 			alias = tableReference.getIdentificationVariable();
 		}
 		else {
-			alias = tableReference.getTableExpression();
+			alias = tableReference.getTableId();
 		}
 		StringBuilder sessionFilterFragment = new StringBuilder();
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1360,7 +1360,7 @@ public abstract class AbstractEntityPersister
 							);
 
 							return new TableReferenceJoin(
-									determineSubclassTableJoinType(
+									shouldInnerJoinSubclassTable(
 											i,
 											Collections.emptySet()
 									),
@@ -1406,7 +1406,7 @@ public abstract class AbstractEntityPersister
 						lhs,
 						joinTableExpression,
 						sqlAliasBase,
-						determineSubclassTableJoinType( i, Collections.emptySet() ),
+						shouldInnerJoinSubclassTable( i, Collections.emptySet() ),
 						getSubclassTableKeyColumns( i ),
 						sqlExpressionResolver
 				);
@@ -1420,18 +1420,18 @@ public abstract class AbstractEntityPersister
 			TableReference lhs,
 			String joinTableExpression,
 			SqlAliasBase sqlAliasBase,
-			SqlAstJoinType joinType,
+			boolean innerJoin,
 			String[] targetColumns,
 			SqlExpressionResolver sqlExpressionResolver) {
 		final NamedTableReference joinedTableReference = new NamedTableReference(
 				joinTableExpression,
 				sqlAliasBase.generateNewAlias(),
-				joinType != SqlAstJoinType.INNER,
+				!innerJoin,
 				getFactory()
 		);
 
 		return new TableReferenceJoin(
-				joinType,
+				innerJoin,
 				joinedTableReference,
 				generateJoinPredicate(
 						lhs,
@@ -4134,7 +4134,7 @@ public abstract class AbstractEntityPersister
 		return false;
 	}
 
-	protected SqlAstJoinType determineSubclassTableJoinType(
+	protected boolean shouldInnerJoinSubclassTable(
 			int subclassTableNumber,
 			Set<String> treatAsDeclarations) {
 		if ( isClassOrSuperclassJoin( subclassTableNumber ) ) {
@@ -4142,7 +4142,7 @@ public abstract class AbstractEntityPersister
 					&& !isNullableTable( subclassTableNumber );
 			// the table is either this persister's driving table or (one of) its super class persister's driving
 			// tables which can be inner joined as long as the `shouldInnerJoin` condition resolves to true
-			return shouldInnerJoin ? SqlAstJoinType.INNER : SqlAstJoinType.LEFT;
+			return shouldInnerJoin;
 		}
 
 		// otherwise we have a subclass table and need to look a little deeper...
@@ -4152,10 +4152,10 @@ public abstract class AbstractEntityPersister
 		// so we give TREAT-AS higher precedence...
 
 		if ( isSubclassTableIndicatedByTreatAsDeclarations( subclassTableNumber, treatAsDeclarations ) ) {
-			return SqlAstJoinType.INNER;
+			return true;
 		}
 
-		return SqlAstJoinType.LEFT;
+		return false;
 	}
 
 	protected boolean isSubclassTableIndicatedByTreatAsDeclarations(

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -229,6 +229,7 @@ import org.hibernate.sql.ast.tree.expression.AliasedExpression;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
@@ -1351,7 +1352,7 @@ public abstract class AbstractEntityPersister
 					for ( int i = 0; i < subclassTableNames.length; i++ ) {
 						if ( tableExpression.equals( subclassTableNames[i] ) ) {
 							final boolean isNullableTable = isNullableSubclassTable( i );
-							final TableReference joinedTableReference = new TableReference(
+							final NamedTableReference joinedTableReference = new NamedTableReference(
 									tableExpression,
 									sqlAliasBase.generateNewAlias(),
 									isNullableTable,
@@ -1422,7 +1423,7 @@ public abstract class AbstractEntityPersister
 			SqlAstJoinType joinType,
 			String[] targetColumns,
 			SqlExpressionResolver sqlExpressionResolver) {
-		final TableReference joinedTableReference = new TableReference(
+		final NamedTableReference joinedTableReference = new NamedTableReference(
 				joinTableExpression,
 				sqlAliasBase.generateNewAlias(),
 				joinType != SqlAstJoinType.INNER,
@@ -1442,7 +1443,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	protected TableReference resolvePrimaryTableReference(SqlAliasBase sqlAliasBase) {
-		return new TableReference(
+		return new NamedTableReference(
 				getTableName(),
 				sqlAliasBase.generateNewAlias(),
 				false,
@@ -4015,7 +4016,7 @@ public abstract class AbstractEntityPersister
 			alias = tableGroup.getPrimaryTableReference().getIdentificationVariable();
 		}
 		else {
-			alias = tableGroup.getPrimaryTableReference().getTableExpression();
+			alias = tableGroup.getPrimaryTableReference().getTableId();
 		}
 		final StringBuilder sessionFilterFragment = new StringBuilder();
 		filterHelper.render( sessionFilterFragment, !useIdentificationVariable || tableGroup == null ? null : getFilterAliasGenerator( tableGroup ), enabledFilters );
@@ -4059,7 +4060,7 @@ public abstract class AbstractEntityPersister
 			alias = tableGroup.getPrimaryTableReference().getIdentificationVariable();
 		}
 		else {
-			alias = tableGroup.getPrimaryTableReference().getTableExpression();
+			alias = tableGroup.getPrimaryTableReference().getTableId();
 		}
 		applyWhereRestriction( generateWhereConditionAlias( alias ), treatAsDeclarations, querySpec, tableGroupJoin );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -1346,7 +1346,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 							&& sharedSuperclassTables.contains( joinedTableReference.getTableExpression() ) ) {
 						tableReferenceJoins.add(
 								new TableReferenceJoin(
-										SqlAstJoinType.INNER,
+										true,
 										joinedTableReference,
 										oldJoin.getPredicate()
 								)

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -22,7 +22,6 @@ import org.hibernate.boot.model.relational.Database;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
@@ -52,6 +51,7 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
@@ -962,7 +962,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			return;
 		}
 		// The optimization is to simply add the discriminator filter fragment for all treated entity names
-		final TableReference tableReference = tableGroup.getPrimaryTableReference();
+		final NamedTableReference tableReference = (NamedTableReference) tableGroup.getPrimaryTableReference();
 		tableReference.setPrunedTableExpression(
 				"(select * from " + getTableName() + " t where " + discriminatorFilterFragment( "t", treatedEntityNames ) + ")"
 		);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -52,6 +52,7 @@ import org.hibernate.sql.ast.spi.SqlAliasBase;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableGroup;
@@ -257,13 +258,13 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			SqlExpressionResolver expressionResolver,
 			FromClauseAccess fromClauseAccess,
 			SqlAstCreationContext creationContext) {
-		final TableReference tableReference = resolvePrimaryTableReference( sqlAliasBase );
+		final UnionTableReference tableReference = resolvePrimaryTableReference( sqlAliasBase );
 
 		return new UnionTableGroup( canUseInnerJoins, navigablePath, tableReference, this, explicitSourceAlias );
 	}
 
 	@Override
-	protected TableReference resolvePrimaryTableReference(SqlAliasBase sqlAliasBase) {
+	protected UnionTableReference resolvePrimaryTableReference(SqlAliasBase sqlAliasBase) {
 		return new UnionTableReference(
 				getTableName(),
 				subclassTableExpressions,
@@ -401,7 +402,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		if ( treatedEntityNames.contains( getEntityName() ) ) {
 			return;
 		}
-		final TableReference tableReference = tableGroup.resolveTableReference( getRootTableName() );
+		final NamedTableReference tableReference = (NamedTableReference) tableGroup.resolveTableReference( getRootTableName() );
 		// Replace the default union sub-query with a specially created one that only selects the tables for the treated entity names
 		tableReference.setPrunedTableExpression( generateSubquery( treatedEntityNames ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/DomainResultCreationStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/DomainResultCreationStateImpl.java
@@ -292,7 +292,7 @@ public class DomainResultCreationStateImpl
 	@Override
 	public SqlSelection resolveSqlSelection(
 			Expression expression,
-			JavaType javaTypeDescriptor,
+			JavaType<?> javaTypeDescriptor,
 			TypeConfiguration typeConfiguration) {
 		if ( expression == null ) {
 			throw new IllegalArgumentException( "Expression cannot be null" );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
@@ -166,7 +166,7 @@ public class DynamicResultBuilderEntityStandard
 					if ( lockMode != null ) {
 						domainResultCreationState.getSqlAstCreationState().registerLockMode( tableAlias, lockMode );
 					}
-					return new TableGroupImpl( navigablePath, tableAlias, tableReference, entityMapping, tableAlias );
+					return new TableGroupImpl( navigablePath, tableAlias, tableReference, entityMapping );
 				}
 		);
 		final TableReference tableReference = tableGroup.getPrimaryTableReference();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SqmMutationStrategyHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SqmMutationStrategyHelper.java
@@ -16,10 +16,10 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.SqlOmittingQueryOptions;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.exec.spi.ExecutionContext;
@@ -130,7 +130,12 @@ public class SqmMutationStrategyHelper {
 		else {
 			// element-collection or many-to-many - delete the collection-table row
 
-			final TableReference tableReference = new TableReference( separateCollectionTable, DeleteStatement.DEFAULT_ALIAS, true, sessionFactory );
+			final NamedTableReference tableReference = new NamedTableReference(
+					separateCollectionTable,
+					DeleteStatement.DEFAULT_ALIAS,
+					true,
+					sessionFactory
+			);
 
 			final DeleteStatement sqlAstDelete = new DeleteStatement(
 					tableReference,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/AbstractCteMutationHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/AbstractCteMutationHandler.java
@@ -45,6 +45,7 @@ import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableReference;
 import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
@@ -177,7 +178,7 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 		querySpec.getSelectClause().addSqlSelection( new SqlSelectionImpl( 1, 0, count ) );
 		querySpec.getFromClause().addRoot(
 				new CteTableGroup(
-						new TableReference(
+						new NamedTableReference(
 								idSelectCte.getCteTable().getTableExpression(),
 								CTE_TABLE_IDENTIFIER,
 								false,
@@ -241,7 +242,7 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 			CteStatement idSelectCte,
 			ModelPart fkModelPart,
 			SessionFactoryImplementor factory) {
-		final TableReference idSelectTableReference = new TableReference(
+		final NamedTableReference idSelectTableReference = new NamedTableReference(
 				idSelectCte.getCteTable().getTableExpression(),
 				CTE_TABLE_IDENTIFIER,
 				false,
@@ -313,11 +314,11 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 			SessionFactoryImplementor factory);
 
 
-	protected TableReference resolveUnionTableReference(
+	protected NamedTableReference resolveUnionTableReference(
 			TableReference tableReference,
 			String tableExpression) {
 		if ( tableReference instanceof UnionTableReference ) {
-			return new TableReference(
+			return new NamedTableReference(
 					tableExpression,
 					tableReference.getIdentificationVariable(),
 					tableReference.isOptional(),
@@ -325,7 +326,7 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 			);
 		}
 		else {
-			return tableReference;
+			return (NamedTableReference) tableReference;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteDeleteHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteDeleteHandler.java
@@ -27,6 +27,7 @@ import org.hibernate.sql.ast.tree.cte.CteTable;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
@@ -106,7 +107,12 @@ public class CteDeleteHandler extends AbstractCteMutationHandler implements Dele
 									idSelectCte.getCteTable().getCteColumns(),
 									factory
 							);
-							final TableReference dmlTableReference = new TableReference( tableExpression, null, true, factory );
+							final NamedTableReference dmlTableReference = new NamedTableReference(
+									tableExpression,
+									DeleteStatement.DEFAULT_ALIAS,
+									true,
+									factory
+							);
 							final List<ColumnReference> columnReferences = new ArrayList<>( idSelectCte.getCteTable().getCteColumns().size() );
 							pluralAttribute.getKeyDescriptor().visitKeySelectables(
 									(index, selectable) -> columnReferences.add(
@@ -147,7 +153,7 @@ public class CteDeleteHandler extends AbstractCteMutationHandler implements Dele
 							true,
 							true
 					);
-					final TableReference dmlTableReference = resolveUnionTableReference(
+					final NamedTableReference dmlTableReference = resolveUnionTableReference(
 							updatingTableReference,
 							tableExpression
 					);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
@@ -76,7 +76,7 @@ import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.Over;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
 import org.hibernate.sql.ast.tree.expression.SelfRenderingSqlFragmentExpression;
-import org.hibernate.sql.ast.tree.from.StandardTableGroup;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableReference;
@@ -189,7 +189,7 @@ public class CteInsertHandler implements InsertHandler {
 		final List<Map.Entry<SqmCteTableColumn, Assignment>> targetPathColumns = new ArrayList<>( size );
 		final List<SqmCteTableColumn> targetPathSqmCteColumns = new ArrayList<>( size );
 		final Map<SqmParameter, MappingModelExpressable> paramTypeResolutions = new LinkedHashMap<>();
-		final TableReference entityTableReference = new TableReference(
+		final NamedTableReference entityTableReference = new NamedTableReference(
 				cteTable.getCteName(),
 				TemporaryTable.DEFAULT_ALIAS,
 				true,
@@ -240,7 +240,7 @@ public class CteInsertHandler implements InsertHandler {
 		final Statement queryStatement;
 		if ( sqmInsertStatement instanceof SqmInsertSelectStatement ) {
 			final QueryPart queryPart = sqmConverter.visitQueryPart( ( (SqmInsertSelectStatement<?>) sqmInsertStatement ).getSelectQueryPart() );
-			queryPart.forEachQuerySpec(
+			queryPart.visitQuerySpecs(
 					querySpec -> {
 						// This returns true if the insertion target uses a sequence with an optimizer
 						// in which case we will fill the row_number column instead of the id column
@@ -407,7 +407,7 @@ public class CteInsertHandler implements InsertHandler {
 				final QuerySpec rowsWithSequenceQuery = new QuerySpec( true );
 				rowsWithSequenceQuery.getFromClause().addRoot(
 						new CteTableGroup(
-								new TableReference(
+								new NamedTableReference(
 										baseTableName,
 										"e",
 										false,
@@ -465,7 +465,7 @@ public class CteInsertHandler implements InsertHandler {
 				final TableGroup baseTableGroup = new TableGroupImpl(
 						navigablePath,
 						null,
-						new TableReference(
+						new NamedTableReference(
 								baseTableName,
 								"e",
 								false,
@@ -475,7 +475,7 @@ public class CteInsertHandler implements InsertHandler {
 						null
 				);
 				final TableGroup rowsWithSequenceTableGroup = new CteTableGroup(
-						new TableReference(
+						new NamedTableReference(
 								ROW_NUMBERS_WITH_SEQUENCE_VALUE,
 								"t",
 								false,
@@ -639,7 +639,7 @@ public class CteInsertHandler implements InsertHandler {
 		querySpec.getSelectClause().addSqlSelection( new SqlSelectionImpl( 1, 0, count ) );
 		querySpec.getFromClause().addRoot(
 				new CteTableGroup(
-						new TableReference(
+						new NamedTableReference(
 								// We want to return the insertion count of the base table
 								baseInsertCte,
 								CTE_TABLE_IDENTIFIER,
@@ -789,7 +789,7 @@ public class CteInsertHandler implements InsertHandler {
 					true
 			);
 			final List<Map.Entry<SqmCteTableColumn, Assignment>> assignmentList = assignmentsByTable.get( updatingTableReference );
-			final TableReference dmlTableReference = resolveUnionTableReference(
+			final NamedTableReference dmlTableReference = resolveUnionTableReference(
 					updatingTableReference,
 					tableExpression
 			);
@@ -806,7 +806,7 @@ public class CteInsertHandler implements InsertHandler {
 				final String baseTableName = "base_" + queryCte.getCteTable().getTableExpression();
 				insertSelectSpec.getFromClause().addRoot(
 						new CteTableGroup(
-								new TableReference(
+								new NamedTableReference(
 										baseTableName,
 										"e",
 										false,
@@ -862,7 +862,7 @@ public class CteInsertHandler implements InsertHandler {
 				final TableGroup baseTableGroup = new TableGroupImpl(
 						navigablePath,
 						null,
-						new TableReference(
+						new NamedTableReference(
 								baseTableName,
 								"e",
 								false,
@@ -872,7 +872,7 @@ public class CteInsertHandler implements InsertHandler {
 						null
 				);
 				final TableGroup rootInsertCteTableGroup = new CteTableGroup(
-						new TableReference(
+						new NamedTableReference(
 								getCteTableName( tableExpression ),
 								"t",
 								false,
@@ -950,7 +950,7 @@ public class CteInsertHandler implements InsertHandler {
 				final QuerySpec finalResultQuery = new QuerySpec( true );
 				finalResultQuery.getFromClause().addRoot(
 						new CteTableGroup(
-							new TableReference(
+							new NamedTableReference(
 									dmlResultCte.getTableExpression(),
 									"e",
 									false,
@@ -1008,7 +1008,7 @@ public class CteInsertHandler implements InsertHandler {
 			else {
 				insertSelectSpec.getFromClause().addRoot(
 						new CteTableGroup(
-								new TableReference(
+								new NamedTableReference(
 										queryCte.getCteTable().getTableExpression(),
 										"e",
 										false,
@@ -1103,11 +1103,11 @@ public class CteInsertHandler implements InsertHandler {
 		return getCteTableName( rootTableName );
 	}
 
-	protected TableReference resolveUnionTableReference(
+	protected NamedTableReference resolveUnionTableReference(
 			TableReference tableReference,
 			String tableExpression) {
 		if ( tableReference instanceof UnionTableReference ) {
-			return new TableReference(
+			return new NamedTableReference(
 					tableExpression,
 					tableReference.getIdentificationVariable(),
 					tableReference.isOptional(),
@@ -1115,7 +1115,7 @@ public class CteInsertHandler implements InsertHandler {
 			);
 		}
 		else {
-			return tableReference;
+			return (NamedTableReference) tableReference;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
@@ -471,7 +471,6 @@ public class CteInsertHandler implements InsertHandler {
 								false,
 								factory
 						),
-						null,
 						null
 				);
 				final TableGroup rowsWithSequenceTableGroup = new CteTableGroup(
@@ -868,7 +867,6 @@ public class CteInsertHandler implements InsertHandler {
 								false,
 								factory
 						),
-						null,
 						null
 				);
 				final TableGroup rootInsertCteTableGroup = new CteTableGroup(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteUpdateHandler.java
@@ -32,6 +32,7 @@ import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.cte.CteTable;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
@@ -154,7 +155,7 @@ public class CteUpdateHandler extends AbstractCteMutationHandler implements Upda
 					if ( assignmentList == null ) {
 						return;
 					}
-					final TableReference dmlTableReference = resolveUnionTableReference(
+					final NamedTableReference dmlTableReference = resolveUnionTableReference(
 							updatingTableReference,
 							tableExpression
 					);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineDeleteHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineDeleteHandler.java
@@ -18,7 +18,6 @@ import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableConsumer;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.metamodel.mapping.SelectableConsumer;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
@@ -27,7 +26,7 @@ import org.hibernate.query.sqm.mutation.internal.MatchingIdSelectionHelper;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.JdbcDelete;
@@ -160,7 +159,7 @@ public class InlineDeleteHandler implements DeleteHandler {
 			ModelPart valueModelPart,
 			JdbcParameterBindings jdbcParameterBindings,
 			DomainQueryExecutionContext executionContext) {
-		final TableReference targetTableReference = new TableReference(
+		final NamedTableReference targetTableReference = new NamedTableReference(
 				targetTableExpression,
 				DeleteStatement.DEFAULT_ALIAS,
 				false,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/ExecuteWithTemporaryTableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/ExecuteWithTemporaryTableHelper.java
@@ -31,6 +31,7 @@ import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
@@ -65,9 +66,9 @@ public final class ExecuteWithTemporaryTableHelper {
 		assert mutatingTableGroup.getModelPart() instanceof EntityMappingType;
 		final EntityMappingType mutatingEntityDescriptor = (EntityMappingType) mutatingTableGroup.getModelPart();
 
-		final TableReference idTableReference = new TableReference(
+		final NamedTableReference idTableReference = new NamedTableReference(
 				idTable.getTableExpression(),
-				null,
+				InsertStatement.DEFAULT_ALIAS,
 				false,
 				factory
 		);
@@ -153,7 +154,7 @@ public final class ExecuteWithTemporaryTableHelper {
 		// Visit the table joins and reset the lock mode if we encounter OUTER joins that are not supported
 		if ( temporaryTableInsert.getSourceSelectStatement() != null
 				&& !jdbcEnvironment.getDialect().supportsOuterJoinForUpdate() ) {
-			temporaryTableInsert.getSourceSelectStatement().forEachQuerySpec(
+			temporaryTableInsert.getSourceSelectStatement().visitQuerySpecs(
 					querySpec -> {
 						querySpec.getFromClause().visitTableJoins(
 								tableJoin -> {
@@ -197,7 +198,7 @@ public final class ExecuteWithTemporaryTableHelper {
 			ExecutionContext executionContext) {
 		final QuerySpec querySpec = new QuerySpec( false );
 
-		final TableReference idTableReference = new TableReference(
+		final NamedTableReference idTableReference = new NamedTableReference(
 				idTable.getTableExpression(),
 				TemporaryTable.DEFAULT_ALIAS,
 				true,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
@@ -273,8 +273,7 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 				updatingTableGroup.getNavigablePath(),
 				null,
 				temporaryTableReference,
-				entityDescriptor,
-				null
+				entityDescriptor
 		);
 		querySpec.getFromClause().addRoot( temporaryTableGroup );
 		final InsertStatement insertStatement = new InsertStatement( dmlTableReference );
@@ -607,8 +606,7 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 						false,
 						sessionFactory
 				),
-				entityDescriptor,
-				null
+				entityDescriptor
 		);
 		querySpec.getFromClause().addRoot( temporaryTableGroup );
 		final InsertStatement insertStatement = new InsertStatement( dmlTargetTableReference );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/RestrictedDeleteExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/RestrictedDeleteExecutionDelegate.java
@@ -49,6 +49,7 @@ import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableReference;
@@ -208,7 +209,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 
 		final EntityPersister rootEntityPersister = entityDescriptor.getEntityPersister();
 		final String rootTableName = ( (Joinable) rootEntityPersister ).getTableName();
-		final TableReference rootTableReference = tableGroup.resolveTableReference(
+		final NamedTableReference rootTableReference = (NamedTableReference) tableGroup.resolveTableReference(
 				tableGroup.getNavigablePath(),
 				rootTableName
 		);
@@ -277,7 +278,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 			final MutableInteger rows = new MutableInteger();
 			entityDescriptor.visitConstraintOrderedTables(
 					(tableExpression, tableKeyColumnVisitationSupplier) -> {
-						final TableReference tableReference = new TableReference(
+						final NamedTableReference tableReference = new NamedTableReference(
 								tableExpression,
 								tableGroup.getPrimaryTableReference().getIdentificationVariable(),
 								false,
@@ -310,7 +311,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 			entityDescriptor.visitConstraintOrderedTables(
 					(tableExpression, tableKeyColumnVisitationSupplier) -> {
 						if ( !tableExpression.equals( rootTableName ) ) {
-							final TableReference tableReference = tableGroup.getTableReference(
+							final NamedTableReference tableReference = (NamedTableReference) tableGroup.getTableReference(
 									tableGroup.getNavigablePath(),
 									tableExpression,
 									true,
@@ -347,7 +348,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 	}
 
 	private int deleteFromRootTableWithoutIdTable(
-			TableReference rootTableReference,
+			NamedTableReference rootTableReference,
 			Predicate predicate,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext) {
@@ -359,7 +360,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 	}
 
 	private int deleteFromNonRootTableWithoutIdTable(
-			TableReference targetTableReference,
+			NamedTableReference targetTableReference,
 			Supplier<Consumer<SelectableConsumer>> tableKeyColumnVisitationSupplier,
 			SqlExpressionResolver sqlExpressionResolver,
 			TableGroup rootTableGroup,
@@ -369,7 +370,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 		assert targetTableReference != null;
 		log.tracef( "deleteFromNonRootTable - %s", targetTableReference.getTableExpression() );
 
-		final TableReference deleteTableReference = new TableReference(
+		final NamedTableReference deleteTableReference = new NamedTableReference(
 				targetTableReference.getTableExpression(),
 				DeleteStatement.DEFAULT_ALIAS,
 				true,
@@ -571,7 +572,7 @@ public class RestrictedDeleteExecutionDelegate implements TableBasedDeleteHandle
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
 
 		final TableKeyExpressionCollector keyColumnCollector = new TableKeyExpressionCollector( entityDescriptor );
-		final TableReference targetTable = new TableReference(
+		final NamedTableReference targetTable = new NamedTableReference(
 				tableExpression,
 				DeleteStatement.DEFAULT_ALIAS,
 				true,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
@@ -41,6 +41,7 @@ import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.expression.Over;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
@@ -140,7 +141,7 @@ public class TableBasedInsertHandler implements InsertHandler {
 
 		final List<Assignment> targetPathColumns = new ArrayList<>();
 		final Map<SqmParameter, MappingModelExpressable> paramTypeResolutions = new LinkedHashMap<>();
-		final TableReference entityTableReference = new TableReference(
+		final NamedTableReference entityTableReference = new NamedTableReference(
 				entityTable.getTableExpression(),
 				TemporaryTable.DEFAULT_ALIAS,
 				true,
@@ -171,7 +172,7 @@ public class TableBasedInsertHandler implements InsertHandler {
 
 		if ( sqmInsertStatement instanceof SqmInsertSelectStatement ) {
 			final QueryPart queryPart = converterDelegate.visitQueryPart( ( (SqmInsertSelectStatement<?>) sqmInsertStatement ).getSelectQueryPart() );
-			queryPart.forEachQuerySpec(
+			queryPart.visitQuerySpecs(
 					querySpec -> {
 						if ( additionalInsertValues.applySelections( querySpec, sessionFactory ) ) {
 							final TemporaryTableColumn rowNumberColumn = entityTable.getColumns()

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/UpdateExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/UpdateExecutionDelegate.java
@@ -31,6 +31,7 @@ import org.hibernate.query.sqm.tree.expression.SqmParameter;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.UnionTableReference;
@@ -200,18 +201,18 @@ public class UpdateExecutionDelegate implements TableBasedUpdateHandler.Executio
 		throw new SemanticException( "Assignment referred to column of a joined association: " + columnReference );
 	}
 
-	private TableReference resolveUnionTableReference(
+	private NamedTableReference resolveUnionTableReference(
 			TableReference tableReference,
 			String tableExpression) {
 		if ( tableReference instanceof UnionTableReference ) {
-			return new TableReference(
+			return new NamedTableReference(
 					tableExpression,
 					tableReference.getIdentificationVariable(),
 					tableReference.isOptional(),
 					sessionFactory
 			);
 		}
-		return tableReference;
+		return (NamedTableReference) tableReference;
 	}
 
 	private void updateTable(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -81,7 +81,6 @@ import org.hibernate.metamodel.mapping.SqlExpressable;
 import org.hibernate.metamodel.mapping.ValueMapping;
 import org.hibernate.metamodel.mapping.internal.EmbeddedCollectionPart;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
-import org.hibernate.metamodel.mapping.internal.ExplicitColumnDiscriminatorMappingImpl;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.metamodel.mapping.ordering.OrderByFragment;
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
@@ -107,7 +106,9 @@ import org.hibernate.query.sqm.tree.domain.SqmTreatedRoot;
 import org.hibernate.sql.ast.tree.expression.Over;
 import org.hibernate.sql.ast.tree.expression.SelfRenderingSqlFragmentExpression;
 import org.hibernate.sql.ast.tree.from.CorrelatedPluralTableGroup;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.PluralTableGroup;
+import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.exec.internal.VersionTypeSeedParameterSpecification;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
@@ -302,7 +303,6 @@ import org.hibernate.sql.ast.tree.from.LazyTableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableGroupJoinProducer;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.VirtualTableGroup;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.ast.tree.insert.Values;
@@ -695,7 +695,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 			return new UpdateStatement(
 					sqmStatement.isWithRecursive(), cteStatements,
-					rootTableGroup.getPrimaryTableReference(),
+					(NamedTableReference) rootTableGroup.getPrimaryTableReference(),
 					assignments,
 					SqlAstTreeHelper.combinePredicates( suppliedPredicate, additionalRestrictions ),
 					Collections.emptyList()
@@ -926,7 +926,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			return new DeleteStatement(
 					statement.isWithRecursive(),
 					cteStatements,
-					rootTableGroup.getPrimaryTableReference(),
+					(NamedTableReference) rootTableGroup.getPrimaryTableReference(),
 					SqlAstTreeHelper.combinePredicates( suppliedPredicate, additionalRestrictions ),
 					Collections.emptyList()
 			);
@@ -981,7 +981,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			insertStatement = new InsertStatement(
 					sqmStatement.isWithRecursive(),
 					cteStatements,
-					rootTableGroup.getPrimaryTableReference(),
+					(NamedTableReference) rootTableGroup.getPrimaryTableReference(),
 					Collections.emptyList()
 			);
 			additionalInsertValues = visitInsertionTargetPaths(
@@ -1005,7 +1005,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 				visitQueryPart( selectQueryPart )
 		);
 
-		insertStatement.getSourceSelectStatement().forEachQuerySpec(
+		insertStatement.getSourceSelectStatement().visitQuerySpecs(
 				querySpec -> {
 					final boolean appliedRowNumber = additionalInsertValues.applySelections(
 							querySpec,
@@ -1060,7 +1060,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			final InsertStatement insertStatement = new InsertStatement(
 					sqmStatement.isWithRecursive(),
 					cteStatements,
-					rootTableGroup.getPrimaryTableReference(),
+					(NamedTableReference) rootTableGroup.getPrimaryTableReference(),
 					Collections.emptyList()
 			);
 
@@ -5791,7 +5791,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		@Override
 		public SqlSelection resolveSqlSelection(
 				Expression expression,
-				JavaType javaTypeDescriptor,
+				JavaType<?> javaTypeDescriptor,
 				TypeConfiguration typeConfiguration) {
 			return delegate.resolveSqlSelection( expression, javaTypeDescriptor, typeConfiguration );
 		}
@@ -5847,7 +5847,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		@Override
 		public SqlSelection resolveSqlSelection(
 				Expression expression,
-				JavaType javaTypeDescriptor,
+				JavaType<?> javaTypeDescriptor,
 				TypeConfiguration typeConfiguration) {
 			SqlSelection selection = delegate.resolveSqlSelection( expression, javaTypeDescriptor, typeConfiguration );
 			List<SqlSelection> sqlSelectionList = sqlSelectionsForSqmSelection[index];

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -92,6 +92,8 @@ import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.internal.CompositeSqmPathSource;
 import org.hibernate.metamodel.model.domain.internal.DiscriminatorSqmPath;
 import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.query.FetchClauseType;
+import org.hibernate.query.SortOrder;
 import org.hibernate.query.criteria.JpaPath;
 import org.hibernate.query.internal.QueryHelper;
 import org.hibernate.query.sqm.function.SelfRenderingFunctionSqlAstExpression;
@@ -108,6 +110,8 @@ import org.hibernate.sql.ast.tree.expression.SelfRenderingSqlFragmentExpression;
 import org.hibernate.sql.ast.tree.from.CorrelatedPluralTableGroup;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.PluralTableGroup;
+import org.hibernate.sql.ast.tree.from.QueryPartTableGroup;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.exec.internal.VersionTypeSeedParameterSpecification;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -3192,22 +3196,22 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 	@Override
 	public Expression visitMaxElementPath(SqmMaxElementPath<?> path) {
-		return createCorrelatedAggregateSubQuery( path, false, true );
+		return createMinOrMaxIndexOrElement( path, false, true );
 	}
 
 	@Override
 	public Expression visitMinElementPath(SqmMinElementPath<?> path) {
-		return createCorrelatedAggregateSubQuery( path, false, false );
+		return createMinOrMaxIndexOrElement( path, false, false );
 	}
 
 	@Override
 	public Expression visitMaxIndexPath(SqmMaxIndexPath<?> path) {
-		return createCorrelatedAggregateSubQuery( path, true, true );
+		return createMinOrMaxIndexOrElement( path, true, true );
 	}
 
 	@Override
 	public Expression visitMinIndexPath(SqmMinIndexPath<?> path) {
-		return createCorrelatedAggregateSubQuery( path, true, false );
+		return createMinOrMaxIndexOrElement( path, true, false );
 	}
 
 	@Override
@@ -3358,6 +3362,19 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		};
 	}
 
+	protected Expression createMinOrMaxIndexOrElement(
+			AbstractSqmSpecificPluralPartPath<?> pluralPartPath,
+			boolean index,
+			boolean max) {
+		// Try to create a lateral sub-query join if possible which allows the re-use of the expression
+		if ( creationContext.getSessionFactory().getJdbcServices().getDialect().supportsLateral() ) {
+			return createLateralJoinExpression( pluralPartPath, index, max );
+		}
+		else {
+			return createCorrelatedAggregateSubQuery( pluralPartPath, index, max );
+		}
+	}
+
 	protected Expression createCorrelatedAggregateSubQuery(
 			AbstractSqmSpecificPluralPartPath<?> pluralPartPath,
 			boolean index,
@@ -3464,6 +3481,219 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			popProcessingStateStack();
 		}
 		return subQuerySpec;
+	}
+
+	protected Expression createLateralJoinExpression(
+			AbstractSqmSpecificPluralPartPath<?> pluralPartPath,
+			boolean index,
+			boolean max) {
+		prepareReusablePath( pluralPartPath.getLhs(), () -> null );
+
+		final PluralAttributeMapping pluralAttributeMapping = (PluralAttributeMapping) determineValueMapping(
+				pluralPartPath.getPluralDomainPath() );
+		final FromClauseAccess parentFromClauseAccess = getFromClauseAccess();
+		final TableGroup parentTableGroup = parentFromClauseAccess.findTableGroup(
+				pluralPartPath.getNavigablePath().getParent()
+		);
+		final CollectionPart collectionPart = index
+				? pluralAttributeMapping.getIndexDescriptor()
+				: pluralAttributeMapping.getElementDescriptor();
+		final ModelPart modelPart;
+		if ( collectionPart instanceof EntityAssociationMapping ) {
+			modelPart = ( (EntityAssociationMapping) collectionPart ).getKeyTargetMatchPart();
+		}
+		else {
+			modelPart = collectionPart;
+		}
+		final int jdbcTypeCount = modelPart.getJdbcTypeCount();
+		final String pathName = ( max ? "max" : "min" ) + ( index ? "_index" : "_element" );
+		final String identifierVariable = parentTableGroup.getPrimaryTableReference().getIdentificationVariable()
+				+ "_" + pathName;
+		final NavigablePath queryPath = new NavigablePath( parentTableGroup.getNavigablePath(), pathName, identifierVariable );
+		TableGroup lateralTableGroup = parentFromClauseAccess.findTableGroup( queryPath );
+		if ( lateralTableGroup == null ) {
+			final QuerySpec subQuerySpec = new QuerySpec( false );
+			pushProcessingState(
+					new SqlAstQueryPartProcessingStateImpl(
+							subQuerySpec,
+							getCurrentProcessingState(),
+							this,
+							currentClauseStack::getCurrent
+					)
+			);
+			try {
+				final TableGroup tableGroup = pluralAttributeMapping.createRootTableGroup(
+						true,
+						pluralPartPath.getNavigablePath(),
+						null,
+						() -> subQuerySpec::applyPredicate,
+						this,
+						creationContext
+				);
+				final FilterPredicate filterPredicate = FilterHelper.createFilterPredicate(
+						getLoadQueryInfluencers(),
+						(Joinable) pluralAttributeMapping.getCollectionDescriptor(),
+						tableGroup
+				);
+				if ( filterPredicate != null ) {
+					subQuerySpec.applyPredicate( filterPredicate );
+				}
+
+				getFromClauseAccess().registerTableGroup( pluralPartPath.getNavigablePath(), tableGroup );
+				registerPluralTableGroupParts( tableGroup );
+				subQuerySpec.getFromClause().addRoot( tableGroup );
+
+				final List<String> columnNames = new ArrayList<>( jdbcTypeCount );
+				final List<ColumnReference> resultColumnReferences = new ArrayList<>( jdbcTypeCount );
+				final NavigablePath navigablePath = pluralPartPath.getNavigablePath();
+				modelPart.forEachSelectable(
+						(selectionIndex, selectionMapping) -> {
+							final ColumnReference columnReference = new ColumnReference(
+									tableGroup.resolveTableReference(
+											navigablePath,
+											selectionMapping.getContainingTableExpression()
+									),
+									selectionMapping,
+									creationContext.getSessionFactory()
+							);
+							final String columnName;
+							if ( selectionMapping.isFormula() ) {
+								columnName = "col" + columnNames.size();
+							}
+							else {
+								columnName = selectionMapping.getSelectionExpression();
+							}
+							columnNames.add( columnName );
+							subQuerySpec.getSelectClause().addSqlSelection(
+									new SqlSelectionImpl(
+											selectionIndex - 1,
+											selectionIndex,
+											columnReference
+									)
+							);
+							subQuerySpec.addSortSpecification(
+									new SortSpecification(
+											columnReference,
+											null,
+											max ? SortOrder.DESCENDING : SortOrder.ASCENDING
+									)
+							);
+							resultColumnReferences.add(
+									new ColumnReference(
+											identifierVariable,
+											columnName,
+											false,
+											null,
+											null,
+											selectionMapping.getJdbcMapping(),
+											creationContext.getSessionFactory()
+									)
+							);
+						}
+				);
+
+				subQuerySpec.setFetchClauseExpression(
+						new QueryLiteral<>( 1, basicType( Integer.class ) ),
+						FetchClauseType.ROWS_ONLY
+				);
+				subQuerySpec.applyPredicate(
+						pluralAttributeMapping.getKeyDescriptor().generateJoinPredicate(
+								parentFromClauseAccess.findTableGroup(
+										pluralPartPath.getPluralDomainPath().getNavigablePath().getParent()
+								),
+								tableGroup,
+								SqlAstJoinType.INNER,
+								getSqlExpressionResolver(),
+								creationContext
+						)
+				);
+				lateralTableGroup = new QueryPartTableGroup(
+						queryPath,
+						null,
+						subQuerySpec,
+						identifierVariable,
+						columnNames,
+						true,
+						false,
+						creationContext.getSessionFactory()
+				);
+				if ( currentlyProcessingJoin == null ) {
+					parentTableGroup.addTableGroupJoin(
+							new TableGroupJoin(
+									lateralTableGroup.getNavigablePath(),
+									SqlAstJoinType.LEFT,
+									lateralTableGroup
+							)
+					);
+				}
+				else {
+					// In case this is used in the ON condition, we must prepend this lateral join
+					final TableGroup targetTableGroup;
+					if ( currentlyProcessingJoin.getLhs() == null ) {
+						targetTableGroup = parentFromClauseAccess.getTableGroup(
+								currentlyProcessingJoin.findRoot().getNavigablePath()
+						);
+					}
+					else {
+						targetTableGroup = parentFromClauseAccess.getTableGroup(
+								currentlyProcessingJoin.getLhs().getNavigablePath()
+						);
+					}
+					// Many databases would support modelling this as nested table group join,
+					// but at least SQL Server doesn't like that, saying that the correlated columns can't be "bound"
+					// Since there is no dependency on the currentlyProcessingJoin, we can safely prepend this join
+					targetTableGroup.prependTableGroupJoin(
+							currentlyProcessingJoin.getNavigablePath(),
+							new TableGroupJoin(
+									lateralTableGroup.getNavigablePath(),
+									SqlAstJoinType.LEFT,
+									lateralTableGroup
+							)
+					);
+				}
+				parentFromClauseAccess.registerTableGroup( lateralTableGroup.getNavigablePath(), lateralTableGroup );
+				if ( jdbcTypeCount == 1 ) {
+					return resultColumnReferences.get( 0 );
+				}
+				else {
+					return new SqlTuple( resultColumnReferences, modelPart );
+				}
+			}
+			finally {
+				popProcessingStateStack();
+			}
+		}
+		final QueryPartTableReference tableReference = (QueryPartTableReference) lateralTableGroup.getPrimaryTableReference();
+		if ( jdbcTypeCount == 1 ) {
+			return new ColumnReference(
+					identifierVariable,
+					tableReference.getColumnNames().get( 0 ),
+					false,
+					null,
+					null,
+					modelPart.getJdbcMappings().get( 0 ),
+					creationContext.getSessionFactory()
+			);
+		}
+		else {
+			final List<ColumnReference> resultColumnReferences = new ArrayList<>( jdbcTypeCount );
+			modelPart.forEachSelectable(
+					(selectionIndex, selectionMapping) -> {
+						resultColumnReferences.add(
+								new ColumnReference(
+										identifierVariable,
+										tableReference.getColumnNames().get( selectionIndex ),
+										false,
+										null,
+										null,
+										selectionMapping.getJdbcMapping(),
+										creationContext.getSessionFactory()
+								)
+						);
+					}
+			);
+			return new SqlTuple( resultColumnReferences, modelPart );
+		}
 	}
 
 	private Expression withTreatRestriction(Expression expression, SqmPath<?> path) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstProcessingStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstProcessingStateImpl.java
@@ -140,7 +140,7 @@ public class SqlAstProcessingStateImpl
 	@Override
 	public SqlSelection resolveSqlSelection(
 			Expression expression,
-			JavaType javaTypeDescriptor,
+			JavaType<?> javaTypeDescriptor,
 			TypeConfiguration typeConfiguration) {
 		throw new ConversionException( "Unexpected call to resolve SqlSelection outside of QuerySpec processing" );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstQueryPartProcessingStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstQueryPartProcessingStateImpl.java
@@ -68,7 +68,7 @@ public class SqlAstQueryPartProcessingStateImpl
 	@Override
 	public SqlSelection resolveSqlSelection(
 			Expression expression,
-			JavaType javaTypeDescriptor,
+			JavaType<?> javaTypeDescriptor,
 			TypeConfiguration typeConfiguration) {
 		final SqlSelection existing;
 		if ( sqlSelectionMap == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
@@ -38,10 +38,12 @@ import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.expression.UnaryOperation;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
@@ -100,7 +102,11 @@ public interface SqlAstWalker {
 
 	void visitTableGroupJoin(TableGroupJoin tableGroupJoin);
 
-	void visitTableReference(TableReference tableReference);
+	void visitNamedTableReference(NamedTableReference tableReference);
+
+	void visitValuesTableReference(ValuesTableReference tableReference);
+
+	void visitQueryPartTableReference(QueryPartTableReference tableReference);
 
 	void visitTableReferenceJoin(TableReferenceJoin tableReferenceJoin);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlAstWalker.java
@@ -38,6 +38,7 @@ import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.expression.UnaryOperation;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
@@ -107,6 +108,8 @@ public interface SqlAstWalker {
 	void visitValuesTableReference(ValuesTableReference tableReference);
 
 	void visitQueryPartTableReference(QueryPartTableReference tableReference);
+
+	void visitFunctionTableReference(FunctionTableReference tableReference);
 
 	void visitTableReferenceJoin(TableReferenceJoin tableReferenceJoin);
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/SqlTreePrinter.java
@@ -12,6 +12,7 @@ import org.hibernate.sql.ast.tree.SqlAstTreeLogger;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.LazyTableGroup;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
@@ -156,6 +157,13 @@ public class SqlTreePrinter {
 			if ( tableGroup.getPrimaryTableReference() instanceof ValuesTableReference ) {
 				logWithIndentation(
 						"primaryTableReference : values (..) as %s",
+						tableGroup.getPrimaryTableReference().getIdentificationVariable()
+				);
+			}
+			else if ( tableGroup.getPrimaryTableReference() instanceof FunctionTableReference ) {
+				logWithIndentation(
+						"primaryTableReference : %s(...) as %s",
+						( (FunctionTableReference) tableGroup.getPrimaryTableReference() ).getFunctionExpression().getFunctionName(),
 						tableGroup.getPrimaryTableReference().getIdentificationVariable()
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -109,7 +109,9 @@ import org.hibernate.sql.ast.tree.expression.Star;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.expression.UnaryOperation;
+import org.hibernate.sql.ast.tree.from.DerivedTableReference;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.LazyTableGroup;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
@@ -192,6 +194,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	private final Set<String> affectedTableNames = new HashSet<>();
 	private MutationStatement dmlStatement;
 	private boolean needsSelectAliases;
+	private Predicate additionalWherePredicate;
 	// We must reset the queryPartForRowNumbering fields to null if a query part is visited that does not
 	// contribute to the row numbering i.e. if the query part is a sub-query in the where clause.
 	// To determine whether a query part contributes to row numbering, we remember the clause depth
@@ -362,6 +365,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 
 	protected SqlAstNodeRenderingMode getParameterRenderingMode() {
 		return parameterRenderingMode;
+	}
+
+	protected void addAdditionalWherePredicate(Predicate predicate) {
+		additionalWherePredicate = Predicate.combinePredicates( additionalWherePredicate, predicate );
 	}
 
 	@Override
@@ -856,16 +863,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			clauseStack.pop();
 		}
 
-		if ( statement.getRestriction() != null ) {
-			try {
-				clauseStack.push( Clause.WHERE );
-				appendSql( " where " );
-				statement.getRestriction().accept( this );
-			}
-			finally {
-				clauseStack.pop();
-			}
-		}
+		visitWhereClause( statement.getRestriction() );
 		visitReturningColumns( statement );
 	}
 
@@ -923,16 +921,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			clauseStack.pop();
 		}
 
-		if ( statement.getRestriction() != null ) {
-			appendSql( " where " );
-			try {
-				clauseStack.push( Clause.WHERE );
-				statement.getRestriction().accept( this );
-			}
-			finally {
-				clauseStack.pop();
-			}
-		}
+		visitWhereClause( statement.getRestriction() );
 		visitReturningColumns( statement );
 	}
 
@@ -1496,8 +1485,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		final QueryPart queryPartForRowNumbering = this.queryPartForRowNumbering;
 		final int queryPartForRowNumberingClauseDepth = this.queryPartForRowNumberingClauseDepth;
 		final boolean needsSelectAliases = this.needsSelectAliases;
+		final Predicate additionalWherePredicate = this.additionalWherePredicate;
 		final ForUpdateClause forUpdate = this.forUpdate;
 		try {
+			this.additionalWherePredicate = null;
 			this.forUpdate = null;
 			// See the field documentation of queryPartForRowNumbering etc. for an explanation about this
 			// In addition, we also reset the row numbering if the currently row numbered query part is a query group
@@ -1534,7 +1525,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			}
 			visitSelectClause( querySpec.getSelectClause() );
 			visitFromClause( querySpec.getFromClause() );
-			visitWhereClause( querySpec );
+			visitWhereClause( querySpec.getWhereClauseRestrictions() );
 			visitGroupByClause( querySpec, getDialect().getGroupBySelectItemReferenceStrategy() );
 			visitHavingClause( querySpec );
 			visitOrderBy( querySpec.getSortSpecifications() );
@@ -1554,6 +1545,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			this.queryPartForRowNumbering = queryPartForRowNumbering;
 			this.queryPartForRowNumberingClauseDepth = queryPartForRowNumberingClauseDepth;
 			this.needsSelectAliases = needsSelectAliases;
+			this.additionalWherePredicate = additionalWherePredicate;
 			if ( queryPartForRowNumbering == null ) {
 				this.forUpdate = forUpdate;
 			}
@@ -1564,14 +1556,24 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		return true;
 	}
 
-	protected final void visitWhereClause(QuerySpec querySpec) {
-		final Predicate whereClauseRestrictions = querySpec.getWhereClauseRestrictions();
-		if ( whereClauseRestrictions != null && !whereClauseRestrictions.isEmpty() ) {
+	protected final void visitWhereClause(Predicate whereClauseRestrictions) {
+		if ( whereClauseRestrictions != null && !whereClauseRestrictions.isEmpty() || additionalWherePredicate != null ) {
 			appendSql( " where " );
 
 			clauseStack.push( Clause.WHERE );
 			try {
-				whereClauseRestrictions.accept( this );
+				if ( whereClauseRestrictions != null && !whereClauseRestrictions.isEmpty() ) {
+					whereClauseRestrictions.accept( this );
+					if ( additionalWherePredicate != null ) {
+						appendSql( " and " );
+						additionalWherePredicate.accept( this );
+						additionalWherePredicate = null;
+					}
+				}
+				else if ( additionalWherePredicate != null ) {
+					additionalWherePredicate.accept( this );
+					additionalWherePredicate = null;
+				}
 			}
 			finally {
 				clauseStack.pop();
@@ -3645,24 +3647,22 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		append( '(' );
 		visitValuesList( tableReference.getValuesList() );
 		append( ')' );
-		final String identificationVariable = tableReference.getIdentificationVariable();
-		if ( identificationVariable != null ) {
-			append( WHITESPACE );
-			append( tableReference.getIdentificationVariable() );
-			final List<String> columnNames = tableReference.getColumnNames();
-			append( '(' );
-			append( columnNames.get( 0 ) );
-			for ( int i = 1; i < columnNames.size(); i++ ) {
-				append( ',' );
-				append( columnNames.get( i ) );
-			}
-			append( ')' );
-		}
+		renderDerivedTableReference( tableReference );
 	}
 
 	@Override
 	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
 		tableReference.getQueryPart().accept( this );
+		renderDerivedTableReference( tableReference );
+	}
+
+	@Override
+	public void visitFunctionTableReference(FunctionTableReference tableReference) {
+		tableReference.getFunctionExpression().accept( this );
+		renderDerivedTableReference( tableReference );
+	}
+
+	protected void renderDerivedTableReference(DerivedTableReference tableReference) {
 		final String identificationVariable = tableReference.getIdentificationVariable();
 		if ( identificationVariable != null ) {
 			append( WHITESPACE );
@@ -3706,9 +3706,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 
 		for ( TableReferenceJoin tableJoin : joins ) {
 			appendSql( WHITESPACE );
-			renderJoinType( tableJoin.getJoinType() );
+			appendSql( tableJoin.getJoinType().getText() );
+			appendSql( "join " );
 
-			renderTableReference( tableJoin.getJoinedTableReference(), LockMode.NONE );
+			renderNamedTableReference( tableJoin.getJoinedTableReference(), LockMode.NONE );
 
 			if ( tableJoin.getPredicate() != null && !tableJoin.getPredicate().isEmpty() ) {
 				appendSql( " on " );
@@ -3748,21 +3749,37 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			}
 		}
 		else if ( realTableGroup != null ) {
-			appendSql( WHITESPACE );
-			renderJoinType( tableGroupJoin.getJoinType() );
-
-			if ( tableGroupJoin.getPredicate() != null && !tableGroupJoin.getPredicate().isEmpty() ) {
-				renderTableGroup( realTableGroup, tableGroupJoin.getPredicate(), tableGroupJoinCollector );
-			}
-			else {
-				renderTableGroup( realTableGroup, tableGroupJoinCollector );
-			}
+			renderTableGroupJoin(
+					tableGroupJoin,
+					tableGroupJoinCollector
+			);
 		}
 	}
 
-	protected void renderJoinType(SqlAstJoinType joinType) {
-		appendSql( joinType.getText() );
+	protected void renderTableGroupJoin(TableGroupJoin tableGroupJoin, List<TableGroupJoin> tableGroupJoinCollector) {
+		appendSql( WHITESPACE );
+		appendSql( tableGroupJoin.getJoinType().getText() );
 		appendSql( "join " );
+
+		final Predicate predicate;
+		if ( tableGroupJoin.isLateral() ) {
+			append( "lateral " );
+			if ( tableGroupJoin.getPredicate() == null ) {
+				predicate = new Junction( Junction.Nature.CONJUNCTION );
+			}
+			else {
+				predicate = tableGroupJoin.getPredicate();
+			}
+		}
+		else {
+			predicate = tableGroupJoin.getPredicate();
+		}
+		if ( predicate != null && !predicate.isEmpty() ) {
+			renderTableGroup( tableGroupJoin.getJoinedGroup(), predicate, tableGroupJoinCollector );
+		}
+		else {
+			renderTableGroup( tableGroupJoin.getJoinedGroup(), tableGroupJoinCollector );
+		}
 	}
 
 	@Override
@@ -4551,7 +4568,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				if ( !subQuery.getGroupByClauseExpressions()
 						.isEmpty() || subQuery.getHavingClauseRestrictions() != null ) {
 					// If we have a group by or having clause, we have to move the tuple comparison emulation to the HAVING clause
-					visitWhereClause( subQuery );
+					visitWhereClause( subQuery.getWhereClauseRestrictions() );
 					visitGroupByClause( subQuery, SelectItemReferenceStrategy.EXPRESSION );
 
 					appendSql( " having " );
@@ -4641,7 +4658,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				appendSql( OPEN_PARENTHESIS );
 				visitSelectClause( subQuery.getSelectClause() );
 				visitFromClause( subQuery.getFromClause() );
-				visitWhereClause( subQuery );
+				visitWhereClause( subQuery.getWhereClauseRestrictions() );
 				visitGroupByClause( subQuery, getDialect().getGroupBySelectItemReferenceStrategy() );
 				visitHavingClause( subQuery );
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
@@ -43,10 +43,12 @@ import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.expression.UnaryOperation;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.ast.tree.insert.Values;
 import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
@@ -468,6 +470,20 @@ public class AbstractSqlAstWalker implements SqlAstWalker {
 	}
 
 	@Override
-	public void visitTableReference(TableReference tableReference) {
+	public void visitNamedTableReference(NamedTableReference tableReference) {
+	}
+
+	@Override
+	public void visitValuesTableReference(ValuesTableReference tableReference) {
+		for ( Values values : tableReference.getValuesList() ) {
+			for ( Expression expression : values.getExpressions() ) {
+				expression.accept( this );
+			}
+		}
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+		tableReference.getQueryPart().accept( this );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstWalker.java
@@ -43,6 +43,7 @@ import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.expression.UnaryOperation;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
@@ -485,5 +486,12 @@ public class AbstractSqlAstWalker implements SqlAstWalker {
 	@Override
 	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
 		tableReference.getQueryPart().accept( this );
+	}
+
+	@Override
+	public void visitFunctionTableReference(FunctionTableReference tableReference) {
+		for ( SqlAstNode argument : tableReference.getFunctionExpression().getArguments() ) {
+			argument.accept( this );
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
@@ -35,6 +35,7 @@ import org.hibernate.sql.ast.tree.expression.Star;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
@@ -248,6 +249,10 @@ public class AggregateFunctionChecker extends AbstractSqlAstWalker {
 
 	@Override
 	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+	}
+
+	@Override
+	public void visitFunctionTableReference(FunctionTableReference tableReference) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
@@ -66,6 +66,16 @@ public class AggregateFunctionChecker extends AbstractSqlAstWalker {
 
 	private static class AggregateFunctionException extends RuntimeException {}
 
+	public static boolean hasAggregateFunctions(Expression expression) {
+		try {
+			expression.accept( INSTANCE );
+			return false;
+		}
+		catch (AggregateFunctionException ex) {
+			return true;
+		}
+	}
+
 	public static boolean hasAggregateFunctions(QuerySpec querySpec) {
 		try {
 			querySpec.getSelectClause().accept( INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AggregateFunctionChecker.java
@@ -20,6 +20,7 @@ import org.hibernate.sql.ast.tree.expression.Duration;
 import org.hibernate.sql.ast.tree.expression.DurationUnit;
 import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
 import org.hibernate.sql.ast.tree.expression.Every;
+import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Format;
 import org.hibernate.sql.ast.tree.expression.FunctionExpression;
@@ -34,11 +35,14 @@ import org.hibernate.sql.ast.tree.expression.Star;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.expression.TrimSpecification;
 import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
-import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
+import org.hibernate.sql.ast.tree.insert.Values;
 import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
 import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
 import org.hibernate.sql.ast.tree.predicate.InListPredicate;
@@ -235,7 +239,15 @@ public class AggregateFunctionChecker extends AbstractSqlAstWalker {
 	}
 
 	@Override
-	public void visitTableReference(TableReference tableReference) {
+	public void visitNamedTableReference(NamedTableReference tableReference) {
+	}
+
+	@Override
+	public void visitValuesTableReference(ValuesTableReference tableReference) {
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AliasCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AliasCollector.java
@@ -11,7 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
+import org.hibernate.sql.ast.tree.insert.Values;
 
 /**
  * A simple walker that checks for aggregate functions.
@@ -29,7 +34,17 @@ public class AliasCollector extends AbstractSqlAstWalker {
 	}
 
 	@Override
-	public void visitTableReference(TableReference tableReference) {
+	public void visitNamedTableReference(NamedTableReference tableReference) {
+		tableReferenceMap.put( tableReference.getIdentificationVariable(), tableReference );
+	}
+
+	@Override
+	public void visitValuesTableReference(ValuesTableReference tableReference) {
+		tableReferenceMap.put( tableReference.getIdentificationVariable(), tableReference );
+	}
+
+	@Override
+	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
 		tableReferenceMap.put( tableReference.getIdentificationVariable(), tableReference );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AliasCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AliasCollector.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
 import org.hibernate.sql.ast.tree.from.TableReference;
@@ -45,6 +46,11 @@ public class AliasCollector extends AbstractSqlAstWalker {
 
 	@Override
 	public void visitQueryPartTableReference(QueryPartTableReference tableReference) {
+		tableReferenceMap.put( tableReference.getIdentificationVariable(), tableReference );
+	}
+
+	@Override
+	public void visitFunctionTableReference(FunctionTableReference tableReference) {
 		tableReferenceMap.put( tableReference.getIdentificationVariable(), tableReference );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.sql.ast.spi;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.hibernate.metamodel.mapping.SelectableMapping;
@@ -50,10 +51,8 @@ public interface SqlExpressionResolver {
 	static String createColumnReferenceKey(TableReference tableReference, String columnExpression) {
 		assert tableReference != null : "tableReference expected to be non-null";
 		assert columnExpression != null : "columnExpression expected to be non-null";
-
-		final String qualifier = tableReference.getIdentificationVariable() == null
-				? tableReference.getTableExpression()
-				: tableReference.getIdentificationVariable();
+		assert tableReference.getIdentificationVariable() != null : "tableReference#identificationVariable expected to be non-null";
+		final String qualifier = tableReference.getIdentificationVariable();
 		return qualifier + columnExpression;
 	}
 
@@ -61,8 +60,8 @@ public interface SqlExpressionResolver {
 	 * Convenience form for creating a key from TableReference and SelectableMapping
 	 */
 	static String createColumnReferenceKey(TableReference tableReference, SelectableMapping selectable) {
-		assert selectable.getContainingTableExpression().equals( tableReference.getTableExpression() )
-				: String.format( ROOT, "Expecting tables to match between TableReference (%s) and SelectableMapping (%s)", tableReference.getTableExpression(), selectable.getContainingTableExpression() );
+		assert Objects.equals( selectable.getContainingTableExpression(), tableReference.getTableId() )
+				: String.format( ROOT, "Expecting tables to match between TableReference (%s) and SelectableMapping (%s)", tableReference.getTableId(), selectable.getContainingTableExpression() );
 		return createColumnReferenceKey( tableReference, selectable.getSelectionExpression() );
 	}
 
@@ -77,6 +76,6 @@ public interface SqlExpressionResolver {
 	 */
 	SqlSelection resolveSqlSelection(
 			Expression expression,
-			JavaType javaTypeDescriptor,
+			JavaType<?> javaTypeDescriptor,
 			TypeConfiguration typeConfiguration);
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/AbstractMutationStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/AbstractMutationStatement.java
@@ -13,30 +13,30 @@ import java.util.Map;
 
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 
 /**
  * @author Christian Beikov
  */
 public abstract class AbstractMutationStatement extends AbstractStatement implements MutationStatement {
 
-	private final TableReference targetTable;
+	private final NamedTableReference targetTable;
 	private final List<ColumnReference> returningColumns;
 
-	public AbstractMutationStatement(TableReference targetTable) {
+	public AbstractMutationStatement(NamedTableReference targetTable) {
 		super( new LinkedHashMap<>() );
 		this.targetTable = targetTable;
 		this.returningColumns = Collections.emptyList();
 	}
 
-	public AbstractMutationStatement(Map<String, CteStatement> cteStatements, TableReference targetTable, List<ColumnReference> returningColumns) {
+	public AbstractMutationStatement(Map<String, CteStatement> cteStatements, NamedTableReference targetTable, List<ColumnReference> returningColumns) {
 		super( cteStatements );
 		this.targetTable = targetTable;
 		this.returningColumns = returningColumns;
 	}
 
 	@Override
-	public TableReference getTargetTable() {
+	public NamedTableReference getTargetTable() {
 		return targetTable;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/MutationStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/MutationStatement.java
@@ -9,7 +9,7 @@ package org.hibernate.sql.ast.tree;
 import java.util.List;
 
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 
 /**
  * Specialization of Statement for mutation (DML) statements
@@ -17,6 +17,6 @@ import org.hibernate.sql.ast.tree.from.TableReference;
  * @author Steve Ebersole
  */
 public interface MutationStatement extends Statement {
-	TableReference getTargetTable();
+	NamedTableReference getTargetTable();
 	List<ColumnReference> getReturningColumns();
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTable.java
@@ -7,24 +7,10 @@
 package org.hibernate.sql.ast.tree.cte;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.metamodel.mapping.Bindable;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.query.NavigablePath;
-import org.hibernate.sql.ast.Clause;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
-import org.hibernate.sql.ast.tree.from.StandardTableGroup;
-import org.hibernate.sql.ast.tree.from.TableReference;
-import org.hibernate.sql.ast.tree.select.QuerySpec;
-import org.hibernate.sql.exec.internal.JdbcParameterImpl;
-import org.hibernate.sql.exec.spi.ExecutionContext;
-import org.hibernate.sql.exec.spi.JdbcParameterBindings;
-import org.hibernate.sql.results.internal.SqlSelectionImpl;
 
 /**
  * Describes the table definition for the CTE - its name amd its columns
@@ -67,120 +53,4 @@ public class CteTable {
 		return new CteTable( name, cteColumns, sessionFactory );
 	}
 
-	public QuerySpec createCteDefinition(
-			List<?> matchingIds,
-			Bindable bindable,
-			JdbcParameterBindings jdbcParameterBindings,
-			ExecutionContext executionContext) {
-		final QuerySpec querySpec = new QuerySpec( false );
-
-		final TableReference tableValueConstructorReference = createCteDefinitionTableValueCtor(
-				matchingIds,
-				bindable,
-				jdbcParameterBindings,
-				executionContext
-		);
-
-		final StandardTableGroup tableValueCtorGroup = new StandardTableGroup(
-				true,
-				new NavigablePath( "cte" ),
-				null,
-				null,
-				tableValueConstructorReference,
-				null,
-				sessionFactory
-		);
-
-		querySpec.getFromClause().addRoot( tableValueCtorGroup );
-
-		applySelections( querySpec, tableValueConstructorReference );
-
-		return querySpec;
-	}
-
-	private TableReference createCteDefinitionTableValueCtor(
-			List<?> matchingValues,
-			Bindable bindable,
-			JdbcParameterBindings jdbcParameterBindings,
-			ExecutionContext executionContext) {
-		// use `DerivedTable` as the TableValueConstructor
-		//		so its `#expression` would be something like `values ( (a1, b1), (a2, b2), ... )`
-
-		final int numberOfColumns = getCteColumns().size();
-
-		final StringBuilder tableValueCtorExpressionBuffer = new StringBuilder( "values(" );
-		final List<JdbcParameter> jdbcParameters = Arrays.asList( new JdbcParameterImpl[numberOfColumns] );
-		String rowSeparator = "";
-		for ( Object matchingId : matchingValues ) {
-			tableValueCtorExpressionBuffer.append( rowSeparator );
-
-			char separator = '(';
-			for ( int i = 0; i < numberOfColumns; i++ ) {
-				tableValueCtorExpressionBuffer.append( separator );
-				tableValueCtorExpressionBuffer.append( '?' );
-				separator = ',';
-				jdbcParameters.set( i, new JdbcParameterImpl( cteColumns.get( i ).getJdbcMapping() ) );
-			}
-			tableValueCtorExpressionBuffer.append( ')' );
-
-			jdbcParameterBindings.registerParametersForEachJdbcValue(
-					matchingId,
-					Clause.IRRELEVANT,
-					bindable,
-					jdbcParameters,
-					executionContext.getSession()
-			);
-
-			rowSeparator = ", ";
-		}
-
-		tableValueCtorExpressionBuffer.append( ')' );
-
-		return new TableReference(
-				tableValueCtorExpressionBuffer.toString(),
-				cteName,
-				false,
-				sessionFactory
-		);
-	}
-
-	public QuerySpec createCteSubQuery(@SuppressWarnings("unused") ExecutionContext executionContext) {
-		final QuerySpec querySpec = new QuerySpec( false );
-
-		final TableReference cteTableReference = new TableReference(
-				getTableExpression(),
-				null,
-				false,
-				sessionFactory
-		);
-
-		final CteTableGroup cteTableGroup = new CteTableGroup( cteTableReference );
-		querySpec.getFromClause().addRoot( cteTableGroup );
-
-		applySelections( querySpec, cteTableReference );
-
-		return querySpec;
-	}
-
-	private void applySelections(QuerySpec querySpec, TableReference tableReference) {
-		for ( int i = 0; i < cteColumns.size(); i++ ) {
-			final CteColumn cteColumn = cteColumns.get( i );
-			querySpec.getSelectClause().addSqlSelection(
-					new SqlSelectionImpl(
-							i + 1,
-							i,
-							// todo (6.0) : handle read/write transformers for the CTE columns
-							new ColumnReference(
-									tableReference,
-									cteColumn.getColumnExpression(),
-									false,
-									null,
-									null,
-									cteColumn.getJdbcMapping(),
-									sessionFactory
-							)
-					)
-			);
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
@@ -10,12 +10,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.hibernate.metamodel.mapping.ModelPart;
-import org.hibernate.metamodel.mapping.ModelPartContainer;
 import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.tree.from.AbstractTableGroup;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
-import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 
@@ -25,92 +23,29 @@ import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
  *
  * @author Steve Ebersole
  */
-public class CteTableGroup implements TableGroup {
-	private final NavigablePath navigablePath;
+public class CteTableGroup extends AbstractTableGroup {
 	private final NamedTableReference cteTableReference;
 
-	@SuppressWarnings("WeakerAccess")
 	public CteTableGroup(NamedTableReference cteTableReference) {
-		this.navigablePath = new NavigablePath( cteTableReference.getTableExpression() );
+		this( false, cteTableReference );
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public CteTableGroup(boolean canUseInnerJoins, NamedTableReference cteTableReference) {
+		super(
+				canUseInnerJoins,
+				new NavigablePath( cteTableReference.getTableExpression() ),
+				null,
+				cteTableReference.getIdentificationVariable(),
+				null,
+				null
+		);
 		this.cteTableReference = cteTableReference;
 	}
 
 	@Override
-	public NavigablePath getNavigablePath() {
-		return navigablePath;
-	}
-
-	@Override
-	public String getSourceAlias() {
-		return null;
-	}
-
-	@Override
-	public ModelPartContainer getModelPart() {
-		return null;
-	}
-
-	@Override
-	public ModelPart getExpressionType() {
-		return getModelPart();
-	}
-
-	@Override
-	public List<TableGroupJoin> getTableGroupJoins() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public List<TableGroupJoin> getNestedTableGroupJoins() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	public boolean canUseInnerJoins() {
-		return false;
-	}
-
-	@Override
-	public TableReference getTableReference(
-			NavigablePath navigablePath,
-			String tableExpression,
-			boolean allowFkOptimization,
-			boolean resolve) {
-		if ( cteTableReference.getTableExpression().equals( tableExpression ) ) {
-			return cteTableReference;
-		}
-		return null;
-	}
-
-	@Override
-	public TableReference resolveTableReference(
-			NavigablePath navigablePath,
-			String tableExpression,
-			boolean allowFkOptimization) {
-		return cteTableReference;
-	}
-
-	@Override
-	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-	}
-
-	@Override
-	public void visitNestedTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-	}
-
-	@Override
 	public String getGroupAlias() {
-		return null;
-	}
-
-	@Override
-	public void addTableGroupJoin(TableGroupJoin join) {
-		throw new UnsupportedOperationException(  );
-	}
-
-	@Override
-	public void addNestedTableGroupJoin(TableGroupJoin join) {
-		throw new UnsupportedOperationException(  );
+		return cteTableReference.getIdentificationVariable();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/cte/CteTableGroup.java
@@ -13,23 +13,24 @@ import java.util.function.Consumer;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.ModelPartContainer;
 import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 
 /**
- * Wraps a {@link TableReference} representing the CTE and adapts it to
+ * Wraps a {@link NamedTableReference} representing the CTE and adapts it to
  * {@link TableGroup} for use in SQL AST
  *
  * @author Steve Ebersole
  */
 public class CteTableGroup implements TableGroup {
 	private final NavigablePath navigablePath;
-	private final TableReference cteTableReference;
+	private final NamedTableReference cteTableReference;
 
 	@SuppressWarnings("WeakerAccess")
-	public CteTableGroup(TableReference cteTableReference) {
+	public CteTableGroup(NamedTableReference cteTableReference) {
 		this.navigablePath = new NavigablePath( cteTableReference.getTableExpression() );
 		this.cteTableReference = cteTableReference;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/delete/DeleteStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/delete/DeleteStatement.java
@@ -15,7 +15,7 @@ import org.hibernate.sql.ast.spi.SqlAstHelper;
 import org.hibernate.sql.ast.tree.AbstractMutationStatement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.predicate.Junction;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 
@@ -27,13 +27,13 @@ public class DeleteStatement extends AbstractMutationStatement {
 	public static final String DEFAULT_ALIAS = "to_delete_";
 	private final Predicate restriction;
 
-	public DeleteStatement(TableReference targetTable, Predicate restriction) {
+	public DeleteStatement(NamedTableReference targetTable, Predicate restriction) {
 		super( targetTable );
 		this.restriction = restriction;
 	}
 
 	public DeleteStatement(
-			TableReference targetTable,
+			NamedTableReference targetTable,
 			Predicate restriction,
 			List<ColumnReference> returningColumns) {
 		super( new LinkedHashMap<>(), targetTable, returningColumns );
@@ -43,7 +43,7 @@ public class DeleteStatement extends AbstractMutationStatement {
 	public DeleteStatement(
 			boolean withRecursive,
 			Map<String, CteStatement> cteStatements,
-			TableReference targetTable,
+			NamedTableReference targetTable,
 			Predicate restriction,
 			List<ColumnReference> returningColumns) {
 		super( cteStatements, targetTable, returningColumns );
@@ -56,10 +56,10 @@ public class DeleteStatement extends AbstractMutationStatement {
 	}
 
 	public static class DeleteStatementBuilder {
-		private final TableReference targetTable;
+		private final NamedTableReference targetTable;
 		private Predicate restriction;
 
-		public DeleteStatementBuilder(TableReference targetTable) {
+		public DeleteStatementBuilder(NamedTableReference targetTable) {
 			this.targetTable = targetTable;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableReference.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package org.hibernate.sql.ast.tree.from;
+
+import java.util.Objects;
+
+public abstract class AbstractTableReference implements TableReference {
+	protected final String identificationVariable;
+	protected final boolean isOptional;
+
+	public AbstractTableReference(String identificationVariable, boolean isOptional) {
+		assert identificationVariable != null;
+		this.identificationVariable = identificationVariable;
+		this.isOptional = isOptional;
+	}
+
+	@Override
+	public String getIdentificationVariable() {
+		return identificationVariable;
+	}
+
+	@Override
+	public boolean isOptional() {
+		return isOptional;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		TableReference that = (TableReference) o;
+		return Objects.equals( identificationVariable, that.getIdentificationVariable() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( identificationVariable );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CorrelatedTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CorrelatedTableGroup.java
@@ -112,7 +112,7 @@ public class CorrelatedTableGroup extends AbstractTableGroup {
 
 	@Override
 	public void applyAffectedTableNames(Consumer<String> nameCollector) {
-		nameCollector.accept( getPrimaryTableReference().getTableExpression() );
+		getPrimaryTableReference().applyAffectedTableNames( nameCollector );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CorrelatedTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/CorrelatedTableGroup.java
@@ -57,6 +57,11 @@ public class CorrelatedTableGroup extends AbstractTableGroup {
 	}
 
 	@Override
+	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void addNestedTableGroupJoin(TableGroupJoin join) {
 		assert !getTableGroupJoins().contains( join );
 		assert join.getJoinType() == SqlAstJoinType.INNER;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DelegatingTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DelegatingTableGroup.java
@@ -1,0 +1,201 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.from;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.hibernate.metamodel.mapping.ModelPart;
+import org.hibernate.metamodel.mapping.ModelPartContainer;
+import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.SqlAstWalker;
+import org.hibernate.sql.ast.spi.SqlSelection;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * @author Christian Beikov
+ */
+public abstract class DelegatingTableGroup implements TableGroup {
+
+	protected abstract TableGroup getTableGroup();
+
+	@Override
+	public ModelPart getExpressionType() {
+		return getTableGroup().getExpressionType();
+	}
+
+	@Override
+	public Expression getSqlExpression() {
+		return getTableGroup().getSqlExpression();
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> target) {
+		return getTableGroup().unwrap( target );
+	}
+
+	@Override
+	public SqlSelection createSqlSelection(
+			int jdbcPosition,
+			int valuesArrayPosition,
+			JavaType javaTypeDescriptor,
+			TypeConfiguration typeConfiguration) {
+		return getTableGroup().createSqlSelection(
+				jdbcPosition,
+				valuesArrayPosition,
+				javaTypeDescriptor,
+				typeConfiguration
+		);
+	}
+
+	@Override
+	public TableReference resolveTableReference(NavigablePath navigablePath, String tableExpression) {
+		return resolveTableReference( navigablePath, tableExpression, true );
+	}
+
+	@Override
+	public TableReference resolveTableReference(String tableExpression) {
+		return resolveTableReference( null, tableExpression, true );
+	}
+
+	@Override
+	public TableReference resolveTableReference(
+			NavigablePath navigablePath,
+			String tableExpression,
+			boolean allowFkOptimization) {
+		return getTableGroup().resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
+	}
+
+	@Override
+	public TableReference getTableReference(NavigablePath navigablePath, String tableExpression) {
+		return getTableReference( navigablePath, tableExpression, true, false );
+	}
+
+	@Override
+	public TableReference getTableReference(String tableExpression) {
+		return getTableReference( null, tableExpression, true, false );
+	}
+
+	@Override
+	public TableReference getTableReference(
+			NavigablePath navigablePath,
+			String tableExpression,
+			boolean allowFkOptimization, boolean resolve) {
+		return getTableGroup().getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve );
+	}
+
+	@Override
+	public NavigablePath getNavigablePath() {
+		return getTableGroup().getNavigablePath();
+	}
+
+	@Override
+	public String getGroupAlias() {
+		return getTableGroup().getGroupAlias();
+	}
+
+	@Override
+	public ModelPartContainer getModelPart() {
+		return getTableGroup().getModelPart();
+	}
+
+	@Override
+	public String getSourceAlias() {
+		return getTableGroup().getSourceAlias();
+	}
+
+	@Override
+	public List<TableGroupJoin> getTableGroupJoins() {
+		return getTableGroup().getTableGroupJoins();
+	}
+
+	@Override
+	public List<TableGroupJoin> getNestedTableGroupJoins() {
+		return getTableGroup().getNestedTableGroupJoins();
+	}
+
+	@Override
+	public boolean canUseInnerJoins() {
+		return getTableGroup().canUseInnerJoins();
+	}
+
+	@Override
+	public boolean isLateral() {
+		return getTableGroup().isLateral();
+	}
+
+	@Override
+	public void addTableGroupJoin(TableGroupJoin join) {
+		getTableGroup().addTableGroupJoin( join );
+	}
+
+	@Override
+	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
+		getTableGroup().prependTableGroupJoin( navigablePath, join );
+	}
+
+	@Override
+	public void addNestedTableGroupJoin(TableGroupJoin join) {
+		getTableGroup().addNestedTableGroupJoin( join );
+	}
+
+	@Override
+	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
+		getTableGroup().visitTableGroupJoins( consumer );
+	}
+
+	@Override
+	public void visitNestedTableGroupJoins(Consumer<TableGroupJoin> consumer) {
+		getTableGroup().visitNestedTableGroupJoins( consumer );
+	}
+
+	@Override
+	public void applyAffectedTableNames(Consumer<String> nameCollector) {
+		getTableGroup().applyAffectedTableNames( nameCollector );
+	}
+
+	@Override
+	public TableReference getPrimaryTableReference() {
+		return getTableGroup().getPrimaryTableReference();
+	}
+
+	@Override
+	public List<TableReferenceJoin> getTableReferenceJoins() {
+		return getTableGroup().getTableReferenceJoins();
+	}
+
+	@Override
+	public DomainResult createDomainResult(
+			String resultVariable,
+			DomainResultCreationState creationState) {
+		return getTableGroup().createDomainResult( resultVariable, creationState );
+	}
+
+	@Override
+	public void applySqlSelections(DomainResultCreationState creationState) {
+		getTableGroup().applySqlSelections( creationState );
+	}
+
+	@Override
+	public void accept(SqlAstWalker sqlTreeWalker) {
+		getTableGroup().accept( sqlTreeWalker );
+	}
+
+	@Override
+	public boolean isRealTableGroup() {
+		return getTableGroup().isRealTableGroup();
+	}
+
+	@Override
+	public boolean isFetched() {
+		return getTableGroup().isFetched();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DerivedTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DerivedTableReference.java
@@ -17,13 +17,16 @@ import org.hibernate.query.NavigablePath;
 public abstract class DerivedTableReference extends AbstractTableReference {
 
 	private final List<String> columnNames;
+	private final boolean lateral;
 
 	public DerivedTableReference(
 			String identificationVariable,
 			List<String> columnNames,
+			boolean lateral,
 			SessionFactoryImplementor sessionFactory) {
 		super( identificationVariable, false );
 		this.columnNames = columnNames;
+		this.lateral = lateral;
 	}
 
 	@Override
@@ -33,6 +36,10 @@ public abstract class DerivedTableReference extends AbstractTableReference {
 
 	public List<String> getColumnNames() {
 		return columnNames;
+	}
+
+	public boolean isLateral() {
+		return lateral;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DerivedTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DerivedTableReference.java
@@ -6,24 +6,33 @@
  */
 package org.hibernate.sql.ast.tree.from;
 
+import java.util.List;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.NavigablePath;
 
 /**
- * @author Andrea Boriero
+ * @author Christian Beikov
  */
-public class UnionTableReference extends NamedTableReference {
-	private final String[] subclassTableSpaceExpressions;
+public abstract class DerivedTableReference extends AbstractTableReference {
 
-	public UnionTableReference(
-			String unionTableExpression,
-			String[] subclassTableSpaceExpressions,
+	private final List<String> columnNames;
+
+	public DerivedTableReference(
 			String identificationVariable,
-			boolean isOptional,
+			List<String> columnNames,
 			SessionFactoryImplementor sessionFactory) {
-		super( unionTableExpression, identificationVariable, isOptional, sessionFactory );
+		super( identificationVariable, false );
+		this.columnNames = columnNames;
+	}
 
-		this.subclassTableSpaceExpressions = subclassTableSpaceExpressions;
+	@Override
+	public String getTableId() {
+		return null;
+	}
+
+	public List<String> getColumnNames() {
+		return columnNames;
 	}
 
 	@Override
@@ -31,9 +40,6 @@ public class UnionTableReference extends NamedTableReference {
 			NavigablePath navigablePath,
 			String tableExpression,
 			boolean allowFkOptimization) {
-		if ( hasTableExpression( tableExpression ) ) {
-			return this;
-		}
 		throw new IllegalStateException( "Could not resolve binding for table `" + tableExpression + "`" );
 	}
 
@@ -43,21 +49,7 @@ public class UnionTableReference extends NamedTableReference {
 			String tableExpression,
 			boolean allowFkOptimization,
 			boolean resolve) {
-		if ( hasTableExpression( tableExpression ) ) {
-			return this;
-		}
 		return null;
 	}
 
-	private boolean hasTableExpression(String tableExpression) {
-		if ( tableExpression.equals( getTableExpression() ) ) {
-			return true;
-		}
-		for ( String expression : subclassTableSpaceExpressions ) {
-			if ( tableExpression.equals( expression ) ) {
-				return true;
-			}
-		}
-		return false;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/FunctionTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/FunctionTableReference.java
@@ -11,42 +11,38 @@ import java.util.function.Function;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.sql.ast.SqlAstWalker;
-import org.hibernate.sql.ast.tree.select.QueryPart;
+import org.hibernate.sql.ast.tree.expression.FunctionExpression;
 
 /**
- * A table reference for a query part.
+ * A table reference for a table valued function.
  *
  * @author Christian Beikov
  */
-public class QueryPartTableReference extends DerivedTableReference {
+public class FunctionTableReference extends DerivedTableReference {
 
-	private final QueryPart queryPart;
+	private final FunctionExpression functionExpression;
 
-	public QueryPartTableReference(
-			QueryPart queryPart,
+	public FunctionTableReference(
+			FunctionExpression functionExpression,
 			String identificationVariable,
 			List<String> columnNames,
 			boolean lateral,
 			SessionFactoryImplementor sessionFactory) {
 		super( identificationVariable, columnNames, lateral, sessionFactory );
-		this.queryPart = queryPart;
+		this.functionExpression = functionExpression;
 	}
 
-	public QueryPart getQueryPart() {
-		return queryPart;
+	public FunctionExpression getFunctionExpression() {
+		return functionExpression;
 	}
 
 	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
-		sqlTreeWalker.visitQueryPartTableReference( this );
+		functionExpression.accept( sqlTreeWalker );
 	}
 
 	@Override
 	public Boolean visitAffectedTableNames(Function<String, Boolean> nameCollector) {
-		final Function<TableReference, Boolean> tableReferenceBooleanFunction =
-				tableReference -> tableReference.visitAffectedTableNames( nameCollector );
-		return queryPart.queryQuerySpecs(
-			querySpec -> querySpec.getFromClause().queryTableReferences( tableReferenceBooleanFunction )
-		);
+		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/LazyTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/LazyTableGroup.java
@@ -147,6 +147,11 @@ public class LazyTableGroup extends AbstractColumnReferenceQualifier implements 
 	}
 
 	@Override
+	public boolean isLateral() {
+		return false;
+	}
+
+	@Override
 	public NavigablePath getNavigablePath() {
 		return navigablePath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MappedByTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MappedByTableGroup.java
@@ -17,7 +17,7 @@ import org.hibernate.query.NavigablePath;
 /**
  * @author Christian Beikov
  */
-public class MappedByTableGroup implements VirtualTableGroup {
+public class MappedByTableGroup extends DelegatingTableGroup implements VirtualTableGroup {
 
 	private final NavigablePath navigablePath;
 	private final ModelPartContainer modelPart;
@@ -39,6 +39,11 @@ public class MappedByTableGroup implements VirtualTableGroup {
 		this.fetched = fetched;
 		this.parentTableGroup = parentTableGroup;
 		this.navigablePathChecker = navigablePathChecker;
+	}
+
+	@Override
+	protected TableGroup getTableGroup() {
+		return underlyingTableGroup;
 	}
 
 	@Override
@@ -67,9 +72,17 @@ public class MappedByTableGroup implements VirtualTableGroup {
 		return modelPart;
 	}
 
+	// Don't provide access to table group joins as this is table group is just a "named reference"
+	// The underlying table group contains the joins and will render them
+
 	@Override
-	public String getSourceAlias() {
-		return underlyingTableGroup.getSourceAlias();
+	public boolean isRealTableGroup() {
+		return false;
+	}
+
+	@Override
+	public boolean isLateral() {
+		return false;
 	}
 
 	@Override
@@ -83,26 +96,6 @@ public class MappedByTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public boolean isRealTableGroup() {
-		return false;
-	}
-
-	@Override
-	public boolean canUseInnerJoins() {
-		return underlyingTableGroup.canUseInnerJoins();
-	}
-
-	@Override
-	public void addTableGroupJoin(TableGroupJoin join) {
-		underlyingTableGroup.addTableGroupJoin( join );
-	}
-
-	@Override
-	public void addNestedTableGroupJoin(TableGroupJoin join) {
-		underlyingTableGroup.addNestedTableGroupJoin( join );
-	}
-
-	@Override
 	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
 		// No-op
 	}
@@ -113,18 +106,8 @@ public class MappedByTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public void applyAffectedTableNames(Consumer<String> nameCollector) {
-		underlyingTableGroup.applyAffectedTableNames( nameCollector );
-	}
-
-	@Override
-	public TableReference getPrimaryTableReference() {
-		return underlyingTableGroup.getPrimaryTableReference();
-	}
-
-	@Override
 	public List<TableReferenceJoin> getTableReferenceJoins() {
-		return underlyingTableGroup.getTableReferenceJoins();
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
@@ -23,12 +23,12 @@ import org.hibernate.query.NavigablePath;
 public class MutatingTableReferenceGroupWrapper implements VirtualTableGroup {
 	private final NavigablePath navigablePath;
 	private final ModelPartContainer modelPart;
-	private final TableReference mutatingTableReference;
+	private final NamedTableReference mutatingTableReference;
 
 	public MutatingTableReferenceGroupWrapper(
 			NavigablePath navigablePath,
 			ModelPartContainer modelPart,
-			TableReference mutatingTableReference) {
+			NamedTableReference mutatingTableReference) {
 		this.navigablePath = navigablePath;
 		this.modelPart = modelPart;
 		this.mutatingTableReference = mutatingTableReference;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/MutatingTableReferenceGroupWrapper.java
@@ -109,6 +109,11 @@ public class MutatingTableReferenceGroupWrapper implements VirtualTableGroup {
 	}
 
 	@Override
+	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void addNestedTableGroupJoin(TableGroupJoin join) {
 		throw new UnsupportedOperationException();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/NamedTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/NamedTableReference.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.ast.tree.from;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.NavigablePath;
+import org.hibernate.sql.ast.SqlAstWalker;
+
+/**
+ * Represents a reference to a "named" table in a query's from clause.
+ *
+ * @author Steve Ebersole
+ */
+public class NamedTableReference extends AbstractTableReference {
+	private final String tableExpression;
+
+	private String prunedTableExpression;
+
+	public NamedTableReference(
+			String tableExpression,
+			String identificationVariable,
+			boolean isOptional,
+			SessionFactoryImplementor sessionFactory) {
+		super( identificationVariable, isOptional );
+		assert tableExpression != null;
+		this.tableExpression = tableExpression;
+	}
+
+	public String getTableExpression() {
+		return prunedTableExpression == null ? tableExpression : prunedTableExpression;
+	}
+
+	@Override
+	public String getTableId() {
+		return getTableExpression();
+	}
+
+	public void setPrunedTableExpression(String prunedTableExpression) {
+		this.prunedTableExpression = prunedTableExpression;
+	}
+
+	@Override
+	public void accept(SqlAstWalker sqlTreeWalker) {
+		sqlTreeWalker.visitNamedTableReference( this );
+	}
+
+	@Override
+	public void applyAffectedTableNames(Consumer<String> nameCollector) {
+		nameCollector.accept( getTableExpression() );
+	}
+
+	@Override
+	public List<String> getAffectedTableNames() {
+		return Collections.singletonList( getTableExpression() );
+	}
+
+	@Override
+	public boolean containsAffectedTableName(String requestedName) {
+		return getTableExpression().equals( requestedName );
+	}
+
+	@Override
+	public Boolean visitAffectedTableNames(Function<String, Boolean> nameCollector) {
+		return nameCollector.apply( getTableExpression() );
+	}
+
+	@Override
+	public TableReference resolveTableReference(
+			NavigablePath navigablePath,
+			String tableExpression,
+			boolean allowFkOptimization) {
+		if ( tableExpression.equals( getTableExpression() ) ) {
+			return this;
+		}
+		throw new IllegalStateException( "Could not resolve binding for table `" + tableExpression + "`" );
+	}
+
+	@Override
+	public TableReference getTableReference(
+			NavigablePath navigablePath,
+			String tableExpression,
+			boolean allowFkOptimization,
+			boolean resolve) {
+		if ( this.tableExpression.equals( tableExpression ) ) {
+			return this;
+		}
+		return null;
+	}
+
+	@Override
+	public String toString() {
+		return getTableExpression() + "(" + getIdentificationVariable() + ')';
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/OneToManyTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/OneToManyTableGroup.java
@@ -121,6 +121,13 @@ public class OneToManyTableGroup extends AbstractColumnReferenceQualifier implem
 	}
 
 	@Override
+	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
+		if ( join.getJoinedGroup() != elementTableGroup ) {
+			elementTableGroup.prependTableGroupJoin( navigablePath, join );
+		}
+	}
+
+	@Override
 	public void addNestedTableGroupJoin(TableGroupJoin join) {
 		if ( join.getJoinedGroup() != elementTableGroup ) {
 			elementTableGroup.addNestedTableGroupJoin( join );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/QueryPartTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/QueryPartTableReference.java
@@ -11,41 +11,39 @@ import java.util.function.Function;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.sql.ast.SqlAstWalker;
-import org.hibernate.sql.ast.tree.insert.Values;
+import org.hibernate.sql.ast.tree.select.QueryPart;
 
 /**
  * @author Christian Beikov
  */
-public class ValuesTableReference extends DerivedTableReference {
+public class QueryPartTableReference extends DerivedTableReference {
 
-	private final List<Values> valuesList;
+	private final QueryPart queryPart;
 
-	public ValuesTableReference(
-			List<Values> valuesList,
+	public QueryPartTableReference(
+			QueryPart queryPart,
 			String identificationVariable,
 			List<String> columnNames,
 			SessionFactoryImplementor sessionFactory) {
 		super( identificationVariable, columnNames, sessionFactory );
-		this.valuesList = valuesList;
+		this.queryPart = queryPart;
 	}
 
-	@Override
-	public String getTableId() {
-		return null;
-	}
-
-	public List<Values> getValuesList() {
-		return valuesList;
+	public QueryPart getQueryPart() {
+		return queryPart;
 	}
 
 	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
-		sqlTreeWalker.visitValuesTableReference( this );
+		sqlTreeWalker.visitQueryPartTableReference( this );
 	}
 
 	@Override
 	public Boolean visitAffectedTableNames(Function<String, Boolean> nameCollector) {
-		return null;
+		final Function<TableReference, Boolean> tableReferenceBooleanFunction =
+				tableReference -> tableReference.visitAffectedTableNames( nameCollector );
+		return queryPart.queryQuerySpecs(
+			querySpec -> querySpec.getFromClause().queryTableReferences( tableReferenceBooleanFunction )
+		);
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardTableGroup.java
@@ -45,7 +45,7 @@ public class StandardTableGroup extends AbstractTableGroup {
 		this.tableReferenceJoinCreator = null;
 		this.tableReferenceJoinNameChecker = s -> {
 			for ( int i = 0; i < tableJoins.size(); i++ ) {
-				if ( tableJoins.get( i ).getJoinedTableReference().getTableExpression().equals( s ) ) {
+				if ( tableJoins.get( i ).getJoinedTableReference().containsAffectedTableName( s ) ) {
 					return true;
 				}
 			}
@@ -97,9 +97,9 @@ public class StandardTableGroup extends AbstractTableGroup {
 	@Override
 	public void applyAffectedTableNames(Consumer<String> nameCollector) {
 		// todo (6.0) : if we implement dynamic TableReference creation, this still needs to return the expressions for all mapped tables not just the ones with a TableReference at this time
-		nameCollector.accept( getPrimaryTableReference().getTableExpression() );
+		getPrimaryTableReference().applyAffectedTableNames( nameCollector );
 		for ( TableReferenceJoin tableReferenceJoin : tableJoins ) {
-			nameCollector.accept( tableReferenceJoin.getJoinedTableReference().getTableExpression() );
+			tableReferenceJoin.getJoinedTableReference().applyAffectedTableNames( nameCollector );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardVirtualTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/StandardVirtualTableGroup.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.sql.ast.tree.from;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -17,29 +15,25 @@ import org.hibernate.query.NavigablePath;
 /**
  * @author Christian Beikov
  */
-public class StandardVirtualTableGroup implements VirtualTableGroup {
-	private final NavigablePath navigablePath;
-	private final ModelPartContainer modelPart;
+public class StandardVirtualTableGroup extends AbstractTableGroup implements VirtualTableGroup {
 	private final TableGroup underlyingTableGroup;
 	private final boolean fetched;
-
-	private List<TableGroupJoin> tableGroupJoins;
-	private List<TableGroupJoin> nestedTableGroupJoins;
 
 	public StandardVirtualTableGroup(
 			NavigablePath navigablePath,
 			ModelPartContainer modelPart,
 			TableGroup underlyingTableGroup,
 			boolean fetched) {
-		this.navigablePath = navigablePath;
-		this.modelPart = modelPart;
+		super(
+				underlyingTableGroup.canUseInnerJoins(),
+				navigablePath,
+				modelPart,
+				underlyingTableGroup.getSourceAlias(),
+				null,
+				null
+		);
 		this.underlyingTableGroup = underlyingTableGroup;
 		this.fetched = fetched;
-	}
-
-	@Override
-	public NavigablePath getNavigablePath() {
-		return navigablePath;
 	}
 
 	@Override
@@ -48,19 +42,8 @@ public class StandardVirtualTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public String getGroupAlias() {
-		// none, although we could also delegate to the underlyingTableGroup's group-alias
-		return null;
-	}
-
-	@Override
 	public boolean isFetched() {
 		return fetched;
-	}
-
-	@Override
-	public ModelPartContainer getModelPart() {
-		return modelPart;
 	}
 
 	@Override
@@ -69,55 +52,8 @@ public class StandardVirtualTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public List<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( tableGroupJoins );
-	}
-
-	@Override
-	public List<TableGroupJoin> getNestedTableGroupJoins() {
-		return nestedTableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( nestedTableGroupJoins );
-	}
-
-	@Override
-	public boolean isRealTableGroup() {
-		return nestedTableGroupJoins != null && !nestedTableGroupJoins.isEmpty();
-	}
-
-	@Override
 	public boolean canUseInnerJoins() {
 		return underlyingTableGroup.canUseInnerJoins();
-	}
-
-	@Override
-	public void addTableGroupJoin(TableGroupJoin join) {
-		if ( tableGroupJoins == null ) {
-			tableGroupJoins = new ArrayList<>();
-		}
-		assert !tableGroupJoins.contains( join );
-		tableGroupJoins.add( join );
-	}
-
-	@Override
-	public void addNestedTableGroupJoin(TableGroupJoin join) {
-		if ( nestedTableGroupJoins == null ) {
-			nestedTableGroupJoins = new ArrayList<>();
-		}
-		assert !nestedTableGroupJoins.contains( join );
-		nestedTableGroupJoins.add( join );
-	}
-
-	@Override
-	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-		if ( tableGroupJoins != null ) {
-			tableGroupJoins.forEach( consumer );
-		}
-	}
-
-	@Override
-	public void visitNestedTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-		if ( nestedTableGroupJoins != null ) {
-			nestedTableGroupJoins.forEach( consumer );
-		}
 	}
 
 	@Override
@@ -136,25 +72,7 @@ public class StandardVirtualTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public TableReference resolveTableReference(
-			NavigablePath navigablePath,
-			String tableExpression,
-			boolean allowFkOptimization) {
-		final TableReference tableReference = getTableReference(
-				navigablePath,
-				tableExpression,
-				allowFkOptimization,
-				true
-		);
-		if ( tableReference == null ) {
-			throw new IllegalStateException( "Could not resolve binding for table `" + tableExpression + "`" );
-		}
-
-		return tableReference;
-	}
-
-	@Override
-	public TableReference getTableReference(
+	public TableReference getTableReferenceInternal(
 			NavigablePath navigablePath,
 			String tableExpression,
 			boolean allowFkOptimization,
@@ -168,23 +86,7 @@ public class StandardVirtualTableGroup implements VirtualTableGroup {
 		if ( tableReference != null ) {
 			return tableReference;
 		}
-		for ( TableGroupJoin tableGroupJoin : getNestedTableGroupJoins() ) {
-			final TableReference primaryTableReference = tableGroupJoin.getJoinedGroup()
-					.getPrimaryTableReference()
-					.getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve );
-			if ( primaryTableReference != null ) {
-				return primaryTableReference;
-			}
-		}
-		for ( TableGroupJoin tableGroupJoin : getTableGroupJoins() ) {
-			final TableReference primaryTableReference = tableGroupJoin.getJoinedGroup()
-					.getPrimaryTableReference()
-					.getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve );
-			if ( primaryTableReference != null ) {
-				return primaryTableReference;
-			}
-		}
-		return null;
+		return super.getTableReferenceInternal( navigablePath, tableExpression, allowFkOptimization, resolve );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
@@ -46,6 +46,11 @@ public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, SqmPat
 	
 	boolean canUseInnerJoins();
 
+	default boolean isLateral() {
+		return getPrimaryTableReference() instanceof DerivedTableReference
+				&& ( (DerivedTableReference) getPrimaryTableReference() ).isLateral();
+	}
+
 	void addTableGroupJoin(TableGroupJoin join);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
@@ -47,11 +47,15 @@ public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, SqmPat
 	boolean canUseInnerJoins();
 
 	default boolean isLateral() {
-		return getPrimaryTableReference() instanceof DerivedTableReference
-				&& ( (DerivedTableReference) getPrimaryTableReference() ).isLateral();
+		return false;
 	}
 
 	void addTableGroupJoin(TableGroupJoin join);
+
+	/**
+	 * Adds the given table group join before a join as found via the given navigable path.
+	 */
+	void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join);
 
 	/**
 	 * A nested table group join is a join against a table group,
@@ -133,12 +137,6 @@ public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, SqmPat
 				getNavigablePath(),
 				creationState.getSqlAstCreationState().getFromClauseAccess().findTableGroup( getNavigablePath() ),
 				creationState
-		);
-	}
-
-	default ColumnReference locateColumnReferenceByName(String name) {
-		throw new UnsupportedOperationException(
-				"Cannot call #locateColumnReferenceByName on this type of TableGroup"
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoin.java
@@ -29,19 +29,23 @@ public class TableGroupJoin implements TableJoin, DomainResultProducer {
 	public TableGroupJoin(
 			NavigablePath navigablePath,
 			SqlAstJoinType sqlAstJoinType,
-			TableGroup joinedGroup,
-			Predicate predicate) {
-		this.navigablePath = navigablePath;
-		this.sqlAstJoinType = sqlAstJoinType;
-		this.joinedGroup = joinedGroup;
-		this.predicate = predicate;
+			TableGroup joinedGroup) {
+		this( navigablePath, sqlAstJoinType, joinedGroup, null );
 	}
 
 	public TableGroupJoin(
 			NavigablePath navigablePath,
 			SqlAstJoinType sqlAstJoinType,
-			TableGroup joinedGroup) {
-		this( navigablePath, sqlAstJoinType, joinedGroup, null );
+			TableGroup joinedGroup,
+			Predicate predicate) {
+		assert !joinedGroup.isLateral() || ( sqlAstJoinType == SqlAstJoinType.INNER
+				|| sqlAstJoinType == SqlAstJoinType.LEFT
+				|| sqlAstJoinType == SqlAstJoinType.CROSS )
+				: "Lateral is only allowed with inner, left or cross joins";
+		this.navigablePath = navigablePath;
+		this.sqlAstJoinType = sqlAstJoinType;
+		this.joinedGroup = joinedGroup;
+		this.predicate = predicate;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReferenceJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReferenceJoin.java
@@ -20,10 +20,10 @@ import org.hibernate.sql.ast.tree.predicate.PredicateContainer;
  */
 public class TableReferenceJoin implements TableJoin, PredicateContainer {
 	private final SqlAstJoinType sqlAstJoinType;
-	private final TableReference joinedTableBinding;
+	private final NamedTableReference joinedTableBinding;
 	private Predicate predicate;
 
-	public TableReferenceJoin(SqlAstJoinType sqlAstJoinType, TableReference joinedTableBinding, Predicate predicate) {
+	public TableReferenceJoin(SqlAstJoinType sqlAstJoinType, NamedTableReference joinedTableBinding, Predicate predicate) {
 		this.sqlAstJoinType = sqlAstJoinType == null ? SqlAstJoinType.LEFT : sqlAstJoinType;
 		this.joinedTableBinding = joinedTableBinding;
 		this.predicate = predicate;
@@ -40,7 +40,7 @@ public class TableReferenceJoin implements TableJoin, PredicateContainer {
 		return sqlAstJoinType;
 	}
 
-	public TableReference getJoinedTableReference() {
+	public NamedTableReference getJoinedTableReference() {
 		return joinedTableBinding;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReferenceJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableReferenceJoin.java
@@ -19,25 +19,19 @@ import org.hibernate.sql.ast.tree.predicate.PredicateContainer;
  * @author Steve Ebersole
  */
 public class TableReferenceJoin implements TableJoin, PredicateContainer {
-	private final SqlAstJoinType sqlAstJoinType;
+	private final boolean innerJoin;
 	private final NamedTableReference joinedTableBinding;
 	private Predicate predicate;
 
-	public TableReferenceJoin(SqlAstJoinType sqlAstJoinType, NamedTableReference joinedTableBinding, Predicate predicate) {
-		this.sqlAstJoinType = sqlAstJoinType == null ? SqlAstJoinType.LEFT : sqlAstJoinType;
+	public TableReferenceJoin(boolean innerJoin, NamedTableReference joinedTableBinding, Predicate predicate) {
+		this.innerJoin = innerJoin;
 		this.joinedTableBinding = joinedTableBinding;
 		this.predicate = predicate;
-
-//		if ( joinType == JoinType.CROSS ) {
-//			if ( predicate != null ) {
-//				throw new IllegalJoinSpecificationException( "Cross join cannot include join predicate" );
-//			}
-//		}
 	}
 
 	@Override
 	public SqlAstJoinType getJoinType() {
-		return sqlAstJoinType;
+		return innerJoin ? SqlAstJoinType.INNER : SqlAstJoinType.LEFT;
 	}
 
 	public NamedTableReference getJoinedTableReference() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
@@ -27,12 +27,12 @@ public class UnionTableGroup implements VirtualTableGroup {
 
 	private final UnionSubclassEntityPersister modelPart;
 	private final String sourceAlias;
-	private final TableReference tableReference;
+	private final UnionTableReference tableReference;
 
 	public UnionTableGroup(
 			boolean canUseInnerJoins,
 			NavigablePath navigablePath,
-			TableReference tableReference,
+			UnionTableReference tableReference,
 			UnionSubclassEntityPersister modelPart,
 			String sourceAlias) {
 		this.canUseInnerJoins = canUseInnerJoins;
@@ -124,7 +124,7 @@ public class UnionTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public TableReference getPrimaryTableReference() {
+	public UnionTableReference getPrimaryTableReference() {
 		return tableReference;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/UnionTableGroup.java
@@ -19,14 +19,7 @@ import org.hibernate.query.NavigablePath;
 /**
  * @author Andrea Boriero
  */
-public class UnionTableGroup implements VirtualTableGroup {
-	private final boolean canUseInnerJoins;
-	private final NavigablePath navigablePath;
-	private List<TableGroupJoin> tableGroupJoins;
-	private List<TableGroupJoin> nestedTableGroupJoins;
-
-	private final UnionSubclassEntityPersister modelPart;
-	private final String sourceAlias;
+public class UnionTableGroup extends AbstractTableGroup implements VirtualTableGroup {
 	private final UnionTableReference tableReference;
 
 	public UnionTableGroup(
@@ -35,88 +28,8 @@ public class UnionTableGroup implements VirtualTableGroup {
 			UnionTableReference tableReference,
 			UnionSubclassEntityPersister modelPart,
 			String sourceAlias) {
-		this.canUseInnerJoins = canUseInnerJoins;
-		this.navigablePath = navigablePath;
+		super( canUseInnerJoins, navigablePath, modelPart, sourceAlias, null, null );
 		this.tableReference = tableReference;
-		this.modelPart = modelPart;
-		this.sourceAlias = sourceAlias;
-	}
-
-	@Override
-	public NavigablePath getNavigablePath() {
-		return navigablePath;
-	}
-
-	@Override
-	public ModelPart getExpressionType() {
-		return getModelPart();
-	}
-
-	@Override
-	public String getGroupAlias() {
-		return null;
-	}
-
-	@Override
-	public ModelPartContainer getModelPart() {
-		return modelPart;
-	}
-
-	@Override
-	public String getSourceAlias() {
-		return sourceAlias;
-	}
-
-	@Override
-	public List<TableGroupJoin> getTableGroupJoins() {
-		return tableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( tableGroupJoins );
-	}
-
-	@Override
-	public List<TableGroupJoin> getNestedTableGroupJoins() {
-		return nestedTableGroupJoins == null ? Collections.emptyList() : Collections.unmodifiableList( nestedTableGroupJoins );
-	}
-
-	@Override
-	public boolean isRealTableGroup() {
-		return nestedTableGroupJoins != null && !nestedTableGroupJoins.isEmpty();
-	}
-
-	@Override
-	public boolean canUseInnerJoins() {
-		return canUseInnerJoins;
-	}
-
-	@Override
-	public void addTableGroupJoin(TableGroupJoin join) {
-		if ( tableGroupJoins == null ) {
-			tableGroupJoins = new ArrayList<>();
-		}
-		assert !tableGroupJoins.contains( join );
-		tableGroupJoins.add( join );
-	}
-
-	@Override
-	public void addNestedTableGroupJoin(TableGroupJoin join) {
-		if ( nestedTableGroupJoins == null ) {
-			nestedTableGroupJoins = new ArrayList<>();
-		}
-		assert !nestedTableGroupJoins.contains( join );
-		nestedTableGroupJoins.add( join );
-	}
-
-	@Override
-	public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-		if ( tableGroupJoins != null ) {
-			tableGroupJoins.forEach( consumer );
-		}
-	}
-
-	@Override
-	public void visitNestedTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-		if ( nestedTableGroupJoins != null ) {
-			nestedTableGroupJoins.forEach( consumer );
-		}
 	}
 
 	@Override
@@ -134,40 +47,14 @@ public class UnionTableGroup implements VirtualTableGroup {
 	}
 
 	@Override
-	public TableReference getTableReference(
+	public TableReference getTableReferenceInternal(
 			NavigablePath navigablePath,
 			String tableExpression,
 			boolean allowFkOptimization,
 			boolean resolve) {
-		return resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
-	}
-
-	@Override
-	public TableReference resolveTableReference(
-			NavigablePath navigablePath,
-			String tableExpression,
-			boolean allowFkOptimization) {
-		if ( tableReference.getTableReference( navigablePath, tableExpression, allowFkOptimization, true ) != null ) {
+		if ( tableReference.getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve ) != null ) {
 			return tableReference;
 		}
-		if ( nestedTableGroupJoins != null ) {
-			for ( TableGroupJoin tableGroupJoin : nestedTableGroupJoins ) {
-				final TableReference tableReference = tableGroupJoin.getJoinedGroup()
-						.resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
-				if ( tableReference != null ) {
-					return tableReference;
-				}
-			}
-		}
-		if ( tableGroupJoins != null ) {
-			for ( TableGroupJoin tableGroupJoin : tableGroupJoins ) {
-				final TableReference tableReference = tableGroupJoin.getJoinedGroup()
-						.resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
-				if ( tableReference != null ) {
-					return tableReference;
-				}
-			}
-		}
-		return null;
+		return super.getTableReferenceInternal( navigablePath, tableExpression, allowFkOptimization, resolve );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/ValuesTableReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/ValuesTableReference.java
@@ -25,7 +25,7 @@ public class ValuesTableReference extends DerivedTableReference {
 			String identificationVariable,
 			List<String> columnNames,
 			SessionFactoryImplementor sessionFactory) {
-		super( identificationVariable, columnNames, sessionFactory );
+		super( identificationVariable, columnNames, false, sessionFactory );
 		this.valuesList = valuesList;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/insert/InsertStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/insert/InsertStatement.java
@@ -14,10 +14,9 @@ import java.util.Map;
 
 import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.ast.tree.AbstractMutationStatement;
-import org.hibernate.sql.ast.tree.MutationStatement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 
 /**
@@ -25,19 +24,20 @@ import org.hibernate.sql.ast.tree.select.QueryPart;
  */
 public class InsertStatement extends AbstractMutationStatement {
 
+	public static final String DEFAULT_ALIAS = "to_insert_";
 	private List<ColumnReference> targetColumnReferences;
 	private QueryPart sourceSelectStatement;
 	private List<Values> valuesList = new ArrayList<>();
 
-	public InsertStatement(TableReference targetTable) {
+	public InsertStatement(NamedTableReference targetTable) {
 		super( targetTable );
 	}
 
-	public InsertStatement(TableReference targetTable, List<ColumnReference> returningColumns) {
+	public InsertStatement(NamedTableReference targetTable, List<ColumnReference> returningColumns) {
 		super( new LinkedHashMap<>(), targetTable, returningColumns );
 	}
 
-	public InsertStatement(boolean withRecursive, Map<String, CteStatement> cteStatements, TableReference targetTable, List<ColumnReference> returningColumns) {
+	public InsertStatement(boolean withRecursive, Map<String, CteStatement> cteStatements, NamedTableReference targetTable, List<ColumnReference> returningColumns) {
 		super( cteStatements, targetTable, returningColumns );
 		setWithRecursive( withRecursive );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/BooleanExpressionPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/predicate/BooleanExpressionPredicate.java
@@ -16,6 +16,11 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 public class BooleanExpressionPredicate extends AbstractPredicate {
 	private final Expression expression;
 
+	public BooleanExpressionPredicate(Expression expression) {
+		super( expression.getExpressionType(), false );
+		this.expression = expression;
+	}
+
 	public BooleanExpressionPredicate(Expression expression, boolean negated, JdbcMappingContainer expressionType) {
 		super( expressionType, negated );
 		this.expression = expression;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryGroup.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.ast.tree.select;
 
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.query.SetOperator;
@@ -39,10 +40,21 @@ public class QueryGroup extends QueryPart {
 	}
 
 	@Override
-	public void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer) {
+	public void visitQuerySpecs(Consumer<QuerySpec> querySpecConsumer) {
 		for ( int i = 0; i < queryParts.size(); i++ ) {
-			queryParts.get( i ).forEachQuerySpec( querySpecConsumer );
+			queryParts.get( i ).visitQuerySpecs( querySpecConsumer );
 		}
+	}
+
+	@Override
+	public <T> T queryQuerySpecs(Function<QuerySpec, T> querySpecConsumer) {
+		for ( int i = 0; i < queryParts.size(); i++ ) {
+			T result = queryParts.get( i ).queryQuerySpecs( querySpecConsumer );
+			if ( result != null ) {
+				return result;
+			}
+		}
+		return null;
 	}
 
 	public SetOperator getSetOperator() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QueryPart.java
@@ -9,6 +9,7 @@ package org.hibernate.sql.ast.tree.select;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.hibernate.query.FetchClauseType;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
@@ -37,7 +38,9 @@ public abstract class QueryPart implements SqlAstNode, Expression, DomainResultP
 
 	public abstract QuerySpec getLastQuerySpec();
 
-	public abstract void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer);
+	public abstract void visitQuerySpecs(Consumer<QuerySpec> querySpecConsumer);
+
+	public abstract <T> T queryQuerySpecs(Function<QuerySpec, T> querySpecConsumer);
 
 	/**
 	 * Does this QueryPart map to the statement's root query (as

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/select/QuerySpec.java
@@ -9,6 +9,7 @@ package org.hibernate.sql.ast.tree.select;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
@@ -63,8 +64,13 @@ public class QuerySpec extends QueryPart implements SqlAstNode, PredicateContain
 	}
 
 	@Override
-	public void forEachQuerySpec(Consumer<QuerySpec> querySpecConsumer) {
+	public void visitQuerySpecs(Consumer<QuerySpec> querySpecConsumer) {
 		querySpecConsumer.accept( this );
+	}
+
+	@Override
+	public <T> T queryQuerySpecs(Function<QuerySpec, T> querySpecConsumer) {
+		return querySpecConsumer.apply( this );
 	}
 
 	public FromClause getFromClause() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/update/UpdateStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/update/UpdateStatement.java
@@ -16,7 +16,7 @@ import org.hibernate.sql.ast.spi.SqlAstTreeHelper;
 import org.hibernate.sql.ast.tree.AbstractMutationStatement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.from.TableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 
 /**
@@ -27,7 +27,7 @@ public class UpdateStatement extends AbstractMutationStatement {
 	private final Predicate restriction;
 
 	public UpdateStatement(
-			TableReference targetTable,
+			NamedTableReference targetTable,
 			List<Assignment> assignments,
 			Predicate restriction) {
 		super( targetTable );
@@ -36,7 +36,7 @@ public class UpdateStatement extends AbstractMutationStatement {
 	}
 
 	public UpdateStatement(
-			TableReference targetTable,
+			NamedTableReference targetTable,
 			List<Assignment> assignments,
 			Predicate restriction,
 			List<ColumnReference> returningColumns) {
@@ -48,7 +48,7 @@ public class UpdateStatement extends AbstractMutationStatement {
 	public UpdateStatement(
 			boolean withRecursive,
 			Map<String, CteStatement> cteStatements,
-			TableReference targetTable,
+			NamedTableReference targetTable,
 			List<Assignment> assignments,
 			Predicate restriction,
 			List<ColumnReference> returningColumns) {
@@ -67,11 +67,11 @@ public class UpdateStatement extends AbstractMutationStatement {
 	}
 
 	public static class UpdateStatementBuilder {
-		private final TableReference targetTableRef;
+		private final NamedTableReference targetTableRef;
 		private List<Assignment> assignments;
 		private Predicate restriction;
 
-		public UpdateStatementBuilder(TableReference targetTableRef) {
+		public UpdateStatementBuilder(NamedTableReference targetTableRef) {
 			this.targetTableRef = targetTableRef;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/map/MapIndexFormulaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/map/MapIndexFormulaTest.java
@@ -48,6 +48,9 @@ public class MapIndexFormulaTest {
 					session.createQuery(
 									"from Group g join g.users u where g.name = 'something' and maxindex(u) = 'nada'" )
 							.list();
+					session.createQuery(
+									"from Group g join g.users u where g.name = 'something' and maxindex(u) = 'nada' and maxindex(u) = 'nada'" )
+							.list();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -96,7 +96,7 @@ public class SmokeTests {
 
 					final TableGroup rootTableGroup = fromClause.getRoots().get( 0 );
 					assertThat( rootTableGroup.getPrimaryTableReference(), notNullValue() );
-					assertThat( rootTableGroup.getPrimaryTableReference().getTableExpression(), is( "mapping_simple_entity" ) );
+					assertThat( rootTableGroup.getPrimaryTableReference().getTableId(), is( "mapping_simple_entity" ) );
 
 					assertThat( rootTableGroup.getTableReferenceJoins().size(), is( 0 ) );
 
@@ -155,7 +155,7 @@ public class SmokeTests {
 
 					final TableGroup rootTableGroup = fromClause.getRoots().get( 0 );
 					assertThat( rootTableGroup.getPrimaryTableReference(), notNullValue() );
-					assertThat( rootTableGroup.getPrimaryTableReference().getTableExpression(), is( "mapping_simple_entity" ) );
+					assertThat( rootTableGroup.getPrimaryTableReference().getTableId(), is( "mapping_simple_entity" ) );
 
 					assertThat( rootTableGroup.getTableReferenceJoins().size(), is( 0 ) );
 

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/CollectionMapWithComponentValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/CollectionMapWithComponentValueTest.java
@@ -179,7 +179,7 @@ public class CollectionMapWithComponentValueTest extends BaseCoreFunctionalTestC
 	@TestForIssue(jiraKey = "HHH-10577")
 	public void testMapKeyExpressionDereferenceInSelect() {
 		doInHibernate( this::sessionFactory, s -> {
-			List<String> keyValueNames = s.createQuery( "select key(v).name as name from TestEntity te join te.values v order by name", String.class ).list();
+			List<String> keyValueNames = s.createQuery( "select key(v).name as name from TestEntity te join te.values v order by name", String.class ).getResultList();
 			assertEquals( 2, keyValueNames.size() );
 			assertEquals( "key1", keyValueNames.get( 0 ) );
 			assertEquals( "key2", keyValueNames.get( 1 ) );

--- a/hibernate-core/src/test/resources/junit-platform.properties
+++ b/hibernate-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$ClassName

--- a/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
@@ -29,6 +29,7 @@ import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.sql.ast.spi.SqlAstQueryPartProcessingState;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableReference;
@@ -117,7 +118,7 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 
 		public AuditingTableGroup(TableGroup delegate, String normalTableExpression) {
 			this.delegate = delegate;
-			this.auditTableExpression = delegate.getPrimaryTableReference().getTableExpression();
+			this.auditTableExpression = ( (NamedTableReference) delegate.getPrimaryTableReference() ).getTableExpression();
 			this.normalTableExpression = normalTableExpression;
 		}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
@@ -8,10 +8,7 @@
 package org.hibernate.envers.function;
 
 import java.util.List;
-import java.util.function.Consumer;
 
-import org.hibernate.metamodel.mapping.ModelPart;
-import org.hibernate.metamodel.mapping.ModelPartContainer;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.ordering.OrderByFragment;
 import org.hibernate.metamodel.model.domain.AllowableFunctionReturnType;
@@ -29,11 +26,10 @@ import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.sql.ast.spi.SqlAstQueryPartProcessingState;
+import org.hibernate.sql.ast.tree.from.DelegatingTableGroup;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
-import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.ast.tree.from.TableReference;
-import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -110,7 +106,7 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 		};
 	}
 
-	private static class AuditingTableGroup implements TableGroup {
+	private static class AuditingTableGroup extends DelegatingTableGroup {
 
 		private final TableGroup delegate;
 		private final String auditTableExpression;
@@ -123,8 +119,8 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 		}
 
 		@Override
-		public ModelPart getExpressionType() {
-			return delegate.getExpressionType();
+		protected TableGroup getTableGroup() {
+			return delegate;
 		}
 
 		@Override
@@ -135,7 +131,7 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 			if ( tableExpression.equals( normalTableExpression ) ) {
 				tableExpression = auditTableExpression;
 			}
-			return delegate.resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
+			return super.resolveTableReference( navigablePath, tableExpression, allowFkOptimization );
 		}
 
 		@Override
@@ -147,77 +143,7 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 			if ( tableExpression.equals( normalTableExpression ) ) {
 				tableExpression = auditTableExpression;
 			}
-			return delegate.getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve );
-		}
-
-		@Override
-		public NavigablePath getNavigablePath() {
-			return delegate.getNavigablePath();
-		}
-
-		@Override
-		public String getGroupAlias() {
-			return delegate.getGroupAlias();
-		}
-
-		@Override
-		public ModelPartContainer getModelPart() {
-			return delegate.getModelPart();
-		}
-
-		@Override
-		public String getSourceAlias() {
-			return delegate.getSourceAlias();
-		}
-
-		@Override
-		public List<TableGroupJoin> getTableGroupJoins() {
-			return delegate.getTableGroupJoins();
-		}
-
-		@Override
-		public List<TableGroupJoin> getNestedTableGroupJoins() {
-			return delegate.getNestedTableGroupJoins();
-		}
-
-		@Override
-		public boolean canUseInnerJoins() {
-			return delegate.canUseInnerJoins();
-		}
-
-		@Override
-		public void addTableGroupJoin(TableGroupJoin join) {
-			delegate.addTableGroupJoin( join );
-		}
-
-		@Override
-		public void addNestedTableGroupJoin(TableGroupJoin join) {
-			delegate.addNestedTableGroupJoin( join );
-		}
-
-		@Override
-		public void visitTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-			delegate.visitTableGroupJoins( consumer );
-		}
-
-		@Override
-		public void visitNestedTableGroupJoins(Consumer<TableGroupJoin> consumer) {
-			delegate.visitNestedTableGroupJoins( consumer );
-		}
-
-		@Override
-		public void applyAffectedTableNames(Consumer<String> nameCollector) {
-			delegate.applyAffectedTableNames( nameCollector );
-		}
-
-		@Override
-		public TableReference getPrimaryTableReference() {
-			return delegate.getPrimaryTableReference();
-		}
-
-		@Override
-		public List<TableReferenceJoin> getTableReferenceJoins() {
-			return delegate.getTableReferenceJoins();
+			return super.getTableReference( navigablePath, tableExpression, allowFkOptimization, resolve );
 		}
 	}
 }


### PR DESCRIPTION
Split TableReference class into interface and NamedTableReference implementation to allow QueryPartTableReference and ValuesTableReference to fit into the picture