### PR TITLE
HHH-15042: add offset-clause usage for DB2zDialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -12,6 +12,7 @@ import org.hibernate.dialect.identity.DB2390IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.FetchLimitHandler;
 import org.hibernate.dialect.pagination.LimitHandler;
+import org.hibernate.dialect.pagination.OffsetFetchLimitHandler;
 import org.hibernate.dialect.sequence.DB2zSequenceSupport;
 import org.hibernate.dialect.sequence.NoSequenceSupport;
 import org.hibernate.dialect.sequence.SequenceSupport;
@@ -82,7 +83,9 @@ public class DB2zDialect extends DB2Dialect {
 
 	@Override
 	public LimitHandler getLimitHandler() {
-		return FetchLimitHandler.INSTANCE;
+		return getZVersion().isBefore(12)
+				? FetchLimitHandler.INSTANCE
+				: OffsetFetchLimitHandler.INSTANCE;
 	}
 
 	@Override


### PR DESCRIPTION
DB2z in Version 12 and beyond supports the "offset"-clause.

Current behavior:
Hibernate uses the "fetch first ..."-clause but does not use "offset" for paging requests.

Expected behavior:
For DB2z Databases in Version 12 and beyond the dialect should use the now supported "offset"-clause

IBM Docs:
https://www.ibm.com/docs/en/db2-for-zos/12?topic=subselect-offset-clause
https://www.ibm.com/docs/en/db2-for-zos/12?topic=subselect-fetch-clause

Test:
Because there is no DB2z Docker-DB testing this comes down to testing against an z/OS DB2 Instance.
I tested it against the DB2z Instance (v12.1.0) at work without any issues.  