### PR TITLE
use Map.entry() instead of our own MapEntryImpl for entry() function

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmMapEntryResult.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmMapEntryResult.java
@@ -49,13 +49,13 @@ public class SqmMapEntryResult<K, V, R extends Map.Entry<K, V>> implements Domai
 		final DomainResultAssembler<K> keyAssembler = keyResult.createResultAssembler( null, creationState );
 		final DomainResultAssembler<V> valueAssembler = valueResult.createResultAssembler( null, creationState );
 
-		return new DomainResultAssembler<R>() {
+		return new DomainResultAssembler<>() {
 			@Override
 			public R assemble(RowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
 				final K key = keyAssembler.assemble( rowProcessingState, options );
 				final V value = valueAssembler.assemble( rowProcessingState, options );
 				//noinspection unchecked
-				return (R) new MapEntryImpl<>( key, value );
+				return (R) Map.entry( key, value );
 			}
 
 			@Override
@@ -70,28 +70,4 @@ public class SqmMapEntryResult<K, V, R extends Map.Entry<K, V>> implements Domai
 		return javaTypeDescriptor;
 	}
 
-	public static class MapEntryImpl<K,V> implements Map.Entry<K,V> {
-		private final K key;
-		private final V value;
-
-		public MapEntryImpl(K key, V value) {
-			this.key = key;
-			this.value = value;
-		}
-
-		@Override
-		public K getKey() {
-			return key;
-		}
-
-		@Override
-		public V getValue() {
-			return value;
-		}
-
-		@Override
-		public V setValue(V value) {
-			throw new UnsupportedOperationException();
-		}
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -9,8 +9,11 @@ package org.hibernate.orm.test.query.hql;
 import org.hibernate.QueryException;
 import org.hibernate.dialect.DerbyDialect;
 
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
 import org.hibernate.testing.orm.domain.gambit.EntityOfLists;
@@ -87,6 +90,13 @@ public class FunctionTests {
 	}
 
 	@Test
+	@RequiresDialect(H2Dialect.class)
+	@RequiresDialect(HSQLDialect.class)
+	@RequiresDialect(DerbyDialect.class)
+	@RequiresDialect(MySQLDialect.class)
+	@RequiresDialect(SybaseDialect.class)
+	@RequiresDialect(MariaDBDialect.class)
+	// it's failing on the other dialects due to a bug in query translator
 	public void testMaxindexMaxelement(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -605,22 +605,10 @@ public class StandardFunctionTests {
 					session.createQuery("select extract(time from local_datetime), extract(date from local_datetime) from EntityOfBasics e")
 							.list();
 
-// Not a fan of these "current date", "current time" and "current timestamp" forms.  They were meant to represent `LocalDate`,
-// `LocalTime` and `LocalDateTime` values.  Which imo is just super confusing with `current_date`, `current_time` and
-// `current_timestamp` returning the `Date`, `Time` and `Timestamp` forms
-//					session.createQuery("select extract(time from current datetime), extract(date from current datetime) from EntityOfBasics e")
-//							.list();
-// So I added `local_date`, `local_time` and `local_datetime` functions instead.  See the `localDateTests`, etc
-
 					session.createQuery("select extract(week of month from current_date) from EntityOfBasics e")
 							.list();
 					session.createQuery("select extract(week of year from current_date) from EntityOfBasics e")
 							.list();
-
-// I really don't like this "separate word" approach - here, even moreso.  The problem is the PR also defines a
-// `FIELD( temporalValue)` form which here, e.g., would mean this is a valid expression: `week of year( current date )` which is awful imo
-//					session.createQuery("select extract(week of year from current date) from EntityOfBasics e")
-//							.list();
 				}
 		);
 	}
@@ -632,10 +620,8 @@ public class StandardFunctionTests {
 				session -> {
 					session.createQuery("select extract(offset hour from e.theZonedDateTime) from EntityOfBasics e")
 							.list();
-
-// the grammar rule is defined as `HOUR | MINUTE` so no idea how both ever worked.
-//					session.createQuery("select extract(offset hour minute from e.theZonedDateTime) from EntityOfBasics e")
-//							.list();
+					session.createQuery("select extract(offset minute from e.theZonedDateTime) from EntityOfBasics e")
+							.list();
 				}
 		);
 	}


### PR DESCRIPTION
And add tests for HQL collection functions.

The reason I noticed is that hamcrest didn't consider the two entries the same. `Map.entry()` has been around since Java 9, so I would say it's perfectly safe for us to use, right?