### PR TITLE
HHH-15060 Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/IsNullAndNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/IsNullAndNotFoundTest.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpa.test.query;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class IsNullAndNotFoundTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Account.class, Person.class };
+	}
+
+	@Test
+	public void testIsNullInWhereClause() {
+
+
+		Account account1 = new Account( 1, null, null );
+		Account account2 = new Account( 2, "Fab", null );
+
+		Person person1 = new Person( 1, "Luigi", account1 );
+		Person person2 = new Person( 2, "Andrea", account2 );
+		Person person3 = new Person( 3, "Andrea", null );
+
+		inTransaction(
+				session -> {
+					session.persist( account1 );
+					session.persist( account2 );
+					session.persist( person1 );
+					session.persist( person2 );
+					session.persist( person3 );
+				}
+		);
+
+		inTransaction(
+				session -> {
+					final List<Integer> people = session.createQuery(
+							"select p.id from Person p where p.account.code is null" ).getResultList();
+
+					assertEquals( 1, people.size() );
+					assertEquals( person1.getId(), people.get( 0 ) );
+				}
+		);
+
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@OneToOne
+		@NotFound(action = NotFoundAction.IGNORE)
+		private Account account;
+
+		Person() {
+		}
+
+		public Person(Integer id, String name, Account account) {
+			this.id = id;
+			this.name = name;
+			this.account = account;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Account getAccount() {
+			return account;
+		}
+	}
+
+	@Entity(name = "Account")
+	@Table(name = "ACCOUNT_TABLE")
+	public static class Account {
+		@Id
+		private Integer id;
+
+		private String code;
+
+		private Double amount;
+
+		public Account() {
+		}
+
+		public Account(
+				Integer id,
+				String code,
+				Double amount) {
+			this.id = id;
+			this.code = code;
+			this.amount = amount;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TypedQueryResultListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TypedQueryResultListTest.java
@@ -1,0 +1,121 @@
+package org.hibernate.jpa.test.query;
+
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.TypedQuery;
+
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+
+public class TypedQueryResultListTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Parent.class };
+	}
+
+	@After
+	public void tearDown() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+					 entityManager.createQuery( "delete from Parent" );
+				 }
+		);
+	}
+
+	@Test
+	public void testIt() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Parent parent1 = new Parent( 1, "usr1", null );
+			Parent parent2 = new Parent( 1, "usr2", null );
+			entityManager.persist( parent1 );
+			entityManager.persist( parent2 );
+
+			TypedQuery<Parent> query = entityManager.createQuery(
+					"select parent " +
+							"from Parent parent " +
+							"where exists (select 1 " +
+							"from Parent otherParent " +
+							"where lower(otherParent.text) like :name and (parent.id = otherParent.sourceParent.id or parent.number = otherParent.number))",
+					Parent.class
+			);
+
+			query.setParameter( "name", "usr1" );
+			List<Parent> entityList = query.getResultList();
+			assertThat( entityList.size(), is( 2 ) );
+		} );
+
+
+	}
+
+	@Test
+	public void testIt2() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			Parent parent1 = new Parent( 1, "usr1", null );
+			Parent parent2 = new Parent( 1, "usr2", null );
+			entityManager.persist( parent1 );
+			entityManager.persist( parent2 );
+
+			TypedQuery<Parent> query = entityManager.createQuery(
+					"select parent " +
+							"from Parent parent " +
+							"where exists (select 1 " +
+							"from Parent otherParent " +
+							"where lower(otherParent.text) like :name and (parent = otherParent.sourceParent or parent.number = otherParent.number))",
+					Parent.class
+			);
+
+			query.setParameter( "name", "usr1" );
+			List<Parent> entityList = query.getResultList();
+			assertThat( entityList.size(), is( 2 ) );
+		} );
+
+
+	}
+
+	@Entity(name = "Parent")
+	public static class Parent {
+
+		@Id
+		@GeneratedValue
+		private int id;
+
+		@Column(name = "NUMBER_COLUMN", nullable = false, precision = 9)
+		private Integer number;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "SOURCE_ID", referencedColumnName = "ID")
+		@NotFound(action = NotFoundAction.IGNORE)
+		private Parent sourceParent;
+
+		@Column(name = "TEXT_COLUMN", nullable = false, length = 20)
+		private String text;
+
+		Parent() {
+		}
+
+		public Parent(Integer num, String txt, Parent source) {
+			this.number = num;
+			this.text = txt;
+			this.sourceParent = source;
+		}
+
+		public int getId() {
+			return id;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15060