### PR TITLE
HHH-15058 Add unwrap() method to SelectionQuery/MutationQuery

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
@@ -17,6 +17,7 @@ import org.hibernate.Session;
 
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.Parameter;
+import jakarta.persistence.PersistenceException;
 import jakarta.persistence.TemporalType;
 
 /**
@@ -544,4 +545,15 @@ public interface CommonQueryContract {
 	 * @return {@code this}, for method chaining
 	 */
 	CommonQueryContract setProperties(@SuppressWarnings("rawtypes") Map bean);
+
+	/**
+	 * Allows unwrapping this query as another, more specific type.
+	 *
+	 * @param type The class of the object to be returned.
+	 * This is normally an interface implemented by the underlying query implementation.
+	 * @return The unwrapped query.
+	 * @throws RuntimeException If the given type is not supported.
+	 */
+	<T> T unwrap(Class<T> type);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
+import jakarta.persistence.PersistenceException;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.CacheMode;
@@ -26,6 +27,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
+import org.hibernate.engine.query.spi.EntityGraphQueryHint;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -555,6 +557,18 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R> implemen
 		putIfNotNull( hints, HINT_FOLLOW_ON_LOCKING, getQueryOptions().getLockOptions().getFollowOnLocking() );
 	}
 
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// unwrap
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(Class<T> cls) {
+		if ( cls.isInstance( this ) ) {
+			return (T) this;
+		}
+
+		throw new PersistenceException( "Unrecognized unwrap type [" + cls.getName() + "]" );
+	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// covariance

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/BasicSelectionQueryTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/BasicSelectionQueryTests.java
@@ -6,16 +6,19 @@
  */
 package org.hibernate.orm.test.query.sqm;
 
-import jakarta.persistence.Basic;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.NamedQuery;
-import jakarta.persistence.Table;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.query.IllegalSelectQueryException;
+import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.SelectionQuery;
+import org.hibernate.query.spi.DomainQueryExecutionContext;
+import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.spi.QueryParameterBindings;
+import org.hibernate.query.spi.SqmQuery;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.contacts.Contact;
@@ -24,7 +27,11 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
 
 /**
  * @author Steve Ebersole
@@ -117,6 +124,17 @@ public class BasicSelectionQueryTests {
 			}
 			catch (IllegalSelectQueryException expected) {
 			}
+		} );
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void unwrapTest(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final SelectionQuery<Contact> query =
+					session.createSelectionQuery( "select c from Contact c", Contact.class )
+							.unwrap( SelectionQuery.class );
+			checkResults( query, session );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/mutation/BasicMutationQueryTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/mutation/BasicMutationQueryTests.java
@@ -6,10 +6,8 @@
  */
 package org.hibernate.orm.test.query.sqm.mutation;
 
-import java.sql.SQLException;
-
-import org.hibernate.annotations.QueryHints;
 import org.hibernate.query.IllegalMutationQueryException;
+import org.hibernate.query.Query;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -23,13 +21,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.PersistenceException;
-import jakarta.persistence.QueryHint;
-import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Steve Ebersole
@@ -94,6 +86,16 @@ public class BasicMutationQueryTests {
 	void basicUnequivocallyInvalidNamedNativeDeleteTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
 			session.createNamedMutationQuery( "invalid-native-result" );
+		} );
+	}
+
+	// Unwrapping to Query<?> is useful for legacy applications in particular.
+	@Test
+	void unwrapTest(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			Query<?> query = session.createMutationQuery( "delete Contact" )
+					.unwrap( Query.class );
+			query.executeUpdate();
 		} );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15058

I did it for `SelectionQuery` as well mostly for consistency: there's no real use to unwrap such a query right now, except maybe for integrators (but those can just cast the query anyway).