### PR TITLE
fix the javadoc of Query.getSingleResult()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -160,15 +160,14 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 
 	/**
 	 * Convenience method to return a single instance that matches
-	 * the query, or {@code null} if the query returns no results.
+	 * the query, throwing an exception if the query returns no results.
 	 *
-	 * @return the single result or <tt>null</tt>
+	 * @return the single result
 	 *
-	 * @throws NonUniqueResultException if there is more than one matching result
+	 * @throws jakarta.persistence.NonUniqueResultException if there is more than one matching result
+	 * @throws jakarta.persistence.NoResultException if there is no result to return
 	 */
-	default R getSingleResult() {
-		return uniqueResult();
-	}
+	R getSingleResult();
 
 	/**
 	 * Convenience method to return a single instance that matches

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -1487,7 +1487,7 @@ public abstract class AbstractQuery<R> implements QueryImplementor<R> {
 	public R getSingleResult() {
 		try {
 			final List<R> list = list();
-			if ( list.size() == 0 ) {
+			if ( list.isEmpty() ) {
 				throw new NoResultException( "No entity found for query" );
 			}
 			return uniqueElement( list );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/ExceptionExpectations.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/ExceptionExpectations.java
@@ -56,6 +56,11 @@ interface ExceptionExpectations {
 			}
 
 			@Override
+			public void onUniqueResultWithMultipleResults(RuntimeException e) {
+				assertThat( e, instanceOf( org.hibernate.NonUniqueResultException.class ) );
+			}
+
+			@Override
 			public void onGetSingleResultWithMultipleResults(RuntimeException e) {
 				assertThat( e, instanceOf( jakarta.persistence.NonUniqueResultException.class ) );
 			}
@@ -134,6 +139,11 @@ interface ExceptionExpectations {
 			}
 
 			@Override
+			public void onUniqueResultWithMultipleResults(RuntimeException e) {
+				assertThat( e, instanceOf( org.hibernate.NonUniqueResultException.class ) );
+			}
+
+			@Override
 			public void onGetSingleResultWithMultipleResults(RuntimeException e) {
 				assertThat( e, instanceOf( org.hibernate.NonUniqueResultException.class ) );
 			}
@@ -209,6 +219,11 @@ interface ExceptionExpectations {
 			}
 
 			@Override
+			public void onUniqueResultWithMultipleResults(RuntimeException e) {
+				assertThat( e, instanceOf( org.hibernate.NonUniqueResultException.class ) );
+			}
+
+			@Override
 			public void onGetSingleResultWithMultipleResults(RuntimeException e) {
 				assertThat( e, instanceOf( jakarta.persistence.NonUniqueResultException.class ) );
 			}
@@ -265,6 +280,8 @@ interface ExceptionExpectations {
 	void onTransientObjectOnPersistAndMergeAndFlush(RuntimeException e);
 
 	void onInvalidQueryExecuted(RuntimeException e);
+
+	void onUniqueResultWithMultipleResults(RuntimeException e);
 
 	void onGetSingleResultWithMultipleResults(RuntimeException e);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/QueryExceptionHandlingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/QueryExceptionHandlingTest.java
@@ -64,6 +64,19 @@ public class QueryExceptionHandlingTest extends BaseExceptionHandlingTest {
 	}
 
 	@Test
+	public void testUniqueResultWithMultipleResults() {
+		try {
+			TransactionUtil2.inSession( sessionFactory(), s -> {
+				s.createQuery( "from A where id in (1, 2)" ).uniqueResult();
+			} );
+			fail( "should have thrown an exception" );
+		}
+		catch (RuntimeException expected) {
+			exceptionExpectations.onUniqueResultWithMultipleResults( expected );
+		}
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HHH-13300")
 	public void testGetSingleResultWithMultipleResults() {
 		try {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
@@ -16,6 +16,7 @@ import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Query;
@@ -1509,6 +1510,25 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			assertTyping( NoResultException.class, e );
 		}
 		finally {
+			entityManager.close();
+		}
+	}
+
+	@Test
+	public void testGetSingleResultWithManyResultsException() {
+		final EntityManager entityManager  = getOrCreateEntityManager();
+		try {
+			entityManager.getTransaction().begin();
+			entityManager.persist( new Item( "1", "1" ) );
+			entityManager.persist( new Item( "2", "2" ) );
+			entityManager.createQuery( "FROM Item" ).getSingleResult();
+			fail( "Expected NoResultException" );
+		}
+		catch ( Exception e ) {
+			assertTyping( NonUniqueResultException.class, e );
+		}
+		finally {
+			entityManager.getTransaction().rollback();
 			entityManager.close();
 		}
 	}


### PR DESCRIPTION
which incorrectly described the semantics of this method