### PR TITLE
Limit concurrent Github Actions builds

### DIFF
--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -13,6 +13,16 @@ on:
   pull_request:
     branches:
       - 'main'
+
+# See https://github.com/hibernate/hibernate-orm/pull/4615 for a description of the behavior we're getting.
+concurrency:
+  # Consider that two builds are in the same concurrency group (cannot run concurrently)
+  # if they use the same workflow and are about the same branch ("ref") or pull request.
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  # Cancel previous builds in the same concurrency group even if they are in process
+  # for pull requests or pushes to forks (not the upstream repository).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-orm' }}
+
 jobs:
   build:
     name: Java 11


### PR DESCRIPTION
So that we don't use too much resources for builds of older commits that we don't care about anymore.

This is basically the same config as Quarkus.

See
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
for the documentation of this feature.

Essentially, this gives the following behavior:

* For pull requests, only the most recent HEAD gets built. Builds for
  previous HEADs get cancelled automatically.
* For branches (main, ...), we can only ever have two concurrent builds:
  one running, and one (more recent) pending.
  If a build is running and another one gets requested (because of a
  push), the second one will be pending and wait for the first one to
  finish.
  If a third build gets requested before the first one finishes,
  the second build gets cancelled and the third build will be pending
  until the first build finishes.