### PR TITLE
HHH-11896 Support 'on-clause' criterion when traversing audit query relations

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/AuditQuery.java
@@ -13,6 +13,7 @@ import jakarta.persistence.criteria.JoinType;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.query.criteria.AuditCriterion;
@@ -21,7 +22,6 @@ import org.hibernate.envers.query.projection.AuditProjection;
 
 /**
  * @author Adam Warski (adam at warski dot org)
- * @see org.hibernate.Criteria
  */
 public interface AuditQuery {
 	List getResultList() throws AuditException;
@@ -30,8 +30,17 @@ public interface AuditQuery {
 
 	AuditAssociationQuery<? extends AuditQuery> traverseRelation(String associationName, JoinType joinType);
 
-	AuditAssociationQuery<? extends AuditQuery> traverseRelation(String associationName, JoinType joinType,
+	AuditAssociationQuery<? extends AuditQuery> traverseRelation(
+			String associationName,
+			JoinType joinType,
 			String alias);
+
+	@Incubating
+	AuditAssociationQuery<? extends AuditQuery> traverseRelation(
+			String associationName,
+			JoinType joinType,
+			String alias,
+			AuditCriterion onClauseCriterion);
 
 	AuditQuery add(AuditCriterion criterion);
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/query/internal/impl/AbstractAuditQuery.java
@@ -59,7 +59,6 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 	protected final AuditReaderImplementor versionsReader;
 
 	protected final List<AuditAssociationQueryImpl<?>> associationQueries = new ArrayList<>();
-	protected final Map<String, AuditAssociationQueryImpl<AuditQueryImplementor>> associationQueryMap = new HashMap<>();
 	protected final List<Pair<String, AuditProjection>> projections = new ArrayList<>();
 
 	protected AbstractAuditQuery(
@@ -196,23 +195,33 @@ public abstract class AbstractAuditQuery implements AuditQueryImplementor {
 
 	@Override
 	public AuditAssociationQuery<? extends AuditQuery> traverseRelation(String associationName, JoinType joinType, String alias) {
-		AuditAssociationQueryImpl<AuditQueryImplementor> result = associationQueryMap.get( associationName );
-		if (result == null) {
-			result = new AuditAssociationQueryImpl<>(
-					enversService,
-					versionsReader,
-					this,
-					qb,
-					associationName,
-					joinType,
-					aliasToEntityNameMap,
-					aliasToComponentPropertyNameMap,
-					REFERENCED_ENTITY_ALIAS,
-					alias
-			);
-			associationQueries.add( result );
-			associationQueryMap.put( associationName, result );
-		}
+		return traverseRelation(
+				associationName,
+				joinType,
+				alias,
+				null );
+	}
+
+	@Override
+	public AuditAssociationQuery<? extends AuditQuery> traverseRelation(
+			String associationName,
+			JoinType joinType,
+			String alias,
+			AuditCriterion onClause) {
+		AuditAssociationQueryImpl<AbstractAuditQuery> result = new AuditAssociationQueryImpl<>(
+				enversService,
+				versionsReader,
+				this,
+				qb,
+				associationName,
+				joinType,
+				aliasToEntityNameMap,
+				aliasToComponentPropertyNameMap,
+				REFERENCED_ENTITY_ALIAS,
+				alias,
+				onClause
+		);
+		associationQueries.add( result );
 		return result;
 	}
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Id;
@@ -101,6 +102,7 @@ public class AssociationQueryWithOnClauseTest extends BaseEnversJPAFunctionalTes
 
 		private String type;
 
+		@Column(name = "num")
 		private int number;
 
 		public Long getId() {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
@@ -1,0 +1,232 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.envers.integration.query;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.criteria.JoinType;
+
+import org.hibernate.envers.AuditJoinTable;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.orm.test.envers.Priority;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Felix Feisst (feisst dot felix at gmail dot com)
+ */
+@TestForIssue(jiraKey = "HHH-11896")
+public class AssociationQueryWithOnClauseTest extends BaseEnversJPAFunctionalTestCase {
+
+	private EntityA a1;
+	private EntityA a2;
+	private EntityA a3;
+
+	@Entity(name = "EntityA")
+	@Audited
+	public static class EntityA {
+
+		@Id
+		private Long id;
+
+		@ManyToOne
+		private EntityB bManyToOne;
+
+		@OneToMany
+		@AuditJoinTable(name = "entitya_onetomany_entityb_aud")
+		private Set<EntityB> bOneToMany = new HashSet<>();
+
+		@ManyToMany
+		@JoinTable(name = "entitya_manytomany_entityb")
+		private Set<EntityB> bManyToMany = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public EntityB getbManyToOne() {
+			return bManyToOne;
+		}
+
+		public void setbManyToOne(EntityB bManyToOne) {
+			this.bManyToOne = bManyToOne;
+		}
+
+		public Set<EntityB> getbOneToMany() {
+			return bOneToMany;
+		}
+
+		public void setbOneToMany(Set<EntityB> bOneToMany) {
+			this.bOneToMany = bOneToMany;
+		}
+
+		public Set<EntityB> getbManyToMany() {
+			return bManyToMany;
+		}
+
+		public void setbManyToMany(Set<EntityB> bManyToMany) {
+			this.bManyToMany = bManyToMany;
+		}
+
+	}
+
+	@Entity(name = "EntityB")
+	@Audited
+	public static class EntityB {
+
+		@Id
+		private Long id;
+
+		private String type;
+
+		private int number;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public int getNumber() {
+			return number;
+		}
+
+		public void setNumber(int number) {
+			this.number = number;
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ EntityA.class, EntityB.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+
+		em.getTransaction().begin();
+		final EntityB b1t1 = new EntityB();
+		b1t1.setId( 21L );
+		b1t1.setType( "T1" );
+		b1t1.setNumber( 1 );
+		em.persist( b1t1 );
+		final EntityB b2t2 = new EntityB();
+		b2t2.setId( 22L );
+		b2t2.setType( "T2" );
+		b2t2.setNumber( 2 );
+		em.persist( b2t2 );
+		final EntityB b3t1 = new EntityB();
+		b3t1.setId( 23L );
+		b3t1.setType( "T1" );
+		b3t1.setNumber( 3 );
+		em.persist( b3t1 );
+
+		a1 = new EntityA();
+		a1.setId( 1L );
+		a1.setbManyToOne( b1t1 );
+		a1.getbOneToMany().add( b1t1 );
+		a1.getbOneToMany().add( b2t2 );
+		a1.getbManyToMany().add( b1t1 );
+		a1.getbManyToMany().add( b2t2 );
+		em.persist( a1 );
+		a2 = new EntityA();
+		a2.setId( 2L );
+		a2.setbManyToOne( b2t2 );
+		a2.getbManyToMany().add( b3t1 );
+		em.persist( a2 );
+		a3 = new EntityA();
+		a3.setId( 3L );
+		a3.setbManyToOne( b3t1 );
+		a3.getbOneToMany().add( b3t1 );
+		a3.getbManyToMany().add( b3t1 );
+		em.persist( a3 );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testManyToOne() {
+		List list = getAuditReader().createQuery()
+				.forEntitiesAtRevision( EntityA.class, 1 )
+				.traverseRelation( "bManyToOne", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
+				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.up()
+				.addProjection( AuditEntity.id() )
+				.addProjection( AuditEntity.property( "b", "number" ) )
+				.getResultList();
+		assertArrayListEquals( list, tuple( a2.getId(), null ), tuple( a1.getId(), 1 ), tuple( a3.getId(), 3 ) );
+	}
+
+	@Test
+	public void testOneToMany() {
+		List list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
+				.traverseRelation( "bOneToMany", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
+				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.up()
+				.addOrder( AuditEntity.id().asc() )
+				.addProjection( AuditEntity.id() )
+				.addProjection( AuditEntity.property( "b", "number" ) )
+				.getResultList();
+		assertArrayListEquals( list, tuple( a1.getId(), null ), tuple( a2.getId(), null ), tuple( a1.getId(), 1 ), tuple( a3.getId(), 3 ) );
+	}
+
+	@Test
+	public void testManyToMany() {
+		List list = getAuditReader().createQuery()
+				.forEntitiesAtRevision( EntityA.class, 1 )
+				.traverseRelation( "bManyToMany", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
+				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.up()
+				.addOrder( AuditEntity.id().asc() ).addProjection( AuditEntity.id() )
+				.addProjection( AuditEntity.property( "b", "number" ) )
+				.getResultList();
+		assertArrayListEquals( list, tuple( a1.getId(), null ), tuple( a1.getId(), 1 ), tuple( a2.getId(), 3 ), tuple( a3.getId(), 3 ) );
+	}
+
+	private Object[] tuple(final Long id, final Integer number) {
+		return new Object[]{ id, number };
+	}
+
+	private void assertArrayListEquals(final List actual, final Object[]... expected) {
+		assertEquals( "Unexpected number of results", expected.length, actual.size() );
+		for ( int i = 0; i < expected.length; i++ ) {
+			final Object[] exp = expected[i];
+			final Object[] act = (Object[]) actual.get( i );
+			assertArrayEquals( exp, act );
+		}
+	}
+
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationQueryWithOnClauseTest.java
@@ -22,6 +22,7 @@ import jakarta.persistence.criteria.JoinType;
 import org.hibernate.envers.AuditJoinTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.envers.query.order.NullPrecedence;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
 import org.hibernate.testing.TestForIssue;
@@ -182,7 +183,7 @@ public class AssociationQueryWithOnClauseTest extends BaseEnversJPAFunctionalTes
 		List list = getAuditReader().createQuery()
 				.forEntitiesAtRevision( EntityA.class, 1 )
 				.traverseRelation( "bManyToOne", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
-				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.addOrder( AuditEntity.property( "b", "number" ).asc().nulls( NullPrecedence.FIRST ) )
 				.up()
 				.addProjection( AuditEntity.id() )
 				.addProjection( AuditEntity.property( "b", "number" ) )
@@ -194,7 +195,7 @@ public class AssociationQueryWithOnClauseTest extends BaseEnversJPAFunctionalTes
 	public void testOneToMany() {
 		List list = getAuditReader().createQuery().forEntitiesAtRevision( EntityA.class, 1 )
 				.traverseRelation( "bOneToMany", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
-				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.addOrder( AuditEntity.property( "b", "number" ).asc().nulls( NullPrecedence.FIRST ) )
 				.up()
 				.addOrder( AuditEntity.id().asc() )
 				.addProjection( AuditEntity.id() )
@@ -208,9 +209,10 @@ public class AssociationQueryWithOnClauseTest extends BaseEnversJPAFunctionalTes
 		List list = getAuditReader().createQuery()
 				.forEntitiesAtRevision( EntityA.class, 1 )
 				.traverseRelation( "bManyToMany", JoinType.LEFT, "b", AuditEntity.property( "b", "type" ).eq( "T1" ) )
-				.addOrder( AuditEntity.property( "b", "number" ).asc() )
+				.addOrder( AuditEntity.property( "b", "number" ).asc().nulls( NullPrecedence.FIRST ) )
 				.up()
-				.addOrder( AuditEntity.id().asc() ).addProjection( AuditEntity.id() )
+				.addOrder( AuditEntity.id().asc().nulls( NullPrecedence.FIRST ) )
+				.addProjection(AuditEntity.id() )
 				.addProjection( AuditEntity.property( "b", "number" ) )
 				.getResultList();
 		assertArrayListEquals( list, tuple( a1.getId(), null ), tuple( a1.getId(), 1 ), tuple( a2.getId(), 3 ), tuple( a3.getId(), 3 ) );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/ComponentQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/ComponentQueryTest.java
@@ -334,4 +334,35 @@ public class ComponentQueryTest extends BaseEnversJPAFunctionalTestCase {
 		assertEquals( "Expecte the symbol identfier of asset2 concatenated with 'Z'", Collections.singletonList( "XZ" ), actual );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HHH-11896")
+	public void testOnClauseOnSingleSymbol() {
+		List actual = getAuditReader().createQuery()
+				.forEntitiesAtRevision( Asset.class, 1 )
+				.addProjection( AuditEntity.id() )
+				.traverseRelation( "singleSymbol", JoinType.LEFT, "s", AuditEntity.property( "s", "type" ).eq( type1 ) )
+				.addOrder( AuditEntity.property( "s", "identifier" ).asc() )
+				.up()
+				.addOrder( AuditEntity.id().asc() )
+				.getResultList();
+		final List<Integer> expected = new ArrayList<>();
+		Collections.addAll( expected, asset1.getId(), asset3.getId(), asset2.getId() );
+		assertEquals( "Expected the correct ordering. Assets which do not have a symbol of type1 should come first (null first)", expected, actual );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-11896")
+	public void testOnClauseOnMultiSymbol() {
+		List actual = getAuditReader().createQuery()
+				.forEntitiesAtRevision( Asset.class, 1 )
+				.addProjection( AuditEntity.id() )
+				.traverseRelation( "multiSymbols", JoinType.LEFT, "s", AuditEntity.property( "s", "type" ).eq( type1 ) )
+				.addOrder( AuditEntity.property( "s", "identifier" ).asc() )
+				.up()
+				.addOrder( AuditEntity.id().asc() )
+				.getResultList();
+		final List<Integer> expected = new ArrayList<>();
+		Collections.addAll( expected, asset1.getId(), asset2.getId(), asset3.getId() );
+		assertEquals( "Expected the correct ordering. Assets which do not have a symbol of type1 should come first (null first)", expected, actual );
+	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/ComponentQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/ComponentQueryTest.java
@@ -341,7 +341,7 @@ public class ComponentQueryTest extends BaseEnversJPAFunctionalTestCase {
 				.forEntitiesAtRevision( Asset.class, 1 )
 				.addProjection( AuditEntity.id() )
 				.traverseRelation( "singleSymbol", JoinType.LEFT, "s", AuditEntity.property( "s", "type" ).eq( type1 ) )
-				.addOrder( AuditEntity.property( "s", "identifier" ).asc() )
+				.addOrder( AuditEntity.property( "s", "identifier" ).asc().nulls( NullPrecedence.FIRST ) )
 				.up()
 				.addOrder( AuditEntity.id().asc() )
 				.getResultList();
@@ -357,7 +357,7 @@ public class ComponentQueryTest extends BaseEnversJPAFunctionalTestCase {
 				.forEntitiesAtRevision( Asset.class, 1 )
 				.addProjection( AuditEntity.id() )
 				.traverseRelation( "multiSymbols", JoinType.LEFT, "s", AuditEntity.property( "s", "type" ).eq( type1 ) )
-				.addOrder( AuditEntity.property( "s", "identifier" ).asc() )
+				.addOrder( AuditEntity.property( "s", "identifier" ).asc().nulls( NullPrecedence.FIRST ) )
 				.up()
 				.addOrder( AuditEntity.id().asc() )
 				.getResultList();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-11896

This PR supersedes PR #1967 by targetting ORM 6 `main` branch.  This PR currently depends upon PR #4479 and should only be merged after the parent pull request passes CI and is merged.