### PR TITLE
HHH-15060 - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -3845,11 +3845,20 @@ public final class AnnotationBinder {
 			JoinColumns joinColumns,
 			MetadataBuildingContext context) {
 		final boolean noConstraintByDefault = context.getBuildingOptions().isNoConstraintByDefault();
-		if ( ( joinColumn != null && ( joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-				|| joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) )
-				|| ( joinColumns != null && ( joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-				|| joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
-			value.disableForeignKey();
+
+		final NotFound notFoundAnn= property.getAnnotation( NotFound.class );
+		if ( notFoundAnn != null ) {
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumn != null && (
+				joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumns != null && (
+				joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT && noConstraintByDefault ) ) ) {
+			value.setForeignKeyName( "none" );
 		}
 		else {
 			final ForeignKey fk = property.getAnnotation( ForeignKey.class );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractNonLazyEntityFetch.java
@@ -7,14 +7,12 @@
 package org.hibernate.sql.results.graph.entity;
 
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.EntityValuedModelPart;
 import org.hibernate.query.spi.NavigablePath;
 import org.hibernate.sql.results.graph.AbstractFetchParent;
 import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.internal.EntityAssembler;
 
 /**
@@ -25,11 +23,11 @@ import org.hibernate.sql.results.graph.entity.internal.EntityAssembler;
 public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent implements EntityFetch {
 	private final FetchParent fetchParent;
 	private final boolean nullable;
-	private final EntityValuedModelPart referencedModelPart;
+	private final EntityValuedFetchable referencedModelPart;
 
 	public AbstractNonLazyEntityFetch(
 			FetchParent fetchParent,
-			EntityValuedModelPart fetchedPart,
+			EntityValuedFetchable fetchedPart,
 			NavigablePath navigablePath,
 			boolean nullable) {
 		super( fetchedPart.getEntityMappingType(), navigablePath );
@@ -39,8 +37,18 @@ public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent imp
 	}
 
 	@Override
-	public EntityMappingType getReferencedMappingType() {
-		return getEntityValuedModelPart().getEntityMappingType();
+	public EntityValuedFetchable getEntityValuedModelPart() {
+		return referencedModelPart;
+	}
+
+	@Override
+	public EntityValuedFetchable getReferencedModePart() {
+		return getEntityValuedModelPart();
+	}
+
+	@Override
+	public EntityValuedFetchable getReferencedMappingType() {
+		return getEntityValuedModelPart();
 	}
 
 	@Override
@@ -49,13 +57,13 @@ public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent imp
 	}
 
 	@Override
-	public FetchParent getFetchParent() {
-		return fetchParent;
+	public EntityValuedFetchable getFetchedMapping() {
+		return getEntityValuedModelPart();
 	}
 
 	@Override
-	public Fetchable getFetchedMapping() {
-		return (Fetchable) getEntityValuedModelPart();
+	public FetchParent getFetchParent() {
+		return fetchParent;
 	}
 
 	@Override
@@ -69,9 +77,4 @@ public abstract class AbstractNonLazyEntityFetch extends AbstractFetchParent imp
 	protected abstract EntityInitializer getEntityInitializer(
 			FetchParentAccess parentAccess,
 			AssemblerCreationState creationState);
-
-	@Override
-	public EntityValuedModelPart getEntityValuedModelPart() {
-		return referencedModelPart;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -51,7 +51,7 @@ public class EntityFetchJoinedImpl extends AbstractNonLazyEntityFetch {
 			AssemblerCreationState creationState) {
 		return (EntityInitializer) creationState.resolveInitializer(
 				getNavigablePath(),
-				getEntityValuedModelPart(),
+				getReferencedModePart(),
 				() -> new EntityJoinedFetchInitializer(
 						entityResult,
 						getReferencedModePart(),

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityJoinedFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityJoinedFetchInitializer.java
@@ -16,6 +16,7 @@ import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
+import org.hibernate.sql.results.graph.entity.EntityValuedFetchable;
 
 /**
  * @author Andrea Boriero
@@ -27,7 +28,7 @@ public class EntityJoinedFetchInitializer extends AbstractEntityInitializer {
 
 	public EntityJoinedFetchInitializer(
 			EntityResultGraphNode resultDescriptor,
-			ModelPart referencedModelPart,
+			EntityValuedFetchable referencedFetchable,
 			NavigablePath navigablePath,
 			LockMode lockMode,
 			Fetch identifierFetch,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
@@ -1,0 +1,219 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for `@OneToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>When loading the `Coin#currency`, `EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = { NotFoundExceptionLogicalOneToOneTest.Coin.class, NotFoundExceptionLogicalOneToOneTest.Currency.class } )
+@SessionFactory
+public class NotFoundExceptionLogicalOneToOneTest {
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testProxy(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testGet(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			try {
+				session.get( Coin.class, 1 );
+				fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryImplicitPathDereferencePredicate(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryOwnerSelection(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@AfterEach
+	public void cleanupTest(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
@@ -1,0 +1,267 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for `@ManyToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = { NotFoundExceptionManyToOneTest.Coin.class, NotFoundExceptionManyToOneTest.Currency.class } )
+@SessionFactory( useCollectingStatementInspector = true )
+public class NotFoundExceptionManyToOneTest {
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testProxy(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "ObjectNotFoundException is thrown but caught and null is returned - see " +
+					"org.hibernate.internal.SessionImpl.IdentifierLoadAccessImpl#doLoad"
+	)
+	public void testGet(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			try {
+				// should fail here loading the Coin due to missing currency (see NOTE#1)
+				session.get( Coin.class, 1 );
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				// technically we could use a subsequent-select rather than a join...
+				assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryImplicitPathDereferencePredicate(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryOwnerSelection(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				// technically we could use a subsequent-select rather than a join...
+				assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+				assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "This one is somewhat debatable.  Is this selecting the association?  Or simply matching Currencies?"
+	)
+	public void testQueryAssociationSelection(SessionFactoryScope scope) {
+		// NOTE: this one is not obvious
+		//		- we are selecting the association so from that perspective, throwing the ObjectNotFoundException is nice
+		//		- the other way to look at it is that there are simply no matching results, so nothing to return
+		scope.inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			try {
+				session.createQuery( hql, Currency.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@AfterEach
+	protected void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
@@ -1,0 +1,246 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for `@ManyToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = { NotFoundIgnoreManyToOneTest.Coin.class, NotFoundIgnoreManyToOneTest.Currency.class } )
+@SessionFactory( useCollectingStatementInspector = true )
+public class NotFoundIgnoreManyToOneTest {
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testProxy(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testGet(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+
+			// technically we could use a subsequent-select rather than a join...
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected( reason = "Bad results due to cross-join" )
+	public void testQueryImplicitPathDereferencePredicate(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createSelectionQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+
+			// technically we could use a subsequent-select rather than a join...
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testQueryOwnerSelection(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createSelectionQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+
+			// at the moment this uses a subsequent-select.  on the bright side, it is at least eagerly fetched.
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 2 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " from Coin " );
+			assertThat( statementInspector.getSqlQueries().get( 1 ) ).contains( " from Currency " );
+
+			// but I believe a jon would be better
+//			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+//			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+//			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected(
+			reason = "Has zero results because of inner-join; & the select w/ inner-join is executed twice for some odd reason"
+	)
+	public void testQueryAssociationSelection(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createSelectionQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@BeforeEach
+	protected void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@AfterEach
+	protected void dropTestData(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
@@ -1,0 +1,237 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for `@OneToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = { NotFoundIgnoreOneToOneTest.Coin.class, NotFoundIgnoreOneToOneTest.Currency.class } )
+@SessionFactory( useCollectingStatementInspector = true )
+public class NotFoundIgnoreOneToOneTest {
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testProxy(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			try {
+				final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testGet(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+
+			// technically we could use a subsequent-select rather than a join...
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected( reason = "Bad results due to cross-join" )
+	public void testQueryImplicitPathDereferencePredicate(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+
+			// technically we could use a subsequent-select rather than a join...
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	public void testQueryOwnerSelection(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+
+			// at the moment this uses a subsequent-select.  on the bright side, it is at least eagerly fetched.
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 2 );
+			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " from Coin " );
+			assertThat( statementInspector.getSqlQueries().get( 1 ) ).contains( " from Currency " );
+
+			// but I believe a jon would be better
+//			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+//			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+//			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+		} );
+	}
+
+	@Test
+	@JiraKey( "HHH-15060" )
+	@FailureExpected( reason = "Has zero results because of inner-join; & the select w/ inner-join is executed twice for some odd reason" )
+	public void testQueryAssociationSelection(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+		} );
+	}
+
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}


### PR DESCRIPTION
DO NOT MERGE!!

HHH-15060 - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

- fix AbstractNonLazyEntityFetch wrt "referenced ModelPart"
- `@NotFound` should disable exporting a physical foreign-key
- tests