### PR TITLE
Fix native query alias validation

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/native/Native.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/native/Native.adoc
@@ -234,7 +234,9 @@ Problems can arise when returning multiple entities of the same type or when the
 Until now, the result set column names are assumed to be the same as the column names specified in the mapping document.
 This can be problematic for SQL queries that join multiple tables since the same column names can appear in more than one table.
 
-Column alias injection is needed in the following query which otherwise throws `NonUniqueDiscoveredSqlAliasException`.
+As of Hibernate 6.0, the source table for selected columns is determined through the JDBC driver to disambiguate same named column,
+which shifts the limits a bit further until changing the SQL is necessary.
+Prior to 6.0, the following queries would fail with a `NonUniqueDiscoveredSqlAliasException`.
 
 [[sql-jpa-multi-entity-query-example]]
 .Jakarta Persistence native query selecting entities with the same column names
@@ -254,8 +256,9 @@ include::{sourcedir}/SQLTest.java[tags=sql-hibernate-multi-entity-query-example]
 ----
 ====
 
-The query was intended to return all `Person` and `Partner` instances with the same name.
-The query fails because there is a conflict of names since the two entities are mapped to the same column names (e.g. `id`, `name`, `version`).
+The query should return all `Person` and `Partner` instances with the same name.
+Since the two entities are mapped to the same column names (e.g. `id`, `name`, `version`),
+the query might fail if the JDBC driver can't provide the source table name for selected columns.
 Also, on some databases, the returned column aliases will most likely be on the form `pr.id`, `pr.name`, etc.
 which are not equal to the columns specified in the mappings (`id` and `name`).
 

--- a/documentation/src/main/java/org/hibernate/userguide/model/Person.java
+++ b/documentation/src/main/java/org/hibernate/userguide/model/Person.java
@@ -102,6 +102,13 @@ import jakarta.persistence.Version;
     resultSetMapping = "person_with_phones"
 )
 //end::sql-entity-associations-NamedNativeQuery-example[]
+@SqlResultSetMapping(
+        name = "person_and_same_named_partner",
+        entities = {
+                @EntityResult(entityClass = Person.class),
+                @EntityResult(entityClass = Partner.class)
+        }
+)
 //tag::sql-entity-associations-NamedNativeQuery-example[]
 @SqlResultSetMapping(
      name = "person_with_phones",

--- a/documentation/src/test/java/org/hibernate/userguide/hql/HQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/hql/HQLTest.java
@@ -40,6 +40,7 @@ import org.hibernate.userguide.model.Account;
 import org.hibernate.userguide.model.AddressType;
 import org.hibernate.userguide.model.Call;
 import org.hibernate.userguide.model.CreditCardPayment;
+import org.hibernate.userguide.model.Partner;
 import org.hibernate.userguide.model.Payment;
 import org.hibernate.userguide.model.Person;
 import org.hibernate.userguide.model.PersonNames;
@@ -70,6 +71,7 @@ public class HQLTest extends BaseEntityManagerFunctionalTestCase {
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
 			Person.class,
+			Partner.class,
 			Phone.class,
 			Call.class,
 			Account.class,

--- a/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
@@ -463,7 +463,7 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 				List<Person> entities = entityManager.createNativeQuery(
 					"SELECT * " +
 					"FROM Person pr, Partner pt " +
-					"WHERE pr.name = pt.name", Person.class)
+					"WHERE pr.name = pt.name")
 				.getResultList();
 				//end::sql-jpa-multi-entity-query-example[]
 				assertEquals(2, entities.size());
@@ -484,7 +484,7 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 				List<Person> entities = session.createNativeQuery(
 					"SELECT * " +
 					"FROM Person pr, Partner pt " +
-					"WHERE pr.name = pt.name", Person.class)
+					"WHERE pr.name = pt.name")
 				.list();
 				//end::sql-hibernate-multi-entity-query-example[]
 				assertEquals(2, entities.size());

--- a/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
@@ -460,15 +460,15 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 		try {
 			doInJPA(this::entityManagerFactory, entityManager -> {
 				//tag::sql-jpa-multi-entity-query-example[]
-				List<Person> entities = entityManager.createNativeQuery(
+				List<Object[]> entities = entityManager.createNativeQuery(
 					"SELECT * " +
 					"FROM Person pr, Partner pt " +
-					"WHERE pr.name = pt.name")
+					"WHERE pr.name = pt.name", "person_and_same_named_partner")
 				.getResultList();
 				//end::sql-jpa-multi-entity-query-example[]
-				assertEquals(2, entities.size());
+				assertEquals(1, entities.size());
 			});
-			fail("Should throw NonUniqueDiscoveredSqlAliasException!");
+//			fail("Should throw NonUniqueDiscoveredSqlAliasException!");
 		}
 		catch (PersistenceException expected) {
 			assertEquals(NonUniqueDiscoveredSqlAliasException.class, expected.getCause().getClass());
@@ -485,11 +485,13 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 					"SELECT * " +
 					"FROM Person pr, Partner pt " +
 					"WHERE pr.name = pt.name")
