### PR TITLE
remove the layer-breaking getLobCreator() methods from Hibernate class

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -28,20 +28,15 @@ import org.hibernate.collection.spi.PersistentSet;
 import org.hibernate.collection.spi.PersistentSortedMap;
 import org.hibernate.collection.spi.PersistentSortedSet;
 import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.engine.jdbc.LobCreator;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.LazyInitializer;
 
 /**
- * Various utility functions for working with proxies and lazy collection references,
- * along with factory methods for obtaining a {@link LobCreator}.
+ * Various utility functions for working with proxies and lazy collection references.
  * <p>
  * Operations like {@link #isInitialized(Object)} and {@link #initialize(Object)} are
  * of general purpose. But {@link #createDetachedProxy(SessionFactory, Class, Object)}
@@ -63,11 +58,7 @@ import org.hibernate.proxy.LazyInitializer;
  * the program to intervene in the process of serialization and of deserialization.
  *
  * @author Gavin King
- * @see java.sql.Clob
- * @see java.sql.Blob
- * @see org.hibernate.type.Type
  */
-
 public final class Hibernate {
 	/**
 	 * Cannot be instantiated.
@@ -112,7 +103,6 @@ public final class Hibernate {
 	 * @param proxy a persistable object, proxy, persistent collection or {@code null}
 	 * @return true if the argument is already initialized, or is not a proxy or collection
 	 */
-	@SuppressWarnings("SimplifiableIfStatement")
 	public static boolean isInitialized(Object proxy) {
 		if ( proxy instanceof HibernateProxy ) {
 			return !( (HibernateProxy) proxy ).getHibernateLazyInitializer().isUninitialized();
@@ -148,45 +138,6 @@ public final class Hibernate {
 			result = proxy.getClass();
 		}
 		return (Class<? extends T>) result;
-	}
-
-	/**
-	 * Obtain a lob creator for the given session.
-	 *
-	 * @param session The session for which to obtain a lob creator
-	 *
-	 * @return The log creator reference
-	 */
-	public static LobCreator getLobCreator(Session session) {
-		return getLobCreator( (SessionImplementor) session );
-	}
-
-	/**
-	 * Obtain a lob creator for the given session.
-	 *
-	 * @param session The session for which to obtain a lob creator
-	 *
-	 * @return The log creator reference
-	 */
-	public static LobCreator getLobCreator(SharedSessionContractImplementor session) {
-		return session.getFactory()
-				.getServiceRegistry()
-				.getService( JdbcServices.class )
-				.getLobCreator( session );
-	}
-
-	/**
-	 * Obtain a lob creator for the given session.
-	 *
-	 * @param session The session for which to obtain a lob creator
-	 *
-	 * @return The log creator reference
-	 */
-	public static LobCreator getLobCreator(SessionImplementor session) {
-		return session.getFactory()
-				.getServiceRegistry()
-				.getService( JdbcServices.class )
-				.getLobCreator( session );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -24,7 +24,6 @@ import org.hibernate.CacheMode;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.FlushMode;
-import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.LockMode;
@@ -57,7 +56,6 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.procedure.internal.ProcedureCallImpl;
 import org.hibernate.procedure.spi.NamedCallableQueryMemento;
-import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.hql.spi.HqlQueryImplementor;
@@ -570,7 +568,10 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public LobCreator getLobCreator() {
-		return Hibernate.getLobCreator( this );
+		return ( (SharedSessionContractImplementor) this ).getFactory()
+				.getServiceRegistry()
+				.getService( JdbcServices.class )
+				.getLobCreator(this);
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/FetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/FetchGraphTest.java
@@ -702,7 +702,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 					d.setOid( 1 );
 
 					byte[] lBytes = "agdfagdfagfgafgsfdgasfdgfgasdfgadsfgasfdgasfdgasdasfdg".getBytes();
-					Blob lBlob = Hibernate.getLobCreator( session ).createBlob( lBytes );
+					Blob lBlob = session.getLobCreator().createBlob( lBytes );
 					d.setBlob( lBlob );
 
 					BEntity b1 = new BEntity();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyDeletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyDeletionTest.java
@@ -96,7 +96,7 @@ public class ProxyDeletionTest extends BaseNonConfigCoreFunctionalTestCase {
 					d.setOid( 1 );
 
 					byte[] lBytes = "agdfagdfagfgafgsfdgasfdgfgasdfgadsfgasfdgasfdgasdasfdg".getBytes();
-					Blob lBlob = Hibernate.getLobCreator( session ).createBlob( lBytes );
+					Blob lBlob = session.getLobCreator().createBlob( lBytes );
 					d.setBlob( lBlob );
 
 					BEntity b1 = new BEntity();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/HibernateCreateBlobFailedCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/HibernateCreateBlobFailedCase.java
@@ -47,9 +47,9 @@ public class HibernateCreateBlobFailedCase extends BaseCoreFunctionalTestCase {
 	public void testLobCreation() throws SQLException {
 		Session session = sessionFactory().getCurrentSession();
 		session.beginTransaction();
-		Blob blob = Hibernate.getLobCreator( session ).createBlob( new byte[] {} );
+		Blob blob = session.getLobHelper().createBlob( new byte[] {} );
 		blob.free();
-		Clob clob = Hibernate.getLobCreator( session ).createClob( "Steve" );
+		Clob clob = session.getLobHelper().createClob( "Steve" );
 		clob.free();
 		session.getTransaction().commit();
 		assertFalse( session.isOpen() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
@@ -249,12 +249,12 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 		doTest(
 				ClobEntity.class,
 				Clob.class,
-				session -> Hibernate.getLobCreator( session ).createClob( "some text" )
+				session -> session.getLobHelper().createClob( "some text" )
 		);
 		doTest(
 				BlobEntity.class,
 				Blob.class,
-				session -> Hibernate.getLobCreator( session ).createBlob( "some text".getBytes() )
+				session -> session.getLobHelper().createBlob( "some text".getBytes() )
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
@@ -141,7 +141,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		Session s = openSession();
 		s.beginTransaction();
 		LobHolder entity = new LobHolder();
-		entity.setBlobLocator( Hibernate.getLobCreator( s ).createBlob( original ) );
+		entity.setBlobLocator( s.getLobHelper().createBlob( original ) );
 		s.save( entity );
 		s.getTransaction().commit();
 		s.close();


### PR DESCRIPTION
This is in principle a breaking change, but one I consider pretty innocuous, since I can't imagine why anyone was calling `Hibernate.getLobCreator(session)` instead of `session.getLobHelper()`.

It's important that we not leak internal APIs like `SessionImplementor` into the signature of public APIs in `org.hibernate`.