### PR TITLE
Fix expression type for arithmetic operations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
@@ -279,10 +279,13 @@ public class DerbySqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 			appendSql( ',' );
 			arithmeticExpression.getRightHandOperand().accept( this );
 			appendSql( CLOSE_PARENTHESIS );
-			return;
 		}
 		else {
-			super.visitBinaryArithmeticExpression( arithmeticExpression );
+			appendSql( OPEN_PARENTHESIS );
+			render( arithmeticExpression.getLeftHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+			appendSql( arithmeticExpression.getOperator().getOperatorSqlTextString() );
+			render( arithmeticExpression.getRightHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+			appendSql( CLOSE_PARENTHESIS );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
@@ -10,10 +10,12 @@ import java.util.List;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.ComparisonOperator;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteStatement;
+import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.SqlTuple;
@@ -136,6 +138,15 @@ public class H2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAstT
 		else {
 			expression.accept( this );
 		}
+	}
+
+	@Override
+	public void visitBinaryArithmeticExpression(BinaryArithmeticExpression arithmeticExpression) {
+		appendSql( OPEN_PARENTHESIS );
+		render( arithmeticExpression.getLeftHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+		appendSql( arithmeticExpression.getOperator().getOperatorSqlTextString() );
+		render( arithmeticExpression.getRightHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+		appendSql( CLOSE_PARENTHESIS );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
@@ -230,10 +230,13 @@ public class HSQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAs
 			appendSql( ',' );
 			arithmeticExpression.getRightHandOperand().accept( this );
 			appendSql( CLOSE_PARENTHESIS );
-			return;
 		}
 		else {
-			super.visitBinaryArithmeticExpression( arithmeticExpression );
+			appendSql( OPEN_PARENTHESIS );
+			render( arithmeticExpression.getLeftHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+			appendSql( arithmeticExpression.getOperator().getOperatorSqlTextString() );
+			render( arithmeticExpression.getRightHandOperand(), SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+			appendSql( CLOSE_PARENTHESIS );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -715,7 +715,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.ADD,
 				(SqmExpression<?>) x,
-				value( y, (SqmExpression) x )
+				value( y )
 		);
 	}
 
@@ -724,7 +724,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	public <N extends Number> SqmExpression<N> sum(N x, Expression<? extends N> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.ADD,
-				value( x, (SqmExpression) y ),
+				value( x ),
 				(SqmExpression<?>) y
 		);
 	}
@@ -743,7 +743,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MULTIPLY,
 				(SqmExpression<?>) x,
-				value( y, (SqmExpression<?>) x )
+				value( y )
 		);
 	}
 
@@ -751,7 +751,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	public <N extends Number> SqmExpression<N> prod(N x, Expression<? extends N> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MULTIPLY,
-				value( x, (SqmExpression<?>) y ),
+				value( x ),
 				(SqmExpression<?>) y
 		);
 	}
@@ -771,7 +771,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.SUBTRACT,
 				(SqmExpression) x,
-				value( y, (SqmExpression) x )
+				value( y )
 		);
 	}
 
@@ -779,7 +779,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	public <N extends Number> SqmExpression<N> diff(N x, Expression<? extends N> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.SUBTRACT,
-				value( x, (SqmExpression<?>) y ),
+				value( x ),
 				(SqmExpression<?>) y
 		);
 	}
@@ -798,7 +798,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.QUOT,
 				(SqmExpression<?>) x,
-				value( y, (SqmExpression<?>) x )
+				value( y )
 		);
 	}
 
@@ -807,7 +807,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	public SqmExpression<Number> quot(Number x, Expression<? extends Number> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.QUOT,
-				value( x, (SqmExpression<? extends Number>) y ),
+				value( x ),
 				(SqmExpression<? extends Number>) y
 		);
 	}
@@ -826,7 +826,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MODULO,
 				(SqmExpression<Integer>) x,
-				value( y, (SqmExpression<Integer>) x )
+				value( y )
 		);
 	}
 
