### PR TITLE
HHH-15046/fix db2z i dialect init error

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import jakarta.persistence.TemporalType;
 import org.hibernate.LockOptions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -55,7 +54,13 @@ import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.descriptor.jdbc.*;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 
-import java.sql.*;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import jakarta.persistence.TemporalType;
 
 import static org.hibernate.type.SqlTypes.*;
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
@@ -51,7 +51,7 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 
 	@Override
 	public void visitBooleanExpressionPredicate(BooleanExpressionPredicate booleanExpressionPredicate) {
-		if ( getDialectVersion().isSameOrAfter( 11 ) ) {
+		if ( getDB2Version().isSameOrAfter( 11 ) ) {
 			booleanExpressionPredicate.getExpression().accept( this );
 		}
 		else {
@@ -132,12 +132,12 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 		// Check if current query part is already row numbering to avoid infinite recursion
 		return getQueryPartForRowNumbering() != queryPart && (
 				useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart )
-						|| getDialectVersion().isBefore( 11, 1 ) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
+						|| getDB2Version().isBefore( 11, 1 ) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
 		);
 	}
 
 	protected boolean supportsOffsetClause() {
-		return getDialectVersion().isSameOrAfter( 11, 1 );
+		return getDB2Version().isSameOrAfter( 11, 1 );
 	}
 
 	@Override
@@ -228,7 +228,7 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 
 	@Override
 	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
-		if ( getDialectVersion().isSameOrAfter( 11, 1 ) ) {
+		if ( getDB2Version().isSameOrAfter( 11, 1 ) ) {
 			renderComparisonStandard( lhs, operator, rhs );
 		}
 		else {
@@ -296,12 +296,8 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 		// For DB2 we use #renderReturningClause to render a wrapper around the DML statement
 	}
 
-	private DatabaseVersion getDialectVersion() {
-		final var dialect = getDialect();
-		if (dialect instanceof DB2Dialect) {
-			return ((DB2Dialect) dialect).getDB2Version();
-		}
-		return dialect.getVersion();
+	public DatabaseVersion getDB2Version() {
+		return this.getDialect().getVersion();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import java.util.List;
-import java.util.function.Consumer;
-
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.query.FetchClauseType;
@@ -18,13 +15,7 @@ import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.MutationStatement;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
-import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
-import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.expression.Expression;
-import org.hibernate.sql.ast.tree.expression.Literal;
-import org.hibernate.sql.ast.tree.expression.SqlTuple;
-import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.expression.*;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
@@ -32,6 +23,9 @@ import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * A SQL AST translator for DB2.
@@ -51,7 +45,7 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 
 	@Override
 	public void visitBooleanExpressionPredicate(BooleanExpressionPredicate booleanExpressionPredicate) {
-		if ( getDialect().getVersion().isSameOrAfter( 11 ) ) {
+		if ( getDialectVersion().isSameOrAfter( 11 ) ) {
 			booleanExpressionPredicate.getExpression().accept( this );
 		}
 		else {
@@ -132,12 +126,12 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 		// Check if current query part is already row numbering to avoid infinite recursion
 		return getQueryPartForRowNumbering() != queryPart && (
 				useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart )
-						|| getDialect().getVersion().isBefore( 11, 1 ) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
+						|| getDialectVersion().isBefore( 11, 1 ) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
 		);
 	}
 
 	protected boolean supportsOffsetClause() {
-		return getDialect().getVersion().isSameOrAfter( 11, 1 );
+		return getDialectVersion().isSameOrAfter( 11, 1 );
 	}
 
 	@Override
@@ -228,7 +222,7 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 
 	@Override
 	protected void renderComparison(Expression lhs, ComparisonOperator operator, Expression rhs) {
-		if ( getDialect().getVersion().isSameOrAfter( 11, 1 ) ) {
+		if ( getDialectVersion().isSameOrAfter( 11, 1 ) ) {
 			renderComparisonStandard( lhs, operator, rhs );
 		}
 		else {
@@ -294,6 +288,14 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 	@Override
 	protected void visitReturningColumns(MutationStatement mutationStatement) {
 		// For DB2 we use #renderReturningClause to render a wrapper around the DML statement
+	}
+
+	private DatabaseVersion getDialectVersion() {
+		final var dialect = getDialect();
+		if (dialect instanceof DB2Dialect) {
+			return ((DB2Dialect) dialect).getDB2Version();
+		}
+		return dialect.getVersion();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.dialect;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.ComparisonOperator;
 import org.hibernate.query.FetchClauseType;
@@ -15,7 +18,13 @@ import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.MutationStatement;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
-import org.hibernate.sql.ast.tree.expression.*;
+import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.Literal;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
@@ -23,9 +32,6 @@ import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
-
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * A SQL AST translator for DB2.

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -33,8 +33,6 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
  */
 public class DB2iDialect extends DB2Dialect {
 
-	private final DatabaseVersion version;
-
 	public DB2iDialect(DialectResolutionInfo info) {
 		this( info.makeCopy() );
 		registerKeywords( info );
@@ -45,17 +43,12 @@ public class DB2iDialect extends DB2Dialect {
 	}
 
 	public DB2iDialect(DatabaseVersion version) {
-		super();
-		this.version = version;
-	}
-
-	public DatabaseVersion getIVersion() {
-		return version;
+		super(version);
 	}
 
 	@Override
 	protected UniqueDelegate createUniqueDelegate() {
-		return getIVersion().isSameOrAfter(7, 3)
+		return getVersion().isSameOrAfter(7, 3)
 				? new DefaultUniqueDelegate(this)
 				: super.createUniqueDelegate();
 	}
@@ -65,13 +58,13 @@ public class DB2iDialect extends DB2Dialect {
 	 */
 	@Override
 	public SequenceSupport getSequenceSupport() {
-		return getIVersion().isSameOrAfter(7, 3)
+		return getVersion().isSameOrAfter(7, 3)
 				? DB2iSequenceSupport.INSTANCE : NoSequenceSupport.INSTANCE;
 	}
 
 	@Override
 	public String getQuerySequencesString() {
-		if ( getIVersion().isSameOrAfter(7,3) ) {
+		if ( getVersion().isSameOrAfter(7,3) ) {
 			return "select distinct sequence_name from qsys2.syssequences " +
 					"where current_schema='*LIBL' and sequence_schema in (select schema_name from qsys2.library_list_info) " +
 					"or sequence_schema=current_schema";
@@ -83,13 +76,13 @@ public class DB2iDialect extends DB2Dialect {
 
 	@Override
 	public LimitHandler getLimitHandler() {
-		return getIVersion().isSameOrAfter(7, 3)
+		return getVersion().isSameOrAfter(7, 3)
 				? FetchLimitHandler.INSTANCE : LegacyDB2LimitHandler.INSTANCE;
 	}
 
 	@Override
 	public IdentityColumnSupport getIdentityColumnSupport() {
-		return getIVersion().isSameOrAfter(7, 3)
+		return getVersion().isSameOrAfter(7, 3)
 				? new DB2IdentityColumnSupport()
 				: new DB2390IdentityColumnSupport();
 	}
@@ -101,7 +94,7 @@ public class DB2iDialect extends DB2Dialect {
 
 	@Override
 	public boolean supportsLateral() {
-		return getIVersion().isSameOrAfter( 7, 1 );
+		return getVersion().isSameOrAfter( 7, 1 );
 	}
 
 	@Override
@@ -110,7 +103,7 @@ public class DB2iDialect extends DB2Dialect {
 			@Override
 			protected <T extends JdbcOperation> SqlAstTranslator<T> buildTranslator(
 					SessionFactoryImplementor sessionFactory, Statement statement) {
-				return new DB2iSqlAstTranslator<>( sessionFactory, statement, version );
+				return new DB2iSqlAstTranslator<>( sessionFactory, statement, getVersion() );
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -47,6 +47,11 @@ public class DB2iDialect extends DB2Dialect {
 	}
 
 	@Override
+	public DatabaseVersion getDB2Version() {
+		return DatabaseVersion.make(9, 0);
+	}
+
+	@Override
 	protected UniqueDelegate createUniqueDelegate() {
 		return getVersion().isSameOrAfter(7, 3)
 				? new DefaultUniqueDelegate(this)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -33,6 +33,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
  */
 public class DB2iDialect extends DB2Dialect {
 
+	final static DatabaseVersion DB2_LUW_VERSION9 = DatabaseVersion.make(9, 0);
+
 	public DB2iDialect(DialectResolutionInfo info) {
 		this( info.makeCopy() );
 		registerKeywords( info );
@@ -48,7 +50,7 @@ public class DB2iDialect extends DB2Dialect {
 
 	@Override
 	public DatabaseVersion getDB2Version() {
-		return DatabaseVersion.make(9, 0);
+		return DB2_LUW_VERSION9;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
@@ -48,4 +48,8 @@ public class DB2iSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 		renderComparisonStandard( lhs, operator, rhs );
 	}
 
+	@Override
+	public DatabaseVersion getDB2Version() {
+		return DatabaseVersion.make(9, 0);
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
@@ -14,6 +14,8 @@ import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
+import static org.hibernate.dialect.DB2iDialect.DB2_LUW_VERSION9;
+
 /**
  * A SQL AST translator for DB2i.
  *
@@ -50,6 +52,6 @@ public class DB2iSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 
 	@Override
 	public DatabaseVersion getDB2Version() {
-		return DatabaseVersion.make(9, 0);
+		return DB2_LUW_VERSION9;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.dialect;
 
 import jakarta.persistence.TemporalType;
-
 import org.hibernate.dialect.identity.DB2390IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.FetchLimitHandler;
@@ -55,6 +54,11 @@ public class DB2zDialect extends DB2Dialect {
 			return "timestamp with time zone";
 		}
 		return super.columnType(jdbcTypeCode);
+	}
+
+	@Override
+	public DatabaseVersion getDB2Version() {
+		return DatabaseVersion.make(9, 0);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -36,6 +36,8 @@ import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
  */
 public class DB2zDialect extends DB2Dialect {
 
+	final static DatabaseVersion DB2_LUW_VERSION9 = DatabaseVersion.make(9, 0);
+
 	public DB2zDialect(DialectResolutionInfo info) {
 		this( info.makeCopy() );
 		registerKeywords( info );
@@ -60,7 +62,7 @@ public class DB2zDialect extends DB2Dialect {
 
 	@Override
 	public DatabaseVersion getDB2Version() {
-		return DatabaseVersion.make(9, 0);
+		return DB2_LUW_VERSION9;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.dialect;
 
+
 import jakarta.persistence.TemporalType;
+
 import org.hibernate.dialect.identity.DB2390IdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.FetchLimitHandler;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -35,8 +35,6 @@ import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
  */
 public class DB2zDialect extends DB2Dialect {
 
-	private final DatabaseVersion version;
-
 	public DB2zDialect(DialectResolutionInfo info) {
 		this( info.makeCopy() );
 		registerKeywords( info );
@@ -47,14 +45,13 @@ public class DB2zDialect extends DB2Dialect {
 	}
 
 	public DB2zDialect(DatabaseVersion version) {
-		super();
-		this.version = version;
+		super(version);
 	}
 
 	@Override
 	protected String columnType(int jdbcTypeCode) {
 		// See https://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/wnew/src/tpc/db2z_10_timestamptimezone.html
-		if ( jdbcTypeCode==TIMESTAMP_WITH_TIMEZONE && version.isAfter(10) ) {
+		if ( jdbcTypeCode==TIMESTAMP_WITH_TIMEZONE && getVersion().isAfter(10) ) {
 			return "timestamp with time zone";
 		}
 		return super.columnType(jdbcTypeCode);
@@ -62,28 +59,24 @@ public class DB2zDialect extends DB2Dialect {
 
 	@Override
 	public TimeZoneSupport getTimeZoneSupport() {
-		return getZVersion().isAfter(10) ? TimeZoneSupport.NATIVE : TimeZoneSupport.NONE;
-	}
-
-	DatabaseVersion getZVersion() {
-		return version;
+		return getVersion().isAfter(10) ? TimeZoneSupport.NATIVE : TimeZoneSupport.NONE;
 	}
 
 	@Override
 	public SequenceSupport getSequenceSupport() {
-		return getZVersion().isBefore(8)
+		return getVersion().isBefore(8)
 				? NoSequenceSupport.INSTANCE
 				: DB2zSequenceSupport.INSTANCE;
 	}
 
 	@Override
 	public String getQuerySequencesString() {
-		return getZVersion().isBefore(8) ? null : "select * from sysibm.syssequences";
+		return getVersion().isBefore(8) ? null : "select * from sysibm.syssequences";
 	}
 
 	@Override
 	public LimitHandler getLimitHandler() {
-		return getZVersion().isBefore(12)
+		return getVersion().isBefore(12)
 				? FetchLimitHandler.INSTANCE
 				: OffsetFetchLimitHandler.INSTANCE;
 	}
@@ -160,7 +153,7 @@ public class DB2zDialect extends DB2Dialect {
 			@Override
 			protected <T extends JdbcOperation> SqlAstTranslator<T> buildTranslator(
 					SessionFactoryImplementor sessionFactory, Statement statement) {
-				return new DB2zSqlAstTranslator<>( sessionFactory, statement, version );
+				return new DB2zSqlAstTranslator<>( sessionFactory, statement, getVersion() );
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
@@ -19,6 +19,8 @@ import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 
+import static org.hibernate.dialect.DB2zDialect.DB2_LUW_VERSION9;
+
 /**
  * A SQL AST translator for DB2z.
  *
@@ -78,6 +80,6 @@ public class DB2zSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 
 	@Override
 	public DatabaseVersion getDB2Version() {
-		return DatabaseVersion.make(9, 0);
+		return DB2_LUW_VERSION9;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zSqlAstTranslator.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import java.util.List;
-
 import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.ComparisonOperator;
@@ -76,5 +74,10 @@ public class DB2zSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 		tableReference.getFunctionExpression().accept( this );
 		append( CLOSE_PARENTHESIS );
 		renderDerivedTableReference( tableReference );
+	}
+
+	@Override
+	public DatabaseVersion getDB2Version() {
+		return DatabaseVersion.make(9, 0);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2iDialectInitTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2iDialectInitTestCase.java
@@ -1,0 +1,23 @@
+package org.hibernate.orm.test.dialect;
+
+import org.hibernate.dialect.DB2iDialect;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Onno Goczol
+ */
+@TestForIssue(jiraKey = "HHH-15046")
+@RequiresDialect(DB2iDialect.class)
+public class DB2iDialectInitTestCase {
+
+    @Test
+    public void testInitUniqueDelegate() {
+        final var db2iDialect = new DB2iDialect();
+        assertNotNull(db2iDialect);
+    }
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2zDialectInitTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2zDialectInitTestCase.java
@@ -1,0 +1,32 @@
+package org.hibernate.orm.test.dialect;
+
+import org.hibernate.dialect.DB2zDialect;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Onno Goczol
+ */
+@TestForIssue(jiraKey = "HHH-15046")
+@RequiresDialect(DB2zDialect.class)
+public class DB2zDialectInitTestCase {
+
+    static class DB2zDialectWithExplicitTimezoneSupport extends DB2zDialect {
+        @Override
+        protected List<Integer> getSupportedJdbcTypeCodes() {
+            return List.of(TIMESTAMP_WITH_TIMEZONE);
+        }
+    }
+
+    @Test
+    public void testInitWithTimezoneSupport() {
+        final var db2zDialect = new DB2zDialectWithExplicitTimezoneSupport();
+        assertNotNull(db2zDialect);
+    }
+}


### PR DESCRIPTION
During DB2zDialect and DB2iDialect initialization the private property “version” might be 
used resulting in an NullpointerException.

For DB2zDialect this is happening when the ColumnType “TIMESTAMP_WITH_TIMEZONE” is being registered in the overriden Method columnType().

For DB2iDialect this is happing because the createUniqueDelegate() Method is override and uses the private property. 
 
Expected Behavior is the correct initialization of both Dialects without errors.

As a fix I merged the version property of the class DB2Dialect and the private version of DB2zDialect/DB2iDialect.
I added two TestCases which reproduce the issues.