### PR TITLE
remove type parameter from BasicValueBinder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BinderHelper.java
@@ -814,8 +814,8 @@ public class BinderHelper {
 		value.setLazy( lazy );
 		value.setCascadeDeleteEnabled( cascadeOnDelete );
 
-		final BasicValueBinder<?> discriminatorValueBinder =
-				new BasicValueBinder<>( BasicValueBinder.Kind.ANY_DISCRIMINATOR, context );
+		final BasicValueBinder discriminatorValueBinder =
+				new BasicValueBinder( BasicValueBinder.Kind.ANY_DISCRIMINATOR, context );
 
 		final AnnotatedColumn[] discriminatorColumns = buildColumnOrFormulaFromAnnotation(
 				discriminatorColumn,
@@ -853,7 +853,7 @@ public class BinderHelper {
 		);
 		value.setDiscriminatorValueMappings( discriminatorValueMappings );
 
-		BasicValueBinder<?> keyValueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.ANY_KEY, context );
+		BasicValueBinder keyValueBinder = new BasicValueBinder( BasicValueBinder.Kind.ANY_KEY, context );
 		assert keyColumns.length == 1;
 		keyColumns[0].setTable( value.getTable() );
 		keyValueBinder.setColumns( keyColumns );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/SetBasicValueTypeSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/SetBasicValueTypeSecondPass.java
@@ -16,9 +16,9 @@ import org.hibernate.mapping.PersistentClass;
  * @author Sharath Reddy
  */
 public class SetBasicValueTypeSecondPass implements SecondPass {
-	private final BasicValueBinder<?> binder;
+	private final BasicValueBinder binder;
 
-	public SetBasicValueTypeSecondPass(BasicValueBinder<?> val) {
+	public SetBasicValueTypeSecondPass(BasicValueBinder val) {
 		binder = val;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ArrayBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ArrayBinder.java
@@ -22,7 +22,10 @@ import org.hibernate.usertype.UserCollectionType;
  * @author Anthony Patricio
  */
 public class ArrayBinder extends ListBinder {
-	public ArrayBinder(Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver, MetadataBuildingContext buildingContext) {
+
+	public ArrayBinder(
+			Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver,
+			MetadataBuildingContext buildingContext) {
 		super( customTypeBeanResolver, buildingContext );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BagBinder.java
@@ -21,7 +21,10 @@ import org.hibernate.usertype.UserCollectionType;
  * @author Matthew Inger
  */
 public class BagBinder extends CollectionBinder {
-	public BagBinder(Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver, MetadataBuildingContext context) {
+
+	public BagBinder(
+			Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver,
+			MetadataBuildingContext context) {
 		super( customTypeBeanResolver, false, context );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -103,7 +103,7 @@ import static org.hibernate.cfg.annotations.HCANNHelper.findAnnotation;
  * @author Steve Ebersole
  * @author Emmanuel Bernard
  */
-public class BasicValueBinder<T> implements JdbcTypeIndicators {
+public class BasicValueBinder implements JdbcTypeIndicators {
 
 	// todo (6.0) : In light of how we want to build Types (specifically BasicTypes) moving forward this class should undergo major changes
 	//		see the comments in #setType
@@ -169,7 +169,7 @@ public class BasicValueBinder<T> implements JdbcTypeIndicators {
 
 	public BasicValueBinder(Kind kind, MetadataBuildingContext buildingContext) {
 		assert kind != null;
-		assert  buildingContext != null;
+		assert buildingContext != null;
 
 		this.kind = kind;
 		this.buildingContext = buildingContext;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -1785,8 +1785,8 @@ public abstract class CollectionBinder {
 		else {
 			holder.prepare(property);
 
-			final BasicValueBinder<?> elementBinder =
-					new BasicValueBinder<>( BasicValueBinder.Kind.COLLECTION_ELEMENT, buildingContext);
+			final BasicValueBinder elementBinder =
+					new BasicValueBinder( BasicValueBinder.Kind.COLLECTION_ELEMENT, buildingContext);
 			elementBinder.setReturnedClassName( collType.getName() );
 			if ( elementColumns == null || elementColumns.length == 0 ) {
 				elementColumns = new AnnotatedColumn[1];

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -109,8 +109,8 @@ public class IdBagBinder extends BagBinder {
 			idColumn.setNullable( false );
 		}
 
-		final BasicValueBinder<?> valueBinder =
-				new BasicValueBinder<>( BasicValueBinder.Kind.COLLECTION_ID, buildingContext );
+		final BasicValueBinder valueBinder =
+				new BasicValueBinder( BasicValueBinder.Kind.COLLECTION_ID, buildingContext );
 
 		final Table table = collection.getCollectionTable();
 		valueBinder.setTable( table );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
@@ -42,7 +42,9 @@ import org.jboss.logging.Logger;
 public class ListBinder extends CollectionBinder {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, ListBinder.class.getName() );
 
-	public ListBinder(Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver, MetadataBuildingContext buildingContext) {
+	public ListBinder(
+			Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver,
+			MetadataBuildingContext buildingContext) {
 		super( customTypeBeanResolver, false, buildingContext );
 	}
 
@@ -112,7 +114,7 @@ public class ListBinder extends CollectionBinder {
 			indexColumn.forceNotNull();
 		}
 		indexColumn.setPropertyHolder( valueHolder );
-		final BasicValueBinder<?> valueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.LIST_INDEX, buildingContext );
+		final BasicValueBinder valueBinder = new BasicValueBinder( BasicValueBinder.Kind.LIST_INDEX, buildingContext );
 		valueBinder.setColumns( new AnnotatedColumn[] { indexColumn } );
 		valueBinder.setReturnedClassName( Integer.class.getName() );
 		valueBinder.setType( property, collType, null, null );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -71,7 +71,7 @@ public class PropertyBinder {
 	private boolean insertable = true;
 	private boolean updatable = true;
 	private String cascade;
-	private BasicValueBinder<?> basicValueBinder;
+	private BasicValueBinder basicValueBinder;
 	private XClass declaringClass;
 	private boolean declaringClassSet;
 	private boolean embedded;
@@ -179,7 +179,7 @@ public class PropertyBinder {
 		final String containerClassName = holder.getClassName();
 		holder.startingProperty( property );
 
-		basicValueBinder = new BasicValueBinder<>( BasicValueBinder.Kind.ATTRIBUTE, buildingContext );
+		basicValueBinder = new BasicValueBinder( BasicValueBinder.Kind.ATTRIBUTE, buildingContext );
 		basicValueBinder.setPropertyName( name );
 		basicValueBinder.setReturnedClassName( returnedClassName );
 		basicValueBinder.setColumns( columns );
@@ -525,7 +525,7 @@ public class PropertyBinder {
 		this.returnedClass = returnedClass;
 	}
 
-	public BasicValueBinder<?> getBasicValueBinder() {
+	public BasicValueBinder getBasicValueBinder() {
 		return basicValueBinder;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SetBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/SetBinder.java
@@ -21,7 +21,11 @@ import org.hibernate.usertype.UserCollectionType;
  * @author Matthew Inger
  */
 public class SetBinder extends CollectionBinder {
-	public SetBinder(Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver, boolean sorted, MetadataBuildingContext buildingContext) {
+
+	public SetBinder(
+			Supplier<ManagedBean<? extends UserCollectionType>> customTypeBeanResolver,
+			boolean sorted,
+			MetadataBuildingContext buildingContext) {
 		super( customTypeBeanResolver, sorted, buildingContext );
 	}
 


### PR DESCRIPTION
I can only speculate as to why `BasicValueBinder` had an unused type parameter. I think it should be removed.