### PR TITLE
HHH-14983: clear second-level cache before executing an HQL update

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CachedDomainDataAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/access/CachedDomainDataAccess.java
@@ -143,7 +143,7 @@ public interface CachedDomainDataAccess {
 	 * Remove all data for this accessed type
 	 *
 	 * @throws CacheException Propagated from underlying cache provider
-	 * @param session
+	 * @param session Current session.
 	 */
 	void removeAll(SharedSessionContractImplementor session);
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -205,11 +205,6 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 		}
 	}
 
-	@Override
-	public void removeAll(SharedSessionContractImplementor session) {
-		// A no-op
-	}
-
 	/**
 	 * Interface type implemented by all wrapper objects in the cache.
 	 */


### PR DESCRIPTION
… to prevent loading stale cache entries (in the same session) upon executing the HQL update query. Changed AbstractReadWriteAccess by removing the no-op removeAll method so that  "affected cache regions" can be cleared before executing an HQL, ensuring strong data consistency.

Merged provided test case into existing ReadWriteCacheTest. Performed code polish by moving book creation and saving into a @Before method as it's needed by all tests. Renamed helper test methods to reveal intention in a better way.

https://hibernate.atlassian.net/browse/HHH-14983