### PR TITLE
remove 'hibernate.query.conventional_java_constants' and 'hibernate.query.validate_parameters'

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -564,16 +564,6 @@ It follows a pattern similar to the ANSI SQL definition of the global temporary 
 +
 This configuration property defines the database catalog used for storing the temporary tables used for bulk HQL operations.
 
-`*hibernate.query.conventional_java_constants*` (e.g. `true` (default value) or `false`)::
-Setting which indicates whether or not Java constants follow the https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html[Java Naming conventions].
-+
-The default is `true`.
-Existing applications may want to disable this (set it `false`) if non-conventional Java constants are used.
-However, there is a significant performance overhead for using non-conventional Java constants
-since Hibernate cannot determine if aliases should be treated as Java constants or not.
-+
-Check out https://hibernate.atlassian.net/browse/HHH-4959[HHH-4959] for more details.
-
 [[configurations-batch]]
 === Batching properties
 

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -492,10 +492,6 @@ Can reference a
 `StatementInspector` implementation `Class` reference or
 `StatementInspector` implementation class name (fully-qualified class name).
 
-`*hibernate.query.validate_parameters*` (e.g. `true` (default value) or `false`)::
-This configuration property can be used to disable parameters validation performed by `org.hibernate.query.Query#setParameter` when the Session is bootstrapped via Jakarta Persistence
-`jakarta.persistence.EntityManagerFactory`.
-
 `*hibernate.criteria.value_handling_mode*` (e.g. `BIND` (default value) or `INLINE`)::
 By default, Criteria queries uses bind parameters for any value passed through the Jakarta Persistence Criteria API.
 +

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -136,22 +136,6 @@ public interface SessionBuilder<T extends SessionBuilder> {
 	T jdbcTimeZone(TimeZone timeZone);
 
 	/**
-	 * Should {@link Query#setParameter} perform parameter validation
-	 * when the Session is bootstrapped via JPA {@link jakarta.persistence.EntityManagerFactory}
-	 *
-	 * @param enabled {@code true} indicates the validation should be performed, {@code false} otherwise
-	 * <p>
-	 * The default value is {@code true}
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
-	}
-
-
-
-	/**
 	 * Should the session be automatically closed after transaction completion?
 	 *
 	 * @param autoClose Should the session be automatically closed

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -40,18 +40,4 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 * @return {@code this}, for method chaining
 	 */
 	T tenantIdentifier(String tenantIdentifier);
-
-	/**
-	 * Should {@link Query#setParameter} perform parameter validation
-	 * when the Session is bootstrapped via JPA {@link jakarta.persistence.EntityManagerFactory}
-	 *
-	 * @param enabled {@code true} indicates the validation should be performed, {@code false} otherwise
-	 * <p>
-	 * The default value is {@code true}
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	default T setQueryParameterValidation(boolean enabled) {
-		return (T) this;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -132,7 +132,6 @@ import static org.hibernate.cfg.AvailableSettings.USE_SCROLLABLE_RESULTSET;
 import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
 import static org.hibernate.cfg.AvailableSettings.USE_SQL_COMMENTS;
 import static org.hibernate.cfg.AvailableSettings.USE_STRUCTURED_CACHE;
-import static org.hibernate.cfg.AvailableSettings.VALIDATE_QUERY_PARAMETERS;
 import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
 import static org.hibernate.internal.CoreLogging.messageLogger;
 import static org.hibernate.internal.log.DeprecationLogger.DEPRECATION_LOGGER;
@@ -246,7 +245,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private PhysicalConnectionHandlingMode connectionHandlingMode;
 	private boolean connectionProviderDisablesAutoCommit;
 	private TimeZone jdbcTimeZone;
-	private boolean queryParametersValidationEnabled;
 	private ValueHandlingMode criteriaValueHandlingMode;
 	private ImmutableEntityUpdateQueryHandlingMode immutableEntityUpdateQueryHandlingMode;
 	// These two settings cannot be modified from the builder,
@@ -557,12 +555,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		else if ( jdbcTimeZoneValue != null ) {
 			throw new IllegalArgumentException( "Configuration property " + JDBC_TIME_ZONE + " value [" + jdbcTimeZoneValue + "] is not supported!" );
 		}
-
-		this.queryParametersValidationEnabled = ConfigurationHelper.getBoolean(
-				VALIDATE_QUERY_PARAMETERS,
-				configurationSettings,
-				true
-		);
 
 		this.criteriaValueHandlingMode = ValueHandlingMode.interpret(
 				configurationSettings.get( CRITERIA_VALUE_HANDLING_MODE )
@@ -1166,11 +1158,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public TimeZone getJdbcTimeZone() {
 		return this.jdbcTimeZone;
-	}
-
-	@Override
-	public boolean isQueryParametersValidationEnabled() {
-		return this.queryParametersValidationEnabled;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -90,7 +90,6 @@ import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_PREFIX;
 import static org.hibernate.cfg.AvailableSettings.CALLABLE_NAMED_PARAMS_ENABLED;
 import static org.hibernate.cfg.AvailableSettings.CHECK_NULLABILITY;
 import static org.hibernate.cfg.AvailableSettings.CONNECTION_HANDLING;
-import static org.hibernate.cfg.AvailableSettings.CONVENTIONAL_JAVA_CONSTANTS;
 import static org.hibernate.cfg.AvailableSettings.CRITERIA_VALUE_HANDLING_MODE;
 import static org.hibernate.cfg.AvailableSettings.CUSTOM_ENTITY_DIRTINESS_STRATEGY;
 import static org.hibernate.cfg.AvailableSettings.DEFAULT_BATCH_FETCH_SIZE;
@@ -220,7 +219,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private SqmTranslatorFactory sqmTranslatorFactory;
 	private Boolean useOfJdbcNamedParametersEnabled;
 	private boolean namedQueryStartupCheckingEnabled;
-	private boolean conventionalJavaConstants;
 	private final boolean omitJoinOfSuperclassTablesEnabled;
 	private final int preferredSqlTypeCodeForBoolean;
 	private final TimeZoneStorageStrategy defaultTimeZoneStorageStrategy;
@@ -441,14 +439,12 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.useOfJdbcNamedParametersEnabled = cfgService.getSetting( CALLABLE_NAMED_PARAMS_ENABLED, BOOLEAN, true );
 
 		this.namedQueryStartupCheckingEnabled = cfgService.getSetting( QUERY_STARTUP_CHECKING, BOOLEAN, true );
-		this.conventionalJavaConstants = cfgService.getSetting(
-				CONVENTIONAL_JAVA_CONSTANTS, BOOLEAN, true );
 		this.omitJoinOfSuperclassTablesEnabled = cfgService.getSetting( OMIT_JOIN_OF_SUPERCLASS_TABLES, BOOLEAN, true );
 		this.preferredSqlTypeCodeForBoolean = ConfigurationHelper.getPreferredSqlTypeCodeForBoolean( serviceRegistry );
 		this.defaultTimeZoneStorageStrategy = context.getMetadataBuildingOptions().getDefaultTimeZoneStorage();
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
-		if ( !NoCachingRegionFactory.class.isInstance( regionFactory ) ) {
+		if ( !(regionFactory instanceof NoCachingRegionFactory) ) {
 			this.secondLevelCacheEnabled = cfgService.getSetting( USE_SECOND_LEVEL_CACHE, BOOLEAN, true );
 			this.queryCacheEnabled = cfgService.getSetting( USE_QUERY_CACHE, BOOLEAN, false );
 			this.timestampsCacheFactory = strategySelector.resolveDefaultableStrategy(
@@ -1045,11 +1041,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public boolean isNamedQueryStartupCheckingEnabled() {
 		return namedQueryStartupCheckingEnabled;
-	}
-
-	@Override
-	public boolean isConventionalJavaConstants() {
-		return conventionalJavaConstants;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -386,11 +386,6 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
-	public boolean isQueryParametersValidationEnabled() {
-		return delegate.isQueryParametersValidationEnabled();
-	}
-
-	@Override
 	public ValueHandlingMode getCriteriaValueHandlingMode() {
 		return delegate.getCriteriaValueHandlingMode();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -230,11 +230,6 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
-	public boolean isConventionalJavaConstants() {
-		return delegate.isConventionalJavaConstants();
-	}
-
-	@Override
 	public boolean isAllowOutOfTransactionUpdateOperations() {
 		return delegate.isAllowOutOfTransactionUpdateOperations();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -252,10 +252,6 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	TimeZone getJdbcTimeZone();
 
-	default boolean isQueryParametersValidationEnabled(){
-		return isJpaBootstrap();
-	}
-
 	default ValueHandlingMode getCriteriaValueHandlingMode() {
 		return ValueHandlingMode.BIND;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -189,8 +189,6 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	boolean isNamedQueryStartupCheckingEnabled();
 
-	boolean isConventionalJavaConstants();
-
 	boolean isSecondLevelCacheEnabled();
 
 	boolean isQueryCacheEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1969,20 +1969,6 @@ public interface AvailableSettings {
 	String MERGE_ENTITY_COPY_OBSERVER = "hibernate.event.merge.entity_copy_observer";
 
 	/**
-	 * Setting which indicates if {@link Query#setParameter} should not perform parameters validation
-	 *
-	 * This setting is applied only when the Session is bootstrapped via JPA {@link jakarta.persistence.EntityManagerFactory}
-	 *
-	 * </p>
-	 * Values are: {@code true} indicates the validation should be performed, {@code false} otherwise
-	 * <p>
-	 * The default value is {@code true} when the Session is bootstrapped via JPA {@link jakarta.persistence.EntityManagerFactory},
-	 * otherwise is {@code false}
-	 *
-	 */
-	String VALIDATE_QUERY_PARAMETERS = "hibernate.query.validate_parameters";
-
-	/**
 	 * By default, Criteria queries uses bind parameters for any value passed through the JPA Criteria API.
 	 *
 	 * The {@link org.hibernate.query.criteria.ValueHandlingMode#BIND} mode (default) will use bind variables for any value.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -986,18 +986,6 @@ public interface AvailableSettings {
 	String QUERY_STARTUP_CHECKING = "hibernate.query.startup_check";
 
 	/**
-	 * Setting which indicates whether or not Java constant follow the Java Naming conventions.
-	 * <p/>
-	 * Default is {@code true}. Existing applications may want to disable this (set it {@code false})
-	 * if unconventional Java constants are used. However, there is a significant performance overhead
-	 * for using unconventional Java constants since Hibernate cannot determine if aliases should be
-	 * treated as Java constants or not.
-	 *
-	 * @since 5.2
-	 */
-	String CONVENTIONAL_JAVA_CONSTANTS = "hibernate.query.conventional_java_constants";
-
-	/**
 	 * Enable ordering of update statements by primary key value
 	 */
 	String ORDER_UPDATES = "hibernate.order_updates";

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -122,12 +122,6 @@ public abstract class AbstractDelegatingSessionBuilder<T extends SessionBuilder>
 	}
 
 	@Override
