### PR TITLE
HHH-15065: Add minimal reproducer and a suggested fix for 5.6

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
@@ -8,7 +8,7 @@ package org.hibernate.graph.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,10 +21,9 @@ import org.hibernate.graph.SubGraph;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.internal.util.collections.CollectionHelper;
-import org.hibernate.metamodel.model.domain.spi.PersistentAttributeDescriptor;
 import org.hibernate.metamodel.model.domain.spi.EntityTypeDescriptor;
 import org.hibernate.metamodel.model.domain.spi.ManagedTypeDescriptor;
+import org.hibernate.metamodel.model.domain.spi.PersistentAttributeDescriptor;
 
 /**
  *  Base class for {@link RootGraph} and {@link SubGraph} implementations.
@@ -47,7 +46,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	protected AbstractGraph(boolean mutable, GraphImplementor<J> original) {
 		this( original.getGraphedType(), mutable, original.sessionFactory() );
 
-		this.attrNodeMap = CollectionHelper.concurrentMap( original.getAttributeNodeList().size() );
+		this.attrNodeMap = new LinkedHashMap<>( original.getAttributeNodeList().size() );
 		original.visitAttributeNodes(
 				node -> attrNodeMap.put(
 						node.getAttributeDescriptor(),
@@ -111,7 +110,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 
 		AttributeNodeImplementor<?> attributeNode = null;
 		if ( attrNodeMap == null ) {
-			attrNodeMap = new HashMap<>();
+			attrNodeMap = new LinkedHashMap<>();
 		}
 		else {
 			attributeNode = attrNodeMap.get( incomingAttributeNode.getAttributeDescriptor() );
@@ -188,7 +187,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 
 		AttributeNodeImplementor attrNode = null;
 		if ( attrNodeMap == null ) {
-			attrNodeMap = new HashMap<>();
+			attrNodeMap = new LinkedHashMap<>();
 		}
 		else {
 			attrNode = attrNodeMap.get( attribute );

--- a/hibernate-core/src/test/java/org/hibernate/graph/HHH15065Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/graph/HHH15065Test.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.graph;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Session;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SQLStatementInterceptor;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+
+@TestForIssue(jiraKey = "HHH-15065")
+public class HHH15065Test extends BaseNonConfigCoreFunctionalTestCase {
+
+	private SQLStatementInterceptor sqlStatementInterceptor;
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		sqlStatementInterceptor = new SQLStatementInterceptor( sfb );
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+			HHH15065Test.Book.class,
+			HHH15065Test.Person.class
+		};
+	}
+
+	@Test
+	public void testDeterministicStatementWithEntityGraphHavingMultipleAttributes() throws Exception {
+		final Session session = openSession();
+		session.beginTransaction();
+
+		RootGraph<Book> entityGraph = session.createEntityGraph(Book.class);
+		entityGraph.addAttributeNodes( "author", "coAuthor", "editor", "coEditor" );
+
+		session.createQuery( "select book from Book book", Book.class )
+			.setHint( "javax.persistence.fetchgraph", entityGraph )
+			.getResultList();
+
+		List<String> sqlQueries = sqlStatementInterceptor.getSqlQueries();
+
+		assertEquals( 1, sqlQueries.size() );
+		assertEquals( "select hhh15065te0_.id as id1_0_0_," +
+					  " hhh15065te1_.id as id1_1_1_," +
+					  " hhh15065te2_.id as id1_1_2_," +
+					  " hhh15065te3_.id as id1_1_3_," +
+					  " hhh15065te4_.id as id1_1_4_," +
+					  " hhh15065te0_.author_id as author_i2_0_0_," +
+					  " hhh15065te0_.coAuthor_id as coauthor3_0_0_," +
+					  " hhh15065te0_.coEditor_id as coeditor4_0_0_," +
+					  " hhh15065te0_.editor_id as editor_i5_0_0_" +
+					  " from Book hhh15065te0_" +
+					  " left outer join Person hhh15065te1_ on hhh15065te0_.author_id=hhh15065te1_.id" +
+					  " left outer join Person hhh15065te2_ on hhh15065te0_.coAuthor_id=hhh15065te2_.id" +
+					  " left outer join Person hhh15065te3_ on hhh15065te0_.editor_id=hhh15065te3_.id" +
+					  " left outer join Person hhh15065te4_ on hhh15065te0_.coEditor_id=hhh15065te4_.id",
+			sqlQueries.get(0) );
+
+		session.close();
+	}
+
+	@Entity(name = "Book")
+	public static class Book {
+		@Id
+		Long id;
+
+		@ManyToOne
+		Person author;
+
+		@ManyToOne
+		Person coAuthor;
+
+		@ManyToOne
+		Person editor;
+
+		@ManyToOne
+		Person coEditor;
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+		@Id
+		Long id;
+	}
+
+}


### PR DESCRIPTION
The [first commit](https://github.com/hibernate/hibernate-orm/pull/4766/commits/876863a5b41ef78ff8b67fb37f4790b0b8ccfead) introduces a minimal reproducer for [HHH-15065](https://hibernate.atlassian.net/browse/HHH-15065). The test fails most of the times but with some luck it is green.

The [second commit](https://github.com/hibernate/hibernate-orm/pull/4766/commits/e08e64f863e6e9f5c39926857f9a9c42d8eded41) contains my suggestion how queries with entity graphs, having multiple attributes can be made fully deterministic.

See https://github.com/hibernate/hibernate-orm/pull/4767 for the corresponding test for the `main` branch.