### PR TITLE
get rid of some warnings about use of deprecated APIs

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/persister/CollectionPersister.java
+++ b/documentation/src/test/java/org/hibernate/userguide/persister/CollectionPersister.java
@@ -10,8 +10,8 @@ import org.hibernate.MappingException;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.mapping.Collection;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.collection.OneToManyPersister;
-import org.hibernate.persister.spi.PersisterCreationContext;
 
 /**
  * @author Shawn Clowater
@@ -24,7 +24,7 @@ public class CollectionPersister
     public CollectionPersister(
             Collection collectionBinding,
             CollectionDataAccess cacheAccessStrategy,
-            PersisterCreationContext creationContext)
+            RuntimeModelCreationContext creationContext)
             throws MappingException, CacheException {
         super(collectionBinding, cacheAccessStrategy, creationContext);
     }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/LazyAttributesMetadata.java
@@ -16,9 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.boot.Metadata;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.persister.spi.PersisterCreationContext;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
@@ -38,7 +38,7 @@ public class LazyAttributesMetadata implements Serializable {
 			PersistentClass mappedEntity,
 			boolean isEnhanced,
 			boolean collectionsInDefaultFetchGroupEnabled,
-			PersisterCreationContext creationContext) {
+			Metadata metadata) {
 		final Map<String, LazyAttributeDescriptor> lazyAttributeDescriptorMap = new LinkedHashMap<>();
 		final Map<String, Set<String>> fetchGroupToAttributesMap = new HashMap<>();
 
@@ -49,8 +49,8 @@ public class LazyAttributesMetadata implements Serializable {
 			final boolean lazy = ! EnhancementHelper.includeInBaseFetchGroup(
 					property,
 					isEnhanced,
-					(entityName) -> {
-						final PersistentClass entityBinding = creationContext.getMetadata().getEntityBinding( entityName );
+					entityName -> {
+						final PersistentClass entityBinding = metadata.getEntityBinding( entityName );
 						assert entityBinding != null;
 						return entityBinding.hasSubclasses();
 					},

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractLockUpgradeEventListener.java
@@ -8,7 +8,6 @@ package org.hibernate.event.internal;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.loader.ast.internal.LoaderHelper;

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -136,6 +136,7 @@ import org.jboss.logging.Logger;
  * Base implementation of the {@code QueryableCollection} interface.
  *
  * @author Gavin King
+ *
  * @see BasicCollectionPersister
  * @see OneToManyPersister
  */
@@ -277,13 +278,18 @@ public abstract class AbstractCollectionPersister
 	private final JdbcMapping convertedElementType;
 	private final JdbcMapping convertedIndexType;
 
+	@Deprecated(since = "6.0")
 	public AbstractCollectionPersister(
 			Collection collectionBootDescriptor,
 			CollectionDataAccess cacheAccessStrategy,
-			PersisterCreationContext persisterCreationContext) throws MappingException, CacheException {
-		assert persisterCreationContext instanceof RuntimeModelCreationContext;
+			PersisterCreationContext creationContext) throws MappingException, CacheException {
+		this( collectionBootDescriptor, cacheAccessStrategy, (RuntimeModelCreationContext) creationContext );
+	}
 
-		final RuntimeModelCreationContext creationContext = (RuntimeModelCreationContext) persisterCreationContext;
+	public AbstractCollectionPersister(
+			Collection collectionBootDescriptor,
+			CollectionDataAccess cacheAccessStrategy,
+			RuntimeModelCreationContext creationContext) throws MappingException, CacheException {
 
 		final Value elementBootDescriptor = collectionBootDescriptor.getElement();
 		final Value indexBootDescriptor = collectionBootDescriptor instanceof IndexedCollection
@@ -514,7 +520,7 @@ public abstract class AbstractCollectionPersister
 			identifierColumnName = col.getQuotedName( dialect );
 			identifierColumnAlias = col.getAlias( dialect );
 			identifierGenerator = idColl.getIdentifier().createIdentifierGenerator(
-					persisterCreationContext.getBootstrapContext().getIdentifierGeneratorFactory(),
+					creationContext.getBootstrapContext().getIdentifierGeneratorFactory(),
 					factory.getJdbcServices().getDialect(),
 					null
 			);

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -25,6 +25,7 @@ import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.jdbc.Expectations;
 import org.hibernate.mapping.Collection;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.sql.Delete;
@@ -47,10 +48,18 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 		return false;
 	}
 
