### PR TITLE
different approach to overriding SQL in annotations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/DialectOverride.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/DialectOverride.java
@@ -1,0 +1,300 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.annotations;
+
+import org.hibernate.Incubating;
+import org.hibernate.dialect.Dialect;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Allows certain annotations to be overridden in a given SQL {@link Dialect}.
+ *
+ * @author Gavin King
+ */
+@Incubating
+public interface DialectOverride {
+
+	/**
+	 * Identifies a database version.
+	 *
+	 * @see org.hibernate.dialect.DatabaseVersion
+	 */
+	@Retention(RUNTIME)
+	@interface Version {
+		int major();
+		int minor() default 0;
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.Check}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@Repeatable(Checks.class)
+	@OverridesAnnotation(org.hibernate.annotations.Check.class)
+	@interface Check {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.Check override();
+	}
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@interface Checks {
+		Check[] value();
+	}
+
+	/**
+	 * Specializes an {@link org.hibernate.annotations.OrderBy}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@Repeatable(OrderBys.class)
+	@OverridesAnnotation(org.hibernate.annotations.OrderBy.class)
+	@interface OrderBy {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.OrderBy override();
+	}
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@interface OrderBys {
+		OrderBy[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.ColumnDefault}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@Repeatable(ColumnDefaults.class)
+	@OverridesAnnotation(org.hibernate.annotations.ColumnDefault.class)
+	@interface ColumnDefault {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.ColumnDefault override();
+	}
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@interface ColumnDefaults {
+		ColumnDefault[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.GeneratedColumn}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@Repeatable(GeneratedColumns.class)
+	@OverridesAnnotation(org.hibernate.annotations.GeneratedColumn.class)
+	@interface GeneratedColumn {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.GeneratedColumn override();
+	}
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@interface GeneratedColumns {
+		GeneratedColumn[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.DiscriminatorFormula}
+	 * in a certain dialect.
+	 */
+	@Target(TYPE)
+	@Retention(RUNTIME)
+	@Repeatable(DiscriminatorFormulas.class)
+	@OverridesAnnotation(org.hibernate.annotations.DiscriminatorFormula.class)
+	@interface DiscriminatorFormula {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.DiscriminatorFormula override();
+	}
+	@Target(TYPE)
+	@Retention(RUNTIME)
+	@interface DiscriminatorFormulas {
+		DiscriminatorFormula[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.Formula}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@Repeatable(Formulas.class)
+	@OverridesAnnotation(org.hibernate.annotations.Formula.class)
+	@interface Formula {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.Formula override();
+	}
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@interface Formulas {
+		Formula[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.JoinFormula}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@OverridesAnnotation(org.hibernate.annotations.JoinFormula.class)
+	@interface JoinFormula {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.JoinFormula override();
+	}
+	@Target({METHOD, FIELD})
+	@Retention(RUNTIME)
+	@interface JoinFormulas {
+		JoinFormula[] value();
+	}
+
+	/**
+	 * Specializes a {@link org.hibernate.annotations.Where}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@OverridesAnnotation(org.hibernate.annotations.Where.class)
+	@interface Where {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.Where override();
+	}
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@interface Wheres {
+		Where[] value();
+	}
+
+	/**
+	 * Specializes {@link org.hibernate.annotations.Filters}
+	 * in a certain dialect.
+	 */
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@Repeatable(FilterOverrides.class)
+	@OverridesAnnotation(org.hibernate.annotations.Filters.class)
+	@interface Filters {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.Filters override();
+	}
+	@Target({METHOD, FIELD, TYPE})
+	@Retention(RUNTIME)
+	@interface FilterOverrides {
+		Filters[] value();
+	}
+
+	/**
+	 * Specializes {@link org.hibernate.annotations.FilterDefs}
+	 * in a certain dialect.
+	 */
+	@Target({PACKAGE, TYPE})
+	@Retention(RUNTIME)
+	@Repeatable(FilterDefOverrides.class)
+	@OverridesAnnotation(org.hibernate.annotations.FilterDefs.class)
+	@interface FilterDefs  {
+		/**
+		 * The {@link Dialect} in which this override applies.
+		 */
+		Class<? extends Dialect> dialect();
+		Version before() default @Version(major = MAX_VALUE);
+		Version sameOrAfter() default @Version(major = MIN_VALUE);
+
+		org.hibernate.annotations.FilterDefs override();
+	}
+	@Target({PACKAGE, TYPE})
+	@Retention(RUNTIME)
+	@interface FilterDefOverrides {
+		FilterDefs[] value();
+	}
+
+	/**
+	 * Marks an annotation type as a dialect-specific override for
+	 * some other annotation type.
+	 * <p>
+	 * The marked annotation must have the following members:
+	 * <ul>
+	 *     <li>{@code Class<? extends Dialect> dialect()},
+	 *     <li>{@code Version before()},
+	 *     <li>{@code Version sameOrAfter()}, and
+	 *     <li>{@code A override()}, where {@code A} is the type
+	 *     of annotation which the marked annotation overrides.
+	 * </ul>
+	 */
+	@Target({ANNOTATION_TYPE})
+	@Retention(RUNTIME)
+	@interface OverridesAnnotation {
+		/**
+		 * The class of the annotation that is overridden.
+		 */
+		Class<? extends Annotation> value();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedColumn.java
@@ -37,6 +37,8 @@ import org.hibernate.mapping.Table;
 
 import org.jboss.logging.Logger;
 
+import static org.hibernate.cfg.AnnotationBinder.getOverridableAnnotation;
+
 /**
  * Wrap state of an EJB3 @Column annotation
  * and build the Hibernate column mapping element
@@ -672,7 +674,7 @@ public class AnnotatedColumn {
 	private void applyColumnDefault(PropertyData inferredData, int length) {
 		final XProperty xProperty = inferredData.getProperty();
 		if ( xProperty != null ) {
-			ColumnDefault columnDefaultAnn = xProperty.getAnnotation( ColumnDefault.class );
+			ColumnDefault columnDefaultAnn = getOverridableAnnotation( xProperty, ColumnDefault.class, context );
 			if ( columnDefaultAnn != null ) {
 				if (length!=1) {
 					throw new MappingException("@ColumnDefault may only be applied to single-column mappings");
@@ -690,7 +692,7 @@ public class AnnotatedColumn {
 	private void applyGeneratedAs(PropertyData inferredData, int length) {
 		final XProperty xProperty = inferredData.getProperty();
 		if ( xProperty != null ) {
-			GeneratedColumn generatedAnn = xProperty.getAnnotation( GeneratedColumn.class );
+			GeneratedColumn generatedAnn = getOverridableAnnotation( xProperty, GeneratedColumn.class, context );
 			if ( generatedAnn != null ) {
 				if (length!=1) {
 					throw new MappingException("@GeneratedColumn may only be applied to single-column mappings");
@@ -708,7 +710,7 @@ public class AnnotatedColumn {
 	private void applyCheckConstraint(PropertyData inferredData, int length) {
 		final XProperty xProperty = inferredData.getProperty();
 		if ( xProperty != null ) {
-			Check columnDefaultAnn = xProperty.getAnnotation( Check.class );
+			Check columnDefaultAnn = AnnotationBinder.getOverridableAnnotation( xProperty, Check.class, context );
 			if ( columnDefaultAnn != null ) {
 				if (length!=1) {
 					throw new MappingException("@Check may only be applied to single-column mappings (use a table-level @Check)");

--- a/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
@@ -816,7 +816,7 @@ public class BinderHelper {
 		value.setLazy( lazy );
 		value.setCascadeDeleteEnabled( cascadeOnDelete );
 
-		final BasicValueBinder discriminatorValueBinder = new BasicValueBinder( BasicValueBinder.Kind.ANY_DISCRIMINATOR, context );
+		final BasicValueBinder<?> discriminatorValueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.ANY_DISCRIMINATOR, context );
 
 		final AnnotatedColumn[] discriminatorColumns = AnnotatedColumn.buildColumnFromAnnotation(
 				new jakarta.persistence.Column[] { discriminatorColumn },

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ColumnsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ColumnsBuilder.java
@@ -28,6 +28,8 @@ import org.hibernate.cfg.annotations.EntityBinder;
 import org.hibernate.cfg.annotations.Nullability;
 import org.hibernate.internal.util.StringHelper;
 
+import static org.hibernate.cfg.AnnotationBinder.getOverridableAnnotation;
+
 /**
  * Do the initial discovery of columns metadata and apply defaults.
  * Also hosts some convenient methods related to column processing
@@ -76,7 +78,7 @@ class ColumnsBuilder {
 		Comment comment = property.getAnnotation(Comment.class);
 		if ( property.isAnnotationPresent( Column.class ) || property.isAnnotationPresent( Formula.class ) ) {
 			Column ann = property.getAnnotation( Column.class );
-			Formula formulaAnn = property.getAnnotation( Formula.class );
+			Formula formulaAnn = getOverridableAnnotation( property, Formula.class, buildingContext );
 			columns = AnnotatedColumn.buildColumnFromAnnotation(
 					new Column[] { ann },
 					formulaAnn,
@@ -249,7 +251,7 @@ class ColumnsBuilder {
 		}
 
 		if (property.isAnnotationPresent( JoinFormula.class)) {
-			JoinFormula ann = property.getAnnotation( JoinFormula.class );
+			JoinFormula ann = getOverridableAnnotation( property, JoinFormula.class, buildingContext );
 			AnnotatedJoinColumn[] annotatedJoinColumns = new AnnotatedJoinColumn[1];
 			annotatedJoinColumns[0] = AnnotatedJoinColumn.buildJoinFormula(
 					ann,

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -131,6 +131,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 
 import static jakarta.persistence.AccessType.PROPERTY;
+import static org.hibernate.cfg.AnnotationBinder.getOverridableAnnotation;
 import static org.hibernate.cfg.BinderHelper.toAliasEntityMap;
 import static org.hibernate.cfg.BinderHelper.toAliasTableMap;
 
@@ -1175,7 +1176,7 @@ public abstract class CollectionBinder {
 						toAliasTableMap(simpleFilter.aliases()), toAliasEntityMap(simpleFilter.aliases()));
 			}
 		}
-		Filters filters = property.getAnnotation( Filters.class );
+		Filters filters = getOverridableAnnotation( property, Filters.class, buildingContext );
 		if ( filters != null ) {
 			for (Filter filter : filters.value()) {
 				if ( hasAssociationTable ) {
@@ -1237,12 +1238,12 @@ public abstract class CollectionBinder {
 		//    for many-to-many e.g., @ManyToMany @Where(clause="...") public Set<Rating> getRatings();
 		String whereOnClassClause = null;
 		if ( useEntityWhereClauseForCollections && property.getElementClass() != null ) {
-			Where whereOnClass = property.getElementClass().getAnnotation( Where.class );
+			Where whereOnClass = getOverridableAnnotation( property.getElementClass(), Where.class, getBuildingContext() );
 			if ( whereOnClass != null ) {
 				whereOnClassClause = whereOnClass.clause();
 			}
 		}
-		Where whereOnCollection = property.getAnnotation( Where.class );
+		Where whereOnCollection = getOverridableAnnotation( property, Where.class, getBuildingContext() );
 		String whereOnCollectionClause = null;
 		if ( whereOnCollection != null ) {
 			whereOnCollectionClause = whereOnCollection.clause();
@@ -1720,8 +1721,9 @@ public abstract class CollectionBinder {
 					buildingContext.getBootstrapContext().getReflectionManager()
 			);
 
-			final jakarta.persistence.Column discriminatorColumnAnn = inferredData.getProperty().getAnnotation( jakarta.persistence.Column.class );
-			final Formula discriminatorFormulaAnn = inferredData.getProperty().getAnnotation( Formula.class );
+			XProperty prop = inferredData.getProperty();
+			final jakarta.persistence.Column discriminatorColumnAnn = prop.getAnnotation( jakarta.persistence.Column.class );
+			final Formula discriminatorFormulaAnn = getOverridableAnnotation( prop, Formula.class, buildingContext );
 
 			//override the table
 			for (AnnotatedColumn column : inverseJoinColumns) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -89,7 +89,7 @@ public class IdBagBinder extends BagBinder {
 				Nullability.FORCED_NOT_NULL,
 				propertyHolder,
 				propertyData,
-				Collections.EMPTY_MAP,
+				Collections.emptyMap(),
 				buildingContext
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/sqldefault/OverriddenDefaultTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/sqldefault/OverriddenDefaultTest.java
@@ -1,0 +1,81 @@
+package org.hibernate.orm.test.mapping.generated.sqldefault;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DialectOverride;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gavin King
+ */
+@DomainModel(annotatedClasses = OverriddenDefaultTest.OrderLine.class)
+@SessionFactory
+public class OverriddenDefaultTest {
+
+    @Test
+    public void test(SessionFactoryScope scope) {
+        BigDecimal unitPrice = new BigDecimal("12.99");
+        scope.inTransaction( session -> {
+            OrderLine entity = new OrderLine( unitPrice, 5 );
+            session.persist(entity);
+            session.flush();
+            assertEquals( getDefault(scope), entity.status );
+            assertEquals( unitPrice, entity.unitPrice );
+            assertEquals( 5, entity.quantity );
+        } );
+        scope.inTransaction( session -> {
+            OrderLine entity = session.createQuery("from WithDefault", OrderLine.class ).getSingleResult();
+            assertEquals( unitPrice, entity.unitPrice );
+            assertEquals( 5, entity.quantity );
+            assertEquals( getDefault(scope), entity.status );
+            entity.status = "old"; //should be ignored when fetch=true
+        } );
+        scope.inTransaction( session -> {
+            OrderLine entity = session.createQuery("from WithDefault", OrderLine.class ).getSingleResult();
+            assertEquals( unitPrice, entity.unitPrice );
+            assertEquals( 5, entity.quantity );
+            assertEquals( getDefault(scope), entity.status );
+        } );
+    }
+
+    String getDefault(SessionFactoryScope scope) {
+        return scope.getMetadataImplementor().getDatabase().getDialect() instanceof H2Dialect ? "NEW" : "new";
+    }
+
+    @AfterEach
+    public void dropTestData(SessionFactoryScope scope) {
+        scope.inTransaction( session -> session.createQuery( "delete WithDefault" ).executeUpdate() );
+    }
+
+    @Entity(name="WithDefault")
+    public static class OrderLine {
+        @Id
+        private BigDecimal unitPrice;
+        @Id @ColumnDefault("1")
+        private int quantity;
+        @Generated(GenerationTime.INSERT)
+        @ColumnDefault("'new'")
+        @DialectOverride.ColumnDefault(dialect = H2Dialect.class,
+                sameOrAfter = @DialectOverride.Version(major=1, minor=4),
+                override = @ColumnDefault("'NEW'"))
+        private String status;
+
+        public OrderLine() {}
+        public OrderLine(BigDecimal unitPrice, int quantity) {
+            this.unitPrice = unitPrice;
+            this.quantity = quantity;
+        }
+    }
+}


### PR DESCRIPTION
Introduces the `@ForDialect` annotation, which is really a perfectly elegant thing if you're careful not to look at its implementation.

This approach has the advantage that it doesn't impact the existing annotations at all: it's completely self-contained.

See https://github.com/hibernate/hibernate-orm/discussions/4528.