+				.addEntity( Person.class )
+				.addEntity( Partner.class )
 				.list();
 				//end::sql-hibernate-multi-entity-query-example[]
-				assertEquals(2, entities.size());
+				assertEquals(1, entities.size());
 			});
-			fail("Should throw NonUniqueDiscoveredSqlAliasException!");
+//			fail("Should throw NonUniqueDiscoveredSqlAliasException!");
 		}
 		catch (NonUniqueDiscoveredSqlAliasException e) {
 			// expected

--- a/hibernate-core/src/main/java/org/hibernate/query/results/DomainResultCreationStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/DomainResultCreationStateImpl.java
@@ -272,7 +272,7 @@ public class DomainResultCreationStateImpl
 		else if ( created instanceof ColumnReference ) {
 			final ColumnReference columnReference = (ColumnReference) created;
 			final String columnExpression = columnReference.getColumnExpression();
-			final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnExpression );
+			final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnExpression, null );
 			final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
 
 			final ResultSetMappingSqlSelection sqlSelection = new ResultSetMappingSqlSelection(

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderBasicPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderBasicPart.java
@@ -82,7 +82,7 @@ public class CompleteFetchBuilderBasicPart implements CompleteFetchBuilder, Basi
 
 		if ( selectionAlias != null ) {
 			try {
-				jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( selectionAlias );
+				jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( selectionAlias, mappedTable );
 			}
 			catch (Exception e) {
 				throw new MissingSqlSelectionException(

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
@@ -86,7 +86,10 @@ public class CompleteFetchBuilderEntityValuedModelPart
 							creationStateImpl.resolveSqlExpression(
 									SqlExpressionResolver.createColumnReferenceKey( tableReference, mappedColumn ),
 									processingState -> {
-										final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+										final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition(
+												columnAlias,
+												selectableMapping.getContainingTableExpression()
+										);
 										final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
 										return new ResultSetMappingSqlSelection( valuesArrayPosition, selectableMapping.getJdbcMapping() );
 									}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicModelPart.java
@@ -81,7 +81,10 @@ public class CompleteResultBuilderBasicModelPart
 				creationStateImpl.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( tableReference, mappedColumn ),
 						processingState -> {
-							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition(
+									columnAlias,
+									modelPart.getContainingTableExpression()
+							);
 							final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
 							return new ResultSetMappingSqlSelection( valuesArrayPosition, modelPart );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
@@ -85,43 +85,16 @@ public class CompleteResultBuilderBasicValuedConverted<O,R> implements CompleteR
 			columnName = jdbcResultsMetadata.resolveColumnName( resultPosition + 1 );
 		}
 
-
-//		final int jdbcPosition;
-//		if ( explicitColumnName != null ) {
-//			jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( explicitColumnName );
-//		}
-//		else {
-//			jdbcPosition = resultPosition + 1;
-//		}
-//
-//		final BasicValuedMapping basicType;
-//		if ( explicitType != null ) {
-//			basicType = explicitType;
-//		}
-//		else {
-//			basicType = jdbcResultsMetadata.resolveType( jdbcPosition, explicitJavaType );
-//		}
-//
-//		final SqlSelection sqlSelection = creationStateImpl.resolveSqlSelection(
-//				creationStateImpl.resolveSqlExpression(
-//						columnName,
-//						processingState -> {
-//							final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
-//							return new SqlSelectionImpl( valuesArrayPosition, basicType );
-//						}
-//				),
-//				basicType.getExpressibleJavaType(),
-//				sessionFactory.getTypeConfiguration()
-//		);
-
-
 		final SqlSelection sqlSelection = creationStateImpl.resolveSqlSelection(
 				creationStateImpl.resolveSqlExpression(
 						columnName,
 						processingState -> {
 							final int jdbcPosition;
 							if ( explicitColumnName != null ) {
-								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( explicitColumnName );
+								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition(
+										explicitColumnName,
+										null
+								);
 							}
 							else {
 								jdbcPosition = resultPosition + 1;

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
@@ -80,42 +80,16 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 			columnName = jdbcResultsMetadata.resolveColumnName( resultPosition + 1 );
 		}
 
-//		final int jdbcPosition;
-//		if ( explicitColumnName != null ) {
-//			jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( explicitColumnName );
-//		}
-//		else {
-//			jdbcPosition = resultPosition + 1;
-//		}
-//
-//		final BasicValuedMapping basicType;
-//		if ( explicitType != null ) {
-//			basicType = explicitType;
-//		}
-//		else {
-//			basicType = jdbcResultsMetadata.resolveType( jdbcPosition, explicitJavaType );
-//		}
-//
-//		final SqlSelection sqlSelection = creationStateImpl.resolveSqlSelection(
-//				creationStateImpl.resolveSqlExpression(
-//						columnName,
-//						processingState -> {
-//							final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
-//							return new SqlSelectionImpl( valuesArrayPosition, basicType );
-//						}
-//				),
-//				basicType.getExpressibleJavaType(),
-//				sessionFactory.getTypeConfiguration()
-//		);
-
-
 		final SqlSelection sqlSelection = creationStateImpl.resolveSqlSelection(
 				creationStateImpl.resolveSqlExpression(
 						columnName,
 						processingState -> {
 							final int jdbcPosition;
 							if ( explicitColumnName != null ) {
-								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( explicitColumnName );
+								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition(
+										explicitColumnName,
+										null
+								);
 							}
 							else {
 								jdbcPosition = resultPosition + 1;

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderCollectionStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderCollectionStandard.java
@@ -157,7 +157,10 @@ public class CompleteResultBuilderCollectionStandard implements CompleteResultBu
 									selectableMapping.getSelectionExpression()
 							),
 							processingState -> {
-								final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnName );
+								final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition(
+										columnName,
+										selectableMapping.getContainingTableExpression()
+								);
 								final BasicValuedMapping basicType = (BasicValuedMapping) selectableMapping.getJdbcMapping();
 								final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition(
 										jdbcPosition );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
@@ -172,6 +172,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 										tableGroup.resolveTableReference( selectableMapping.getContainingTableExpression() ),
 										selectableMapping.getSelectionExpression()
 								),
+								selectableMapping.getContainingTableExpression(),
 								selectableMapping.getJdbcMapping(),
 								jdbcResultsMetadata,
 								domainResultCreationState
@@ -204,6 +205,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	private void resolveSqlSelection(
 			String columnAlias,
 			String columnKey,
+			String tableExpression,
 			JdbcMapping jdbcMapping,
 			JdbcValuesMetadata jdbcResultsMetadata,
 			DomainResultCreationState domainResultCreationState) {
@@ -212,7 +214,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 				sqlExpressionResolver.resolveSqlExpression(
 						columnKey,
 						state -> {
-							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias, tableExpression );
 							final int valuesArrayPosition = jdbcPosition - 1;
 							return new ResultSetMappingSqlSelection( valuesArrayPosition, jdbcMapping );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderStandard.java
@@ -101,7 +101,10 @@ public class DynamicFetchBuilderStandard
 					sqlExpressionResolver.resolveSqlExpression(
 							createColumnReferenceKey( tableReference, selectableMapping.getSelectionExpression() ),
 							state -> {
-								final int resultSetPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+								final int resultSetPosition = jdbcResultsMetadata.resolveColumnPosition(
+										columnAlias,
+										selectableMapping.getContainingTableExpression()
+								);
 								final int valuesArrayPosition = resultSetPosition - 1;
 								return new ResultSetMappingSqlSelection( valuesArrayPosition, selectableMapping.getJdbcMapping() );
 							}
@@ -126,7 +129,9 @@ public class DynamicFetchBuilderStandard
 		}
 		else if ( attributeMapping instanceof ToOneAttributeMapping ) {
 			final ToOneAttributeMapping toOneAttributeMapping = (ToOneAttributeMapping) attributeMapping;
-			toOneAttributeMapping.getForeignKeyDescriptor().visitKeySelectables( selectableConsumer );
+			toOneAttributeMapping.getForeignKeyDescriptor().getSide( toOneAttributeMapping.getSideNature() )
+					.getModelPart()
+					.forEachSelectable( selectableConsumer );
 			return parent.generateFetchableFetch(
 					attributeMapping,
 					fetchPath,

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderAttribute.java
@@ -83,7 +83,10 @@ public class DynamicResultBuilderAttribute implements DynamicResultBuilder, Nati
 				sqlExpressionResolver.resolveSqlExpression(
 						columnAlias,
 						state -> {
-							final int resultSetPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+							final int resultSetPosition = jdbcResultsMetadata.resolveColumnPosition(
+									columnAlias,
+									attributeMapping.getContainingTableExpression()
+							);
 							final int valuesArrayPosition = resultSetPosition - 1;
 							return new ResultSetMappingSqlSelection( valuesArrayPosition, attributeMapping );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicConverted.java
@@ -109,7 +109,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 
 							final int jdbcPosition;
 							if ( columnAlias != null ) {
-								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+								jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias, null );
 							}
 							else {
 								jdbcPosition = currentJdbcPosition;

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
@@ -133,7 +133,7 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 						jdbcPosition = columnPosition;
 					}
 					else {
-						jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnName );
+						jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnName, null );
 					}
 					final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
@@ -204,6 +204,7 @@ public class DynamicResultBuilderEntityStandard
 						resolveSqlSelection(
 								idColumnAliases.get( selectionIndex ),
 								createColumnReferenceKey( tableReference, selectableMapping.getSelectionExpression() ),
+								selectableMapping.getContainingTableExpression(),
 								selectableMapping.getJdbcMapping(),
 								jdbcResultsMetadata,
 								domainResultCreationState
@@ -219,6 +220,7 @@ public class DynamicResultBuilderEntityStandard
 							tableReference,
 							entityMapping.getDiscriminatorMapping().getSelectionExpression()
 					),
+					entityMapping.getDiscriminatorMapping().getContainingTableExpression(),
 					entityMapping.getDiscriminatorMapping().getJdbcMapping(),
 					jdbcResultsMetadata,
 					domainResultCreationState
@@ -267,6 +269,7 @@ public class DynamicResultBuilderEntityStandard
 	private void resolveSqlSelection(
 			String columnAlias,
 			String columnKey,
+			String tableExpression,
 			JdbcMapping jdbcMapping,
 			JdbcValuesMetadata jdbcResultsMetadata,
 			DomainResultCreationState domainResultCreationState) {
@@ -275,7 +278,7 @@ public class DynamicResultBuilderEntityStandard
 				sqlExpressionResolver.resolveSqlExpression(
 						columnKey,
 						state -> {
-							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias );
+							final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( columnAlias, tableExpression );
 							final int valuesArrayPosition = jdbcPosition - 1;
 							return new ResultSetMappingSqlSelection( valuesArrayPosition, jdbcMapping );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderBasic.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderBasic.java
@@ -77,7 +77,7 @@ public class ImplicitFetchBuilderBasic implements ImplicitFetchBuilder, BasicVal
 						fetchable.getSelectionExpression()
 				),
 				processingState -> {
-					final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( column );
+					final int jdbcPosition = jdbcResultsMetadata.resolveColumnPosition( column, table );
 					final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
 					return new ResultSetMappingSqlSelection( valuesArrayPosition, fetchable );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/ResultSetAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/ResultSetAccess.java
@@ -44,9 +44,21 @@ public interface ResultSetAccess extends JdbcValuesMetadata {
 		}
 	}
 
-	default int resolveColumnPosition(String columnName) {
+	default int resolveColumnPosition(String columnName, String tableName) {
 		try {
-			return getResultSet().findColumn( columnName );
+			if ( tableName == null ) {
+				return getResultSet().findColumn( columnName );
+			}
+			else {
+				final ResultSetMetaData metaData = getResultSet().getMetaData();
+				for ( int i = 1; i <= metaData.getColumnCount(); i++ ) {
+					if ( columnName.equals( metaData.getColumnLabel( i ) )
+							&& tableName.equals( metaData.getTableName( i ) ) ) {
+						return i;
+					}
+				}
+				return getResultSet().findColumn( columnName );
+			}
 		}
 		catch (SQLException e) {
 			throw getFactory().getJdbcServices().getJdbcEnvironment().getSqlExceptionHelper().convert(
@@ -67,6 +79,18 @@ public interface ResultSetAccess extends JdbcValuesMetadata {
 			throw getFactory().getJdbcServices().getJdbcEnvironment().getSqlExceptionHelper().convert(
 					e,
 					"Unable to find column name by position"
+			);
+		}
+	}
+
+	default String resolveColumnTableName(int position) {
+		try {
+			return getResultSet().getMetaData().getTableName( position );
+		}
+		catch (SQLException e) {
+			throw getFactory().getJdbcServices().getJdbcEnvironment().getSqlExceptionHelper().convert(
+					e,
+					"Unable to find column table name by position"
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMetadata.java
@@ -23,12 +23,17 @@ public interface JdbcValuesMetadata {
 	/**
 	 * Position of a particular result value by name
 	 */
-	int resolveColumnPosition(String columnName);
+	int resolveColumnPosition(String columnName, String tableName);
 
 	/**
 	 * Name of a particular result value by position
 	 */
 	String resolveColumnName(int position);
+
+	/**
+	 * Table name of a particular result value by position
+	 */
+	String resolveColumnTableName(int position);
 
 	/**
 	 * The basic type of a particular result value by position

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
@@ -11,11 +11,8 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
-import org.hibernate.dialect.AbstractTransactSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
 
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -120,9 +117,6 @@ public class ColumnTransformerTest {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = PostgreSQLDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
-	@SkipForDialect(dialectClass = AbstractTransactSQLDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
-	@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
 	public void testStoredValues(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -131,50 +125,6 @@ public class ColumnTransformerTest {
 							"select size_in_cm / 2.54E0"
 							+ ", radiusS / 2.54E0"
 							+ ", diamet / 2.54E0"
-							+ " from t_staff"
-							+ " where t_staff.id = 4";
-
-					final Object result = session
-							.createNativeQuery( sqlString )
-							.getSingleResult();
-					assertThat( result, notNullValue() );
-					assertThat( result, instanceOf( Object[].class ) );
-
-					final Object[] values = (Object[]) result;
-					assertThat( values.length, is( 3 ) );
-
-					assertThat( ( (Number) values[0] ).doubleValue(), closeTo( 1, 0.01d ) );
-					assertThat( ( (Number) values[1] ).doubleValue(), closeTo( 2, 0.01d ) );
-					assertThat( ( (Number) values[2] ).doubleValue(), closeTo( 3, 0.01d ) );
-				}
-		);
-
-		scope.inTransaction(
-				session -> {
-					final String sqlString =
-							// represents how each is mapped in the mappings - see their @ColumnTransformer#read
-							"select i.integer_val"
-							+ " from t_staff s join integers i on s.id = i.Staff_id"
-							+ " where s.id = 12";
-
-					final List<?> results = session
-							.createNativeQuery( sqlString )
-							.getResultList();
-
-					assertThat( results, contains( 1-20, 2-20, 3-20, 4-20 ) );
-				}
-		);
-	}
-
-	@Test
-	public void testStoredValues2(SessionFactoryScope scope) {
-		scope.inTransaction(
-				session -> {
-					final String sqlString =
-							// represents how each is mapped in the mappings - see their @ColumnTransformer#read
-							"select size_in_cm / 2.54E0 as a"
-							+ ", radiusS / 2.54E0 as b"
-							+ ", diamet / 2.54E0 as c"
 							+ " from t_staff"
 							+ " where t_staff.id = 4";
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columntransformer/ColumnTransformerTest.java
@@ -11,8 +11,11 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.dialect.AbstractTransactSQLDialect;
 import org.hibernate.dialect.MySQLDialect;
 
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -117,6 +120,9 @@ public class ColumnTransformerTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = PostgreSQLDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
+	@SkipForDialect(dialectClass = AbstractTransactSQLDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
+	@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "The dialect returns the same alias for the 3 selected columns ", matchSubTypes = true)
 	public void testStoredValues(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -125,6 +131,50 @@ public class ColumnTransformerTest {
 							"select size_in_cm / 2.54E0"
 							+ ", radiusS / 2.54E0"
 							+ ", diamet / 2.54E0"
+							+ " from t_staff"
+							+ " where t_staff.id = 4";
+
+					final Object result = session
+							.createNativeQuery( sqlString )
+							.getSingleResult();
+					assertThat( result, notNullValue() );
+					assertThat( result, instanceOf( Object[].class ) );
+
+					final Object[] values = (Object[]) result;
+					assertThat( values.length, is( 3 ) );
+
+					assertThat( ( (Number) values[0] ).doubleValue(), closeTo( 1, 0.01d ) );
+					assertThat( ( (Number) values[1] ).doubleValue(), closeTo( 2, 0.01d ) );
+					assertThat( ( (Number) values[2] ).doubleValue(), closeTo( 3, 0.01d ) );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					final String sqlString =
+							// represents how each is mapped in the mappings - see their @ColumnTransformer#read
+							"select i.integer_val"
+							+ " from t_staff s join integers i on s.id = i.Staff_id"
+							+ " where s.id = 12";
+
+					final List<?> results = session
+							.createNativeQuery( sqlString )
+							.getResultList();
+
+					assertThat( results, contains( 1-20, 2-20, 3-20, 4-20 ) );
+				}
+		);
+	}
+
+	@Test
+	public void testStoredValues2(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final String sqlString =
+							// represents how each is mapped in the mappings - see their @ColumnTransformer#read
+							"select size_in_cm / 2.54E0 as a"
+							+ ", radiusS / 2.54E0 as b"
+							+ ", diamet / 2.54E0 as c"
 							+ " from t_staff"
 							+ " where t_staff.id = 4";
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/nativequery/NativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/nativequery/NativeQueryTest.java
@@ -1,0 +1,193 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.jpa.compliance.nativequery;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityResult;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Jpa(
+		annotatedClasses = { NativeQueryTest.Item.class, NativeQueryTest.Order.class }
+)
+public class NativeQueryTest {
+
+	@Test
+	public void testIt(EntityManagerFactoryScope scope) {
+
+		scope.inTransaction(
+				entityManager -> {
+					final Item item1 = new Item( 1, "WaterShoes" );
+					final Item item2 = new Item( 2, "FlipFlops" );
+					final Item item3 = new Item( 3, "Sandals" );
+
+					entityManager.persist( item1 );
+					entityManager.persist( item2 );
+					entityManager.persist( item3 );
+
+					Order order1 = new Order( 1, 25.0D, item1 );
+					entityManager.persist( order1 );
+					Order order2 = new Order( 2, 125.0D, item2 );
+					entityManager.persist( order2 );
+					Order order3 = new Order( 3, 150.0D, item3 );
+					entityManager.persist( order3 );
+
+					List<Object[]> results = entityManager.createNativeQuery(
+							"Select o.ID, o.ORDER_PRICE, o.ORDER_ITEM , i.ID, i.ITEM_NAME from ORDER_TABLE o, ITEM_TABLE i "
+									+ " WHERE (o.ORDER_PRICE > 140) AND (o.ORDER_ITEM = i.ID)",
+							"OrderItemResult"
+					).getResultList();
+
+					assertEquals( 1, results.size(), "Wrong result size" );
+
+					for ( Object[] result : results ) {
+						assertEquals( 2, result.length,  "Wrong number of objects in the array result" );
+						for ( Object o : result ) {
+							if ( o instanceof Order ) {
+								assertEquals( order3, o );
+							}
+							else if ( o instanceof Item ) {
+								assertEquals( item3, o );
+							}
+							else {
+								fail( "Received an unexpected object result:" + o );
+							}
+						}
+					}
+				}
+		);
+	}
+
+	@Entity(name = "Item")
+	@Table(name = "ITEM_TABLE")
+	public static class Item {
+
+		@Id
+		@Column(name = "ID")
+		private Integer id;
+
+		@Column(name = "ITEM_NAME")
+		private String itemName;
+
+		@OneToOne(mappedBy = "item")
+		private Order order;
+
+		public Item() {
+		}
+
+		public Item(Integer id, String itemName) {
+			this.id = id;
+			this.itemName = itemName;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public Order getOrder() {
+			return this.order;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Item item = (Item) o;
+			return id == item.id && Objects.equals( itemName, item.itemName ) && Objects.equals(
+					order,
+					item.order
+			);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( id, itemName, order );
+		}
+	}
+
+
+	@SqlResultSetMapping(name = "OrderItemResult", entities = {
+			@EntityResult(entityClass = Order.class),
+			@EntityResult(entityClass = Item.class)
+	})
+	@Entity(name = "Order")
+	@Table(name = "ORDER_TABLE")
+	public static class Order implements java.io.Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Integer id;
+
+		@Column(name = "ORDER_PRICE")
+		private double price;
+
+		@OneToOne
+		@JoinColumn(name = "ORDER_ITEM")
+		private Item item;
+
+		public Order() {
+		}
+
+		public Order(Integer id, double price, Item item) {
+			this.id = id;
+			this.price = price;
+			item.order = this;
+			this.item = item;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public double getPrice() {
+			return this.price;
+		}
+
+		public Item getItem() {
+			return item;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Order order = (Order) o;
+			return id == order.id && Double.compare( order.price, price ) == 0 && Objects.equals(
+					item,
+					order.item
+			);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( id, price, item );
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/autodiscovery/AutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/autodiscovery/AutoDiscoveryTest.java
@@ -13,128 +13,170 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.hibernate.Session;
-import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jdbc.Work;
+import org.hibernate.loader.NonUniqueDiscoveredSqlAliasException;
 
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import jakarta.persistence.PersistenceException;
+
+import static org.hibernate.testing.orm.junit.ExtraAssertions.assertTyping;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 /**
  * @author Steve Ebersole
  */
-public class AutoDiscoveryTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = { Group.class, User.class, Membership.class }
+)
+@SessionFactory
+@ServiceRegistry(
+		settings = @Setting(name = AvailableSettings.IMPLICIT_NAMING_STRATEGY, value = "jpa")
+)
+public class AutoDiscoveryTest {
 	private static final String QUERY_STRING =
 			"select u.name as username, g.name as groupname, m.joinDate " +
 					"from t_membership m " +
 					"        inner join t_user u on m.member_id = u.id " +
 					"        inner join t_group g on m.group_id = g.id";
 
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-		configuration.setImplicitNamingStrategy( ImplicitNamingStrategyJpaCompliantImpl.INSTANCE );
-	}
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { Group.class, User.class, Membership.class };
-	}
-
-	@Test
-	public void testAutoDiscoveryWithDuplicateColumnLabels() {
-		Session session = openSession();
-		session.beginTransaction();
-		session.save( new User( "steve" ) );
-		session.save( new User( "stliu" ) );
-		session.getTransaction().commit();
-		session.close();
-
-		session = openSession();
-		session.beginTransaction();
-		List results = session.createNativeQuery(
-				"select u.name, u2.name from t_user u, t_user u2 where u.name='steve'" ).list();
-		// this should result in a result set like:
-		//   [0] steve, steve
-		//   [1] steve, stliu
-		// although the rows could be reversed
-		assertEquals( 2, results.size() );
-		final Object[] row1 = (Object[]) results.get( 0 );
-		final Object[] row2 = (Object[]) results.get( 1 );
-		assertEquals( "steve", row1[0] );
-		assertEquals( "steve", row2[0] );
-		if ( "steve".equals( row1[1] ) ) {
-			assertEquals( "stliu", row2[1] );
-		}
-		else {
-			assertEquals( "stliu", row1[1] );
-		}
-		session.getTransaction().commit();
-		session.close();
-
-		session = openSession();
-		session.beginTransaction();
-		session.createQuery( "delete from User" ).executeUpdate();
-		session.getTransaction().commit();
-		session.close();
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "delete from User" ).executeUpdate();
+				}
+		);
 	}
 
 	@Test
-	public void testSqlQueryAutoDiscovery() throws Exception {
-		Session session = openSession();
-		session.beginTransaction();
-		User u = new User( "steve" );
-		Group g = new Group( "developer" );
-		Membership m = new Membership( u, g );
-		session.save( u );
-		session.save( g );
-		session.save( m );
-		session.getTransaction().commit();
-		session.close();
+	public void testAutoDiscoveryWithDuplicateColumnLabels(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.save( new User( "steve" ) );
+					session.save( new User( "stliu" ) );
+				}
+		);
 
-		session = openSession();
-		session.beginTransaction();
-		List result = session.createNativeQuery( QUERY_STRING ).list();
-		Object[] row = (Object[]) result.get( 0 );
-		Assert.assertEquals( "steve", row[0] );
-		Assert.assertEquals( "developer", row[1] );
-		session.delete( m );
-		session.delete( u );
-		session.delete( g );
-		session.getTransaction().commit();
-		session.close();
-	}
-
-	@Test
-	public void testDialectGetColumnAliasExtractor() {
-		Session session = openSession();
-		final SessionImplementor sessionImplementor = (SessionImplementor) session;
-		session.beginTransaction();
-		session.doWork(
-				new Work() {
-					@Override
-					public void execute(Connection connection) throws SQLException {
-						PreparedStatement ps = sessionImplementor.getJdbcCoordinator().getStatementPreparer().prepareStatement( QUERY_STRING );
-						ResultSet rs = sessionImplementor.getJdbcCoordinator().getResultSetReturn().extract( ps );
-						try {
-							ResultSetMetaData metadata = rs.getMetaData();
-							String column1Alias = getDialect().getColumnAliasExtractor().extractColumnAlias( metadata, 1 );
-							String column2Alias = getDialect().getColumnAliasExtractor().extractColumnAlias( metadata, 2 );
-							Assert.assertFalse( "bad dialect.getColumnAliasExtractor impl", column1Alias.equals( column2Alias ) );
+		scope.inSession(
+				session -> {
+					try {
+						session.beginTransaction();
+						List results = session.createNativeQuery(
+								"select u.name, u2.name from t_user u, t_user u2 where u.name='steve'" ).list();
+						// this should result in a result set like:
+						//   [0] steve, steve
+						//   [1] steve, stliu
+						// although the rows could be reversed
+						assertEquals( 2, results.size() );
+						final Object[] row1 = (Object[]) results.get( 0 );
+						final Object[] row2 = (Object[]) results.get( 1 );
+						assertEquals( "steve", row1[0] );
+						assertEquals( "steve", row2[0] );
+						if ( "steve".equals( row1[1] ) ) {
+							assertEquals( "stliu", row2[1] );
 						}
-						finally {
-                            sessionImplementor.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( rs, ps );
-                            sessionImplementor.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( ps );
+						else {
+							assertEquals( "stliu", row1[1] );
+						}
+						session.getTransaction().commit();
+						fail("NonUniqueDiscoveredSqlAliasException expected ");
+					}
+					catch (PersistenceException e) {
+						//expected
+						assertTyping( NonUniqueDiscoveredSqlAliasException.class, e.getCause() );
+					}
+					finally {
+						if ( session.getTransaction().isActive() ) {
+							session.getTransaction().rollback();
 						}
 					}
 				}
 		);
-		session.getTransaction().commit();
-		session.close();
+	}
+
+	@Test
+	public void testSqlQueryAutoDiscovery(SessionFactoryScope scope) {
+		User u = new User( "steve" );
+		Group g = new Group( "developer" );
+		Membership m = new Membership( u, g );
+
+		scope.inTransaction(
+				session -> {
+					session.save( u );
+					session.save( g );
+					session.save( m );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					List result = session.createNativeQuery( QUERY_STRING ).list();
+					Object[] row = (Object[]) result.get( 0 );
+					assertEquals( "steve", row[0] );
+					assertEquals( "developer", row[1] );
+					session.delete( m );
+					session.delete( u );
+					session.delete( g );
+				}
+		);
+	}
+
+	@Test
+	public void testDialectGetColumnAliasExtractor(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.doWork(
+							new Work() {
+								@Override
+								public void execute(Connection connection) throws SQLException {
+									PreparedStatement ps = session.getJdbcCoordinator()
+											.getStatementPreparer()
+											.prepareStatement( QUERY_STRING );
+									ResultSet rs = session.getJdbcCoordinator().getResultSetReturn().extract(
+											ps );
+									try {
+										ResultSetMetaData metadata = rs.getMetaData();
+										String column1Alias = session.getFactory()
+												.getJdbcServices()
+												.getDialect()
+												.getColumnAliasExtractor()
+												.extractColumnAlias(
+														metadata,
+														1
+												);
+										String column2Alias = session.getFactory()
+												.getJdbcServices()
+												.getDialect()
+												.getColumnAliasExtractor()
+												.extractColumnAlias(
+														metadata,
+														2
+												);
+										assertFalse(
+												column1Alias.equals( column2Alias ),
+												"bad dialect.getColumnAliasExtractor impl"
+										);
+									}
+									finally {
+										session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( rs, ps );
+										session.getJdbcCoordinator().getLogicalConnection().getResourceRegistry().release( ps );
+									}
+								}
+							}
+					);
+				}
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/autodiscovery/AutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/autodiscovery/AutoDiscoveryTest.java
@@ -69,38 +69,24 @@ public class AutoDiscoveryTest {
 				}
 		);
 
-		scope.inSession(
+		scope.inTransaction(
 				session -> {
-					try {
-						session.beginTransaction();
-						List results = session.createNativeQuery(
-								"select u.name, u2.name from t_user u, t_user u2 where u.name='steve'" ).list();
-						// this should result in a result set like:
-						//   [0] steve, steve
-						//   [1] steve, stliu
-						// although the rows could be reversed
-						assertEquals( 2, results.size() );
-						final Object[] row1 = (Object[]) results.get( 0 );
-						final Object[] row2 = (Object[]) results.get( 1 );
-						assertEquals( "steve", row1[0] );
-						assertEquals( "steve", row2[0] );
-						if ( "steve".equals( row1[1] ) ) {
-							assertEquals( "stliu", row2[1] );
-						}
-						else {
-							assertEquals( "stliu", row1[1] );
-						}
-						session.getTransaction().commit();
-						fail("NonUniqueDiscoveredSqlAliasException expected ");
+					List results = session.createNativeQuery(
+							"select u.name, u2.name from t_user u, t_user u2 where u.name='steve'" ).list();
+					// this should result in a result set like:
+					//   [0] steve, steve
+					//   [1] steve, stliu
+					// although the rows could be reversed
+					assertEquals( 2, results.size() );
+					final Object[] row1 = (Object[]) results.get( 0 );
+					final Object[] row2 = (Object[]) results.get( 1 );
+					assertEquals( "steve", row1[0] );
+					assertEquals( "steve", row2[0] );
+					if ( "steve".equals( row1[1] ) ) {
+						assertEquals( "stliu", row2[1] );
 					}
-					catch (PersistenceException e) {
-						//expected
-						assertTyping( NonUniqueDiscoveredSqlAliasException.class, e.getCause() );
-					}
-					finally {
-						if ( session.getTransaction().isActive() ) {
-							session.getTransaction().rollback();
-						}
+					else {
+						assertEquals( "stliu", row1[1] );
 					}
 				}
 		);


### PR DESCRIPTION
may be I'm wrong but provably we can just remove the check for duplicate alias and not throwing the`NonUniqueDiscoveredSqlAliasException` , the test added when this exception was introduced seems not failing anymore even with duplicate aliases.
