### PR TITLE
proposed fixes to Query API

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SynchronizeableQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/SynchronizeableQuery.java
@@ -46,8 +46,8 @@ public interface SynchronizeableQuery<T> {
 	 */
 	default SynchronizeableQuery<T> addSynchronizedQuerySpace(String... querySpaces) {
 		if ( querySpaces != null ) {
-			for ( int i = 0; i < querySpaces.length; i++ ) {
-				addSynchronizedQuerySpace( querySpaces[i] );
+			for (String querySpace : querySpaces) {
+				addSynchronizedQuerySpace(querySpace);
 			}
 		}
 		return this;
@@ -84,8 +84,8 @@ public interface SynchronizeableQuery<T> {
 	 */
 	default SynchronizeableQuery<T> addSynchronizedEntityName(String... entityNames) throws MappingException {
 		if ( entityNames != null ) {
-			for ( int i = 0; i < entityNames.length; i++ ) {
-				addSynchronizedEntityName( entityNames[i] );
+			for (String entityName : entityNames) {
+				addSynchronizedEntityName(entityName);
 			}
 		}
 		return this;
@@ -101,16 +101,15 @@ public interface SynchronizeableQuery<T> {
 	 *
 	 * @throws MappingException Indicates the given class could not be resolved as an entity
 	 */
-	@SuppressWarnings( "rawtypes" )
-	SynchronizeableQuery<T> addSynchronizedEntityClass(Class entityClass) throws MappingException;
+	SynchronizeableQuery<T> addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) throws MappingException;
 
 	/**
 	 * Adds one-or-more entities (by class) whose tables should be added as synchronized spaces
 	 */
 	default SynchronizeableQuery<T> addSynchronizedEntityClass(Class<?>... entityClasses) throws MappingException {
 		if ( entityClasses != null ) {
-			for ( int i = 0; i < entityClasses.length; i++ ) {
-				addSynchronizedEntityClass( entityClasses[i] );
+			for (Class<?> entityClass : entityClasses) {
+				addSynchronizedEntityClass(entityClass);
 			}
 		}
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -511,9 +511,19 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 		return queryDelegate().createNativeQuery( sqlString, resultClass );
 	}
 
+	@Override @SuppressWarnings({"rawtypes", "unchecked"})
+	public NativeQueryImplementor createNativeQuery(String sqlString, Class resultClass, String tableAlias) {
+		return queryDelegate().createNativeQuery( sqlString, resultClass, tableAlias );
+	}
+
 	@Override @SuppressWarnings("rawtypes")
 	public NativeQueryImplementor createNativeQuery(String sqlString, String resultSetMappingName) {
 		return queryDelegate().createNativeQuery( sqlString, resultSetMappingName );
+	}
+
+	@Override @SuppressWarnings({"rawtypes", "unchecked"})
+	public NativeQueryImplementor createNativeQuery(String sqlString, String resultSetMappingName, Class resultClass) {
+		return queryDelegate().createNativeQuery( sqlString, resultSetMappingName, resultClass );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -456,13 +456,13 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 		return queryDelegate().createQuery( criteriaQuery );
 	}
 
-	@Override @SuppressWarnings("rawtypes")
-	public QueryImplementor createQuery(CriteriaUpdate updateQuery) {
+	@Override
+	public QueryImplementor<Void> createQuery(CriteriaUpdate updateQuery) {
 		return queryDelegate().createQuery( updateQuery );
 	}
 
-	@Override @SuppressWarnings("rawtypes")
-	public QueryImplementor createQuery(CriteriaDelete deleteQuery) {
+	@Override
+	public QueryImplementor<Void> createQuery(CriteriaDelete deleteQuery) {
 		return queryDelegate().createQuery( deleteQuery );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -31,6 +31,7 @@ import org.hibernate.LockMode;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionException;
 import org.hibernate.Transaction;
+import org.hibernate.UnknownEntityTypeException;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
 import org.hibernate.engine.internal.SessionEventListenerManagerImpl;
 import org.hibernate.engine.jdbc.LobCreator;
@@ -729,7 +730,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		if ( Tuple.class.equals(resultClass) ) {
 			query.setTupleTransformer( new NativeQueryTupleTransformer() );
 		}
-		else if ( getFactory().getMetamodel().findEntityDescriptor(resultClass)!=null ) {
+		else if ( getFactory().getMetamodel().isEntityClass(resultClass) ) {
 			query.addEntity( "alias1", resultClass.getName(), LockMode.READ );
 		}
 		return query;
@@ -738,11 +739,11 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override @SuppressWarnings({"rawtypes", "unchecked"})
 	public NativeQueryImplementor createNativeQuery(String sqlString, Class resultClass, String tableAlias) {
 		NativeQueryImplementor query = createNativeQuery( sqlString );
-		if ( Tuple.class.equals(resultClass) ) {
-			query.setTupleTransformer( new NativeQueryTupleTransformer() );
-		}
-		else if ( getFactory().getMetamodel().findEntityDescriptor(resultClass)!=null ) {
+		if ( getFactory().getMetamodel().isEntityClass(resultClass) ) {
 			query.addEntity( tableAlias, resultClass.getName(), LockMode.READ );
+		}
+		else {
+			throw new UnknownEntityTypeException( "unable to locate persister: " + resultClass.getName() );
 		}
 		return query;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -1006,12 +1006,12 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 	}
 
-	@Override @SuppressWarnings("rawtypes")
-	public QueryImplementor createQuery(CriteriaUpdate criteriaUpdate) {
+	@Override @SuppressWarnings("unchecked")
+	public QueryImplementor<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate criteriaUpdate) {
 		checkOpen();
 		try {
 			return new QuerySqmImpl<>(
-					(SqmUpdateStatement<?>) criteriaUpdate,
+					(SqmUpdateStatement<Void>) criteriaUpdate,
 					null,
 					this
 			);
@@ -1021,12 +1021,12 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 	}
 
-	@Override @SuppressWarnings("rawtypes")
-	public QueryImplementor createQuery(CriteriaDelete criteriaDelete) {
+	@Override @SuppressWarnings("unchecked")
+	public QueryImplementor<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaDelete criteriaDelete) {
 		checkOpen();
 		try {
 			return new QuerySqmImpl<>(
-					(SqmDeleteStatement<?>) criteriaDelete,
+					(SqmDeleteStatement<Void>) criteriaDelete,
 					null,
 					this
 			);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/MappingMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/MappingMetamodel.java
@@ -20,7 +20,6 @@ import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.NavigablePath;
 import org.hibernate.query.sqm.SqmExpressable;
-import org.hibernate.sql.ast.spi.SqlAstCreationState;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -90,7 +89,7 @@ public interface MappingMetamodel {
 	 *
 	 * @see #findEntityDescriptor
 	 */
-	EntityPersister getEntityDescriptor(Class entityJavaType);
+	EntityPersister getEntityDescriptor(Class<?> entityJavaType);
 
 	/**
 	 * Find an entity mapping descriptor based on its Hibernate entity-name.
@@ -104,7 +103,9 @@ public interface MappingMetamodel {
 	 *
 	 * @apiNote Returns {@code null} rather than throwing exception
 	 */
-	EntityPersister findEntityDescriptor(Class entityJavaType);
+	EntityPersister findEntityDescriptor(Class<?> entityJavaType);
+	
+	boolean isEntityClass(Class<?> entityJavaType);
 
 	/**
 	 * Locate an entity mapping descriptor by Class.  The passed Class might
@@ -114,7 +115,7 @@ public interface MappingMetamodel {
 	 *
 	 * @throws org.hibernate.UnknownEntityTypeException If a matching EntityPersister cannot be located
 	 */
-	EntityPersister locateEntityDescriptor(Class byClass);
+	EntityPersister locateEntityDescriptor(Class<?> byClass);
 
 	/**
 	 * @see #locateEntityDescriptor
@@ -122,7 +123,7 @@ public interface MappingMetamodel {
 	 * @deprecated (since 6.0) use {@link #locateEntityDescriptor(Class)} instead
 	 */
 	@Deprecated
-	default EntityPersister locateEntityPersister(Class byClass) {
+	default EntityPersister locateEntityPersister(Class<?> byClass) {
 		return locateEntityDescriptor( byClass );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -401,8 +401,13 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 	}
 
 	@Override
-	public EntityPersister findEntityDescriptor(Class entityJavaType) {
+	public EntityPersister findEntityDescriptor(Class<?> entityJavaType) {
 		return findEntityDescriptor( entityJavaType.getName() );
+	}
+
+	@Override
+	public boolean isEntityClass(Class<?> entityJavaType) {
+		return entityPersisterMap.containsKey( entityJavaType.getName() );
 	}
 
 	@Override
@@ -411,7 +416,7 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 	}
 
 	@Override
-	public EntityPersister getEntityDescriptor(Class entityJavaType) {
+	public EntityPersister getEntityDescriptor(Class<?> entityJavaType) {
 		EntityPersister entityPersister = entityPersisterMap.get( entityJavaType.getName() );
 		if ( entityPersister == null ) {
 			String mappedEntityName = entityProxyInterfaceMap.get( entityJavaType );
@@ -428,7 +433,7 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 	}
 
 	@Override
-	public EntityPersister locateEntityDescriptor(Class byClass) {
+	public EntityPersister locateEntityDescriptor(Class<?> byClass) {
 		EntityPersister entityPersister = entityPersisterMap.get( byClass.getName() );
 		if ( entityPersister == null ) {
 			String mappedEntityName = entityProxyInterfaceMap.get( byClass );
@@ -562,7 +567,7 @@ public class MappingMetamodelImpl implements MappingMetamodel, MetamodelImplemen
 	}
 
 	@Override
-	public EntityPersister entityPersister(Class entityClass) {
+	public EntityPersister entityPersister(Class<?> entityClass) {
 		return entityPersister( entityClass.getName() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MetamodelImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MetamodelImplementor.java
@@ -46,7 +46,7 @@ public interface MetamodelImplementor extends MappingMetamodel, Metamodel {
 	 *
 	 * @throws MappingException Indicates persister for that class could not be found.
 	 */
-	EntityPersister entityPersister(Class entityClass);
+	EntityPersister entityPersister(Class<?> entityClass);
 
 	/**
 	 * Locate the persister for an entity by the entity-name

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -222,7 +222,7 @@ public interface ProcedureCall
 	@Override
 	ProcedureCall addSynchronizedEntityName(String entityName) throws MappingException;
 
-	@Override
+	@Override @SuppressWarnings("rawtypes")
 	ProcedureCall addSynchronizedEntityClass(Class entityClass) throws MappingException;
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -744,7 +744,7 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
-	public ProcedureCallImplementor<R> addSynchronizedEntityClass(Class entityClass) {
+	public ProcedureCallImplementor<R> addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) {
 		addSynchronizedQuerySpaces( getSession().getFactory().getMetamodel().entityPersister( entityClass.getName() ) );
 		return this;
 	}
@@ -801,12 +801,12 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
-	protected void applyEntityGraphQueryHint(String hintName, RootGraphImplementor entityGraph) {
+	protected void applyEntityGraphQueryHint(String hintName, @SuppressWarnings("rawtypes") RootGraphImplementor entityGraph) {
 		throw new IllegalStateException( "EntityGraph hints are not supported for ProcedureCall/StoredProcedureQuery" );
 	}
 
 	@Override
-	public Query<R> applyGraph(RootGraph<?> graph, GraphSemantic semantic) {
+	public Query<R> applyGraph(@SuppressWarnings("rawtypes") RootGraph graph, GraphSemantic semantic) {
 		throw new IllegalStateException( "EntityGraph hints are not supported for ProcedureCall/StoredProcedureQuery" );
 	}
 
@@ -819,8 +819,7 @@ public class ProcedureCallImpl<R>
 	@Override
 	public boolean execute() {
 		try {
-			final Output rtn = outputs().getCurrent();
-			return ResultSetOutput.class.isInstance( rtn );
+			return outputs().getCurrent() instanceof ResultSetOutput;
 		}
 		catch (NoMoreOutputsException e) {
 			return false;
@@ -887,7 +886,7 @@ public class ProcedureCallImpl<R>
 
 	@Override
 	public boolean hasMoreResults() {
-		return outputs().goToNext() && ResultSetOutput.class.isInstance( outputs().getCurrent() );
+		return outputs().goToNext() && outputs().getCurrent() instanceof ResultSetOutput;
 	}
 
 	@Override
@@ -897,7 +896,7 @@ public class ProcedureCallImpl<R>
 			if ( rtn == null ) {
 				return -1;
 			}
-			else if ( UpdateCountOutput.class.isInstance( rtn ) ) {
+			else if ( rtn instanceof UpdateCountOutput ) {
 				return ( (UpdateCountOutput) rtn ).getUpdateCount();
 			}
 			else {
@@ -923,7 +922,7 @@ public class ProcedureCallImpl<R>
 		}
 		try {
 			final Output rtn = outputs().getCurrent();
-			if ( !ResultSetOutput.class.isInstance( rtn ) ) {
+			if ( !(rtn instanceof ResultSetOutput) ) {
 				throw new IllegalStateException( "Current CallableStatement ou was not a ResultSet, but getResultList was called" );
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -92,7 +92,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	NativeQuery<T> addScalar(String columnAlias, BasicTypeReference<?> type);
+	NativeQuery<T> addScalar(String columnAlias, @SuppressWarnings("rawtypes") BasicTypeReference type);
 
 	/**
 	 * Declare a scalar query result.
@@ -106,7 +106,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	NativeQuery<T> addScalar(String columnAlias, BasicDomainType<?> type);
+	NativeQuery<T> addScalar(String columnAlias, @SuppressWarnings("rawtypes") BasicDomainType type);
 
 	/**
 	 * Declare a scalar query result using the specified result type.
@@ -118,7 +118,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @since 6.0
 	 */
-	NativeQuery<T> addScalar(String columnAlias, Class<?> javaType);
+	NativeQuery<T> addScalar(String columnAlias, @SuppressWarnings("rawtypes") Class javaType);
 
 	/**
 	 * Declare a scalar query result with an explicit conversion
@@ -189,7 +189,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @since 6.0
 	 */
-	NativeQuery<T> addAttributeResult(String columnAlias, Class<?> entityJavaType, String attributePath);
+	NativeQuery<T> addAttributeResult(String columnAlias, @SuppressWarnings("rawtypes") Class entityJavaType, String attributePath);
 
 	/**
 	 * Defines a result based on a specified attribute.  Differs from adding a scalar in that
@@ -213,7 +213,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @since 6.0
 	 */
-	NativeQuery<T> addAttributeResult(String columnAlias, SingularAttribute<?,?> attribute);
+	NativeQuery<T> addAttributeResult(String columnAlias, @SuppressWarnings("rawtypes") SingularAttribute attribute);
 
 	/**
 	 * Add a new root return mapping, returning a {@link RootReturn} to allow
@@ -238,7 +238,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @since 3.6
 	 */
-	RootReturn addRoot(String tableAlias, Class entityType);
+	RootReturn addRoot(String tableAlias, @SuppressWarnings("rawtypes") Class entityType);
 
 	/**
 	 * Declare a "root" entity, without specifying an alias.  The expectation here is that the table alias is the
@@ -281,7 +281,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	NativeQuery<T> addEntity(Class<?> entityType);
+	NativeQuery<T> addEntity(@SuppressWarnings("rawtypes") Class entityType);
 
 	/**
 	 * Declare a "root" entity.
@@ -291,7 +291,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	NativeQuery<T> addEntity(String tableAlias, Class<?> entityType);
+	NativeQuery<T> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityType);
 
 	/**
 	 * Declare a "root" entity, specifying a lock mode.
@@ -302,7 +302,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	NativeQuery<T> addEntity(String tableAlias, Class<?> entityClass, LockMode lockMode);
+	NativeQuery<T> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityClass, LockMode lockMode);
 
 	/**
 	 * Declare a join fetch result.
@@ -507,7 +507,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	NativeQuery<T> addSynchronizedEntityName(String entityName) throws MappingException;
 
 	@Override
-	NativeQuery<T> addSynchronizedEntityClass(Class<?> entityClass) throws MappingException;
+	NativeQuery<T> addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) throws MappingException;
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -567,7 +567,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	@Override
 	NativeQuery<T> setResultListTransformer(ResultListTransformer transformer);
 
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	NativeQuery<T> setResultTransformer(ResultTransformer transformer);
 
 
@@ -664,7 +664,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	<P> NativeQuery<T> setParameterList(QueryParameter<P> parameter, Collection<P> values);
 
 	@Override
-	NativeQuery<T> setParameterList(String name, Collection<?> values);
+	NativeQuery<T> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values);
 
 //	@Override
 //	default NativeQuery<T> setParameterList(String name, Collection values, Type type) {
@@ -678,7 +678,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 //	NativeQuery<T> setParameterList(String name, Object[] values, Type type);
 
 	@Override
-	NativeQuery<T> setParameterList(String name, Object[] values, AllowableParameterType<?> type);
+	NativeQuery<T> setParameterList(String name, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	@Override
 	NativeQuery<T> setParameterList(String name, Object[] values);
@@ -702,7 +702,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	<P> NativeQuery<T> setParameter(QueryParameter<P> parameter, P val, BasicTypeReference<P> type);
 
 	@Override
-	NativeQuery<T> setParameterList(int position, Collection<?> values);
+	NativeQuery<T> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values);
 
 	@Override
 	<P> NativeQuery<T> setParameterList(String name, Collection<? extends P> values, Class<P> type);
@@ -720,7 +720,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 //	NativeQuery<T> setParameterList(int position, Object[] values, Type type);
 
 	@Override
-	NativeQuery<T> setParameterList(int position, Object[] values, AllowableParameterType<?> type);
+	NativeQuery<T> setParameterList(int position, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	@Override
 	NativeQuery<T> setParameterList(int position, Object[] values);
@@ -729,5 +729,5 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	NativeQuery<T> setProperties(Object bean);
 
 	@Override
-	NativeQuery<T> setProperties(Map<?,?> bean);
+	NativeQuery<T> setProperties(@SuppressWarnings("rawtypes") Map bean);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -77,7 +77,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return this - for method chaining
 	 */
-	Query<R> applyGraph(RootGraph<?> graph, GraphSemantic semantic);
+	Query<R> applyGraph(@SuppressWarnings("rawtypes") RootGraph graph, GraphSemantic semantic);
 
 	/**
 	 * Apply the given graph using {@linkplain GraphSemantic#FETCH fetch semantics}
@@ -85,7 +85,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * @apiNote This method calls {@link #applyGraph(RootGraph, GraphSemantic)} using
 	 * {@link GraphSemantic#FETCH} as the semantic
 	 */
-	default Query<R> applyFetchGraph(RootGraph<?> graph) {
+	default Query<R> applyFetchGraph(@SuppressWarnings("rawtypes") RootGraph graph) {
 		return applyGraph( graph, GraphSemantic.FETCH );
 	}
 
@@ -96,7 +96,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * {@link GraphSemantic#LOAD} as the semantic
 	 */
 	@SuppressWarnings("UnusedDeclaration")
-	default Query<R> applyLoadGraph(RootGraph<?> graph) {
+	default Query<R> applyLoadGraph(@SuppressWarnings("rawtypes") RootGraph graph) {
 		return applyGraph( graph, GraphSemantic.LOAD );
 	}
 
@@ -541,7 +541,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	Query<R> setParameterList(String name, Collection<?> values);
+	Query<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values);
 
 	/**
 	 * Bind multiple values to a positional query parameter. The Hibernate type of the parameter is
@@ -554,7 +554,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	Query<R> setParameterList(int position, Collection<?> values);
+	Query<R> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values);
 
 	/**
 	 * Bind multiple values to a named query parameter. The Hibernate type of the parameter is
@@ -650,7 +650,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	Query<R> setParameterList(String name, Object[] values, AllowableParameterType<?> type);
+	Query<R> setParameterList(String name, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	/**
 	 * Bind multiple values to a named query parameter. This is useful for binding
@@ -662,7 +662,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	Query<R> setParameterList(int position, Object[] values, AllowableParameterType<?> type);
+	Query<R> setParameterList(int position, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	/**
 	 * Bind multiple values to a named query parameter. The Hibernate type of the parameter is
@@ -710,7 +710,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	Query<R> setProperties(Map<?,?> bean);
+	Query<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
 
 	/**
 	 * @deprecated (since 5.2) Use {@link #setTupleTransformer} or {@link #setResultListTransformer}

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -128,10 +128,22 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 */
 	List<R> list();
 
+	/**
+	 * Return the query results as a <tt>List</tt>. If the query contains
+	 * multiple results per row, the results are returned in an instance
+	 * of <tt>Object[]</tt>.
+	 *
+	 * @return the results as a  list
+	 */
 	default List<R> getResultList() {
 		return list();
 	}
 
+	/**
+	 * Retrieve a <tt>Stream</tt> over the query results.
+	 *
+	 * @return The results as a {@link Stream}
+	 */
 	default Stream<R> getResultStream() {
 		return stream();
 	}
@@ -146,20 +158,34 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 */
 	R uniqueResult();
 
+	/**
+	 * Convenience method to return a single instance that matches
+	 * the query, or {@code null} if the query returns no results.
+	 *
+	 * @return the single result or <tt>null</tt>
+	 *
+	 * @throws NonUniqueResultException if there is more than one matching result
+	 */
 	default R getSingleResult() {
 		return uniqueResult();
 	}
 
+	/**
+	 * Convenience method to return a single instance that matches
+	 * the query, as an {@link Optional}.
+	 *
+	 * @return the single result as an <tt>Optional</tt>
+	 *
+	 * @throws NonUniqueResultException if there is more than one matching result
+	 */
 	Optional<R> uniqueResultOptional();
 
 	/**
 	 * Retrieve a Stream over the query results.
 	 * <p/>
 	 * In the initial implementation (5.2) this returns a simple sequential Stream.  The plan
-	 * is to return a a smarter stream in 6.x leveraging the SQM model.
-	 *
+	 * is to return a smarter stream in 6.x leveraging the SQM model.
 	 * <p>
-	 *
 	 * You should call {@link Stream#close()} after processing the stream
 	 * so that the underlying resources are deallocated right away.
 	 *
@@ -167,7 +193,9 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 *
 	 * @since 5.2
 	 */
-	Stream<R> stream();
+	default Stream<R> stream() {
+		return getResultStream();
+	}
 
 	/**
 	 * Obtain the comment currently associated with this query.  Provided SQL commenting is enabled
@@ -246,8 +274,14 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 */
 	Query<R> setLockMode(String alias, LockMode lockMode);
 
+	/**
+	 * Set a {@link TupleTransformer}
+	 */
 	Query<R> setTupleTransformer(TupleTransformer<R> transformer);
 
+	/**
+	 * Set a {@link ResultListTransformer}
+	 */
 	Query<R> setResultListTransformer(ResultListTransformer transformer);
 
 	/**
@@ -330,43 +364,6 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	<P> Query<R> setParameter(int position, P val, BasicTypeReference<P> type);
 
 	/**
-	 * Bind a named query parameter as some form of date/time using
-	 * the indicated temporal-type.
-	 *
-	 * @param name the parameter name
-	 * @param val the possibly-null parameter value
-	 * @param temporalType the temporal-type to use in binding the date/time
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	<P> Query<R> setParameter(String name, P val, TemporalType temporalType);
-
-	/**
-	 * Bind a positional query parameter as some form of date/time using
-	 * the indicated temporal-type.
-	 *
-	 * @param position the position of the parameter in the query
-	 * string, numbered from {@code 0}.
-	 * @param val the possibly-null parameter value
-	 * @param temporalType the temporal-type to use in binding the date/time
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	<P> Query<R> setParameter(int position, P val, TemporalType temporalType);
-
-	/**
-	 * Bind a query parameter as some form of date/time using the indicated
-	 * temporal-type.
-	 *
-	 * @param parameter The query parameter memento
-	 * @param val the possibly-null parameter value
-	 * @param temporalType the temporal-type to use in binding the date/time
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	<P> Query<R> setParameter(QueryParameter<P> parameter, P val, TemporalType temporalType);
-
-	/**
 	 * Bind a query parameter using the supplied Type
 	 *
 	 * @param parameter The query parameter memento
@@ -387,83 +384,6 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * @return {@code this}, for method chaining
 	 */
 	<P> Query<R> setParameter(QueryParameter<P> parameter, P val, BasicTypeReference<P> type);
-
-	Query<R> setParameter(Parameter<Instant> param, Instant value, TemporalType temporalType);
-
-	Query<R> setParameter(
-			Parameter<LocalDateTime> param,
-			LocalDateTime value,
-			TemporalType temporalType);
-
-	Query<R> setParameter(
-			Parameter<ZonedDateTime> param,
-			ZonedDateTime value,
-			TemporalType temporalType);
-
-	Query<R> setParameter(
-			Parameter<OffsetDateTime> param,
-			OffsetDateTime value,
-			TemporalType temporalType);
-
-	Query<R> setParameter(String name, Instant value, TemporalType temporalType);
-
-	Query<R> setParameter(String name, LocalDateTime value, TemporalType temporalType);
-
-	Query<R> setParameter(String name, ZonedDateTime value, TemporalType temporalType);
-
-	Query<R> setParameter(String name, OffsetDateTime value, TemporalType temporalType);
-
-	Query<R> setParameter(int position, Instant value, TemporalType temporalType);
-
-	Query<R> setParameter(int position, LocalDateTime value, TemporalType temporalType);
-
-	Query<R> setParameter(int position, ZonedDateTime value, TemporalType temporalType);
-
-	Query<R> setParameter(int position, OffsetDateTime value, TemporalType temporalType);
-
-
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// covariant overrides - CommonQueryContract
-
-	@Override
-	Query<R> setHibernateFlushMode(FlushMode flushMode);
-
-	@Override
-	Query<R> setCacheable(boolean cacheable);
-
-	@Override
-	Query<R> setCacheRegion(String cacheRegion);
-
-	@Override
-	Query<R> setCacheMode(CacheMode cacheMode);
-
-	@Override
-	Query<R> setTimeout(int timeout);
-
-	@Override
-	Query<R> setFetchSize(int fetchSize);
-
-	@Override
-	Query<R> setReadOnly(boolean readOnly);
-
-
-	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// covariant overrides - jakarta.persistence.Query/TypedQuery
-
-	@Override
-	Query<R> setMaxResults(int maxResult);
-
-	@Override
-	Query<R> setFirstResult(int startPosition);
-
-	@Override
-	Query<R> setHint(String hintName, Object value);
-
-	@Override
-	Query<R> setFlushMode(FlushModeType flushMode);
-
-	@Override
-	Query<R> setLockMode(LockModeType lockMode);
 
 	/**
 	 * Bind a named query parameter using its inferred Type.  If the parameter is
@@ -496,26 +416,6 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 
 	@Override
 	<T> Query<R> setParameter(Parameter<T> param, T value);
-
-	@Override
-	Query<R> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType);
-
-	@Override
-	Query<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType);
-
-	@Override
-	Query<R> setParameter(String name, Calendar value, TemporalType temporalType);
-
-	@Override
-	Query<R> setParameter(String name, Date value, TemporalType temporalType);
-
-	@Override
-	Query<R> setParameter(int position, Calendar value, TemporalType temporalType);
-
-	@Override
-	Query<R> setParameter(int position, Date value, TemporalType temporalType);
-
-
 
 	/**
 	 * Bind multiple values to a query parameter using its inferred Type. The Hibernate type of the parameter values is
@@ -706,11 +606,56 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * matching key names with parameter names and mapping value types to
 	 * Hibernate types using heuristics.
 	 *
-	 * @param bean a java.util.Map
+	 * @param bean a {@link Map} of names to arguments
 	 *
 	 * @return {@code this}, for method chaining
 	 */
 	Query<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// covariant overrides - CommonQueryContract
+
+	@Override
+	Query<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	Query<R> setCacheable(boolean cacheable);
+
+	@Override
+	Query<R> setCacheRegion(String cacheRegion);
+
+	@Override
+	Query<R> setCacheMode(CacheMode cacheMode);
+
+	@Override
+	Query<R> setTimeout(int timeout);
+
+	@Override
+	Query<R> setFetchSize(int fetchSize);
+
+	@Override
+	Query<R> setReadOnly(boolean readOnly);
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// covariant overrides - jakarta.persistence.Query/TypedQuery
+
+	@Override
+	Query<R> setMaxResults(int maxResult);
+
+	@Override
+	Query<R> setFirstResult(int startPosition);
+
+	@Override
+	Query<R> setHint(String hintName, Object value);
+
+	@Override
+	Query<R> setFlushMode(FlushModeType flushMode);
+
+	@Override
+	Query<R> setLockMode(LockModeType lockMode);
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// deprecated methods
 
 	/**
 	 * @deprecated (since 5.2) Use {@link #setTupleTransformer} or {@link #setResultListTransformer}
@@ -722,4 +667,183 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 		setResultListTransformer( transformer );
 		return this;
 	}
+
+	/**
+	 * Bind a positional query parameter as some form of date/time using
+	 * the indicated temporal-type.
+	 *
+	 * @param position the position of the parameter in the query
+	 * string, numbered from <tt>0</tt>.
+	 * @param val the possibly-null parameter value
+	 * @param temporalType the temporal-type to use in binding the date/time
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Deprecated
+	Query<R> setParameter(int position, Object val, TemporalType temporalType);
+
+	/**
+	 * Bind a named query parameter as some form of date/time using
+	 * the indicated temporal-type.
+	 *
+	 * @param name the parameter name
+	 * @param val the possibly-null parameter value
+	 * @param temporalType the temporal-type to use in binding the date/time
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Deprecated
+	Query<R> setParameter(String name, Object val, TemporalType temporalType);
+
+	/**
+	 * Bind a query parameter as some form of date/time using the indicated
+	 * temporal-type.
+	 *
+	 * @param parameter The query parameter memento
+	 * @param val the possibly-null parameter value
+	 * @param temporalType the temporal-type to use in binding the date/time
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Deprecated
+	<P> Query<R> setParameter(QueryParameter<P> parameter, P val, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)},
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)},
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(String name, Calendar value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(String name, Date value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(int position, Calendar value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 *             passing a {@link java.time.LocalDate}, {@link java.time.LocalTime},
+	 *             or {@link java.time.LocalDateTime}
+	 */
+	@Override @Deprecated
+	Query<R> setParameter(int position, Date value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(Parameter<Instant> param, Instant value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(
+			Parameter<LocalDateTime> param,
+			LocalDateTime value,
+			TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(
+			Parameter<ZonedDateTime> param,
+			ZonedDateTime value,
+			TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(Parameter, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(
+			Parameter<OffsetDateTime> param,
+			OffsetDateTime value,
+			TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(String name, Instant value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(String name, LocalDateTime value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(String name, ZonedDateTime value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(String, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(String name, OffsetDateTime value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(int position, Instant value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(int position, LocalDateTime value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(int position, ZonedDateTime value, TemporalType temporalType);
+
+	/**
+	 * @deprecated use {@link #setParameter(int, Object)}
+	 */
+	@Deprecated
+	Query<R> setParameter(int position, OffsetDateTime value, TemporalType temporalType);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -21,20 +21,6 @@ import jakarta.persistence.criteria.CriteriaUpdate;
  */
 public interface QueryProducer {
 	/**
-	 * Create a {@link Query} instance for the named query.
-	 *
-	 * @param queryName the name of a pre-defined, named query
-	 *
-	 * @return The Query instance for manipulation and execution
-	 *
-	 * @throws IllegalArgumentException if a query has not been
-	 * defined with the given name or if the query string is
-	 * found to be invalid
-	 */
-	@SuppressWarnings("rawtypes")
-	Query getNamedQuery(String queryName);
-
-	/**
 	 * Create a {@link Query} instance for the given HQL/JPQL query string.
 	 *
 	 * @param queryString The HQL/JPQL query
@@ -42,8 +28,9 @@ public interface QueryProducer {
 	 * @return The Query instance for manipulation and execution
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(String)
+	 * @deprecated use {@link #createQuery(String, Class)}
 	 */
-	@SuppressWarnings("rawtypes")
+	@Deprecated @SuppressWarnings("rawtypes")
 	Query createQuery(String queryString);
 
 	/**
@@ -70,8 +57,10 @@ public interface QueryProducer {
 	 * found to be invalid
 	 *
 	 * @see jakarta.persistence.EntityManager#createNamedQuery(String)
+	 * 
+	 * @deprecated use {@link #createNamedQuery(String, Class)}
 	 */
-	@SuppressWarnings("rawtypes")
+	@Deprecated @SuppressWarnings("rawtypes")
 	Query createNamedQuery(String name);
 
 	/**
@@ -100,8 +89,10 @@ public interface QueryProducer {
 	 * @return The NativeQuery instance for manipulation and execution
 	 *
 	 * @see jakarta.persistence.EntityManager#createNativeQuery(String)
+	 *
+	 * @deprecated use {@link #createNativeQuery(String, Class)}
 	 */
-	@SuppressWarnings("rawtypes")
+	@Deprecated @SuppressWarnings("rawtypes")
 	NativeQuery createNativeQuery(String sqlString);
 
 	/**
@@ -128,29 +119,25 @@ public interface QueryProducer {
 	 *
 	 * @see jakarta.persistence.EntityManager#createNativeQuery(String,Class)
 	 * @see jakarta.persistence.SqlResultSetMapping
+	 * 
+	 * @deprecated use {@link #createNativeQuery(String, String, Class)}
 	 */
-	@SuppressWarnings("rawtypes")
+	@Deprecated @SuppressWarnings("rawtypes")
 	NativeQuery createNativeQuery(String sqlString, String resultSetMappingName);
 
 	/**
-	 * Get a NativeQuery instance for a named native SQL query
+	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * implicit mapping to the specified Java type.
 	 *
-	 * @param name The name of the pre-defined query
-	 *
-	 * @return The NativeQuery instance for manipulation and execution
-	 */
-	@SuppressWarnings("rawtypes")
-	NativeQuery getNamedNativeQuery(String name);
-
-	/**
-	 * Get a NativeQuery instance for a named native SQL query
-	 *
-	 * @param name The name of the pre-defined query
+	 * @param sqlString Native (SQL) query string
+	 * @param resultSetMappingName The explicit result mapping name
 	 *
 	 * @return The NativeQuery instance for manipulation and execution
+	 *
+	 * @see jakarta.persistence.EntityManager#createNativeQuery(String,Class)
+	 * @see jakarta.persistence.SqlResultSetMapping
 	 */
-	@SuppressWarnings("rawtypes")
-	NativeQuery getNamedNativeQuery(String name, String resultSetMapping);
+	<R> NativeQuery<R> createNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass);
 
 	/**
 	 * Create a Query for the given JPA {@link CriteriaQuery}
@@ -174,4 +161,44 @@ public interface QueryProducer {
 	 */
 	@SuppressWarnings("rawtypes")
 	Query createQuery(CriteriaDelete<?> deleteQuery);
+
+	/**
+	 * Create a {@link Query} instance for the named query.
+	 *
+	 * @param queryName the name of a pre-defined, named query
+	 *
+	 * @return The Query instance for manipulation and execution
+	 *
+	 * @throws IllegalArgumentException if a query has not been
+	 * defined with the given name or if the query string is
+	 * found to be invalid
+	 *
+	 * @deprecated use {@link #createNamedQuery(String, Class)}
+	c	 */
+	@Deprecated @SuppressWarnings("rawtypes")
+	Query getNamedQuery(String queryName);
+
+	/**
+	 * Get a NativeQuery instance for a named native SQL query
+	 *
+	 * @param name The name of the pre-defined query
+	 *
+	 * @return The NativeQuery instance for manipulation and execution
+	 *
+	 * @deprecated use {@link #createNamedQuery(String, Class)}
+	 */
+	@Deprecated @SuppressWarnings("rawtypes")
+	NativeQuery getNamedNativeQuery(String name);
+
+	/**
+	 * Get a NativeQuery instance for a named native SQL query
+	 *
+	 * @param name The name of the pre-defined query
+	 *
+	 * @return The NativeQuery instance for manipulation and execution
+	 *
+	 * @deprecated use {@link #createNamedQuery(String, Class)}
+	 */
+	@Deprecated @SuppressWarnings("rawtypes")
+	NativeQuery getNamedNativeQuery(String name, String resultSetMapping);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -98,6 +98,9 @@ public interface QueryProducer {
 	/**
 	 * Create a NativeQuery instance for the given native (SQL) query using
 	 * implicit mapping to the specified Java type.
+	 * <p>
+	 * If the given class is an entity class, this method is equivalent to
+	 * {@code createNativeQuery(sqlString).addEntity("alias1", resultClass)}.
 	 *
 	 * @param sqlString Native (SQL) query string
 	 * @param resultClass The Java entity type to map results to
@@ -107,6 +110,23 @@ public interface QueryProducer {
 	 * @see jakarta.persistence.EntityManager#createNativeQuery(String,Class)
 	 */
 	<R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass);
+
+	/**
+	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * implicit mapping to the specified Java type.
+	 * <p>
+	 * If the given class is an entity class, this method is equivalent to
+	 * {@code createNativeQuery(sqlString).addEntity(tableAlias, resultClass)}.
+	 *
+	 * @param sqlString Native (SQL) query string
+	 * @param resultClass The Java entity type to map results to
+	 * @param tableAlias The table alias for columns in the result set
+	 *
+	 * @return The NativeQuery instance for manipulation and execution
+	 *
+	 * @see jakarta.persistence.EntityManager#createNativeQuery(String,Class)
+	 */
+	<R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass, String tableAlias);
 
 	/**
 	 * Create a NativeQuery instance for the given native (SQL) query using

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -171,16 +171,14 @@ public interface QueryProducer {
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(CriteriaUpdate)
 	 */
-	@SuppressWarnings("rawtypes")
-	Query createQuery(CriteriaUpdate<?> updateQuery);
+	Query<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate updateQuery);
 
 	/**
 	 * Create a Query for the given JPA {@link CriteriaDelete}
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(CriteriaDelete)
 	 */
-	@SuppressWarnings("rawtypes")
-	Query createQuery(CriteriaDelete<?> deleteQuery);
+	Query<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaDelete deleteQuery);
 
 	/**
 	 * Create a {@link Query} instance for the named query.

--- a/hibernate-core/src/main/java/org/hibernate/query/TupleTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/TupleTransformer.java
@@ -11,15 +11,9 @@ import org.hibernate.sql.results.internal.RowTransformerTupleTransformerAdapter;
 /**
  * User hook for applying transformations of the query result tuples (the result "row").
  *
- * Ultimately, gets wrapped in a
- * {@link RowTransformerTupleTransformerAdapter}
+ * Ultimately, gets wrapped in a {@link RowTransformerTupleTransformerAdapter}
  * to adapt the TupleTransformer to the {@link org.hibernate.sql.results.spi.RowTransformer}
  * contract, which is the thing actually used to process the results internally.
- *
- * Note that {@link JpaTupleTransformer} is a special sub-type applications may use
- * to transform the row into a JPA {@link jakarta.persistence.Tuple}.  JpaTupleTransformer is
- * deprecated as it is much more appropriate (and simpler) to simply specify the Query
- * return type as Tuple
  *
  * @see org.hibernate.transform.ResultTransformer
  * @see org.hibernate.sql.results.spi.RowTransformer

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
@@ -50,8 +50,14 @@ public interface QueryProducerImplementor extends QueryProducer {
 	@Override
 	<R> NativeQueryImplementor<R> createNativeQuery(String sqlString, Class<R> resultClass);
 
+	@Override
+	<R> NativeQueryImplementor<R> createNativeQuery(String sqlString, Class<R> resultClass, String tableAlias);
+
 	@Override @SuppressWarnings("rawtypes")
 	NativeQueryImplementor createNativeQuery(String sqlString, String resultSetMappingName);
+
+	@Override
+	<R> NativeQueryImplementor<R> createNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass);
 
 	@Override @SuppressWarnings("rawtypes")
 	NativeQueryImplementor getNamedNativeQuery(String name);

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
@@ -68,9 +68,9 @@ public interface QueryProducerImplementor extends QueryProducer {
 	@Override
 	<R> QueryImplementor<R> createQuery(CriteriaQuery<R> criteriaQuery);
 
-	@Override @SuppressWarnings("rawtypes")
-	QueryImplementor createQuery(CriteriaUpdate<?> updateQuery);
+	@Override
+	QueryImplementor<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate updateQuery);
 
-	@Override @SuppressWarnings("rawtypes")
-	QueryImplementor createQuery(CriteriaDelete<?> deleteQuery);
+	@Override
+	QueryImplementor<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaDelete deleteQuery);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -46,7 +46,6 @@ import org.hibernate.jpa.internal.util.LockModeTypeHelper;
 import org.hibernate.jpa.spi.NativeQueryTupleTransformer;
 import org.hibernate.metamodel.model.domain.AllowableParameterType;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
-import org.hibernate.query.Limit;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.Query;
@@ -127,7 +126,6 @@ public class NativeQueryImpl<R>
 	private Callback callback;
 
 	private Object collectionKey;
-	private NativeQueryInterpreter nativeQueryInterpreter;
 
 	/**
 	 * Constructs a NativeQueryImpl given a sql query defined in the mappings.
@@ -366,7 +364,7 @@ public class NativeQueryImpl<R>
 								.getService( NativeQueryInterpreter.class )
 								.recognizeParameters( sqlString, parameterRecognizer );
 
-						return new ParameterInterpretationImpl( sqlString, parameterRecognizer );
+						return new ParameterInterpretationImpl( parameterRecognizer );
 					}
 			);
 	}
@@ -503,12 +501,12 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public Query<R> applyGraph(RootGraph graph, GraphSemantic semantic) {
+	public Query<R> applyGraph(@SuppressWarnings("rawtypes") RootGraph graph, GraphSemantic semantic) {
 		throw new HibernateException( "A native SQL query cannot use EntityGraphs" );
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setTupleTransformer(TupleTransformer transformer) {
+	public NativeQueryImplementor<R> setTupleTransformer(@SuppressWarnings("rawtypes") TupleTransformer transformer) {
 		return (NativeQueryImplementor<R>) super.setTupleTransformer( transformer );
 	}
 
@@ -565,9 +563,7 @@ public class NativeQueryImpl<R>
 			}
 
 			if ( effectiveFlushMode == FlushMode.AUTO ) {
-				if ( getSession().getFactory().getSessionFactoryOptions().isJpaBootstrap() ) {
-					return true;
-				}
+				return getSession().getFactory().getSessionFactoryOptions().isJpaBootstrap();
 			}
 		}
 
@@ -594,7 +590,7 @@ public class NativeQueryImpl<R>
 
 	private NativeSelectQueryPlan<R> createQueryPlan(ResultSetMapping resultSetMapping) {
 		final String sqlString = expandParameterLists();
-		final NativeSelectQueryDefinition<R> queryDefinition = new NativeSelectQueryDefinition<R>() {
+		final NativeSelectQueryDefinition<R> queryDefinition = new NativeSelectQueryDefinition<>() {
 			@Override
 			public String getSqlString() {
 				return sqlString;
@@ -788,10 +784,6 @@ public class NativeQueryImpl<R>
 		return !query.parameterBindings.hasAnyMultiValuedBindings();
 	}
 
-	private static boolean hasLimit(Limit limit) {
-		return limit.getFirstRow() != null || limit.getMaxRows() != null;
-	}
-
 	@Override
 	public ScrollableResultsImplementor<R> scroll(ScrollMode scrollMode) {
 		return resolveSelectQueryPlan().performScroll( scrollMode, this );
@@ -834,7 +826,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor setCollectionKey(Object key) {
+	public NativeQueryImplementor<R> setCollectionKey(Object key) {
 		this.collectionKey = key;
 		return this;
 	}
@@ -850,7 +842,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQuery<R> addScalar(String columnAlias, BasicTypeReference<?> type) {
+	public NativeQuery<R> addScalar(String columnAlias, @SuppressWarnings("rawtypes") BasicTypeReference type) {
 		return registerBuilder(
 				Builders.scalar(
 						columnAlias,
@@ -860,12 +852,12 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addScalar(String columnAlias, BasicDomainType<?> type) {
+	public NativeQueryImplementor<R> addScalar(String columnAlias, @SuppressWarnings("rawtypes") BasicDomainType type) {
 		return registerBuilder( Builders.scalar( columnAlias, (BasicType<?>) type ) );
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addScalar(String columnAlias, Class<?> javaType) {
+	public NativeQueryImplementor<R> addScalar(String columnAlias, @SuppressWarnings("rawtypes") Class javaType) {
 		return registerBuilder( Builders.scalar( columnAlias, javaType, getSessionFactory() ) );
 	}
 
@@ -916,7 +908,7 @@ public class NativeQueryImpl<R>
 	@Override
 	public NativeQueryImplementor<R> addAttributeResult(
 			String columnAlias,
-			Class<?> entityJavaType,
+			@SuppressWarnings("rawtypes") Class entityJavaType,
 			String attributePath) {
 		return addAttributeResult( columnAlias, entityJavaType.getName(), attributePath );
 	}
@@ -933,7 +925,7 @@ public class NativeQueryImpl<R>
 	@Override
 	public NativeQueryImplementor<R> addAttributeResult(
 			String columnAlias,
-			SingularAttribute<?, ?> attribute) {
+			@SuppressWarnings("rawtypes") SingularAttribute attribute) {
 		registerBuilder( Builders.attributeResult( columnAlias, attribute ) );
 		return this;
 	}
@@ -950,7 +942,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public DynamicResultBuilderEntityStandard addRoot(String tableAlias, Class entityType) {
+	public DynamicResultBuilderEntityStandard addRoot(String tableAlias, @SuppressWarnings("rawtypes") Class entityType) {
 		return addRoot( tableAlias, entityType.getName() );
 	}
 
@@ -972,17 +964,17 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addEntity(Class<?> entityType) {
+	public NativeQueryImplementor<R> addEntity(@SuppressWarnings("rawtypes") Class entityType) {
 		return addEntity( entityType.getName() );
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addEntity(String tableAlias, Class<?> entityClass) {
+	public NativeQueryImplementor<R> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityClass) {
 		return addEntity( tableAlias, entityClass.getName() );
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addEntity(String tableAlias, Class<?> entityClass, LockMode lockMode) {
+	public NativeQueryImplementor<R> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityClass, LockMode lockMode) {
 		return addEntity( tableAlias, entityClass.getName(), lockMode );
 	}
 
@@ -1057,7 +1049,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor<R> addSynchronizedEntityClass(Class<?> entityClass) throws MappingException {
+	public NativeQueryImplementor<R> addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) throws MappingException {
 		addQuerySpaces( getSession().getFactory().getMetamodel().entityPersister( entityClass.getName() ).getQuerySpaces() );
 		return this;
 	}
@@ -1161,18 +1153,16 @@ public class NativeQueryImpl<R>
 			addSynchronizedQuerySpace( (String) value );
 		}
 		else if ( value instanceof String[] ) {
-			final String[] strings = (String[]) value;
-			for ( int i = 0; i < strings.length; i++ ) {
-				addSynchronizedQuerySpace( strings[i] );
+			for (String string : (String[]) value) {
+				addSynchronizedQuerySpace(string);
 			}
 		}
 		else if ( value instanceof Class ) {
 			addSynchronizedEntityClass( (Class<?>) value );
 		}
 		else if ( value instanceof Class[] ) {
-			final Class<?>[] classes = (Class<?>[]) value;
-			for ( int i = 0; i < classes.length; i++ ) {
-				addSynchronizedEntityClass( classes[i] );
+			for (Class<?> aClass : (Class<?>[]) value) {
+				addSynchronizedEntityClass(aClass);
 			}
 		}
 		else if ( value instanceof List ) {
@@ -1200,7 +1190,7 @@ public class NativeQueryImpl<R>
 		else if ( value instanceof LockModeType ) {
 			applyLockModeTypeHint( (LockModeType) value );
 		}
-		else if ( String.class.isInstance( value ) ) {
+		else if ( value instanceof String ) {
 			applyHibernateLockModeHint( LockModeTypeHelper.interpretLockMode( value ) );
 		}
 		else {
@@ -1315,19 +1305,25 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public <P> NativeQueryImplementor<R> setParameterList(int position, Collection<? extends P> values, AllowableParameterType<P> type) {
+	public <P> NativeQueryImplementor<R> setParameterList(
+			int position, Collection<? extends P> values,
+			AllowableParameterType<P> type) {
 		super.setParameterList( position, values, type );
 		return this;
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setParameterList(String name, Object[] values, AllowableParameterType<?> type) {
+	public NativeQueryImplementor<R> setParameterList(
+			String name, Object[] values,
+			@SuppressWarnings("rawtypes") AllowableParameterType type) {
 		super.setParameterList( name, values, type );
 		return this;
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setParameterList(int position, Object[] values, AllowableParameterType<?> type) {
+	public NativeQueryImplementor<R> setParameterList(
+			int position, Object[] values,
+			@SuppressWarnings("rawtypes") AllowableParameterType type) {
 		super.setParameterList( position, values, type );
 		return this;
 	}
@@ -1392,7 +1388,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setParameterList(String name, Collection<?> values) {
+	public NativeQueryImplementor<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values) {
 		super.setParameterList( name, values );
 		return this;
 	}
@@ -1451,14 +1447,14 @@ public class NativeQueryImpl<R>
 		return this;
 	}
 
-	@Override
+	@Override @SuppressWarnings("deprecation")
 	public NativeQueryImplementor<R> setResultTransformer(ResultTransformer transformer) {
 		super.setResultTransformer( transformer );
 		return this;
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setProperties(Map<?,?> map) {
+	public NativeQueryImplementor<R> setProperties(@SuppressWarnings("rawtypes") Map map) {
 		super.setProperties( map );
 		return this;
 	}
@@ -1518,7 +1514,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	public NativeQueryImplementor<R> setParameterList(int position, Collection<?> values) {
+	public NativeQueryImplementor<R> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values) {
 		super.setParameterList( position, values );
 		return this;
 	}
@@ -1552,7 +1548,7 @@ public class NativeQueryImpl<R>
 	}
 
 	@Override
-	protected void applyEntityGraphQueryHint(String hintName, RootGraphImplementor entityGraph) {
+	protected void applyEntityGraphQueryHint(String hintName, @SuppressWarnings("rawtypes") RootGraphImplementor entityGraph) {
 		throw new HibernateException( "A native SQL query cannot use EntityGraphs" );
 	}
 
@@ -1562,7 +1558,7 @@ public class NativeQueryImpl<R>
 		private final Map<Integer, QueryParameterImplementor<?>> positionalParameters;
 		private final Map<String, QueryParameterImplementor<?>> namedParameters;
 
-		public ParameterInterpretationImpl(String sqlString, ParameterRecognizerImpl parameterRecognizer) {
+		public ParameterInterpretationImpl(ParameterRecognizerImpl parameterRecognizer) {
 			this.sqlString = parameterRecognizer.getAdjustedSqlString();
 			this.parameterList = parameterRecognizer.getParameterList();
 			this.positionalParameters = parameterRecognizer.getPositionalQueryParameters();

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -43,7 +43,9 @@ import org.hibernate.type.BasicTypeReference;
  */
 @Incubating
 public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQuery<R>, NameableQuery {
-	NativeQueryImplementor setCollectionKey(Object key);
+
+	//TODO: this method is no longer used. Can it be deleted?
+	NativeQueryImplementor<R> setCollectionKey(Object key);
 
 	@Override
 	default LockOptions getLockOptions() {
@@ -66,10 +68,10 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> addScalar(String columnAlias);
 
 	@Override
-	NativeQueryImplementor<R> addScalar(String columnAlias, BasicDomainType<?> type);
+	NativeQueryImplementor<R> addScalar(String columnAlias, @SuppressWarnings("rawtypes") BasicDomainType type);
 
 	@Override
-	NativeQueryImplementor<R> addScalar(String columnAlias, Class<?> javaType);
+	NativeQueryImplementor<R> addScalar(String columnAlias, @SuppressWarnings("rawtypes") Class javaType);
 
 	@Override
 	<C> NativeQueryImplementor<R> addScalar(String columnAlias, Class<C> relationalJavaType, AttributeConverter<?,C> converter);
@@ -88,13 +90,13 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 			Class<? extends AttributeConverter<O, J>> converter);
 
 	@Override
-	NativeQueryImplementor<R> addAttributeResult(String columnAlias, Class<?> entityJavaType, String attributePath);
+	NativeQueryImplementor<R> addAttributeResult(String columnAlias, @SuppressWarnings("rawtypes") Class entityJavaType, String attributePath);
 
 	@Override
 	NativeQueryImplementor<R> addAttributeResult(String columnAlias, String entityName, String attributePath);
 
 	@Override
-	NativeQueryImplementor<R> addAttributeResult(String columnAlias, SingularAttribute<?, ?> attribute);
+	NativeQueryImplementor<R> addAttributeResult(String columnAlias, @SuppressWarnings("rawtypes") SingularAttribute attribute);
 
 	@Override
 	DynamicResultBuilderEntityStandard addRoot(String tableAlias, String entityName);
@@ -109,13 +111,13 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> addEntity(String tableAlias, String entityName, LockMode lockMode);
 
 	@Override
-	NativeQueryImplementor<R> addEntity(Class<?> entityType);
+	NativeQueryImplementor<R> addEntity(@SuppressWarnings("rawtypes") Class entityType);
 
 	@Override
-	NativeQueryImplementor<R> addEntity(String tableAlias, Class<?> entityType);
+	NativeQueryImplementor<R> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityType);
 
 	@Override
-	NativeQueryImplementor<R> addEntity(String tableAlias, Class<?> entityClass, LockMode lockMode);
+	NativeQueryImplementor<R> addEntity(String tableAlias, @SuppressWarnings("rawtypes") Class entityClass, LockMode lockMode);
 
 	@Override
 	NativeQueryImplementor<R> addJoin(String tableAlias, String path);
@@ -136,7 +138,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> addSynchronizedEntityName(String entityName) throws MappingException;
 
 	@Override
-	NativeQueryImplementor<R> addSynchronizedEntityClass(Class<?> entityClass) throws MappingException;
+	NativeQueryImplementor<R> addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) throws MappingException;
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -253,7 +255,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 			Collection<P> values);
 
 	@Override
-	NativeQueryImplementor<R> setParameterList(String name, Collection<?> values);
+	NativeQueryImplementor<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values);
 
 //	@Override
 //	default NativeQueryImplementor<R> setParameterList(String name, Collection values, Type type) {
@@ -269,7 +271,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 //	}
 
 	@Override
-	NativeQueryImplementor<R> setParameterList(String name, Object[] values, AllowableParameterType<?> type);
+	NativeQueryImplementor<R> setParameterList(String name, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	@Override
 	NativeQueryImplementor<R> setParameterList(String name, Object[] values);
@@ -278,7 +280,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> setProperties(Object bean);
 
 	@Override
-	NativeQueryImplementor<R> setProperties(Map<?,?> bean);
+	NativeQueryImplementor<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
 
 	@Override
 	NativeQueryImplementor<R> setParameter(
@@ -314,7 +316,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> setParameter(String name, Instant value, TemporalType temporalType);
 
 	@Override
-	NativeQueryImplementor<R> setTupleTransformer(TupleTransformer transformer);
+	NativeQueryImplementor<R> setTupleTransformer(@SuppressWarnings("rawtypes") TupleTransformer transformer);
 
 	@Override
 	NativeQueryImplementor<R> setResultListTransformer(ResultListTransformer transformer);
@@ -353,7 +355,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> setParameter(Parameter<OffsetDateTime> param, OffsetDateTime value, TemporalType temporalType);
 
 	@Override
-	NativeQueryImplementor<R> setParameterList(int position, Collection<?> values);
+	NativeQueryImplementor<R> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values);
 
 	@Override
 	<P> NativeQueryImplementor<R> setParameterList(String name, Collection<? extends P> values, Class<P> type);
@@ -371,7 +373,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 //	NativeQueryImplementor<R> setParameterList(int position, Object[] values, Type type);
 
 	@Override
-	NativeQueryImplementor<R> setParameterList(int position, Object[] values, AllowableParameterType<?> type);
+	NativeQueryImplementor<R> setParameterList(int position, Object[] values, @SuppressWarnings("rawtypes") AllowableParameterType type);
 
 	@Override
 	NativeQueryImplementor<R> setParameterList(int position, Object[] values);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -541,13 +541,13 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public HqlQueryImplementor<R> applyGraph(RootGraph graph, GraphSemantic semantic) {
+	public HqlQueryImplementor<R> applyGraph(@SuppressWarnings("rawtypes") RootGraph graph, GraphSemantic semantic) {
 		queryOptions.applyGraph( (RootGraphImplementor<?>) graph, semantic );
 		return this;
 	}
 
 	@Override
-	protected void applyEntityGraphQueryHint(String hintName, RootGraphImplementor entityGraph) {
+	protected void applyEntityGraphQueryHint(String hintName, @SuppressWarnings("rawtypes") RootGraphImplementor entityGraph) {
 		final GraphSemantic graphSemantic = GraphSemantic.fromJpaHintName( hintName );
 
 		applyGraph( entityGraph, graphSemantic );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/QueryAndSQLTest.java
@@ -99,11 +99,11 @@ public class QueryAndSQLTest {
 				.currentDate();
 
 		String sql = String.format(
-				"select t.TABLE_NAME as {t.tableName}, %s as {t.daysOld} from ALL_TABLES t  where t.TABLE_NAME = 'AUDIT_ACTIONS' ",
+				"select t.TABLE_NAME as {t.tableName}, %s as {t.daysOld} from ALL_TABLES t where t.TABLE_NAME = 'AUDIT_ACTIONS' ",
 				dateFunctionRendered
 		);
 		String sql2 = String.format(
-				"select TABLE_NAME as t_name, %s as t_time from ALL_TABLES   where TABLE_NAME = 'AUDIT_ACTIONS' ",
+				"select TABLE_NAME as t_name, %s as t_time from ALL_TABLES where TABLE_NAME = 'AUDIT_ACTIONS' ",
 				dateFunctionRendered
 		);
 
@@ -111,7 +111,9 @@ public class QueryAndSQLTest {
 		scope.inTransaction(
 				session -> {
 					session.createNativeQuery( sql ).addEntity( "t", AllTables.class ).list();
+					List<AllTables> allTables = session.createNativeQuery( sql, AllTables.class, "t" ).list();
 					session.createNativeQuery( sql2, "all" ).list();
+					List<String> allTableNames = session.createNativeQuery( sql2, "all", String.class ).list();
 					NativeQuery q = session.createNativeQuery( sql2 );
 					q.addRoot( "t", AllTables.class ).addProperty( "tableName", "t_name" ).addProperty(
 							"daysOld",

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/QueryTest.java
@@ -81,6 +81,19 @@ public class QueryTest extends BaseNonConfigCoreFunctionalTestCase {
 		} );
 	}
 
+	public void testNativeQueryResultWithResultClass() {
+		inTransaction( (session) -> {
+			final NativeQueryImplementor<Object[]> query = session.createNativeQuery( "select id, salary from EMP", "emp_id_salary", Object[].class );
+
+			final List<Object[]> results = query.list();
+			assertThat( results ).hasSize( 1 );
+
+			final Object[] values = results.get( 0 );
+			assertThat( values[0] ).isEqualTo( 1 );
+			assertThat( values[1] ).isEqualTo( SALARY );
+		} );
+	}
+
 	@Test
 	@FailureExpected( jiraKey = "HHH-14975", message = "Not yet implemented" )
 	@NotImplementedYet

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaNativeQueryTest.java
@@ -75,7 +75,7 @@ public class FormulaNativeQueryTest {
 	public void testNativeQueryWithAllFields(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					Query query = session.createNativeQuery(
+					Query<Foo> query = session.createNativeQuery(
 							"SELECT ft.*, abs(locationEnd - locationStart) as distance FROM foo_table ft",
 							Foo.class
 					);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/EntityResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/EntityResultTests.java
@@ -172,6 +172,28 @@ public class EntityResultTests extends AbstractUsageTest {
 	}
 
 	@Test
+	public void testExplicitDiscriminatedMappingWithResultClass(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final String qryString =
+							"select id as id_alias,"
+									+ "   type_code as type_code_alias,"
+									+ "   root_name as root_name_alias,"
+									+ "   subtype1_name as sub_type1_name_alias,"
+									+ "   subtype2_name as sub_type2_name_alias"
+									+ " from discriminated_entity";
+
+					final List<DiscriminatedRoot> results = session.createNativeQuery( qryString, "root-explicit", DiscriminatedRoot.class ).list();
+					assertThat( results.size(), is( 4 ) );
+
+					final Set<Integer> idsFound = new HashSet<>();
+					results.forEach( result -> idsFound.add( result.getId() ) );
+					assertThat( idsFound, containsInAnyOrder( 1, 2, 3, 4 ) );
+				}
+		);
+	}
+
+	@Test
 	public void testConvertedAttributes(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/sql/hand/query/NativeSQLQueriesTest.java
@@ -49,7 +49,6 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.PersistenceException;
@@ -250,6 +249,34 @@ public class NativeSQLQueriesTest {
 					assertEquals( l.size(), 2 );
 
 					l = session.createNativeQuery( getOrgEmpPersonSQL(), "org-emp-person" ).list();
+					assertEquals( l.size(), 1 );
+
+					session.delete(emp);
+					session.delete(gavin);
+					session.delete(ifa);
+					session.delete(jboss);
+				}
+		);
+	}
+
+	@Test
+	public void testResultSetMappingDefinitionWithResultClass(SessionFactoryScope scope) {
+		Organization ifa = new Organization("IFA");
+		Organization jboss = new Organization("JBoss");
+		Person gavin = new Person("Gavin");
+		Employment emp = new Employment(gavin, jboss, "AU");
+
+		scope.inTransaction(
+				session -> {
+					session.persist(ifa);
+					session.persist(jboss);
+					session.persist(gavin);
+					session.persist(emp);
+
+					List<Object[]> l = session.createNativeQuery( getOrgEmpRegionSQL(), "org-emp-regionCode", Object[].class ).list();
+					assertEquals( l.size(), 2 );
+
+					l = session.createNativeQuery( getOrgEmpPersonSQL(), "org-emp-person", Object[].class ).list();
 					assertEquals( l.size(), 1 );
 
 					session.delete(emp);


### PR DESCRIPTION
The main goal of this work is to alleviate the problem of warning in the client program resulting from invocations of raw `Query`s returned by Hibernate `Session` methods.

This is a difficult problem due to the requirements of backward compatibility with ancient versions of Hibernate, and due to the inheritance from `EntityManager` which still uses raw types.

As discussed, I have:

- Preferred the use of `@SuppressWarnings("rawtypes")` to wildcards `<?>` in methods of `Query`.
- `@Deprecated` `createXxxxQuery()` methods which accept no class.
- improved the `createNativeQuery()` methods with additional overloads, and the ability to accept a non-entity result class.

This solution is imperfect, but it's at least an improvement.