### PR TITLE
id(), version(), and naturalid()

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
@@ -974,6 +974,16 @@ Next, functions for working with numeric values:
 | `greatest()` | Return the largest of the given arguments | `greatest(x, y, z)` | Very common in SQL dialects
 |===
 
+Functions that evaluate to id, version, or natural id of an entity:
+
+|===
+| HQL Function | Purpose
+
+| `id()` | The value of the entity `@Id` attribute.
+| `version()` | The value of the entity `@Version` attribute.
+| `naturalid()` | The value of the entity `@NaturalId` attribute.
+|===
+
 Finally, specialized functions for working with collection-valued attributes and to-many associations:
 
 |===

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -288,7 +288,12 @@ public class MetadataContext {
 						);
 						if ( attribute != null ) {
 							( (AttributeContainer<Object>) jpaMapping ).getInFlightAccess().addAttribute( attribute );
+							if ( property.isNaturalIdentifier() ) {
+								( ( AttributeContainer<Object>) jpaMapping ).getInFlightAccess()
+										.applyNaturalIdAttribute( attribute );
+							}
 						}
+
 					}
 
 					( (AttributeContainer<?>) jpaMapping ).getInFlightAccess().finishUp();
@@ -313,6 +318,7 @@ public class MetadataContext {
 
 					applyIdMetadata( safeMapping, jpaType );
 					applyVersionAttribute( safeMapping, jpaType );
+//					applyNaturalIdAttribute( safeMapping, jpaType );
 
 					Iterator<Property> properties = safeMapping.getDeclaredPropertyIterator();
 					while ( properties.hasNext() ) {
@@ -324,6 +330,10 @@ public class MetadataContext {
 						final PersistentAttribute<Object, ?> attribute = attributeFactory.buildAttribute( jpaType, property );
 						if ( attribute != null ) {
 							( (AttributeContainer<Object>) jpaType ).getInFlightAccess().addAttribute( attribute );
+							if ( property.isNaturalIdentifier() ) {
+								( ( AttributeContainer<Object>) jpaType ).getInFlightAccess()
+										.applyNaturalIdAttribute( attribute );
+							}
 						}
 					}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.metamodel.model.domain;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import jakarta.persistence.metamodel.IdentifiableType;
@@ -49,4 +50,6 @@ public interface IdentifiableDomainType<J> extends ManagedDomainType<J>, Identif
 	void visitIdClassAttributes(Consumer<SingularPersistentAttribute<? super J,?>> action);
 
 	SingularPersistentAttribute<? super J, ?> findVersionAttribute();
+
+	List<? extends PersistentAttribute<? super J, ?>> findNaturalIdAttributes();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AttributeContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AttributeContainer.java
@@ -60,6 +60,11 @@ public interface AttributeContainer<J> {
 			);
 		}
 
+		default void applyNaturalIdAttribute(PersistentAttribute<J, ?> versionAttribute) {
+			throw new UnsupportedMappingException(
+					"AttributeContainer [" + getClass().getName() + "] does not support natural ids"
+			);
+		}
 
 		/**
 		 * Called when configuration of the type is complete

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -468,6 +468,11 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
+	public List<? extends SingularPersistentAttribute<? super T, ?>> findNaturalIdAttributes() {
+		throw new UnsupportedOperationException(  );
+	}
+
+	@Override
 	public boolean hasSingleIdAttribute() {
 		throw new UnsupportedOperationException(  );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -61,6 +61,20 @@ public class FunctionTests {
 	}
 
 	@Test
+	public void testIdVersionFunctions(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery("select id(w) from VersionedEntity w")
+							.list();
+					session.createQuery("select version(w) from VersionedEntity w")
+							.list();
+					session.createQuery("select naturalid(w) from VersionedEntity w")
+							.list();
+				}
+		);
+	}
+
+	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsCharCodeConversion.class)
 	public void testAsciiChrFunctions(SessionFactoryScope scope) {
 		scope.inTransaction(

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/GambitDomainModel.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/GambitDomainModel.java
@@ -17,6 +17,7 @@ public class GambitDomainModel extends AbstractDomainModelDescriptor {
 	public GambitDomainModel() {
 		super(
 				BasicEntity.class,
+				VersionedEntity.class,
 				Component.class,
 				EmbeddedIdEntity.class,
 				EntityOfArrays.class,

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/VersionedEntity.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/VersionedEntity.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.orm.domain.gambit;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.NaturalId;
+
+import java.util.Objects;
+
+/**
+ * @author Chris Cranford
+ */
+@Entity
+public class VersionedEntity {
+	@Id
+	private Integer id;
+	@Version
+	private Integer version;
+	@NaturalId
+	private String code;
+	private String data;
+
+	public VersionedEntity() {
+
+	}
+
+	public VersionedEntity(Integer id, String data) {
+		this.id = id;
+		this.data = data;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getData() {
+		return data;
+	}
+
+	public void setData(String data) {
+		this.data = data;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		VersionedEntity that = (VersionedEntity) o;
+		return Objects.equals( id, that.id ) &&
+				Objects.equals( data, that.data );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( id, data );
+	}
+}


### PR DESCRIPTION
I noticed that the grammar defines `id()`, `version()`, and `naturalid()` functions.

Two of these were already working, but weren't documented, and I could not find where they were tested. So I added documentation and tests.

`naturalid()` was unimplemented, so I (roughly) implemented it, at least for the case of a single`@NaturalId` field.