### PR TITLE
HHH-15060 - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/FetchNotFoundException.java
+++ b/hibernate-core/src/main/java/org/hibernate/FetchNotFoundException.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate;
+
+import java.util.Locale;
+import javax.persistence.EntityNotFoundException;
+
+/**
+ * Exception for {@link org.hibernate.annotations.NotFoundAction#EXCEPTION}
+ *
+ * @see org.hibernate.annotations.NotFound
+ *
+ * @author Steve Ebersole
+ */
+public class FetchNotFoundException extends EntityNotFoundException {
+	private final String entityName;
+	private final Object identifier;
+
+	public FetchNotFoundException(String entityName, Object identifier) {
+		super(
+				String.format(
+						Locale.ROOT,
+						"Entity `%s` with identifier value `%s` does not exist",
+						entityName,
+						identifier
+				)
+		);
+		this.entityName = entityName;
+		this.identifier = identifier;
+	}
+
+	public String getEntityName() {
+		return entityName;
+	}
+
+	public Object getIdentifier() {
+		return identifier;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
@@ -7,8 +7,8 @@
 package org.hibernate.annotations;
 
 /**
- * Fetch options on associations.  Defines more of the "how" of fetching, whereas JPA {@link javax.persistence.FetchType}
- * focuses on the "when".
+ * Defines how the association should be fetched, compared to
+ * {@link javax.persistence.FetchType} which defines when it should be fetched
  *
  * @author Emmanuel Bernard
  */

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
@@ -16,13 +16,27 @@ public enum FetchMode {
 	/**
 	 * Use a secondary select for each individual entity, collection, or join load.
 	 */
-	SELECT,
+	SELECT( org.hibernate.FetchMode.SELECT ),
 	/**
 	 * Use an outer join to load the related entities, collections or joins.
 	 */
-	JOIN,
+	JOIN( org.hibernate.FetchMode.JOIN ),
 	/**
-	 * Available for collections only.  When accessing a non-initialized collection, this fetch mode will trigger loading all elements of all collections of the same role for all owners associated with the persistence context using a single secondary select.
+	 * Available for collections only.
+	 *
+	 * When accessing a non-initialized collection, this fetch mode will trigger
+	 * loading all elements of all collections of the same role for all owners
+	 * associated with the persistence context using a single secondary select.
 	 */
-	SUBSELECT
+	SUBSELECT( org.hibernate.FetchMode.SELECT );
+
+	private final org.hibernate.FetchMode hibernateFetchMode;
+
+	FetchMode(org.hibernate.FetchMode hibernateFetchMode) {
+		this.hibernateFetchMode = hibernateFetchMode;
+	}
+
+	public org.hibernate.FetchMode getHibernateFetchMode() {
+		return hibernateFetchMode;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NotFoundAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NotFoundAction.java
@@ -6,20 +6,36 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.FetchNotFoundException;
 
 /**
- * Possible actions when an associated entity is not found in the database.  Often seen with "legacy" foreign-key
- * schemes which do not use {@code NULL} to indicate a missing reference, instead using a "magic value".
+ * Possible actions when the database contains a non-null fk with no
+ * matching target. This also implies that there are no physical
+ * foreign-key constraints on the database.
  *
+ * As an example, consider a typical Customer/Order model.  These actions apply
+ * when a non-null `orders.customer_fk` value does not have a corresponding value
+ * in `customers.id`.
+ *
+ * Generally this will occur in 2 scenarios:<ul>
+ *     <li>the associated data has been deleted</li>
+ *     <li>the model uses special "magic" values to indicate null</li>
+ * </ul>
+ *
+ * @author Steve Ebersole
  * @author Emmanuel Bernard
  */
 public enum NotFoundAction {
 	/**
-	 * Raise an exception when an element is not found (default and recommended).
+	 * Throw an exception when the association is not found (default and recommended).
+	 *
+	 * @see FetchNotFoundException
 	 */
 	EXCEPTION,
+
 	/**
-	 * Ignore the element when not found in database.
+	 * Ignore the association when not found in database.  Effectively treats the
+	 * association as null, despite the non-null foreign-key value.
 	 */
 	IGNORE
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -3462,10 +3462,20 @@ public final class AnnotationBinder {
 			JoinColumns joinColumns,
 			MetadataBuildingContext context) {
 		final boolean noConstraintByDefault = context.getBuildingOptions().isNoConstraintByDefault();
-		if ( ( joinColumn != null && ( joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-				|| joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) )
-				|| ( joinColumns != null && ( joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-				|| joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
+
+		final NotFound notFoundAnn= property.getAnnotation( NotFound.class );
+		if ( notFoundAnn != null ) {
+			// supersedes all others
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumn != null && (
+				joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumns != null && (
+				joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
 			value.setForeignKeyName( "none" );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
@@ -16,6 +16,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.IndexedCollection;
 import org.hibernate.mapping.OneToMany;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Value;
 
@@ -68,8 +69,7 @@ public abstract class CollectionSecondPass implements SecondPass {
 		}
 	}
 
-	abstract public void secondPass(java.util.Map persistentClasses, java.util.Map inheritedMetas)
-			throws MappingException;
+	abstract public void secondPass(java.util.Map persistentClasses, java.util.Map inheritedMetas);
 
 	private static String columns(Value val) {
 		StringBuilder columns = new StringBuilder();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -8,14 +8,13 @@ package org.hibernate.cfg;
 
 import java.util.Iterator;
 import java.util.Map;
-
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 
 import org.hibernate.AnnotationException;
-import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
 import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.annotations.PropertyBinder;
@@ -41,7 +40,7 @@ public class OneToOneSecondPass implements SecondPass {
 	private String ownerEntity;
 	private String ownerProperty;
 	private PropertyHolder propertyHolder;
-	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 	private PropertyData inferredData;
 	private XClass targetEntity;
 	private boolean cascadeOnDelete;
@@ -57,7 +56,7 @@ public class OneToOneSecondPass implements SecondPass {
 			PropertyHolder propertyHolder,
 			PropertyData inferredData,
 			XClass targetEntity,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean cascadeOnDelete,
 			boolean optional,
 			String cascadeStrategy,
@@ -68,7 +67,7 @@ public class OneToOneSecondPass implements SecondPass {
 		this.mappedBy = mappedBy;
 		this.propertyHolder = propertyHolder;
 		this.buildingContext = buildingContext;
-		this.ignoreNotFound = ignoreNotFound;
+		this.notFoundAction = notFoundAction;
 		this.inferredData = inferredData;
 		this.targetEntity = targetEntity;
 		this.cascadeOnDelete = cascadeOnDelete;
@@ -191,7 +190,7 @@ public class OneToOneSecondPass implements SecondPass {
 					);
 					ManyToOne manyToOne = new ManyToOne( buildingContext, mappedByJoin.getTable() );
 					//FIXME use ignore not found here
-					manyToOne.setIgnoreNotFound( ignoreNotFound );
+					manyToOne.setNotFoundAction( notFoundAction );
 					manyToOne.setCascadeDeleteEnabled( value.isCascadeDeleteEnabled() );
 					manyToOne.setFetchMode( value.getFetchMode() );
 					manyToOne.setLazy( value.isLazy() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
@@ -106,7 +106,9 @@ public class ToOneFkSecondPass extends FkSecondPass {
 			/*
 			 * HbmMetadataSourceProcessorImpl does this only when property-ref != null, but IMO, it makes sense event if it is null
 			 */
-			if ( !manyToOne.isIgnoreNotFound() ) manyToOne.createPropertyRefConstraints( persistentClasses );
+			if ( manyToOne.getNotFoundAction() == null ) {
+				manyToOne.createPropertyRefConstraints( persistentClasses );
+			}
 		}
 		else if ( value instanceof OneToOne ) {
 			value.createForeignKey();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -13,6 +13,7 @@ import javax.persistence.Column;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.annotations.CollectionId;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
@@ -52,11 +53,11 @@ public class IdBagBinder extends BagBinder {
 			XProperty property,
 			boolean unique,
 			TableBinder associationTableBinder,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			MetadataBuildingContext buildingContext) {
 		boolean result = super.bindStarToManySecondPass(
 				persistentClasses, collType, fkJoinColumns, keyColumns, inverseColumns, elementColumns, isEmbedded,
-				property, unique, associationTableBinder, ignoreNotFound, getBuildingContext()
+				property, unique, associationTableBinder, notFoundAction, getBuildingContext()
 		);
 		CollectionId collectionIdAnn = property.getAnnotation( CollectionId.class );
 		if ( collectionIdAnn != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.OrderBy;
 import org.hibernate.annotations.Sort;
 import org.hibernate.annotations.common.reflection.XClass;
@@ -76,14 +77,13 @@ public class ListBinder extends CollectionBinder {
 			final boolean isEmbedded,
 			final XProperty property,
 			final XClass collType,
-			final boolean ignoreNotFound,
+			final NotFoundAction notFoundAction,
 			final boolean unique,
 			final TableBinder assocTableBinder,
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( getBuildingContext(), ListBinder.this.collection ) {
 			@Override
-            public void secondPass(Map persistentClasses, Map inheritedMetas)
-					throws MappingException {
+            public void secondPass(Map persistentClasses, Map inheritedMetas) {
 				bindStarToManySecondPass(
 						persistentClasses,
 						collType,
@@ -95,7 +95,7 @@ public class ListBinder extends CollectionBinder {
 						property,
 						unique,
 						assocTableBinder,
-						ignoreNotFound,
+						notFoundAction,
 						buildingContext
 				);
 				bindIndex( buildingContext );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -23,6 +23,7 @@ import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.spi.BootstrapContext;
@@ -87,16 +88,15 @@ public class MapBinder extends CollectionBinder {
 			final boolean isEmbedded,
 			final XProperty property,
 			final XClass collType,
-			final boolean ignoreNotFound,
+			final NotFoundAction notFoundAction,
 			final boolean unique,
 			final TableBinder assocTableBinder,
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( buildingContext, MapBinder.this.collection ) {
-			public void secondPass(Map persistentClasses, Map inheritedMetas)
-					throws MappingException {
+			public void secondPass(Map persistentClasses, Map inheritedMetas) {
 				bindStarToManySecondPass(
 						persistentClasses, collType, fkJoinColumns, keyColumns, inverseColumns, elementColumns,
-						isEmbedded, property, unique, assocTableBinder, ignoreNotFound, buildingContext
+						isEmbedded, property, unique, assocTableBinder, notFoundAction, buildingContext
 				);
 				bindKeyFromAssociationTable(
 						collType, persistentClasses, mapKeyPropertyName, property, isEmbedded, buildingContext,

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.type.EntityType;
@@ -22,6 +23,7 @@ import org.hibernate.type.Type;
  */
 public class ManyToOne extends ToOne {
 	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 	private boolean isLogicalOneToOne;
 
 	/**
@@ -44,7 +46,7 @@ public class ManyToOne extends ToOne {
 				getPropertyName(),
 				isLazy(),
 				isUnwrapProxy(),
-				isIgnoreNotFound(),
+				getNotFoundAction(),
 				isLogicalOneToOne
 		);
 	}
@@ -97,12 +99,25 @@ public class ManyToOne extends ToOne {
 		return visitor.accept(this);
 	}
 
+	public NotFoundAction getNotFoundAction() {
+		return notFoundAction;
+	}
+
+	public void setNotFoundAction(NotFoundAction notFoundAction) {
+		this.notFoundAction = notFoundAction;
+	}
+
 	public boolean isIgnoreNotFound() {
-		return ignoreNotFound;
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	public void setIgnoreNotFound(boolean ignoreNotFound) {
-		this.ignoreNotFound = ignoreNotFound;
+		if ( ignoreNotFound ) {
+			notFoundAction = NotFoundAction.IGNORE;
+		}
+		else {
+			notFoundAction = null;
+		}
 	}
 
 	public void markAsLogicalOneToOne() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.engine.spi.Mapping;
@@ -29,7 +30,7 @@ public class OneToMany implements Value {
 
 	private String referencedEntityName;
 	private PersistentClass associatedClass;
-	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 
 	/**
 	 * @deprecated Use {@link OneToMany#OneToMany(MetadataBuildingContext, PersistentClass)} instead.
@@ -57,7 +58,7 @@ public class OneToMany implements Value {
 				null,
 				false,
 				false,
-				isIgnoreNotFound(),
+				notFoundAction,
 				false
 		);
 	}
@@ -162,12 +163,25 @@ public class OneToMany implements Value {
 		throw new UnsupportedOperationException();
 	}
 
+	public NotFoundAction getNotFoundAction() {
+		return notFoundAction;
+	}
+
+	public void setNotFoundAction(NotFoundAction notFoundAction) {
+		this.notFoundAction = notFoundAction;
+	}
+
 	public boolean isIgnoreNotFound() {
-		return ignoreNotFound;
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	public void setIgnoreNotFound(boolean ignoreNotFound) {
-		this.ignoreNotFound = ignoreNotFound;
+		if ( ignoreNotFound ) {
+			notFoundAction = NotFoundAction.IGNORE;
+		}
+		else {
+			notFoundAction = null;
+		}
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
@@ -12,8 +12,11 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.FetchNotFoundException;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.*;
@@ -27,7 +30,7 @@ import org.hibernate.persister.entity.Loadable;
  */
 public class ManyToOneType extends EntityType {
 	private final String propertyName;
-	private final boolean ignoreNotFound;
+	private final NotFoundAction notFoundAction;
 	private boolean isLogicalOneToOne;
 
 	/**
@@ -49,12 +52,12 @@ public class ManyToOneType extends EntityType {
 	 * @param lazy Should the association be handled lazily
 	 */
 	public ManyToOneType(TypeFactory.TypeScope scope, String referencedEntityName, boolean lazy) {
-		this( scope, referencedEntityName, true, null, lazy, true, false, false );
+		this( scope, referencedEntityName, true, null, lazy, true, null, false );
 	}
 
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -64,13 +67,13 @@ public class ManyToOneType extends EntityType {
 			boolean lazy,
 			boolean unwrapProxy,
 			boolean isEmbeddedInXML,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
-		this( scope, referencedEntityName, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, ignoreNotFound, isLogicalOneToOne );
+		this( scope, referencedEntityName, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, notFoundAction, isLogicalOneToOne );
 	}
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -80,9 +83,9 @@ public class ManyToOneType extends EntityType {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
-		this( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, null, lazy, unwrapProxy, ignoreNotFound, isLogicalOneToOne );
+		this( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, null, lazy, unwrapProxy, notFoundAction, isLogicalOneToOne );
 	}
 
 	public ManyToOneType(
@@ -93,24 +96,25 @@ public class ManyToOneType extends EntityType {
 			String propertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		super( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, !lazy, unwrapProxy );
 		this.propertyName = propertyName;
-		this.ignoreNotFound = ignoreNotFound;
+		this.notFoundAction = notFoundAction;
 		this.isLogicalOneToOne = isLogicalOneToOne;
 	}
 
 	public ManyToOneType(ManyToOneType original, String superTypeEntityName) {
 		super( original, superTypeEntityName );
 		this.propertyName = original.propertyName;
-		this.ignoreNotFound = original.ignoreNotFound;
+		this.notFoundAction = original.notFoundAction;
 		this.isLogicalOneToOne = original.isLogicalOneToOne;
 	}
 
 	@Override
 	public boolean isNullable() {
-		return ignoreNotFound;
+		// this matches the original check, but this seems wrong.
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	@Override
@@ -237,7 +241,14 @@ public class ManyToOneType extends EntityType {
 
 	@Override
 	public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) throws HibernateException {
-		Object resolvedValue = super.resolve(value, session, owner, overridingEager);
+		final Object resolvedValue;
+		try {
+			resolvedValue = super.resolve( value, session, owner, overridingEager );
+		}
+		catch (ObjectNotFoundException e) {
+			throw new FetchNotFoundException( getAssociatedEntityName(), value );
+		}
+
 		if ( isLogicalOneToOne && value != null && getPropertyName() != null ) {
 			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 			EntityEntry entry = persistenceContext.getEntry( owner );

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.classic.Lifecycle;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -41,7 +42,7 @@ import org.hibernate.usertype.UserType;
 @SuppressWarnings({"unchecked"})
 public final class TypeFactory implements Serializable, TypeBootstrapContext {
 	/**
-	 * @deprecated Use {@link TypeConfiguration}/{@link TypeConfiguration.Scope} instead
+	 * @deprecated Use {@link TypeConfiguration}
 	 */
 	@Deprecated
 	public interface TypeScope extends Serializable {
@@ -295,7 +296,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 	}
 
 	/**
-	 * @deprecated Use {@link #manyToOne(String, boolean, String, boolean, boolean, boolean, boolean)} instead.
+	 * @deprecated Use {@link #manyToOne(String, boolean, String, boolean, boolean, NotFoundAction, boolean)} instead.
 	 */
 	@Deprecated
 	public EntityType manyToOne(
@@ -303,7 +304,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return manyToOne(
 				persistentClass,
@@ -311,13 +312,13 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 				uniqueKeyPropertyName,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}
 
 	/**
-	 * @deprecated Use {@link #manyToOne(String, boolean, String, String, boolean, boolean, boolean, boolean)} instead.
+	 * @deprecated Use {@link #manyToOne(String, boolean, String, String, boolean, boolean, NotFoundAction, boolean)} instead.
 	 */
 	@Deprecated
 	public EntityType manyToOne(
@@ -326,7 +327,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return manyToOne(
 				persistentClass,
@@ -335,7 +336,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 				null,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}
@@ -347,7 +348,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 			String propertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return new ManyToOneType(
 				typeScope,
@@ -357,7 +358,7 @@ public final class TypeFactory implements Serializable, TypeBootstrapContext {
 				propertyName,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
@@ -65,7 +65,7 @@ public class CollectionBinderTest extends BaseUnitTestCase {
 
 		String expectMessage = "Association [abc] for entity [CollectionBinderTest] references unmapped class [List]";
 		try {
-			collectionBinder.bindOneToManySecondPass(collection, new HashMap(), null, collectionType, false, false, buildingContext, null);
+			collectionBinder.bindOneToManySecondPass(collection, new HashMap(), null, collectionType, false, null, buildingContext, null);
 		} catch (MappingException e) {
 			assertEquals(expectMessage, e.getMessage());
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
@@ -1,0 +1,221 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@OneToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>When loading the `Coin#currency`, `EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundExceptionLogicalOneToOneTest extends BaseCoreFunctionalTestCase {
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testGet() {
+		inTransaction( (session) -> {
+			try {
+				session.get( Coin.class, 1 );
+				fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
@@ -1,0 +1,281 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@ManyToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundExceptionManyToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "ObjectNotFoundException is thrown but caught and null is returned - see " +
+					"org.hibernate.internal.SessionImpl.IdentifierLoadAccessImpl#doLoad"
+	)
+	public void testGet() {
+		inTransaction( (session) -> {
+			try {
+				final Coin coin = session.get( Coin.class, 1 );
+				coin.getCurrency().getName();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryOwnerSelection() {
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "This one is somewhat debatable.  Is this selecting the association?  Or simply matching Currencies?"
+	)
+	public void testQueryAssociationSelection() {
+		// NOTE: this one is not obvious
+		//		- we are selecting the association so from that perspective, throwing the ObjectNotFoundException is nice
+		//		- the other way to look at it is that there are simply no matching results, so nothing to return
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			try {
+				session.createQuery( hql, Currency.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	public static class CollectionStatementInspector implements StatementInspector {
+		private List<String> queries = new ArrayList<>();
+
+		@Override
+		public String inspect(String sql) {
+			queries.add( sql );
+			return sql;
+		}
+
+		public void clear() {
+			queries.clear();
+		}
+
+		public List<String> getQueries() {
+			return queries;
+		}
+	}
+
+	private final CollectionStatementInspector statementInspector = new CollectionStatementInspector();
+
+	@Override
+	protected void configure(Configuration configuration) {
+		super.configure( configuration );
+		configuration.getProperties().put( AvailableSettings.STATEMENT_INSPECTOR, statementInspector );
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
@@ -1,0 +1,215 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@ManyToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundIgnoreManyToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			try {
+				final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	public void testGet() {
+		inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Bad results due to cross-join"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Has zero results because of inner-join - the select w/ inner-join is executed twice for some odd reason"
+	)
+	public void testQueryAssociationSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
@@ -1,0 +1,210 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for `@ManyToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundIgnoreOneToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			try {
+				final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	public void testGet() {
+		inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Bad results due to cross-join"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Has zero results because of inner-join - the select w/ inner-join is executed twice for some odd reason"
+	)
+	public void testQueryAssociationSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/JoinFormulaOneToManyNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/JoinFormulaOneToManyNotIgnoreLazyFetchingTest.java
@@ -19,23 +19,28 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import org.hibernate.Hibernate;
 import org.hibernate.LazyInitializationException;
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinFormula;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.cfg.AnnotationBinder;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.logger.LoggerInspectionRule;
 import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.hibernate.testing.transaction.TransactionUtil2;
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.jboss.logging.Logger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -82,25 +87,21 @@ public class JoinFormulaOneToManyNotIgnoreLazyFetchingTest extends BaseEntityMan
 	}
 
 	@Test
-	public void testLazyLoading() {
+	public void testLoading() {
 
 		assertFalse( triggerable.wasTriggered() );
 
-		List<Stock> stocks = doInJPA( this::entityManagerFactory, entityManager -> {
-			return entityManager.createQuery(
-					"SELECT s FROM Stock s", Stock.class )
-					.getResultList();
+		List<Stock> stocks = TransactionUtil2.fromTransaction( entityManagerFactory().unwrap( SessionFactoryImplementor.class ), (session) -> {
+			return session.createQuery("SELECT s FROM Stock s order by id", Stock.class ).getResultList();
 		} );
-		assertEquals( 2, stocks.size() );
 
-		try {
-			assertEquals( "ABC", stocks.get( 0 ).getCodes().get( 0 ).getRefNumber() );
+		assertThat( stocks ).hasSize( 2 );
 
-			fail( "Should have thrown LazyInitializationException" );
-		}
-		catch (LazyInitializationException expected) {
+		final Stock firstStock = stocks.get( 0 );
+		final Stock secondStock = stocks.get( 1 );
 
-		}
+		assertThat( firstStock.getCodes() ).hasSize( 1 );
+		assertThat( secondStock.getCodes() ).hasSize( 0 );
 	}
 
 	@Entity(name = "Stock")

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
@@ -91,7 +91,7 @@ public class NotFoundLogicalOneToOneTest extends BaseCoreFunctionalTestCase {
 		}
 
 		@OneToOne(fetch = FetchType.LAZY)
-		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+//		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 		@NotFound(action = NotFoundAction.IGNORE)
 		public Currency getCurrency() {
 			return currency;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
@@ -28,9 +28,8 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Gail Badner
@@ -70,8 +69,12 @@ public class LazyNotFoundManyToOneNonUpdatableNonInsertableTest extends BaseCore
 		doInHibernate(
 				this::sessionFactory, session -> {
 					User user = session.find( User.class, ID );
-					assertFalse( Hibernate.isPropertyInitialized( user, "lazy" ) );
-					assertNull( user.getLazy() );
+					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) )
+							.describedAs( "Expecting `User#lazy to be (bytecode) initialized due to `@NotFound`" )
+							.isTrue();
+					assertThat( user.getLazy() )
+							.describedAs( "Expecting `User#lazy to null due to `NotFoundAction#IGNORE`" )
+							.isNull();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneNonUpdatableNonInsertableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneNonUpdatableNonInsertableTest.java
@@ -33,6 +33,7 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -73,9 +74,14 @@ public class LazyNotFoundOneToOneNonUpdatableNonInsertableTest extends BaseCoreF
 		doInHibernate(
 				this::sessionFactory, session -> {
 					User user = session.find( User.class, ID );
-					assertFalse( Hibernate.isPropertyInitialized( user, "lazy" ) );
-					assertNull( user.getLazy() );
-					assertTrue( Hibernate.isPropertyInitialized( user, "lazy" ) );
+
+					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) )
+							.describedAs( "Expecting `User#lazy to be (bytecode) initialized due to `@NotFound`" )
+							.isTrue();
+					assertThat( user.getLazy() )
+							.describedAs( "Expecting `User#lazy to null due to `NotFoundAction#IGNORE`" )
+							.isNull();
+
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneTest.java
@@ -21,7 +21,6 @@ import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
@@ -31,11 +30,8 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Gail Badner
@@ -86,10 +82,10 @@ public class LazyNotFoundOneToOneTest extends BaseCoreFunctionalTestCase {
 				this::sessionFactory, session -> {
 					User user = session.find( User.class, ID );
 
-					assertThat( sqlInterceptor.getQueryCount(), is( 1 ) );
-					assertFalse( Hibernate.isPropertyInitialized( user, "lazy" ) );
+					assertThat( sqlInterceptor.getQueryCount() ).isEqualTo( 2 );
+					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) ).isTrue();
 
-					assertNull( user.getLazy() );
+					assertThat( user.getLazy() ).isNull();
 				}
 		);
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
@@ -11,21 +11,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import javax.persistence.spi.PersistenceUnitInfo;
 
-import org.hibernate.SessionFactoryObserver;
-import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.tool.schema.Action;
-import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
-import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.ActionGrouping;
 
 import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.hibernate.testing.orm.domain.DomainModelDescriptor;
@@ -38,8 +32,6 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 import org.jboss.logging.Logger;
-
-import javax.persistence.spi.PersistenceUnitInfo;
 
 /**
  * hibernate-testing implementation of a few JUnit5 contracts to support SessionFactory-based testing,
@@ -89,7 +81,6 @@ public class EntityManagerFactoryExtension
 		// JpaCompliance
 		pui.getProperties().put( AvailableSettings.JPA_QUERY_COMPLIANCE, emfAnn.queryComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_TRANSACTION_COMPLIANCE, emfAnn.transactionComplianceEnabled() );
-		pui.getProperties().put( AvailableSettings.JPA_LIST_COMPLIANCE, emfAnn.listMappingComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_CLOSED_COMPLIANCE, emfAnn.closedComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_PROXY_COMPLIANCE, emfAnn.proxyComplianceEnabled() );
 		pui.getProperties().put( AvailableSettings.JPA_CACHING_COMPLIANCE, emfAnn.cacheComplianceEnabled() );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -143,21 +143,21 @@ public class SessionFactoryExtension
 			SessionFactoryImplementor sessionFactory,
 			MetadataImplementor model,
 			boolean createSecondarySchemas) {
-		final Map<String, Object> baseProperties = sessionFactory.getProperties();
-
-		final ActionGrouping grouping = ActionGrouping.interpret( baseProperties );
-		if ( grouping.getDatabaseAction() == Action.NONE && grouping.getScriptAction() == Action.NONE ) {
+		final ActionGrouping grouping = ActionGrouping.interpret( sessionFactory.getProperties() );
+		if ( grouping.getDatabaseAction() != Action.NONE || grouping.getScriptAction() != Action.NONE ) {
+			// the properties contained explicit settings for auto schema tooling; skip here as part of
+			// @SessionFactory handling
 			return;
 		}
 
-		final HashMap<String,Object> settings = new HashMap<>( baseProperties );
-		settings.put( AvailableSettings.HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP );
+		final HashMap<String,Object> settings = new HashMap<>( sessionFactory.getProperties() );
+		settings.put( AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP );
 		if ( createSecondarySchemas ) {
 			if ( !( model.getDatabase().getDialect().canCreateSchema() ) ) {
 				throw new UnsupportedOperationException(
 						model.getDatabase().getDialect() + " does not support schema creation" );
 			}
-			settings.put( AvailableSettings.HBM2DDL_CREATE_SCHEMAS, true );
+			settings.put( AvailableSettings.JAKARTA_HBM2DDL_CREATE_SCHEMAS, true );
 		}
 
 		final StandardServiceRegistry serviceRegistry = model.getMetadataBuildingOptions().getServiceRegistry();


### PR DESCRIPTION
DO NOT MERGE YET!


HHH-15060 - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

- `@NotFound` no longer exports a physical foreign-key
- tests showing bugs and inconsistencies wrt `@NotFound` handling