+	@Deprecated(since = "6.0")
 	public BasicCollectionPersister(
 			Collection collectionBinding,
 			CollectionDataAccess cacheAccessStrategy,
 			PersisterCreationContext creationContext) throws MappingException, CacheException {
+		this( collectionBinding, cacheAccessStrategy, (RuntimeModelCreationContext) creationContext );
+	}
+
+	public BasicCollectionPersister(
+			Collection collectionBinding,
+			CollectionDataAccess cacheAccessStrategy,
+			RuntimeModelCreationContext creationContext) throws MappingException, CacheException {
 		super( collectionBinding, cacheAccessStrategy, creationContext );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
@@ -23,6 +23,7 @@ import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.jdbc.Expectations;
 import org.hibernate.mapping.Collection;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.Joinable;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.pretty.MessageHelper;
@@ -60,10 +61,18 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 		return cascadeDeleteEnabled;
 	}
 
+	@Deprecated(since = "6.0")
 	public OneToManyPersister(
 			Collection collectionBinding,
 			CollectionDataAccess cacheAccessStrategy,
 			PersisterCreationContext creationContext) throws MappingException, CacheException {
+		this( collectionBinding, cacheAccessStrategy, (RuntimeModelCreationContext) creationContext );
+	}
+
+	public OneToManyPersister(
+			Collection collectionBinding,
+			CollectionDataAccess cacheAccessStrategy,
+			RuntimeModelCreationContext creationContext) throws MappingException, CacheException {
 		super( collectionBinding, cacheAccessStrategy, creationContext );
 		cascadeDeleteEnabled = collectionBinding.getKey().isCascadeDeleteEnabled()
 				&& creationContext.getSessionFactory().getJdbcServices().getDialect().supportsCascadeDelete();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -673,13 +673,21 @@ public abstract class AbstractEntityPersister
 		return tableNames;
 	}
 
+	@Deprecated(since = "6.0")
 	public AbstractEntityPersister(
 			final PersistentClass bootDescriptor,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
-			final PersisterCreationContext pcc) throws HibernateException {
+			final PersisterCreationContext creationContext) throws HibernateException {
+		this( bootDescriptor, cacheAccessStrategy, naturalIdRegionAccessStrategy,
+				(RuntimeModelCreationContext) creationContext );
+	}
 
