### PR TITLE
quote column names with initial _

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/Identifier.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/Identifier.java
@@ -102,7 +102,7 @@ public class Identifier implements Comparable<Identifier> {
 		else if ( quoteOnNonIdentifierChar && !quote ) {
 			// Check the letters to determine if we must quote the text
 			char c = text.charAt( start );
-			if ( !Character.isLetter( c ) && c != '_' ) {
+			if ( !Character.isLetter( c ) && (c != '_' || start == 0) ) {
 				// SQL identifiers must begin with a letter or underscore
 				quote = true;
 			}


### PR DESCRIPTION
DB2 and Oracle don't allow `_identifiers` and it looks like this is the ANSI standard.

So maybe we should just auto quote identifiers that start with an _.

(I wish I could make this depend on the `Dialect` but that would be a much more impactful change for such a small thing.)