### PR TITLE
HHH-15057 JdbcSQLException: NULL not allowed for column "BOOKS_ORDER" when inserting into many-to-many list

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/CollectionBinder.java
@@ -557,6 +557,11 @@ public abstract class CollectionBinder {
 					|| property.isAnnotationPresent( OrderBy.class ) ) {
 				return CollectionClassification.BAG;
 			}
+			ManyToMany manyToMany = property.getAnnotation( ManyToMany.class );
+			if ( manyToMany != null && ! StringHelper.isEmpty( manyToMany.mappedBy() ) ) {
+				// We don't support @OrderColumn on the non-owning side of a many-to-many association.
+				return CollectionClassification.BAG;
+			}
 			// otherwise, return the implicit classification for List attributes
 			return buildingContext.getBuildingOptions().getMappingDefaults().getImplicitListClassification();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytomany/ManyToManyListBidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytomany/ManyToManyListBidirectionalTest.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.mapping.manytomany;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+
+@DomainModel(
+		annotatedClasses = {
+				ManyToManyListBidirectionalTest.Book.class,
+				ManyToManyListBidirectionalTest.Author.class
+		}
+)
+@SessionFactory
+@ServiceRegistry
+@SuppressWarnings( "unused" )
+public class ManyToManyListBidirectionalTest {
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Author author1 = new Author( 1 );
+			final Author author2 = new Author( 2 );
+
+			final Book bookByAuthor1 = new Book( 1 );
+			bookByAuthor1.addAuthor( author1 );
+
+			final Book bookByAuthor2 = new Book( 2 );
+			bookByAuthor2.addAuthor( author2 );
+
+			final Book bookByAuthor1AndAuthor2 = new Book( 3 );
+			bookByAuthor1AndAuthor2.addAuthor( author1 );
+			bookByAuthor1AndAuthor2.addAuthor( author2 );
+
+			session.persist( author1 );
+			session.persist( author2 );
+			session.persist( bookByAuthor1 );
+			session.persist( bookByAuthor2 );
+			session.persist( bookByAuthor1AndAuthor2 );
+		} );
+
+		scope.inTransaction( session -> {
+			assertThat( session.createQuery( "from Book b", Book.class ).list() )
+					.hasSize( 3 )
+					.allSatisfy( book -> assertThat( book.authors )
+							.allSatisfy( author -> assertThat( author.books ).contains( book ) ) );
+		} );
+
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from Book" ).executeUpdate();
+			session.createMutationQuery( "delete from Author" ).executeUpdate();
+		} );
+
+		scope.inTransaction( session -> {
+			assertThat( session.createQuery( "from Book", Book.class ).list() ).isEmpty();
+			assertThat( session.createQuery( "from Author", Author.class ).list() ).isEmpty();
+		} );
+	}
+
+	@Entity(name = "Book")
+	public static class Book {
+
+		@Id
+		private int id;
+
+		public Book() {
+		}
+
+		public Book(int id) {
+			this.id = id;
+		}
+
+		@ManyToMany
+		@JoinTable(name = "book_author",
+				joinColumns = { @JoinColumn(name = "fk_book") },
+				inverseJoinColumns = { @JoinColumn(name = "fk_author") })
+		private List<Author> authors = new ArrayList<>();
+
+		public void addAuthor(Author author) {
+			authors.add( author );
+			author.books.add( this );
+		}
+	}
+
+	@Entity(name = "Author")
+	public static class Author {
+
+		@Id
+		private int id;
+
+		public Author() {
+		}
+
+		public Author(int id) {
+			this.id = id;
+		}
+
+		@ManyToMany(mappedBy = "authors")
+		private List<Book> books = new ArrayList<>();
+
+		public void addBook(Book book) {
+			books.add( book );
+			book.authors.add( this );
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15057

Explanation (copied from the ticket):

> See https://hibernate.zulipchat.com/#narrow/stream/132094-hibernate-orm-dev/topic/List.20are.20no.20longer.20bags.20by.20default.3F
> 
> The problem seems to be that we add an order column for both sides of the association, which is not supported (even when using `@OrderColumn` explicitly, even in ORM 5.x).
>
> So the non-owning side of a many-to-many association will have to remain a bag, independently from whatever is configured as the default list semantics.
> 
> From what I’ve seen this will have to be implemented in `org.hibernate.cfg.annotations.CollectionBinder#determineCollectionClassification(java.lang.Class<?>, org.hibernate.annotations.common.reflection.XProperty, org.hibernate.boot.spi.MetadataBuildingContext)`

I decided to keep applying the default list semantics to the owning side of the many-to-many association.