-	public T setQueryParameterValidation(boolean enabled) {
-		delegate.setQueryParameterValidation( enabled );
-		return getThis();
-	}
-
-	@Override
 	public T connectionHandlingMode(PhysicalConnectionHandlingMode mode) {
 		delegate.connectionHandlingMode( mode );
 		return getThis();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -328,11 +328,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public boolean isQueryParametersValidationEnabled() {
-		return delegate.isQueryParametersValidationEnabled();
-	}
-
-	@Override
 	public boolean shouldAutoJoinTransaction() {
 		return delegate.shouldAutoJoinTransaction();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -396,10 +396,6 @@ public interface SharedSessionContractImplementor
 
 	boolean isAutoCloseSessionEnabled();
 
-	default boolean isQueryParametersValidationEnabled(){
-		return getFactory().getSessionFactoryOptions().isQueryParametersValidationEnabled();
-	}
-
 	/**
 	 * Get the load query influencers associated with this session.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
@@ -72,6 +72,4 @@ public interface SessionCreationOptions {
 	AfterCompletionAction getAfterCompletionAction();
 
 	ManagedFlushChecker getManagedFlushChecker();
-
-	boolean isQueryParametersValidationEnabled();
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1170,7 +1170,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		private boolean autoClear;
 		private String tenantIdentifier;
 		private TimeZone jdbcTimeZone;
-		private boolean queryParametersValidationEnabled;
 		private boolean explicitNoInterceptor;
 
 		// Lazy: defaults can be built by invoking the builder in fastSessionServices.defaultSessionEventListeners
@@ -1195,7 +1194,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 				tenantIdentifier = currentTenantIdentifierResolver.resolveCurrentTenantIdentifier();
 			}
 			this.jdbcTimeZone = sessionFactoryOptions.getJdbcTimeZone();
-			this.queryParametersValidationEnabled = sessionFactoryOptions.isQueryParametersValidationEnabled();
 		}
 
 
@@ -1226,11 +1224,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			return sessionOwnerBehavior == SessionOwnerBehavior.LEGACY_JPA
 					? ManagedFlushCheckerLegacyJpaImpl.INSTANCE
 					: null;
-		}
-
-		@Override
-		public boolean isQueryParametersValidationEnabled() {
-			return this.queryParametersValidationEnabled;
 		}
 
 		@Override
@@ -1419,19 +1412,12 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			jdbcTimeZone = timeZone;
 			return (T) this;
 		}
-
-		@Override
-		public T setQueryParameterValidation(boolean enabled) {
-			queryParametersValidationEnabled = enabled;
-			return (T) this;
-		}
 	}
 
 	public static class StatelessSessionBuilderImpl implements StatelessSessionBuilder, SessionCreationOptions {
 		private final SessionFactoryImpl sessionFactory;
 		private Connection connection;
 		private String tenantIdentifier;
-		private boolean queryParametersValidationEnabled;
 
 		public StatelessSessionBuilderImpl(SessionFactoryImpl sessionFactory) {
 			this.sessionFactory = sessionFactory;
@@ -1440,7 +1426,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			if ( tenantIdentifierResolver != null ) {
 				tenantIdentifier = tenantIdentifierResolver.resolveCurrentTenantIdentifier();
 			}
-			queryParametersValidationEnabled = sessionFactory.getSessionFactoryOptions().isQueryParametersValidationEnabled();
 		}
 
 		@Override
@@ -1534,17 +1519,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		@Override
 		public ManagedFlushChecker getManagedFlushChecker() {
 			return null;
-		}
-
-		@Override
-		public boolean isQueryParametersValidationEnabled() {
-			return queryParametersValidationEnabled;
-		}
-
-		@Override
-		public StatelessSessionBuilder setQueryParameterValidation(boolean enabled) {
-			queryParametersValidationEnabled = enabled;
-			return this;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -183,7 +183,6 @@ public class SessionImpl
 
 	private boolean autoClear;
 	private boolean autoClose;
-	private boolean queryParametersValidationEnabled;
 
 	private transient int dontFlushFromFind;
 
@@ -201,7 +200,6 @@ public class SessionImpl
 
 		this.autoClear = options.shouldAutoClear();
 		this.autoClose = options.shouldAutoClose();
-		this.queryParametersValidationEnabled = options.isQueryParametersValidationEnabled();
 
 		if ( options instanceof SharedSessionCreationOptions ) {
 			final SharedSessionCreationOptions sharedOptions = (SharedSessionCreationOptions) options;
@@ -429,11 +427,6 @@ public class SessionImpl
 	@Override
 	public boolean isAutoCloseSessionEnabled() {
 		return autoClose;
-	}
-
-	@Override
-	public boolean isQueryParametersValidationEnabled() {
-		return queryParametersValidationEnabled;
 	}
 
 	@Override
@@ -2066,11 +2059,6 @@ public class SessionImpl
 			return shareTransactionContext ?
 					session.getActionQueue().getTransactionCompletionProcesses() :
 					null;
-		}
-
-		@Override
-		public boolean isQueryParametersValidationEnabled() {
-			return session.isQueryParametersValidationEnabled();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -254,28 +254,6 @@ public final class ReflectHelper {
 		return PropertyAccessStrategyMixedImpl.INSTANCE.buildPropertyAccess( clazz, name, true ).getGetter();
 	}
 
-	public static Object getConstantValue(String name, SessionFactoryImplementor factory) {
-		boolean conventionalJavaConstants = factory.getSessionFactoryOptions().isConventionalJavaConstants();
-		Class clazz;
-		try {
-			if ( conventionalJavaConstants &&
-				!JAVA_CONSTANT_PATTERN.matcher( name ).find() ) {
-				return null;
-			}
-			ClassLoaderService classLoaderService = factory.getServiceRegistry().getService( ClassLoaderService.class );
-			clazz = classLoaderService.classForName( StringHelper.qualifier( name ) );
-		}
-		catch ( Throwable t ) {
-			return null;
-		}
-		try {
-			return clazz.getField( StringHelper.unqualify( name ) ).get( null );
-		}
-		catch ( Throwable t ) {
-			return null;
-		}
-	}
-
 	/**
 	 * Retrieve the default (no arg) constructor from the given class.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/JpaCompliance.java
@@ -41,7 +41,7 @@ public interface JpaCompliance {
 	 * Controls how Hibernate interprets a mapped List without an "order columns"
 	 * specified.  Historically Hibernate defines this as a "bag", which is a concept
 	 * JPA does not have.
-	 *
+	 * <p>
 	 * If enabled, Hibernate will recognize this condition as defining
 	 * a {@link org.hibernate.collection.spi.PersistentList}, otherwise
 	 * Hibernate will treat is as a {@link org.hibernate.collection.spi.PersistentBag}
@@ -56,7 +56,7 @@ public interface JpaCompliance {
 	 * {@link jakarta.persistence.EntityManager} and {@link jakarta.persistence.EntityManagerFactory}
 	 * when those objects have been closed.  This setting controls
 	 * whether the spec defined behavior or Hibernate's behavior will be used.
-	 *
+	 * <p>
 	 * If enabled Hibernate will operate in the JPA specified way throwing
 	 * exceptions when the spec says it should with regard to close checking
 	 *
@@ -68,10 +68,11 @@ public interface JpaCompliance {
 	 * JPA spec says that an {@link jakarta.persistence.EntityNotFoundException}
 	 * should be thrown when accessing an entity Proxy which does not have an associated
 	 * table row in the database.
-	 *
+	 * <p>
 	 * Traditionally, Hibernate does not initialize an entity Proxy when accessing its
-	 * identifier since we already know the identifier value, hence we can save a database roundtrip.
-	 *
+	 * identifier since we already know the identifier value, hence we can save a database
+	 * round trip.
+	 * <p>
 	 * If enabled Hibernate will initialize the entity Proxy even when accessing its identifier.
 	 *
 	 * @return {@code true} indicates to behave in the spec-defined way
@@ -91,8 +92,9 @@ public interface JpaCompliance {
 	boolean isJpaCacheComplianceEnabled();
 
 	/**
-	 * Should the the scope of {@link jakarta.persistence.TableGenerator#name()} and {@link jakarta.persistence.SequenceGenerator#name()} be
-	 * considered globally or locally defined?
+	 * Should the the scope of {@link jakarta.persistence.TableGenerator#name()} and
+	 * {@link jakarta.persistence.SequenceGenerator#name()} be considered globally or locally
+	 * defined?
 	 *
 	 * @return {@code true} indicates the generator name scope is considered global.
 	 */
@@ -100,20 +102,23 @@ public interface JpaCompliance {
 
 	/**
 	 * Should we strictly handle {@link jakarta.persistence.OrderBy} expressions?
-	 *
-	 * JPA says the order-items can only be attribute references whereas Hibernate supports a wide range of items.  With
-	 * this enabled, Hibernate will throw a compliance error when a non-attribute-reference is used.
+	 * <p>
+	 * JPA says the order-items can only be attribute references whereas Hibernate supports a
+	 * wide range of items.  With this enabled, Hibernate will throw a compliance error when a
+	 * non-attribute-reference is used.
 	 */
 	boolean isJpaOrderByMappingComplianceEnabled();
 
 	/**
 	 * JPA says that the id passed to {@link jakarta.persistence.EntityManager#getReference} and
-	 * {@link jakarta.persistence.EntityManager#find} should be the exact expected type, allowing
+	 * {@link jakarta.persistence.EntityManager#find} should be exactly the expected type, allowing
 	 * no type coercion.
-	 *
-	 * Historically, Hibernate behaved the same way.  Since 6.0 however, Hibernate has the ability to
-	 * coerce the passed type to the expected type.
-	 *
+	 * <p>
+	 * Historically, Hibernate behaved the same way.  Since 6.0 however, Hibernate has the ability
+	 * to coerce the passed type to the expected type.  For example, an {@link Integer} may be
+	 * widened to {@link Long}.  Coercion is performed by calling
+	 * {@link org.hibernate.type.descriptor.java.JavaType#coerce}.
+	 * <p>
 	 * This setting controls whether such a coercion should be allowed.
 	 *
 	 * @since 6.0

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterBindingImpl.java
@@ -23,6 +23,6 @@ public class ProcedureParameterBindingImpl<T>
 	public ProcedureParameterBindingImpl(
 			ProcedureParameterImplementor<T> queryParameter,
 			SessionFactoryImplementor sessionFactory) {
-		super( queryParameter, sessionFactory, true );
+		super( queryParameter, sessionFactory );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -33,7 +33,6 @@ import jakarta.persistence.TemporalType;
 public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, JavaType.CoercionContext {
 	private final QueryParameter<T> queryParameter;
 	private final SessionFactoryImplementor sessionFactory;
-	private final boolean isBindingValidationRequired;
 
 	private boolean isBound;
 	private boolean isMultiValued;
@@ -50,11 +49,9 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	 */
 	protected QueryParameterBindingImpl(
 			QueryParameter<T> queryParameter,
-			SessionFactoryImplementor sessionFactory,
-			boolean isBindingValidationRequired) {
+			SessionFactoryImplementor sessionFactory) {
 		this.queryParameter = queryParameter;
 		this.sessionFactory = sessionFactory;
-		this.isBindingValidationRequired = isBindingValidationRequired;
 		this.bindType = queryParameter.getHibernateType();
 	}
 
@@ -64,11 +61,9 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	public QueryParameterBindingImpl(
 			QueryParameter<T> queryParameter,
 			SessionFactoryImplementor sessionFactory,
-			BindableType<T> bindType,
-			boolean isBindingValidationRequired) {
+			BindableType<T> bindType) {
 		this.queryParameter = queryParameter;
 		this.sessionFactory = sessionFactory;
-		this.isBindingValidationRequired = isBindingValidationRequired;
 		this.bindType = bindType;
 	}
 
@@ -132,9 +127,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 			}
 		}
 
-		if ( isBindingValidationRequired ) {
-			validate( value );
-		}
+		validate( value );
 
 		if ( resolveJdbcTypeIfNecessary && bindType == null && value == null ) {
 			bindType = getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( "null" );
@@ -203,9 +196,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 			value = coerce( value, queryParameter.getHibernateType() );
 		}
 
-		if ( isBindingValidationRequired ) {
-			validate( value, clarifiedType );
-		}
+		validate( value, clarifiedType );
 
 		bindValue( value );
 	}
