### PR TITLE
HHH-15067 Set add() method as public to allow non-nullable associations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/NonNullableTransientDependencies.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/NonNullableTransientDependencies.java
@@ -24,7 +24,7 @@ public final class NonNullableTransientDependencies {
 	// for the map value.
 	private Map<Object,Set<String>> propertyPathsByTransientEntity; // lazily initialized
 
-	void add(String propertyName, Object transientEntity) {
+	public void add(String propertyName, Object transientEntity) {
 		if ( propertyPathsByTransientEntity == null ) {
 			propertyPathsByTransientEntity = new IdentityHashMap<>();
 		}


### PR DESCRIPTION
See hibernate-reactive issue [#1077](https://github.com/hibernate/hibernate-reactive/issues/1077) 

non-nullable association requires reactive to determine non-nullable transient dependencies in order to perform the insert.  The non-visible `NonNullableTransientDependencies.add(..)` method is preventing access to using this class.