### PR TITLE
HHH-15037 Criteria Update/Delete with vararg parameters throws NullPointerException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmRestrictedDmlStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmRestrictedDmlStatement.java
@@ -62,11 +62,7 @@ public abstract class AbstractSqmRestrictedDmlStatement<T> extends AbstractSqmDm
 			return;
 		}
 
-		if ( whereClause == null ) {
-			whereClause = new SqmWhereClause( nodeBuilder() );
-		}
-
-		whereClause.applyPredicate( predicate );
+		initAndGetWhereClause().applyPredicate( predicate );
 	}
 
 	public void setWhereClause(SqmWhereClause whereClause) {
@@ -79,13 +75,21 @@ public abstract class AbstractSqmRestrictedDmlStatement<T> extends AbstractSqmDm
 	}
 
 	protected void setWhere(Expression<Boolean> restriction) {
-		applyPredicate( null );
-		applyPredicate( (SqmPredicate) restriction );
+		// Replaces the current predicate if one is present
+		initAndGetWhereClause().setPredicate( (SqmPredicate) restriction );
+	}
+
+	protected SqmWhereClause initAndGetWhereClause() {
+		if ( whereClause == null ) {
+			whereClause = new SqmWhereClause( nodeBuilder() );
+		}
+		return whereClause;
 	}
 
 	protected void setWhere(Predicate... restrictions) {
-		applyPredicate( null );
-		final SqmWhereClause whereClause = getWhereClause();
+		final SqmWhereClause whereClause = initAndGetWhereClause();
+		// Clear the current predicate if one is present
+		whereClause.setPredicate(null);
 		for ( Predicate restriction : restrictions ) {
 			whereClause.applyPredicate( (SqmPredicate) restriction );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/ManipulationCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/ManipulationCriteriaTest.java
@@ -65,7 +65,7 @@ public class ManipulationCriteriaTest extends AbstractMetamodelSpecificTest {
 		{
 			CriteriaUpdate<Customer> updateCriteria = builder.createCriteriaUpdate( Customer.class );
 			Root<Customer> root = updateCriteria.from( Customer.class );
-			updateCriteria.set( Customer_.name, "Acme" );
+			updateCriteria.set( Customer_.age, 23 );
 			updateCriteria.where(
 					builder.equal(
 							root.get( Customer_.name ),
@@ -73,6 +73,22 @@ public class ManipulationCriteriaTest extends AbstractMetamodelSpecificTest {
 					)
 			);
 			em.createQuery( updateCriteria ).executeUpdate();
+		}
+
+		{
+			CriteriaDelete<Customer> deleteCriteria = builder.createCriteriaDelete( Customer.class );
+			Root<Customer> root = deleteCriteria.from( Customer.class );
+			deleteCriteria.where(
+					builder.equal(
+							root.get( Customer_.name ),
+							"Acme"
+					),
+					builder.equal(
+							root.get(Customer_.age),
+							23
+					)
+			);
+			em.createQuery( deleteCriteria ).executeUpdate();
 		}
 
 		em.getTransaction().commit();


### PR DESCRIPTION
multiple arguments

Also removed extraneous `applyPredicate(null)` calls.

https://hibernate.atlassian.net/browse/HHH-15037