@@ -242,9 +233,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 			}
 		}
 
-		if ( isBindingValidationRequired ) {
-			validate( value, temporalTypePrecision );
-		}
+		validate( value, temporalTypePrecision );
 
 		bindValue( value );
 		setExplicitTemporalPrecision( temporalTypePrecision );

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -41,57 +41,34 @@ import org.hibernate.type.spi.TypeConfiguration;
 public class QueryParameterBindingsImpl implements QueryParameterBindings {
 	private final SessionFactoryImplementor sessionFactory;
 	private final ParameterMetadataImplementor parameterMetadata;
-	private final boolean queryParametersValidationEnabled;
 
 	private Map<QueryParameter<?>, QueryParameterBinding<?>> parameterBindingMap;
 
 	/**
 	 * Constructs a QueryParameterBindings based on the passed information
-	 *
-	 * @apiNote Calls {@link #from(ParameterMetadataImplementor,SessionFactoryImplementor,boolean)}
-	 * using {@link org.hibernate.boot.spi.SessionFactoryOptions#isQueryParametersValidationEnabled}
-	 * as `queryParametersValidationEnabled`
 	 */
 	public static QueryParameterBindingsImpl from(
 			ParameterMetadataImplementor parameterMetadata,
 			SessionFactoryImplementor sessionFactory) {
-		return from(
-				parameterMetadata,
-				sessionFactory,
-				sessionFactory.getSessionFactoryOptions().isQueryParametersValidationEnabled()
-		);
-	}
-
-	/**
-	 * Constructs a QueryParameterBindings based on the passed information
-	 */
-	public static QueryParameterBindingsImpl from(
-			ParameterMetadataImplementor parameterMetadata,
-			SessionFactoryImplementor sessionFactory,
-			boolean queryParametersValidationEnabled) {
 		if ( parameterMetadata == null ) {
 			throw new QueryParameterException( "Query parameter metadata cannot be null" );
 		}
 
 		return new QueryParameterBindingsImpl(
 				sessionFactory,
-				parameterMetadata,
-				queryParametersValidationEnabled
+				parameterMetadata
 		);
 	}
 
 	private QueryParameterBindingsImpl(
 			SessionFactoryImplementor sessionFactory,
-			ParameterMetadataImplementor parameterMetadata,
-			boolean queryParametersValidationEnabled) {
+			ParameterMetadataImplementor parameterMetadata) {
 		this.sessionFactory = sessionFactory;
 		this.parameterMetadata = parameterMetadata;
-		this.queryParametersValidationEnabled = queryParametersValidationEnabled;
 
 		this.parameterBindingMap = new ConcurrentHashMap<>( parameterMetadata.getParameterCount() );
 	}
 
-	@SuppressWarnings({"WeakerAccess" })
 	protected <T> QueryParameterBinding<T> makeBinding(QueryParameterImplementor<T> queryParameter) {
 		if ( parameterBindingMap == null ) {
 			parameterBindingMap = new IdentityHashMap<>();
@@ -109,8 +86,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 		final QueryParameterBinding<T> binding = new QueryParameterBindingImpl<>(
 				queryParameter,
 				sessionFactory,
-				parameterMetadata.getInferredParameterType( queryParameter ),
-				queryParametersValidationEnabled
+				parameterMetadata.getInferredParameterType( queryParameter )
 		);
 		parameterBindingMap.put( queryParameter, binding );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingValidator.java
@@ -79,8 +79,9 @@ public class QueryParameterBindingValidator {
 			if ( !isValidBindValue( parameterJavaType, bind, temporalPrecision ) ) {
 				throw new IllegalArgumentException(
 						String.format(
-								"Parameter value [%s] did not match expected type [%s (%s)]",
+								"Argument [%s] of type [%s] did not match parameter type [%s (%s)]",
 								bind,
+								bind.getClass().getName(),
 								parameterJavaType.getName(),
 								extractName( temporalPrecision )
 						)

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -190,11 +190,7 @@ public class NativeQueryImpl<R>
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		this.parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				session.getFactory(),
-				session.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, session.getFactory() );
 		this.querySpaces = new HashSet<>();
 
 		this.resultSetMapping = resultSetMappingCreator.get();
@@ -327,11 +323,7 @@ public class NativeQueryImpl<R>
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		this.parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				session.getFactory(),
-				session.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, session.getFactory() );
 		this.querySpaces = new HashSet<>();
 
 		this.resultSetMapping = new ResultSetMappingImpl( resultSetMappingMemento.getName() );
@@ -386,11 +378,7 @@ public class NativeQueryImpl<R>
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		this.parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				session.getFactory(),
-				session.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, session.getFactory() );
 
 		this.resultSetMapping = new ResultSetMappingImpl( sqlString, true );
 		this.resultMappingSuppliedToCtor = false;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -159,11 +159,7 @@ public class QuerySqmImpl<R>
 		this.domainParameterXref = hqlInterpretation.getDomainParameterXref();
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();
 
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				producer.getFactory(),
-				producer.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, producer.getFactory() );
 
 		applyOptions( memento );
 	}
@@ -224,11 +220,7 @@ public class QuerySqmImpl<R>
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();
 		this.domainParameterXref = hqlInterpretation.getDomainParameterXref();
 
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				producer.getFactory(),
-				producer.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, producer.getFactory() );
 	}
 
 	/**
@@ -275,11 +267,8 @@ public class QuerySqmImpl<R>
 			this.parameterMetadata = new ParameterMetadataImpl( domainParameterXref.getQueryParameters() );
 		}
 
-		this.parameterBindings = QueryParameterBindingsImpl.from(
-				parameterMetadata,
-				producer.getFactory(),
-				producer.isQueryParametersValidationEnabled()
-		);
+		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, producer.getFactory() );
+
 		// Parameters might be created through HibernateCriteriaBuilder.value which we need to bind here
 		for ( SqmParameter<?> sqmParameter : this.domainParameterXref.getParameterResolutions().getSqmParameters() ) {
 			if ( sqmParameter instanceof SqmJpaCriteriaParameterWrapper<?> ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/ReflectHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/ReflectHelperTest.java
@@ -123,82 +123,6 @@ public class ReflectHelperTest {
 	}
 
 	@Test
-	public void test_getConstantValue_simpleAlias() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-
-		Object value = ReflectHelper.getConstantValue( "alias.b", sessionFactoryImplementorMock);
-		assertNull(value);
-		verify(classLoaderServiceMock, never()).classForName( anyString() );
-	}
-
-	@Test
-	public void test_getConstantValue_simpleAlias_non_conventional() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( false );
-
-		Object value = ReflectHelper.getConstantValue( "alias.b", sessionFactoryImplementorMock);
-		assertNull(value);
-		verify(classLoaderServiceMock, times(1)).classForName( eq( "alias" ) );
-	}
-
-	@Test
-	public void test_getConstantValue_nestedAlias() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-
-		Object value = ReflectHelper.getConstantValue( "alias.b.c", sessionFactoryImplementorMock);
-		assertNull(value);
-		verify(classLoaderServiceMock, never()).classForName( anyString() );
-	}
-
-	@Test
-	public void test_getConstantValue_nestedAlias_non_conventional() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( false );
-
-		Object value = ReflectHelper.getConstantValue( "alias.b.c", sessionFactoryImplementorMock);
-		assertNull(value);
-		verify(classLoaderServiceMock, times(1)).classForName( eq( "alias.b" ) );
-	}
-
-	@Test
-	public void test_getConstantValue_outerEnum() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-
-		when( classLoaderServiceMock.classForName( "jakarta.persistence.FetchType" ) ).thenReturn( (Class) FetchType.class );
-		Object value = ReflectHelper.getConstantValue( "jakarta.persistence.FetchType.LAZY", sessionFactoryImplementorMock);
-		assertEquals( FetchType.LAZY, value );
-		verify(classLoaderServiceMock, times(1)).classForName( eq("jakarta.persistence.FetchType") );
-	}
-
-	@Test
-	public void test_getConstantValue_enumClass() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-
-		when( classLoaderServiceMock.classForName( "org.hibernate.orm.test.internal.util.ReflectHelperTest$Status" ) ).thenReturn( (Class) Status.class );
-		Object value = ReflectHelper.getConstantValue( "org.hibernate.orm.test.internal.util.ReflectHelperTest$Status", sessionFactoryImplementorMock);
-		assertNull(value);
-		verify(classLoaderServiceMock, never()).classForName( eq("org.hibernate.internal.util") );
-	}
-
-	@Test
-	public void test_getConstantValue_nestedEnum() {
-
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-		when( classLoaderServiceMock.classForName( "org.hibernate.orm.test.internal.util.ReflectHelperTest$Status" ) ).thenReturn( (Class) Status.class );
-		Object value = ReflectHelper.getConstantValue( "org.hibernate.orm.test.internal.util.ReflectHelperTest$Status.ON", sessionFactoryImplementorMock);
-		assertEquals( ON, value );
-		verify(classLoaderServiceMock, times(1)).classForName( eq("org.hibernate.orm.test.internal.util.ReflectHelperTest$Status") );
-	}
-
-	@Test
-	public void test_getConstantValue_constant_digits() {
-
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-		when( classLoaderServiceMock.classForName( "org.hibernate.orm.test.internal.util.hib3rnat3.C0nst4nts३" ) ).thenReturn( (Class) C0nst4nts३.class );
-		Object value = ReflectHelper.getConstantValue( "org.hibernate.orm.test.internal.util.hib3rnat3.C0nst4nts३.ABC_DEF", sessionFactoryImplementorMock);
-		assertEquals( C0nst4nts३.ABC_DEF, value );
-		verify(classLoaderServiceMock, times(1)).classForName( eq("org.hibernate.orm.test.internal.util.hib3rnat3.C0nst4nts३") );
-	}
-
-	@Test
 	public void test_getMethod_nestedInterfaces() {
 		assertNotNull( ReflectHelper.findGetterMethod( C.class, "id" ) );
 	}
@@ -230,16 +154,5 @@ public class ReflectHelperTest {
 	@Test
 	public void test_setMethod_nestedInterfaces_on_superclasses() {
 		assertNotNull( ReflectHelper.findSetterMethod( E.class, "id", String.class ) );
-	}
-
-	@TestForIssue(jiraKey = "HHH-14059")
-	@Test
-	public void test_getConstantValue_UpperCaseEnum() {
-		when( sessionFactoryOptionsMock.isConventionalJavaConstants() ).thenReturn( true );
-
-		when( classLoaderServiceMock.classForName( "com.example.UStatus" ) ).thenReturn( (Class) Status.class );
-		Object value = ReflectHelper.getConstantValue( "com.example.UStatus.OFF", sessionFactoryImplementorMock);
-		assertEquals( OFF, value );
-		verify(classLoaderServiceMock, times(1)).classForName( eq("com.example.UStatus") );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
@@ -15,8 +15,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.hibernate.HibernateException;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.annotations.Type;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -102,7 +100,7 @@ public class QueryParametersValidationTest extends BaseEntityManagerFunctionalTe
 	}
 
 	@Entity(name = "TestEntity")
-	public class TestEntity {
+	public static class TestEntity {
 
 		@Id
 		@GeneratedValue(strategy = GenerationType.AUTO)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
@@ -60,20 +60,6 @@ public class QueryParametersValidationTest extends BaseEntityManagerFunctionalTe
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11579")
-	public void setParameterWithWrongTypeShouldNotThrowIllegalArgumentExceptionWhenValidationIsDisabled() {
-		final SessionFactory sessionFactory = entityManagerFactory().unwrap( SessionFactory.class );
-		final Session session = sessionFactory.withOptions().setQueryParameterValidation( false ).openSession();
-		try {
-			session.createQuery( "select e from TestEntity e where e.id = :id" ).setParameter( "id", 1 );
-		}
-		finally {
-			session.close();
-			sessionFactory.close();
-		}
-	}
-
-	@Test
 	public void setParameterWithCorrectTypeShouldNotThrowIllegalArgumentException() {
 		final EntityManager entityManager = entityManagerFactory().createEntityManager();
 		try {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersWithDisabledValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersWithDisabledValidationTest.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.Test;
 @Jpa(
 		annotatedClasses = {
 				QueryParametersWithDisabledValidationTest.TestEntity.class
-		},
-		integrationSettings = { @Setting(name = AvailableSettings.VALIDATE_QUERY_PARAMETERS, value = "false") }
+		}
 )
 public class QueryParametersWithDisabledValidationTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersWithDisabledValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersWithDisabledValidationTest.java
@@ -11,12 +11,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
-import org.hibernate.cfg.AvailableSettings;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
-import org.hibernate.testing.orm.junit.Setting;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,9 +22,7 @@ import org.junit.jupiter.api.Test;
  */
 @TestForIssue(jiraKey = "HHH-11579")
 @Jpa(
-		annotatedClasses = {
-				QueryParametersWithDisabledValidationTest.TestEntity.class
-		}
+		annotatedClasses = {QueryParametersWithDisabledValidationTest.TestEntity.class}
 )
 public class QueryParametersWithDisabledValidationTest {
 
@@ -46,7 +41,7 @@ public class QueryParametersWithDisabledValidationTest {
 	}
 
 	@Entity(name = "TestEntity")
-	public class TestEntity {
+	public static class TestEntity {
 
 		@Id
 		@GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
This was apparently a sorta nasty bandaid to a performance problem in query compilation and it caused problems for some users, breaking interpretation of enum values.
