### PR TITLE
attempt to fix long-standing bug with collections of a subclass type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -2494,6 +2494,22 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					sqmJoin.getJoinPredicate() != null,
 					this
 			);
+			final Joinable joinable = pluralAttributeMapping
+					.getCollectionDescriptor()
+					.getCollectionType()
+					.getAssociatedJoinable( getCreationContext().getSessionFactory() );
+			final TableGroup tableGroup = joinedTableGroupJoin.getJoinedGroup();
+			final FilterPredicate collectionFieldFilterPredicate = FilterHelper.createFilterPredicate(
+					getLoadQueryInfluencers(),
+					joinable,
+					tableGroup
+			);
+			if ( collectionFieldFilterPredicate != null ) {
+				if ( collectionFilterPredicates == null ) {
+					collectionFilterPredicates = new HashMap<>();
+				}
+				collectionFilterPredicates.put( tableGroup.getGroupAlias(), collectionFieldFilterPredicate );
+			}
 		}
 		else {
 			assert modelPart instanceof TableGroupJoinProducer;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/DiscriminatedCollectionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/discriminatedcollections/DiscriminatedCollectionsTest.java
@@ -15,8 +15,11 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -28,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 		}
 )
 @SessionFactory
-public class TempTest {
+public class DiscriminatedCollectionsTest {
 
 	@Test
 	public void test(SessionFactoryScope scope) {
@@ -92,6 +95,20 @@ public class TempTest {
 							client.getDebitAccounts().iterator().next().getId(),
 							client.getCreditAccounts().iterator().next().getId()
 					);
+				}
+		);
+
+		scope.inSession(
+				session -> {
+					List<Object[]> clients = session.createQuery( "select c, da from Client c inner join c.debitAccounts da", Object[].class)
+							.getResultList();
+					assertEquals( 1, clients.size() );
+					assertTrue( clients.get(0)[1] instanceof DebitAccount );
+					List<Object[]> accounts = session.createQuery( "select ca, da from Client c inner join c.creditAccounts ca inner join c.debitAccounts da", Object[].class)
+							.getResultList();
+					assertEquals( 1, accounts.size() );
+					assertTrue( accounts.get(0)[0] instanceof CreditAccount );
+					assertTrue( accounts.get(0)[1] instanceof DebitAccount );
 				}
 		);
 


### PR DESCRIPTION
- automatically include discriminator in join in HQL query
- will also do the same for filters and @Where conditions

For reference:

1. https://github.com/eclipse-ee4j/jpa-api/issues/39
2. https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/'discriminated'.20collection.20mappings

I'm not sure this fix is perfectly correct, please review carefully.