### PR TITLE
createStatement() methods for QueryProducer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -50,6 +50,8 @@ import org.hibernate.jdbc.ReturningWork;
 import org.hibernate.jdbc.Work;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
@@ -524,6 +526,21 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override @SuppressWarnings({"rawtypes", "unchecked"})
 	public NativeQueryImplementor createNativeQuery(String sqlString, String resultSetMappingName, Class resultClass) {
 		return queryDelegate().createNativeQuery( sqlString, resultSetMappingName, resultClass );
+	}
+
+	@Override
+	public QueryImplementor<Void> createStatement(String statementString) {
+		return delegate.createStatement( statementString );
+	}
+
+	@Override
+	public QueryImplementor<Void> createNamedStatement(String name) {
+		return delegate.createNamedStatement( name );
+	}
+
+	@Override
+	public NativeQueryImplementor<Void> createNativeStatement(String sqlString) {
+		return delegate.createNativeStatement( sqlString );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -57,6 +57,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.procedure.internal.ProcedureCallImpl;
 import org.hibernate.procedure.spi.NamedCallableQueryMemento;
+import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.hql.spi.HqlQueryImplementor;
@@ -879,6 +880,21 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 
 		throw getExceptionConverter().convert( new IllegalArgumentException( "No query defined for that name [" + queryName + "]" ) );
+	}
+
+	@Override @SuppressWarnings("unchecked")
+	public QueryImplementor<Void> createStatement(String statementString) {
+		return createQuery(statementString);
+	}
+
+	@Override @SuppressWarnings("unchecked")
+	public QueryImplementor<Void> createNamedStatement(String name) {
+		return createNamedQuery(name);
+	}
+
+	@Override @SuppressWarnings("unchecked")
+	public NativeQueryImplementor<Void> createNativeStatement(String sqlString) {
+		return createNativeQuery(sqlString);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -120,27 +120,35 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	ScrollableResults<R> scroll(ScrollMode scrollMode);
 
 	/**
-	 * Return the query results as a {@code List}. If the query contains
-	 * multiple results per row, the results are returned in an instance
-	 * of {@code Object[]}.
+	 * Execute the query and return the query results as a {@link List}.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the list is packaged in an array of type
+	 * {@code Object[]}.
 	 *
 	 * @return the result list
 	 */
 	List<R> list();
 
 	/**
-	 * Return the query results as a {@link List}. If the query contains
-	 * multiple results per row, the results are returned in an instance
-	 * of {@code Object[]}.
+	 * Execute the query and return the query results as a {@link List}.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the list is packaged in an array of type
+	 * {@code Object[]}.
 	 *
-	 * @return the results as a  list
+	 * @return the results as a list
 	 */
 	default List<R> getResultList() {
 		return list();
 	}
 
 	/**
-	 * Retrieve a {@link Stream} over the query results.
+	 * Execute the query and return the query results as a {@link Stream}.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the stream is packaged in an array of type
+	 * {@code Object[]}.
+	 * <p>
+	 * The client should call {@link Stream#close()} after processing the
+	 * stream so that resources are freed as soon as possible.
 	 *
 	 * @return The results as a {@link Stream}
 	 */
@@ -149,8 +157,31 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	}
 
 	/**
-	 * Convenience method to return a single instance that matches
-	 * the query, or {@code null} if the query returns no results.
+	 * Execute an insert, update, or delete statement, and return the
+	 * number of affected entities.
+	 * <p>
+	 * For use with instances of {@code Query<Void>} created using
+	 * {@link QueryProducer#createStatement(String)},
+	 * {@link QueryProducer#createNamedStatement(String)},
+	 * {@link QueryProducer#createNativeStatement(String)},
+	 * {@link QueryProducer#createQuery(jakarta.persistence.criteria.CriteriaUpdate)}, or
+	 * {@link QueryProducer#createQuery(jakarta.persistence.criteria.CriteriaDelete)}.
+	 *
+	 * @return the number of affected entity instances
+	 *         (may differ from the number of affected rows)
+	 *
+	 * @see QueryProducer#createStatement(String)
+	 * @see QueryProducer#createNamedStatement(String)
+	 * @see QueryProducer#createNativeStatement(String)
+	 *
+	 * @see jakarta.persistence.Query#executeUpdate()
+	 */
+	@Override
+	int executeUpdate();
+
+	/**
+	 * Execute the query and return the single result of the query,
+	 * or {@code null} if the query returns no results.
 	 *
 	 * @return the single result or {@code null}
 	 *
@@ -159,8 +190,8 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	R uniqueResult();
 
 	/**
-	 * Convenience method to return a single instance that matches
-	 * the query, throwing an exception if the query returns no results.
+	 * Execute the query and return the single result of the query,
+	 * throwing an exception if the query returns no results.
 	 *
 	 * @return the single result, only if there is exactly one
 	 *
@@ -170,8 +201,8 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	R getSingleResult();
 
 	/**
-	 * Convenience method to return a single instance that matches
-	 * the query, as an {@link Optional}.
+	 * Execute the query and return the single result of the query,
+	 * as an {@link Optional}.
 	 *
 	 * @return the single result as an {@code Optional}
 	 *
@@ -180,15 +211,15 @@ public interface Query<R> extends TypedQuery<R>, CommonQueryContract {
 	Optional<R> uniqueResultOptional();
 
 	/**
-	 * Retrieve a Stream over the query results.
-	 * <p/>
-	 * In the initial implementation (5.2) this returns a simple sequential Stream.  The plan
-	 * is to return a smarter stream in 6.x leveraging the SQM model.
+	 * Execute the query and return the query results as a {@link Stream}.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the stream is packaged in an array of type
+	 * {@code Object[]}.
 	 * <p>
-	 * You should call {@link Stream#close()} after processing the stream
-	 * so that the underlying resources are deallocated right away.
+	 * The client should call {@link Stream#close()} after processing the
+	 * stream so that resources are freed as soon as possible.
 	 *
-	 * @return The results Stream
+	 * @return The results as a {@link Stream}
 	 *
 	 * @since 5.2
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -21,20 +21,24 @@ import jakarta.persistence.criteria.CriteriaUpdate;
  */
 public interface QueryProducer {
 	/**
-	 * Create a {@link Query} instance for the given HQL/JPQL query string.
+	 * Create a {@link Query} instance for the given HQL/JPQL query, or
+	 * HQL/JPQL insert, update, or delete statement.
 	 *
 	 * @param queryString The HQL/JPQL query
 	 *
 	 * @return The Query instance for manipulation and execution
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(String)
-	 * @deprecated use {@link #createQuery(String, Class)}
+	 * @deprecated use {@link #createQuery(String, Class)} or {@link #createStatement(String)}
 	 */
 	@Deprecated @SuppressWarnings("rawtypes")
 	Query createQuery(String queryString);
 
 	/**
 	 * Create a typed {@link Query} instance for the given HQL/JPQL query string.
+	 * <p>
+	 * The returned {@code Query} may be executed by calling
+	 * {@link Query#getResultList()} or {@link Query#getSingleResult()}.
 	 *
 	 * @param queryString The HQL/JPQL query
 	 * @param resultClass The type of the query result
@@ -45,8 +49,20 @@ public interface QueryProducer {
 	<R> Query<R> createQuery(String queryString, Class<R> resultClass);
 
 	/**
-	 * The JPA-defined named query creation method.  This form can represent an
-	 * HQL/JPQL query or a native query.
+	 * Create a typed {@link Query} instance for the given HQL/JPQL insert,
+	 * update, or delete statement.
+	 * <p>
+	 * The returned {@code Query} must be executed by calling
+	 * {@link Query#executeUpdate()}.
+	 *
+	 * @param statementString The HQL/JPQL insert, update, or delete statement
+	 * @return The Query instance for manipulation and execution
+	 */
+	Query<Void> createStatement(String statementString);
+
+	/**
+	 * Create a typed {@link Query} instance for the given named query.
+	 * The named query might be defined in HQL or in native SQL.
 	 *
 	 * @param name the name of a pre-defined, named query
 	 *
@@ -58,14 +74,14 @@ public interface QueryProducer {
 	 *
 	 * @see jakarta.persistence.EntityManager#createNamedQuery(String)
 	 * 
-	 * @deprecated use {@link #createNamedQuery(String, Class)}
+	 * @deprecated use {@link #createNamedQuery(String, Class)} or {@link #createNamedStatement(String)}
 	 */
 	@Deprecated @SuppressWarnings("rawtypes")
 	Query createNamedQuery(String name);
 
 	/**
-	 * The JPA-defined named, typed query creation method.  This form can only
-	 * represent an HQL/JPQL query (not a native query).
+	 * Create a typed {@link Query} instance for the given named query.
+	 * The named query might be defined in HQL or in native SQL.
 	 *
 	 * @param name the name of a query defined in metadata
 	 * @param resultClass the type of the query result
@@ -82,7 +98,22 @@ public interface QueryProducer {
 	<R> Query<R> createNamedQuery(String name, Class<R> resultClass);
 
 	/**
-	 * Create a NativeQuery instance for the given native (SQL) query
+	 * Create a typed {@link Query} instance for the given named insert,
+	 * update, or delete statement. The named query might be defined in
+	 * HQL or in native SQL.
+	 *
+	 * @param name the name of a pre-defined, named query
+	 *
+	 * @return The Query instance for manipulation and execution
+	 *
+	 * @throws IllegalArgumentException if a query has not been
+	 * defined with the given name or if the query string is
+	 * found to be invalid
+	 */
+	Query<Void> createNamedStatement(String name);
+
+	/**
+	 * Create a {@link NativeQuery} instance for the given native (SQL) query
 	 *
 	 * @param sqlString a native SQL query string
 	 *
@@ -96,7 +127,7 @@ public interface QueryProducer {
 	NativeQuery createNativeQuery(String sqlString);
 
 	/**
-	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * Create a {@link NativeQuery} instance for the given native (SQL) query using
 	 * implicit mapping to the specified Java type.
 	 * <p>
 	 * If the given class is an entity class, this method is equivalent to
@@ -112,7 +143,7 @@ public interface QueryProducer {
 	<R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass);
 
 	/**
-	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * Create a {@link NativeQuery} instance for the given native (SQL) query using
 	 * implicit mapping to the specified Java type.
 	 * <p>
 	 * If the given class is an entity class, this method is equivalent to
@@ -129,7 +160,7 @@ public interface QueryProducer {
 	<R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass, String tableAlias);
 
 	/**
-	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * Create a {@link NativeQuery} instance for the given native (SQL) query using
 	 * implicit mapping to the specified Java type.
 	 *
 	 * @param sqlString Native (SQL) query string
@@ -146,7 +177,7 @@ public interface QueryProducer {
 	NativeQuery createNativeQuery(String sqlString, String resultSetMappingName);
 
 	/**
-	 * Create a NativeQuery instance for the given native (SQL) query using
+	 * Create a {@link NativeQuery} instance for the given native (SQL) query using
 	 * implicit mapping to the specified Java type.
 	 *
 	 * @param sqlString Native (SQL) query string
@@ -160,21 +191,30 @@ public interface QueryProducer {
 	<R> NativeQuery<R> createNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass);
 
 	/**
-	 * Create a Query for the given JPA {@link CriteriaQuery}
+	 * Create a {@link NativeQuery} instance for the given native (SQL) statement
+	 *
+	 * @param sqlString a native SQL statement string
+	 *
+	 * @return The NativeQuery instance for manipulation and execution
+	 */
+	NativeQuery<Void> createNativeStatement(String sqlString);
+
+	/**
+	 * Create a {@link Query} for the given JPA {@link CriteriaQuery}
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(CriteriaQuery)
 	 */
 	<R> Query<R> createQuery(CriteriaQuery<R> criteriaQuery);
 
 	/**
-	 * Create a Query for the given JPA {@link CriteriaUpdate}
+	 * Create a {@link Query} for the given JPA {@link CriteriaUpdate}
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(CriteriaUpdate)
 	 */
 	Query<Void> createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate updateQuery);
 
 	/**
-	 * Create a Query for the given JPA {@link CriteriaDelete}
+	 * Create a {@link Query} for the given JPA {@link CriteriaDelete}
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(CriteriaDelete)
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryProducerImplementor.java
@@ -12,6 +12,8 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
 import org.hibernate.query.QueryProducer;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
 
@@ -32,19 +34,19 @@ public interface QueryProducerImplementor extends QueryProducer {
 	@Override @SuppressWarnings("rawtypes")
 	QueryImplementor getNamedQuery(String queryName);
 
-	@Override @SuppressWarnings("rawtypes")
+	@Override @Deprecated @SuppressWarnings("rawtypes")
 	QueryImplementor createQuery(String queryString);
 
 	@Override
 	<R> QueryImplementor<R> createQuery(String queryString, Class<R> resultClass);
 
-	@Override @SuppressWarnings("rawtypes")
+	@Override @Deprecated @SuppressWarnings("rawtypes")
 	QueryImplementor createNamedQuery(String name);
 
 	@Override
 	<R> QueryImplementor<R> createNamedQuery(String name, Class<R> resultClass);
 
-	@Override @SuppressWarnings("rawtypes")
+	@Override @Deprecated @SuppressWarnings("rawtypes")
 	NativeQueryImplementor createNativeQuery(String sqlString);
 
 	@Override
@@ -64,6 +66,15 @@ public interface QueryProducerImplementor extends QueryProducer {
 
 	@Override @SuppressWarnings("rawtypes")
 	NativeQueryImplementor getNamedNativeQuery(String name, String resultSetMapping);
+
+	@Override
+	QueryImplementor<Void> createStatement(String statementString);
+
+	@Override
+	QueryImplementor<Void> createNamedStatement(String name);
+
+	@Override
+	NativeQueryImplementor<Void> createNativeStatement(String sqlString);
 
 	@Override
 	<R> QueryImplementor<R> createQuery(CriteriaQuery<R> criteriaQuery);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertUpdateTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertUpdateTests.java
@@ -11,7 +11,6 @@ import org.hibernate.testing.orm.domain.contacts.Contact;
 import org.hibernate.testing.orm.domain.contacts.Contact.Name;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -33,9 +32,9 @@ public class InsertUpdateTests {
 	public void testUpdate(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("update Ticket set subject = 'Outage', details = 'The service is down' where id = 1").executeUpdate();
-					session.createQuery("update Ticket t set t.subject = 'Outage' where t.id = 1").executeUpdate();
-					session.createQuery("update Ticket t set t.subject = upper(t.subject) where t.id = 1").executeUpdate();
+					session.createStatement("update Ticket set subject = 'Outage', details = 'The service is down' where id = 1").executeUpdate();
+					session.createStatement("update Ticket t set t.subject = 'Outage' where t.id = 1").executeUpdate();
+					session.createStatement("update Ticket t set t.subject = upper(t.subject) where t.id = 1").executeUpdate();
 				}
 		);
 	}
@@ -44,7 +43,7 @@ public class InsertUpdateTests {
 	public void testUpdateSecondaryTable(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("update Contact set birthDay = local date").executeUpdate();
+					session.createStatement("update Contact set birthDay = local date").executeUpdate();
 				}
 		);
 	}
@@ -53,7 +52,7 @@ public class InsertUpdateTests {
 	public void testUpdateEmbedded(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("update Contact set name.first = 'Hibernate'").executeUpdate();
+					session.createStatement("update Contact set name.first = 'Hibernate'").executeUpdate();
 				}
 		);
 	}
@@ -62,8 +61,8 @@ public class InsertUpdateTests {
 	public void testDelete(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("delete from Ticket where id = 1").executeUpdate();
-					session.createQuery("delete from Ticket t where t.id = 1").executeUpdate();
+					session.createStatement("delete from Ticket where id = 1").executeUpdate();
+					session.createStatement("delete from Ticket t where t.id = 1").executeUpdate();
 				}
 		);
 	}
@@ -77,7 +76,7 @@ public class InsertUpdateTests {
 					contact.setName( new Name("Hibernate", "ORM") );
 					contact.setBirthDay( LocalDate.now() );
 					session.persist(contact);
-					session.createQuery("delete from Contact").executeUpdate();
+					session.createStatement("delete from Contact").executeUpdate();
 				}
 		);
 	}
@@ -86,8 +85,8 @@ public class InsertUpdateTests {
 	public void testInsertValues(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("delete from Ticket").executeUpdate();
-					session.createQuery("insert into Ticket (id, key, subject, details) values (6, 'ABC123', 'Outage', 'Something is broken')").executeUpdate();
+					session.createStatement("delete from Ticket").executeUpdate();
+					session.createStatement("insert into Ticket (id, key, subject, details) values (6, 'ABC123', 'Outage', 'Something is broken')").executeUpdate();
 				}
 		);
 	}
@@ -97,8 +96,8 @@ public class InsertUpdateTests {
 	public void testInsertMultipleValues(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("delete from Ticket").executeUpdate();
-					session.createQuery("insert into Ticket (id, key, subject, details) values (2, 'XYZ123', 'Outage', 'Something is broken'), (13, 'HIJ456', 'x', 'x')").executeUpdate();
+					session.createStatement("delete from Ticket").executeUpdate();
+					session.createStatement("insert into Ticket (id, key, subject, details) values (2, 'XYZ123', 'Outage', 'Something is broken'), (13, 'HIJ456', 'x', 'x')").executeUpdate();
 				}
 		);
 	}
@@ -107,9 +106,9 @@ public class InsertUpdateTests {
 	public void testInsertSelect(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("delete from Ticket").executeUpdate();
-					session.createQuery("insert into Ticket (id, key, subject, details) select 6, 'ABC123', 'Outage', 'Something is broken'").executeUpdate();
-					session.createQuery("insert into Ticket (id, key, subject, details) select 13, 'DEF456', tt.subject, tt.details from Ticket tt").executeUpdate();
+					session.createStatement("delete from Ticket").executeUpdate();
+					session.createStatement("insert into Ticket (id, key, subject, details) select 6, 'ABC123', 'Outage', 'Something is broken'").executeUpdate();
+					session.createStatement("insert into Ticket (id, key, subject, details) select 13, 'DEF456', tt.subject, tt.details from Ticket tt").executeUpdate();
 				}
 		);
 	}
@@ -118,9 +117,9 @@ public class InsertUpdateTests {
 	public void testAliasedInsertSelect(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery("delete from Ticket").executeUpdate();
-					session.createQuery("insert into Ticket t (t.id, t.key, t.subject, t.details) select 12, 'ABC123', 'Outage', 'Something is broken'").executeUpdate();
-					session.createQuery("insert into Ticket as t (t.id, t.key, t.subject, t.details) select 5, 'DEF456', tt.subject, tt.details from Ticket tt").executeUpdate();
+					session.createStatement("delete from Ticket").executeUpdate();
+					session.createStatement("insert into Ticket t (t.id, t.key, t.subject, t.details) select 12, 'ABC123', 'Outage', 'Something is broken'").executeUpdate();
+					session.createStatement("insert into Ticket as t (t.id, t.key, t.subject, t.details) select 5, 'DEF456', tt.subject, tt.details from Ticket tt").executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertWithSubSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/InsertWithSubSelectTest.java
@@ -33,7 +33,7 @@ public class InsertWithSubSelectTest {
 	public void testInsert(SessionFactoryScope scope) {
 		scope.inTransaction(
 				(session) -> {
-					session.createQuery(
+					session.createStatement(
 							"insert into C (id) " +
 									"select a.id from A a " +
 									"where exists (" +

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/LiteralTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/LiteralTests.java
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"deprecation","WeakerAccess"})
 @ServiceRegistry
 @DomainModel( standardModels = StandardDomainModel.GAMBIT )
 @SessionFactory

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/NamedHqlQueriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/NamedHqlQueriesTest.java
@@ -69,11 +69,10 @@ public class NamedHqlQueriesTest {
 	@AfterEach
 	public void tearDown(SessionFactoryScope scope) {
 		scope.inTransaction(
-				session -> {
-					session.createQuery( "from VideoGame vg" )
-							.list()
-							.forEach( vg -> session.delete( vg ) );
-				} );
+				session -> session.createQuery( "from VideoGame vg", VideoGame.class )
+						.list()
+						.forEach(session::delete)
+		);
 	}
 
 	@Entity(name = "VideoGame")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/OrderByTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/OrderByTests.java
@@ -17,9 +17,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
-import org.hibernate.query.hql.HqlTranslator;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
 import org.hibernate.orm.test.hql.Address;
@@ -215,38 +213,44 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by name, address"
+						"select name, address from Zoo order by name, address",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.name, z.address"
+						"select z.name, z.address from Zoo z order by z.name, z.address",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z2.name, z2.address from Zoo z2 where z2.name in ( select name from Zoo ) order by z2.name, z2.address"
+						"select z2.name, z2.address from Zoo z2 where z2.name in ( select name from Zoo ) order by z2.name, z2.address",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		// using ASC
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by name ASC, address ASC"
+						"select name, address from Zoo order by name ASC, address ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.name ASC, z.address ASC"
+						"select z.name, z.address from Zoo z order by z.name ASC, z.address ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z2.name, z2.address from Zoo z2 where z2.name in ( select name from Zoo ) order by z2.name ASC, z2.address ASC"
+						"select z2.name, z2.address from Zoo z2 where z2.name in ( select name from Zoo ) order by z2.name ASC, z2.address ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
@@ -277,7 +281,8 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 								"    z.address.city," +
 								"    z.address.postalCode, " +
 								"    z.address.country," +
-								"    z.name"
+								"    z.name",
+						Object[].class
 				).list(),
 				zoo3, zoo4, zoo2, zoo1, null
 		);
@@ -290,7 +295,8 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.address, z.name"
+						"select z.name, z.address from Zoo z order by z.address, z.name",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
@@ -298,14 +304,16 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		// NOTE (6.0) - continued 3 : and the functionally equiv "full ordering"
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.address.city, z.address.country, z.address.stateProvince, z.address.street, z.name"
+						"select z.name, z.address from Zoo z order by z.address.city, z.address.country, z.address.stateProvince, z.address.street, z.name",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
 
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by address, name"
+						"select name, address from Zoo order by address, name",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
@@ -327,13 +335,15 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//		is the order used by 5.x
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.address.street, z.address.city"
+						"select z.name, z.address from Zoo z order by z.address.street, z.address.city",
+						Object[].class
 				).list(),
 				zoo3, zoo4, null, null, zoosWithSameAddress
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by address.street, address.city"
+						"select name, address from Zoo order by address.street, address.city",
+						Object[].class
 				).list(),
 				zoo3, zoo4, null, null, zoosWithSameAddress
 		);
@@ -346,13 +356,15 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.name"
+						"select z.name, z.address from Zoo z order by z.name",
+						Object[].class
 				).list(),
 				zoo2, zoo4, null, null, zoosWithSameName
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by name"
+						"select name, address from Zoo order by name",
+						Object[].class
 				).list(),
 				zoo2, zoo4, null, null, zoosWithSameName
 		);
@@ -376,13 +388,15 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address from Zoo z order by z.address DESC, z.name DESC"
+						"select z.name, z.address from Zoo z order by z.address DESC, z.name DESC",
+						Object[].class
 				).list(),
 				zoo4, zoo1, zoo2, zoo3, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select name, address from Zoo order by address DESC, name DESC"
+						"select name, address from Zoo order by address DESC, name DESC",
+						Object[].class
 				).list(),
 				zoo4, zoo1, zoo2, zoo3, null
 		);
@@ -405,62 +419,72 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z2.name as zname, z2.address as zooAddress from Zoo z2 where z2.name in ( select name from Zoo ) order by zname, zooAddress"
+						"select z2.name as zname, z2.address as zooAddress from Zoo z2 where z2.name in ( select name from Zoo ) order by zname, zooAddress",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as name, z.address as address from Zoo z order by name, address"
+						"select z.name as name, z.address as address from Zoo z order by name, address",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName, zooAddress"
+						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName, zooAddress",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by z.name, name"
+						"select z.name, z.address as name from Zoo z order by z.name, name",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by z.name, name"
+						"select z.name, z.address as name from Zoo z order by z.name, name",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		// using ASC
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z2.name as zname, z2.address as zooAddress from Zoo z2 where z2.name in ( select name from Zoo ) order by zname ASC, zooAddress ASC"
+						"select z2.name as zname, z2.address as zooAddress from Zoo z2 where z2.name in ( select name from Zoo ) order by zname ASC, zooAddress ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as name, z.address as address from Zoo z order by name ASC, address ASC"
+						"select z.name as name, z.address as address from Zoo z order by name ASC, address ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName ASC, zooAddress ASC"
+						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName ASC, zooAddress ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by z.name ASC, name ASC"
+						"select z.name, z.address as name from Zoo z order by z.name ASC, name ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by z.name ASC, name ASC"
+						"select z.name, z.address as name from Zoo z order by z.name ASC, name ASC",
+						Object[].class
 				).list(),
 				zoo2, zoo4, zoo3, zoo1, null
 		);
@@ -479,26 +503,30 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as address, z.address as name from Zoo z order by name, address"
+						"select z.name as address, z.address as name from Zoo z order by name, address",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by name, z.name"
+						"select z.name, z.address as name from Zoo z order by name, z.name",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
 		// using ASC
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as address, z.address as name from Zoo z order by name ASC, address ASC"
+						"select z.name as address, z.address as name from Zoo z order by name ASC, address ASC",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name, z.address as name from Zoo z order by name ASC, z.name ASC"
+						"select z.name, z.address as name from Zoo z order by name ASC, z.name ASC",
+						Object[].class
 				).list(),
 				zoo3, zoo2, zoo1, zoo4, null
 		);
@@ -534,14 +562,16 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName"
+						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooName",
+						Object[].class
 				).list(),
 				zoo2, zoo4, null, null, zoosWithSameName
 		);
 
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as address, z.address as name from Zoo z order by address"
+						"select z.name as address, z.address as name from Zoo z order by address",
+						Object[].class
 				).list(),
 				zoo2, zoo4, null, null, zoosWithSameName
 		);
@@ -566,7 +596,8 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		// using DESC
 		checkTestOrderByResults(
 				s.createQuery(
-						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooAddress DESC, zooName DESC"
+						"select z.name as zooName, z.address as zooAddress from Zoo z order by zooAddress DESC, zooName DESC",
+						Object[].class
 				).list(),
 				zoo4, zoo1, zoo2, zoo3, null
 		);
@@ -590,7 +621,7 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo2  A Zoo       1313 Mockingbird Lane, Anywhere, IL USA
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
 		// using DESC
-		List list = s.createQuery( "from Zoo z join fetch z.mammals" ).list();
+		List<Zoo> list = s.createQuery( "from Zoo z join fetch z.mammals", Zoo.class ).list();
 
 		t.commit();
 		s.close();
@@ -610,9 +641,10 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
-		List list =
+		List<Zoo> list =
 				s.createQuery(
-						"select new Zoo( z.name as zname, z.address as zaddress) from Zoo z order by zname, zaddress"
+						"select new Zoo( z.name as zname, z.address as zaddress) from Zoo z order by zname, zaddress",
+						Zoo.class
 				).list();
 		assertEquals( 4, list.size() );
 		assertEquals( zoo2, list.get( 0 ) );
@@ -627,7 +659,8 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		list =
 				s.createQuery(
-						"select new Zoo( z.name as zname, z.address as zaddress) from Zoo z order by zaddress, zname"
+						"select new Zoo( z.name as zname, z.address as zaddress) from Zoo z order by zaddress, zname",
+						Zoo.class
 				).list();
 		assertEquals( 4, list.size() );
 		assertEquals( zoo3, list.get( 0 ) );
@@ -654,19 +687,20 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
-		List list =
+		List<Map> list =
 				s.createQuery(
-						"select new map( z.name as zname, z.address as zaddress ) from Zoo z left join z.mammals m order by zname, zaddress"
+						"select new map( z.name as zname, z.address as zaddress ) from Zoo z left join z.mammals m order by zname, zaddress",
+						Map.class
 				).list();
 		assertEquals( 4, list.size() );
-		assertEquals( zoo2.getName(), ( ( Map ) list.get( 0 ) ).get( "zname" ) );
-		assertEquals( zoo2.getAddress(), ( ( Map ) list.get( 0 ) ).get( "zaddress" ) );
-		assertEquals( zoo4.getName(), ( ( Map ) list.get( 1 ) ).get( "zname" ) );
-		assertEquals( zoo4.getAddress(), ( ( Map ) list.get( 1 ) ).get( "zaddress" ) );
-		assertEquals( zoo3.getName(), ( ( Map ) list.get( 2 ) ).get( "zname" ) );
-		assertEquals( zoo3.getAddress(), ( ( Map ) list.get( 2 ) ).get( "zaddress" ) );
-		assertEquals( zoo1.getName(), ( ( Map ) list.get( 3 ) ).get( "zname" ) );
-		assertEquals( zoo1.getAddress(), ( ( Map ) list.get( 3 ) ).get( "zaddress" ) );
+		assertEquals( zoo2.getName(), list.get( 0 ).get( "zname" ) );
+		assertEquals( zoo2.getAddress(), list.get( 0 ).get( "zaddress" ) );
+		assertEquals( zoo4.getName(), list.get( 1 ).get( "zname" ) );
+		assertEquals( zoo4.getAddress(), list.get( 1 ).get( "zaddress" ) );
+		assertEquals( zoo3.getName(), list.get( 2 ).get( "zname" ) );
+		assertEquals( zoo3.getAddress(), list.get( 2 ).get( "zaddress" ) );
+		assertEquals( zoo1.getName(), list.get( 3 ).get( "zname" ) );
+		assertEquals( zoo1.getAddress(), list.get( 3 ).get( "zaddress" ) );
 
 		// ordered by address, name:
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
@@ -675,21 +709,22 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		list =
 				s.createQuery(
-						"select new map( z.name as zname, z.address as zaddress ) from Zoo z left join z.mammals m order by zaddress, zname"
+						"select new map( z.name as zname, z.address as zaddress ) from Zoo z left join z.mammals m order by zaddress, zname",
+						Map.class
 				).list();
 		assertEquals( 4, list.size() );
 
-		assertEquals( zoo3.getName(), ( ( Map ) list.get( 0 ) ).get( "zname" ) );
-		assertEquals( zoo3.getAddress(), ( ( Map ) list.get( 0 ) ).get( "zaddress" ) );
+		assertEquals( zoo3.getName(), list.get( 0 ).get( "zname" ) );
+		assertEquals( zoo3.getAddress(), list.get( 0 ).get( "zaddress" ) );
 
-		assertEquals( zoo2.getName(), ( ( Map ) list.get( 1 ) ).get( "zname" ) );
-		assertEquals( zoo2.getAddress(), ( ( Map ) list.get( 1 ) ).get( "zaddress" ) );
+		assertEquals( zoo2.getName(), list.get( 1 ).get( "zname" ) );
+		assertEquals( zoo2.getAddress(), list.get( 1 ).get( "zaddress" ) );
 
-		assertEquals( zoo1.getName(), ( ( Map ) list.get( 2 ) ).get( "zname" ) );
-		assertEquals( zoo1.getAddress(), ( ( Map ) list.get( 2 ) ).get( "zaddress" ) );
+		assertEquals( zoo1.getName(), list.get( 2 ).get( "zname" ) );
+		assertEquals( zoo1.getAddress(), list.get( 2 ).get( "zaddress" ) );
 
-		assertEquals( zoo4.getName(), ( ( Map ) list.get( 3 ) ).get( "zname" ) );
-		assertEquals( zoo4.getAddress(), ( ( Map ) list.get( 3 ) ).get( "zaddress" ) );
+		assertEquals( zoo4.getName(), list.get( 3 ).get( "zname" ) );
+		assertEquals( zoo4.getAddress(), list.get( 3 ).get( "zaddress" ) );
 		t.commit();
 		s.close();
 
@@ -708,17 +743,18 @@ public class OrderByTests extends BaseCoreFunctionalTestCase {
 		//   zoo4  Duh Zoo     1312 Mockingbird Lane, Nowhere, IL USA
 		//   zoo3  Zoo         1312 Mockingbird Lane, Anywhere, IL USA
 		//   zoo1  Zoo         1313 Mockingbird Lane, Anywhere, IL USA
-		List list =
+		List<Object[]> list =
 				s.createQuery(
-						"select z.name as zname, count(*) as cnt from Zoo z group by z.name order by cnt desc, zname"
+						"select z.name as zname, count(*) as cnt from Zoo z group by z.name order by cnt desc, zname",
+						Object[].class
 				).list();
 		assertEquals( 3, list.size() );
-		assertEquals( zoo3.getName(), ( ( Object[] ) list.get( 0 ) )[ 0 ] );
-		assertEquals( Long.valueOf( 2 ), ( ( Object[] ) list.get( 0 ) )[ 1 ] );
-		assertEquals( zoo2.getName(), ( ( Object[] ) list.get( 1 ) )[ 0 ] );
-		assertEquals( Long.valueOf( 1 ), ( ( Object[] ) list.get( 1 ) )[ 1 ] );
-		assertEquals( zoo4.getName(), ( ( Object[] ) list.get( 2 ) )[ 0 ] );
-		assertEquals( Long.valueOf( 1 ), ( ( Object[] ) list.get( 2 ) )[ 1 ] );
+		assertEquals( zoo3.getName(), list.get( 0 )[ 0 ] );
+		assertEquals(2L, list.get( 0 )[ 1 ] );
+		assertEquals( zoo2.getName(), list.get( 1 )[ 0 ] );
+		assertEquals(1L, list.get( 1 )[ 1 ] );
+		assertEquals( zoo4.getName(), list.get( 2 )[ 0 ] );
+		assertEquals(1L, list.get( 2 )[ 1 ] );
 		t.commit();
 		s.close();
 		cleanupData();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ScrollableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ScrollableTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.orm.test.query.hql;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
@@ -59,7 +58,7 @@ public class ScrollableTest extends BaseCoreFunctionalTestCase {
 		try (Session session = openSession()) {
 			session.getTransaction().begin();
 			try {
-				session.createQuery( "delete from MyEntity" ).executeUpdate();
+				session.createStatement( "delete from MyEntity" ).executeUpdate();
 				session.getTransaction().commit();
 			}
 			catch (Exception e) {
@@ -74,22 +73,22 @@ public class ScrollableTest extends BaseCoreFunctionalTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10860")
 	public void testScrollableResults() {
-		final List params = new ArrayList();
+		final List<Long> params = new ArrayList<>();
 		params.add( 1L );
 		params.add( 2L );
 
 		try (Session s = openSession()) {
-			final Query query = s.createQuery( "from MyEntity e where e.id in (:ids)" )
+			final Query<MyEntity> query = s.createQuery( "from MyEntity e where e.id in (:ids)", MyEntity.class )
 					.setParameter( "ids", params )
 					.setFetchSize( 10 );
-			try (ScrollableResults scroll = query.scroll( ScrollMode.FORWARD_ONLY )) {
+			try (ScrollableResults<MyEntity> scroll = query.scroll( ScrollMode.FORWARD_ONLY )) {
 				int i = 0;
 				while ( scroll.next() ) {
 					if ( i == 0 ) {
-						assertThat( ((MyEntity) scroll.get()).getDescription(), is( "entity_1" ) );
+						assertThat( scroll.get().getDescription(), is( "entity_1" ) );
 					}
 					else {
-						assertThat( ((MyEntity) scroll.get()).getDescription(), is( "entity_2" ) );
+						assertThat( scroll.get().getDescription(), is( "entity_2" ) );
 					}
 					i++;
 				}
@@ -100,22 +99,22 @@ public class ScrollableTest extends BaseCoreFunctionalTestCase {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10860")
 	public void testScrollableResults2() {
-		final List params = new ArrayList();
+		final List<Long> params = new ArrayList<>();
 		params.add( 1L );
 		params.add( 2L );
 
 		try (Session s = openSession()) {
-			final Query query = s.createQuery( "from MyEntity e where e.id in (:ids)" )
+			final Query<MyEntity> query = s.createQuery( "from MyEntity e where e.id in (:ids)", MyEntity.class )
 					.setParameter( "ids", params )
 					.setFetchSize( 10 );
-			try (ScrollableResults scroll = query.scroll( )) {
+			try (ScrollableResults<MyEntity> scroll = query.scroll( )) {
 				int i = 0;
 				while ( scroll.next() ) {
 					if ( i == 0 ) {
-						assertThat( ((MyEntity) scroll.get()).getDescription(), is( "entity_1" ) );
+						assertThat( scroll.get().getDescription(), is( "entity_1" ) );
 					}
 					else {
-						assertThat( ((MyEntity) scroll.get()).getDescription(), is( "entity_2" ) );
+						assertThat( scroll.get().getDescription(), is( "entity_2" ) );
 					}
 					i++;
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SizeAttributeReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SizeAttributeReferenceTest.java
@@ -33,7 +33,7 @@ public class SizeAttributeReferenceTest extends BaseNonConfigCoreFunctionalTestC
 	public void controlGroup() {
 		Session session = openSession();
 		session.getTransaction().begin();
-		session.createQuery( "from EntityWithAttributeNamedSize e join e.children c where size(c) > 1" ).list();
+		session.createQuery( "from EntityWithAttributeNamedSize e join e.children c where size(c) > 1", EntityWithAttributeNamedSize.class ).list();
 		session.getTransaction().commit();
 		session.close();
 	}
@@ -42,13 +42,13 @@ public class SizeAttributeReferenceTest extends BaseNonConfigCoreFunctionalTestC
 	public void testSizeAttributeReference() {
 		Session session = openSession();
 		session.getTransaction().begin();
-		session.createQuery( "from EntityWithAttributeNamedSize e join e.children c where c.size = 'abc'" ).list();
+		session.createQuery( "from EntityWithAttributeNamedSize e join e.children c where c.size = 'abc'", EntityWithAttributeNamedSize.class ).list();
 		session.getTransaction().commit();
 		session.close();
 	}
 
 	@Override
-	protected Class[] getAnnotatedClasses() {
+	protected Class<?>[] getAnnotatedClasses() {
 		return new Class[] { EntityWithAttributeNamedSize.class };
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -30,7 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"deprecation", "WeakerAccess"})
 @ServiceRegistry
 @DomainModel( standardModels = StandardDomainModel.GAMBIT )
 @SessionFactory

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/SubqueryOperatorsTest.java
@@ -34,8 +34,8 @@ public class SubqueryOperatorsTest {
 	public void testEvery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					List results = session.createQuery(
-							"from SimpleEntity o where o.someString >= every (select someString from SimpleEntity)" )
+					List<SimpleEntity> results = session.createQuery(
+							"from SimpleEntity o where o.someString >= every (select someString from SimpleEntity)", SimpleEntity.class )
 							.list();
 					assertThat( results.size(), is( 1 ) );
 				}
@@ -46,15 +46,15 @@ public class SubqueryOperatorsTest {
 	public void testAny(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					List results = session.createQuery(
-							"from SimpleEntity o where o.someString >= any (select someString from SimpleEntity)" )
+					List<SimpleEntity> results = session.createQuery(
+							"from SimpleEntity o where o.someString >= any (select someString from SimpleEntity)", SimpleEntity.class )
 							.list();
 					assertThat( results.size(), is( 2 ) );
 				}
 		);
 	}
 
-	@Test
+	@Test @SuppressWarnings("deprecation")
 	@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "Sybase ASE does not allow a subquery in the order by clause, but we could move it to the select clause and refer to it by position", matchSubTypes = true)
 	public void testSubqueryInVariousClauses(SessionFactoryScope scope) {
 		scope.inTransaction(
@@ -87,12 +87,12 @@ public class SubqueryOperatorsTest {
 	public void testExists(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					List results = session.createQuery(
-							"from SimpleEntity o where exists (select someString from SimpleEntity where someString>o.someString)" )
+					List<SimpleEntity> results = session.createQuery(
+							"from SimpleEntity o where exists (select someString from SimpleEntity where someString>o.someString)", SimpleEntity.class )
 							.list();
 					assertThat( results.size(), is( 1 ) );
 					results = session.createQuery(
-							"from SimpleEntity o where not exists (select someString from SimpleEntity where someString>o.someString)" )
+							"from SimpleEntity o where not exists (select someString from SimpleEntity where someString>o.someString)", SimpleEntity.class )
 							.list();
 					assertThat( results.size(), is( 1 ) );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/TupleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/TupleTest.java
@@ -32,11 +32,11 @@ public class TupleTest {
 	public void testSelectTuple(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					List results = session.createQuery(
-							"select o.id, (o.someString, o.someInteger), o.someLong from SimpleEntity o" )
+					List<Object[]> results = session.createQuery(
+							"select o.id, (o.someString, o.someInteger), o.someLong from SimpleEntity o", Object[].class )
 							.list();
 					assertThat( results.size(), is( 1 ) );
-					Object[] result = (Object[]) results.get( 0 );
+					Object[] result = results.get( 0 );
 					assertThat( result[0], is( 1 ) );
 					assertThat( result[1], instanceOf( Object[].class ) );
 					Object[] tuple = (Object[]) result[1];
@@ -67,9 +67,7 @@ public class TupleTest {
 	@AfterEach
 	public void tearDown(SessionFactoryScope scope) {
 		scope.inTransaction(
-				session -> {
-					session.createQuery( "delete SimpleEntity" ).executeUpdate();
-				}
+				session -> session.createStatement( "delete SimpleEntity" ).executeUpdate()
 		);
 	}
 }


### PR DESCRIPTION
So, I kinda messed up, and forgot that `createQuery()` is used for running things that aren't queries (insert, update, and delete statements).

But it's OK, because this is much better anyway.