### PR TITLE
squash lots of warnings in services

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/multitenancy/AbstractMultiTenancyTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/multitenancy/AbstractMultiTenancyTest.java
@@ -27,6 +27,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.Stoppable;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
@@ -88,7 +89,7 @@ public abstract class AbstractMultiTenancyTest extends BaseUnitTestCase {
 
         DriverManagerConnectionProviderImpl connectionProvider =
             new DriverManagerConnectionProviderImpl();
-        connectionProvider.configure(properties);
+        connectionProvider.configure( PropertiesHelper.map(properties) );
         connectionProviderMap.put(tenantIdentifier, connectionProvider);
     }
     //end::multitenacy-hibernate-MultiTenantConnectionProvider-example[]

--- a/documentation/src/test/java/org/hibernate/userguide/multitenancy/DatabaseTimeZoneMultiTenancyTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/multitenancy/DatabaseTimeZoneMultiTenancyTest.java
@@ -34,6 +34,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.Stoppable;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
@@ -101,12 +102,12 @@ public class DatabaseTimeZoneMultiTenancyTest extends BaseUnitTestCase {
         Properties properties = properties();
         properties.put(
             Environment.URL,
-            tenantUrl(properties.getProperty(Environment.URL), tenantIdentifier)
+            tenantUrl( properties.getProperty(Environment.URL), tenantIdentifier )
        );
 
         DriverManagerConnectionProviderImpl connectionProvider =
                 new DriverManagerConnectionProviderImpl();
-        connectionProvider.configure(properties);
+        connectionProvider.configure( PropertiesHelper.map(properties) );
 
         connectionProviderMap.put(tenantIdentifier, connectionProvider);
 

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ConnectionProviderTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ConnectionProviderTest.java
@@ -7,7 +7,8 @@
 package org.hibernate.test.c3p0;
 
 import java.lang.management.ManagementFactory;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -94,8 +95,8 @@ public class C3P0ConnectionProviderTest extends BaseCoreFunctionalTestCase {
 	public void testIsolationPropertyCouldBeEmpty() {
 		C3P0ConnectionProvider provider = new C3P0ConnectionProvider();
 		try {
-			Properties configuration = new Properties();
-			configuration.setProperty( Environment.ISOLATION, "" );
+			Map<String,Object> configuration = new HashMap<>();
+			configuration.put( Environment.ISOLATION, "" );
 			provider.configure( configuration );
 		}
 		finally {

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DefaultIsolationLevelTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DefaultIsolationLevelTest.java
@@ -46,7 +46,7 @@ public class C3P0DefaultIsolationLevelTest extends
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		connectionProvider = new C3P0ProxyConnectionProvider();
 		settings.put( AvailableSettings.CONNECTION_PROVIDER, connectionProvider );
 		settings.put( AvailableSettings.ISOLATION, "READ_COMMITTED" );

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DifferentIsolationLevelTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DifferentIsolationLevelTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -47,7 +46,7 @@ public class C3P0DifferentIsolationLevelTest extends
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		connectionProvider = new C3P0ProxyConnectionProvider();
 		settings.put( AvailableSettings.CONNECTION_PROVIDER, connectionProvider );
 		settings.put( AvailableSettings.ISOLATION, "REPEATABLE_READ" );

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ProxyConnectionProvider.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ProxyConnectionProvider.java
@@ -28,7 +28,7 @@ public class C3P0ProxyConnectionProvider extends C3P0ConnectionProvider {
 	}
 
 	@Override
-	public void configure(Map props) {
+	public void configure(Map<String, Object> props) {
 		super.configure( props );
 		DataSource ds = unwrap( DataSource.class );
 		DataSource dataSource = spy( ds );
@@ -45,7 +45,7 @@ public class C3P0ProxyConnectionProvider extends C3P0ConnectionProvider {
 			throw new IllegalStateException( e );
 		}
 
-		ReflectionUtil.setField( C3P0ConnectionProvider.class.cast( this ), "ds", dataSource );
+		ReflectionUtil.setField( this, "ds", dataSource );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CommunityDialectFactoryTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CommunityDialectFactoryTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
-import java.util.Properties;
+import java.util.HashMap;
 
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
@@ -14,8 +14,6 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl;
-import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
-import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfoSource;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolver;
 import org.hibernate.orm.test.dialect.resolver.TestingDialectResolutionInfo;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -80,13 +78,8 @@ public class CommunityDialectFactoryTest extends BaseUnitTestCase {
 			DialectResolver resolver) {
 		dialectFactory.setDialectResolver( resolver );
 		Dialect resolved = dialectFactory.buildDialect(
-				new Properties(),
-				new DialectResolutionInfoSource() {
-					@Override
-					public DialectResolutionInfo getDialectResolutionInfo() {
-						return TestingDialectResolutionInfo.forDatabaseInfo( databaseName, driverName, majorVersion, minorVersion );
-					}
-				}
+				new HashMap<>(),
+				() -> TestingDialectResolutionInfo.forDatabaseInfo( databaseName, driverName, majorVersion, minorVersion )
 		);
 		assertEquals( expected, resolved.getClass() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceImpl.java
@@ -17,7 +17,7 @@ import org.hibernate.boot.cfgxml.spi.LoadedConfig;
 public class CfgXmlAccessServiceImpl implements CfgXmlAccessService {
 	private final LoadedConfig aggregatedCfgXml;
 
-	public CfgXmlAccessServiceImpl(Map configurationValues) {
+	public CfgXmlAccessServiceImpl(Map<?,?> configurationValues) {
 		aggregatedCfgXml = (LoadedConfig) configurationValues.get( LOADED_CONFIG_KEY );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/internal/CfgXmlAccessServiceInitiator.java
@@ -22,7 +22,7 @@ public class CfgXmlAccessServiceInitiator implements StandardServiceInitiator<Cf
 	public static final CfgXmlAccessServiceInitiator INSTANCE = new CfgXmlAccessServiceInitiator();
 
 	@Override
-	public CfgXmlAccessService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public CfgXmlAccessService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new CfgXmlAccessServiceImpl( configurationValues );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/spi/LoadedConfig.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/cfgxml/spi/LoadedConfig.java
@@ -38,11 +38,11 @@ public class LoadedConfig {
 
 	private String sessionFactoryName;
 
-	private final Map configurationValues = new ConcurrentHashMap( 16, 0.75f, 1 );
+	private final Map<String,Object> configurationValues = new ConcurrentHashMap<>( 16, 0.75f, 1 );
 
 	private List<CacheRegionDefinition> cacheRegionDefinitions;
 	private List<MappingReference> mappingReferences;
-	private Map<EventType,Set<String>> eventListenerMap;
+	private Map<EventType<?>,Set<String>> eventListenerMap;
 
 	public LoadedConfig(String sessionFactoryName) {
 		this.sessionFactoryName = sessionFactoryName;
@@ -52,7 +52,7 @@ public class LoadedConfig {
 		return sessionFactoryName;
 	}
 
-	public Map getConfigurationValues() {
+	public Map<String,Object> getConfigurationValues() {
 		return configurationValues;
 	}
 
@@ -64,7 +64,7 @@ public class LoadedConfig {
 		return mappingReferences == null ? Collections.emptyList() : mappingReferences;
 	}
 
-	public Map<EventType, Set<String>> getEventListenerMap() {
+	public Map<EventType<?>, Set<String>> getEventListenerMap() {
 		return eventListenerMap == null ? Collections.emptyMap() : eventListenerMap;
 	}
 
@@ -93,7 +93,7 @@ public class LoadedConfig {
 
 		if ( !jaxbCfg.getSessionFactory().getListener().isEmpty() ) {
 			for ( JaxbCfgEventListenerType listener : jaxbCfg.getSessionFactory().getListener() ) {
-				final EventType eventType = EventType.resolveEventTypeByName( listener.getType().value() );
+				final EventType<?> eventType = EventType.resolveEventTypeByName( listener.getType().value() );
 				cfg.addEventListener( eventType, listener.getClazz() );
 			}
 		}
@@ -105,7 +105,7 @@ public class LoadedConfig {
 				}
 
 				final String eventTypeName = listenerGroup.getType().value();
-				final EventType eventType = EventType.resolveEventTypeByName( eventTypeName );
+				final EventType<?> eventType = EventType.resolveEventTypeByName( eventTypeName );
 
 				for ( JaxbCfgEventListenerType listener : listenerGroup.getListener() ) {
 					if ( listener.getType() != null ) {
@@ -127,7 +127,6 @@ public class LoadedConfig {
 		return value.trim();
 	}
 
-	@SuppressWarnings("unchecked")
 	private void addConfigurationValue(String propertyName, String value) {
 		value = trim( value );
 		configurationValues.put( propertyName, value );
@@ -146,7 +145,7 @@ public class LoadedConfig {
 	}
 
 	private static CacheRegionDefinition parseCacheRegionDefinition(Object cacheDeclaration) {
-		if ( JaxbCfgEntityCacheType.class.isInstance( cacheDeclaration ) ) {
+		if ( cacheDeclaration instanceof JaxbCfgEntityCacheType ) {
 			final JaxbCfgEntityCacheType jaxbClassCache = (JaxbCfgEntityCacheType) cacheDeclaration;
 			return new CacheRegionDefinition(
 					CacheRegionDefinition.CacheRegionType.ENTITY,
@@ -175,7 +174,7 @@ public class LoadedConfig {
 		cacheRegionDefinitions.add( cacheRegionDefinition );
 	}
 
-	public void addEventListener(EventType eventType, String listenerClass) {
+	public void addEventListener(EventType<?> eventType, String listenerClass) {
 		if ( eventListenerMap == null ) {
 			eventListenerMap = new HashMap<>();
 		}
@@ -216,8 +215,7 @@ public class LoadedConfig {
 		addEventListeners( incoming.getEventListenerMap() );
 	}
 
-	@SuppressWarnings("unchecked")
-	protected void addConfigurationValues(Map configurationValues) {
+	protected void addConfigurationValues(Map<String,Object> configurationValues) {
 		if ( configurationValues == null ) {
 			return;
 		}
@@ -247,7 +245,7 @@ public class LoadedConfig {
 		this.cacheRegionDefinitions.addAll( cacheRegionDefinitions );
 	}
 
-	private void addEventListeners(Map<EventType, Set<String>> eventListenerMap) {
+	private void addEventListeners(Map<EventType<?>, Set<String>> eventListenerMap) {
 		if ( eventListenerMap == null ) {
 			return;
 		}
@@ -256,7 +254,7 @@ public class LoadedConfig {
 			this.eventListenerMap = new HashMap<>();
 		}
 
-		for ( Map.Entry<EventType, Set<String>> incomingEntry : eventListenerMap.entrySet() ) {
+		for ( Map.Entry<EventType<?>, Set<String>> incomingEntry : eventListenerMap.entrySet() ) {
 			Set<String> listenerClasses = this.eventListenerMap.get( incomingEntry.getKey() );
 			if ( listenerClasses == null ) {
 				listenerClasses = new HashSet<>();

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/DefaultSessionFactoryBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/DefaultSessionFactoryBuilderInitiator.java
@@ -20,7 +20,7 @@ public final class DefaultSessionFactoryBuilderInitiator implements StandardServ
 	}
 
 	@Override
-	public SessionFactoryBuilderService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public SessionFactoryBuilderService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return DefaultSessionFactoryBuilderService.INSTANCE;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -17,7 +17,6 @@ import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.EntityNameResolver;
@@ -50,6 +49,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.id.uuid.LocalObjectUuidHelper;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.NullnessHelper;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.spi.JpaCompliance;
@@ -268,8 +268,8 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		ConfigurationService cfgService = serviceRegistry.getService( ConfigurationService.class );
 		final JdbcServices jdbcServices = serviceRegistry.getService( JdbcServices.class );
 
-		final Map<Object,Object> configurationSettings = new HashMap<>();
-		configurationSettings.putAll( jdbcServices.getJdbcEnvironment().getDialect().getDefaultProperties() );
+		final Map<String,Object> configurationSettings = new HashMap<>();
+		configurationSettings.putAll( PropertiesHelper.map( jdbcServices.getJdbcEnvironment().getDialect().getDefaultProperties() ) );
 		configurationSettings.putAll( cfgService.getSettings() );
 		if ( cfgService == null ) {
 			cfgService = new ConfigurationServiceImpl( configurationSettings );
@@ -702,7 +702,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	private static Interceptor determineInterceptor(
-			Map<Object,Object> configurationSettings,
+			Map<String,Object> configurationSettings,
 			StrategySelector strategySelector) {
 		Object setting = configurationSettings.get( INTERCEPTOR );
 		if ( setting == null ) {
@@ -724,7 +724,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	@SuppressWarnings("unchecked")
 	private static Supplier<? extends Interceptor> determineStatelessInterceptor(
-			Map<Object,Object> configurationSettings,
+			Map<String,Object> configurationSettings,
 			StrategySelector strategySelector) {
 		Object setting = configurationSettings.get( SESSION_SCOPED_INTERCEPTOR );
 
@@ -761,7 +761,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	private PhysicalConnectionHandlingMode interpretConnectionHandlingMode(
-			Map<Object,Object> configurationSettings,
+			Map<String,Object> configurationSettings,
 			StandardServiceRegistry serviceRegistry) {
 		final PhysicalConnectionHandlingMode specifiedHandlingMode = PhysicalConnectionHandlingMode.interpret(
 				configurationSettings.get( CONNECTION_HANDLING )

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeBeanInstanceProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeBeanInstanceProducer.java
@@ -54,7 +54,6 @@ public class TypeBeanInstanceProducer implements BeanInstanceProducer, TypeBoots
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public Map<String, Object> getConfigurationSettings() {
 		return typeConfiguration.getServiceRegistry().getService( ConfigurationService.class ).getSettings();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/StandardServiceInitiator.java
@@ -28,5 +28,5 @@ public interface StandardServiceInitiator<R extends Service> extends ServiceInit
 	 *
 	 * @return The initiated service.
 	 */
-	R initiateService(Map configurationValues, ServiceRegistryImplementor registry);
+	R initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry);
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
@@ -21,7 +21,7 @@ public final class BytecodeProviderInitiator implements StandardServiceInitiator
 	public static final StandardServiceInitiator<BytecodeProvider> INSTANCE = new BytecodeProviderInitiator();
 
 	@Override
-	public BytecodeProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public BytecodeProvider initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		// TODO in 6 this will no longer use Environment, which is configured via global environment variables,
 		// but move to a component which can be reconfigured differently in each registry.
 		return Environment.getBytecodeProvider();

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/ProxyFactoryFactoryInitiator.java
@@ -27,7 +27,7 @@ public final class ProxyFactoryFactoryInitiator implements StandardServiceInitia
 	public static final StandardServiceInitiator<ProxyFactoryFactory> INSTANCE = new ProxyFactoryFactoryInitiator();
 
 	@Override
-	public ProxyFactoryFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public ProxyFactoryFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final BytecodeProvider bytecodeProvider = registry.getService( BytecodeProvider.class );
 		return bytecodeProvider.getProxyFactoryFactory();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
@@ -40,7 +40,7 @@ public class NoCachingRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	public void start(SessionFactoryOptions settings, Map configValues) throws CacheException {
+	public void start(SessionFactoryOptions settings, Map<String,Object> configValues) throws CacheException {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/RegionFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/RegionFactoryInitiator.java
@@ -43,7 +43,7 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 	}
 
 	@Override
-	public RegionFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public RegionFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final RegionFactory regionFactory = resolveRegionFactory( configurationValues, registry );
 
 		LOG.debugf( "Cache region factory : %s", regionFactory.getClass().getName() );
@@ -52,7 +52,7 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 	}
 
 
-	protected RegionFactory resolveRegionFactory(Map configurationValues, ServiceRegistryImplementor registry) {
+	protected RegionFactory resolveRegionFactory(Map<String,Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Properties p = new Properties();
 		p.putAll( configurationValues );
 
@@ -83,8 +83,7 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 
 		if ( setting == null && implementors.size() != 1 ) {
 			// if either is explicitly defined as TRUE we need a RegionFactory
-			if ( ( useSecondLevelCache != null && useSecondLevelCache == TRUE )
-					|| ( useQueryCache != null && useQueryCache == TRUE ) ) {
+			if ( useSecondLevelCache == TRUE || useQueryCache == TRUE ) {
 				throw new CacheException( "Caching was explicitly requested, but no RegionFactory was defined and there is not a single registered RegionFactory" );
 			}
 		}
@@ -125,7 +124,7 @@ public class RegionFactoryInitiator implements StandardServiceInitiator<RegionFa
 		return NoCachingRegionFactory.INSTANCE;
 	}
 
-	protected RegionFactory getFallback(Map configurationValues, ServiceRegistryImplementor registry) {
+	protected RegionFactory getFallback(Map<?,?> configurationValues, ServiceRegistryImplementor registry) {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractRegionFactory.java
@@ -79,7 +79,7 @@ public abstract class AbstractRegionFactory implements RegionFactory {
 	}
 
 	@Override
-	public final void start(SessionFactoryOptions settings, Map configValues) throws CacheException {
+	public final void start(SessionFactoryOptions settings, Map<String,Object> configValues) throws CacheException {
 		if ( started.compareAndSet( false, true ) ) {
 			synchronized (this) {
 				this.options = settings;
@@ -99,7 +99,7 @@ public abstract class AbstractRegionFactory implements RegionFactory {
 		}
 	}
 
-	protected abstract void prepareForUse(SessionFactoryOptions settings, Map configValues);
+	protected abstract void prepareForUse(SessionFactoryOptions settings, Map<String,Object> configValues);
 
 	@Override
 	public final void stop() {

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/RegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/RegionFactory.java
@@ -51,7 +51,7 @@ public interface RegionFactory extends Service, Stoppable {
 	 * considered as a sign to stop {@link org.hibernate.SessionFactory}
 	 * building.
 	 */
-	void start(SessionFactoryOptions settings, Map configValues) throws CacheException;
+	void start(SessionFactoryOptions settings, Map<String,Object> configValues) throws CacheException;
 
 	/**
 	 * By default should we perform "minimal puts" when using this second

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Configuration.java
@@ -165,7 +165,7 @@ public class Configuration {
 		entityTuplizerFactory = new EntityTuplizerFactory();
 		interceptor = EmptyInterceptor.INSTANCE;
 		properties = new Properties(  );
-		properties.putAll( standardServiceRegistryBuilder.getSettings());
+		properties.putAll( standardServiceRegistryBuilder.getSettings() );
 	}
 
 
@@ -320,7 +320,7 @@ public class Configuration {
 	 *
 	 * @param type The type to register.
 	 */
-	public Configuration registerTypeOverride(BasicType type) {
+	public Configuration registerTypeOverride(BasicType<?> type) {
 		basicTypes.add( type );
 		return this;
 	}
@@ -865,7 +865,7 @@ public class Configuration {
 	 * @return this for method chaining
 	 */
 	public Configuration mergeProperties(Properties properties) {
-		for ( Map.Entry entry : properties.entrySet() ) {
+		for ( Map.Entry<Object,Object> entry : properties.entrySet() ) {
 			if ( this.properties.containsKey( entry.getKey() ) ) {
 				continue;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
@@ -29,7 +29,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 			ConfigurationServiceImpl.class.getName()
 	);
 
-	private final Map settings;
+	private final Map<String, Object> settings;
 	private ServiceRegistryImplementor serviceRegistry;
 
 	/**
@@ -37,13 +37,12 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 	 *
 	 * @param settings The map of settings
 	 */
-	@SuppressWarnings( "unchecked" )
-	public ConfigurationServiceImpl(Map settings) {
+	public ConfigurationServiceImpl(Map<String, Object> settings) {
 		this.settings = Collections.unmodifiableMap( settings );
 	}
 
 	@Override
-	public Map getSettings() {
+	public Map<String, Object> getSettings() {
 		return settings;
 	}
 
@@ -86,7 +85,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, ServiceRe
 
 		Class<T> target;
 		if (candidate instanceof Class) {
-			target = (Class) candidate;
+			target = (Class<T>) candidate;
 		}
 		else {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceInitiator.java
@@ -24,7 +24,7 @@ public class ConfigurationServiceInitiator implements StandardServiceInitiator<C
 	public static final ConfigurationServiceInitiator INSTANCE = new ConfigurationServiceInitiator();
 
 	@Override
-	public ConfigurationService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public ConfigurationService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new ConfigurationServiceImpl( configurationValues );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/spi/ConfigurationService.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/spi/ConfigurationService.java
@@ -27,7 +27,7 @@ public interface ConfigurationService extends Service {
 	 *
 	 * @return The immutable map of config settings.
 	 */
-	Map getSettings();
+	Map<String,Object> getSettings();
 
 	/**
 	 * Get the named setting, using the specified converter.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchBuilderInitiator.java
@@ -38,7 +38,7 @@ public class BatchBuilderInitiator implements StandardServiceInitiator<BatchBuil
 	}
 
 	@Override
-	public BatchBuilder initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public BatchBuilder initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object builder = configurationValues.get( BUILDER );
 		if ( builder == null ) {
 			return new BatchBuilderImpl(
@@ -46,7 +46,7 @@ public class BatchBuilderInitiator implements StandardServiceInitiator<BatchBuil
 			);
 		}
 
-		if ( BatchBuilder.class.isInstance( builder ) ) {
+		if ( builder instanceof BatchBuilder ) {
 			return (BatchBuilder) builder;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/UnmodifiableBatchBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/UnmodifiableBatchBuilderInitiator.java
@@ -9,7 +9,6 @@ package org.hibernate.engine.jdbc.batch.internal;
 import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.internal.util.config.ConfigurationHelper;
@@ -36,7 +35,7 @@ public final class UnmodifiableBatchBuilderInitiator implements StandardServiceI
 	}
 
 	@Override
-	public BatchBuilder initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public BatchBuilder initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object builder = configurationValues.get( BatchBuilderInitiator.BUILDER );
 		if ( builder == null ) {
 			return new UnmodifiableBatchBuilderImpl(

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionCreatorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionCreatorFactory.java
@@ -27,6 +27,6 @@ interface ConnectionCreatorFactory {
 			Boolean autocommit,
 			Integer isolation,
 			String initSql,
-			Map<Object, Object> configurationValues);
+			Map<String, Object> configurationValues);
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionCreatorFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionCreatorFactoryImpl.java
@@ -33,7 +33,7 @@ public class ConnectionCreatorFactoryImpl implements ConnectionCreatorFactory {
 			Boolean autoCommit,
 			Integer isolation,
 			String initSql,
-			Map<Object, Object> configurationValues) {
+			Map<String, Object> configurationValues) {
 		if ( driver == null ) {
 			return new DriverManagerConnectionCreator(
 					serviceRegistry,

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
@@ -56,7 +56,7 @@ public class DatasourceConnectionProviderImpl implements ConnectionProvider, Con
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType ) ||
 				DatasourceConnectionProviderImpl.class.isAssignableFrom( unwrapType ) ||
 				DataSource.class.isAssignableFrom( unwrapType );
@@ -78,10 +78,10 @@ public class DatasourceConnectionProviderImpl implements ConnectionProvider, Con
 	}
 
 	@Override
-	public void configure(Map configValues) {
+	public void configure(Map<String, Object> configValues) {
 		if ( this.dataSource == null ) {
 			final Object dataSource = configValues.get( Environment.DATASOURCE );
-			if ( DataSource.class.isInstance( dataSource ) ) {
+			if ( dataSource instanceof DataSource ) {
 				this.dataSource = (DataSource) dataSource;
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DriverManagerConnectionProviderImpl.java
@@ -73,15 +73,14 @@ public class DriverManagerConnectionProviderImpl
 	}
 
 	@Override
-	public void configure(Map configurationValues) {
+	public void configure(Map<String, Object> configurationValues) {
 		CONNECTIONS_MESSAGE_LOGGER.usingHibernateBuiltInConnectionPool();
 		PooledConnections pool = buildPool( configurationValues, serviceRegistry );
 		final long validationInterval = ConfigurationHelper.getLong( VALIDATION_INTERVAL, configurationValues, 30 );
-		PoolState newstate = new PoolState( pool, validationInterval );
-		this.state = newstate;
+		this.state = new PoolState( pool, validationInterval );
 	}
 
-	private PooledConnections buildPool(Map configurationValues, ServiceRegistryImplementor serviceRegistry) {
+	private PooledConnections buildPool(Map<String,Object> configurationValues, ServiceRegistryImplementor serviceRegistry) {
 		final boolean autoCommit = ConfigurationHelper.getBoolean(
 				AvailableSettings.AUTOCOMMIT,
 				configurationValues,
@@ -103,7 +102,7 @@ public class DriverManagerConnectionProviderImpl
 		return pooledConnectionBuilder.build();
 	}
 
-	private static ConnectionCreator buildCreator(Map configurationValues, ServiceRegistryImplementor serviceRegistry) {
+	private static ConnectionCreator buildCreator(Map<String,Object> configurationValues, ServiceRegistryImplementor serviceRegistry) {
 		final String url = (String) configurationValues.get( AvailableSettings.URL );
 
 		String driverClassName = (String) configurationValues.get( AvailableSettings.DRIVER );
@@ -276,7 +275,7 @@ public class DriverManagerConnectionProviderImpl
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType ) ||
 				DriverManagerConnectionProviderImpl.class.isAssignableFrom( unwrapType );
 	}
@@ -516,7 +515,7 @@ public class DriverManagerConnectionProviderImpl
 		public static class Builder {
 			private final ConnectionCreator connectionCreator;
 			private ConnectionValidator connectionValidator;
-			private boolean autoCommit;
+			private final boolean autoCommit;
 			private int initialSize = 1;
 			private int minSize = 1;
 			private int maxSize = 20;

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/MultiTenantConnectionProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/MultiTenantConnectionProviderInitiator.java
@@ -38,8 +38,7 @@ public class MultiTenantConnectionProviderInitiator implements StandardServiceIn
 	}
 
 	@Override
-	@SuppressWarnings( {"unchecked"})
-	public MultiTenantConnectionProvider initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public MultiTenantConnectionProvider initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		if ( !configurationValues.containsKey( AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER ) ) {
 			// nothing to do, but given the separate hierarchies have to handle this here.
 			return null;
@@ -50,20 +49,22 @@ public class MultiTenantConnectionProviderInitiator implements StandardServiceIn
 			// if they also specified the data source *name*, then lets assume they want
 			// DataSourceBasedMultiTenantConnectionProviderImpl
 			final Object dataSourceConfigValue = configurationValues.get( AvailableSettings.DATASOURCE );
-			if ( String.class.isInstance( dataSourceConfigValue ) ) {
+			if ( dataSourceConfigValue instanceof String ) {
 				return new DataSourceBasedMultiTenantConnectionProviderImpl();
 			}
 
 			return null;
 		}
 
-		if ( MultiTenantConnectionProvider.class.isInstance( configValue ) ) {
+		if ( configValue instanceof MultiTenantConnectionProvider ) {
 			return (MultiTenantConnectionProvider) configValue;
 		}
 		else {
 			final Class<MultiTenantConnectionProvider> implClass;
-			if ( Class.class.isInstance( configValue ) ) {
-				implClass = (Class) configValue;
+			if ( configValue instanceof Class ) {
+				@SuppressWarnings("unchecked")
+				Class<MultiTenantConnectionProvider> clazz = (Class<MultiTenantConnectionProvider>) configValue;
+				implClass = clazz;
 			}
 			else {
 				final String className = configValue.toString();

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/UserSuppliedConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/UserSuppliedConnectionProviderImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.service.UnknownUnwrapTypeException;
  */
 public class UserSuppliedConnectionProviderImpl implements ConnectionProvider {
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType ) ||
 				UserSuppliedConnectionProviderImpl.class.isAssignableFrom( unwrapType );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/AbstractDataSourceBasedMultiTenantConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/AbstractDataSourceBasedMultiTenantConnectionProviderImpl.java
@@ -46,7 +46,7 @@ public abstract class AbstractDataSourceBasedMultiTenantConnectionProviderImpl i
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return
 			DataSource.class.isAssignableFrom( unwrapType ) ||
 			MultiTenantConnectionProvider.class.isAssignableFrom( unwrapType );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/AbstractMultiTenantConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/AbstractMultiTenantConnectionProvider.java
@@ -47,7 +47,7 @@ public abstract class AbstractMultiTenantConnectionProvider implements MultiTena
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return
 			ConnectionProvider.class.isAssignableFrom( unwrapType ) ||
 			MultiTenantConnectionProvider.class.isAssignableFrom( unwrapType );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/RefCursorSupportInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/cursor/internal/RefCursorSupportInitiator.java
@@ -24,7 +24,7 @@ public class RefCursorSupportInitiator implements StandardServiceInitiator<RefCu
 	public static final RefCursorSupportInitiator INSTANCE = new RefCursorSupportInitiator();
 
 	@Override
-	public RefCursorSupport initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public RefCursorSupport initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new StandardRefCursorSupport();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryImpl.java
@@ -53,7 +53,7 @@ public class DialectFactoryImpl implements DialectFactory, ServiceRegistryAwareS
 	}
 
 	@Override
-	public Dialect buildDialect(Map configValues, DialectResolutionInfoSource resolutionInfoSource) throws HibernateException {
+	public Dialect buildDialect(Map<String,Object> configValues, DialectResolutionInfoSource resolutionInfoSource) throws HibernateException {
 		final Object dialectReference = configValues.get( AvailableSettings.DIALECT );
 		Dialect dialect = !isEmpty( dialectReference ) ?
 				constructDialect( dialectReference, resolutionInfoSource ) :

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryInitiator.java
@@ -29,7 +29,7 @@ public class DialectFactoryInitiator implements StandardServiceInitiator<Dialect
 	}
 
 	@Override
-	public DialectFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public DialectFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new DialectFactoryImpl();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectResolverInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectResolverInitiator.java
@@ -36,7 +36,7 @@ public class DialectResolverInitiator implements StandardServiceInitiator<Dialec
 	}
 
 	@Override
-	public DialectResolver initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public DialectResolver initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final DialectResolverSet resolverSet = new DialectResolverSet();
 
 		applyCustomerResolvers( resolverSet, registry, configurationValues );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/spi/DialectFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/spi/DialectFactory.java
@@ -35,5 +35,5 @@ public interface DialectFactory extends Service {
 	 *
 	 * @throws HibernateException No dialect specified and no resolver could make the determination.
 	 */
-	Dialect buildDialect(Map configValues, DialectResolutionInfoSource resolutionInfoSource) throws HibernateException;
+	Dialect buildDialect(Map<String,Object> configValues, DialectResolutionInfoSource resolutionInfoSource) throws HibernateException;
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -47,7 +47,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 	}
 
 	@Override
-	public JdbcEnvironment initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JdbcEnvironment initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final DialectFactory dialectFactory = registry.getService( DialectFactory.class );
 
 		// 'hibernate.temp.use_jdbc_metadata_defaults' is a temporary magic value.
@@ -244,7 +244,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		return new JdbcEnvironmentImpl( registry, dialectFactory.buildDialect( configurationValues, null ) );
 	}
 
-	private JdbcConnectionAccess buildJdbcConnectionAccess(Map configValues, ServiceRegistryImplementor registry) {
+	private JdbcConnectionAccess buildJdbcConnectionAccess(Map<?,?> configValues, ServiceRegistryImplementor registry) {
 		if ( !configValues.containsKey( AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER ) ) {
 			ConnectionProvider connectionProvider = registry.getService( ConnectionProvider.class );
 			return new ConnectionProviderJdbcConnectionAccess( connectionProvider );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.engine.jdbc.internal;
 
 import java.util.Map;
 
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.LobCreationContext;
@@ -45,7 +44,7 @@ public class JdbcServicesImpl implements JdbcServices, ServiceRegistryAwareServi
 	}
 
 	@Override
-	public void configure(Map configValues) {
+	public void configure(Map<String, Object> configValues) {
 		this.jdbcEnvironment = serviceRegistry.getService( JdbcEnvironment.class );
 		assert jdbcEnvironment != null : "JdbcEnvironment was not found!";
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesInitiator.java
@@ -31,7 +31,7 @@ public class JdbcServicesInitiator implements StandardServiceInitiator<JdbcServi
 	}
 
 	@Override
-	public JdbcServices initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JdbcServices initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new JdbcServicesImpl();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlStatementLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlStatementLogger.java
@@ -34,14 +34,14 @@ public class SqlStatementLogger {
 	private final long logSlowQuery;
 
 	/**
-	 * Constructs a new SqlStatementLogger instance.
+	 * Constructs a new {@code SqlStatementLogger} instance.
 	 */
 	public SqlStatementLogger() {
 		this( false, false, false );
 	}
 
 	/**
-	 * Constructs a new SqlStatementLogger instance.
+	 * Constructs a new {@code SqlStatementLogger} instance.
 	 *
 	 * @param logToStdout Should we log to STDOUT in addition to our internal logger.
 	 * @param format Should we format the statements in the console and log
@@ -51,7 +51,7 @@ public class SqlStatementLogger {
 	}
 
 	/**
-	 * Constructs a new SqlStatementLogger instance.
+	 * Constructs a new {@code SqlStatementLogger} instance.
 	 *
 	 * @param logToStdout Should we log to STDOUT in addition to our internal logger.
 	 * @param format Should we format the statements in the console and log
@@ -62,7 +62,7 @@ public class SqlStatementLogger {
 	}
 
 	/**
-	 * Constructs a new SqlStatementLogger instance.
+	 * Constructs a new {@code SqlStatementLogger} instance.
 	 *
 	 * @param logToStdout Should we log to STDOUT in addition to our internal logger.
 	 * @param format Should we format the statements in the console and log

--- a/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
@@ -10,7 +10,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.Set;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.InvalidNameException;
@@ -39,14 +38,14 @@ final class JndiServiceImpl implements JndiService {
 			JndiServiceImpl.class.getName()
 	);
 
-	private final Hashtable initialContextSettings;
+	private final Hashtable<String,Object> initialContextSettings;
 
 	/**
 	 * Constructs a JndiServiceImpl
 	 *
 	 * @param configurationValues Map of configuration settings, some of which apply to JNDI support.
 	 */
-	public JndiServiceImpl(Map configurationValues) {
+	public JndiServiceImpl(Map<?,?> configurationValues) {
 		this.initialContextSettings = extractJndiProperties( configurationValues );
 	}
 
@@ -57,18 +56,17 @@ final class JndiServiceImpl implements JndiService {
 	 *
 	 * @return The extracted JNDI specific properties.
 	 */
-	@SuppressWarnings({ "unchecked" })
-	private static Hashtable extractJndiProperties(Map configurationValues) {
-		final Hashtable jndiProperties = new Hashtable();
+	private static Hashtable<String,Object> extractJndiProperties(Map<?,?> configurationValues) {
+		final Hashtable<String,Object> jndiProperties = new Hashtable<>();
 
-		for ( Map.Entry entry : (Set<Map.Entry>) configurationValues.entrySet() ) {
-			if ( !String.class.isInstance( entry.getKey() ) ) {
+		for ( Map.Entry<?,?> entry : configurationValues.entrySet() ) {
+			if ( !(entry.getKey() instanceof String) ) {
 				continue;
 			}
 			final String propertyName = (String) entry.getKey();
 			final Object propertyValue = entry.getValue();
 			if ( propertyName.startsWith( Environment.JNDI_PREFIX ) ) {
-				// write the IntialContextFactory class and provider url to the result only if they are
+				// write the InitialContextFactory class and provider url to the result only if they are
 				// non-null; this allows the environmental defaults (if any) to remain in effect
 				if ( Environment.JNDI_CLASS.equals( propertyName ) ) {
 					if ( propertyValue != null ) {
@@ -81,8 +79,8 @@ final class JndiServiceImpl implements JndiService {
 					}
 				}
 				else {
-					final String passThruPropertyname = propertyName.substring( Environment.JNDI_PREFIX.length() + 1 );
-					jndiProperties.put( passThruPropertyname, propertyValue );
+					final String passThruPropertyName = propertyName.substring( Environment.JNDI_PREFIX.length() + 1 );
+					jndiProperties.put( passThruPropertyName, propertyValue );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceInitiator.java
@@ -29,7 +29,7 @@ public final class JndiServiceInitiator implements StandardServiceInitiator<Jndi
 	}
 
 	@Override
-	public JndiService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JndiService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new JndiServiceImpl( configurationValues );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/AbstractJtaPlatform.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/AbstractJtaPlatform.java
@@ -49,7 +49,7 @@ public abstract class AbstractJtaPlatform
 	protected abstract TransactionManager locateTransactionManager();
 	protected abstract UserTransaction locateUserTransaction();
 
-	public void configure(Map configValues) {
+	public void configure(Map<String, Object> configValues) {
 		cacheTransactionManager = ConfigurationHelper.getBoolean(
 				AvailableSettings.JTA_CACHE_TM,
 				configValues,

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
@@ -34,8 +34,7 @@ public class JtaPlatformInitiator implements StandardServiceInitiator<JtaPlatfor
 	}
 
 	@Override
-	@SuppressWarnings( {"unchecked"})
-	public JtaPlatform initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JtaPlatform initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object setting = configurationValues.get( AvailableSettings.JTA_PLATFORM );
 		JtaPlatform platform = registry.getService( StrategySelector.class ).resolveStrategy( JtaPlatform.class, setting );
 
@@ -53,7 +52,7 @@ public class JtaPlatformInitiator implements StandardServiceInitiator<JtaPlatfor
 		return platform;
 	}
 
-	protected JtaPlatform getFallbackProvider(Map configurationValues, ServiceRegistryImplementor registry) {
+	protected JtaPlatform getFallbackProvider(Map<?,?> configurationValues, ServiceRegistryImplementor registry) {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformResolverInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformResolverInitiator.java
@@ -25,7 +25,7 @@ public class JtaPlatformResolverInitiator implements StandardServiceInitiator<Jt
 	private static final Logger log = Logger.getLogger( JtaPlatformResolverInitiator.class );
 
 	@Override
-	public JtaPlatformResolver initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public JtaPlatformResolver initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object setting = configurationValues.get( AvailableSettings.JTA_PLATFORM_RESOLVER );
 		final JtaPlatformResolver resolver = registry.getService( StrategySelector.class )
 				.resolveStrategy( JtaPlatformResolver.class, setting );

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyObserverFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EntityCopyObserverFactoryInitiator.java
@@ -32,7 +32,7 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( EntityCopyObserverFactoryInitiator.class );
 
 	@Override
-	public EntityCopyObserverFactory initiateService(final Map configurationValues, final ServiceRegistryImplementor registry) {
+	public EntityCopyObserverFactory initiateService(final Map<String, Object> configurationValues, final ServiceRegistryImplementor registry) {
 		final Object value = getConfigurationValue( configurationValues );
 		if ( value.equals( EntityCopyNotAllowedObserver.SHORT_NAME ) || value.equals( EntityCopyNotAllowedObserver.class.getName() ) ) {
 			LOG.debugf( "Configured EntityCopyObserver strategy: %s", EntityCopyNotAllowedObserver.SHORT_NAME );
@@ -51,13 +51,13 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 			//this might look excessive, but it also happens to test eagerly (at boot) that we can actually construct these
 			//and that they are indeed of the right type.
 			EntityCopyObserver exampleInstance = registry.getService( StrategySelector.class ).resolveStrategy( EntityCopyObserver.class, value );
-			Class observerType = exampleInstance.getClass();
+			Class<?> observerType = exampleInstance.getClass();
 			LOG.debugf( "Configured EntityCopyObserver is a custom implementation of type %s", observerType.getName() );
 			return new EntityObserversFactoryFromClass( observerType );
 		}
 	}
 
-	private Object getConfigurationValue(final Map configurationValues) {
+	private Object getConfigurationValue(final Map<?,?> configurationValues) {
 		final Object o = configurationValues.get( AvailableSettings.MERGE_ENTITY_COPY_OBSERVER );
 		if ( o == null ) {
 			return EntityCopyNotAllowedObserver.SHORT_NAME; //default
@@ -77,9 +77,9 @@ public class EntityCopyObserverFactoryInitiator implements StandardServiceInitia
 
 	private static class EntityObserversFactoryFromClass implements EntityCopyObserverFactory {
 
-		private final Class value;
+		private final Class<?> value;
 
-		public EntityObserversFactoryFromClass(Class value) {
+		public EntityObserversFactoryFromClass(Class<?> value) {
 			this.value = value;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/exception/spi/Configurable.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/spi/Configurable.java
@@ -11,8 +11,9 @@ import java.util.Properties;
 import org.hibernate.HibernateException;
 
 /**
- * The Configurable interface defines the contract for SQLExceptionConverter impls that
- * want to be configured prior to usage given the currently defined Hibernate properties.
+ * This interface defines the contract for {@link SQLExceptionConverter}
+ * implementations that want to be configured prior to usage given the
+ * currently defined Hibernate properties.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/exception/spi/SQLExceptionConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/spi/SQLExceptionConverter.java
@@ -12,15 +12,14 @@ import java.sql.SQLException;
 import org.hibernate.JDBCException;
 
 /**
- * Defines a contract for implementations that know how to convert a SQLException
- * into Hibernate's JDBCException hierarchy.  Inspired by Spring's
- * SQLExceptionTranslator.
+ * Defines a contract for implementations that know how to convert a
+ * {@link SQLException} to Hibernate's {@link JDBCException} hierarchy.
  * <p/>
  * Implementations <b>must</b> have a constructor which takes a
  * {@link ViolatedConstraintNameExtractor} parameter.
  * <p/>
- * Implementations may implement {@link Configurable} if they need to perform
- * configuration steps prior to first use.
+ * Implementations may implement {@link Configurable} if they need to
+ * perform configuration steps prior to first use.
  *
  * @author Steve Ebersole
  */
@@ -31,7 +30,11 @@ public interface SQLExceptionConverter extends Serializable {
 	 * @param sqlException The SQLException to be converted.
 	 * @param message      An optional error message.
 	 * @return The resulting JDBCException.
-	 * @see org.hibernate.exception.ConstraintViolationException , JDBCConnectionException, SQLGrammarException, LockAcquisitionException
+	 *
+	 * @see org.hibernate.exception.ConstraintViolationException
+	 * @see org.hibernate.exception.JDBCConnectionException
+	 * @see org.hibernate.exception.SQLGrammarException
+	 * @see org.hibernate.exception.LockAcquisitionException
 	 */
 	JDBCException convert(SQLException sqlException, String message, String sql);
 }

--- a/hibernate-core/src/main/java/org/hibernate/exception/spi/ViolatedConstraintNameExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/spi/ViolatedConstraintNameExtractor.java
@@ -10,7 +10,8 @@ import java.sql.SQLException;
 
 /**
  * Defines a contract for implementations that can extract the name of a violated
- * constraint from a SQLException that is the result of that constraint violation.
+ * constraint from a {@link SQLException} that is the result of that constraint
+ * violation.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/PropertiesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/PropertiesHelper.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal.util;
+
+import java.util.Map;
+import java.util.Properties;
+
+public class PropertiesHelper {
+
+	/**
+	 * Pretend that a {@link Properties} object is really a
+	 * {@link Map Map&lt;String,Object&gt;}, which of course it
+	 * should be anyway.
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static Map<String, Object> map(Properties properties) {
+		//yup, I'm really doing this, and yep, I know it's rubbish:
+		return (Map) properties;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceProvider.java
@@ -55,25 +55,25 @@ public class HibernatePersistenceProvider implements PersistenceProvider {
 		return builder.build();
 	}
 
-	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map properties) {
+	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map<?,?> properties) {
 		return getEntityManagerFactoryBuilderOrNull( persistenceUnitName, properties, null, null );
 	}
 
-	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map properties,
+	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map<?,?> properties,
 			ClassLoader providedClassLoader) {
 		return getEntityManagerFactoryBuilderOrNull( persistenceUnitName, properties, providedClassLoader, null );
 	}
 
-	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map properties,
+	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map<?,?> properties,
 			ClassLoaderService providedClassLoaderService) {
 		return getEntityManagerFactoryBuilderOrNull( persistenceUnitName, properties, null, providedClassLoaderService );
 	}
 
-	private EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map properties,
+	private EntityManagerFactoryBuilder getEntityManagerFactoryBuilderOrNull(String persistenceUnitName, Map<?,?> properties,
 			ClassLoader providedClassLoader, ClassLoaderService providedClassLoaderService) {
 		log.tracef( "Attempting to obtain correct EntityManagerFactoryBuilder for persistenceUnitName : %s", persistenceUnitName );
 
-		final Map integration = wrap( properties );
+		final Map<?,?> integration = wrap( properties );
 		final List<ParsedPersistenceXmlDescriptor> units;
 		try {
 			units = PersistenceXmlParser.locatePersistenceUnits( integration );
@@ -124,8 +124,7 @@ public class HibernatePersistenceProvider implements PersistenceProvider {
 		return null;
 	}
 
-	@SuppressWarnings("unchecked")
-	protected static Map wrap(Map properties) {
+	protected static Map<?,?> wrap(Map<?,?> properties) {
 		return properties == null ? Collections.emptyMap() : Collections.unmodifiableMap( properties );
 	}
 
@@ -166,17 +165,17 @@ public class HibernatePersistenceProvider implements PersistenceProvider {
 		return true;
 	}
 
-	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilder(PersistenceUnitInfo info, Map integration) {
+	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilder(PersistenceUnitInfo info, Map<?,?> integration) {
 		return Bootstrap.getEntityManagerFactoryBuilder( info, integration );
 	}
 
 	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilder(PersistenceUnitDescriptor persistenceUnitDescriptor,
-			Map integration, ClassLoader providedClassLoader) {
+			Map<?,?> integration, ClassLoader providedClassLoader) {
 		return Bootstrap.getEntityManagerFactoryBuilder( persistenceUnitDescriptor, integration, providedClassLoader );
 	}
 
 	protected EntityManagerFactoryBuilder getEntityManagerFactoryBuilder(PersistenceUnitDescriptor persistenceUnitDescriptor,
-			Map integration, ClassLoaderService providedClassLoaderService) {
+			Map<?,?> integration, ClassLoaderService providedClassLoaderService) {
 		return Bootstrap.getEntityManagerFactoryBuilder( persistenceUnitDescriptor, integration, providedClassLoaderService );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/internal/PersisterClassResolverInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/internal/PersisterClassResolverInitiator.java
@@ -27,14 +27,13 @@ public class PersisterClassResolverInitiator implements StandardServiceInitiator
 	}
 
 	@Override
-	@SuppressWarnings( {"unchecked"})
-	public PersisterClassResolver initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public PersisterClassResolver initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object customImpl = configurationValues.get( IMPL_NAME );
 		if ( customImpl == null ) {
 			return new StandardPersisterClassResolver();
 		}
 
-		if ( PersisterClassResolver.class.isInstance( customImpl ) ) {
+		if ( customImpl instanceof PersisterClassResolver ) {
 			return (PersisterClassResolver) customImpl;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/internal/PersisterFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/internal/PersisterFactoryInitiator.java
@@ -28,18 +28,18 @@ public class PersisterFactoryInitiator implements StandardServiceInitiator<Persi
 	}
 
 	@Override
-	@SuppressWarnings( {"unchecked"})
-	public PersisterFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public PersisterFactory initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object customImpl = configurationValues.get( IMPL_NAME );
 		if ( customImpl == null ) {
 			return new PersisterFactoryImpl();
 		}
 
-		if ( PersisterFactory.class.isInstance( customImpl ) ) {
+		if ( customImpl instanceof PersisterFactory ) {
 			return (PersisterFactory) customImpl;
 		}
 
-		final Class<? extends PersisterFactory> customImplClass = Class.class.isInstance( customImpl )
+		@SuppressWarnings("unchecked")
+		final Class<? extends PersisterFactory> customImplClass = customImpl instanceof Class
 				? ( Class<? extends PersisterFactory> ) customImpl
 				: locate( registry, customImpl.toString() );
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyResolverInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyResolverInitiator.java
@@ -27,7 +27,7 @@ public class PropertyAccessStrategyResolverInitiator implements StandardServiceI
 	}
 
 	@Override
-	public PropertyAccessStrategyResolver initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public PropertyAccessStrategyResolver initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new PropertyAccessStrategyResolverStandardImpl( registry );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
@@ -240,7 +240,6 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 		return this;
 	}
 
-	@SuppressWarnings("deprecation")
 	public final boolean applyHint(String hintName, Object value) {
 		getSession().checkOpen( true );
 
@@ -632,13 +631,12 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 		setHibernateFlushMode( FlushModeTypeHelper.getFlushMode( flushModeType ) );
 	}
 
-	@SuppressWarnings( "rawtypes" )
-	public boolean applyTupleTransformer(TupleTransformer transformer) {
+	public boolean applyTupleTransformer(TupleTransformer<?> transformer) {
 		getQueryOptions().setTupleTransformer( transformer );
 		return true;
 	}
 
-	public boolean applyResultListTransformer(ResultListTransformer transformer) {
+	public boolean applyResultListTransformer(ResultListTransformer<?> transformer) {
 		getQueryOptions().setResultListTransformer( transformer );
 		return true;
 	}
@@ -649,7 +647,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 
 	protected abstract ParameterMetadataImplementor getParameterMetadata();
 
-	@SuppressWarnings( {"unchecked", "rawtypes"} )
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public Set<Parameter<?>> getParameters() {
 		getSession().checkOpen( false );
 		return (Set) getParameterMetadata().getRegistrations();
@@ -1394,7 +1392,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 	}
 
 	@Override
-	public CommonQueryContract setProperties(Map map) {
+	public CommonQueryContract setProperties(@SuppressWarnings("rawtypes") Map map) {
 		for ( String paramName : getParameterMetadata().getNamedParameterNames() ) {
 			final Object object = map.get( paramName );
 			if ( object == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/ContainedBeanImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/ContainedBeanImplementor.java
@@ -7,7 +7,7 @@
 package org.hibernate.resource.beans.container.spi;
 
 /**
- * Release-able extension to ContainedBean.  We make the split to make it
+ * Release-able extension to {@link ContainedBean}.  We make the split to make it
  * clear that generally speaking the callers to BeanContainer should not perform
  * the release
  *

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/ExtendedBeanManager.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/ExtendedBeanManager.java
@@ -11,7 +11,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 /**
  * This contract and the nested LifecycleListener contract represent the changes
  * we'd like to propose to the CDI spec.  The idea being simply to allow contextual
- * registration of BeanManager lifecycle callbacks
+ * registration of {@link BeanManager} lifecycle callbacks
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBean.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBean.java
@@ -7,7 +7,7 @@
 package org.hibernate.resource.beans.spi;
 
 /**
- * Generalized contract for a "ManagedBean" as seen by Hibernate
+ * Generalized contract for a (CDI or Spring) "managed bean" as seen by Hibernate
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBeanRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBeanRegistry.java
@@ -10,7 +10,7 @@ import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.service.Service;
 
 /**
- * A registry for ManagedBean instances.  Responsible for managing the lifecycle.
+ * A registry for {@link ManagedBean} instances.  Responsible for managing the lifecycle.
  * <p/>
  * Access to the beans and usage of them are only valid between the time
  * the registry is initialized and released (however those events are recognized).

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBeanRegistryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ManagedBeanRegistryInitiator.java
@@ -22,7 +22,7 @@ import org.hibernate.resource.beans.internal.ManagedBeanRegistryImpl;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 /**
- * Hibernate's standard initializer for the ManagedBeanRegistry service.
+ * Hibernate's standard initializer for the {@link ManagedBeanRegistry} service.
  *
  * Produces a {@link ManagedBeanRegistryImpl}
  *
@@ -41,12 +41,12 @@ public class ManagedBeanRegistryInitiator implements StandardServiceInitiator<Ma
 
 	@Override
 	public ManagedBeanRegistry initiateService(
-			Map configurationValues,
+			Map<String, Object> configurationValues,
 			ServiceRegistryImplementor serviceRegistry) {
 		return new ManagedBeanRegistryImpl( resolveBeanContainer( configurationValues, serviceRegistry ) );
 	}
 
-	private BeanContainer resolveBeanContainer(Map configurationValues, ServiceRegistryImplementor serviceRegistry) {
+	private BeanContainer resolveBeanContainer(Map<?,?> configurationValues, ServiceRegistryImplementor serviceRegistry) {
 		final ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
 		final ConfigurationService cfgSvc = serviceRegistry.getService( ConfigurationService.class );
 
@@ -92,14 +92,14 @@ public class ManagedBeanRegistryInitiator implements StandardServiceInitiator<Ma
 		}
 
 		// otherwise we ultimately need to resolve this to a class
-		final Class containerClass;
+		final Class<?> containerClass;
 		if ( explicitSetting instanceof Class ) {
-			containerClass = (Class) explicitSetting;
+			containerClass = (Class<?>) explicitSetting;
 		}
 		else {
 			final String name = explicitSetting.toString();
 			// try the StrategySelector service
-			final Class selected = serviceRegistry.getService( StrategySelector.class )
+			final Class<?> selected = serviceRegistry.getService( StrategySelector.class )
 					.selectStrategyImplementor( BeanContainer.class, name );
 			if ( selected != null ) {
 				containerClass = selected;
@@ -128,7 +128,7 @@ public class ManagedBeanRegistryInitiator implements StandardServiceInitiator<Ma
 		}
 	}
 
-	public static Class cdiBeanManagerClass(ClassLoaderService classLoaderService) throws ClassLoadingException {
+	public static Class<?> cdiBeanManagerClass(ClassLoaderService classLoaderService) throws ClassLoadingException {
 		try {
 			return classLoaderService.classForName( "jakarta.enterprise.inject.spi.BeanManager" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ProvidedInstanceManagedBeanImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/spi/ProvidedInstanceManagedBeanImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.resource.beans.spi;
 
 /**
- * ManagedBean implementation for cases where we have been handed an actual
+ * {@link ManagedBean} implementation for cases where we have been handed an actual
  * instance to use.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/internal/TransactionCoordinatorBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/internal/TransactionCoordinatorBuilderInitiator.java
@@ -31,7 +31,7 @@ public class TransactionCoordinatorBuilderInitiator implements StandardServiceIn
 	public static final TransactionCoordinatorBuilderInitiator INSTANCE = new TransactionCoordinatorBuilderInitiator();
 
 	@Override
-	public TransactionCoordinatorBuilder initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public TransactionCoordinatorBuilder initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return registry.getService( StrategySelector.class ).resolveDefaultableStrategy(
 				TransactionCoordinatorBuilder.class,
 				determineStrategySelection( configurationValues ),

--- a/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
@@ -47,10 +47,10 @@ public final class StandardServiceInitiators {
 	private StandardServiceInitiators() {
 	}
 
-	public static final List<StandardServiceInitiator> LIST = buildStandardServiceInitiatorList();
+	public static final List<StandardServiceInitiator<?>> LIST = buildStandardServiceInitiatorList();
 
-	private static List<StandardServiceInitiator> buildStandardServiceInitiatorList() {
-		final ArrayList<StandardServiceInitiator> serviceInitiators = new ArrayList<>();
+	private static List<StandardServiceInitiator<?>> buildStandardServiceInitiatorList() {
+		final ArrayList<StandardServiceInitiator<?>> serviceInitiators = new ArrayList<>();
 
 		serviceInitiators.add( DefaultSessionFactoryBuilderInitiator.INSTANCE );
 

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryBuilderImpl.java
@@ -23,8 +23,8 @@ import org.hibernate.service.spi.SessionFactoryServiceRegistryBuilder;
 public class SessionFactoryServiceRegistryBuilderImpl implements SessionFactoryServiceRegistryBuilder {
 	private final ServiceRegistryImplementor parent;
 
-	private final List<SessionFactoryServiceInitiator> initiators = StandardSessionFactoryServiceInitiators.buildStandardServiceInitiatorList();
-	private final List<ProvidedService> providedServices = new ArrayList<>();
+	private final List<SessionFactoryServiceInitiator<?>> initiators = StandardSessionFactoryServiceInitiators.buildStandardServiceInitiatorList();
+	private final List<ProvidedService<?>> providedServices = new ArrayList<>();
 
 	public SessionFactoryServiceRegistryBuilderImpl(ServiceRegistryImplementor parent) {
 		this.parent = parent;
@@ -38,8 +38,7 @@ public class SessionFactoryServiceRegistryBuilderImpl implements SessionFactoryS
 	 * @return this, for method chaining
 	 */
 	@Override
-	@SuppressWarnings( {"UnusedDeclaration"})
-	public SessionFactoryServiceRegistryBuilder addInitiator(SessionFactoryServiceInitiator initiator) {
+	public SessionFactoryServiceRegistryBuilder addInitiator(SessionFactoryServiceInitiator<?> initiator) {
 		initiators.add( initiator );
 		return this;
 	}
@@ -53,9 +52,8 @@ public class SessionFactoryServiceRegistryBuilderImpl implements SessionFactoryS
 	 * @return this, for method chaining
 	 */
 	@Override
-	@SuppressWarnings( {"unchecked"})
-	public SessionFactoryServiceRegistryBuilder addService(final Class serviceRole, final Service service) {
-		providedServices.add( new ProvidedService( serviceRole, service ) );
+	public <R extends Service> SessionFactoryServiceRegistryBuilder addService(final Class<R> serviceRole, final R service) {
+		providedServices.add( new ProvidedService<>( serviceRole, service ) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryInitiator.java
@@ -24,7 +24,7 @@ public class SessionFactoryServiceRegistryFactoryInitiator implements StandardSe
 	}
 
 	@Override
-	public SessionFactoryServiceRegistryFactoryImpl initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public SessionFactoryServiceRegistryFactoryImpl initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		return new SessionFactoryServiceRegistryFactoryImpl( registry );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
@@ -35,11 +35,10 @@ public class SessionFactoryServiceRegistryImpl
 	private final SessionFactoryOptions sessionFactoryOptions;
 	private final SessionFactoryImplementor sessionFactory;
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	public SessionFactoryServiceRegistryImpl(
 			ServiceRegistryImplementor parent,
-			List<SessionFactoryServiceInitiator> initiators,
-			List<ProvidedService> providedServices,
+			List<SessionFactoryServiceInitiator<?>> initiators,
+			List<ProvidedService<?>> providedServices,
 			SessionFactoryImplementor sessionFactory,
 			SessionFactoryOptions sessionFactoryOptions) {
 		super( parent );
@@ -48,7 +47,7 @@ public class SessionFactoryServiceRegistryImpl
 		this.sessionFactoryOptions = sessionFactoryOptions;
 
 		// for now, just use the standard initiator list
-		for ( SessionFactoryServiceInitiator initiator : initiators ) {
+		for ( SessionFactoryServiceInitiator<?> initiator : initiators ) {
 			// create the bindings up front to help identify to which registry services belong
 			createServiceBinding( initiator );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/StandardSessionFactoryServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/StandardSessionFactoryServiceInitiators.java
@@ -22,8 +22,8 @@ import org.hibernate.stat.internal.StatisticsInitiator;
  */
 public final class StandardSessionFactoryServiceInitiators {
 
-	public static List<SessionFactoryServiceInitiator> buildStandardServiceInitiatorList() {
-		final ArrayList<SessionFactoryServiceInitiator> serviceInitiators = new ArrayList<>();
+	public static List<SessionFactoryServiceInitiator<?>> buildStandardServiceInitiatorList() {
+		final ArrayList<SessionFactoryServiceInitiator<?>> serviceInitiators = new ArrayList<>();
 
 		serviceInitiators.add( StatisticsInitiator.INSTANCE );
 		serviceInitiators.add( CacheInitiator.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/Configurable.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/Configurable.java
@@ -18,5 +18,5 @@ public interface Configurable {
 	 *
 	 * @param configurationValues The configuration properties.
 	 */
-	void configure(Map configurationValues);
+	void configure(Map<String, Object> configurationValues);
 }

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/SessionFactoryServiceRegistryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/SessionFactoryServiceRegistryBuilder.java
@@ -12,8 +12,7 @@ import org.hibernate.service.Service;
  * @author Steve Ebersole
  */
 public interface SessionFactoryServiceRegistryBuilder {
-	SessionFactoryServiceRegistryBuilder addInitiator(SessionFactoryServiceInitiator initiator);
+	SessionFactoryServiceRegistryBuilder addInitiator(SessionFactoryServiceInitiator<?> initiator);
 
-	@SuppressWarnings( {"unchecked"})
-	SessionFactoryServiceRegistryBuilder addService(Class serviceRole, Service service);
+	<R extends Service> SessionFactoryServiceRegistryBuilder addService(Class<R> serviceRole, R service);
 }

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/Wrapped.java
@@ -21,7 +21,7 @@ public interface Wrapped {
 	 *
 	 * @return True/false.
 	 */
-	boolean isUnwrappableAs(Class unwrapType);
+	boolean isUnwrappableAs(Class<?> unwrapType);
 
 	/**
 	 * Unproxy the service proxy

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/Helper.java
@@ -125,7 +125,7 @@ public class Helper {
 		}
 	}
 
-	public static boolean interpretNamespaceHandling(Map configurationValues) {
+	public static boolean interpretNamespaceHandling(Map<String,Object> configurationValues) {
 		//Print a warning if multiple conflicting properties are being set:
 		int count = 0;
 		if ( configurationValues.containsKey( AvailableSettings.HBM2DDL_CREATE_SCHEMAS ) ) {
@@ -158,7 +158,7 @@ public class Helper {
 		);
 	}
 
-	public static boolean interpretFormattingEnabled(Map configurationValues) {
+	public static boolean interpretFormattingEnabled(Map<String,Object> configurationValues) {
 		return ConfigurationHelper.getBoolean(
 				AvailableSettings.FORMAT_SQL,
 				configurationValues,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -9,7 +9,6 @@ package org.hibernate.tool.schema.internal;
 import java.sql.Connection;
 import java.util.Map;
 
-import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.cfg.AvailableSettings;
@@ -83,17 +82,17 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	}
 
 	@Override
-	public SchemaCreator getSchemaCreator(Map options) {
+	public SchemaCreator getSchemaCreator(Map<String,Object> options) {
 		return new SchemaCreatorImpl( this, getSchemaFilterProvider( options ).getCreateFilter() );
 	}
 
 	@Override
-	public SchemaDropper getSchemaDropper(Map options) {
+	public SchemaDropper getSchemaDropper(Map<String,Object> options) {
 		return new SchemaDropperImpl( this, getSchemaFilterProvider( options ).getDropFilter() );
 	}
 
 	@Override
-	public SchemaMigrator getSchemaMigrator(Map options) {
+	public SchemaMigrator getSchemaMigrator(Map<String,Object> options) {
 		if ( determineJdbcMetadaAccessStrategy( options ) == JdbcMetadaAccessStrategy.GROUPED ) {
 			return new GroupedSchemaMigratorImpl( this, getSchemaFilterProvider( options ).getMigrateFilter() );
 		}
@@ -103,7 +102,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	}
 
 	@Override
-	public SchemaValidator getSchemaValidator(Map options) {
+	public SchemaValidator getSchemaValidator(Map<String,Object> options) {
 		if ( determineJdbcMetadaAccessStrategy( options ) == JdbcMetadaAccessStrategy.GROUPED ) {
 			return new GroupedSchemaValidatorImpl( this, getSchemaFilterProvider( options ).getValidateFilter() );
 		}
@@ -112,7 +111,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		}
 	}
 
-	private SchemaFilterProvider getSchemaFilterProvider(Map options) {
+	private SchemaFilterProvider getSchemaFilterProvider(Map<String,Object> options) {
 		final Object configuredOption = (options == null)
 				? null
 				: options.get( AvailableSettings.HBM2DDL_FILTER_PROVIDER );
@@ -123,7 +122,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		);
 	}
 
-	private JdbcMetadaAccessStrategy determineJdbcMetadaAccessStrategy(Map options) {
+	private JdbcMetadaAccessStrategy determineJdbcMetadaAccessStrategy(Map<String,Object> options) {
 		return JdbcMetadaAccessStrategy.interpretSetting( options );
 	}
 
@@ -144,7 +143,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	GenerationTarget[] buildGenerationTargets(
 			TargetDescriptor targetDescriptor,
 			JdbcContext jdbcContext,
-			Map options,
+			Map<String,Object> options,
 			boolean needsAutoCommit) {
 		final String scriptDelimiter = ConfigurationHelper.getString( HBM2DDL_DELIMITER, options, ";" );
 
@@ -178,7 +177,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 	GenerationTarget[] buildGenerationTargets(
 			TargetDescriptor targetDescriptor,
 			DdlTransactionIsolator ddlTransactionIsolator,
-			Map options) {
+			Map<String,Object> options) {
 		final String scriptDelimiter = ConfigurationHelper.getString( HBM2DDL_DELIMITER, options, ";" );
 
 		final GenerationTarget[] targets = new GenerationTarget[ targetDescriptor.getTargetTypes().size() ];
@@ -215,7 +214,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 		return serviceRegistry.getService( TransactionCoordinatorBuilder.class ).buildDdlTransactionIsolator( jdbcContext );
 	}
 
-	public JdbcContext resolveJdbcContext(Map configurationValues) {
+	public JdbcContext resolveJdbcContext(Map<String,Object> configurationValues) {
 		final JdbcContextBuilder jdbcContextBuilder = new JdbcContextBuilder( serviceRegistry );
 
 		// see if a specific connection has been provided

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -97,7 +97,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 
 	public SchemaCreatorImpl(ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
 		SchemaManagementTool smt = serviceRegistry.getService( SchemaManagementTool.class );
-		if ( !HibernateSchemaManagementTool.class.isInstance( smt ) ) {
+		if ( !(smt instanceof HibernateSchemaManagementTool) ) {
 			smt = new HibernateSchemaManagementTool();
 			( (HibernateSchemaManagementTool) smt ).injectServices( (ServiceRegistryImplementor) serviceRegistry );
 		}
@@ -382,9 +382,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 
 				// indexes
-				final Iterator indexItr = table.getIndexIterator();
+				final Iterator<Index> indexItr = table.getIndexIterator();
 				while ( indexItr.hasNext() ) {
-					final Index index = (Index) indexItr.next();
+					final Index index = indexItr.next();
 					checkExportIdentifier( index, exportIdentifiers );
 					applySqlStrings(
 							dialect.getIndexExporter().getSqlCreateStrings( index, metadata,
@@ -397,9 +397,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 
 				// unique keys
-				final Iterator ukItr = table.getUniqueKeyIterator();
+				final Iterator<UniqueKey> ukItr = table.getUniqueKeyIterator();
 				while ( ukItr.hasNext() ) {
-					final UniqueKey uniqueKey = (UniqueKey) ukItr.next();
+					final UniqueKey uniqueKey = ukItr.next();
 					checkExportIdentifier( uniqueKey, exportIdentifiers );
 					applySqlStrings(
 							dialect.getUniqueKeyExporter().getSqlCreateStrings( uniqueKey, metadata,
@@ -431,9 +431,9 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 
 				// foreign keys
-				final Iterator fkItr = table.getForeignKeyIterator();
+				final Iterator<ForeignKey> fkItr = table.getForeignKeyIterator();
 				while ( fkItr.hasNext() ) {
-					final ForeignKey foreignKey = (ForeignKey) fkItr.next();
+					final ForeignKey foreignKey = fkItr.next();
 					applySqlStrings(
 							dialect.getForeignKeyExporter().getSqlCreateStrings( foreignKey, metadata,
 									sqlStringGenerationContext
@@ -549,7 +549,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 
 		for ( String currentFile : importFiles.split( "," ) ) {
 			final String resourceName = currentFile.trim();
-			if ( resourceName != null && resourceName.isEmpty() ) {
+			if ( resourceName.isEmpty() ) {
 				//skip empty resource names
 				continue;
 			}
@@ -602,7 +602,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 			}
 
 			@Override
-			public Map getConfigurationValues() {
+			public Map<String,Object> getConfigurationValues() {
 				return Collections.emptyMap();
 			}
 
@@ -647,7 +647,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 	public void doCreation(
 			Metadata metadata,
 			final ServiceRegistry serviceRegistry,
-			final Map settings,
+			final Map<String,Object> settings,
 			final boolean manageNamespaces,
 			GenerationTarget... targets) {
 		doCreation(
@@ -660,7 +660,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 					}
 
 					@Override
-					public Map getConfigurationValues() {
+					public Map<String,Object> getConfigurationValues() {
 						return settings;
 					}
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -91,7 +91,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 
 	public SchemaDropperImpl(ServiceRegistry serviceRegistry, SchemaFilter schemaFilter) {
 		SchemaManagementTool smt = serviceRegistry.getService( SchemaManagementTool.class );
-		if ( !HibernateSchemaManagementTool.class.isInstance( smt ) ) {
+		if ( !(smt instanceof HibernateSchemaManagementTool) ) {
 			smt = new HibernateSchemaManagementTool();
 			( (HibernateSchemaManagementTool) smt ).injectServices( (ServiceRegistryImplementor) serviceRegistry );
 		}
@@ -370,9 +370,9 @@ public class SchemaDropperImpl implements SchemaDropper {
 				continue;
 			}
 
-			final Iterator fks = table.getForeignKeyIterator();
+			final Iterator<ForeignKey> fks = table.getForeignKeyIterator();
 			while ( fks.hasNext() ) {
-				final ForeignKey foreignKey = (ForeignKey) fks.next();
+				final ForeignKey foreignKey = fks.next();
 				applySqlStrings(
 						dialect.getForeignKeyExporter().getSqlDropStrings( foreignKey, metadata,
 								sqlStringGenerationContext
@@ -448,7 +448,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 			}
 
 			@Override
-			public Map getConfigurationValues() {
+			public Map<String,Object> getConfigurationValues() {
 				return Collections.emptyMap();
 			}
 
@@ -502,7 +502,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 	public void doDrop(
 			Metadata metadata,
 			final ServiceRegistry serviceRegistry,
-			final Map settings,
+			final Map<String,Object> settings,
 			final boolean manageNamespaces,
 			GenerationTarget... targets) {
 		if ( targets == null || targets.length == 0 ) {
@@ -524,7 +524,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 					}
 
 					@Override
-					public Map getConfigurationValues() {
+					public Map<String,Object> getConfigurationValues() {
 						return settings;
 					}
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaManagementToolInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaManagementToolInitiator.java
@@ -20,7 +20,7 @@ import org.hibernate.tool.schema.spi.SchemaManagementTool;
 public class SchemaManagementToolInitiator implements StandardServiceInitiator<SchemaManagementTool> {
 	public static final SchemaManagementToolInitiator INSTANCE = new SchemaManagementToolInitiator();
 
-	public SchemaManagementTool initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public SchemaManagementTool initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object setting = configurationValues.get( AvailableSettings.SCHEMA_MANAGEMENT_TOOL );
 		SchemaManagementTool tool = registry.getService( StrategySelector.class ).resolveStrategy( SchemaManagementTool.class, setting );
 		if ( tool == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/SqlScriptExtractorInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/script/SqlScriptExtractorInitiator.java
@@ -27,7 +27,7 @@ public class SqlScriptExtractorInitiator implements StandardServiceInitiator<Sql
 	}
 
 	@Override
-	public SqlScriptCommandExtractor initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+	public SqlScriptCommandExtractor initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object explicitSettingValue = configurationValues.get( Environment.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR );
 
 		if ( explicitSettingValue == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ExecutionOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/ExecutionOptions.java
@@ -18,7 +18,7 @@ import org.hibernate.boot.model.relational.Exportable;
  */
 @Incubating
 public interface ExecutionOptions {
-	Map getConfigurationValues();
+	Map<String,Object> getConfigurationValues();
 
 	boolean shouldManageNamespaces();
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
@@ -19,10 +19,10 @@ import org.hibernate.tool.schema.internal.exec.GenerationTarget;
  */
 @Incubating
 public interface SchemaManagementTool extends Service {
-	SchemaCreator getSchemaCreator(Map options);
-	SchemaDropper getSchemaDropper(Map options);
-	SchemaMigrator getSchemaMigrator(Map options);
-	SchemaValidator getSchemaValidator(Map options);
+	SchemaCreator getSchemaCreator(Map<String,Object> options);
+	SchemaDropper getSchemaDropper(Map<String,Object> options);
+	SchemaMigrator getSchemaMigrator(Map<String,Object> options);
+	SchemaValidator getSchemaValidator(Map<String,Object> options);
 
 	/**
 	 * This allows to set an alternative implementation for the Database

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
@@ -63,7 +63,7 @@ public class SchemaManagementToolCoordinator {
 	public static void process(
 			final Metadata metadata,
 			final ServiceRegistry serviceRegistry,
-			final Map<?,?> configurationValues,
+			final Map<String,Object> configurationValues,
 			DelayedDropRegistry delayedDropRegistry) {
 		final Set<ActionGrouping> groupings = ActionGrouping.interpret( metadata, configurationValues );
 
@@ -169,7 +169,7 @@ public class SchemaManagementToolCoordinator {
 	}
 
 	public static ExecutionOptions buildExecutionOptions(
-			final Map<?,?> configurationValues,
+			final Map<String,Object> configurationValues,
 			final ExceptionHandler exceptionHandler) {
 		return buildExecutionOptions(
 				configurationValues,
@@ -179,7 +179,7 @@ public class SchemaManagementToolCoordinator {
 	}
 
 	public static ExecutionOptions buildExecutionOptions(
-			final Map<?,?> configurationValues,
+			final Map<String,Object> configurationValues,
 			final SchemaFilter schemaFilter,
 			final ExceptionHandler exceptionHandler) {
 		return new ExecutionOptions() {
@@ -189,7 +189,7 @@ public class SchemaManagementToolCoordinator {
 			}
 
 			@Override
-			public Map<?,?> getConfigurationValues() {
+			public Map<String,Object> getConfigurationValues() {
 				return configurationValues;
 			}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/SafeMappingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/SafeMappingTest.java
@@ -7,6 +7,7 @@
 
 //$Id$
 package org.hibernate.orm.test.annotations;
+
 import org.junit.Test;
 
 import org.hibernate.AnnotationException;
@@ -23,7 +24,7 @@ import static org.junit.Assert.fail;
  */
 public class SafeMappingTest {
     @Test
-	public void testDeclarativeMix() throws Exception {
+	public void testDeclarativeMix() {
 		Configuration cfg = new Configuration();
 		cfg.addAnnotatedClass( IncorrectEntity.class );
 		cfg.setProperty( Environment.HBM2DDL_AUTO, "create-drop" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/SecuredBindingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/SecuredBindingTest.java
@@ -27,7 +27,7 @@ public class SecuredBindingTest {
 
 
      @Test
-	public void testConfigurationMethods() throws Exception {
+	public void testConfigurationMethods() {
 		Configuration ac = new Configuration();
 		Properties p = new Properties();
 		p.put( Environment.DIALECT, "org.hibernate.dialect.HSQLDialect" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/BeanValidationDisabledTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/BeanValidationDisabledTest.java
@@ -50,7 +50,7 @@ public class BeanValidationDisabledTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( "javax.persistence.validation.mode", "none" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLTest.java
@@ -83,7 +83,7 @@ public class DDLTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( "javax.persistence.validation.mode", "ddl" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLWithoutCallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/DDLWithoutCallbackTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
 public class DDLWithoutCallbackTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( "javax.persistence.validation.mode", "ddl" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/duplicatedgenerator/DuplicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/duplicatedgenerator/DuplicateTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class DuplicateTest  {
     @Test
-	public void testDuplicateEntityName() throws Exception {
+	public void testDuplicateEntityName() {
 		Configuration cfg = new Configuration();
 		cfg.setProperty( Environment.HBM2DDL_AUTO, "create-drop" );
 		ServiceRegistry serviceRegistry = null;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableEntityUpdateQueryHandlingModeExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableEntityUpdateQueryHandlingModeExceptionTest.java
@@ -41,7 +41,7 @@ public class ImmutableEntityUpdateQueryHandlingModeExceptionTest extends BaseNon
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE, "exception" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/AbstractCharsetNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/AbstractCharsetNamingStrategyTest.java
@@ -21,6 +21,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.service.ServiceRegistry;
 
@@ -44,7 +45,7 @@ public abstract class AbstractCharsetNamingStrategyTest extends BaseUnitTestCase
 
 	@Before
     public void setUp() {
-		Map<Object, Object> properties = new HashMap<>( Environment.getProperties() );
+		Map<String, Object> properties = PropertiesHelper.map( Environment.getProperties() );
 		properties.put( AvailableSettings.HBM2DDL_CHARSET_NAME, charsetName() );
 		serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( properties );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/OneToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/OneToManyTest.java
@@ -574,7 +574,7 @@ public class OneToManyTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		// needed for `#testListWithBagSemanticAndOrderBy`
 		settings.put( DEFAULT_LIST_SEMANTICS, CollectionClassification.BAG.name() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
@@ -43,7 +43,7 @@ public class BatchOptimisticLockingTest extends
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.STATEMENT_BATCH_SIZE, String.valueOf( 2 ) );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/OptionalSecondaryTableBatchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/OptionalSecondaryTableBatchTest.java
@@ -105,7 +105,7 @@ public class OptionalSecondaryTableBatchTest extends BaseNonConfigCoreFunctional
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.STATEMENT_BATCH_SIZE, 5 );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/QualifiedTableNamingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/QualifiedTableNamingTest.java
@@ -44,7 +44,7 @@ public class QualifiedTableNamingTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.DIALECT, TestDialect.class );
 		settings.put( AvailableSettings.CONNECTION_PROVIDER, MockedConnectionProvider.class.getName() );
@@ -119,7 +119,7 @@ public class QualifiedTableNamingTest extends BaseNonConfigCoreFunctionalTestCas
 
 
 		@Override
-		public boolean isUnwrappableAs(Class unwrapType) {
+		public boolean isUnwrappableAs(Class<?> unwrapType) {
 			return false;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/mixed/XMLMappingDisabledTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/mixed/XMLMappingDisabledTest.java
@@ -45,7 +45,7 @@ public class XMLMappingDisabledTest extends BaseNonConfigCoreFunctionalTestCase 
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.XML_MAPPING_ENABLED, "false" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedTest.java
@@ -52,7 +52,7 @@ public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.FORMAT_SQL, "true" );
 		sqlInterceptor = new SQLStatementInterceptor( settings );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/BytecodeEnhancedLazyLoadingOnDeletedEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/BytecodeEnhancedLazyLoadingOnDeletedEntityTest.java
@@ -43,7 +43,7 @@ public class BytecodeEnhancedLazyLoadingOnDeletedEntityTest
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( DEFAULT_LIST_SEMANTICS, CollectionClassification.BAG.name() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
@@ -50,7 +50,7 @@ public class NonRootEntityWithCacheAnnotationTest {
 
 	@Test
 	public void testCacheOnNonRootEntity() {
-		Map settings = new HashMap();
+		Map<String,Object> settings = new HashMap<>();
 		settings.put( Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName() );
 		settings.put( AvailableSettings.JPA_SHARED_CACHE_MODE, SharedCacheMode.ENABLE_SELECTIVE );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheableAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheableAnnotationTest.java
@@ -48,7 +48,7 @@ public class NonRootEntityWithCacheableAnnotationTest {
 
 	@Test
 	public void testCacheableOnNonRootEntity() {
-		Map settings = new HashMap();
+		Map<String,Object> settings = new HashMap<>();
 		settings.put( Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName() );
 		settings.put( AvailableSettings.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "read-write" );
 		settings.put( AvailableSettings.JPA_SHARED_CACHE_MODE, SharedCacheMode.ENABLE_SELECTIVE );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/PersisterClassProviderTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.fail;
  */
 public class PersisterClassProviderTest extends BaseUnitTestCase {
 	@Test
-	public void testPersisterClassProvider() throws Exception {
+	public void testPersisterClassProvider() {
 
 		Configuration cfg = new Configuration();
 		cfg.addAnnotatedClass( Gate.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connection/ConnectionCreatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connection/ConnectionCreatorTest.java
@@ -39,8 +39,8 @@ public class ConnectionCreatorTest extends BaseUnitTestCase {
 				new StandardServiceRegistryImpl(
 						true,
 						new BootstrapServiceRegistryImpl(),
-						Collections.<StandardServiceInitiator>emptyList(),
-						Collections.<ProvidedService>emptyList(),
+						Collections.emptyList(),
+						Collections.emptyList(),
 						Collections.emptyMap()
 				) {
 					@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connection/PropertiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connection/PropertiesTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.connection;
 import java.util.Properties;
 
+import org.hibernate.internal.util.PropertiesHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,7 +19,7 @@ import org.hibernate.testing.junit4.BaseUnitTestCase;
  */
 public class PropertiesTest extends BaseUnitTestCase {
 	@Test
-	public void testProperties() throws Exception {
+	public void testProperties() {
 		final Properties props = new Properties();
 
 		props.put("rpt.1.hibernate.dialect", "org.hibernate.dialect.DerbyDialect");
@@ -29,7 +30,7 @@ public class PropertiesTest extends BaseUnitTestCase {
 		props.put("rpt.6.hibernate.connection.password_enc", "76f271db3661fd50082e68d4b953fbee");
 		props.put("hibernate.connection.create", "true");
 
-		final Properties outputProps = ConnectionProviderInitiator.getConnectionProperties( props );
+		final Properties outputProps = ConnectionProviderInitiator.getConnectionProperties( PropertiesHelper.map(props) );
 		Assert.assertEquals( 1, outputProps.size() );
 		Assert.assertEquals( "true", outputProps.get( "create" ) );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/AggressiveReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/AggressiveReleaseTest.java
@@ -41,8 +41,7 @@ import static org.junit.Assert.fail;
 @RequiresDialect(H2Dialect.class)
 public class AggressiveReleaseTest extends ConnectionManagementTestCase {
 	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		TestingJtaBootstrap.prepare( settings );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/BasicConnectionProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/BasicConnectionProviderTest.java
@@ -34,8 +34,7 @@ public class BasicConnectionProviderTest extends ConnectionManagementTestCase {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( Environment.CONNECTION_HANDLING, PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_HOLD.toString() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ExplicitConnectionProviderInstanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ExplicitConnectionProviderInstanceTest.java
@@ -56,7 +56,7 @@ public class ExplicitConnectionProviderInstanceTest extends BaseUnitTestCase {
 		}
 
 		@Override
-		public boolean isUnwrappableAs(Class unwrapType) {
+		public boolean isUnwrappableAs(Class<?> unwrapType) {
 			return false;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/JdbcBatchingAgressiveReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/JdbcBatchingAgressiveReleaseTest.java
@@ -49,8 +49,7 @@ public class JdbcBatchingAgressiveReleaseTest extends BaseNonConfigCoreFunctiona
 
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		TestingJtaBootstrap.prepare( settings );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/SuppliedConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/SuppliedConnectionTest.java
@@ -78,8 +78,7 @@ public class SuppliedConnectionTest extends ConnectionManagementTestCase {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( Environment.CONNECTION_HANDLING, PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_HOLD.toString() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ThreadLocalCurrentSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ThreadLocalCurrentSessionTest.java
@@ -32,8 +32,7 @@ import static org.junit.Assert.fail;
 @RequiresDialect(H2Dialect.class)
 public class ThreadLocalCurrentSessionTest extends ConnectionManagementTestCase {
 	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( Environment.CURRENT_SESSION_CONTEXT_CLASS, TestableThreadLocalContext.class.getName() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/MariaDBExtractSequenceMetadataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/MariaDBExtractSequenceMetadataTest.java
@@ -51,7 +51,8 @@ public class MariaDBExtractSequenceMetadataTest {
 	@Test
 	@TestForIssue(jiraKey = "HHH-13373")
 	public void testHibernateLaunchedSuccessfully() {
-		JdbcEnvironment jdbcEnvironment = ServiceRegistryBuilder.buildServiceRegistry(Environment.getProperties()).getService( JdbcEnvironment.class );
+		JdbcEnvironment jdbcEnvironment = ServiceRegistryBuilder.buildServiceRegistry( Environment.getProperties() )
+				.getService( JdbcEnvironment.class );
 		Assertions.assertFalse( jdbcEnvironment.getExtractedDatabaseMetaData().getSequenceInformationList().isEmpty() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SequenceInformationMariaDBTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SequenceInformationMariaDBTest.java
@@ -21,6 +21,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -54,7 +55,7 @@ public class SequenceInformationMariaDBTest {
 	@BeforeAll
 	public void init() {
 		connectionProvider = new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( Environment.getProperties() );
+		connectionProvider.configure( PropertiesHelper.map( Environment.getProperties() ) );
 
 		try(Connection connection = connectionProvider.getConnection();
 			Statement statement = connection.createStatement()) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/resolver/DialectFactoryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/resolver/DialectFactoryTest.java
@@ -61,7 +61,7 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 
 	@Test
 	public void testExplicitShortNameUse() {
-		final Map<String, String> configValues = new HashMap<String, String>();
+		final Map<String, Object> configValues = new HashMap<>();
 
 		configValues.put( Environment.DIALECT, "H2" );
 		assertEquals( H2Dialect.class, dialectFactory.buildDialect( configValues, null ).getClass() );
@@ -72,7 +72,7 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 
 	@Test
 	public void testExplicitlySuppliedDialectClassName() {
-		final Map<String, String> configValues = new HashMap<String, String>();
+		final Map<String, Object> configValues = new HashMap<>();
 
 		configValues.put( Environment.DIALECT, "org.hibernate.dialect.HSQLDialect" );
 		assertEquals( HSQLDialect.class, dialectFactory.buildDialect( configValues, null ).getClass() );
@@ -98,17 +98,17 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 
 	@Test
 	public void testBuildDialectByProperties() {
-		Properties props = new Properties();
 
 		try {
-			dialectFactory.buildDialect( props, null );
+			dialectFactory.buildDialect( new HashMap<>(), null );
 			fail();
 		}
 		catch ( HibernateException e ) {
 			assertNull( e.getCause() );
 		}
 
-		props.setProperty( Environment.DIALECT, "org.hibernate.dialect.HSQLDialect" );
+		Map<String,Object> props = new HashMap<>();
+		props.put( Environment.DIALECT, "org.hibernate.dialect.HSQLDialect" );
 		assertEquals( HSQLDialect.class, dialectFactory.buildDialect( props, null ).getClass() );
 	}
 
@@ -242,7 +242,7 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 			DialectResolver resolver) {
 		dialectFactory.setDialectResolver( resolver );
 		Dialect resolved = dialectFactory.buildDialect(
-				new Properties(),
+				new HashMap<>(),
 				new DialectResolutionInfoSource() {
 					@Override
 					public DialectResolutionInfo getDialectResolutionInfo() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/BaseExceptionHandlingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/BaseExceptionHandlingTest.java
@@ -34,5 +34,5 @@ public abstract class BaseExceptionHandlingTest extends BaseJpaOrNativeBootstrap
 	}
 
 	@Override
-	protected void configure(Map<Object, Object> properties) {}
+	protected void configure(Map<String, Object> properties) {}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/BaseJpaOrNativeBootstrapFunctionalTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/exceptionhandling/BaseJpaOrNativeBootstrapFunctionalTestCase.java
@@ -28,6 +28,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.hibernate.jpa.boot.spi.Bootstrap;
@@ -283,7 +284,7 @@ public abstract class BaseJpaOrNativeBootstrapFunctionalTestCase extends BaseUni
 			properties.put( AvailableSettings.COLLECTION_CACHE_PREFIX + "." + entry.getKey(), entry.getValue() );
 		}
 
-		configure( properties );
+		configure( PropertiesHelper.map( properties ) );
 
 		if ( createSchema() ) {
 			properties.put( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
@@ -293,7 +294,7 @@ public abstract class BaseJpaOrNativeBootstrapFunctionalTestCase extends BaseUni
 		return properties;
 	}
 
-	protected void configure(Map<Object, Object> properties) {
+	protected void configure(Map<String, Object> properties) {
 	}
 
 	protected static final Class<?>[] NO_CLASSES = new Class[0];

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/DynamicFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/DynamicFilterTest.java
@@ -88,7 +88,7 @@ public class DynamicFilterTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	public void addSettings(Map settings) {
+	public void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.MAX_FETCH_DEPTH, "1" );
 		settings.put( AvailableSettings.GENERATE_STATISTICS, "true" );
 		settings.put( AvailableSettings.USE_QUERY_CACHE, "true" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestFlushJoinTransaction.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestFlushJoinTransaction.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.fail;
 public class TestFlushJoinTransaction extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		TestingJtaBootstrap.prepare( settings );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/PostgreSQLIdentitySequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/PostgreSQLIdentitySequenceTest.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -46,7 +47,7 @@ public class PostgreSQLIdentitySequenceTest {
 	@BeforeAll
 	public void produceEntityManagerFactory() throws SQLException {
 		connectionProvider = new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( Environment.getProperties() );
+		connectionProvider.configure( PropertiesHelper.map( Environment.getProperties() ) );
 
 		try (Connection connection = connectionProvider.getConnection();
 			 Statement statement = connection.createStatement()) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/interceptor/InterceptorNonNullTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/interceptor/InterceptorNonNullTransactionTest.java
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized;
 public class InterceptorNonNullTransactionTest extends BaseJpaOrNativeBootstrapFunctionalTestCase {
 
 	public enum JpaComplianceTransactionSetting { DEFAULT, TRUE, FALSE }
-	public enum JtaAllowTransactionAccessSetting { DEFAULT, TRUE, FALSE; };
+	public enum JtaAllowTransactionAccessSetting { DEFAULT, TRUE, FALSE }
 
 	@Parameterized.Parameters(name = "Bootstrap={0}, JpaComplianceTransactionSetting={1}, JtaAllowTransactionAccessSetting={2}")
 	public static Iterable<Object[]> parameters() {
@@ -72,7 +72,7 @@ public class InterceptorNonNullTransactionTest extends BaseJpaOrNativeBootstrapF
 	}
 
 	@Override
-	protected void configure(Map<Object, Object> properties) {
+	protected void configure(Map<String, Object> properties) {
 		super.configure( properties );
 
 		switch ( jpaComplianceTransactionSetting ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/internal/SessionJdbcBatchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/internal/SessionJdbcBatchTest.java
@@ -42,7 +42,7 @@ public class SessionJdbcBatchTest
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.STATEMENT_BATCH_SIZE, 2 );
 		connectionProvider.setConnectionProvider( (ConnectionProvider) settings.get( AvailableSettings.CONNECTION_PROVIDER ) );
 		settings.put(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateCustomEntityDirtinessStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateCustomEntityDirtinessStrategyTest.java
@@ -71,7 +71,7 @@ public class PreUpdateCustomEntityDirtinessStrategyTest
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.CUSTOM_ENTITY_DIRTINESS_STRATEGY, DefaultCustomEntityDirtinessStrategy.INSTANCE );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/QueryApiTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/QueryApiTest.java
@@ -42,7 +42,7 @@ public class QueryApiTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "true" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/CachingWithSecondaryTablesTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/CachingWithSecondaryTablesTests.java
@@ -131,8 +131,8 @@ public class CachingWithSecondaryTablesTests extends BaseUnitTestCase {
 	}
 
 
-	private SessionFactoryImplementor buildSessionFactory(Class entityClass, boolean strict) {
-		final Map settings = new HashMap();
+	private SessionFactoryImplementor buildSessionFactory(Class<?> entityClass, boolean strict) {
+		final Map<String,Object> settings = new HashMap<>();
 		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );
 		settings.put( AvailableSettings.JPA_SHARED_CACHE_MODE, SharedCacheMode.ENABLE_SELECTIVE );
 		settings.put( AvailableSettings.GENERATE_STATISTICS, "true" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/InheritedCacheableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/InheritedCacheableTest.java
@@ -94,7 +94,7 @@ public class InheritedCacheableTest extends BaseNonConfigCoreFunctionalTestCase 
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/SubclassOnlyCachingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/tck2_2/caching/SubclassOnlyCachingTests.java
@@ -82,7 +82,7 @@ public class SubclassOnlyCachingTests extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/ConfigurationObjectSettingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/ConfigurationObjectSettingTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.jpa.ejb3configuration;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -311,7 +312,11 @@ public class ConfigurationObjectSettingTest {
 		assertThat( grouping.getScriptAction() ).isEqualTo( scriptAction );
 
 		// verify also interpreting the db-name, etc... they are used by SF/EMF to resolve Dialect
-		final DialectResolver dialectResolver = new DialectResolverInitiator().initiateService( settings, (ServiceRegistryImplementor) new StandardServiceRegistryBuilder().build() );
+		final DialectResolver dialectResolver = new DialectResolverInitiator()
+				.initiateService(
+						new HashMap<>(settings),
+						(ServiceRegistryImplementor) new StandardServiceRegistryBuilder().build()
+				);
 		final Dialect dialect = dialectResolver.resolveDialect( TestingDialectResolutionInfo.forDatabaseInfo( dbName ) );
 		assertThat( dialect ).isInstanceOf( H2Dialect.class );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/DiscriminatorMultiTenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/DiscriminatorMultiTenancyTest.java
@@ -57,7 +57,7 @@ public class DiscriminatorMultiTenancyTest extends BaseUnitTestCase {
 
 	@Before
 	public void setUp() {
-		Map settings = new HashMap();
+		Map<String,Object> settings = new HashMap<>();
 		settings.put(Environment.MULTI_TENANT_IDENTIFIER_RESOLVER, currentTenantResolver);
 		settings.put(Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName());
 		settings.put(Environment.GENERATE_STATISTICS, "true");

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/AbstractSchemaBasedMultiTenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/AbstractSchemaBasedMultiTenancyTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractSchemaBasedMultiTenancyTest<T extends MultiTenantC
 	public void setUp() {
 		T multiTenantConnectionProvider = buildMultiTenantConnectionProvider();
 
-		Map settings = new HashMap();
+		Map<String,Object> settings = new HashMap<>();
 		settings.put( Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName() );
 		settings.put( Environment.GENERATE_STATISTICS, "true" );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/QueryTimeOutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/QueryTimeOutTest.java
@@ -56,7 +56,7 @@ public class QueryTimeOutTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		CONNECTION_PROVIDER.setConnectionProvider( (ConnectionProvider) settings.get( AvailableSettings.CONNECTION_PROVIDER ) );
 		settings.put( AvailableSettings.CONNECTION_PROVIDER, CONNECTION_PROVIDER );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/resource/transaction/jta/JpaComplianceAlreadyStartedTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/resource/transaction/jta/JpaComplianceAlreadyStartedTransactionTest.java
@@ -28,7 +28,7 @@ public class JpaComplianceAlreadyStartedTransactionTest extends BaseNonConfigCor
 	private TransactionManager tm;
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		TestingJtaBootstrap.prepare( settings );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/resource/transaction/jta/NonJpaComplianceAlreadyStartedTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/resource/transaction/jta/NonJpaComplianceAlreadyStartedTransactionTest.java
@@ -31,7 +31,7 @@ public class NonJpaComplianceAlreadyStartedTransactionTest extends BaseNonConfig
 	private TransactionManager tm;
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		TestingJtaBootstrap.prepare( settings );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ConnectionsReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ConnectionsReleaseTest.java
@@ -22,6 +22,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.hbm2ddl.SchemaValidator;
 import org.hibernate.tool.schema.TargetType;
@@ -57,7 +58,7 @@ public class ConnectionsReleaseTest extends BaseUnitTestCase {
 	@Before
 	public void setUp() {
 		connectionProvider = new ConnectionProviderDecorator();
-		connectionProvider.configure( getConnectionProviderProperties() );
+		connectionProvider.configure( PropertiesHelper.map( getConnectionProviderProperties() ) );
 
 		ssr = new StandardServiceRegistryBuilder()
 				.addService( ConnectionProvider.class, connectionProvider )
@@ -75,13 +76,13 @@ public class ConnectionsReleaseTest extends BaseUnitTestCase {
 	}
 
 	@Test
-	public void testSchemaUpdateReleasesAllConnections() throws SQLException {
+	public void testSchemaUpdateReleasesAllConnections() {
 		new SchemaUpdate().execute( EnumSet.of( TargetType.DATABASE ), metadata );
 		assertThat( connectionProvider.getOpenConnection(), is( 0 ) );
 	}
 
 	@Test
-	public void testSchemaValidatorReleasesAllConnections() throws SQLException {
+	public void testSchemaValidatorReleasesAllConnections() {
 		new SchemaValidator().validate( metadata );
 		assertThat( connectionProvider.getOpenConnection(), is( 0 ) );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/ServiceRegistryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/ServiceRegistryTest.java
@@ -152,7 +152,7 @@ public class ServiceRegistryTest {
 		}
 
 		@Override
-		public void configure(Map configurationValues) {
+		public void configure(Map<String, Object> configurationValues) {
 			try {
 				Thread.sleep( TIME_TO_SLEEP );
 			}
@@ -194,7 +194,7 @@ public class ServiceRegistryTest {
 		}
 
 		@Override
-		public SlowInitializationService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		public SlowInitializationService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 			return new SlowInitializationService();
 		}
 	}
@@ -207,7 +207,7 @@ public class ServiceRegistryTest {
 		}
 
 		@Override
-		public FakeService initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		public FakeService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 			return null;
 		}
 	}
@@ -220,7 +220,7 @@ public class ServiceRegistryTest {
 		}
 
 		@Override
-		public void configure(Map configurationValues) {
+		public void configure(Map<String, Object> configurationValues) {
 
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/syncSpace/NativeQuerySyncSpaceCachingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/syncSpace/NativeQuerySyncSpaceCachingTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class NativeQuerySyncSpaceCachingTest extends BaseNonConfigCoreFunctionalTestCase {
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/subclassProxyInterface/SubclassProxyInterfaceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/subclassProxyInterface/SubclassProxyInterfaceTest.java
@@ -24,7 +24,7 @@ public class SubclassProxyInterfaceTest {
         final Configuration cfg = new Configuration()
 				.setProperty( Environment.DIALECT, H2Dialect.class.getName() )
 				.addClass( Person.class );
-		try (ServiceRegistry serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( cfg.getProperties() )) {
+		try (ServiceRegistry serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( cfg.getProperties() ) ) {
 			cfg.buildSessionFactory( serviceRegistry ).close();
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tm/InterceptorTransactionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tm/InterceptorTransactionTest.java
@@ -112,7 +112,7 @@ public class InterceptorTransactionTest extends BaseJpaOrNativeBootstrapFunction
 		return new Class<?>[] { SimpleEntity.class };
 	}
 
-	protected void configure(Map<Object, Object> properties) {
+	protected void configure(Map<String, Object> properties) {
 		super.configure( properties );
 		TestingJtaBootstrap.prepare( properties );
 		properties.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/DropSchemaDuringJtaTxnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/DropSchemaDuringJtaTxnTest.java
@@ -19,6 +19,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.testing.jta.TestingJtaBootstrap;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.hibernate.orm.test.resource.transaction.jta.JtaPlatformStandardTestingImpl;
@@ -29,7 +30,7 @@ import org.junit.Test;
  */
 public class DropSchemaDuringJtaTxnTest extends BaseUnitTestCase {
 	@Test
-	public void testDrop() throws Exception {
+	public void testDrop() {
 		final SessionFactory sessionFactory = buildSessionFactory();
 		sessionFactory.close();
 	}
@@ -47,8 +48,7 @@ public class DropSchemaDuringJtaTxnTest extends BaseUnitTestCase {
 	}
 
 	private SessionFactory buildSessionFactory() {
-		Map settings = new HashMap();
-		settings.putAll( Environment.getProperties() );
+		Map<String, Object> settings = new HashMap<>( PropertiesHelper.map( Environment.getProperties() ) );
 		TestingJtaBootstrap.prepare( settings );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplConnectionTest.java
@@ -27,6 +27,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.schema.internal.DefaultSchemaFilter;
 import org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl;
@@ -55,9 +56,7 @@ import org.junit.Test;
 
 import org.jboss.logging.Logger;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Vlad Mihalcea
@@ -86,7 +85,7 @@ public class IndividuallySchemaValidatorImplConnectionTest extends BaseUnitTestC
 	public void setUp() throws Exception {
 		connectionProvider =
 				new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( properties() );
+		connectionProvider.configure( PropertiesHelper.map( properties() ) );
 
 		connection = connectionProvider.getConnection();
 
@@ -149,7 +148,7 @@ public class IndividuallySchemaValidatorImplConnectionTest extends BaseUnitTestC
 
 		DriverManagerConnectionProviderImpl connectionProvider =
 				new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( properties() );
+		connectionProvider.configure( PropertiesHelper.map( properties() ) );
 
 		final GenerationTargetToDatabase schemaGenerator =  new GenerationTargetToDatabase(
 				new DdlTransactionIsolatorTestingImpl(
@@ -188,7 +187,7 @@ public class IndividuallySchemaValidatorImplConnectionTest extends BaseUnitTestC
 	protected Properties properties() {
 		Properties properties = new Properties( );
 		URL propertiesURL = Thread.currentThread().getContextClassLoader().getResource( "hibernate.properties" );
-		try(FileInputStream inputStream = new FileInputStream( propertiesURL.getFile() )) {
+		try(FileInputStream inputStream = new FileInputStream( propertiesURL.getFile() ) ) {
 			properties.load( inputStream );
 		}
 		catch (IOException e) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplTest.java
@@ -25,6 +25,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.schema.internal.DefaultSchemaFilter;
 import org.hibernate.tool.schema.internal.ExceptionHandlerLoggedImpl;
@@ -112,7 +113,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 	}
 
 	@Test
-	public void testMissingEntityContainsQualifiedEntityName() throws Exception {
+	public void testMissingEntityContainsQualifiedEntityName() {
 		final MetadataSources metadataSources = new MetadataSources( ssr );
 		metadataSources.addAnnotatedClass( MissingEntity.class );
 
@@ -129,7 +130,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 	}
 
 	@Test
-	public void testMissingEntityContainsUnqualifiedEntityName() throws Exception {
+	public void testMissingEntityContainsUnqualifiedEntityName() {
 		final MetadataSources metadataSources = new MetadataSources( ssr );
 		metadataSources.addAnnotatedClass( UnqualifiedMissingEntity.class );
 
@@ -146,7 +147,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 	}
 
 	@Test
-	public void testMissingColumn() throws Exception {
+	public void testMissingColumn() {
 		MetadataSources metadataSources = new MetadataSources( ssr );
 		metadataSources.addAnnotatedClass( NoNameColumn.class );
 
@@ -161,7 +162,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 
 		DriverManagerConnectionProviderImpl connectionProvider =
 				new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( properties() );
+		connectionProvider.configure( PropertiesHelper.map( properties() ) );
 
 		final GenerationTargetToDatabase schemaGenerator =  new GenerationTargetToDatabase(
 				new DdlTransactionIsolatorTestingImpl(
@@ -201,7 +202,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 	}
 
 	@Test
-	public void testMismatchColumnType() throws Exception {
+	public void testMismatchColumnType() {
 		MetadataSources metadataSources = new MetadataSources( ssr );
 		metadataSources.addAnnotatedClass( NameColumn.class );
 
@@ -216,7 +217,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 
 		DriverManagerConnectionProviderImpl connectionProvider =
 				new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( properties() );
+		connectionProvider.configure( PropertiesHelper.map( properties() ) );
 
 		final GenerationTargetToDatabase schemaGenerator =  new GenerationTargetToDatabase(
 				new DdlTransactionIsolatorTestingImpl(
@@ -275,7 +276,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 	protected Properties properties() {
 		Properties properties = new Properties( );
 		URL propertiesURL = Thread.currentThread().getContextClassLoader().getResource( "hibernate.properties" );
-		try(FileInputStream inputStream = new FileInputStream( propertiesURL.getFile() )) {
+		try ( FileInputStream inputStream = new FileInputStream( propertiesURL.getFile() ) ) {
 			properties.load( inputStream );
 		}
 		catch (IOException e) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/JtaPlatformLoggingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/JtaPlatformLoggingTest.java
@@ -40,7 +40,7 @@ public class JtaPlatformLoggingTest extends BaseNonConfigCoreFunctionalTestCase 
 	private Triggerable triggerable = logInspection.watchForLogMessages( "HHH000490" );
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		TestingJtaBootstrap.prepare( settings );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, "jta" );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerManyToOneFetchModeSelectWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerManyToOneFetchModeSelectWhereTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertSame;
 public class EagerManyToOneFetchModeSelectWhereTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.CREATE_EMPTY_COMPOSITES_ENABLED, true );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereDontUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereDontUseClassWhereTest.java
@@ -47,7 +47,7 @@ public class EagerToManyWhereDontUseClassWhereTest extends BaseNonConfigCoreFunc
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "false" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/EagerToManyWhereUseClassWhereTest.java
@@ -47,7 +47,7 @@ public class EagerToManyWhereUseClassWhereTest extends BaseNonConfigCoreFunction
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "true" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/LazyToManyWhereDontUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/LazyToManyWhereDontUseClassWhereTest.java
@@ -47,7 +47,7 @@ public class LazyToManyWhereDontUseClassWhereTest extends BaseNonConfigCoreFunct
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "false" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/LazyToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/annotations/LazyToManyWhereUseClassWhereTest.java
@@ -47,7 +47,7 @@ public class LazyToManyWhereUseClassWhereTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "true" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerManyToOneFetchModeSelectWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerManyToOneFetchModeSelectWhereTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertSame;
 public class EagerManyToOneFetchModeSelectWhereTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.CREATE_EMPTY_COMPOSITES_ENABLED, true );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereDontUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereDontUseClassWhereTest.java
@@ -41,7 +41,7 @@ public class EagerToManyWhereDontUseClassWhereTest extends BaseNonConfigCoreFunc
 	}
 	
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "false" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/EagerToManyWhereUseClassWhereTest.java
@@ -41,7 +41,7 @@ public class EagerToManyWhereUseClassWhereTest extends BaseNonConfigCoreFunction
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "true" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/LazyToManyWhereDontUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/LazyToManyWhereDontUseClassWhereTest.java
@@ -41,7 +41,7 @@ public class LazyToManyWhereDontUseClassWhereTest extends BaseNonConfigCoreFunct
 	}
 	
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "false" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/LazyToManyWhereUseClassWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/where/hbm/LazyToManyWhereUseClassWhereTest.java
@@ -41,7 +41,7 @@ public class LazyToManyWhereUseClassWhereTest extends BaseNonConfigCoreFunctiona
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_ENTITY_WHERE_CLAUSE_FOR_COLLECTIONS, "true" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/queryhint/QueryHintHANATest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/queryhint/QueryHintHANATest.java
@@ -44,7 +44,7 @@ public class QueryHintHANATest extends BaseNonConfigCoreFunctionalTestCase {
 	private SQLStatementInterceptor sqlStatementInterceptor;
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.USE_SQL_COMMENTS, "true" );
 		sqlStatementInterceptor = new SQLStatementInterceptor( settings );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/timestamp/LocalDateCustomSessionLevelTimeZoneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/timestamp/LocalDateCustomSessionLevelTimeZoneTest.java
@@ -36,9 +36,9 @@ public class LocalDateCustomSessionLevelTimeZoneTest extends BaseSessionFactoryF
 	private static final TimeZone TIME_ZONE = TimeZone.getTimeZone(
 			"Europe/Berlin" );
 
-	private ConnectionProviderDelegate connectionProvider = new ConnectionProviderDelegate() {
+	private final ConnectionProviderDelegate connectionProvider = new ConnectionProviderDelegate() {
 		@Override
-		public void configure(Map configurationValues) {
+		public void configure(Map<String, Object> configurationValues) {
 			String url = (String) configurationValues.get( AvailableSettings.URL );
 			if ( !url.contains( "?" ) ) {
 				url += "?";

--- a/hibernate-core/src/test/java/org/hibernate/test/tm/CMTTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/tm/CMTTest.java
@@ -43,7 +43,7 @@ public class CMTTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		TestingJtaBootstrap.prepare( settings );
 		//settings.put( AvailableSettings.TRANSACTION_STRATEGY, CMTTransactionFactory.class.getName() );
 		settings.put( AvailableSettings.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName() );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceImpl.java
@@ -62,7 +62,7 @@ public class EnversServiceImpl implements EnversService, Configurable, Stoppable
 	private EntitiesConfigurations entitiesConfigurations;
 
 	@Override
-	public void configure(Map configurationValues) {
+	public void configure(Map<String, Object> configurationValues) {
 		if ( configurationValues.containsKey( LEGACY_AUTO_REGISTER ) ) {
 			log.debugf(
 					"Encountered deprecated Envers setting [%s]; use [%s] or [%s] instead",

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceInitiator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversServiceInitiator.java
@@ -22,7 +22,7 @@ public class EnversServiceInitiator implements StandardServiceInitiator<EnversSe
 
 	@Override
 	public EnversService initiateService(
-			Map configurationValues,
+			Map<String, Object> configurationValues,
 			ServiceRegistryImplementor registry) {
 		return new EnversServiceImpl();
 	}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/UnspecifiedEnumTypeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/UnspecifiedEnumTypeTest.java
@@ -38,7 +38,7 @@ public class UnspecifiedEnumTypeTest extends BaseEnversFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( AvailableSettings.SHOW_SQL, "true" );

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/dynamic/AuditedDynamicComponentsAdvancedCasesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/dynamic/AuditedDynamicComponentsAdvancedCasesTest.java
@@ -54,7 +54,7 @@ public class AuditedDynamicComponentsAdvancedCasesTest extends BaseEnversFunctio
 	public static final String INTERNAL_LIST_OF_USER_TYPES = "internalListOfUserTypes";
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, "false" );
 	}

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/lazy/ManyToOneLazyDeleteTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/manytoone/lazy/ManyToOneLazyDeleteTest.java
@@ -78,7 +78,7 @@ public class ManyToOneLazyDeleteTest extends BaseEnversFunctionalTestCase {
     }
 
     @Override
-    protected void addSettings(Map settings) {
+    protected void addSettings(Map<String,Object> settings) {
         super.addSettings( settings );
 
         settings.put(EnversSettings.STORE_DATA_AT_DELETE, "true");

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractOneSessionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractOneSessionTest.java
@@ -14,10 +14,10 @@ import org.hibernate.MappingException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.AfterClassOnce;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/BaseEnversFunctionalTestCase.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/BaseEnversFunctionalTestCase.java
@@ -72,7 +72,7 @@ public abstract class BaseEnversFunctionalTestCase extends BaseNonConfigCoreFunc
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( EnversSettings.USE_REVISION_ENTITY_WITH_NATIVE_ID, "false" );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/basic/OutsideTransactionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/basic/OutsideTransactionTest.java
@@ -33,7 +33,7 @@ public class OutsideTransactionTest extends BaseEnversFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( EnversSettings.STORE_DATA_AT_DELETE, "true" );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/dynamic/AuditedDynamicComponentTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/dynamic/AuditedDynamicComponentTest.java
@@ -20,8 +20,6 @@ import org.hibernate.envers.internal.tools.StringTools;
 import org.hibernate.envers.query.AuditEntity;
 import org.hibernate.orm.test.envers.BaseEnversFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
-import org.hibernate.orm.test.envers.integration.components.dynamic.AuditedDynamicComponentEntity;
-import org.hibernate.orm.test.envers.integration.components.dynamic.SimpleEntity;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.ServiceRegistryBuilder;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest.java
@@ -18,7 +18,7 @@ import org.hibernate.testing.TestForIssue;
 @TestForIssue( jiraKey = "HHH-13817" )
 public class AssociationRevisionsOfEntitiesQueryStoreAtDeletionTest extends AssociationRevisionsOfEntitiesQueryTest {
     @Override
-    protected void addSettings(Map settings) {
+    protected void addSettings(Map<String,Object> settings) {
         super.addSettings( settings );
         settings.put( EnversSettings.STORE_DATA_AT_DELETE, true );
     }

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/EntityNamesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/EntityNamesTest.java
@@ -30,7 +30,7 @@ public class EntityNamesTest extends BaseEnversFunctionalTestCase {
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 
 		settings.put( EnversSettings.TRACK_ENTITIES_CHANGED_IN_REVISION, "true" );

--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
@@ -49,9 +49,8 @@ public class HikariCPConnectionProvider implements ConnectionProvider, Configura
 	// Configurable
 	// *************************************************************************
 
-	@SuppressWarnings("rawtypes")
 	@Override
-	public void configure(Map props) throws HibernateException {
+	public void configure(Map<String, Object> props) throws HibernateException {
 		try {
 			LOGGER.debug( "Configuring HikariCP" );
 
@@ -91,8 +90,7 @@ public class HikariCPConnectionProvider implements ConnectionProvider, Configura
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType )
 				|| HikariCPConnectionProvider.class.isAssignableFrom( unwrapType )
 				|| DataSource.class.isAssignableFrom( unwrapType );

--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariConfigurationUtil.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariConfigurationUtil.java
@@ -31,8 +31,7 @@ public class HikariConfigurationUtil {
 	 * @param props a map of Hibernate properties
 	 * @return a HikariConfig
 	 */
-	@SuppressWarnings("rawtypes")
-	public static HikariConfig loadConfiguration(Map props) {
+	public static HikariConfig loadConfiguration(Map<String,Object> props) {
 		Properties hikariProps = new Properties();
 		copyProperty( AvailableSettings.AUTOCOMMIT, props, "autoCommit", hikariProps );
 
@@ -43,11 +42,7 @@ public class HikariConfigurationUtil {
 
 		copyIsolationSetting( props, hikariProps );
 
-		for ( Object keyo : props.keySet() ) {
-			if ( !(keyo instanceof String) ) {
-				continue;
-			}
-			String key = (String) keyo;
+		for ( String key : props.keySet() ) {
 			if ( key.startsWith( CONFIG_PREFIX ) ) {
 				hikariProps.setProperty( key.substring( CONFIG_PREFIX.length() ), (String) props.get( key ) );
 			}
@@ -56,14 +51,13 @@ public class HikariConfigurationUtil {
 		return new HikariConfig( hikariProps );
 	}
 
-	@SuppressWarnings("rawtypes")
-	private static void copyProperty(String srcKey, Map src, String dstKey, Properties dst) {
+	private static void copyProperty(String srcKey, Map<String,Object> src, String dstKey, Properties dst) {
 		if ( src.containsKey( srcKey ) ) {
 			dst.setProperty( dstKey, (String) src.get( srcKey ) );
 		}
 	}
 
-	private static void copyIsolationSetting(Map props, Properties hikariProps) {
+	private static void copyIsolationSetting(Map<String,Object> props, Properties hikariProps) {
 		final Integer isolation = ConnectionProviderInitiator.extractIsolation( props );
 		if ( isolation != null ) {
 			hikariProps.put(

--- a/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/JCacheRegionFactory.java
+++ b/hibernate-jcache/src/main/java/org/hibernate/cache/jcache/internal/JCacheRegionFactory.java
@@ -183,7 +183,7 @@ public class JCacheRegionFactory extends RegionFactoryTemplate {
 	}
 
 	@Override
-	protected void prepareForUse(SessionFactoryOptions settings, Map configValues) {
+	protected void prepareForUse(SessionFactoryOptions settings, Map<String,Object> configValues) {
 		this.cacheManager = resolveCacheManager( settings, configValues );
 		if ( this.cacheManager == null ) {
 			throw new CacheException( "Could not locate/create CacheManager" );
@@ -193,7 +193,7 @@ public class JCacheRegionFactory extends RegionFactoryTemplate {
 		);
 	}
 
-	protected CacheManager resolveCacheManager(SessionFactoryOptions settings, Map properties) {
+	protected CacheManager resolveCacheManager(SessionFactoryOptions settings, Map<String,Object> properties) {
 		final Object explicitCacheManager = properties.get( ConfigSettings.CACHE_MANAGER );
 		if ( explicitCacheManager != null ) {
 			return useExplicitCacheManager( settings, explicitCacheManager );
@@ -216,7 +216,7 @@ public class JCacheRegionFactory extends RegionFactoryTemplate {
 		return cachingProvider.getDefaultClassLoader();
 	}
 
-	protected URI getUri(SessionFactoryOptions settings, Map properties) {
+	protected URI getUri(SessionFactoryOptions settings, Map<String,Object> properties) {
 		String cacheManagerUri = getProp( properties, ConfigSettings.CONFIG_URI );
 		if ( cacheManagerUri == null ) {
 			return null;
@@ -238,11 +238,11 @@ public class JCacheRegionFactory extends RegionFactoryTemplate {
 		}
 	}
 
-	private String getProp(Map properties, String prop) {
+	private String getProp(Map<String,Object> properties, String prop) {
 		return properties != null ? (String) properties.get( prop ) : null;
 	}
 
-	protected CachingProvider getCachingProvider(final Map properties){
+	protected CachingProvider getCachingProvider(final Map<String,Object> properties){
 		final CachingProvider cachingProvider;
 		final String provider = getProp( properties, ConfigSettings.PROVIDER );
 		if ( provider != null ) {

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheClasspathConfigUriTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheClasspathConfigUriTest.java
@@ -21,7 +21,7 @@ public class JCacheClasspathConfigUriTest
 		extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
 		settings.put( ConfigSettings.CONFIG_URI, "classpath://hibernate-config/ehcache/jcache-ehcache-config.xml" );
 	}

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigRelativePathTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigRelativePathTest.java
@@ -21,7 +21,7 @@ public class JCacheConfigRelativePathTest
 		extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
 		settings.put( ConfigSettings.CONFIG_URI, "/hibernate-config/ehcache/jcache-ehcache-config.xml" );
 	}

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigUrlTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigUrlTest.java
@@ -21,7 +21,7 @@ public class JCacheConfigUrlTest
 		extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
 		settings.put(
 				ConfigSettings.CONFIG_URI,

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheTransactionalCacheConcurrencyStrategyTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheTransactionalCacheConcurrencyStrategyTest.java
@@ -42,7 +42,7 @@ public class JCacheTransactionalCacheConcurrencyStrategyTest
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		settings.put( Environment.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
 
 		TestingJtaBootstrap.prepare( settings );

--- a/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerCacheStatisticsTest.java
+++ b/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerCacheStatisticsTest.java
@@ -64,7 +64,7 @@ public class MicrometerCacheStatisticsTest extends BaseNonConfigCoreFunctionalTe
 	}
 
 	@Override
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 		super.addSettings( settings );
 		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );
 		settings.put( AvailableSettings.USE_QUERY_CACHE, "true" );

--- a/hibernate-proxool/src/main/java/org/hibernate/proxool/internal/ProxoolConnectionProvider.java
+++ b/hibernate-proxool/src/main/java/org/hibernate/proxool/internal/ProxoolConnectionProvider.java
@@ -83,7 +83,7 @@ public class ProxoolConnectionProvider
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType ) ||
 				ProxoolConnectionProvider.class.isAssignableFrom( unwrapType );
 	}
@@ -111,7 +111,7 @@ public class ProxoolConnectionProvider
 	}
 
 	@Override
-	public void configure(Map props) {
+	public void configure(Map<String, Object> props) {
 		// Get the configurator files (if available)
 		final String jaxpFile = (String) props.get( Environment.PROXOOL_XML );
 		final String propFile = (String) props.get( Environment.PROXOOL_PROPERTIES );

--- a/hibernate-proxool/src/test/java/org/hibernate/test/proxool/ProxoolTransactionIsolationConfigTest.java
+++ b/hibernate-proxool/src/test/java/org/hibernate/test/proxool/ProxoolTransactionIsolationConfigTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.test.proxool;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -22,14 +24,14 @@ import org.junit.Before;
  * @author Steve Ebersole
  */
 public class ProxoolTransactionIsolationConfigTest extends BaseTransactionIsolationConfigTest {
-	private Properties properties;
+	private Map<String,Object> properties;
 	private StandardServiceRegistry ssr;
 
 	@Before
 	public void setUp() {
 		String poolName = "pool-one";
 
-		properties = new Properties();
+		properties = new HashMap<>();
 		properties.put( AvailableSettings.PROXOOL_POOL_ALIAS, poolName );
 		properties.put( AvailableSettings.PROXOOL_PROPERTIES, poolName + ".properties" );
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/ServiceRegistryBuilder.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/ServiceRegistryBuilder.java
@@ -7,10 +7,12 @@
 package org.hibernate.testing;
 
 import java.util.Map;
+import java.util.Properties;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.ServiceRegistry;
 
 /**
@@ -21,10 +23,16 @@ public final class ServiceRegistryBuilder {
 	}
 
 	public static StandardServiceRegistryImpl buildServiceRegistry() {
-		return buildServiceRegistry( Environment.getProperties() );
+		return buildServiceRegistry( PropertiesHelper.map( Environment.getProperties() ) );
 	}
 
-	public static StandardServiceRegistryImpl buildServiceRegistry(Map serviceRegistryConfig) {
+	public static StandardServiceRegistryImpl buildServiceRegistry(Map<String,Object> serviceRegistryConfig) {
+		return (StandardServiceRegistryImpl) new StandardServiceRegistryBuilder()
+				.applySettings( serviceRegistryConfig )
+				.build();
+	}
+
+	public static StandardServiceRegistryImpl buildServiceRegistry(Properties serviceRegistryConfig) {
 		return (StandardServiceRegistryImpl) new StandardServiceRegistryBuilder()
 				.applySettings( serviceRegistryConfig )
 				.build();

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/DialectFactoryTestingImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/DialectFactoryTestingImpl.java
@@ -29,7 +29,7 @@ public class DialectFactoryTestingImpl implements DialectFactory {
 	}
 
 	@Override
-	public Dialect buildDialect(Map configValues, DialectResolutionInfoSource resolutionInfoSource) {
+	public Dialect buildDialect(Map<String,Object> configValues, DialectResolutionInfoSource resolutionInfoSource) {
 		return dialect;
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/ServiceRegistryTestingImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/ServiceRegistryTestingImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.StandardServiceInitiators;
 import org.hibernate.service.internal.ProvidedService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -41,11 +42,11 @@ public class ServiceRegistryTestingImpl
 						dialectFactoryService(),
 						connectionProviderService()
 				),
-				Environment.getProperties()
+				PropertiesHelper.map( Environment.getProperties() )
 		);
 	}
 
-	public static ServiceRegistryTestingImpl forUnitTesting(Map settings) {
+	public static ServiceRegistryTestingImpl forUnitTesting(Map<String,Object> settings) {
 		return new ServiceRegistryTestingImpl(
 				true,
 				new BootstrapServiceRegistryBuilder().build(),
@@ -58,12 +59,12 @@ public class ServiceRegistryTestingImpl
 		);
 	}
 
-	private static ProvidedService dialectFactoryService() {
-		return new ProvidedService<DialectFactory>( DialectFactory.class, new DialectFactoryTestingImpl() );
+	private static ProvidedService<DialectFactory> dialectFactoryService() {
+		return new ProvidedService<>( DialectFactory.class, new DialectFactoryTestingImpl() );
 	}
 
-	private static ProvidedService connectionProviderService() {
-		return new ProvidedService<ConnectionProvider>(
+	private static ProvidedService<ConnectionProvider> connectionProviderService() {
+		return new ProvidedService<>(
 				ConnectionProvider.class,
 				ConnectionProviderBuilder.buildConnectionProvider( true )
 		);
@@ -72,9 +73,9 @@ public class ServiceRegistryTestingImpl
 	public ServiceRegistryTestingImpl(
 			boolean autoCloseRegistry,
 			BootstrapServiceRegistry bootstrapServiceRegistry,
-			List<StandardServiceInitiator> serviceInitiators,
-			List<ProvidedService> providedServices,
-			Map<?, ?> configurationValues) {
+			List<StandardServiceInitiator<?>> serviceInitiators,
+			List<ProvidedService<?>> providedServices,
+			Map<String,Object> configurationValues) {
 		super( autoCloseRegistry, bootstrapServiceRegistry, serviceInitiators, providedServices, configurationValues );
 	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/CachingRegionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/CachingRegionFactory.java
@@ -50,7 +50,7 @@ public class CachingRegionFactory extends RegionFactoryTemplate {
 	}
 
 	@Override
-	protected void prepareForUse(SessionFactoryOptions settings, Map configValues) {
+	protected void prepareForUse(SessionFactoryOptions settings, Map<String,Object> configValues) {
 	}
 
 	@Override

--- a/hibernate-testing/src/main/java/org/hibernate/testing/common/connections/BaseTransactionIsolationConfigTest.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/common/connections/BaseTransactionIsolationConfigTest.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.spi.Configurable;
 import org.hibernate.service.spi.Startable;
 import org.hibernate.service.spi.Stoppable;
@@ -39,9 +40,9 @@ public abstract class BaseTransactionIsolationConfigTest extends BaseUnitTestCas
 		ConnectionProvider provider = getConnectionProviderUnderTest();
 
 		try {
-			( (Configurable) provider ).configure( properties );
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
 
-			if ( Startable.class.isInstance( provider ) ) {
+			if ( provider instanceof Startable ) {
 				( (Startable) provider ).start();
 			}
 
@@ -63,9 +64,9 @@ public abstract class BaseTransactionIsolationConfigTest extends BaseUnitTestCas
 		ConnectionProvider provider = getConnectionProviderUnderTest();
 
 		try {
-			( (Configurable) provider ).configure( properties );
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
 
-			if ( Startable.class.isInstance( provider ) ) {
+			if ( provider instanceof Startable ) {
 				( (Startable) provider ).start();
 			}
 
@@ -87,9 +88,9 @@ public abstract class BaseTransactionIsolationConfigTest extends BaseUnitTestCas
 		ConnectionProvider provider = getConnectionProviderUnderTest();
 
 		try {
-			( (Configurable) provider ).configure( properties );
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
 
-			if ( Startable.class.isInstance( provider ) ) {
+			if ( provider instanceof Startable ) {
 				( (Startable) provider ).start();
 			}
 
@@ -111,9 +112,9 @@ public abstract class BaseTransactionIsolationConfigTest extends BaseUnitTestCas
 		ConnectionProvider provider = getConnectionProviderUnderTest();
 
 		try {
-			( (Configurable) provider ).configure( properties );
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
 
-			if ( Startable.class.isInstance( provider ) ) {
+			if ( provider instanceof Startable ) {
 				( (Startable) provider ).start();
 			}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
@@ -19,6 +19,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.internal.util.ReflectHelper;
 
 import org.hibernate.testing.DialectCheck;
@@ -76,7 +77,7 @@ public class ConnectionProviderBuilder implements DialectCheck {
 
 	public static DatasourceConnectionProviderImpl buildDataSourceConnectionProvider(String dbName) {
 		try {
-			Class dataSourceClass = ReflectHelper.classForName( DATA_SOURCE, ConnectionProviderBuilder.class );
+			Class<?> dataSourceClass = ReflectHelper.classForName( DATA_SOURCE, ConnectionProviderBuilder.class );
 			DataSource actualDataSource = (DataSource) dataSourceClass.newInstance();
 			ReflectHelper.findSetterMethod( dataSourceClass, "URL", String.class ).invoke(
 					actualDataSource,
@@ -127,7 +128,7 @@ public class ConnectionProviderBuilder implements DialectCheck {
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			if ("getConnection".equals(method.getName())) {
+			if ( "getConnection".equals( method.getName() ) ) {
 				if(actualConnection == null) {
 					actualConnection = (Connection) method.invoke( target, args);
 					connectionProxy = (Connection) Proxy.newProxyInstance(
@@ -177,7 +178,7 @@ public class ConnectionProviderBuilder implements DialectCheck {
 				return allowAggressiveRelease;
 			}
 		};
-		connectionProvider.configure( props );
+		connectionProvider.configure( PropertiesHelper.map( props ) );
 		return connectionProvider;
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/ConnectionProviderDelegate.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/ConnectionProviderDelegate.java
@@ -64,10 +64,9 @@ public class ConnectionProviderDelegate implements
 	}
 
 	@Override
-	public void configure(Map configurationValues) {
+	public void configure(Map<String, Object> configurationValues) {
 		if ( !configured ) {
 			if ( connectionProvider == null ) {
-				@SuppressWarnings("unchecked")
 				Map<String, Object> settings = new HashMap<>( configurationValues );
 				settings.remove( AvailableSettings.CONNECTION_PROVIDER );
 				connectionProvider = ConnectionProviderInitiator.INSTANCE.initiateService(
@@ -105,7 +104,7 @@ public class ConnectionProviderDelegate implements
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return connectionProvider.isUnwrappableAs( unwrapType );
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/DataSourceStub.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/DataSourceStub.java
@@ -14,6 +14,7 @@ import javax.sql.DataSource;
 
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.testing.env.ConnectionProviderBuilder;
 
 /**
@@ -27,7 +28,7 @@ public class DataSourceStub implements DataSource {
 	public DataSourceStub(String id) {
 		this.id = id;
 		connectionProvider = new DriverManagerConnectionProviderImpl();
-		connectionProvider.configure( ConnectionProviderBuilder.getConnectionProviderProperties() );
+		connectionProvider.configure( PropertiesHelper.map( ConnectionProviderBuilder.getConnectionProviderProperties() ) );
 
 		printWriter = null;
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInterceptor.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInterceptor.java
@@ -13,6 +13,7 @@ import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +35,7 @@ public class SQLStatementInterceptor {
 		} );
 	}
 
-	public SQLStatementInterceptor(Map settings) {
+	public SQLStatementInterceptor(Map<String,Object> settings) {
 		settings.put( AvailableSettings.STATEMENT_INSPECTOR, (StatementInspector) sql -> {
 			sqlQueries.add( sql );
 			return sql;
@@ -52,7 +53,7 @@ public class SQLStatementInterceptor {
 	}
 
 	public SQLStatementInterceptor(Configuration configuration) {
-		this( configuration.getProperties() );
+		this( PropertiesHelper.map( configuration.getProperties() ) );
 	}
 
 	public LinkedList<String> getSqlQueries() {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProviderImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProviderImpl.java
@@ -34,7 +34,7 @@ public class SharedDriverManagerConnectionProviderImpl extends DriverManagerConn
 	private Boolean supportsIsValid;
 
 	@Override
-	public void configure(Map configurationValues) {
+	public void configure(Map<String, Object> configurationValues) {
 		final Config c = new Config( configurationValues );
 		if ( !c.isCompatible( config ) ) {
 			if ( config != null ) {
@@ -86,7 +86,7 @@ public class SharedDriverManagerConnectionProviderImpl extends DriverManagerConn
 		private final Properties connectionProps;
 		private final Integer isolation;
 
-		public Config(Map configurationValues) {
+		public Config(Map<String,Object> configurationValues) {
 			this.autoCommit = ConfigurationHelper.getBoolean( AvailableSettings.AUTOCOMMIT, configurationValues, false );
 			this.minSize = ConfigurationHelper.getInt( MIN_SIZE, configurationValues, 2 );
 			this.maxSize = ConfigurationHelper.getInt( AvailableSettings.POOL_SIZE, configurationValues, 20 );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jta/TestingJtaBootstrap.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jta/TestingJtaBootstrap.java
@@ -17,8 +17,7 @@ import org.hibernate.cfg.AvailableSettings;
 public final class TestingJtaBootstrap {
 	public static final TestingJtaBootstrap INSTANCE = new TestingJtaBootstrap();
 
-	@SuppressWarnings("unchecked")
-	public static void prepare(Map configValues) {
+	public static void prepare(Map<String,Object> configValues) {
 		configValues.put( AvailableSettings.JTA_PLATFORM, TestingJtaPlatformImpl.INSTANCE );
 		configValues.put( AvailableSettings.CONNECTION_PROVIDER, JtaAwareConnectionProviderImpl.class.getName() );
 		configValues.put( "javax.persistence.transactionType", "JTA" );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseCoreFunctionalTestCase.java
@@ -36,6 +36,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.build.AllowSysOut;
+import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseNonConfigCoreFunctionalTestCase.java
@@ -173,7 +173,7 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 		final BootstrapServiceRegistry bsr = bsrb.build();
 		afterBootstrapServiceRegistryBuilt( bsr );
 
-		final Map settings = new HashMap();
+		final Map<String,Object> settings = new HashMap<>();
 		settings.put( GlobalTemporaryTableMutationStrategy.DROP_ID_TABLES, "true" );
 		settings.put( LocalTemporaryTableMutationStrategy.DROP_ID_TABLES, "true" );
 		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
@@ -191,7 +191,7 @@ public class BaseNonConfigCoreFunctionalTestCase extends BaseUnitTestCase {
 		return ssrb;
 	}
 
-	protected void addSettings(Map settings) {
+	protected void addSettings(Map<String,Object> settings) {
 	}
 
 	/**

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
@@ -239,8 +239,7 @@ public class EntityManagerFactoryExtension
 			return;
 		}
 
-		final HashMap settings = new HashMap<>( baseProperties );
-		//noinspection unchecked
+		final HashMap<String,Object> settings = new HashMap<>( baseProperties );
 		settings.put( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP );
 
 		final StandardServiceRegistry serviceRegistry = model.getMetadataBuildingOptions().getServiceRegistry();

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ExtraAssertions.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ExtraAssertions.java
@@ -65,13 +65,13 @@ public final class ExtraAssertions {
 		return jdbcTypeCodeMap;
 	}
 
-	private static Map generateJdbcTypeCache() {
+	private static Map<Integer,String> generateJdbcTypeCache() {
 		final Field[] fields = Types.class.getFields();
-		Map cache = new HashMap( (int) ( fields.length * .75 ) + 1 );
+		Map<Integer,String> cache = new HashMap<>( (int) ( fields.length * .75 ) + 1 );
 		for ( Field field : fields ) {
 			if ( Modifier.isStatic( field.getModifiers() ) ) {
 				try {
-					cache.put( field.get( null ), field.getName() );
+					cache.put( (Integer) field.get( null ), field.getName() );
 				}
 				catch (Throwable ignore) {
 				}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
@@ -210,7 +210,7 @@ public class ServiceRegistryExtension
 			}
 
 			for ( ServiceRegistry.Service service : serviceRegistryAnn.services() ) {
-				ssrb.addService( service.role(), service.impl().newInstance() );
+				ssrb.addService( (Class) service.role(), service.impl().newInstance() );
 			}
 		}
 		catch (Exception e) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -72,7 +72,7 @@ public class SessionFactoryExtension
 			producer = (SessionFactoryProducer) testInstance;
 		}
 		else {
-			if ( !context.getElement().isPresent() ) {
+			if ( context.getElement().isEmpty() ) {
 				throw new RuntimeException( "Unable to determine how to handle given ExtensionContext : " + context.getDisplayName() );
 			}
 
@@ -154,8 +154,7 @@ public class SessionFactoryExtension
 			return;
 		}
 
-		final HashMap settings = new HashMap<>( baseProperties );
-		//noinspection unchecked
+		final HashMap<String,Object> settings = new HashMap<>( baseProperties );
 		settings.put( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP );
 		if ( createSecondarySchemas ) {
 			if ( !( model.getDatabase().getDialect().canCreateSchema() ) ) {
@@ -373,7 +372,7 @@ public class SessionFactoryExtension
 		public void inStatelessSession(Consumer<StatelessSession> action) {
 			log.trace( "#inStatelessSession(Consumer)" );
 
-			try (final StatelessSession statelessSession = getSessionFactory().openStatelessSession();) {
+			try ( final StatelessSession statelessSession = getSessionFactory().openStatelessSession() ) {
 				log.trace( "StatelessSession opened, calling action" );
 				action.accept( statelessSession );
 			}
@@ -386,7 +385,7 @@ public class SessionFactoryExtension
 		public void inStatelessTransaction(Consumer<StatelessSession> action) {
 			log.trace( "#inStatelessTransaction(Consumer)" );
 
-			try (final StatelessSession statelessSession = getSessionFactory().openStatelessSession();) {
+			try ( final StatelessSession statelessSession = getSessionFactory().openStatelessSession() ) {
 				log.trace( "StatelessSession opened, calling action" );
 				inStatelessTransaction( statelessSession, action );
 			}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/transaction/TransactionUtil.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/transaction/TransactionUtil.java
@@ -643,7 +643,7 @@ public class TransactionUtil {
 	 * @param consumer {@link Statement} callback to execute statements in auto-commit mode
 	 * @param settings Settings to build a new {@link ServiceRegistry}
 	 */
-	public static void doInAutoCommit(Consumer<Statement> consumer, Map settings) {
+	public static void doInAutoCommit(Consumer<Statement> consumer, Map<String,Object> settings) {
 		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
 		if ( settings != null ) {
 			ssrb.applySettings( settings );
@@ -688,7 +688,7 @@ public class TransactionUtil {
 	 * @param settings Settings to build a new {@link ServiceRegistry}
 	 * @param statements statements to be executed in auto-commit mode
 	 */
-	public static void doInAutoCommit(Map settings, String... statements) {
+	public static void doInAutoCommit(Map<String,Object> settings, String... statements) {
 		doInAutoCommit( s -> {
 			for ( String statement : statements ) {
 				try {

--- a/hibernate-vibur/src/main/java/org/hibernate/vibur/internal/ViburDBCPConnectionProvider.java
+++ b/hibernate-vibur/src/main/java/org/hibernate/vibur/internal/ViburDBCPConnectionProvider.java
@@ -51,8 +51,7 @@ public class ViburDBCPConnectionProvider implements ConnectionProvider, Configur
 	private ViburDBCPDataSource dataSource = null;
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public void configure(Map configurationValues) {
+	public void configure(Map<String, Object> configurationValues) {
 		dataSource = new ViburDBCPDataSource( transform( configurationValues ) );
 		dataSource.start();
 	}
@@ -81,7 +80,7 @@ public class ViburDBCPConnectionProvider implements ConnectionProvider, Configur
 	}
 
 	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
+	public boolean isUnwrappableAs(Class<?> unwrapType) {
 		return ConnectionProvider.class.equals( unwrapType ) ||
 				ViburDBCPConnectionProvider.class.isAssignableFrom( unwrapType );
 	}
@@ -97,41 +96,41 @@ public class ViburDBCPConnectionProvider implements ConnectionProvider, Configur
 		}
 	}
 
-	private static Properties transform(Map<String, String> configurationValues) {
+	private static Properties transform(Map<String, Object> configurationValues) {
 		Properties result = new Properties();
 
-		String driverClassName = configurationValues.get( DRIVER );
+		String driverClassName = (String) configurationValues.get( DRIVER );
 		if ( driverClassName != null ) {
 			result.setProperty( "driverClassName", driverClassName );
 		}
-		String jdbcUrl = configurationValues.get( URL );
+		String jdbcUrl = (String) configurationValues.get( URL );
 		if ( jdbcUrl != null ) {
 			result.setProperty( "jdbcUrl", jdbcUrl );
 		}
 
-		String username = configurationValues.get( USER );
+		String username = (String) configurationValues.get( USER );
 		if ( username != null ) {
 			result.setProperty( "username", username );
 		}
-		String password = configurationValues.get( PASS );
+		String password = (String) configurationValues.get( PASS );
 		if ( password != null ) {
 			result.setProperty( "password", password );
 		}
 
-		String defaultTransactionIsolationValue = configurationValues.get( ISOLATION );
+		String defaultTransactionIsolationValue = (String) configurationValues.get( ISOLATION );
 		if ( defaultTransactionIsolationValue != null ) {
 			result.setProperty( "defaultTransactionIsolationValue", defaultTransactionIsolationValue );
 		}
-		String defaultAutoCommit = configurationValues.get( AUTOCOMMIT );
+		String defaultAutoCommit = (String) configurationValues.get( AUTOCOMMIT );
 		if ( defaultAutoCommit != null ) {
 			result.setProperty( "defaultAutoCommit", defaultAutoCommit );
 		}
 
-		for ( Map.Entry<String, String> entry : configurationValues.entrySet() ) {
+		for ( Map.Entry<String, Object> entry : configurationValues.entrySet() ) {
 			String key = entry.getKey();
 			if ( key.startsWith( VIBUR_PREFIX ) ) {
 				key = key.substring( VIBUR_PREFIX.length() );
-				result.setProperty( key, entry.getValue() );
+				result.setProperty( key, (String) entry.getValue() );
 			}
 		}
 

--- a/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/ManagedProviderConnectionHelper.java
+++ b/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/ManagedProviderConnectionHelper.java
@@ -46,7 +46,8 @@ class ManagedProviderConnectionHelper implements ConnectionHelper {
 
 	private static StandardServiceRegistryImpl createServiceRegistry(Properties properties) {
 		ConfigurationHelper.resolvePlaceHolders( properties );
-		return (StandardServiceRegistryImpl) new StandardServiceRegistryBuilder().applySettings( properties ).build();
+		return (StandardServiceRegistryImpl)
+				new StandardServiceRegistryBuilder().applySettings( properties ).build();
 	}
 
 	public Connection getConnection() throws SQLException {

--- a/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdate.java
+++ b/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/SchemaUpdate.java
@@ -64,7 +64,6 @@ public class SchemaUpdate {
 		execute( targetTypes, metadata, ( (MetadataImplementor) metadata ).getMetadataBuildingOptions().getServiceRegistry() );
 	}
 
-	@SuppressWarnings("unchecked")
 	public void execute(EnumSet<TargetType> targetTypes, Metadata metadata, ServiceRegistry serviceRegistry) {
 		if ( targetTypes.isEmpty() ) {
 			LOG.debug( "Skipping SchemaExport as no targets were specified" );
@@ -74,7 +73,7 @@ public class SchemaUpdate {
 		exceptions.clear();
 		LOG.runningHbm2ddlSchemaUpdate();
 
-		Map config = new HashMap( serviceRegistry.getService( ConfigurationService.class ).getSettings() );
+		Map<String,Object> config = new HashMap<>( serviceRegistry.getService( ConfigurationService.class ).getSettings() );
 		config.put( AvailableSettings.HBM2DDL_DELIMITER, delimiter );
 		config.put( AvailableSettings.FORMAT_SQL, format );
 
@@ -106,7 +105,7 @@ public class SchemaUpdate {
 	 *
 	 * @return A List containing the Exceptions occurred during the export
 	 */
-	public List getExceptions() {
+	public List<Exception> getExceptions() {
 		return exceptions;
 	}
 
@@ -189,8 +188,7 @@ public class SchemaUpdate {
 		return ssrBuilder.build();
 	}
 
-	private static MetadataImplementor buildMetadata(CommandLineArgs parsedArgs, ServiceRegistry serviceRegistry)
-			throws Exception {
+	private static MetadataImplementor buildMetadata(CommandLineArgs parsedArgs, ServiceRegistry serviceRegistry) {
 		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
 
 		for ( String filename : parsedArgs.hbmXmlFiles ) {


### PR DESCRIPTION
Change the raw `Map` representation of config properties to `Map<String,Object>`.