### PR TITLE
propose Query.getSingleResultOrNull()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -1002,6 +1002,24 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
+	public R getSingleResultOrNull() {
+		final List<R> resultList = getResultList();
+		if ( resultList == null || resultList.isEmpty() ) {
+			return null;
+		}
+		else if ( resultList.size() > 1 ) {
+			throw new NonUniqueResultException(
+					String.format(
+							"Call to stored procedure [%s] returned multiple results",
+							getProcedureName()
+					)
+			);
+		}
+
+		return resultList.get( 0 );
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T unwrap(Class<T> cls) {
 		if ( cls.isInstance( this ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -183,7 +183,7 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * Execute the query and return the single result of the query,
 	 * or {@code null} if the query returns no results.
 	 *
-	 * @return the single result or {@code null}
+	 * @return the single result or {@code null} if there is no result to return
 	 *
 	 * @throws NonUniqueResultException if there is more than one matching result
 	 */
@@ -199,6 +199,16 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	 * @throws jakarta.persistence.NoResultException if there is no result to return
 	 */
 	R getSingleResult();
+
+	/**
+	 * Execute the query and return the single result of the query,
+	 * or {@code null} if the query returns no results.
+	 *
+	 * @return the single result or {@code null} if there is no result to return
+	 *
+	 * @throws jakarta.persistence.NonUniqueResultException if there is more than one matching result
+	 */
+	R getSingleResultOrNull();
 
 	/**
 	 * Execute the query and return the single result of the query,

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -1497,6 +1497,16 @@ public abstract class AbstractQuery<R> implements QueryImplementor<R> {
 		}
 	}
 
+	@Override
+	public R getSingleResultOrNull() {
+		try {
+			return uniqueElement( list() );
+		}
+		catch ( HibernateException e ) {
+			throw getSession().getExceptionConverter().convert( e, getLockOptions() );
+		}
+	}
+
 	@SuppressWarnings("WeakerAccess")
 	public static <R> R uniqueElement(List<R> list) throws NonUniqueResultException {
 		int size = list.size();


### PR DESCRIPTION
This is a method we have in Hibernate Reactive.

It's _very_ similar to the existing `uniqueResult()` method, but its name is much clearer, and it throws the JPA exception type.

The main reason for introducing this is so that:

1. users can find it more easily, and
2. people reading the code understand what's going on (it's not clear with `uniqueResult()`).

I doubt that many people appreciate the difference between `getSingleResult()`  and `uniqueResult()`, especially since the Javadoc in Hibernate has been incorrect for a long time.