### PR TITLE
HHH-15050 Fix NullPointerException in StatefulPersistenceContext.extractNaturalIdValues()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -2160,6 +2160,9 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		@Override
 		public Object[] extractNaturalIdValues(Object[] state, EntityPersister persister) {
 			final int[] naturalIdPropertyIndexes = persister.getNaturalIdentifierProperties();
+			if ( state == null || naturalIdPropertyIndexes == null ) {
+				return new Object[0];
+			}
 			if ( state.length == naturalIdPropertyIndexes.length ) {
 				return state;
 			}
@@ -2181,6 +2184,9 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			}
 
 			final int[] naturalIdentifierProperties = persister.getNaturalIdentifierProperties();
+			if ( naturalIdentifierProperties == null ) {
+				return new Object[0];
+			}
 			final Object[] naturalIdValues = new Object[naturalIdentifierProperties.length];
 
 			for ( int i = 0; i < naturalIdentifierProperties.length; i++ ) {


### PR DESCRIPTION
StatefulPersistenceContext.extractNaturalIdValues(). See example below.

https://hibernate.atlassian.net/browse/HHH-15050
```
Caused by: java.lang.NullPointerException
	at org.hibernate.engine.internal.StatefulPersistenceContext$1.extractNaturalIdValues(StatefulPersistenceContext.java:2163)
	at org.hibernate.persister.entity.AbstractEntityPersister.handleNaturalIdReattachment(AbstractEntityPersister.java:4956)
	at org.hibernate.persister.entity.AbstractEntityPersister.afterReassociate(AbstractEntityPersister.java:4930)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.performUpdate(DefaultSaveOrUpdateEventListener.java:322)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.entityIsDetached(DefaultSaveOrUpdateEventListener.java:230)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.performSaveOrUpdate(DefaultSaveOrUpdateEventListener.java:95)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.onSaveOrUpdate(DefaultSaveOrUpdateEventListener.java:75)
	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
	at org.hibernate.internal.SessionImpl.fireSaveOrUpdate(SessionImpl.java:670)
	at org.hibernate.internal.SessionImpl.saveOrUpdate(SessionImpl.java:663)
	at org.hibernate.engine.spi.CascadingActions$5.cascade(CascadingActions.java:219)
	at org.hibernate.engine.internal.Cascade.cascadeToOne(Cascade.java:510)
	at org.hibernate.engine.internal.Cascade.cascadeAssociation(Cascade.java:434)
	at org.hibernate.engine.internal.Cascade.cascadeProperty(Cascade.java:220)
	at org.hibernate.engine.internal.Cascade.cascade(Cascade.java:153)
	at org.hibernate.engine.internal.Cascade.cascade(Cascade.java:65)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.cascadeOnUpdate(DefaultSaveOrUpdateEventListener.java:361)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.performUpdate(DefaultSaveOrUpdateEventListener.java:334)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.entityIsDetached(DefaultSaveOrUpdateEventListener.java:230)
	at org.hibernate.event.internal.DefaultUpdateEventListener.performSaveOrUpdate(DefaultUpdateEventListener.java:38)
	at org.hibernate.event.internal.DefaultSaveOrUpdateEventListener.onSaveOrUpdate(DefaultSaveOrUpdateEventListener.java:75)
	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
	at org.hibernate.internal.SessionImpl.fireUpdate(SessionImpl.java:712)
	at org.hibernate.internal.SessionImpl.update(SessionImpl.java:705)
	at org.hibernate.internal.SessionImpl.update(SessionImpl.java:700)
    ...<snip>...
```