@@ -834,7 +834,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	public SqmExpression<Integer> mod(Integer x, Expression<Integer> y) {
 		return createSqmArithmeticNode(
 				BinaryArithmeticOperator.MODULO,
-				value( x, (SqmExpression<Integer>) y ),
+				value( x ),
 				(SqmExpression<Integer>) y
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -4685,17 +4685,16 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 	}
 
 	private BasicValuedMapping getExpressionType(SqmBinaryArithmetic<?> expression) {
-		final SqmExpressable<?> sqmExpressable = QueryHelper.highestPrecedenceType(
-				expression.getLeftHandOperand().getNodeType(),
-				expression.getRightHandOperand().getNodeType()
-		);
-		if ( sqmExpressable instanceof BasicValuedMapping ) {
-			return (BasicValuedMapping) sqmExpressable;
-		}
-		else if ( sqmExpressable != null ) {
-			return getTypeConfiguration().getBasicTypeForJavaType(
-					sqmExpressable.getExpressableJavaTypeDescriptor().getJavaTypeClass()
-			);
+		final SqmExpressable<?> nodeType = expression.getNodeType();
+		if ( nodeType != null ) {
+			if ( nodeType instanceof BasicValuedMapping ) {
+				return (BasicValuedMapping) nodeType;
+			}
+			else {
+				return getTypeConfiguration().getBasicTypeForJavaType(
+						nodeType.getExpressableJavaTypeDescriptor().getJavaTypeClass()
+				);
+			}
 		}
 		return JavaObjectType.INSTANCE;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmExpression.java
@@ -103,8 +103,11 @@ public interface SqmExpression<T> extends SqmSelectableNode<T>, JpaExpression<T>
 	SqmPredicate in(Expression<Collection<?>> values);
 
 	default <X> SqmExpression<X> castAs(DomainType<X> type) {
-		QueryEngine queryEngine = nodeBuilder().getQueryEngine();
-		SqmCastTarget<T> target = new SqmCastTarget<>( (ReturnableType<T>) type, nodeBuilder() );
+		if ( getNodeType() == type ) {
+			return (SqmExpression<X>) this;
+		}
+		final QueryEngine queryEngine = nodeBuilder().getQueryEngine();
+		final SqmCastTarget<T> target = new SqmCastTarget<>( (ReturnableType<T>) type, nodeBuilder() );
 		return queryEngine.getSqmFunctionRegistry()
 				.findFunctionDescriptor("cast")
 					.generateSqmExpression(

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -547,51 +547,11 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			return getBasicTypeRegistry().getRegisteredType( Duration.class );
 		}
 
-		if ( matchesJavaType( firstType, Double.class ) ) {
+		if ( secondType == null || firstType != null
+				&& firstType.getExpressableJavaTypeDescriptor().isWider( secondType.getExpressableJavaTypeDescriptor() ) ) {
 			return firstType;
 		}
-		else if ( matchesJavaType( secondType, Double.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, Float.class ) ) {
-			return firstType;
-		}
-		else if ( matchesJavaType( secondType, Float.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, BigDecimal.class ) ) {
-			return firstType;
-		}
-		else if ( matchesJavaType( secondType, BigDecimal.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, BigInteger.class ) ) {
-			return firstType;
-		}
-		else if ( matchesJavaType( secondType, BigInteger.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, Long.class ) ) {
-			return firstType;
-		}
-		else if ( matchesJavaType( secondType, Long.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, Integer.class ) ) {
-			return firstType;
-		}
-		else if ( matchesJavaType( secondType, Integer.class ) ) {
-			return secondType;
-		}
-		else if ( matchesJavaType( firstType, Short.class ) ) {
-			return getBasicTypeRegistry().getRegisteredType( Integer.class.getName() );
-		}
-		else if ( matchesJavaType( secondType, Short.class ) ) {
-			return getBasicTypeRegistry().getRegisteredType( Integer.class.getName() );
-		}
-		else {
-			return getBasicTypeRegistry().getRegisteredType( Number.class.getName() );
-		}
+		return secondType;
 	}
 
 	private static boolean matchesJavaType(SqmExpressable<?> type, Class<?> javaType) {

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -511,19 +511,18 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			SqmExpressable<?> firstType,
 			SqmExpressable<?> secondType,
 			BinaryArithmeticOperator operator) {
-		return resolveArithmeticType( firstType, secondType, operator == DIVIDE );
+		return resolveArithmeticType( firstType, secondType );
 	}
 
 	/**
 	 * Determine the result type of an arithmetic operation as defined by the
-	 * rules in section 6.5.7.1.
+	 * rules in section 6.5.8.1.
 	 *
 	 * @see QueryHelper#highestPrecedenceType2
 	 */
 	public SqmExpressable<?> resolveArithmeticType(
 			SqmExpressable<?> firstType,
-			SqmExpressable<?> secondType,
-			boolean isDivision) {
+			SqmExpressable<?> secondType) {
 
 		if ( getSqlTemporalType( firstType ) != null ) {
 			if ( secondType==null || getSqlTemporalType( secondType ) != null ) {
@@ -547,15 +546,6 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			// parameter (which doesn't have a type yet)
 			return getBasicTypeRegistry().getRegisteredType( Duration.class );
 		}
-
-		if ( isDivision ) {
-			// covered under the note in 6.5.7.1 discussing the unportable
-			// "semantics of the SQL division operation"..
-			return getBasicTypeRegistry().getRegisteredType( Number.class.getName() );
-		}
-
-
-		// non-division
 
 		if ( matchesJavaType( firstType, Double.class ) ) {
 			return firstType;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/formulajoin/FormulaJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/formulajoin/FormulaJoinTest.java
@@ -103,6 +103,7 @@ public class FormulaJoinTest extends BaseCoreFunctionalTestCase {
 		tx = s.beginTransaction();
 		l = s.createQuery("from Detail d join fetch d.currentRoot.root m join fetch m.detail").list();
 		assertEquals( l.size(), 2 );
+		tx.commit();
 
 		s = openSession();
 		tx = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/CriteriaToBigDecimalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/CriteriaToBigDecimalTest.java
@@ -1,0 +1,94 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.jpa.compliance;
+
+import java.math.BigDecimal;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(
+		annotatedClasses = CriteriaToBigDecimalTest.Person.class
+)
+public class CriteriaToBigDecimalTest {
+
+	@BeforeEach
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager ->
+						entityManager.persist( new Person( 1, "Luigi", 20 ) )
+		);
+	}
+
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager ->
+						entityManager.createQuery( "delete from Person" ).executeUpdate()
+		);
+	}
+
+	@Test
+	public void testToBigDecimal(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+
+					final CriteriaQuery<BigDecimal> query = criteriaBuilder.createQuery( BigDecimal.class );
+
+					final Root<Person> person = query.from( Person.class );
+
+					final Path<BigDecimal> ageAttribute = person.get( "age" );
+
+					final Expression<BigDecimal> prod = criteriaBuilder.prod(
+							ageAttribute,
+							new BigDecimal( "5.5" )
+					);
+
+					query.select( criteriaBuilder.toBigDecimal( prod ) );
+
+					query.where( criteriaBuilder.equal( ageAttribute, 20 ) );
+
+					BigDecimal result = entityManager.createQuery( query ).getSingleResult();
+
+					assertEquals( new BigDecimal( "110.0" ).stripTrailingZeros(), result.stripTrailingZeros() );
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		private Integer age;
+
+		Person() {
+		}
+
+		public Person(Integer id, String name, Integer age) {
+			this.id = id;
+			this.name = name;
+			this.age = age;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/ProdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/ProdTest.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.jpa.compliance;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@Jpa(
+		annotatedClasses = ProdTest.Person.class
+)
+public class ProdTest {
+	@BeforeEach
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					entityManager.persist( new Person( 1, "Luigi ", 42 ) );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager ->
+						entityManager.createQuery( "delete from Person" ).executeUpdate()
+		);
+	}
+
+	@Test
+	public void testCriteriaMod(EntityManagerFactoryScope scope) {
+		scope.inEntityManager(
+				entityManager -> {
+					final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+					final CriteriaQuery<Number> query = criteriaBuilder.createQuery( Number.class );
+					final Root<Person> person = query.from( Person.class );
+					query.select( criteriaBuilder.prod( person.get( "age" ), 1F ) );
+
+					final Number id = entityManager.createQuery( query ).getSingleResult();
+
+					assertInstanceOf( Float.class, id );
+					assertEquals( 42F, id.floatValue() );
+				}
+		);
+	}
+
+	@Test
+	public void testQueryMod(EntityManagerFactoryScope scope) {
+		scope.inEntityManager(
+				entityManager -> {
+					final Object id = entityManager.createQuery( "select p.age * 1F from Person p" )
+							.getSingleResult();
+					assertInstanceOf( Float.class, id );
+					assertEquals( 42F, id );
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "PERSON_TABLE")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		private Integer age;
+
+		Person() {
+		}
+
+		public Person(Integer id, String name, Integer age) {
+			this.id = id;
+			this.name = name;
+			this.age = age;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}


### PR DESCRIPTION
for `SqmBinaryArithmetic` i think we do not need the following code
```
final SqmExpressable<?> sqmExpressable = QueryHelper.highestPrecedenceType(
				expression.getLeftHandOperand().getNodeType(),
				expression.getRightHandOperand().getNodeType()
		);
```
to determine the correct expression type, when we built it we already resolve the correct type 
```
(SqmExpressable<T>) domainModel.getTypeConfiguration().resolveArithmeticType(
						lhsOperand.getNodeType(),
						rhsOperand.getNodeType(),
						operator
				)
```