### PR TITLE
HHH-15036 Disable DefaultCatalogAndSchemaTest when testing against MariaDB < 10.3

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -52,6 +52,9 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.MariaDB102Dialect;
+import org.hibernate.dialect.MariaDB10Dialect;
+import org.hibernate.dialect.MariaDB53Dialect;
 import org.hibernate.dialect.SQLServer2012Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
@@ -72,6 +75,7 @@ import org.hibernate.tool.schema.spi.TargetDescriptor;
 
 import org.hibernate.testing.AfterClassOnce;
 import org.hibernate.testing.BeforeClassOnce;
+import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.hibernate.testing.junit4.CustomParameterized;
@@ -81,6 +85,12 @@ import org.junit.runners.Parameterized;
 
 @RunWith(CustomParameterized.class)
 @TestForIssue(jiraKey = { "HHH-14921", "HHH-14922" })
+@SkipForDialect(value = MariaDB53Dialect.class, strictMatching = true,
+		comment = "MariaDB < 10.3 doesn't support sequences")
+@SkipForDialect(value = MariaDB10Dialect.class, strictMatching = true,
+		comment = "MariaDB < 10.3 doesn't support sequences")
+@SkipForDialect(value = MariaDB102Dialect.class, strictMatching = true,
+		comment = "MariaDB < 10.3 doesn't support sequences")
 public class DefaultCatalogAndSchemaTest {
 
 	private static final String SQL_QUOTE_CHARACTER_CLASS = "([`\"]|\\[|\\])";


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15036

> MariaDB < 10.3 doesn’t support sequences, and adapting this test to only use sequences conditionally would be a hassle, so I’d rather not even try.

This should fix test failures on https://ci.hibernate.org/job/hibernate-orm-5.6-mariadb/

I don't think we need to port this to 6.0 as, to the best of my knowledge, we don't even run ORM 6.0 tests against older MariaDB versions.

