### PR TITLE
get rid of the iterators in the mapping package

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -1872,16 +1872,14 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 			final MetadataBuildingContext buildingContext) throws MappingException {
 		table.createForeignKeys();
 
-		Iterator itr = table.getForeignKeyIterator();
-		while ( itr.hasNext() ) {
-			final ForeignKey fk = (ForeignKey) itr.next();
-			if ( !done.contains( fk ) ) {
-				done.add( fk );
-				final String referencedEntityName = fk.getReferencedEntityName();
+		for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+			if ( !done.contains( foreignKey ) ) {
+				done.add( foreignKey );
+				final String referencedEntityName = foreignKey.getReferencedEntityName();
 				if ( referencedEntityName == null ) {
 					throw new MappingException(
 							"An association from the table " +
-									fk.getTable().getName() +
+									foreignKey.getTable().getName() +
 									" does not specify the referenced entity"
 					);
 				}
@@ -1891,7 +1889,7 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 				if ( referencedClass == null ) {
 					throw new MappingException(
 							"An association from the table " +
-									fk.getTable().getName() +
+									foreignKey.getTable().getName() +
 									" refers to an unmapped class: " +
 									referencedEntityName
 					);
@@ -1900,12 +1898,12 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 					secondPassCompileForeignKeys( referencedClass.getSuperclass().getTable(), done, buildingContext );
 				}
 
-				fk.setReferencedTable( referencedClass.getTable() );
+				foreignKey.setReferencedTable( referencedClass.getTable() );
 
 				Identifier nameIdentifier;
 
 				ImplicitForeignKeyNameSource foreignKeyNameSource = new ImplicitForeignKeyNameSource() {
-					final List<Identifier> columnNames = extractColumnNames( fk.getColumns() );
+					final List<Identifier> columnNames = extractColumnNames( foreignKey.getColumns() );
 					List<Identifier> referencedColumnNames = null;
 
 					@Override
@@ -1920,20 +1918,20 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 
 					@Override
 					public Identifier getReferencedTableName() {
-						return fk.getReferencedTable().getNameIdentifier();
+						return foreignKey.getReferencedTable().getNameIdentifier();
 					}
 
 					@Override
 					public List<Identifier> getReferencedColumnNames() {
 						if ( referencedColumnNames == null ) {
-							referencedColumnNames = extractColumnNames( fk.getReferencedColumns() );
+							referencedColumnNames = extractColumnNames( foreignKey.getReferencedColumns() );
 						}
 						return referencedColumnNames;
 					}
 
 					@Override
 					public Identifier getUserProvidedIdentifier() {
-						return fk.getName() != null ? Identifier.toIdentifier( fk.getName() ) : null;
+						return foreignKey.getName() != null ? Identifier.toIdentifier( foreignKey.getName() ) : null;
 					}
 
 					@Override
@@ -1944,9 +1942,9 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 
 				nameIdentifier = getMetadataBuildingOptions().getImplicitNamingStrategy().determineForeignKeyName(foreignKeyNameSource);
 
-				fk.setName( nameIdentifier.render( getDatabase().getJdbcEnvironment().getDialect() ) );
+				foreignKey.setName( nameIdentifier.render( getDatabase().getJdbcEnvironment().getDialect() ) );
 
-				fk.alignColumns();
+				foreignKey.alignColumns();
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -1814,19 +1814,19 @@ public class ModelBinder {
 			secondaryTableJoin.createForeignKey();
 		}
 	}
-
-	private List<ColumnSource> sortColumns(List<ColumnSource> primaryKeyColumnSources, KeyValue identifier) {
-		if ( primaryKeyColumnSources.size() == 1 || !identifier.getType().isComponentType() ) {
-			return primaryKeyColumnSources;
-		}
-		final ComponentType componentType = (ComponentType) identifier.getType();
-		final List<ColumnSource> sortedColumnSource = new ArrayList<>( primaryKeyColumnSources.size() );
-		final int[] originalPropertyOrder = componentType.getOriginalPropertyOrder();
-		for ( int originalIndex : originalPropertyOrder ) {
-			sortedColumnSource.add( primaryKeyColumnSources.get( originalIndex ) );
-		}
-		return sortedColumnSource;
-	}
+//
+//	private List<ColumnSource> sortColumns(List<ColumnSource> primaryKeyColumnSources, KeyValue identifier) {
+//		if ( primaryKeyColumnSources.size() == 1 || !identifier.getType().isComponentType() ) {
+//			return primaryKeyColumnSources;
+//		}
+//		final ComponentType componentType = (ComponentType) identifier.getType();
+//		final List<ColumnSource> sortedColumnSource = new ArrayList<>( primaryKeyColumnSources.size() );
+//		final int[] originalPropertyOrder = componentType.getOriginalPropertyOrder();
+//		for ( int originalIndex : originalPropertyOrder ) {
+//			sortedColumnSource.add( primaryKeyColumnSources.get( originalIndex ) );
+//		}
+//		return sortedColumnSource;
+//	}
 
 	private Property createEmbeddedAttribute(
 			MappingDocument sourceDocument,
@@ -3168,7 +3168,7 @@ public class ModelBinder {
 		}
 
 		@Override
-		public void doSecondPass(Map persistentClasses) throws org.hibernate.MappingException {
+		public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws org.hibernate.MappingException {
 			bindCollectionTable();
 
 			bindCollectionKey();
@@ -4108,7 +4108,7 @@ public class ModelBinder {
 		}
 
 		@Override
-		public void doSecondPass(Map persistentClasses) throws org.hibernate.MappingException {
+		public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws org.hibernate.MappingException {
 			if ( allColumnsNamed ) {
 				relationalObjectBinder.bindColumnsAndFormulas(
 						mappingDocument,
@@ -4202,7 +4202,7 @@ public class ModelBinder {
 		}
 
 		@Override
-		public void doSecondPass(Map persistentClasses) throws org.hibernate.MappingException {
+		public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws org.hibernate.MappingException {
 			if ( referencedEntityAttributeName == null ) {
 				manyToOneBinding.createForeignKey();
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/NaturalIdDataCachingConfigImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/cfg/internal/NaturalIdDataCachingConfigImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.cache.cfg.internal;
 
-import java.util.Iterator;
-
 import org.hibernate.cache.cfg.spi.NaturalIdDataCachingConfig;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.mapping.Property;
@@ -36,10 +34,8 @@ public class NaturalIdDataCachingConfigImpl
 	}
 
 	private boolean hasAnyMutableNaturalIdProps() {
-		final Iterator itr = rootEntityDescriptor.getDeclaredPropertyIterator();
-		while ( itr.hasNext() ) {
-			final Property prop = (Property) itr.next();
-			if ( prop.isNaturalIdentifier() && prop.isUpdateable() ) {
+		for ( Property property : rootEntityDescriptor.getDeclaredProperties() ) {
+			if ( property.isNaturalIdentifier() && property.isUpdateable() ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -133,6 +133,7 @@ import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Subclass;
@@ -1284,9 +1285,8 @@ public final class AnnotationBinder {
 			persistentClass.addProperty( property );
 			entityBinder.setIgnoreIdAnnotations( true );
 
-			Iterator properties = mapper.getPropertyIterator();
-			while ( properties.hasNext() ) {
-				idPropertiesIfIdClass.add( ( ( Property ) properties.next() ).getName() );
+			for ( Property prop : mapper.getProperties() ) {
+				idPropertiesIfIdClass.add( prop.getName() );
 			}
 			return true;
 		}
@@ -3442,15 +3442,12 @@ public final class AnnotationBinder {
 				mapToPK = false;
 			}
 			else {
-				Iterator idColumns = identifier.getColumnIterator();
 				List<String> idColumnNames = new ArrayList<>();
-				org.hibernate.mapping.Column currentColumn;
 				if ( identifier.getColumnSpan() != joinColumns.length ) {
 					mapToPK = false;
 				}
 				else {
-					while ( idColumns.hasNext() ) {
-						currentColumn = ( org.hibernate.mapping.Column ) idColumns.next();
+					for ( org.hibernate.mapping.Column currentColumn : identifier.getColumns() ) {
 						idColumnNames.add( currentColumn.getName() );
 					}
 					for ( AnnotatedJoinColumn col : joinColumns ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -1617,17 +1617,12 @@ public final class AnnotationBinder {
 					reflectionManager, entityClass, callbackType ) );
 		}
 
-		context.getMetadataCollector().addSecondPass( new SecondPass() {
-			@Override
-			public void doSecondPass(Map persistentClasses) throws MappingException {
-				for ( @SuppressWarnings("unchecked") Iterator<Property> propertyIterator = persistentClass.getDeclaredPropertyIterator();
-						propertyIterator.hasNext(); ) {
-					Property property = propertyIterator.next();
-					if ( property.isComposite() ) {
-						for ( CallbackType callbackType : CallbackType.values() ) {
-							property.addCallbackDefinitions( CallbackDefinitionResolverLegacyImpl.resolveEmbeddableCallbacks(
-									reflectionManager, persistentClass.getMappedClass(), property, callbackType ) );
-						}
+		context.getMetadataCollector().addSecondPass( persistentClasses -> {
+			for ( Property property : persistentClass.getDeclaredProperties() ) {
+				if ( property.isComposite() ) {
+					for ( CallbackType callbackType : CallbackType.values() ) {
+						property.addCallbackDefinitions( CallbackDefinitionResolverLegacyImpl.resolveEmbeddableCallbacks(
+								reflectionManager, persistentClass.getMappedClass(), property, callbackType ) );
 					}
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
@@ -478,7 +478,7 @@ public class BinderHelper {
 			catch (MappingException me) {
 				//swallow it
 			}
-			Iterator joins = current.getJoinIterator();
+			Iterator<Join> joins = current.getJoinIterator();
 			while ( !found && joins.hasNext() ) {
 				result = joins.next();
 				currentTable = ( (Join) result ).getTable();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
@@ -16,6 +16,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.IndexedCollection;
 import org.hibernate.mapping.OneToMany;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Value;
 
@@ -44,7 +45,7 @@ public abstract class CollectionSecondPass implements SecondPass {
 		this( buildingContext, collection, Collections.EMPTY_MAP );
 	}
 
-	public void doSecondPass(Map persistentClasses)
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses)
 			throws MappingException {
 		if ( LOG.isDebugEnabled() ) {
 			LOG.debugf( "Second pass for collection: %s", collection.getRole() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CopyIdentifierComponentSecondPass.java
@@ -63,8 +63,8 @@ public class CopyIdentifierComponentSecondPass extends FkSecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map persistentClasses) throws MappingException {
-		PersistentClass referencedPersistentClass = (PersistentClass) persistentClasses.get( referencedEntityName );
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
+		PersistentClass referencedPersistentClass = persistentClasses.get( referencedEntityName );
 		// TODO better error names
 		if ( referencedPersistentClass == null ) {
 			throw new AnnotationException( "Unknown entity name: " + referencedEntityName );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CreateKeySecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CreateKeySecondPass.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.hibernate.MappingException;
 import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 
 /**
@@ -26,7 +27,7 @@ public class CreateKeySecondPass implements SecondPass {
 		this.joinedSubClass = joinedSubClass;
 	}
 
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		if ( rootClass != null ) {
 			rootClass.createPrimaryKey();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/IdGeneratorResolverSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/IdGeneratorResolverSecondPass.java
@@ -12,6 +12,7 @@ import org.hibernate.MappingException;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
 
 /**
@@ -50,7 +51,7 @@ public class IdGeneratorResolverSecondPass implements SecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map idGeneratorDefinitionMap) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> idGeneratorDefinitionMap) throws MappingException {
 		BinderHelper.makeIdGenerator( id, idXProperty, generatorType, generatorName, buildingContext, localIdentifierGeneratorDefinition );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/IndexOrUniqueKeySecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/IndexOrUniqueKeySecondPass.java
@@ -18,6 +18,7 @@ import org.hibernate.mapping.Component;
 import org.hibernate.mapping.Index;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 
@@ -64,7 +65,7 @@ public class IndexOrUniqueKeySecondPass implements SecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		if ( columns != null ) {
 			for ( String column1 : columns ) {
 				addConstraintToColumn( column1 );
@@ -79,18 +80,18 @@ public class IndexOrUniqueKeySecondPass implements SecondPass {
 					propertyHolder.getPersistentClass().getEntityName() :
 					propertyHolder.getEntityName();
 
-			final PersistentClass persistentClass = (PersistentClass) persistentClasses.get( entityName );
+			final PersistentClass persistentClass = persistentClasses.get( entityName );
 			final Property property = persistentClass.getProperty( column.getPropertyName() );
 
 			if ( property.getValue() instanceof Component ) {
 				final Component component = (Component) property.getValue();
 
 				List<Column> columns = new ArrayList<>();
-				component.getColumnIterator().forEachRemaining( selectable -> {
+				for ( Selectable selectable: component.getSelectables() ) {
 					if ( selectable instanceof Column ) {
 						columns.add( (Column) selectable );
 					}
-				} );
+				}
 				addConstraintToColumns( columns );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/JoinedSubclassFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/JoinedSubclassFkSecondPass.java
@@ -11,6 +11,7 @@ import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.annotations.TableBinder;
 import org.hibernate.mapping.JoinedSubclass;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
 
 /**
@@ -39,7 +40,7 @@ public class JoinedSubclassFkSecondPass extends FkSecondPass {
 		return true;
 	}
 
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		TableBinder.bindFk( entity.getSuperclass(), entity, columns, value, false, buildingContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.cfg;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import jakarta.persistence.JoinColumn;
@@ -27,7 +26,6 @@ import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SortableValue;
 import org.hibernate.type.ForeignKeyDirection;
 
@@ -176,10 +174,8 @@ public class OneToOneSecondPass implements SecondPass {
 				propertyHolder.addProperty( prop, inferredData.getDeclaringClass() );
 			}
 			else if ( otherSideProperty.getValue() instanceof ManyToOne ) {
-				Iterator<Join> it = otherSide.getJoinIterator();
 				Join otherSideJoin = null;
-				while ( it.hasNext() ) {
-					Join otherSideJoinValue = it.next();
+				for ( Join otherSideJoinValue : otherSide.getJoins() ) {
 					if ( otherSideJoinValue.containsProperty( otherSideProperty ) ) {
 						otherSideJoin = otherSideJoinValue;
 						break;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -76,7 +76,7 @@ public class OneToOneSecondPass implements SecondPass {
 	}
 
 	//TODO refactor this code, there is a lot of duplication in this method
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		OneToOne value = new OneToOne(
 				buildingContext,
 				propertyHolder.getTable(),
@@ -141,14 +141,13 @@ public class OneToOneSecondPass implements SecondPass {
 				//no column associated since its a one to one
 				propertyHolder.addProperty( prop, inferredData.getDeclaringClass() );
 			}
-			else {
+//			else {
 				//this is a many to one with Formula
-
-			}
+//			}
 		}
 		else {
 			value.setMappedByProperty( mappedBy );
-			PersistentClass otherSide = (PersistentClass) persistentClasses.get( value.getReferencedEntityName() );
+			PersistentClass otherSide = persistentClasses.get( value.getReferencedEntityName() );
 			Property otherSideProperty;
 			try {
 				if ( otherSide == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -27,7 +27,7 @@ import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.mapping.SimpleValue;
+import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SortableValue;
 import org.hibernate.type.ForeignKeyDirection;
 
@@ -36,18 +36,18 @@ import org.hibernate.type.ForeignKeyDirection;
  * -
  */
 public class OneToOneSecondPass implements SecondPass {
-	private MetadataBuildingContext buildingContext;
-	private String mappedBy;
-	private String ownerEntity;
-	private String ownerProperty;
-	private PropertyHolder propertyHolder;
-	private boolean ignoreNotFound;
-	private PropertyData inferredData;
-	private XClass targetEntity;
-	private boolean cascadeOnDelete;
-	private boolean optional;
-	private String cascadeStrategy;
-	private AnnotatedJoinColumn[] joinColumns;
+	private final MetadataBuildingContext buildingContext;
+	private final String mappedBy;
+	private final String ownerEntity;
+	private final String ownerProperty;
+	private final PropertyHolder propertyHolder;
+	private final boolean ignoreNotFound;
+	private final PropertyData inferredData;
+	private final XClass targetEntity;
+	private final boolean cascadeOnDelete;
+	private final boolean optional;
+	private final String cascadeStrategy;
+	private final AnnotatedJoinColumn[] joinColumns;
 
 	//that sucks, we should read that from the property mainly
 	public OneToOneSecondPass(
@@ -176,10 +176,10 @@ public class OneToOneSecondPass implements SecondPass {
 				propertyHolder.addProperty( prop, inferredData.getDeclaringClass() );
 			}
 			else if ( otherSideProperty.getValue() instanceof ManyToOne ) {
-				Iterator it = otherSide.getJoinIterator();
+				Iterator<Join> it = otherSide.getJoinIterator();
 				Join otherSideJoin = null;
 				while ( it.hasNext() ) {
-					Join otherSideJoinValue = (Join) it.next();
+					Join otherSideJoinValue = it.next();
 					if ( otherSideJoinValue.containsProperty( otherSideProperty ) ) {
 						otherSideJoin = otherSideJoinValue;
 						break;
@@ -200,9 +200,7 @@ public class OneToOneSecondPass implements SecondPass {
 					manyToOne.setUnwrapProxy( value.isUnwrapProxy() );
 					manyToOne.markAsLogicalOneToOne();
 					prop.setValue( manyToOne );
-					Iterator otherSideJoinKeyColumns = otherSideJoin.getKey().getColumnIterator();
-					while ( otherSideJoinKeyColumns.hasNext() ) {
-						Column column = (Column) otherSideJoinKeyColumns.next();
+					for ( Column column: otherSideJoin.getKey().getColumns() ) {
 						Column copy = new Column();
 						copy.setLength( column.getLength() );
 						copy.setScale( column.getScale() );
@@ -287,9 +285,7 @@ public class OneToOneSecondPass implements SecondPass {
 		//TODO support for inverse and optional
 		join.setOptional( true ); //perhaps not quite per-spec, but a Good Thing anyway
 		key.setCascadeDeleteEnabled( false );
-		Iterator mappedByColumns = otherSideProperty.getValue().getColumnIterator();
-		while ( mappedByColumns.hasNext() ) {
-			Column column = (Column) mappedByColumns.next();
+		for ( Column column: otherSideProperty.getValue().getColumns() ) {
 			Column copy = new Column();
 			copy.setLength( column.getLength() );
 			copy.setScale( column.getScale() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PkDrivenByDefaultMapsIdSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PkDrivenByDefaultMapsIdSecondPass.java
@@ -41,8 +41,8 @@ public class PkDrivenByDefaultMapsIdSecondPass extends FkSecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map persistentClasses) throws MappingException {
-		PersistentClass referencedEntity = (PersistentClass) persistentClasses.get( referencedEntityName );
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
+		PersistentClass referencedEntity = persistentClasses.get( referencedEntityName );
 		if ( referencedEntity == null ) {
 			throw new AnnotationException(
 					"Unknown entity name: " + referencedEntityName

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PkDrivenByDefaultMapsIdSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PkDrivenByDefaultMapsIdSecondPass.java
@@ -50,7 +50,7 @@ public class PkDrivenByDefaultMapsIdSecondPass extends FkSecondPass {
 		}
 		TableBinder.linkJoinColumnWithValueOverridingNameIfImplicit(
 				referencedEntity,
-				referencedEntity.getKey().getColumnIterator(),
+				referencedEntity.getKey(),
 				columns,
 				value);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolderBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolderBuilder.java
@@ -5,6 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.cfg;
+
 import java.util.Map;
 
 import org.hibernate.annotations.common.reflection.XClass;
@@ -45,7 +46,7 @@ public final class PropertyHolderBuilder {
 	 *
 	 * @param component component to wrap
 	 * @param path	  component path
-	 * @param context
+	 *
 	 * @return PropertyHolder
 	 */
 	public static PropertyHolder buildPropertyHolder(

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyInferredData.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyInferredData.java
@@ -5,6 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.cfg;
+
 import jakarta.persistence.Access;
 
 import org.hibernate.MappingException;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SecondPass.java
@@ -8,6 +8,7 @@ package org.hibernate.cfg;
 import java.io.Serializable;
 
 import org.hibernate.MappingException;
+import org.hibernate.mapping.PersistentClass;
 
 /**
  * Second pass operation
@@ -16,7 +17,7 @@ import org.hibernate.MappingException;
  */
 public interface SecondPass extends Serializable {
 
-	void doSecondPass(java.util.Map persistentClasses)
+	void doSecondPass(java.util.Map<String, PersistentClass> persistentClasses)
 				throws MappingException;
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SecondaryTableSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SecondaryTableSecondPass.java
@@ -5,19 +5,21 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.cfg;
+
 import java.util.Map;
 
 import org.hibernate.MappingException;
 import org.hibernate.annotations.common.reflection.XAnnotatedElement;
 import org.hibernate.cfg.annotations.EntityBinder;
+import org.hibernate.mapping.PersistentClass;
 
 /**
  * @author Emmanuel Bernard
  */
 public class SecondaryTableSecondPass implements SecondPass {
-	private EntityBinder entityBinder;
-	private PropertyHolder propertyHolder;
-	private XAnnotatedElement annotatedClass;
+	private final EntityBinder entityBinder;
+	private final PropertyHolder propertyHolder;
+	private final XAnnotatedElement annotatedClass;
 
 	public SecondaryTableSecondPass(EntityBinder entityBinder, PropertyHolder propertyHolder, XAnnotatedElement annotatedClass) {
 		this.entityBinder = entityBinder;
@@ -25,7 +27,7 @@ public class SecondaryTableSecondPass implements SecondPass {
 		this.annotatedClass = annotatedClass;
 	}
 
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		entityBinder.finalSecondaryTableBinding( propertyHolder );
 		
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SetBasicValueTypeSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SetBasicValueTypeSecondPass.java
@@ -10,18 +10,19 @@ import java.util.Map;
 
 import org.hibernate.MappingException;
 import org.hibernate.cfg.annotations.BasicValueBinder;
+import org.hibernate.mapping.PersistentClass;
 
 /**
  * @author Sharath Reddy
  */
 public class SetBasicValueTypeSecondPass implements SecondPass {
-	private final BasicValueBinder binder;
+	private final BasicValueBinder<?> binder;
 
-	public SetBasicValueTypeSecondPass(BasicValueBinder val) {
+	public SetBasicValueTypeSecondPass(BasicValueBinder<?> val) {
 		binder = val;
 	}
 
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		binder.fillSimpleValue();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SimpleToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SimpleToOneFkSecondPass.java
@@ -7,6 +7,7 @@
 package org.hibernate.cfg;
 
 import org.hibernate.MappingException;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.ToOne;
 
 /**
@@ -30,7 +31,7 @@ public class SimpleToOneFkSecondPass extends FkSecondPass {
 		return false;
 	}
 
-	public void doSecondPass(java.util.Map persistentClasses) throws MappingException {
+	public void doSecondPass(java.util.Map<String, PersistentClass> persistentClasses) throws MappingException {
 		value.createForeignKey();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.cfg;
 
-import java.util.Iterator;
-
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
@@ -88,10 +86,10 @@ public class ToOneFkSecondPass extends FkSecondPass {
 		return false;
 	}
 
-	public void doSecondPass(java.util.Map persistentClasses) throws MappingException {
+	public void doSecondPass(java.util.Map<String, PersistentClass> persistentClasses) throws MappingException {
 		if ( value instanceof ManyToOne ) {
 			ManyToOne manyToOne = (ManyToOne) value;
-			PersistentClass ref = (PersistentClass) persistentClasses.get( manyToOne.getReferencedEntityName() );
+			PersistentClass ref = persistentClasses.get( manyToOne.getReferencedEntityName() );
 			if ( ref == null ) {
 				throw new AnnotationException(
 						"@OneToOne or @ManyToOne on "

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
@@ -30,10 +30,10 @@ import org.hibernate.mapping.ToOne;
  * @author Emmanuel Bernard
  */
 public class ToOneFkSecondPass extends FkSecondPass {
-	private MetadataBuildingContext buildingContext;
-	private boolean unique;
-	private String path;
-	private String entityClassName;
+	private final MetadataBuildingContext buildingContext;
+	private final boolean unique;
+	private final String path;
+	private final String entityClassName;
 
 	public ToOneFkSecondPass(
 			ToOne value,
@@ -76,9 +76,9 @@ public class ToOneFkSecondPass extends FkSecondPass {
 				if ( path.startsWith( "id." ) ) {
 					localPath = path.substring( 3 );
 				}
-				Iterator it = ( (Component) valueIdentifier ).getPropertyIterator();
-				while ( it.hasNext() ) {
-					Property idProperty = (Property) it.next();
+
+				Component component = (Component) valueIdentifier;
+				for ( Property idProperty : component.getProperties() ) {
 					if ( localPath.equals( idProperty.getName() ) || localPath.startsWith( idProperty.getName() + "." ) ) {
 						return true;
 					}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/VerifyFetchProfileReferenceSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/VerifyFetchProfileReferenceSecondPass.java
@@ -18,9 +18,9 @@ import org.hibernate.mapping.PersistentClass;
  * @author Hardy Ferentschik
  */
 public class VerifyFetchProfileReferenceSecondPass implements SecondPass {
-	private String fetchProfileName;
-	private FetchProfile.FetchOverride fetch;
-	private MetadataBuildingContext buildingContext;
+	private final String fetchProfileName;
+	private final FetchProfile.FetchOverride fetch;
+	private final MetadataBuildingContext buildingContext;
 
 	public VerifyFetchProfileReferenceSecondPass(
 			String fetchProfileName,
@@ -31,7 +31,7 @@ public class VerifyFetchProfileReferenceSecondPass implements SecondPass {
 		this.buildingContext = buildingContext;
 	}
 
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		org.hibernate.mapping.FetchProfile profile = buildingContext.getMetadataCollector().getFetchProfile(
 				fetchProfileName
 		);

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -1352,9 +1352,7 @@ public abstract class CollectionBinder {
 
 	private static String buildOrderById(PersistentClass associatedClass, String order) {
 		final StringBuilder sb = new StringBuilder();
-		final Iterator<Selectable> columnIterator = associatedClass.getIdentifier().getColumnIterator();
-		while ( columnIterator.hasNext() ) {
-			final Selectable selectable = columnIterator.next();
+		for ( Selectable selectable: associatedClass.getIdentifier().getSelectables() ) {
 			sb.append( selectable.getText() );
 			sb.append( order );
 			sb.append( ", " );
@@ -1812,7 +1810,7 @@ public abstract class CollectionBinder {
 				}
 				else if ( owner.getIdentifierMapper() != null && owner.getIdentifierMapper().getPropertySpan() > 0 ) {
 					// use the access for the owning entity's "id mapper", if one
-					Property prop = owner.getIdentifierMapper().getPropertyIterator().next();
+					Property prop = owner.getIdentifierMapper().getProperties().get(0);
 					baseAccessType = prop.getPropertyAccessorName().equals( "property" )
 							? AccessType.PROPERTY
 							: AccessType.FIELD;
@@ -2016,16 +2014,16 @@ public abstract class CollectionBinder {
 		final String mappedBy = columns[0].getMappedBy();
 		if ( StringHelper.isNotEmpty( mappedBy ) ) {
 			final Property property = referencedEntity.getRecursiveProperty( mappedBy );
-			Iterator<Selectable> mappedByColumns;
+			List<Selectable> mappedByColumns;
 			if ( property.getValue() instanceof Collection ) {
-				mappedByColumns = ( (Collection) property.getValue() ).getKey().getColumnIterator();
+				mappedByColumns = ( (Collection) property.getValue() ).getKey().getSelectables();
 			}
 			else {
 				//find the appropriate reference key, can be in a join
 				Iterator<Join> joinsIt = referencedEntity.getJoinIterator();
 				KeyValue key = null;
 				while ( joinsIt.hasNext() ) {
-					Join join = (Join) joinsIt.next();
+					Join join = joinsIt.next();
 					if ( join.containsProperty( property ) ) {
 						key = join.getKey();
 						break;
@@ -2034,10 +2032,10 @@ public abstract class CollectionBinder {
 				if ( key == null ) {
 					key = property.getPersistentClass().getIdentifier();
 				}
-				mappedByColumns = key.getColumnIterator();
+				mappedByColumns = key.getSelectables();
 			}
-			while ( mappedByColumns.hasNext() ) {
-				Column column = (Column) mappedByColumns.next();
+			for ( Selectable selectable: mappedByColumns ) {
+				Column column = (Column) selectable;
 				columns[0].linkValueUsingAColumnCopy( column, value );
 			}
 			String referencedPropertyName =

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -2020,10 +2020,8 @@ public abstract class CollectionBinder {
 			}
 			else {
 				//find the appropriate reference key, can be in a join
-				Iterator<Join> joinsIt = referencedEntity.getJoinIterator();
 				KeyValue key = null;
-				while ( joinsIt.hasNext() ) {
-					Join join = joinsIt.next();
+				for ( Join join : referencedEntity.getJoins() ) {
 					if ( join.containsProperty( property ) ) {
 						key = join.getKey();
 						break;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/EntityBinder.java
@@ -31,6 +31,7 @@ import org.hibernate.MappingException;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Columns;
 import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -844,12 +845,12 @@ public class EntityBinder {
 		 * Those operations has to be done after the id definition of the persistence class.
 		 * ie after the properties parsing
 		 */
-		Iterator joins = secondaryTables.values().iterator();
-		Iterator joinColumns = secondaryTableJoins.values().iterator();
+		Iterator<Join> joins = secondaryTables.values().iterator();
+		Iterator<Object> joinColumns = secondaryTableJoins.values().iterator();
 
 		while ( joins.hasNext() ) {
 			Object uncastedColumn = joinColumns.next();
-			Join join = (Join) joins.next();
+			Join join = joins.next();
 			createPrimaryColumnsToSecondaryTable( uncastedColumn, propertyHolder, join );
 		}
 	}
@@ -1203,16 +1204,13 @@ public class EntityBinder {
 		//comment and index are processed here
 		if ( table == null ) return;
 		String appliedTable = table.appliesTo();
-		Iterator tables = persistentClass.getTableClosureIterator();
 		Table hibTable = null;
-		while ( tables.hasNext() ) {
-			Table pcTable = (Table) tables.next();
+		for ( Table pcTable : persistentClass.getTableClosure() ) {
 			if ( pcTable.getQuotedName().equals( appliedTable ) ) {
 				//we are in the correct table to find columns
 				hibTable = pcTable;
 				break;
 			}
-			hibTable = null;
 		}
 		if ( hibTable == null ) {
 			//maybe a join/secondary table

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -7,7 +7,7 @@
 package org.hibernate.cfg.annotations;
 
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -129,7 +129,7 @@ public class MapBinder extends CollectionBinder {
 				// check if the index column has been mapped by the associated entity to a property;
 				// @MapKeyColumn only maps a column to the primary table for the one-to-many, so we only
 				// need to check "un-joined" properties.
-				if ( !propertyIteratorContainsColumn( persistentClass.getUnjoinedPropertyIterator(), column ) ) {
+				if ( !propertiesContainColumn( persistentClass.getUnjoinedProperties(), column ) ) {
 					// The index column is not mapped to an associated entity property so we can
 					// safely make the index column nullable.
 					column.setNullable( true );
@@ -138,9 +138,8 @@ public class MapBinder extends CollectionBinder {
 		}
 	}
 
-	private boolean propertyIteratorContainsColumn(Iterator<Property> propertyIterator, Column column) {
-		for (; propertyIterator.hasNext(); ) {
-			final Property property = propertyIterator.next();
+	private boolean propertiesContainColumn(List<Property> properties, Column column) {
+		for ( Property property : properties ) {
 			for ( Selectable selectable: property.getSelectables() ) {
 				if ( column.equals( selectable ) ) {
 					final Column iteratedColumn = (Column) selectable;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
@@ -6,29 +6,20 @@
  */
 package org.hibernate.cfg.annotations;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import jakarta.persistence.SqlResultSetMapping;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.QuerySecondPass;
-import org.hibernate.internal.CoreLogging;
-import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.Property;
-import org.hibernate.mapping.ToOne;
-import org.hibernate.mapping.Value;
 import org.hibernate.boot.query.SqlResultSetMappingDescriptor;
 
 /**
  * @author Emmanuel Bernard
  */
 public class ResultsetMappingSecondPass implements QuerySecondPass {
-	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( ResultsetMappingSecondPass.class );
+//	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( ResultsetMappingSecondPass.class );
 
 	private final SqlResultSetMapping ann;
 	private final MetadataBuildingContext context;
@@ -41,7 +32,7 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 	}
 
 	@Override
-	public void doSecondPass(Map persistentClasses) throws MappingException {
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
 		if ( ann == null ) {
 			return;
 		}
@@ -196,26 +187,26 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 //			context.getMetadataCollector().addResultSetMapping( definition );
 //		}
 	}
-
-	private String normalizeColumnQuoting(String name) {
-		return context.getMetadataCollector().getDatabase().toIdentifier( name ).render();
-	}
-
-	private List<String> getFollowers(Iterator parentPropIter, String reducedName, String name) {
-		boolean hasFollowers = false;
-		List<String> followers = new ArrayList<>();
-		while ( parentPropIter.hasNext() ) {
-			String currentPropertyName = ( (Property) parentPropIter.next() ).getName();
-			String currentName = reducedName + '.' + currentPropertyName;
-			if ( hasFollowers ) {
-				followers.add( currentName );
-			}
-			if ( name.equals( currentName ) ) {
-				hasFollowers = true;
-			}
-		}
-		return followers;
-	}
+//
+//	private String normalizeColumnQuoting(String name) {
+//		return context.getMetadataCollector().getDatabase().toIdentifier( name ).render();
+//	}
+//
+//	private List<String> getFollowers(Iterator<Property> parentPropIter, String reducedName, String name) {
+//		boolean hasFollowers = false;
+//		List<String> followers = new ArrayList<>();
+//		while ( parentPropIter.hasNext() ) {
+//			String currentPropertyName = parentPropIter.next().getName();
+//			String currentName = reducedName + '.' + currentPropertyName;
+//			if ( hasFollowers ) {
+//				followers.add( currentName );
+//			}
+//			if ( name.equals( currentName ) ) {
+//				hasFollowers = true;
+//			}
+//		}
+//		return followers;
+//	}
 //
 //	private Iterator getSubPropertyIterator(PersistentClass pc, String reducedName) {
 //		Value value = pc.getRecursiveProperty( reducedName ).getValue();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ResultsetMappingSecondPass.java
@@ -216,59 +216,59 @@ public class ResultsetMappingSecondPass implements QuerySecondPass {
 		}
 		return followers;
 	}
-
-	private Iterator getSubPropertyIterator(PersistentClass pc, String reducedName) {
-		Value value = pc.getRecursiveProperty( reducedName ).getValue();
-		Iterator parentPropIter;
-		if ( value instanceof Component ) {
-			Component comp = (Component) value;
-			parentPropIter = comp.getPropertyIterator();
-		}
-		else if ( value instanceof ToOne ) {
-			ToOne toOne = (ToOne) value;
-			PersistentClass referencedPc = context.getMetadataCollector().getEntityBinding( toOne.getReferencedEntityName() );
-			if ( toOne.getReferencedPropertyName() != null ) {
-				try {
-					parentPropIter = ( (Component) referencedPc.getRecursiveProperty(
-							toOne.getReferencedPropertyName()
-					).getValue() ).getPropertyIterator();
-				}
-				catch (ClassCastException e) {
-					throw new MappingException(
-							"dotted notation references neither a component nor a many/one to one", e
-					);
-				}
-			}
-			else {
-				try {
-					if ( referencedPc.getIdentifierMapper() == null ) {
-						parentPropIter = ( (Component) referencedPc.getIdentifierProperty()
-								.getValue() ).getPropertyIterator();
-					}
-					else {
-						parentPropIter = referencedPc.getIdentifierMapper().getPropertyIterator();
-					}
-				}
-				catch (ClassCastException e) {
-					throw new MappingException(
-							"dotted notation references neither a component nor a many/one to one", e
-					);
-				}
-			}
-		}
-		else {
-			throw new MappingException( "dotted notation references neither a component nor a many/one to one" );
-		}
-		return parentPropIter;
-	}
-
-	private static int getIndexOfFirstMatchingProperty(List propertyNames, String follower) {
-		int propertySize = propertyNames.size();
-		for (int propIndex = 0; propIndex < propertySize; propIndex++) {
-			if ( ( (String) propertyNames.get( propIndex ) ).startsWith( follower ) ) {
-				return propIndex;
-			}
-		}
-		return -1;
-	}
+//
+//	private Iterator getSubPropertyIterator(PersistentClass pc, String reducedName) {
+//		Value value = pc.getRecursiveProperty( reducedName ).getValue();
+//		Iterator parentPropIter;
+//		if ( value instanceof Component ) {
+//			Component comp = (Component) value;
+//			parentPropIter = comp.getPropertyIterator();
+//		}
+//		else if ( value instanceof ToOne ) {
+//			ToOne toOne = (ToOne) value;
+//			PersistentClass referencedPc = context.getMetadataCollector().getEntityBinding( toOne.getReferencedEntityName() );
+//			if ( toOne.getReferencedPropertyName() != null ) {
+//				try {
+//					parentPropIter = ( (Component) referencedPc.getRecursiveProperty(
+//							toOne.getReferencedPropertyName()
+//					).getValue() ).getPropertyIterator();
+//				}
+//				catch (ClassCastException e) {
+//					throw new MappingException(
+//							"dotted notation references neither a component nor a many/one to one", e
+//					);
+//				}
+//			}
+//			else {
+//				try {
+//					if ( referencedPc.getIdentifierMapper() == null ) {
+//						parentPropIter = ( (Component) referencedPc.getIdentifierProperty()
+//								.getValue() ).getPropertyIterator();
+//					}
+//					else {
+//						parentPropIter = referencedPc.getIdentifierMapper().getPropertyIterator();
+//					}
+//				}
+//				catch (ClassCastException e) {
+//					throw new MappingException(
+//							"dotted notation references neither a component nor a many/one to one", e
+//					);
+//				}
+//			}
+//		}
+//		else {
+//			throw new MappingException( "dotted notation references neither a component nor a many/one to one" );
+//		}
+//		return parentPropIter;
+//	}
+//
+//	private static int getIndexOfFirstMatchingProperty(List propertyNames, String follower) {
+//		int propertySize = propertyNames.size();
+//		for (int propIndex = 0; propIndex < propertySize; propIndex++) {
+//			if ( ( (String) propertyNames.get( propIndex ) ).startsWith( follower ) ) {
+//				return propIndex;
+//			}
+//		}
+//		return -1;
+//	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/TypeSafeActivator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/beanvalidation/TypeSafeActivator.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -280,9 +279,7 @@ class TypeSafeActivator {
 			ConstraintDescriptor<Min> minConstraint = (ConstraintDescriptor<Min>) descriptor;
 			long min = minConstraint.getAnnotation().value();
 
-			final Iterator<Selectable> itor = property.getColumnIterator();
-			if ( itor.hasNext() ) {
-				final Selectable selectable = itor.next();
+			for ( Selectable selectable : property.getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					Column col = (Column) selectable;
 					String checkConstraint = col.getQuotedName(dialect) + ">=" + min;
@@ -298,9 +295,7 @@ class TypeSafeActivator {
 			ConstraintDescriptor<Max> maxConstraint = (ConstraintDescriptor<Max>) descriptor;
 			long max = maxConstraint.getAnnotation().value();
 
-			final Iterator<Selectable> itor = property.getColumnIterator();
-			if ( itor.hasNext() ) {
-				final Selectable selectable = itor.next();
+			for ( Selectable selectable : property.getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					Column col = (Column) selectable;
 					String checkConstraint = col.getQuotedName( dialect ) + "<=" + max;
@@ -327,9 +322,7 @@ class TypeSafeActivator {
 			if ( !( property.getPersistentClass() instanceof SingleTableSubclass ) ) {
 				//composite should not add not-null on all columns
 				if ( !property.isComposite() ) {
-					final Iterator<Selectable> itr = property.getColumnIterator();
-					while ( itr.hasNext() ) {
-						final Selectable selectable = itr.next();
+					for ( Selectable selectable : property.getSelectables() ) {
 						if ( selectable instanceof Column ) {
 							((Column) selectable).setNullable( false );
 						}
@@ -356,9 +349,7 @@ class TypeSafeActivator {
 			int integerDigits = digitsConstraint.getAnnotation().integer();
 			int fractionalDigits = digitsConstraint.getAnnotation().fraction();
 
-			final Iterator<Selectable> itor = property.getColumnIterator();
-			if ( itor.hasNext() ) {
-				final Selectable selectable = itor.next();
+			for ( Selectable selectable : property.getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					Column col = (Column) selectable;
 					col.setPrecision( integerDigits + fractionalDigits );
@@ -376,10 +367,7 @@ class TypeSafeActivator {
 			ConstraintDescriptor<Size> sizeConstraint = (ConstraintDescriptor<Size>) descriptor;
 			int max = sizeConstraint.getAnnotation().max();
 
-			final Iterator<Selectable> itor = property.getColumnIterator();
-			if ( itor.hasNext() ) {
-				final Selectable selectable = itor.next();
-				Column col = (Column) selectable;
+			for ( Column col : property.getColumns() ) {
 				if ( max < Integer.MAX_VALUE ) {
 					col.setLength( max );
 				}
@@ -394,9 +382,7 @@ class TypeSafeActivator {
 				&& String.class.equals( propertyDescriptor.getElementClass() ) ) {
 			int max = (Integer) descriptor.getAttributes().get( "max" );
 
-			final Iterator<Selectable> itor = property.getColumnIterator();
-			if ( itor.hasNext() ) {
-				final Selectable selectable = itor.next();
+			for ( Selectable selectable : property.getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					Column col = (Column) selectable;
 					if ( max < Integer.MAX_VALUE ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/internal/NullableDiscriminatorColumnSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/internal/NullableDiscriminatorColumnSecondPass.java
@@ -24,9 +24,8 @@ public class NullableDiscriminatorColumnSecondPass implements SecondPass {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public void doSecondPass(Map persistentClasses) throws MappingException {
-		PersistentClass rootPersistenceClass = (PersistentClass) persistentClasses.get( rootEntityName );
+	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
+		PersistentClass rootPersistenceClass = persistentClasses.get( rootEntityName );
 		if ( hasNullDiscriminatorValue( rootPersistenceClass ) ) {
 			for ( Selectable selectable: rootPersistenceClass.getDiscriminator().getSelectables() ) {
 				if ( selectable instanceof Column ) {
@@ -40,9 +39,8 @@ public class NullableDiscriminatorColumnSecondPass implements SecondPass {
 		if ( rootPersistenceClass.isDiscriminatorValueNull() ) {
 			return true;
 		}
-		Iterator<Subclass> subclassIterator = rootPersistenceClass.getSubclassIterator();
-		while ( subclassIterator.hasNext() ) {
-			if ( subclassIterator.next().isDiscriminatorValueNull() ) {
+		for ( Subclass subclass : rootPersistenceClass.getSubclasses() ) {
+			if ( subclass.isDiscriminatorValueNull() ) {
 				return true;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/cfg/internal/NullableDiscriminatorColumnSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/internal/NullableDiscriminatorColumnSecondPass.java
@@ -28,9 +28,7 @@ public class NullableDiscriminatorColumnSecondPass implements SecondPass {
 	public void doSecondPass(Map persistentClasses) throws MappingException {
 		PersistentClass rootPersistenceClass = (PersistentClass) persistentClasses.get( rootEntityName );
 		if ( hasNullDiscriminatorValue( rootPersistenceClass ) ) {
-			for ( Iterator<Selectable> iterator = rootPersistenceClass.getDiscriminator().getColumnIterator();
-					iterator.hasNext(); ) {
-				Selectable selectable = iterator.next();
+			for ( Selectable selectable: rootPersistenceClass.getDiscriminator().getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					( (Column) selectable ).setNullable( true );
 				}
@@ -38,7 +36,6 @@ public class NullableDiscriminatorColumnSecondPass implements SecondPass {
 		}
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	private boolean hasNullDiscriminatorValue(PersistentClass rootPersistenceClass) {
 		if ( rootPersistenceClass.isDiscriminatorValueNull() ) {
 			return true;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialectTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialectTableExporter.java
@@ -56,10 +56,7 @@ class SpannerDialectTableExporter implements Exporter<Table> {
 		}
 		else if ( table.getForeignKeys().size() > 0 ) {
 			// a table with no PK's but has FK's; often corresponds to element collection properties
-			keyColumns = new ArrayList<>();
-			for (Iterator<Column> column = table.getColumnIterator(); column.hasNext();) {
-				keyColumns.add( column.next() );
-			}
+			keyColumns = table.getColumns();
 		}
 		else {
 			// the case corresponding to a sequence-table that will only have 1 row.
@@ -77,12 +74,11 @@ class SpannerDialectTableExporter implements Exporter<Table> {
 		StringJoiner colsAndTypes = new StringJoiner( "," );
 
 
-		for (Iterator<Column> column = table.getColumnIterator(); column.hasNext();) {
-			Column col = column.next();
+		for ( Column column : table.getColumns() ) {
 			String columnDeclaration =
-					col.getName()
-							+ " " + col.getSqlType()
-							+ ( col.isNullable() ? this.spannerDialect.getNullColumnString( col.getSqlType() ) : " not null" );
+					column.getName()
+							+ " " + column.getSqlType()
+							+ ( column.isNullable() ? this.spannerDialect.getNullColumnString( column.getSqlType() ) : " not null" );
 			colsAndTypes.add( columnDeclaration );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
@@ -125,12 +125,10 @@ public class TemporaryTable implements Exportable, Contributable {
 					final PersistentClass entityBinding = runtimeModelCreationContext.getBootModel()
 							.getEntityBinding( entityDescriptor.getEntityName() );
 
-					final Iterator<Selectable> itr = entityBinding.getKey().getColumnIterator();
 					final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
 							.getJdbcMappings()
 							.iterator();
-					while ( itr.hasNext() ) {
-						final Column column = (Column) itr.next();
+					for ( Column column : entityBinding.getKey().getColumns() ) {
 						final JdbcMapping jdbcMapping = jdbcMappings.next();
 						columns.add(
 								new TemporaryTableColumn(
@@ -155,8 +153,8 @@ public class TemporaryTable implements Exportable, Contributable {
 										if ( !( fkTarget instanceof EntityIdentifierMapping ) ) {
 											final Value value = entityBinding.getSubclassProperty( pluralAttribute.getAttributeName() )
 													.getValue();
-											final Iterator<Selectable> columnIterator = ( (Collection) value ).getKey()
-													.getColumnIterator();
+											final Iterator<Selectable> columnIterator =
+													( (Collection) value ).getKey().getColumnIterator();
 											fkTarget.forEachSelectable(
 													(columnIndex, selection) -> {
 														final Selectable selectable = columnIterator.next();
@@ -207,12 +205,10 @@ public class TemporaryTable implements Exportable, Contributable {
 					final boolean hasOptimizer;
 					if ( identityColumn ) {
 						hasOptimizer = false;
-						final Iterator<Selectable> itr = entityBinding.getKey().getColumnIterator();
 						final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
 								.getJdbcMappings()
 								.iterator();
-						while ( itr.hasNext() ) {
-							final Column column = (Column) itr.next();
+						for ( Column column : entityBinding.getKey().getColumns() ) {
 							final JdbcMapping jdbcMapping = jdbcMappings.next();
 							columns.add(
 									new TemporaryTableColumn(
@@ -237,12 +233,10 @@ public class TemporaryTable implements Exportable, Contributable {
 							hasOptimizer = false;
 						}
 					}
-					final Iterator<Selectable> itr = entityBinding.getKey().getColumnIterator();
 					final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
 							.getJdbcMappings()
 							.iterator();
-					while ( itr.hasNext() ) {
-						final Column column = (Column) itr.next();
+					for ( Column column : entityBinding.getKey().getColumns() ) {
 						final JdbcMapping jdbcMapping = jdbcMappings.next();
 						columns.add(
 								new TemporaryTableColumn(
@@ -259,7 +253,7 @@ public class TemporaryTable implements Exportable, Contributable {
 
 					final EntityDiscriminatorMapping discriminatorMapping = entityDescriptor.getDiscriminatorMapping();
 					if ( entityBinding.getDiscriminator() != null && !discriminatorMapping.isFormula() ) {
-						final Column discriminator = (Column) entityBinding.getDiscriminator().getColumnIterator().next();
+						final Column discriminator = entityBinding.getDiscriminator().getColumns().get(0);
 						columns.add(
 								new TemporaryTableColumn(
 										temporaryTable,

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
@@ -48,10 +48,10 @@ public interface UniqueDelegate {
 	String getColumnDefinitionUniquenessFragment(Column column, SqlStringGenerationContext context);
 
 	/**
-	 * Get the fragment that can be used to apply unique constraints as part of table creation.  The implementation
-	 * should iterate over the {@link UniqueKey} instances for the given table (see
-	 * {@link org.hibernate.mapping.Table#getUniqueKeyIterator()} and generate the whole fragment for all
-	 * unique keys
+	 * Get the fragment that can be used to apply unique constraints as part of table creation.  The
+	 * implementation should iterate over the {@link UniqueKey} instances for the given table (see
+	 * {@link org.hibernate.mapping.Table#getUniqueKeyIterator()} and generate the whole fragment for
+	 * all unique keys
 	 * <p/>
 	 * Intended for Dialects which support unique constraint definitions, but just not in separate ALTER statements.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.id;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -69,14 +68,19 @@ public class ExportableColumn extends Column {
 			return 1;
 		}
 
-		@Override
+		@Override @Deprecated
 		public Iterator<Selectable> getColumnIterator() {
 			return new ColumnIterator( column );
 		}
 
 		@Override
 		public List<Selectable> getSelectables() {
-			return Arrays.asList( column );
+			return List.of( column );
+		}
+
+		@Override
+		public List<Column> getColumns() {
+			return List.of( column );
 		}
 
 		@Override
@@ -130,7 +134,11 @@ public class ExportableColumn extends Column {
 		}
 
 		@Override
-		public void createForeignKey() throws MappingException {
+		public void createForeignKey() {
+		}
+
+		@Override
+		public void createUniqueKey() {
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/IdentityMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/IdentityMap.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 public final class IdentityMap<K,V> implements Map<K,V> {
 
 	private final LinkedHashMap<IdentityKey<K>,V> map;
-	@SuppressWarnings( {"unchecked"})
+
 	private transient Entry<IdentityKey<K>,V>[] entryArray = null;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedIterator.java
@@ -30,6 +30,7 @@ public class JoinedIterator<T> implements Iterator<T> {
 		this( wrappedIterators.toArray(new Iterator[0]) );
 	}
 
+	@SafeVarargs
 	public JoinedIterator(Iterator<? extends T>... iteratorsToWrap) {
 		if( iteratorsToWrap == null ) {
 			throw new NullPointerException( "Iterators to join were null" );

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedList.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/JoinedList.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal.util.collections;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Gavin King
+ */
+public class JoinedList<E> extends AbstractList<E> {
+	private final List<List<E>> lists;
+	private final int size;
+
+	public JoinedList(List<List<E>> lists) {
+		this.lists = lists;
+		size = lists.stream().map(List::size).reduce(0, Integer::sum);
+	}
+
+	@SafeVarargs
+	public JoinedList(List<E>... lists) {
+		this( Arrays.asList(lists) );
+	}
+
+	@Override
+	public E get(int index) {
+		for (List<E> list: lists) {
+			if ( list.size() > index ) {
+				return list.get(index);
+			}
+			index -= list.size();
+		}
+		return null;
+	}
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return lists.stream().flatMap(List::stream).iterator();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbacksFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbacksFactory.java
@@ -13,11 +13,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.jpa.event.spi.Callback;
 import org.hibernate.jpa.event.spi.CallbackDefinition;
-import org.hibernate.jpa.event.spi.CallbackType;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
@@ -68,9 +66,7 @@ public final class CallbacksFactory {
 			registry.registerCallbacks( persistentClass.getMappedClass(),
 					buildCallbacks( persistentClass.getCallbackDefinitions(), beanRegistry ) );
 
-			for ( @SuppressWarnings("unchecked") Iterator<Property> propertyIterator = persistentClass.getDeclaredPropertyIterator();
-					propertyIterator.hasNext(); ) {
-				final Property property = propertyIterator.next();
+			for ( Property property : persistentClass.getDeclaredProperties() ) {
 				registry.registerCallbacks( persistentClass.getMappedClass(),
 						buildCallbacks( property.getCallbackDefinitions(), beanRegistry ) );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
@@ -129,11 +130,13 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		}
 	}
 
-	public void addColumns(Iterator columnIterator) {
-		while ( columnIterator.hasNext() ) {
-			Selectable col = (Selectable) columnIterator.next();
-			if ( !col.isFormula() ) {
-				addColumn( (Column) col );
+	public void addColumns(Value value) {
+		for ( Selectable selectable : value.getSelectables() ) {
+			if ( selectable.isFormula() ) {
+				throw new MappingException( "constraint involves a formula: " + this.name );
+			}
+			else {
+				addColumn( (Column) selectable );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -84,7 +84,8 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 			if ( o instanceof Column ) {
 				defensive.add( (Column) o );
 			}
-			//else: others might be Formula instances. They don't need to be part of the name generation.
+			// else: others might be Formula instances.
+			// They don't need to be part of the name generation.
 		}
 		return generateName( prefix, table, defensive.toArray( new Column[0] ) );
 	}
@@ -156,6 +157,7 @@ public abstract class Constraint implements RelationalModel, Exportable, Seriali
 		return  columns.get( i );
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<Column> getColumnIterator() {
 		return columns.iterator();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Contributable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Contributable.java
@@ -7,7 +7,9 @@
 package org.hibernate.mapping;
 
 /**
- * Part of the mapping model that is associated with a contributor.  ORM, Envers, Search, etc
+ * Part of the mapping model that is associated with a contributor.
+ * ORM, Envers, Search, etc
+ *
  * @author Steve Ebersole
  */
 public interface Contributable {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
@@ -60,19 +60,17 @@ public class DenormalizedTable extends Table {
 	@Override
 	public void createForeignKeys() {
 		includedTable.createForeignKeys();
-		Iterator<ForeignKey> iter = includedTable.getForeignKeyIterator();
-		while ( iter.hasNext() ) {
-			ForeignKey fk = iter.next();
+		for ( ForeignKey foreignKey : includedTable.getForeignKeys().values() ) {
 			createForeignKey(
 					Constraint.generateName(
-							fk.generatedConstraintNamePrefix(),
+							foreignKey.generatedConstraintNamePrefix(),
 							this,
-							fk.getColumns()
+							foreignKey.getColumns()
 					),
-					fk.getColumns(),
-					fk.getReferencedEntityName(),
-					fk.getKeyDefinition(),
-					fk.getReferencedColumns()
+					foreignKey.getColumns(),
+					foreignKey.getReferencedEntityName(),
+					foreignKey.getKeyDefinition(),
+					foreignKey.getReferencedColumns()
 			);
 		}
 	}
@@ -117,10 +115,8 @@ public class DenormalizedTable extends Table {
 	@Override
 	public Iterator<UniqueKey> getUniqueKeyIterator() {
 		if ( !includedTable.isPhysicalTable() ) {
-			Iterator<UniqueKey> iter = includedTable.getUniqueKeyIterator();
-			while ( iter.hasNext() ) {
-				UniqueKey uk = iter.next();
-				createUniqueKey( uk.getColumns() );
+			for ( UniqueKey uniqueKey : includedTable.getUniqueKeys().values() ) {
+				createUniqueKey( uniqueKey.getColumns() );
 			}
 		}
 		return getUniqueKeys().values().iterator();

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DependantBasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DependantBasicValue.java
@@ -14,8 +14,8 @@ import org.hibernate.boot.spi.MetadataBuildingContext;
 public class DependantBasicValue extends BasicValue {
 	private final BasicValue referencedValue;
 
-	private boolean nullable;
-	private boolean updateable;
+	private final boolean nullable;
+	private final boolean updateable;
 
 	public DependantBasicValue(
 			MetadataBuildingContext buildingContext,

--- a/hibernate-core/src/main/java/org/hibernate/mapping/FetchProfile.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/FetchProfile.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashSet;
 public class FetchProfile {
 	private final String name;
 	private final MetadataSource source;
-	private LinkedHashSet<Fetch> fetches = new LinkedHashSet<>();
+	private final LinkedHashSet<Fetch> fetches = new LinkedHashSet<>();
 
 	/**
 	 * Create a fetch profile representation.

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Fetchable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Fetchable.java
@@ -9,6 +9,7 @@ import org.hibernate.FetchMode;
 
 /**
  * Any mapping with an outer-join attribute
+ *
  * @author Gavin King
  */
 public interface Fetchable {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -65,20 +65,14 @@ public class ForeignKey extends Constraint {
 		String[] columnNames = new String[getColumnSpan()];
 		String[] referencedColumnNames = new String[getColumnSpan()];
 
-		final Iterator<Column> referencedColumnItr;
-		if ( isReferenceToPrimaryKey() ) {
-			referencedColumnItr = referencedTable.getPrimaryKey().getColumnIterator();
-		}
-		else {
-			referencedColumnItr = referencedColumns.iterator();
-		}
+		final List<Column> referencedColumns = isReferenceToPrimaryKey()
+				? referencedTable.getPrimaryKey().getColumns()
+				: this.referencedColumns;
 
-		Iterator<Column> columnItr = getColumnIterator();
-		int i = 0;
-		while ( columnItr.hasNext() ) {
-			columnNames[i] = columnItr.next().getQuotedName( dialect );
-			referencedColumnNames[i] = referencedColumnItr.next().getQuotedName( dialect );
-			i++;
+		List<Column> columns = getColumns();
+		for ( int i=0; i<referencedColumns.size() && i<columns.size(); i++ ) {
+			columnNames[i] = columns.get(i).getQuotedName( dialect );
+			referencedColumnNames[i] = referencedColumns.get(i).getQuotedName( dialect );
 		}
 
 		final String result = keyDefinition != null ?
@@ -218,12 +212,11 @@ public class ForeignKey extends Constraint {
 		return referencedColumns.isEmpty();
 	}
 
-	public void addReferencedColumns(Iterator<Column> referencedColumnsIterator) {
-		while ( referencedColumnsIterator.hasNext() ) {
-			Selectable col = referencedColumnsIterator.next();
-			if ( !col.isFormula() ) {
-				addReferencedColumn( (Column) col );
-			}
+	public void addReferencedColumns(List<Column> referencedColumns) {
+		for (Column referencedColumn : referencedColumns) {
+//			if ( !referencedColumn.isFormula() ) {
+				addReferencedColumn( referencedColumn );
+//			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -25,7 +25,7 @@ public class ForeignKey extends Constraint {
 	private String referencedEntityName;
 	private String keyDefinition;
 	private boolean cascadeDeleteEnabled;
-	private List<Column> referencedColumns = new ArrayList<>();
+	private final List<Column> referencedColumns = new ArrayList<>();
 	private boolean creationEnabled = true;
 
 	public ForeignKey() {
@@ -73,10 +73,10 @@ public class ForeignKey extends Constraint {
 			referencedColumnItr = referencedColumns.iterator();
 		}
 
-		Iterator columnItr = getColumnIterator();
+		Iterator<Column> columnItr = getColumnIterator();
 		int i = 0;
 		while ( columnItr.hasNext() ) {
-			columnNames[i] = ( (Column) columnItr.next() ).getQuotedName( dialect );
+			columnNames[i] = columnItr.next().getQuotedName( dialect );
 			referencedColumnNames[i] = referencedColumnItr.next().getQuotedName( dialect );
 			i++;
 		}
@@ -105,9 +105,9 @@ public class ForeignKey extends Constraint {
 		return referencedTable;
 	}
 
-	private void appendColumns(StringBuilder buf, Iterator columns) {
+	private void appendColumns(StringBuilder buf, Iterator<Column> columns) {
 		while ( columns.hasNext() ) {
-			Column column = (Column) columns.next();
+			Column column = columns.next();
 			buf.append( column.getName() );
 			if ( columns.hasNext() ) {
 				buf.append( "," );
@@ -149,10 +149,10 @@ public class ForeignKey extends Constraint {
 			throw new MappingException( sb.toString() );
 		}
 
-		Iterator fkCols = getColumnIterator();
-		Iterator pkCols = referencedTable.getPrimaryKey().getColumnIterator();
+		Iterator<Column> fkCols = getColumnIterator();
+		Iterator<Column> pkCols = referencedTable.getPrimaryKey().getColumnIterator();
 		while ( pkCols.hasNext() ) {
-			( (Column) fkCols.next() ).setLength( ( (Column) pkCols.next() ).getLength() );
+			fkCols.next().setLength( pkCols.next().getLength() );
 		}
 
 	}
@@ -207,7 +207,7 @@ public class ForeignKey extends Constraint {
 	/**
 	 * Returns the referenced columns if the foreignkey does not refer to the primary key
 	 */
-	public List getReferencedColumns() {
+	public List<Column> getReferencedColumns() {
 		return referencedColumns;
 	}
 
@@ -218,9 +218,9 @@ public class ForeignKey extends Constraint {
 		return referencedColumns.isEmpty();
 	}
 
-	public void addReferencedColumns(Iterator referencedColumnsIterator) {
+	public void addReferencedColumns(Iterator<Column> referencedColumnsIterator) {
 		while ( referencedColumnsIterator.hasNext() ) {
-			Selectable col = (Selectable) referencedColumnsIterator.next();
+			Selectable col = referencedColumnsIterator.next();
 			if ( !col.isFormula() ) {
 				addReferencedColumn( (Column) col );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IdentifierCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IdentifierCollection.java
@@ -55,7 +55,7 @@ public abstract class IdentifierCollection extends Collection {
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );
-			pk.addColumns( getIdentifier().getColumnIterator() );
+			pk.addColumns( getIdentifier() );
 			getCollectionTable().setPrimaryKey(pk);
 		}
 		// create an index on the key columns??

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.mapping;
 
-import java.util.Iterator;
 import java.util.function.Supplier;
 
 import org.hibernate.MappingException;
@@ -76,7 +75,7 @@ public abstract class IndexedCollection extends Collection {
 			}
 			getCollectionTable().setPrimaryKey(pk);
 		}
-		else {
+//		else {
 			// don't create a unique key, 'cos some
 			// databases don't like a UK on nullable
 			// columns
@@ -84,7 +83,7 @@ public abstract class IndexedCollection extends Collection {
 			list.addAll( getKey().getConstraintColumns() );
 			list.addAll( getIndex().getConstraintColumns() );
 			getCollectionTable().createUniqueKey(list);*/
-		}
+//		}
 	}
 
 	public void validate(Mapping mapping) throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/IndexedCollection.java
@@ -58,23 +58,21 @@ public abstract class IndexedCollection extends Collection {
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );
-			pk.addColumns( getKey().getColumnIterator() );
+			pk.addColumns( getKey() );
 
 			// index should be last column listed
 			boolean indexIsPartOfElement = false;
-			final Iterator<Selectable> iter = getIndex().getColumnIterator();
-			while ( iter.hasNext() ) {
-				final Selectable selectable = iter.next();
+			for ( Selectable selectable: getIndex().getSelectables() ) {
 				if ( selectable.isFormula() || !getCollectionTable().containsColumn( (Column) selectable ) ) {
 					indexIsPartOfElement = true;
 				}
 			}
 			if ( indexIsPartOfElement ) {
 				//if it is part of the element, use the element columns in the PK
-				pk.addColumns( getElement().getColumnIterator() );
+				pk.addColumns( getElement() );
 			}
 			else {
-				pk.addColumns( getIndex().getColumnIterator() );
+				pk.addColumns( getIndex() );
 			}
 			getCollectionTable().setPrimaryKey(pk);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -9,6 +9,7 @@ package org.hibernate.mapping;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.sql.Alias;
@@ -52,6 +53,15 @@ public class Join implements AttributeContainer, Serializable {
 		prop.setPersistentClass( getPersistentClass() );
 	}
 
+	public List<Property> getDeclaredProperties() {
+		return declaredProperties;
+	}
+
+	public List<Property> getProperties() {
+		return properties;
+	}
+
+	@Deprecated(since = "6.0")
 	public Iterator<Property> getDeclaredPropertyIterator() {
 		return declaredProperties.iterator();
 	}
@@ -59,6 +69,8 @@ public class Join implements AttributeContainer, Serializable {
 	public boolean containsProperty(Property prop) {
 		return properties.contains(prop);
 	}
+
+	@Deprecated(since = "6.0")
 	public Iterator<Property> getPropertyIterator() {
 		return properties.iterator();
 	}
@@ -95,7 +107,7 @@ public class Join implements AttributeContainer, Serializable {
 		pk.setName( PK_ALIAS.toAliasString( table.getName() ) );
 		table.setPrimaryKey(pk);
 
-		pk.addColumns( getKey().getColumnIterator() );
+		pk.addColumns( getKey() );
 	}
 
 	public int getPropertySpan() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/JoinedSubclass.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.mapping;
 import java.util.Iterator;
+import java.util.List;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -52,8 +53,13 @@ public class JoinedSubclass extends Subclass implements TableOwner {
 		}
 	}
 
+	@Deprecated
 	public Iterator<Property> getReferenceablePropertyIterator() {
 		return getPropertyIterator();
+	}
+
+	public List<Property> getReferenceableProperties() {
+		return getProperties();
 	}
 
 	public Object accept(PersistentClassVisitor mv) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
@@ -7,12 +7,10 @@
 package org.hibernate.mapping;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
-import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
 
@@ -64,11 +62,11 @@ public class ManyToOne extends ToOne {
 		}
 	}
 
-	public void createPropertyRefConstraints(Map persistentClasses) {
+	public void createPropertyRefConstraints(Map<String, PersistentClass> persistentClasses) {
 		if (referencedPropertyName!=null) {
 			// Ensure properties are sorted before we create a foreign key
 			sortProperties();
-			PersistentClass pc = (PersistentClass) persistentClasses.get(getReferencedEntityName() );
+			PersistentClass pc = persistentClasses.get(getReferencedEntityName() );
 			
 			Property property = pc.getReferencedProperty( getReferencedPropertyName() );
 			

--- a/hibernate-core/src/main/java/org/hibernate/mapping/MappedSuperclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/MappedSuperclass.java
@@ -30,8 +30,8 @@ import java.util.List;
 public class MappedSuperclass {
 	private final MappedSuperclass superMappedSuperclass;
 	private final PersistentClass superPersistentClass;
-	private final List declaredProperties;
-	private Class mappedClass;
+	private final List<Property> declaredProperties;
+	private Class<?> mappedClass;
 	private Property identifierProperty;
 	private Property version;
 	private Component identifierMapper;
@@ -39,7 +39,7 @@ public class MappedSuperclass {
 	public MappedSuperclass(MappedSuperclass superMappedSuperclass, PersistentClass superPersistentClass) {
 		this.superMappedSuperclass = superMappedSuperclass;
 		this.superPersistentClass = superPersistentClass;
-		this.declaredProperties = new ArrayList();
+		this.declaredProperties = new ArrayList<>();
 	}
 
 	/**
@@ -71,28 +71,32 @@ public class MappedSuperclass {
 		return superPersistentClass;
 	}
 
-	public Iterator getDeclaredPropertyIterator() {
+	@Deprecated(since = "6.0")
+	public Iterator<Property> getDeclaredPropertyIterator() {
 		return declaredProperties.iterator();
+	}
+
+	public List<Property> getDeclaredProperties() {
+		return declaredProperties;
 	}
 
 	public void addDeclaredProperty(Property p) {
 		//Do not add duplicate properties
 		//TODO is it efficient enough?
 		String name = p.getName();
-		Iterator it = declaredProperties.iterator();
-		while (it.hasNext()) {
-			if ( name.equals( ((Property)it.next()).getName() ) ) {
+		for (Property declaredProperty : declaredProperties) {
+			if ( name.equals( declaredProperty.getName() ) ) {
 				return;
 			}
 		}
 		declaredProperties.add(p);
 	}
 
-	public Class getMappedClass() {
+	public Class<?> getMappedClass() {
 		return mappedClass;
 	}
 
-	public void setMappedClass(Class mappedClass) {
+	public void setMappedClass(Class<?> mappedClass) {
 		this.mappedClass = mappedClass;
 	}
 
@@ -173,9 +177,7 @@ public class MappedSuperclass {
 	 * @return {@code true} if a property with that name exists; {@code false} if not
 	 */
 	public boolean hasProperty(String name) {
-		final Iterator itr = getDeclaredPropertyIterator();
-		while ( itr.hasNext() ) {
-			final Property property = (Property) itr.next();
+		for ( Property property : getDeclaredProperties() ) {
 			if ( property.getName().equals( name ) ) {
 				return true;
 			}
@@ -210,8 +212,7 @@ public class MappedSuperclass {
 		return false;
 	}
 
-	@SuppressWarnings( "unchecked" )
 	public void prepareForMappingModel() {
-		( (List<Property>) declaredProperties ).sort( Comparator.comparing( Property::getName ) );
+		declaredProperties.sort( Comparator.comparing( Property::getName ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/MappingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/MappingHelper.java
@@ -67,12 +67,7 @@ public final class MappingHelper {
 
 	public static void injectParameters(Object type, Properties parameters) {
 		if ( type instanceof ParameterizedType ) {
-			if ( parameters == null ) {
-				( (ParameterizedType) type ).setParameterValues( EMPTY_PROPERTIES );
-			}
-			else {
-				( (ParameterizedType) type ).setParameterValues( parameters );
-			}
+			( (ParameterizedType) type ).setParameterValues( parameters == null ? EMPTY_PROPERTIES : parameters );
 		}
 		else if ( parameters != null && !parameters.isEmpty() ) {
 			MappingModelCreationLogger.LOGGER.debugf(

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -33,7 +33,7 @@ public class OneToMany implements Value {
 
 	public OneToMany(MetadataBuildingContext buildingContext, PersistentClass owner) throws MappingException {
 		this.buildingContext = buildingContext;
-		this.referencingTable = ( owner == null ) ? null : owner.getTable();
+		this.referencingTable = owner == null ? null : owner.getTable();
 	}
 
 	public MetadataBuildingContext getBuildingContext() {
@@ -74,6 +74,11 @@ public class OneToMany implements Value {
 		// no foreign key element for a one-to-many
 	}
 
+	@Override
+	public void createUniqueKey() {
+	}
+
+	@Deprecated
 	public Iterator<Selectable> getColumnIterator() {
 		return associatedClass.getKey().getColumnIterator();
 	}
@@ -81,6 +86,11 @@ public class OneToMany implements Value {
 	@Override
 	public List<Selectable> getSelectables() {
 		return associatedClass.getKey().getSelectables();
+	}
+
+	@Override
+	public List<Column> getColumns() {
+		return associatedClass.getKey().getColumns();
 	}
 
 	public int getColumnSpan() {
@@ -150,8 +160,8 @@ public class OneToMany implements Value {
 
 	public boolean isSame(OneToMany other) {
 		return Objects.equals( referencingTable, other.referencingTable )
-				&& Objects.equals( referencedEntityName, other.referencedEntityName )
-				&& Objects.equals( associatedClass, other.associatedClass );
+			&& Objects.equals( referencedEntityName, other.referencedEntityName )
+			&& Objects.equals( associatedClass, other.associatedClass );
 	}
 
 	public boolean[] getColumnInsertability() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -323,6 +323,9 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 	@Deprecated(since = "6.0")
 	public abstract Iterator<Property> getPropertyClosureIterator();
 
+	public abstract List<Table> getTableClosure();
+
+	@Deprecated(since = "6.0")
 	public abstract Iterator<Table> getTableClosureIterator();
 
 	public abstract Iterator<KeyValue> getKeyClosureIterator();
@@ -360,10 +363,20 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		return new JoinedList<>( lists );
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<Join> getSubclassJoinClosureIterator() {
 		return new JoinedIterator<>( getJoinClosureIterator(), subclassJoins.iterator() );
 	}
 
+	public List<Join> getSubclassJoinClosure() {
+		return new JoinedList<>( getJoinClosure(), subclassJoins );
+	}
+
+	public List<Table> getSubclassTableClosure() {
+		return new JoinedList<>( getTableClosure(), subclassTables );
+	}
+
+	@Deprecated(since = "6.0")
 	public Iterator<Table> getSubclassTableClosureIterator() {
 		return new JoinedIterator<>( getTableClosureIterator(), subclassTables.iterator() );
 	}
@@ -712,10 +725,20 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		return getClass().getName() + '(' + getEntityName() + ')';
 	}
 
+	public List<Join> getJoins() {
+		return joins;
+	}
+
+	public List<Join> getJoinClosure() {
+		return joins;
+	}
+
+	@Deprecated(since = "6.0")
 	public Iterator<Join> getJoinIterator() {
 		return joins.iterator();
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<Join> getJoinClosureIterator() {
 		return joins.iterator();
 	}
@@ -739,9 +762,7 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 
 	public int getJoinNumber(Property prop) {
 		int result = 1;
-		Iterator<Join> iter = getSubclassJoinClosureIterator();
-		while ( iter.hasNext() ) {
-			Join join = iter.next();
+		for ( Join join : getSubclassJoinClosure() ) {
 			if ( join.containsProperty( prop ) ) {
 				return result;
 			}
@@ -998,10 +1019,8 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		}
 		checkColumnDuplication( cols, getDiscriminator() );
 		checkPropertyColumnDuplication( cols, getNonDuplicatedProperties() );
-		Iterator<Join> iter = getJoinIterator();
-		while ( iter.hasNext() ) {
+		for ( Join join : getJoins() ) {
 			cols.clear();
-			Join join = iter.next();
 			checkColumnDuplication( cols, join.getKey() );
 			checkPropertyColumnDuplication( cols, join.getProperties() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
@@ -28,9 +28,7 @@ public class PrimaryKey extends Constraint {
 
 	@Override
 	public void addColumn(Column column) {
-		final Iterator<Column> columnIterator = getTable().getColumnIterator();
-		while ( columnIterator.hasNext() ) {
-			final Column next = columnIterator.next();
+		for ( Column next : getTable().getColumns() ) {
 			if ( next.getCanonicalName().equals( column.getCanonicalName() ) ) {
 				next.setNullable( false );
 				if ( log.isDebugEnabled() ) {
@@ -62,9 +60,9 @@ public class PrimaryKey extends Constraint {
 
 	public String sqlConstraintString(Dialect dialect) {
 		StringBuilder buf = new StringBuilder("primary key (");
-		Iterator iter = getColumnIterator();
+		Iterator<Column> iter = getColumnIterator();
 		while ( iter.hasNext() ) {
-			buf.append( ( (Column) iter.next() ).getQuotedName(dialect) );
+			buf.append( iter.next().getQuotedName(dialect) );
 			if ( iter.hasNext() ) {
 				buf.append(", ");
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -77,9 +77,29 @@ public class Property implements Serializable, MetaAttributable {
 	public int getColumnSpan() {
 		return value.getColumnSpan();
 	}
-	
+
+	/**
+	 * @deprecated moving away from the use of {@link Iterator} as a return type
+	 */
+	@Deprecated(since = "6.0")
 	public Iterator<Selectable> getColumnIterator() {
 		return value.getColumnIterator();
+	}
+
+	/**
+	 * Delegates to {@link Value#getSelectables()}.
+	 */
+	public java.util.List<Selectable> getSelectables() {
+		return value.getSelectables();
+	}
+
+	/**
+	 * Delegates to {@link Value#getColumns()}.
+	 *
+	 * @throws org.hibernate.AssertionFailure if the mapping involves formulas
+	 */
+	public java.util.List<Column> getColumns() {
+		return value.getColumns();
 	}
 	
 	public String getName() {
@@ -104,9 +124,7 @@ public class Property implements Serializable, MetaAttributable {
 
 	public void resetOptional(boolean optional) {
 		setOptional(optional);
-		Iterator<Selectable> columnIterator = getValue().getColumnIterator();
-		while ( columnIterator.hasNext() ) {
-			Selectable column = columnIterator.next();
+		for ( Selectable column: getValue().getSelectables() ) {
 			if (column instanceof Column) {
 				( (Column) column ).setNullable(optional);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -146,9 +146,14 @@ public class RootClass extends PersistentClass implements TableOwner {
 		return List.of( getTable() );
 	}
 
-	@Override
+	@Override @Deprecated
 	public Iterator<KeyValue> getKeyClosureIterator() {
 		return new SingletonIterator<>( getKey() );
+	}
+
+	@Override
+	public List<KeyValue> getKeyClosure() {
+		return List.of( getKey() );
 	}
 
 	@Override
@@ -351,9 +356,7 @@ public class RootClass extends PersistentClass implements TableOwner {
 
 	public Set<Table> getIdentityTables() {
 		Set<Table> tables = new HashSet<>();
-		Iterator<PersistentClass> iter = getSubclassClosureIterator();
-		while ( iter.hasNext() ) {
-			PersistentClass clazz = iter.next();
+		for ( PersistentClass clazz : getSubclassClosure() ) {
 			if ( clazz.isAbstract() == null || !clazz.isAbstract() ) {
 				tables.add( clazz.getIdentityTable() );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -136,9 +136,14 @@ public class RootClass extends PersistentClass implements TableOwner {
 		return getProperties();
 	}
 
-	@Override
+	@Override @Deprecated
 	public Iterator<Table> getTableClosureIterator() {
 		return new SingletonIterator<>( getTable() );
+	}
+
+	@Override
+	public List<Table> getTableClosure() {
+		return List.of( getTable() );
 	}
 
 	@Override
@@ -344,13 +349,12 @@ public class RootClass extends PersistentClass implements TableOwner {
 		return synchronizedTables;
 	}
 
-	@SuppressWarnings("UnnecessaryUnboxing")
 	public Set<Table> getIdentityTables() {
 		Set<Table> tables = new HashSet<>();
-		Iterator iter = getSubclassClosureIterator();
+		Iterator<PersistentClass> iter = getSubclassClosureIterator();
 		while ( iter.hasNext() ) {
-			PersistentClass clazz = (PersistentClass) iter.next();
-			if ( clazz.isAbstract() == null || !clazz.isAbstract().booleanValue() ) {
+			PersistentClass clazz = iter.next();
+			if ( clazz.isAbstract() == null || !clazz.isAbstract() ) {
 				tables.add( clazz.getIdentityTable() );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/RootClass.java
@@ -8,6 +8,7 @@ package org.hibernate.mapping;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.MappingException;
@@ -125,9 +126,14 @@ public class RootClass extends PersistentClass implements TableOwner {
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public Iterator<Property> getPropertyClosureIterator() {
 		return getPropertyIterator();
+	}
+
+	@Override
+	public List<Property> getPropertyClosure() {
+		return getProperties();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Set.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.mapping;
 
-import java.util.Iterator;
 import java.util.function.Supplier;
 
 import org.hibernate.MappingException;
@@ -71,10 +70,8 @@ public class Set extends Collection {
 	void createPrimaryKey() {
 		if ( !isOneToMany() ) {
 			PrimaryKey pk = new PrimaryKey( getCollectionTable() );
-			pk.addColumns( getKey().getColumnIterator() );
-			Iterator<?> iter = getElement().getColumnIterator();
-			while ( iter.hasNext() ) {
-				Object selectable = iter.next();
+			pk.addColumns( getKey() );
+			for ( Selectable selectable : getElement().getSelectables() ) {
 				if ( selectable instanceof Column ) {
 					Column col = (Column) selectable;
 					if ( !col.isNullable() ) {
@@ -85,18 +82,18 @@ public class Set extends Collection {
 					}
 				}
 			}
-			if ( pk.getColumnSpan() == getKey().getColumnSpan() ) {
+			if ( pk.getColumnSpan() != getKey().getColumnSpan() ) {
+				getCollectionTable().setPrimaryKey( pk );
+			}
+//			else {
 				//for backward compatibility, allow a set with no not-null
 				//element columns, using all columns in the row locator SQL
 				//TODO: create an implicit not null constraint on all cols?
-			}
-			else {
-				getCollectionTable().setPrimaryKey( pk );
-			}
+//			}
 		}
-		else {
+//		else {
 			//create an index on the key columns??
-		}
+//		}
 	}
 
 	public Object accept(ValueVisitor visitor) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -7,11 +7,13 @@
 package org.hibernate.mapping;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.collections.JoinedIterator;
+import org.hibernate.internal.util.collections.JoinedList;
 
 /**
  * @author Gavin King
@@ -22,7 +24,7 @@ public class SingleTableSubclass extends Subclass {
 		super( superclass, metadataBuildingContext );
 	}
 
-	@SuppressWarnings("unchecked")
+	@Deprecated
 	protected Iterator<Property> getNonDuplicatedPropertyIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getUnjoinedPropertyIterator(),
@@ -30,13 +32,14 @@ public class SingleTableSubclass extends Subclass {
 		);
 	}
 
+	protected List<Property> getNonDuplicatedProperties() {
+		return new JoinedList<>( getSuperclass().getUnjoinedProperties(), getUnjoinedProperties() );
+	}
+
 	protected Iterator<Selectable> getDiscriminatorColumnIterator() {
-		if ( isDiscriminatorInsertable() && !getDiscriminator().hasFormula() ) {
-			return getDiscriminator().getColumnIterator();
-		}
-		else {
-			return super.getDiscriminatorColumnIterator();
-		}
+		return isDiscriminatorInsertable() && !getDiscriminator().hasFormula()
+				? getDiscriminator().getColumnIterator()
+				: super.getDiscriminatorColumnIterator();
 	}
 
 	public Object accept(PersistentClassVisitor mv) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SingleTableSubclass.java
@@ -36,6 +36,7 @@ public class SingleTableSubclass extends Subclass {
 		return new JoinedList<>( getSuperclass().getUnjoinedProperties(), getUnjoinedProperties() );
 	}
 
+	@Deprecated
 	protected Iterator<Selectable> getDiscriminatorColumnIterator() {
 		return isDiscriminatorInsertable() && !getDiscriminator().hasFormula()
 				? getDiscriminator().getColumnIterator()

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SortableValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SortableValue.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.mapping;
 
-/**
- *
- */
 public interface SortableValue {
 
 	boolean isSorted();

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -155,12 +155,20 @@ public class Subclass extends PersistentClass {
 		);
 	}
 
-	@Override
+	@Override @Deprecated
 	public Iterator<KeyValue> getKeyClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getKeyClosureIterator(),
 				new SingletonIterator<>( getKey() )
 			);
+	}
+
+	@Override
+	public List<KeyValue> getKeyClosure() {
+		return new JoinedList<>(
+				getSuperclass().getKeyClosure(),
+				List.of( getKey() )
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -38,10 +38,12 @@ public class Subclass extends PersistentClass {
 		this.subclassId = superclass.nextSubclassId();
 	}
 
+	@Override
 	int nextSubclassId() {
 		return getSuperclass().nextSubclassId();
 	}
 
+	@Override
 	public int getSubclassId() {
 		return subclassId;
 	}
@@ -51,55 +53,74 @@ public class Subclass extends PersistentClass {
 		return getSuperclass().getNaturalIdCacheRegionName();
 	}
 
+	@Override
 	public String getCacheConcurrencyStrategy() {
 		return getRootClass().getCacheConcurrencyStrategy();
 	}
 
+	@Override
 	public RootClass getRootClass() {
 		return getSuperclass().getRootClass();
 	}
 
+	@Override
 	public PersistentClass getSuperclass() {
 		return superclass;
 	}
 
+	@Override
 	public Property getIdentifierProperty() {
 		return getSuperclass().getIdentifierProperty();
 	}
 
+	@Override
 	public Property getDeclaredIdentifierProperty() {
 		return null;
 	}
 
+	@Override
 	public KeyValue getIdentifier() {
 		return getSuperclass().getIdentifier();
 	}
+
+	@Override
 	public boolean hasIdentifierProperty() {
 		return getSuperclass().hasIdentifierProperty();
 	}
+
+	@Override
 	public Value getDiscriminator() {
 		return getSuperclass().getDiscriminator();
 	}
+
+	@Override
 	public boolean isMutable() {
 		return getSuperclass().isMutable();
 	}
+
+	@Override
 	public boolean isInherited() {
 		return true;
 	}
+
+	@Override
 	public boolean isPolymorphic() {
 		return true;
 	}
 
+	@Override
 	public void addProperty(Property p) {
 		super.addProperty(p);
 		getSuperclass().addSubclassProperty(p);
 	}
 
+	@Override
 	public void addMappedsuperclassProperty(Property p) {
 		super.addMappedsuperclassProperty( p );
 		getSuperclass().addSubclassProperty(p);
 	}
 
+	@Override
 	public void addJoin(Join j) {
 		super.addJoin(j);
 		getSuperclass().addSubclassJoin(j);
@@ -110,7 +131,7 @@ public class Subclass extends PersistentClass {
 		return new JoinedList<>( getSuperclass().getPropertyClosure(), getProperties() );
 	}
 
-	@Deprecated
+	@Deprecated @Override
 	public Iterator<Property> getPropertyClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getPropertyClosureIterator(),
@@ -118,60 +139,86 @@ public class Subclass extends PersistentClass {
 			);
 	}
 
+	@Deprecated @Override
 	public Iterator<Table> getTableClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getTableClosureIterator(),
 				new SingletonIterator<>( getTable() )
 			);
 	}
+
+	@Override
+	public List<Table> getTableClosure() {
+		return new JoinedList<>(
+				getSuperclass().getTableClosure(),
+				List.of( getTable() )
+		);
+	}
+
+	@Override
 	public Iterator<KeyValue> getKeyClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getKeyClosureIterator(),
 				new SingletonIterator<>( getKey() )
 			);
 	}
+
+	@Override
 	protected void addSubclassProperty(Property p) {
 		super.addSubclassProperty(p);
 		getSuperclass().addSubclassProperty(p);
 	}
+
+	@Override
 	protected void addSubclassJoin(Join j) {
 		super.addSubclassJoin(j);
 		getSuperclass().addSubclassJoin(j);
 	}
 
+	@Override
 	protected void addSubclassTable(Table table) {
 		super.addSubclassTable(table);
 		getSuperclass().addSubclassTable(table);
 	}
 
+	@Override
 	public boolean isVersioned() {
 		return getSuperclass().isVersioned();
 	}
+
+	@Override
 	public Property getVersion() {
 		return getSuperclass().getVersion();
 	}
 
+	@Override
 	public Property getDeclaredVersion() {
 		return null;
 	}
 
+	@Override
 	public boolean hasEmbeddedIdentifier() {
 		return getSuperclass().hasEmbeddedIdentifier();
 	}
+
+	@Override
 	public Class<? extends EntityPersister> getEntityPersisterClass() {
 		return classPersisterClass == null
 				? getSuperclass().getEntityPersisterClass()
 				: classPersisterClass;
 	}
 
+	@Override
 	public Table getRootTable() {
 		return getSuperclass().getRootTable();
 	}
 
+	@Override
 	public KeyValue getKey() {
 		return getSuperclass().getIdentifier();
 	}
 
+	@Override
 	public boolean isExplicitPolymorphism() {
 		return getSuperclass().isExplicitPolymorphism();
 	}
@@ -180,10 +227,12 @@ public class Subclass extends PersistentClass {
 		this.superclass = superclass;
 	}
 
+	@Override
 	public String getWhere() {
 		return getSuperclass().getWhere();
 	}
 
+	@Override
 	public boolean isJoinedSubclass() {
 		return getTable()!=getRootTable();
 	}
@@ -195,18 +244,28 @@ public class Subclass extends PersistentClass {
 		getKey().createForeignKeyOfEntity( getSuperclass().getEntityName() );
 	}
 
+	@Override
 	public void setEntityPersisterClass(Class<? extends EntityPersister> classPersisterClass) {
 		this.classPersisterClass = classPersisterClass;
 	}
 
+
+	@Override
 	public int getJoinClosureSpan() {
 		return getSuperclass().getJoinClosureSpan() + super.getJoinClosureSpan();
 	}
 
+	@Override
 	public int getPropertyClosureSpan() {
 		return getSuperclass().getPropertyClosureSpan() + super.getPropertyClosureSpan();
 	}
 
+	@Override
+	public List<Join> getJoinClosure() {
+		return new JoinedList<>( getSuperclass().getJoinClosure(), super.getJoinClosure() );
+	}
+
+	@Deprecated(since = "6.0")
 	public Iterator<Join> getJoinClosureIterator() {
 		return new JoinedIterator<>(
 			getSuperclass().getJoinClosureIterator(),
@@ -214,26 +273,33 @@ public class Subclass extends PersistentClass {
 		);
 	}
 
+
+	@Override
 	public boolean isClassOrSuperclassJoin(Join join) {
 		return super.isClassOrSuperclassJoin(join) || getSuperclass().isClassOrSuperclassJoin(join);
 	}
 
+	@Override
 	public boolean isClassOrSuperclassTable(Table table) {
 		return super.isClassOrSuperclassTable(table) || getSuperclass().isClassOrSuperclassTable(table);
 	}
 
+	@Override
 	public Table getTable() {
 		return getSuperclass().getTable();
 	}
 
+	@Override
 	public boolean isForceDiscriminator() {
 		return getSuperclass().isForceDiscriminator();
 	}
 
+	@Override
 	public boolean isDiscriminatorInsertable() {
 		return getSuperclass().isDiscriminatorInsertable();
 	}
 
+	@Override
 	public java.util.Set<String> getSynchronizedTables() {
 		HashSet<String> result = new HashSet<>();
 		result.addAll(synchronizedTables);
@@ -241,21 +307,25 @@ public class Subclass extends PersistentClass {
 		return result;
 	}
 
+	@Override
 	public Object accept(PersistentClassVisitor mv) {
 		return mv.accept(this);
 	}
 
+	@Override
 	public java.util.List<FilterConfiguration> getFilters() {
 		java.util.List<FilterConfiguration> filters = new ArrayList<>(super.getFilters());
 		filters.addAll(getSuperclass().getFilters());
 		return filters;
 	}
 
+	@Override
 	public boolean hasSubselectLoadableCollections() {
 		return super.hasSubselectLoadableCollections() ||
 			getSuperclass().hasSubselectLoadableCollections();
 	}
 
+	@Override
 	public String getTuplizerImplClassName(RepresentationMode mode) {
 		String impl = super.getTuplizerImplClassName( mode );
 		if ( impl == null ) {
@@ -264,6 +334,7 @@ public class Subclass extends PersistentClass {
 		return impl;
 	}
 
+	@Override
 	public Map getTuplizerMap() {
 		Map specificTuplizerDefs = super.getTuplizerMap();
 		Map superclassTuplizerDefs = getSuperclass().getTuplizerMap();
@@ -282,6 +353,7 @@ public class Subclass extends PersistentClass {
 		}
 	}
 
+	@Override
 	public Component getIdentifierMapper() {
 		return superclass.getIdentifierMapper();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Subclass.java
@@ -5,10 +5,12 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.mapping;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.hibernate.AssertionFailure;
@@ -16,6 +18,7 @@ import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.engine.OptimisticLockStyle;
 import org.hibernate.internal.FilterConfiguration;
 import org.hibernate.internal.util.collections.JoinedIterator;
+import org.hibernate.internal.util.collections.JoinedList;
 import org.hibernate.internal.util.collections.SingletonIterator;
 import org.hibernate.metamodel.RepresentationMode;
 import org.hibernate.persister.entity.EntityPersister;
@@ -102,12 +105,19 @@ public class Subclass extends PersistentClass {
 		getSuperclass().addSubclassJoin(j);
 	}
 
+	@Override
+	public List<Property> getPropertyClosure() {
+		return new JoinedList<>( getSuperclass().getPropertyClosure(), getProperties() );
+	}
+
+	@Deprecated
 	public Iterator<Property> getPropertyClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getPropertyClosureIterator(),
 				getPropertyIterator()
 			);
 	}
+
 	public Iterator<Table> getTableClosureIterator() {
 		return new JoinedIterator<>(
 				getSuperclass().getTableClosureIterator(),
@@ -149,12 +159,9 @@ public class Subclass extends PersistentClass {
 		return getSuperclass().hasEmbeddedIdentifier();
 	}
 	public Class<? extends EntityPersister> getEntityPersisterClass() {
-		if (classPersisterClass==null) {
-			return getSuperclass().getEntityPersisterClass();
-		}
-		else {
-			return classPersisterClass;
-		}
+		return classPersisterClass == null
+				? getSuperclass().getEntityPersisterClass()
+				: classPersisterClass;
 	}
 
 	public Table getRootTable() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -281,6 +281,7 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 		return columns.size();
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<Column> getColumnIterator() {
 		return columns.values().iterator();
 	}
@@ -293,6 +294,7 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 		return indexes.values().iterator();
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<ForeignKey> getForeignKeyIterator() {
 		return foreignKeys.values().iterator();
 	}
@@ -301,11 +303,12 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 		return Collections.unmodifiableMap( foreignKeys );
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<UniqueKey> getUniqueKeyIterator() {
 		return getUniqueKeys().values().iterator();
 	}
 
-	Map<String, UniqueKey> getUniqueKeys() {
+	public Map<String, UniqueKey> getUniqueKeys() {
 		cleanseUniqueKeyMapIfNeeded();
 		return uniqueKeys;
 	}
@@ -425,12 +428,12 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 				.append( ' ' )
 				.append( dialect.getAddColumnString() );
 
-		Iterator<Column> iter = getColumnIterator();
 		List<String> results = new ArrayList<>();
 
-		while ( iter.hasNext() ) {
-			final Column column = iter.next();
-			final ColumnInformation columnInfo = tableInfo.getColumn( Identifier.toIdentifier( column.getName(), column.isQuoted() ) );
+		for ( Column column : getColumns() ) {
+			final ColumnInformation columnInfo = tableInfo.getColumn(
+					Identifier.toIdentifier( column.getName(), column.isQuoted() )
+			);
 
 			if ( columnInfo == null ) {
 				// the column doesnt exist at all.
@@ -702,7 +705,7 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 				fk.addColumn( keyColumn );
 			}
 			if ( referencedColumns != null ) {
-				fk.addReferencedColumns( referencedColumns.iterator() );
+				fk.addReferencedColumns( referencedColumns );
 			}
 
 			// NOTE : if the name is null, we will generate an implicit name during second pass processing
@@ -811,8 +814,13 @@ public class Table implements RelationalModel, Serializable, ContributableDataba
 		this.comment = comment;
 	}
 
+	@Deprecated(since = "6.0")
 	public Iterator<String> getCheckConstraintsIterator() {
 		return checkConstraints.iterator();
+	}
+
+	public List<String> getCheckConstraints() {
+		return checkConstraints;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
@@ -12,8 +12,6 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.ReflectHelper;
-import org.hibernate.type.ComponentType;
-import org.hibernate.type.Type;
 
 import java.util.Objects;
 
@@ -43,9 +41,6 @@ public abstract class ToOne extends SimpleValue implements Fetchable, SortableVa
 	public void setFetchMode(FetchMode fetchMode) {
 		this.fetchMode=fetchMode;
 	}
-
-	public abstract void createForeignKey() throws MappingException;
-	public abstract Type getType() throws MappingException;
 
 	public String getReferencedPropertyName() {
 		return referencedPropertyName;
@@ -98,8 +93,8 @@ public abstract class ToOne extends SimpleValue implements Fetchable, SortableVa
 
 	public boolean isSame(ToOne other) {
 		return super.isSame( other )
-				&& Objects.equals( referencedPropertyName, other.referencedPropertyName )
-				&& Objects.equals( referencedEntityName, other.referencedEntityName );
+			&& Objects.equals( referencedPropertyName, other.referencedPropertyName )
+			&& Objects.equals( referencedEntityName, other.referencedEntityName );
 	}
 
 	public boolean isValid(Mapping mapping) throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UnionSubclass.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.mapping;
 import java.util.Iterator;
+import java.util.List;
 
 import org.hibernate.MappingException;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -35,9 +36,15 @@ public class UnionSubclass extends Subclass implements TableOwner {
 	public java.util.Set<String> getSynchronizedTables() {
 		return synchronizedTables;
 	}
-	
+
+	@Deprecated
 	protected Iterator<Property> getNonDuplicatedPropertyIterator() {
 		return getPropertyClosureIterator();
+	}
+
+	@Override
+	protected List<Property> getNonDuplicatedProperties() {
+		return getPropertyClosure();
 	}
 
 	public void validate(Mapping mapping) throws MappingException {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
@@ -17,8 +17,8 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
 /**
- * A value is anything that is persisted by value, instead of
- * by reference. It is essentially a Hibernate Type, together
+ * A value is anything that is persisted by value, instead of by
+ * reference. It is essentially a Hibernate {@link Type}, together
  * with zero or more columns. Values are wrapped by things with
  * higher level semantics, for example properties, collections,
  * classes.
@@ -26,20 +26,71 @@ import org.hibernate.type.Type;
  * @author Gavin King
  */
 public interface Value extends Serializable {
+
+	/**
+	 * The number of columns and formulas in the mapping.
+	 */
 	int getColumnSpan();
+
+	/**
+	 * @deprecated moving away from the use of {@link Iterator} as a return type
+	 */
+	@Deprecated(since = "6.0")
 	Iterator<Selectable> getColumnIterator();
+
+	/**
+	 * The mapping to columns and formulas.
+	 */
 	List<Selectable> getSelectables();
+
+	/**
+	 * If the mapping involves only columns, return them.
+	 *
+	 * @throws org.hibernate.AssertionFailure if the mapping involves formulas
+	 */
+	List<Column> getColumns();
+
+	/**
+	 * Same as {@link #getSelectables()} except it returns the PK for the
+	 * non-owning side of a one-to-one association.
+	 */
+	default List<Selectable> getVirtualSelectables() {
+		return getSelectables();
+	}
+
+	/**
+	 * Same as {@link #getColumns()} except it returns the PK for the
+	 * non-owning side of a one-to-one association.
+	 *
+	 * @throws org.hibernate.AssertionFailure if the mapping involves formulas
+	 */
+	default List<Column> getConstraintColumns() {
+		return getColumns();
+	}
+
 	Type getType() throws MappingException;
+
 	FetchMode getFetchMode();
+
 	Table getTable();
+
 	boolean hasFormula();
+
 	boolean isAlternateUniqueKey();
+
 	boolean isNullable();
-	void createForeignKey() throws MappingException;
+
+	void createForeignKey();
+	void createUniqueKey();
+
 	boolean isSimpleValue();
+
 	boolean isValid(Mapping mapping) throws MappingException;
+
 	void setTypeUsingReflection(String className, String propertyName) throws MappingException;
+
 	Object accept(ValueVisitor visitor);
+
 	boolean isSame(Value other);
 
 	boolean[] getColumnInsertability();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEmbeddableRepresentationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEmbeddableRepresentationStrategy.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.metamodel.internal;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -40,14 +39,12 @@ public abstract class AbstractEmbeddableRepresentationStrategy implements Embedd
 		this.attributeNameToPositionMap = new ConcurrentHashMap<>( propertySpan );
 
 		boolean foundCustomAccessor = false;
-		Iterator itr = bootDescriptor.getPropertyIterator();
 		int i = 0;
-		while ( itr.hasNext() ) {
-			final Property prop = ( Property ) itr.next();
-			propertyAccesses[i] = buildPropertyAccess( prop );
-			attributeNameToPositionMap.put( prop.getName(), i );
+		for ( Property property : bootDescriptor.getProperties() ) {
+			propertyAccesses[i] = buildPropertyAccess( property );
+			attributeNameToPositionMap.put( property.getName(), i );
 
-			if ( !prop.isBasicPropertyAccessor() ) {
+			if ( !property.isBasicPropertyAccessor() ) {
 				foundCustomAccessor = true;
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -251,7 +251,8 @@ public class AttributeFactory {
 				else {
 					// we should have a non-dynamic embeddable
 					assert component.getComponentClassName() != null;
-					final Class<Y> embeddableClass = component.getComponentClass();
+					@SuppressWarnings("unchecked")
+					final Class<Y> embeddableClass = (Class<Y>) component.getComponentClass();
 
 					final EmbeddableDomainType<Y> cached = context.locateEmbeddable( embeddableClass, component );
 					if ( cached != null ) {
@@ -274,9 +275,7 @@ public class AttributeFactory {
 				}
 
 				final EmbeddableTypeImpl.InFlightAccess<Y> inFlightAccess = embeddableType.getInFlightAccess();
-				final Iterator<Property> subProperties = component.getPropertyIterator();
-				while ( subProperties.hasNext() ) {
-					final Property property = subProperties.next();
+				for ( Property property : component.getProperties() ) {
 					final PersistentAttribute<Y, Y> attribute = buildAttribute( embeddableType, property, context );
 					if ( attribute != null ) {
 						inFlightAccess.addAttribute( attribute );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorDynamicMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorDynamicMap.java
@@ -32,9 +32,7 @@ public class EntityInstantiatorDynamicMap
 
 		entityRoleNames.add( getRoleName() );
 		if ( bootDescriptor.hasSubclasses() ) {
-			final Iterator<PersistentClass> itr = bootDescriptor.getSubclassClosureIterator();
-			while ( itr.hasNext() ) {
-				final PersistentClass subclassInfo = itr.next();
+			for ( PersistentClass subclassInfo : bootDescriptor.getSubclassClosure() ) {
 				entityRoleNames.add( subclassInfo.getEntityName() );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -113,7 +113,8 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 				if ( bootDescriptor.getIdentifierMapper() != null ) {
 					mapsIdRepresentationStrategy = new EmbeddableRepresentationStrategyPojo(
 							bootDescriptor.getIdentifierMapper(),
-							() -> ( ( CompositeTypeImplementor) bootDescriptor.getIdentifierMapper().getType() ).getMappingModelPart().getEmbeddableTypeDescriptor(),
+							() -> ( ( CompositeTypeImplementor) bootDescriptor.getIdentifierMapper().getType() )
+									.getMappingModelPart().getEmbeddableTypeDescriptor(),
 							// we currently do not support custom instantiators for identifiers
 							null,
 							creationContext
@@ -122,7 +123,8 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 				else if ( bootDescriptorIdentifier != null ) {
 					mapsIdRepresentationStrategy = new EmbeddableRepresentationStrategyPojo(
 							(Component) bootDescriptorIdentifier,
-							() -> ( ( CompositeTypeImplementor) bootDescriptor.getIdentifierMapper().getType() ).getMappingModelPart().getEmbeddableTypeDescriptor(),
+							() -> ( ( CompositeTypeImplementor) bootDescriptor.getIdentifierMapper().getType() )
+									.getMappingModelPart().getEmbeddableTypeDescriptor(),
 							// we currently do not support custom instantiators for identifiers
 							null,
 							creationContext
@@ -223,14 +225,11 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 
 		proxyInterfaces.add( HibernateProxy.class );
 
-		Iterator<?> properties = bootDescriptor.getPropertyIterator();
 		Class<?> clazz = bootDescriptor.getMappedClass();
 		final Method idGetterMethod;
 		final Method idSetterMethod;
-
 		try {
-			while ( properties.hasNext() ) {
-				Property property = (Property) properties.next();
+			for ( Property property : bootDescriptor.getProperties() ) {
 				ProxyFactoryHelper.validateGetterSetterMethodProxyability(
 						"Getter",
 						property.getGetter( clazz ).getMethod()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -208,9 +208,7 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 			proxyInterfaces.add( mappedClass );
 		}
 
-		final Iterator<Subclass> subclasses = bootDescriptor.getSubclassIterator();
-		while ( subclasses.hasNext() ) {
-			final Subclass subclass = subclasses.next();
+		for ( Subclass subclass : bootDescriptor.getSubclasses() ) {
 			final Class<?> subclassProxy = subclass.getProxyInterface();
 			final Class<?> subclassClass = subclass.getMappedClass();
 			if ( subclassProxy != null && !subclassClass.equals( subclassProxy ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -273,9 +272,7 @@ public class MetadataContext {
 					applyIdMetadata( safeMapping, jpaMapping );
 					applyVersionAttribute( safeMapping, jpaMapping );
 
-					Iterator<Property> properties = safeMapping.getDeclaredPropertyIterator();
-					while ( properties.hasNext() ) {
-						final Property property = properties.next();
+					for ( Property property : safeMapping.getDeclaredProperties() ) {
 						if ( property.getValue() == safeMapping.getIdentifierMapper() ) {
 							// property represents special handling for id-class mappings but we have already
 							// accounted for the embedded property mappings in #applyIdMetadata &&
@@ -324,9 +321,7 @@ public class MetadataContext {
 					applyVersionAttribute( safeMapping, jpaType );
 //					applyNaturalIdAttribute( safeMapping, jpaType );
 
-					Iterator<Property> properties = safeMapping.getDeclaredPropertyIterator();
-					while ( properties.hasNext() ) {
-						final Property property = properties.next();
+					for ( Property property : safeMapping.getDeclaredProperties() ) {
 						if ( safeMapping.isVersioned() && property == safeMapping.getVersion() ) {
 							// skip the version property, it was already handled previously.
 							continue;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -7,7 +7,6 @@
 package org.hibernate.metamodel.mapping.internal;
 
 import java.io.Serializable;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -152,9 +151,7 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 		int attributeIndex = 0;
 		int columnPosition = 0;
 
-		final Iterator<Property> propertyIterator = bootDescriptor.getPropertyIterator();
-		while ( propertyIterator.hasNext() ) {
-			final Property bootPropertyDescriptor = propertyIterator.next();
+		for ( Property bootPropertyDescriptor : bootDescriptor.getProperties() ) {
 			final Type subtype = subtypes[ attributeIndex ];
 
 			attributeTypeValidator.check( bootPropertyDescriptor.getName(), subtype );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -292,9 +292,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		// Reset the attribute mappings that were added in previous attempts
 		this.attributeMappings.clear();
 
-		final Iterator<Property> propertyIterator = bootDescriptor.getPropertyIterator();
-		while ( propertyIterator.hasNext() ) {
-			final Property bootPropertyDescriptor = propertyIterator.next();
+		for ( Property bootPropertyDescriptor : bootDescriptor.getProperties() ) {
 			final AttributeMapping attributeMapping;
 
 			final Type subtype = subtypes[attributeIndex];

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityCollectionPart.java
@@ -286,7 +286,7 @@ public class EntityCollectionPart
 			final BasicValuedModelPart basicFkTargetPart = (BasicValuedModelPart) fkTargetPart;
 			final SelectableMapping keySelectableMapping = SelectableMappingImpl.from(
 					fkKeyTableName,
-					fkBootDescriptorSource.getColumnIterator().next(),
+					fkBootDescriptorSource.getSelectables().get(0),
 					basicFkTargetPart.getJdbcMapping(),
 					dialect,
 					creationProcess.getSqmFunctionRegistry()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
@@ -580,7 +580,7 @@ public class MappingModelCreationHelper {
 				final BasicValue index = (BasicValue) ( (IndexedCollection) bootValueMapping ).getIndex();
 				final SelectableMapping selectableMapping = SelectableMappingImpl.from(
 						tableExpression,
-						index.getColumnIterator().next(),
+						index.getSelectables().get(0),
 						creationContext.getTypeConfiguration().getBasicTypeForJavaType( Integer.class ),
 						dialect,
 						creationProcess.getSqmFunctionRegistry()
@@ -631,7 +631,7 @@ public class MappingModelCreationHelper {
 				final BasicValue index = (BasicValue) ( (IndexedCollection) bootValueMapping ).getIndex();
 				final SelectableMapping selectableMapping = SelectableMappingImpl.from(
 						tableExpression,
-						index.getColumnIterator().next(),
+						index.getSelectables().get(0),
 						creationContext.getTypeConfiguration().getBasicTypeForJavaType( Integer.class ),
 						dialect,
 						creationProcess.getSqmFunctionRegistry()
@@ -858,7 +858,7 @@ public class MappingModelCreationHelper {
 			final String tableExpression = getTableIdentifierExpression( bootValueMappingKey.getTable(), creationProcess );
 			final SelectableMapping keySelectableMapping = SelectableMappingImpl.from(
 					tableExpression,
-					bootValueMappingKey.getColumnIterator().next(),
+					bootValueMappingKey.getSelectables().get(0),
 					(JdbcMapping) keyType,
 					dialect,
 					creationProcess.getSqmFunctionRegistry()
@@ -1320,7 +1320,7 @@ public class MappingModelCreationHelper {
 			final BasicValue basicValue = (BasicValue) bootMapKeyDescriptor;
 			final SelectableMapping selectableMapping = SelectableMappingImpl.from(
 					tableExpression,
-					basicValue.getColumnIterator().next(),
+					basicValue.getSelectables().get(0),
 					basicValue.resolve().getJdbcMapping(),
 					dialect,
 					creationProcess.getSqmFunctionRegistry()
@@ -1403,7 +1403,7 @@ public class MappingModelCreationHelper {
 			final BasicValue basicElement = (BasicValue) element;
 			final SelectableMapping selectableMapping = SelectableMappingImpl.from(
 					tableExpression,
-					basicElement.getColumnIterator().next(),
+					basicElement.getSelectables().get(0),
 					basicElement.resolve().getJdbcMapping(),
 					dialect,
 					creationProcess.getSqmFunctionRegistry()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SelectableMappingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SelectableMappingsImpl.java
@@ -64,13 +64,13 @@ public class SelectableMappingsImpl implements SelectableMappings {
 		final List<JdbcMapping> jdbcMappings = new ArrayList<>();
 		resolveJdbcMappings( jdbcMappings, mapping, value.getType() );
 
-		final List<Selectable> constraintColumns = value.getSelectables();
+		final List<Selectable> selectables = value.getVirtualSelectables();
 
 		final SelectableMapping[] selectableMappings = new SelectableMapping[jdbcMappings.size()];
-		for ( int i = 0; i < constraintColumns.size(); i++ ) {
+		for ( int i = 0; i < selectables.size(); i++ ) {
 			selectableMappings[propertyOrder[i]] = SelectableMappingImpl.from(
 					containingTableExpression,
-					constraintColumns.get( i ),
+					selectables.get( i ),
 					jdbcMappings.get( propertyOrder[i] ),
 					dialect,
 					sqmFunctionRegistry
@@ -85,13 +85,9 @@ public class SelectableMappingsImpl implements SelectableMappings {
 		final List<SelectableMapping> selectableMappings = CollectionHelper.arrayList( propertySpan );
 
 		embeddableMappingType.forEachAttributeMapping(
-				(index, attributeMapping) -> {
-					attributeMapping.forEachSelectable(
-							(columnIndex, selection) -> {
-								selectableMappings.add( selection );
-							}
-					);
-				}
+				(index, attributeMapping) -> attributeMapping.forEachSelectable(
+						(columnIndex, selection) -> selectableMappings.add( selection )
+				)
 		);
 
 		return new SelectableMappingsImpl( selectableMappings.toArray( new SelectableMapping[0] ) );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -229,7 +229,7 @@ public class ToOneAttributeMapping
 						if ( join.getPersistentClass().getEntityName().equals( entityBinding.getEntityName() )
 								&& join.getPropertySpan() == 1
 								&& join.getTable() == manyToOne.getTable()
-								&& equal( join.getKey().getColumnIterator(), manyToOne.getColumnIterator() ) ) {
+								&& equal( join.getKey(), manyToOne ) ) {
 							bidirectionalAttributeName = join.getPropertyIterator().next().getName();
 							break;
 						}
@@ -503,7 +503,9 @@ public class ToOneAttributeMapping
 		this.isConstrained = original.isConstrained;
 	}
 
-	private static boolean equal(Iterator<Selectable> lhsColumns, Iterator<Selectable> rhsColumns) {
+	private static boolean equal(Value lhsValue, Value rhsValue) {
+		Iterator<Selectable> lhsColumns = lhsValue.getColumnIterator();
+		Iterator<Selectable> rhsColumns = rhsValue.getColumnIterator();
 		boolean hasNext;
 		do {
 			final Selectable lhs = lhsColumns.next();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -223,9 +223,7 @@ public class ToOneAttributeMapping
 						.getEntityBinding( manyToOne.getReferencedEntityName() );
 				if ( cardinality == Cardinality.LOGICAL_ONE_TO_ONE ) {
 					// Handle join table cases
-					final Iterator<Join> joinClosureIterator = entityBinding.getJoinClosureIterator();
-					while ( joinClosureIterator.hasNext() ) {
-						final Join join = joinClosureIterator.next();
+					for ( Join join : entityBinding.getJoinClosure() ) {
 						if ( join.getPersistentClass().getEntityName().equals( entityBinding.getEntityName() )
 								&& join.getPropertySpan() == 1
 								&& join.getTable() == manyToOne.getTable()

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -358,14 +358,12 @@ public abstract class AbstractCollectionPersister
 		// KEY
 
 		keyType = collectionBootDescriptor.getKey().getType();
-		Iterator<Selectable> columnIter = collectionBootDescriptor.getKey().getColumnIterator();
 		int keySpan = collectionBootDescriptor.getKey().getColumnSpan();
 		keyColumnNames = new String[keySpan];
 		keyColumnAliases = new String[keySpan];
 		int k = 0;
-		while ( columnIter.hasNext() ) {
+		for ( Column column: collectionBootDescriptor.getKey().getColumns() ) {
 			// NativeSQL: collect key column and auto-aliases
-			Column column = (Column) columnIter.next();
 			keyColumnNames[k] = column.getQuotedName( dialect );
 			keyColumnAliases[k] = column.getAlias( dialect, table );
 			k++;
@@ -404,9 +402,7 @@ public abstract class AbstractCollectionPersister
 			columnInsertability = elementBootDescriptor.getColumnInsertability();
 		}
 		int j = 0;
-		columnIter = elementBootDescriptor.getColumnIterator();
-		while ( columnIter.hasNext() ) {
-			Selectable selectable = columnIter.next();
+		for ( Selectable selectable: elementBootDescriptor.getSelectables() ) {
 			elementColumnAliases[j] = selectable.getAlias( dialect, table );
 			if ( selectable.isFormula() ) {
 				Formula form = (Formula) selectable;
@@ -455,7 +451,6 @@ public abstract class AbstractCollectionPersister
 			int indexSpan = indexedCollection.getIndex().getColumnSpan();
 			boolean[] indexColumnInsertability = indexedCollection.getIndex().getColumnInsertability();
 			boolean[] indexColumnUpdatability = indexedCollection.getIndex().getColumnUpdateability();
-			columnIter = indexedCollection.getIndex().getColumnIterator();
 			indexColumnNames = new String[indexSpan];
 			indexFormulaTemplates = new String[indexSpan];
 			indexFormulas = new String[indexSpan];
@@ -464,8 +459,7 @@ public abstract class AbstractCollectionPersister
 			indexColumnAliases = new String[indexSpan];
 			int i = 0;
 			boolean hasFormula = false;
-			while ( columnIter.hasNext() ) {
-				Selectable s = columnIter.next();
+			for ( Selectable s: indexedCollection.getIndex().getSelectables() ) {
 				indexColumnAliases[i] = s.getAlias( dialect );
 				if ( s.isFormula() ) {
 					Formula indexForm = (Formula) s;
@@ -516,8 +510,7 @@ public abstract class AbstractCollectionPersister
 			}
 			IdentifierCollection idColl = (IdentifierCollection) collectionBootDescriptor;
 			identifierType = idColl.getIdentifier().getType();
-			columnIter = idColl.getIdentifier().getColumnIterator();
-			Column col = (Column) columnIter.next();
+			Column col = idColl.getIdentifier().getColumns().get(0);
 			identifierColumnName = col.getQuotedName( dialect );
 			identifierColumnAlias = col.getAlias( dialect );
 			identifierGenerator = idColl.getIdentifier().createIdentifierGenerator(

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1155,9 +1155,7 @@ public abstract class AbstractEntityPersister
 			return true;
 		}
 
-		final Iterator<Subclass> subclassIterator = persistentClass.getSubclassIterator();
-		while ( subclassIterator.hasNext() ) {
-			final Subclass subclass = subclassIterator.next();
+		for ( Subclass subclass : persistentClass.getSubclasses() ) {
 			if ( subclass.isCached() ) {
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -282,10 +282,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		isNullableTable = new boolean[tableSpan];
 		isInverseTable = new boolean[tableSpan];
 
-		Iterator<Join> joinItr = persistentClass.getJoinClosureIterator();
-		for ( int tableIndex = 0; joinItr.hasNext(); tableIndex++ ) {
-			Join join = joinItr.next();
-
+		int tableIndex = 0;
+		for ( Join join : persistentClass.getJoinClosure() ) {
 			isNullableTable[tableIndex] = join.isOptional();
 			isInverseTable[tableIndex] = join.isInverse();
 
@@ -311,6 +309,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			keyColumnReaders.add( keyColReaders );
 			keyColumnReaderTemplates.add( keyColReaderTemplates );
 			cascadeDeletes.add( key.isCascadeDeleteEnabled() && factory.getJdbcServices().getDialect().supportsCascadeDelete() );
+
+			tableIndex++;
 		}
 
 		naturalOrderTableNames = ArrayHelper.toStringArray( tableNames );
@@ -327,18 +327,16 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		ArrayList<Boolean> isNullables = new ArrayList<>();
 
 		keyColumns = new ArrayList<>();
-		tItr = persistentClass.getSubclassTableClosureIterator();
-		while ( tItr.hasNext() ) {
-			Table tab = tItr.next();
-			isConcretes.add( persistentClass.isClassOrSuperclassTable( tab ) );
+		for ( Table table : persistentClass.getSubclassTableClosure() ) {
+			isConcretes.add( persistentClass.isClassOrSuperclassTable( table ) );
 			isDeferreds.add( Boolean.FALSE );
 			isLazies.add( Boolean.FALSE );
 			isInverses.add( Boolean.FALSE );
 			isNullables.add( Boolean.FALSE );
-			final String tableName = determineTableName( tab );
+			final String tableName = determineTableName( table );
 			subclassTableNames.add( tableName );
 			String[] key = new String[idColumnSpan];
-			List<Column> columns = tab.getPrimaryKey().getColumns();
+			List<Column> columns = table.getPrimaryKey().getColumns();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
 				key[k] = columns.get(k).getQuotedName( factory.getJdbcServices().getDialect() );
 			}
@@ -346,9 +344,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 
 		//Add joins
-		joinItr = persistentClass.getSubclassJoinClosureIterator();
-		while ( joinItr.hasNext() ) {
-			final Join join = joinItr.next();
+		for ( Join join : persistentClass.getSubclassJoinClosure() ) {
 			final Table joinTable = join.getTable();
 
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( joinTable ) );
@@ -446,11 +442,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			throw new AssertionFailure( "Tablespan does not match height of joined-subclass hiearchy." );
 		}
 
-		joinItr = persistentClass.getJoinClosureIterator();
 		int j = coreTableSpan;
-		while ( joinItr.hasNext() ) {
-			Join join = joinItr.next();
-
+		for ( Join join : persistentClass.getJoinClosure() ) {
 			isInverseTable[j] = join.isInverse();
 			isNullableTable[j] = join.isOptional();
 
@@ -746,9 +739,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		associateSubclassNamesToSubclassTableIndex( tableName, classNames, mapping );
 
-		Iterator<Join> itr = persistentClass.getJoinIterator();
-		while ( itr.hasNext() ) {
-			final Join join = itr.next();
+		for ( Join join : persistentClass.getJoins() ) {
 			final String secondaryTableName = join.getTable().getQualifiedName(
 					factory.getSqlStringGenerationContext()
 			);

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -9,7 +9,6 @@ package org.hibernate.persister.entity;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -412,23 +411,21 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 		// SUBCLASSES
 		if ( persistentClass.isPolymorphic() ) {
-			Iterator<Subclass> subclasses = persistentClass.getSubclassIterator();
 			int k = 1;
-			while ( subclasses.hasNext() ) {
-				Subclass sc = subclasses.next();
-				subclassClosure[k++] = sc.getEntityName();
-				if ( sc.isDiscriminatorValueNull() ) {
-					addSubclassByDiscriminatorValue( subclassesByDiscriminatorValueLocal, NULL_DISCRIMINATOR, sc.getEntityName() );
+			for ( Subclass subclass : persistentClass.getSubclasses() ) {
+				subclassClosure[k++] = subclass.getEntityName();
+				if ( subclass.isDiscriminatorValueNull() ) {
+					addSubclassByDiscriminatorValue( subclassesByDiscriminatorValueLocal, NULL_DISCRIMINATOR, subclass.getEntityName() );
 				}
-				else if ( sc.isDiscriminatorValueNotNull() ) {
-					addSubclassByDiscriminatorValue( subclassesByDiscriminatorValueLocal, NOT_NULL_DISCRIMINATOR, sc.getEntityName() );
+				else if ( subclass.isDiscriminatorValueNotNull() ) {
+					addSubclassByDiscriminatorValue( subclassesByDiscriminatorValueLocal, NOT_NULL_DISCRIMINATOR, subclass.getEntityName() );
 				}
 				else {
 					try {
 						addSubclassByDiscriminatorValue(
 								subclassesByDiscriminatorValueLocal,
-								discriminatorType.getJavaTypeDescriptor().fromString( sc.getDiscriminatorValue() ),
-								sc.getEntityName()
+								discriminatorType.getJavaTypeDescriptor().fromString( subclass.getDiscriminatorValue() ),
+								subclass.getEntityName()
 						);
 					}
 					catch (ClassCastException cce) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -187,11 +187,9 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 		// JOINS
 
-		Iterator<Join> joinIter = persistentClass.getJoinClosureIterator();
 		int j = 1;
 		final Dialect dialect = factory.getJdbcServices().getDialect();
-		while ( joinIter.hasNext() ) {
-			Join join = joinIter.next();
+		for ( Join join : persistentClass.getJoinClosure() ) {
 			qualifiedTableNames[j] = determineTableName( join.getTable() );
 			isInverseTable[j] = join.isInverse();
 			isNullableTable[j] = join.isOptional();
@@ -253,9 +251,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		isInverses.add( Boolean.FALSE );
 		isNullables.add( Boolean.FALSE );
 		isLazies.add( Boolean.FALSE );
-		joinIter = persistentClass.getSubclassJoinClosureIterator();
-		while ( joinIter.hasNext() ) {
-			Join join = joinIter.next();
+		for ( Join join : persistentClass.getSubclassJoinClosure() ) {
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( join.getTable() ) );
 			isClassOrSuperclassJoins.add( persistentClass.isClassOrSuperclassJoin( join ) );
 			isInverses.add( join.isInverse() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -217,9 +217,9 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 					final String tableName = determineTableName( tab );
 					tableNames.add( tableName );
 					String[] key = new String[idColumnSpan];
-					Iterator<Column> citer = tab.getPrimaryKey().getColumnIterator();
+					List<Column> columns = tab.getPrimaryKey().getColumns();
 					for ( int k = 0; k < idColumnSpan; k++ ) {
-						key[k] = citer.next().getQuotedName( factory.getJdbcServices().getDialect() );
+						key[k] = columns.get(k).getQuotedName( factory.getJdbcServices().getDialect() );
 					}
 					keyColumns.add( key );
 				}
@@ -473,9 +473,8 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		while ( titer.hasNext() ) {
 			Table table = titer.next();
 			if ( !table.isAbstractUnionTable() ) {
-				Iterator<Column> citer = table.getColumnIterator();
-				while ( citer.hasNext() ) {
-					columns.add( citer.next() );
+				for ( Column column : table.getColumns() ) {
+					columns.add( column );
 				}
 			}
 		}
@@ -483,7 +482,6 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		StringBuilder buf = new StringBuilder()
 				.append( "( " );
 
-		@SuppressWarnings("unchecked")
 		Iterator<PersistentClass> siter = new JoinedIterator<>(
 				new SingletonIterator<>( model ),
 				model.getSubclassIterator()

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -182,9 +182,8 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		}
 
 		HashSet<String> subclassTables = new HashSet<>();
-		Iterator<Table> subclassTableIter = persistentClass.getSubclassTableClosureIterator();
-		while ( subclassTableIter.hasNext() ) {
-			subclassTables.add( determineTableName( subclassTableIter.next() ) );
+		for ( Table table : persistentClass.getSubclassTableClosure() ) {
+			subclassTables.add( determineTableName( table ) );
 		}
 		subclassSpaces = ArrayHelper.toStringArray( subclassTables );
 
@@ -210,14 +209,12 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			int idColumnSpan = getIdentifierColumnSpan();
 			ArrayList<String> tableNames = new ArrayList<>();
 			ArrayList<String[]> keyColumns = new ArrayList<>();
-			Iterator<Table> tableIter = persistentClass.getSubclassTableClosureIterator();
-			while ( tableIter.hasNext() ) {
-				Table tab = tableIter.next();
-				if ( !tab.isAbstractUnionTable() ) {
-					final String tableName = determineTableName( tab );
+			for ( Table table : persistentClass.getSubclassTableClosure() ) {
+				if ( !table.isAbstractUnionTable() ) {
+					final String tableName = determineTableName( table );
 					tableNames.add( tableName );
 					String[] key = new String[idColumnSpan];
-					List<Column> columns = tab.getPrimaryKey().getColumns();
+					List<Column> columns = table.getPrimaryKey().getColumns();
 					for ( int k = 0; k < idColumnSpan; k++ ) {
 						key[k] = columns.get(k).getQuotedName( factory.getJdbcServices().getDialect() );
 					}
@@ -468,14 +465,10 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			);
 		}
 
-		HashSet<Column> columns = new LinkedHashSet<>();
-		Iterator<Table> titer = model.getSubclassTableClosureIterator();
-		while ( titer.hasNext() ) {
-			Table table = titer.next();
+		Set<Column> columns = new LinkedHashSet<>();
+		for ( Table table : model.getSubclassTableClosure() ) {
 			if ( !table.isAbstractUnionTable() ) {
-				for ( Column column : table.getColumns() ) {
-					columns.add( column );
-				}
+				columns.addAll( table.getColumns() );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/internal/StandardPersisterClassResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/internal/StandardPersisterClassResolver.java
@@ -28,29 +28,30 @@ import org.hibernate.persister.spi.UnknownPersisterException;
 public class StandardPersisterClassResolver implements PersisterClassResolver {
 
 	@Override
-	public Class<? extends EntityPersister> getEntityPersisterClass(PersistentClass metadata) {
-		// todo : make sure this is based on an attribute kept on the metamodel in the new code, not the concrete PersistentClass impl found!
-		if ( RootClass.class.isInstance( metadata ) ) {
-			if ( metadata.hasSubclasses() ) {
+	public Class<? extends EntityPersister> getEntityPersisterClass(PersistentClass model) {
+		// todo : make sure this is based on an attribute kept on the metamodel in the new code,
+		//        not the concrete PersistentClass impl found!
+		if ( model instanceof RootClass ) {
+			if ( model.hasSubclasses() ) {
 				//If the class has children, we need to find of which kind
-				metadata = (PersistentClass) metadata.getDirectSubclasses().next();
+				model = model.getDirectSubclasses().get(0);
 			}
 			else {
 				return singleTableEntityPersister();
 			}
 		}
-		if ( JoinedSubclass.class.isInstance( metadata ) ) {
+		if ( model instanceof JoinedSubclass ) {
 			return joinedSubclassEntityPersister();
 		}
-		else if ( UnionSubclass.class.isInstance( metadata ) ) {
+		else if ( model instanceof UnionSubclass ) {
 			return unionSubclassEntityPersister();
 		}
-		else if ( SingleTableSubclass.class.isInstance( metadata ) ) {
+		else if ( model instanceof SingleTableSubclass ) {
 			return singleTableEntityPersister();
 		}
 		else {
 			throw new UnknownPersisterException(
-					"Could not determine persister implementation for entity [" + metadata.getEntityName() + "]"
+					"Could not determine persister implementation for entity [" + model.getEntityName() + "]"
 			);
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
@@ -8,7 +8,6 @@ package org.hibernate.proxy.pojo;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
@@ -51,9 +50,7 @@ public final class ProxyFactoryHelper {
 			proxyInterfaces.add( mappedClass );
 		}
 
-		Iterator<Subclass> subclasses = persistentClass.getSubclassIterator();
-		while ( subclasses.hasNext() ) {
-			final Subclass subclass = subclasses.next();
+		for ( Subclass subclass : persistentClass.getSubclasses() ) {
 			final Class<?> subclassProxy = subclass.getProxyInterface();
 			final Class<?> subclassClass = subclass.getMappedClass();
 			if ( subclassProxy != null && !subclassClass.equals( subclassProxy ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/ProxyFactoryHelper.java
@@ -71,10 +71,8 @@ public final class ProxyFactoryHelper {
 	}
 
 	public static void validateProxyability(final PersistentClass persistentClass) {
-		Iterator<?> properties = persistentClass.getPropertyIterator();
 		Class<?> clazz = persistentClass.getMappedClass();
-		while ( properties.hasNext() ) {
-			Property property = (Property) properties.next();
+		for ( Property property : persistentClass.getProperties() ) {
 			validateGetterSetterMethodProxyability( "Getter", property.getGetter( clazz ).getMethod() );
 			validateGetterSetterMethodProxyability( "Setter", property.getSetter( clazz ).getMethod() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -75,12 +75,9 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			HibernateSchemaManagementTool tool,
 			SchemaFilter schemaFilter) {
 		this.tool = tool;
-		if ( schemaFilter == null ) {
-			this.schemaFilter = DefaultSchemaFilter.INSTANCE;
-		}
-		else {
-			this.schemaFilter = schemaFilter;
-		}
+		this.schemaFilter = schemaFilter == null
+				? DefaultSchemaFilter.INSTANCE
+				: schemaFilter;
 	}
 
 	private UniqueConstraintSchemaUpdateStrategy uniqueConstraintStrategy;
@@ -325,9 +322,6 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			ExecutionOptions options,
 			SqlStringGenerationContext sqlStringGenerationContext,
 			GenerationTarget... targets) {
-		final Database database = metadata.getDatabase();
-
-		//noinspection unchecked
 		applySqlStrings(
 				false,
 				table.sqlAlterStrings(
@@ -394,9 +388,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 		if ( uniqueConstraintStrategy != UniqueConstraintSchemaUpdateStrategy.SKIP ) {
 			final Exporter<Constraint> exporter = dialect.getUniqueKeyExporter();
 
-			final Iterator ukItr = table.getUniqueKeyIterator();
-			while ( ukItr.hasNext() ) {
-				final UniqueKey uniqueKey = (UniqueKey) ukItr.next();
+			for ( UniqueKey uniqueKey : table.getUniqueKeys().values() ) {
 				// Skip if index already exists. Most of the time, this
 				// won't work since most Dialects use Constraints. However,
 				// keep it for the few that do use Indexes.
@@ -449,10 +441,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 		if ( dialect.hasAlterTable() ) {
 			final Exporter<ForeignKey> exporter = dialect.getForeignKeyExporter();
 
-			@SuppressWarnings("unchecked")
-			final Iterator<ForeignKey> fkItr = table.getForeignKeyIterator();
-			while ( fkItr.hasNext() ) {
-				final ForeignKey foreignKey = fkItr.next();
+			for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
 				if ( foreignKey.isPhysicalConstraint() && foreignKey.isCreationEnabled() ) {
 					boolean existingForeignKeyFound = false;
 					if ( tableInformation != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaValidator.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.tool.schema.internal;
 
-import java.util.Iterator;
 import java.util.Locale;
 
 import org.hibernate.boot.Metadata;
@@ -137,9 +136,7 @@ public abstract class AbstractSchemaValidator implements SchemaValidator {
 			);
 		}
 
-		final Iterator<Column> columnIter = table.getColumnIterator();
-		while ( columnIter.hasNext() ) {
-			final Column column = columnIter.next();
+		for ( Column column : table.getColumns() ) {
 			final ColumnInformation existingColumn = tableInformation.getColumn( Identifier.toIdentifier( column.getQuotedName() ) );
 			if ( existingColumn == null ) {
 				throw new SchemaManagementException(

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -397,9 +397,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 
 				// unique keys
-				final Iterator<UniqueKey> ukItr = table.getUniqueKeyIterator();
-				while ( ukItr.hasNext() ) {
-					final UniqueKey uniqueKey = ukItr.next();
+				for ( UniqueKey uniqueKey : table.getUniqueKeys().values() ) {
 					checkExportIdentifier( uniqueKey, exportIdentifiers );
 					applySqlStrings(
 							dialect.getUniqueKeyExporter().getSqlCreateStrings( uniqueKey, metadata,
@@ -431,9 +429,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 				}
 
 				// foreign keys
-				final Iterator<ForeignKey> fkItr = table.getForeignKeyIterator();
-				while ( fkItr.hasNext() ) {
-					final ForeignKey foreignKey = fkItr.next();
+				for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
 					applySqlStrings(
 							dialect.getForeignKeyExporter().getSqlCreateStrings( foreignKey, metadata,
 									sqlStringGenerationContext

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -370,9 +369,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 				continue;
 			}
 
-			final Iterator<ForeignKey> fks = table.getForeignKeyIterator();
-			while ( fks.hasNext() ) {
-				final ForeignKey foreignKey = fks.next();
+			for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
 				applySqlStrings(
 						dialect.getForeignKeyExporter().getSqlDropStrings( foreignKey, metadata,
 								sqlStringGenerationContext

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -20,6 +20,7 @@ import org.hibernate.boot.model.relational.QualifiedNameParser;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.Table;
@@ -70,10 +71,8 @@ public class StandardTableExporter implements Exporter<Table> {
 				pkColName = pkColumn.getQuotedName( dialect );
 			}
 
-			final Iterator columnItr = table.getColumnIterator();
 			boolean isFirst = true;
-			while ( columnItr.hasNext() ) {
-				final Column col = (Column) columnItr.next();
+			for ( Column col : table.getColumns() ) {
 				if ( isFirst ) {
 					isFirst = false;
 				}
@@ -162,7 +161,7 @@ public class StandardTableExporter implements Exporter<Table> {
 
 		applyInitCommands( table, sqlStrings, context );
 
-			return sqlStrings.toArray( new String[ sqlStrings.size() ] );
+			return sqlStrings.toArray(StringHelper.EMPTY_STRINGS);
 		}
 		catch (Exception e) {
 			throw new MappingException( "Error creating SQL create commands for table : " + tableName, e );
@@ -174,9 +173,7 @@ public class StandardTableExporter implements Exporter<Table> {
 			if ( table.getComment() != null ) {
 				sqlStrings.add( "comment on table " + tableName + " is '" + table.getComment() + "'" );
 			}
-			final Iterator iter = table.getColumnIterator();
-			while ( iter.hasNext() ) {
-				Column column = (Column) iter.next();
+			for ( Column column : table.getColumns() ) {
 				String columnComment = column.getComment();
 				if ( columnComment != null ) {
 					sqlStrings.add( "comment on column " + tableName + '.' + column.getQuotedName( dialect ) + " is '" + columnComment + "'" );
@@ -197,10 +194,9 @@ public class StandardTableExporter implements Exporter<Table> {
 
 	protected void applyTableCheck(Table table, StringBuilder buf) {
 		if ( dialect.supportsTableCheck() ) {
-			final Iterator<String> checkConstraints = table.getCheckConstraintsIterator();
-			while ( checkConstraints.hasNext() ) {
+			for (String constraint : table.getCheckConstraints() ) {
 				buf.append( ", check (" )
-						.append( checkConstraints.next() )
+						.append( constraint )
 						.append( ')' );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
@@ -8,7 +8,6 @@ package org.hibernate.tuple;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,9 +27,7 @@ public class DynamicMapInstantiator implements Instantiator {
 		this.roleName = mappingInfo.getEntityName();
 		isInstanceEntityNames.add( roleName );
 		if ( mappingInfo.hasSubclasses() ) {
-			Iterator<PersistentClass> itr = mappingInfo.getSubclassClosureIterator();
-			while ( itr.hasNext() ) {
-				final PersistentClass subclassInfo = itr.next();
+			for ( PersistentClass subclassInfo : mappingInfo.getSubclassClosure() ) {
 				isInstanceEntityNames.add( subclassInfo.getEntityName() );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/DynamicMapInstantiator.java
@@ -28,9 +28,9 @@ public class DynamicMapInstantiator implements Instantiator {
 		this.roleName = mappingInfo.getEntityName();
 		isInstanceEntityNames.add( roleName );
 		if ( mappingInfo.hasSubclasses() ) {
-			Iterator itr = mappingInfo.getSubclassClosureIterator();
+			Iterator<PersistentClass> itr = mappingInfo.getSubclassClosureIterator();
 			while ( itr.hasNext() ) {
-				final PersistentClass subclassInfo = ( PersistentClass ) itr.next();
+				final PersistentClass subclassInfo = itr.next();
 				isInstanceEntityNames.add( subclassInfo.getEntityName() );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/TenantIdBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/TenantIdBinder.java
@@ -90,10 +90,10 @@ public class TenantIdBinder implements AttributeBinder<TenantId> {
 		if ( property.getColumnSpan()!=1 ) {
 			throw new MappingException("@TenantId attribute must be mapped to a single column or formula");
 		}
-		Selectable column = property.getColumnIterator().next();
-		return column.isFormula()
-				? ((Formula) column).getFormula()
-				: ((Column) column).getName();
+		Selectable selectable = property.getSelectables().get(0);
+		return selectable.isFormula()
+				? ((Formula) selectable).getFormula()
+				: ((Column) selectable).getName();
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -35,6 +35,7 @@ import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Subclass;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.tuple.GenerationTiming;
@@ -404,10 +405,9 @@ public class EntityMetamodel implements Serializable {
 		hasCollections = foundCollection;
 		mutablePropertiesIndexes = mutableIndexes;
 
-		Iterator<?> iter = persistentClass.getSubclassIterator();
 		final Set<String> subclassEntityNamesLocal = new HashSet<>();
-		while ( iter.hasNext() ) {
-			subclassEntityNamesLocal.add( ( (PersistentClass) iter.next() ).getEntityName() );
+		for ( Subclass subclass : persistentClass.getSubclasses() ) {
+			subclassEntityNamesLocal.add( subclass.getEntityName() );
 		}
 		subclassEntityNamesLocal.add( name );
 		subclassEntityNames = CollectionHelper.toSmallSet( subclassEntityNamesLocal );
@@ -415,10 +415,8 @@ public class EntityMetamodel implements Serializable {
 		HashMap<Class<?>, String> entityNameByInheritanceClassMapLocal = new HashMap<>();
 		if ( persistentClass.hasPojoRepresentation() ) {
 			entityNameByInheritanceClassMapLocal.put( persistentClass.getMappedClass(), persistentClass.getEntityName() );
-			iter = persistentClass.getSubclassIterator();
-			while ( iter.hasNext() ) {
-				final PersistentClass pc = ( PersistentClass ) iter.next();
-				entityNameByInheritanceClassMapLocal.put( pc.getMappedClass(), pc.getEntityName() );
+			for ( Subclass subclass : persistentClass.getSubclasses() ) {
+				entityNameByInheritanceClassMapLocal.put( subclass.getMappedClass(), subclass.getEntityName() );
 			}
 		}
 		entityNameByInheritenceClassMap = CollectionHelper.toSmallMap( entityNameByInheritanceClassMapLocal );

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -154,9 +154,8 @@ public class EntityMetamodel implements Serializable {
 			if ( identifierMapperComponent != null ) {
 				nonAggregatedCidMapper = (CompositeType) identifierMapperComponent.getType();
 				idAttributeNames = new HashSet<>( );
-				final Iterator<Property> propertyItr = identifierMapperComponent.getPropertyIterator();
-				while ( propertyItr.hasNext() ) {
-					idAttributeNames.add( propertyItr.next().getName() );
+				for ( Property property : identifierMapperComponent.getProperties() ) {
+					idAttributeNames.add( property.getName() );
 				}
 			}
 			else {
@@ -463,10 +462,8 @@ public class EntityMetamodel implements Serializable {
 			SessionFactoryImplementor sessionFactory,
 			Component composite,
 			CompositeGenerationStrategyPairBuilder builder) {
-		Iterator<?> subProperties = composite.getPropertyIterator();
-		while ( subProperties.hasNext() ) {
-			final Property subProperty = (Property) subProperties.next();
-			builder.addPair( buildGenerationStrategyPair( sessionFactory, subProperty ) );
+		for ( Property property : composite.getProperties() ) {
+			builder.addPair( buildGenerationStrategyPair( sessionFactory, property ) );
 		}
 	}
 
@@ -616,10 +613,8 @@ public class EntityMetamodel implements Serializable {
 				// start building the aggregate values
 				int propertyIndex = -1;
 				int columnIndex = 0;
-				Iterator<?> subProperties = composite.getPropertyIterator();
-				while ( subProperties.hasNext() ) {
+				for ( Property property : composite.getProperties() ) {
 					propertyIndex++;
-					final Property subProperty = (Property) subProperties.next();
 					final InDatabaseValueGenerationStrategy subStrategy = inDatabaseStrategies.get( propertyIndex );
 
 					if ( subStrategy.getGenerationTiming() == GenerationTiming.ALWAYS ) {
@@ -632,11 +627,11 @@ public class EntityMetamodel implements Serializable {
 						referenceColumns = true;
 					}
 					if ( subStrategy.getReferencedColumnValues() != null ) {
-						if ( subStrategy.getReferencedColumnValues().length != subProperty.getColumnSpan() ) {
+						if ( subStrategy.getReferencedColumnValues().length != property.getColumnSpan() ) {
 							throw new ValueGenerationStrategyException(
 									"Internal error : mismatch between number of collected 'referenced column values'" +
 											" and number of columns for composite attribute : " + mappingProperty.getName() +
-											'.' + subProperty.getName()
+											'.' + property.getName()
 							);
 						}
 						System.arraycopy(
@@ -644,7 +639,7 @@ public class EntityMetamodel implements Serializable {
 								0,
 								columnValues,
 								columnIndex,
-								subProperty.getColumnSpan()
+								property.getColumnSpan()
 						);
 					}
 				}
@@ -760,9 +755,8 @@ public class EntityMetamodel implements Serializable {
 	private void mapPropertyToIndex(Property prop, int i) {
 		propertyIndexes.put( prop.getName(), i );
 		if ( prop.getValue() instanceof Component ) {
-			Iterator<?> iter = ( (Component) prop.getValue() ).getPropertyIterator();
-			while ( iter.hasNext() ) {
-				Property subprop = (Property) iter.next();
+			Component composite = (Component) prop.getValue();
+			for ( Property subprop : composite.getProperties() ) {
 				propertyIndexes.put(
 						prop.getName() + '.' + subprop.getName(),
 						i

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -82,10 +82,8 @@ public class ComponentType extends AbstractType implements CompositeTypeImplemen
 		this.cascade = new CascadeStyle[propertySpan];
 		this.joinedFetch = new FetchMode[propertySpan];
 
-		final Iterator<Property> itr = component.getPropertyIterator();
 		int i = 0;
-		while ( itr.hasNext() ) {
-			final Property property = itr.next();
+		for ( Property property : component.getProperties() ) {
 			// todo (6.0) : see if we really need to create these
 			final StandardProperty prop = PropertyFactory.buildStandardProperty( property, false );
 			this.propertyNames[i] = prop.getName();

--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -118,7 +118,7 @@ public class EnumType<T extends Enum<T>>
 		// the `reader != null` block handles annotations, while the `else` block
 		// handles hbm.xml
 		if ( reader != null ) {
-			enumClass = reader.getReturnedClass().asSubclass( Enum.class );
+			enumClass = (Class<T>) reader.getReturnedClass().asSubclass( Enum.class );
 
 			final Long columnLength = reader.getColumnLengths()[0];
 

--- a/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
@@ -73,7 +73,7 @@ public class SerializableToBlobType<T extends Serializable> implements BasicType
 		ParameterType reader = (ParameterType) parameters.get( PARAMETER_TYPE );
 		if ( reader != null ) {
 			@SuppressWarnings("unchecked")
-			Class<T> returnedClass = reader.getReturnedClass();
+			Class<T> returnedClass = (Class<T>) reader.getReturnedClass();
 			setJavaTypeDescriptor( new SerializableJavaType<>(returnedClass) );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/usertype/DynamicParameterizedType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/DynamicParameterizedType.java
@@ -32,7 +32,7 @@ public interface DynamicParameterizedType extends ParameterizedType {
 
 	interface ParameterType {
 
-		Class getReturnedClass();
+		Class<?> getReturnedClass();
 
 		Annotation[] getAnnotationsMethod();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableTest.java
@@ -32,11 +32,10 @@ import static org.junit.Assert.fail;
  *
  * @author Hardy Ferentschik
  */
-@SuppressWarnings("unchecked")
 public class ImmutableTest extends BaseCoreFunctionalTestCase {
 
 	@Test
-	public void testImmutableEntity() throws Exception {
+	public void testImmutableEntity() {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();
 		Country country = new Country();
@@ -48,7 +47,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 		// try changing the entity
 		s = openSession();
 		tx = s.beginTransaction();
-		Country germany = (Country) s.get(Country.class, country.getId());
+		Country germany = s.get(Country.class, country.getId());
 		assertNotNull(germany);
 		germany.setName("France");
 		assertEquals("Local name can be changed", "France", germany.getName());
@@ -59,7 +58,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 		// retrieving the country again - it should be unmodified
 		s = openSession();
 		tx = s.beginTransaction();
-		germany = (Country) s.get(Country.class, country.getId());
+		germany = s.get(Country.class, country.getId());
 		assertNotNull(germany);
 		assertEquals("Name should not have changed", "Germany", germany.getName());
 		tx.commit();
@@ -70,7 +69,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 	public void testImmutableCollection() {
 		Country country = new Country();
 		country.setName("Germany");
-		List states = new ArrayList<State>();
+		List<State> states = new ArrayList<>();
 		State bayern = new State();
 		bayern.setName("Bayern");
 		State hessen = new State();
@@ -90,7 +89,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		tx = s.beginTransaction();
-		Country germany = (Country) s.get(Country.class, country.getId());
+		Country germany = s.get(Country.class, country.getId());
 		assertNotNull(germany);
 		assertEquals("Wrong number of states", 3, germany.getStates().size());
 
@@ -112,7 +111,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		tx = s.beginTransaction();
-		germany = (Country) s.get(Country.class, country.getId());
+		germany = s.get(Country.class, country.getId());
 		assertNotNull(germany);
 		assertEquals("Wrong number of states", 3, germany.getStates().size());
 
@@ -129,7 +128,7 @@ public class ImmutableTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		tx = s.beginTransaction();
-		germany = (Country) s.get(Country.class, country.getId());
+		germany = s.get(Country.class, country.getId());
 		assertNotNull(germany);
 		assertEquals("Wrong number of states", 3, germany.getStates().size());
 		tx.commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyDeletionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyDeletionTest.java
@@ -22,7 +22,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
@@ -108,7 +108,7 @@ import static org.junit.Assert.fail;
 @RequiresDialectFeature(DialectChecks.SupportsTemporaryTable.class)
 public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 
-	private List<Long> createdAnimalIds = new ArrayList<>();
+	private final List<Long> createdAnimalIds = new ArrayList<>();
 
 	@After
 	public void cleanUpTestData() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/unionsubclass/alias/SellCarTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/unionsubclass/alias/SellCarTest.java
@@ -34,7 +34,7 @@ public class SellCarTest extends BaseCoreFunctionalTestCase {
     }
 
 	@Test
-    public void testSellCar() throws Exception {
+    public void testSellCar() {
         prepareData();
         Session session = openSession();
         Transaction tx = session.beginTransaction();
@@ -54,7 +54,6 @@ public class SellCarTest extends BaseCoreFunctionalTestCase {
         session.close();
     }
 
-    @SuppressWarnings( {"unchecked"})
 	private Object createData() {
         Seller stliu = new Seller();
         stliu.setId( createID( "stliu" ) );
@@ -69,7 +68,7 @@ public class SellCarTest extends BaseCoreFunctionalTestCase {
 	private PersonID createID( String name ) {
         PersonID id = new PersonID();
         id.setName( name );
-        id.setNum( Long.valueOf( 100 ) );
+        id.setNum(100L);
         return id;
     }
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMappedByResolver.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMappedByResolver.java
@@ -22,7 +22,6 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
-import org.hibernate.mapping.Value;
 
 import org.jboss.logging.Logger;
 
@@ -149,12 +148,10 @@ public class CollectionMappedByResolver {
 	}
 
 	private static String searchMappedByKey(PersistentClass referencedClass, Collection collectionValue) {
-		final Iterator<KeyValue> assocIdClassProps = referencedClass.getKeyClosureIterator();
-		while ( assocIdClassProps.hasNext() ) {
-			final Value value = assocIdClassProps.next();
+		for ( KeyValue keyValue : referencedClass.getKeyClosure() ) {
 			// make sure it's a 'Component' because IdClass is registered as this type.
-			if ( value instanceof Component ) {
-				final Component component = (Component) value;
+			if ( keyValue instanceof Component ) {
+				final Component component = (Component) keyValue;
 				final Iterator<Property> componentPropertyIterator = component.getPropertyIterator();
 				while ( componentPropertyIterator.hasNext() ) {
 					final Property property = componentPropertyIterator.next();


### PR DESCRIPTION
This was something I meant to do many years ago: replace the operations in the mapping package which return `Iterator` with operations that return regular `List`s.

(Remember, all that code was written before Java had generics and `Iterable` and "enhanced" `for` loops.)

I'm not *quite* finished yet, but I'm most of the way there.