-		final RuntimeModelCreationContext creationContext = (RuntimeModelCreationContext) pcc;
+	public AbstractEntityPersister(
+			final PersistentClass bootDescriptor,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext) throws HibernateException {
 
 		this.factory = creationContext.getSessionFactory();
 		this.sqlAliasStem = SqlAliasStemHelper.INSTANCE.generateStemFromEntityName( bootDescriptor.getEntityName() );
@@ -1081,7 +1089,7 @@ public abstract class AbstractEntityPersister
 	 */
 	private boolean shouldInvalidateCache(
 			PersistentClass persistentClass,
-			PersisterCreationContext creationContext) {
+			RuntimeModelCreationContext creationContext) {
 		if ( hasFormulaProperties() ) {
 			// we need to evaluate formulas in the database
 			return true;
@@ -1112,7 +1120,7 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
-	private boolean isCacheComplianceEnabled(PersisterCreationContext creationContext) {
+	private boolean isCacheComplianceEnabled(RuntimeModelCreationContext creationContext) {
 		return creationContext.getSessionFactory()
 				.getSessionFactoryOptions()
 				.getJpaCompliance()

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -85,7 +85,7 @@ import org.hibernate.type.descriptor.java.VersionJavaType;
  *         for any natural id defined for this entity
  *     </li>
  *     <li>
- *         {@link org.hibernate.persister.spi.PersisterCreationContext} -
+ *         {@link org.hibernate.metamodel.spi.RuntimeModelCreationContext} -
  *         access to additional information useful while constructing the
  *         persister.
  *     </li>
@@ -503,7 +503,9 @@ public interface EntityPersister
 	 * @deprecated Use {@link #load(Object, Object, LockMode, SharedSessionContractImplementor)}
 	 */
 	@Deprecated(since = "6.0")
-	default Object load(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session, Boolean readOnly)
+	default Object load(
+			Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session,
+			@SuppressWarnings("unused") Boolean readOnly)
 			throws HibernateException {
 		return load( id, optionalObject, lockMode, session );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -49,6 +49,7 @@ import org.hibernate.metamodel.mapping.internal.BasicEntityIdentifierMappingImpl
 import org.hibernate.metamodel.mapping.internal.CaseStatementDiscriminatorMappingImpl;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationHelper;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.query.spi.NavigablePath;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
@@ -157,11 +158,21 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	//INITIALIZATION:
 
+	@Deprecated(since = "6.0")
 	public JoinedSubclassEntityPersister(
 			final PersistentClass persistentClass,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final PersisterCreationContext creationContext) throws HibernateException {
+		this( persistentClass,cacheAccessStrategy,naturalIdRegionAccessStrategy,
+				(RuntimeModelCreationContext) creationContext );
+	}
+
+	public JoinedSubclassEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext) throws HibernateException {
 
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -37,6 +37,7 @@ import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Subclass;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.query.spi.NavigablePath;
@@ -132,11 +133,21 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 	//INITIALIZATION:
 
+	@Deprecated(since = "6.0")
 	public SingleTableEntityPersister(
 			final PersistentClass persistentClass,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final PersisterCreationContext creationContext) throws HibernateException {
+		this( persistentClass,cacheAccessStrategy,naturalIdRegionAccessStrategy,
+				(RuntimeModelCreationContext) creationContext );
+	}
+
+	public SingleTableEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext) throws HibernateException {
 
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -42,6 +42,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.query.spi.NavigablePath;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
@@ -88,11 +89,21 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 
 	//INITIALIZATION:
 
+	@Deprecated(since = "6.0")
 	public UnionSubclassEntityPersister(
 			final PersistentClass persistentClass,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final PersisterCreationContext creationContext) throws HibernateException {
+		this( persistentClass,cacheAccessStrategy,naturalIdRegionAccessStrategy,
+				(RuntimeModelCreationContext) creationContext );
+	}
+
+	public UnionSubclassEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext) throws HibernateException {
 
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/BytecodeEnhancementMetadataPojoImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.tuple.entity;
 import java.util.Set;
 
 import org.hibernate.LockMode;
+import org.hibernate.boot.Metadata;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
@@ -24,7 +25,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.type.CompositeType;
 
 /**
@@ -39,11 +39,11 @@ public final class BytecodeEnhancementMetadataPojoImpl implements BytecodeEnhanc
 			Set<String> identifierAttributeNames,
 			CompositeType nonAggregatedCidMapper,
 			boolean collectionsInDefaultFetchGroupEnabled,
-			PersisterCreationContext creationContext) {
+			Metadata metadata) {
 		final Class<?> mappedClass = persistentClass.getMappedClass();
 		final boolean enhancedForLazyLoading = PersistentAttributeInterceptable.class.isAssignableFrom( mappedClass );
 		final LazyAttributesMetadata lazyAttributesMetadata = enhancedForLazyLoading
-				? LazyAttributesMetadata.from( persistentClass, true, collectionsInDefaultFetchGroupEnabled, creationContext )
+				? LazyAttributesMetadata.from( persistentClass, true, collectionsInDefaultFetchGroupEnabled, metadata )
 				: LazyAttributesMetadata.nonEnhanced( persistentClass.getEntityName() );
 
 		return new BytecodeEnhancementMetadataPojoImpl(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/persister/PersisterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/persister/PersisterTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class PersisterTest extends BaseNonConfigCoreFunctionalTestCase {
 	@Test
-	public void testEntityEntityPersisterAndPersisterSpecified() throws Exception {
+	public void testEntityEntityPersisterAndPersisterSpecified() {
 		//checks to see that the persister specified with the @Persister annotation takes precedence if a @Entity.persister() is also specified		
 		PersistentClass persistentClass = metadata().getEntityBinding( Deck.class.getName() );
 		assertEquals( "Incorrect Persister class for " + persistentClass.getMappedClass(), EntityPersister.class,
@@ -28,7 +28,7 @@ public class PersisterTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testEntityEntityPersisterSpecified() throws Exception {
+	public void testEntityEntityPersisterSpecified() {
 		//tests the persister specified with an @Entity.persister()		
 		PersistentClass persistentClass = metadata().getEntityBinding( Card.class.getName() );
 		assertEquals( "Incorrect Persister class for " + persistentClass.getMappedClass(),
@@ -36,7 +36,7 @@ public class PersisterTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCollectionPersisterSpecified() throws Exception {
+	public void testCollectionPersisterSpecified() {
 		//tests the persister specified by the @Persister annotation on a collection
 		Collection collection = metadata().getCollectionBinding( Deck.class.getName() + ".cards" );
 		assertEquals( "Incorrect Persister class for collection " + collection.getRole(), CollectionPersister.class,


### PR DESCRIPTION
`PersisterCreationContext` was deprecated, but was still being used.