### PR TITLE
change getNationalizationSupport() on Sybase to use UNSUPPORTED

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -196,7 +196,9 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 	@Override
 	public NationalizationSupport getNationalizationSupport() {
 		// At least the jTDS driver doesn't support this
-		return jtdsDriver ? NationalizationSupport.IMPLICIT : super.getNationalizationSupport();
+		return jtdsDriver
+			? NationalizationSupport.UNSUPPORTED
+			: super.getNationalizationSupport();
 	}
 
 	@Override


### PR DESCRIPTION
`getNationalizationSupport()` currently returns `IMPLICIT` for the jTDS driver. But from the comment I _think_ it should probably return `UNSUPPORTED`.

WDYT @sebersole @beikov ?