### PR TITLE
Implement support for CompositeUserType and re-enable tests that make use of it

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/MonetaryAmountUserType.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/MonetaryAmountUserType.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.orm.test.sql.hand;
+package org.hibernate.userguide.mapping.basic;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -16,10 +16,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.usertype.CompositeUserType;
 
 /**
- * This is a simple Hibernate custom mapping type for MonetaryAmount value types.
- * <p>
- *
- * @author Max & Christian
+ * @author Emmanuel Bernard
  */
 public class MonetaryAmountUserType implements CompositeUserType<MonetaryAmount> {
 
@@ -27,9 +24,9 @@ public class MonetaryAmountUserType implements CompositeUserType<MonetaryAmount>
 	public Object getPropertyValue(MonetaryAmount component, int property) throws HibernateException {
 		switch ( property ) {
 			case 0:
-				return component.getCurrency();
+				return component.getAmount();
 			case 1:
-				return component.getValue();
+				return component.getCurrency();
 		}
 		throw new HibernateException( "Illegal property index: " + property );
 	}
@@ -52,12 +49,13 @@ public class MonetaryAmountUserType implements CompositeUserType<MonetaryAmount>
 
 	@Override
 	public boolean isMutable() {
-		return false;
+		return true;
 	}
 
 	@Override
 	public Object deepCopy(Object value) {
-		return value; // MonetaryAmount is immutable
+		MonetaryAmount ma = (MonetaryAmount) value;
+		return new MonetaryAmount( ma.getAmount(), ma.getCurrency() );
 	}
 
 	@Override
@@ -73,17 +71,17 @@ public class MonetaryAmountUserType implements CompositeUserType<MonetaryAmount>
 
 	@Override
 	public Serializable disassemble(Object value) throws HibernateException {
-		return (Serializable) value;
+		return (Serializable) deepCopy( value );
 	}
 
 	@Override
 	public Object assemble(Serializable cached, Object owner) throws HibernateException {
-		return cached;
+		return deepCopy( cached );
 	}
 
 	@Override
 	public Object replace(Object original, Object target, Object owner) throws HibernateException {
-		return original;
+		return deepCopy( original ); //TODO: improve
 	}
 
 	@Override
@@ -92,7 +90,7 @@ public class MonetaryAmountUserType implements CompositeUserType<MonetaryAmount>
 	}
 
 	public static class MonetaryAmountEmbeddable {
-		private BigDecimal value;
+		private BigDecimal amount;
 		private Currency currency;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CompositeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CompositeType.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.annotations;
+
+import java.lang.annotation.Retention;
+
+import org.hibernate.usertype.CompositeUserType;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Applies a custom {@link CompositeUserType} for the attribute mapping.
+ */
+@java.lang.annotation.Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface CompositeType {
+
+	/**
+	 * The custom type implementor class
+	 */
+	Class<? extends CompositeUserType<?>> value();
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistration.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.hibernate.usertype.CompositeUserType;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Registers a custom composite user type implementation to be used
+ * for all references to a particular {@link jakarta.persistence.Embeddable}.
+ * <p/>
+ * May be overridden for a specific embedded using {@link org.hibernate.annotations.CompositeType}
+ */
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Retention( RUNTIME )
+@Repeatable( CompositeTypeRegistrations.class )
+public @interface CompositeTypeRegistration {
+	Class<?> embeddableClass();
+	Class<? extends CompositeUserType<?>> userType();
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistrations.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CompositeTypeRegistrations.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Grouping of {@link CompositeTypeRegistration}
+ *
+ * @author Steve Ebersole
+ */
+@Target( {TYPE, ANNOTATION_TYPE, PACKAGE} )
+@Retention( RUNTIME )
+public @interface CompositeTypeRegistrations {
+	CompositeTypeRegistration[] value();
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/MapKeyCustomCompositeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/MapKeyCustomCompositeType.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.annotations;
+
+import org.hibernate.usertype.CompositeUserType;
+
+/**
+ * Form of {@link CompositeType} for use with map-keys
+ *
+ * @since 6.0
+ */
+public @interface MapKeyCustomCompositeType {
+	/**
+	 * The custom type implementor class
+	 *
+	 * @see CompositeType#value
+	 */
+	Class<? extends CompositeUserType<?>> value();
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -104,6 +104,7 @@ import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
+import org.hibernate.usertype.CompositeUserType;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Embeddable;
@@ -408,6 +409,25 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector 
 		}
 
 		return registeredInstantiators.get( embeddableType );
+	}
+
+	private Map<Class<?>, Class<? extends CompositeUserType<?>>> registeredCompositeUserTypes;
+
+	@Override
+	public void registerCompositeUserType(Class<?> embeddableType, Class<? extends CompositeUserType<?>> userType) {
+		if ( registeredCompositeUserTypes == null ) {
+			registeredCompositeUserTypes = new HashMap<>();
+		}
+		registeredCompositeUserTypes.put( embeddableType, userType );
+	}
+
+	@Override
+	public Class<? extends CompositeUserType<?>> findRegisteredCompositeUserType(Class<?> embeddableType) {
+		if ( registeredCompositeUserTypes == null ) {
+			return null;
+		}
+
+		return registeredCompositeUserTypes.get( embeddableType );
 	}
 
 	private Map<CollectionClassification, CollectionTypeRegistrationDescriptor> collectionTypeRegistrations;

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
@@ -653,11 +653,11 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 
 			final FetchParentMemento fetchParentMemento = parent.resolveParentMemento( resolutionContext );
 
-			NavigablePath navigablePath = fetchParentMemento.getNavigablePath().append( propertyPathParts[ 0 ] );
 			Fetchable fetchable = (Fetchable) fetchParentMemento.getFetchableContainer().findSubPart(
 					propertyPathParts[ 0 ],
 					null
 			);
+			NavigablePath navigablePath = fetchParentMemento.getNavigablePath().append( fetchable.getFetchableName() );
 
 			for ( int i = 1; i < propertyPathParts.length; i++ ) {
 				if ( ! ( fetchable instanceof FetchableContainer ) ) {
@@ -666,8 +666,8 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 									+ " did not reference FetchableContainer"
 					);
 				}
-				navigablePath = navigablePath.append( propertyPathParts[ i ] );
 				fetchable = (Fetchable) ( (FetchableContainer) fetchable ).findSubPart( propertyPathParts[i], null );
+				navigablePath = navigablePath.append( fetchable.getFetchableName() );
 			}
 
 			if ( fetchable instanceof BasicValuedModelPart ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/InFlightMetadataCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/InFlightMetadataCollector.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.spi;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,6 +54,7 @@ import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.usertype.CompositeUserType;
 import org.hibernate.usertype.UserCollectionType;
 
 import jakarta.persistence.AttributeConverter;
@@ -311,6 +313,9 @@ public interface InFlightMetadataCollector extends Mapping, MetadataImplementor 
 
 	void registerEmbeddableInstantiator(Class<?> embeddableType, Class<? extends EmbeddableInstantiator> instantiator);
 	Class<? extends EmbeddableInstantiator> findRegisteredEmbeddableInstantiator(Class<?> embeddableType);
+
+	void registerCompositeUserType(Class<?> embeddableType, Class<? extends CompositeUserType<?>> userType);
+	Class<? extends CompositeUserType<?>> findRegisteredCompositeUserType(Class<?> embeddableType);
 
 	void addCollectionTypeRegistration(CollectionTypeRegistration registrationAnnotation);
 	void addCollectionTypeRegistration(CollectionClassification classification, CollectionTypeRegistrationDescriptor descriptor);

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotatedColumn.java
@@ -843,6 +843,9 @@ public class AnnotatedColumn {
 		if ( inferredData != null ) {
 			XProperty property = inferredData.getProperty();
 			if ( property != null ) {
+				if ( propertyHolder.isComponent() ) {
+					processExpression( propertyHolder.getOverriddenColumnTransformer( logicalColumnName ) );
+				}
 				processExpression( property.getAnnotation( ColumnTransformer.class ) );
 				ColumnTransformers annotations = property.getAnnotation( ColumnTransformers.class );
 				if (annotations != null) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PropertyHolder.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
@@ -75,6 +76,8 @@ public interface PropertyHolder {
 		// todo: does this necessarily need to be a default method?
 		return null;
 	}
+
+	ColumnTransformer getOverriddenColumnTransformer(String logicalColumnName);
 
 	/**
 	 * return

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/PropertyBinder.java
@@ -40,6 +40,7 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.tuple.AnnotationValueGeneration;
 import org.hibernate.tuple.AttributeBinder;
 import org.hibernate.tuple.GenerationTiming;
@@ -78,6 +79,7 @@ public class PropertyBinder {
 	private EntityBinder entityBinder;
 	private boolean isXToMany;
 	private String referencedEntityName;
+	private PropertyAccessStrategy propertyAccessStrategy;
 
 	public void setReferencedEntityName(String referencedEntityName) {
 		this.referencedEntityName = referencedEntityName;
@@ -149,6 +151,10 @@ public class PropertyBinder {
 
 	public void setBuildingContext(MetadataBuildingContext buildingContext) {
 		this.buildingContext = buildingContext;
+	}
+
+	public void setPropertyAccessStrategy(PropertyAccessStrategy propertyAccessStrategy) {
+		this.propertyAccessStrategy = propertyAccessStrategy;
 	}
 
 	public void setDeclaringClass(XClass declaringClass) {
@@ -319,6 +325,7 @@ public class PropertyBinder {
 
 		property.setInsertable( insertable );
 		property.setUpdateable( updatable );
+		property.setPropertyAccessStrategy( propertyAccessStrategy );
 
 		inferOptimisticLocking(property);
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3951,33 +3951,21 @@ public abstract class Dialect implements ConversionContext {
 				Long length) {
 			final Size size = new Size();
 			int jdbcTypeCode = jdbcType.getDefaultSqlTypeCode();
+			// Set the explicit length to null if we encounter the JPA default 255
+			if ( length != null && length == Size.DEFAULT_LENGTH ) {
+				length = null;
+			}
 
-			switch (jdbcTypeCode) {
+			switch ( jdbcTypeCode ) {
 				case Types.BIT:
-					// Use the default length for Boolean if we encounter the JPA default 255 instead
-					if ( javaType.getJavaTypeClass() == Boolean.class && length != null && length == Size.DEFAULT_LENGTH ) {
-						length = null;
-					}
-					size.setLength( javaType.getDefaultSqlLength( Dialect.this, jdbcType ) );
-					break;
 				case Types.CHAR:
 				case Types.NCHAR:
-					// Use the default length for char and UUID if we encounter the JPA default 255 instead
-					if ( length != null && length == Size.DEFAULT_LENGTH ) {
-						if ( javaType.getJavaTypeClass() == Character.class || javaType.getJavaTypeClass() == UUID.class ) {
-							length = null;
-						}
-					}
-					size.setLength( javaType.getDefaultSqlLength( Dialect.this, jdbcType ) );
-					break;
 				case Types.VARCHAR:
 				case Types.NVARCHAR:
 				case Types.BINARY:
 				case Types.VARBINARY:
-					// Use the default length for UUID if we encounter the JPA default 255 instead
-					if ( javaType.getJavaTypeClass() == UUID.class && length != null && length == Size.DEFAULT_LENGTH ) {
-						length = null;
-					}
+				case Types.CLOB:
+				case Types.BLOB:
 					size.setLength( javaType.getDefaultSqlLength( Dialect.this, jdbcType ) );
 					break;
 				case Types.LONGVARCHAR:
@@ -4009,13 +3997,6 @@ public abstract class Dialect implements ConversionContext {
 					break;
 				case Types.NUMERIC:
 				case Types.DECIMAL:
-					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
-					size.setScale( javaType.getDefaultSqlScale( Dialect.this, jdbcType ) );
-					break;
-				case Types.CLOB:
-				case Types.BLOB:
-					size.setLength( javaType.getDefaultSqlLength( Dialect.this, jdbcType ) );
-					break;
 				case SqlTypes.INTERVAL_SECOND:
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
 					size.setScale( javaType.getDefaultSqlScale( Dialect.this, jdbcType ) );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -45,6 +45,7 @@ public class Property implements Serializable, MetaAttributable {
 	private boolean optimisticLocked = true;
 	private ValueGeneration valueGenerationStrategy;
 	private String propertyAccessorName;
+	private PropertyAccessStrategy propertyAccessStrategy;
 	private boolean lazy;
 	private String lazyGroup;
 	private boolean optional;
@@ -237,6 +238,14 @@ public class Property implements Serializable, MetaAttributable {
 		propertyAccessorName = string;
 	}
 
+	public PropertyAccessStrategy getPropertyAccessStrategy() {
+		return propertyAccessStrategy;
+	}
+
+	public void setPropertyAccessStrategy(PropertyAccessStrategy propertyAccessStrategy) {
+		this.propertyAccessStrategy = propertyAccessStrategy;
+	}
+
 	/**
 	 * Approximate!
 	 */
@@ -355,6 +364,10 @@ public class Property implements Serializable, MetaAttributable {
 
 	// todo : remove
 	public PropertyAccessStrategy getPropertyAccessStrategy(Class clazz) throws MappingException {
+		final PropertyAccessStrategy propertyAccessStrategy = getPropertyAccessStrategy();
+		if ( propertyAccessStrategy != null ) {
+			return propertyAccessStrategy;
+		}
 		String accessName = getPropertyAccessorName();
 		if ( accessName == null ) {
 			if ( clazz == null || java.util.Map.class.equals( clazz ) ) {
@@ -438,6 +451,7 @@ public class Property implements Serializable, MetaAttributable {
 		prop.setOptimisticLocked( isOptimisticLocked() );
 		prop.setValueGenerationStrategy( getValueGenerationStrategy() );
 		prop.setPropertyAccessorName( getPropertyAccessorName() );
+		prop.setPropertyAccessStrategy( getPropertyAccessStrategy() );
 		prop.setLazy( isLazy() );
 		prop.setLazyGroup( getLazyGroup() );
 		prop.setOptional( isOptional() );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableCompositeUserTypeInstantiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableCompositeUserTypeInstantiator.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.metamodel.internal;
+
+import java.util.function.Supplier;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
+import org.hibernate.usertype.CompositeUserType;
+
+/**
+ * @author Christian Beikov
+ */
+public class EmbeddableCompositeUserTypeInstantiator implements EmbeddableInstantiator {
+
+	private final CompositeUserType<Object> userType;
+
+	public EmbeddableCompositeUserTypeInstantiator(CompositeUserType<Object> userType) {
+		this.userType = userType;
+	}
+
+	@Override
+	public Object instantiate(Supplier<Object[]> valuesAccess, SessionFactoryImplementor sessionFactory) {
+		return userType.instantiate( valuesAccess, sessionFactory );
+	}
+
+	@Override
+	public boolean isInstance(Object object, SessionFactoryImplementor sessionFactory) {
+		return userType.returnedClass().isInstance( object );
+	}
+
+	@Override
+	public boolean isSameClass(Object object, SessionFactoryImplementor sessionFactory) {
+		return object.getClass().equals( userType.returnedClass() );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -117,6 +117,7 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 									.getMappingModelPart().getEmbeddableTypeDescriptor(),
 							// we currently do not support custom instantiators for identifiers
 							null,
+							null,
 							creationContext
 					);
 				}
@@ -126,6 +127,7 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 							() -> ( ( CompositeTypeImplementor) bootDescriptor.getIdentifierMapper().getType() )
 									.getMappingModelPart().getEmbeddableTypeDescriptor(),
 							// we currently do not support custom instantiators for identifiers
+							null,
 							null,
 							creationContext
 					);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
@@ -213,7 +213,7 @@ public class BasicValuedCollectionPart
 
 	@Override
 	public String getFetchableName() {
-		return nature == Nature.ELEMENT ? "{value}" : "{key}";
+		return nature.getName();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessCompositeUserTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessCompositeUserTypeImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.internal;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.ReflectHelper;
+import org.hibernate.property.access.spi.Getter;
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
+import org.hibernate.property.access.spi.Setter;
+
+/**
+ * PropertyAccessor for accessing the wrapped property via get/set pair, which may be nonpublic.
+ *
+ * @author Steve Ebersole
+ *
+ * @see PropertyAccessStrategyBasicImpl
+ */
+public class PropertyAccessCompositeUserTypeImpl implements PropertyAccess, Getter {
+
+	private final PropertyAccessStrategyCompositeUserTypeImpl strategy;
+	private final int propertyIndex;
+
+	public PropertyAccessCompositeUserTypeImpl(PropertyAccessStrategyCompositeUserTypeImpl strategy, String property) {
+		this.strategy = strategy;
+		this.propertyIndex = strategy.sortedPropertyNames.indexOf( property );
+	}
+
+	@Override
+	public PropertyAccessStrategy getPropertyAccessStrategy() {
+		return strategy;
+	}
+
+	@Override
+	public Getter getGetter() {
+		return this;
+	}
+
+	@Override
+	public Setter getSetter() {
+		return null;
+	}
+
+	@Override
+	public Object get(Object owner) {
+		return strategy.compositeUserType.getPropertyValue( owner, propertyIndex );
+	}
+
+	@Override
+	public Object getForInsert(Object owner, Map mergeMap, SharedSessionContractImplementor session) {
+		return get( owner );
+	}
+
+	@Override
+	public Class<?> getReturnTypeClass() {
+		return ReflectHelper.getClass( strategy.sortedPropertyTypes.get(propertyIndex) );
+	}
+
+	@Override
+	public Type getReturnType() {
+		return strategy.sortedPropertyTypes.get(propertyIndex);
+	}
+
+	@Override
+	public Member getMember() {
+		return null;
+	}
+
+	@Override
+	public String getMethodName() {
+		return null;
+	}
+
+	@Override
+	public Method getMethod() {
+		return null;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyCompositeUserTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyCompositeUserTypeImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.property.access.internal;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.hibernate.property.access.spi.PropertyAccess;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
+import org.hibernate.usertype.CompositeUserType;
+
+/**
+ * Defines a strategy for accessing property values via a CompositeUserType.
+ *
+ * @author Christian Beikov
+ */
+public class PropertyAccessStrategyCompositeUserTypeImpl implements PropertyAccessStrategy {
+
+	final CompositeUserType<Object> compositeUserType;
+	final List<String> sortedPropertyNames;
+	final List<Type> sortedPropertyTypes;
+
+	public PropertyAccessStrategyCompositeUserTypeImpl(
+			CompositeUserType<?> compositeUserType,
+			List<String> sortedPropertyNames,
+			List<Type> sortedPropertyTypes) {
+		//noinspection unchecked
+		this.compositeUserType = (CompositeUserType<Object>) compositeUserType;
+		this.sortedPropertyNames = sortedPropertyNames;
+		this.sortedPropertyTypes = sortedPropertyTypes;
+	}
+
+	@Override
+	public PropertyAccess buildPropertyAccess(Class<?> containerJavaType, final String propertyName, boolean setterRequired) {
+		return new PropertyAccessCompositeUserTypeImpl( this, propertyName );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
@@ -66,6 +66,10 @@ public class CompleteFetchBuilderEntityValuedModelPart
 		return modelPart;
 	}
 
+	public List<String> getColumnAliases() {
+		return columnAliases;
+	}
+
 	@Override
 	public Fetch buildFetch(
 			FetchParent parent,

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/AbstractFetchBuilderContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/AbstractFetchBuilderContainer.java
@@ -19,16 +19,16 @@ import org.hibernate.query.results.FetchBuilder;
  */
 public abstract class AbstractFetchBuilderContainer<T extends AbstractFetchBuilderContainer<T>>
 		implements DynamicFetchBuilderContainer {
-	private Map<String, DynamicFetchBuilder> fetchBuilderMap;
+	private Map<String, FetchBuilder> fetchBuilderMap;
 
 	protected AbstractFetchBuilderContainer() {
 	}
 
 	protected AbstractFetchBuilderContainer(AbstractFetchBuilderContainer<T> original) {
 		if ( original.fetchBuilderMap != null ) {
-			final Map<String, DynamicFetchBuilder> fetchBuilderMap = new HashMap<>( original.fetchBuilderMap.size() );
-			for ( Map.Entry<String, DynamicFetchBuilder> entry : original.fetchBuilderMap.entrySet() ) {
-				final DynamicFetchBuilder fetchBuilder;
+			final Map<String, FetchBuilder> fetchBuilderMap = new HashMap<>( original.fetchBuilderMap.size() );
+			for ( Map.Entry<String, FetchBuilder> entry : original.fetchBuilderMap.entrySet() ) {
+				final FetchBuilder fetchBuilder;
 				if ( entry.getValue() instanceof DynamicFetchBuilderStandard ) {
 					fetchBuilder = ( (DynamicFetchBuilderStandard) entry.getValue() ).cacheKeyInstance( this );
 				}
@@ -44,7 +44,7 @@ public abstract class AbstractFetchBuilderContainer<T extends AbstractFetchBuild
 	protected abstract String getPropertyBase();
 
 	@Override
-	public DynamicFetchBuilder findFetchBuilder(String fetchableName) {
+	public FetchBuilder findFetchBuilder(String fetchableName) {
 		return fetchBuilderMap == null ? null : fetchBuilderMap.get( fetchableName );
 	}
 
@@ -93,7 +93,7 @@ public abstract class AbstractFetchBuilderContainer<T extends AbstractFetchBuild
 		return fetchBuilder;
 	}
 
-	public void addFetchBuilder(String propertyName, DynamicFetchBuilder fetchBuilder) {
+	public void addFetchBuilder(String propertyName, FetchBuilder fetchBuilder) {
 		if ( fetchBuilderMap == null ) {
 			fetchBuilderMap = new HashMap<>();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderContainer.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.query.results.dynamic;
 
+import org.hibernate.query.results.FetchBuilder;
+
 /**
  * @author Steve Ebersole
  */
@@ -13,7 +15,7 @@ public interface DynamicFetchBuilderContainer {
 	/**
 	 * Locate an explicit fetch definition for the named fetchable
 	 */
-	DynamicFetchBuilder findFetchBuilder(String fetchableName);
+	FetchBuilder findFetchBuilder(String fetchableName);
 
 	/**
 	 * Add a property mapped to a single column.
@@ -29,4 +31,6 @@ public interface DynamicFetchBuilderContainer {
 	 * Add a property whose columns can later be defined using {@link DynamicFetchBuilder#addColumnAlias}
 	 */
 	DynamicFetchBuilder addProperty(String propertyName);
+
+	void addFetchBuilder(String propertyName, FetchBuilder fetchBuilder);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderStandard.java
@@ -127,7 +127,8 @@ public class DynamicFetchBuilderStandard
 		}
 		else if ( attributeMapping instanceof ToOneAttributeMapping ) {
 			final ToOneAttributeMapping toOneAttributeMapping = (ToOneAttributeMapping) attributeMapping;
-			toOneAttributeMapping.getForeignKeyDescriptor().visitKeySelectables( selectableConsumer );
+			toOneAttributeMapping.getForeignKeyDescriptor().getPart( toOneAttributeMapping.getSideNature() )
+							.forEachSelectable( selectableConsumer );
 			return parent.generateFetchableFetch(
 					attributeMapping,
 					fetchPath,

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
@@ -8,7 +8,9 @@ package org.hibernate.type.descriptor.java;
 
 import java.util.Currency;
 
+import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
  * Descriptor for {@link Currency} handling.
@@ -52,5 +54,10 @@ public class CurrencyJavaType extends AbstractClassJavaType<Currency> {
 			return Currency.getInstance( (String) value );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public long getDefaultSqlLength(Dialect dialect, JdbcType jdbcType) {
+		return 3;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/CompositeUserTypeJavaTypeWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/CompositeUserTypeJavaTypeWrapper.java
@@ -1,0 +1,154 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.type.internal;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import org.hibernate.SharedSessionContract;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.MutabilityPlan;
+import org.hibernate.type.descriptor.java.MutabilityPlanExposer;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.usertype.CompositeUserType;
+
+/**
+ *
+ * @author Christian Beikov
+ */
+public class CompositeUserTypeJavaTypeWrapper<J> implements JavaType<J> {
+	protected final CompositeUserType<J> userType;
+	private final MutabilityPlan<J> mutabilityPlan;
+
+	private final Comparator<J> comparator;
+
+	public CompositeUserTypeJavaTypeWrapper(CompositeUserType<J> userType) {
+		this.userType = userType;
+
+		MutabilityPlan<J> resolvedMutabilityPlan = null;
+
+		if ( userType instanceof MutabilityPlanExposer ) {
+			//noinspection unchecked
+			resolvedMutabilityPlan = ( (MutabilityPlanExposer<J>) userType ).getExposedMutabilityPlan();
+		}
+
+		if ( resolvedMutabilityPlan == null ) {
+			final Class<J> jClass = userType.returnedClass();
+			if ( jClass != null ) {
+				if ( jClass.getAnnotation( Immutable.class ) != null ) {
+					resolvedMutabilityPlan = ImmutableMutabilityPlan.instance();
+				}
+			}
+		}
+
+		if ( resolvedMutabilityPlan == null ) {
+			resolvedMutabilityPlan = new MutabilityPlanWrapper<>( userType );
+		}
+
+		this.mutabilityPlan = resolvedMutabilityPlan;
+
+		if ( userType instanceof Comparator ) {
+			//noinspection unchecked
+			this.comparator = ( (Comparator<J>) userType );
+		}
+		else {
+			this.comparator = this::compare;
+		}
+	}
+
+	private int compare(J first, J second) {
+		if ( userType.equals( first, second ) ) {
+			return 0;
+		}
+		return Comparator.comparing( userType::hashCode ).compare( first, second );
+	}
+
+	@Override
+	public MutabilityPlan<J> getMutabilityPlan() {
+		return mutabilityPlan;
+	}
+
+	@Override
+	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
+		return null;
+	}
+
+	@Override
+	public Comparator<J> getComparator() {
+		return comparator;
+	}
+
+	@Override
+	public int extractHashCode(J value) {
+		return userType.hashCode(value );
+	}
+
+	@Override
+	public boolean areEqual(J one, J another) {
+		return userType.equals( one, another );
+	}
+
+	@Override
+	public J fromString(CharSequence string) {
+		throw new UnsupportedOperationException( "No support for parsing UserType values from String: " + userType );
+	}
+
+	@Override
+	public <X> X unwrap(J value, Class<X> type, WrapperOptions options) {
+		assert value == null || userType.returnedClass().isInstance( value );
+
+		//noinspection unchecked
+		return (X) value;
+	}
+
+	@Override
+	public <X> J wrap(X value, WrapperOptions options) {
+//		assert value == null || userType.returnedClass().isInstance( value );
+
+		//noinspection unchecked
+		return (J) value;
+	}
+
+	@Override
+	public Class<J> getJavaTypeClass() {
+		return userType.returnedClass();
+	}
+
+	public static class MutabilityPlanWrapper<J> implements MutabilityPlan<J> {
+		private final CompositeUserType<J> userType;
+
+		public MutabilityPlanWrapper(CompositeUserType<J> userType) {
+			this.userType = userType;
+		}
+
+		@Override
+		public boolean isMutable() {
+			return userType.isMutable();
+		}
+
+		@Override
+		public J deepCopy(J value) {
+			//noinspection unchecked
+			return (J) userType.deepCopy( value );
+		}
+
+		@Override
+		public Serializable disassemble(J value, SharedSessionContract session) {
+			return userType.disassemble( value );
+		}
+
+		@Override
+		public J assemble(Serializable cached, SharedSessionContract session) {
+			//noinspection unchecked
+			return (J) userType.disassemble( cached );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.usertype;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Incubating;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
+
+/**
+ * A <tt>UserType</tt> that may be dereferenced in a query.
+ * This interface allows a custom type to define "properties".
+ * These need not necessarily correspond to physical JavaBeans
+ * style properties.<br>
+ * <br>
+ * A <tt>CompositeUserType</tt> may be used in almost every way
+ * that a component may be used. It may even contain many-to-one
+ * associations.<br>
+ * <br>
+ * Implementors must be immutable and must declare a public
+ * default constructor.<br>
+ * <br>
+ * Unlike <tt>UserType</tt>, cacheability does not depend upon
+ * serializability. Instead, <tt>assemble()</tt> and
+ * <tt>disassemble</tt> provide conversion to/from a cacheable
+ * representation.
+ * <br>
+ * Properties are ordered by the order of their names
+ * i.e. they are alphabetically ordered, such that
+ * <code>properties[i].name < properties[i + 1].name</code>
+ * for all <code>i >= 0</code>.
+ */
+@Incubating
+public interface CompositeUserType<J> extends EmbeddableInstantiator {
+
+	/**
+	 * Get the value of a property.
+	 *
+	 * @param component an instance of class mapped by this "type"
+	 * @param property the property index
+	 * @return the property value
+	 * @throws HibernateException
+	 */
+	Object getPropertyValue(J component, int property) throws HibernateException;
+
+	@Override
+	J instantiate(Supplier<Object[]> values, SessionFactoryImplementor sessionFactory);
+
+	/**
+	 * The class that represents the embeddable mapping of the type.
+	 *
+	 * @return Class
+	 */
+	Class<?> embeddable();
+
+	/**
+	 * The class returned by {@code instantiate()}.
+	 *
+	 * @return Class
+	 */
+	Class<J> returnedClass();
+
+	/**
+	 * Compare two instances of the class mapped by this type for persistence "equality".
+	 * Equality of the persistent state.
+	 */
+	boolean equals(Object x, Object y);
+
+	/**
+	 * Get a hashcode for the instance, consistent with persistence "equality"
+	 */
+	int hashCode(Object x);
+
+	/**
+	 * Return a deep copy of the persistent state, stopping at entities and at
+	 * collections. It is not necessary to copy immutable objects, or null
+	 * values, in which case it is safe to simply return the argument.
+	 *
+	 * @param value the object to be cloned, which may be null
+	 * @return Object a copy
+	 */
+	Object deepCopy(Object value);
+
+	/**
+	 * Are objects of this type mutable?
+	 *
+	 * @return boolean
+	 */
+	boolean isMutable();
+
+	/**
+	 * Transform the object into its cacheable representation. At the very least this
+	 * method should perform a deep copy if the type is mutable. That may not be enough
+	 * for some implementations, however; for example, associations must be cached as
+	 * identifier values. (optional operation)
+	 *
+	 * @param value the object to be cached
+	 * @return a cacheable representation of the object
+	 */
+	Serializable disassemble(Object value);
+
+	/**
+	 * Reconstruct an object from the cacheable representation. At the very least this
+	 * method should perform a deep copy if the type is mutable. (optional operation)
+	 *
+	 * @param cached the object to be cached
+	 * @param owner the owner of the cached object
+	 * @return a reconstructed object from the cacheable representation
+	 */
+	Object assemble(Serializable cached, Object owner);
+
+	/**
+	 * During merge, replace the existing (target) value in the entity we are merging to
+	 * with a new (original) value from the detached entity we are merging. For immutable
+	 * objects, or null values, it is safe to simply return the first parameter. For
+	 * mutable objects, it is safe to return a copy of the first parameter. For objects
+	 * with component values, it might make sense to recursively replace component values.
+	 *
+	 * @param detached the value from the detached entity being merged
+	 * @param managed the value in the managed entity
+	 *
+	 * @return the value to be merged
+	 */
+	Object replace(Object detached, Object managed, Object owner);
+
+	@Override
+	default boolean isInstance(Object object, SessionFactoryImplementor sessionFactory) {
+		return returnedClass().isInstance( object );
+	}
+
+	@Override
+	default boolean isSameClass(Object object, SessionFactoryImplementor sessionFactory) {
+		return object.getClass().equals( returnedClass() );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/CustomSQLTestSupport.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/CustomSQLTestSupport.java
@@ -135,7 +135,8 @@ public abstract class CustomSQLTestSupport extends BaseCoreFunctionalTestCase {
 	public void testImageProperty() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
-		byte[] photo = buildLongByteArray( 15000, true );
+		// Make sure the last byte is non-zero as Sybase cuts that off
+		byte[] photo = buildLongByteArray( 14999, true );
 		ImageHolder holder = new ImageHolder( photo );
 		s.save( holder );
 		t.commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/datadirect/oracle/StoredProcedures.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/datadirect/oracle/StoredProcedures.hbm.xml
@@ -38,11 +38,11 @@
 			<return-property name="startDate" column="STARTDATE"/>
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
-			<return-property name="employmentId" column="EMPID"/>						
-			<return-property name="salary">
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+			<return-property name="employmentId" column="EMPID"/>
+			<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 	 { call allEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/db2/DB2CustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/db2/DB2CustomSQLTest.java
@@ -10,8 +10,6 @@ import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
 
 /**
  * Custom SQL tests for DB2
@@ -19,9 +17,6 @@ import org.junit.Ignore;
  * @author Max Rydahl Andersen
  */
 @RequiresDialect( DB2Dialect.class )
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
 public class DB2CustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] { "sql/hand/custom/db2/Mappings.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/db2/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/db2/Mappings.hbm.xml
@@ -56,10 +56,12 @@
 		<property name="startDate" column="STARTDATE" not-null="true" update="false" insert="false"/>
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
-        <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="`VALUE`" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="`VALUE`">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 		<loader query-ref="employment"/>
    		<sql-insert>
 			INSERT INTO EMPLOYMENT 
@@ -164,13 +166,11 @@
 
 
 	<sql-query name="organizationCurrentEmployments">
-		<return alias="emp" class="Employment">		    
-			<return-property name="salary"> 
-		      <!-- as multi column properties are not supported via the
-		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+		<return alias="emp" class="Employment">
+		    <!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
 			<return-property name="endDate" column="myEndDate"/>
 		</return>
@@ -209,12 +209,10 @@
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
 			<return-property name="id" column="EMPID"/>						
-			<return-property name="salary"> 
-				<!-- as multi column properties are not supported via the
-				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="`VALUE`"/>
-				<return-column name="CURRENCY"/>			
-			</return-property>
+			<!-- as multi column properties are not supported via the
+			{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 		{ call selectAllEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/DerbyCustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/DerbyCustomSQLTest.java
@@ -10,16 +10,11 @@ import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
 
 /**
  * @author Andrea Boriero
  */
 @RequiresDialect(DerbyDialect.class)
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
 public class DerbyCustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] {"sql/hand/custom/derby/Mappings.hbm.xml"};

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/DerbyStoreProcedures.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/DerbyStoreProcedures.java
@@ -22,7 +22,7 @@ public class DerbyStoreProcedures {
 
 		PreparedStatement statement = conn.prepareStatement(
 				"select EMPLOYEE, EMPLOYER, STARTDATE, ENDDATE," +
-						" REGIONCODE, EMPID, 'VALUE', CURRENCY" +
+						" REGIONCODE, EMPID, \"VALUE\", CURRENCY" +
 						" FROM EMPLOYMENT"
 		);
 		resultSets[0] = statement.executeQuery();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/derby/Mappings.hbm.xml
@@ -56,10 +56,12 @@
 		<property name="startDate" column="STARTDATE" not-null="true" update="false" insert="false"/>
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
-        <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="`VALUE`" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="`VALUE`">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 		<loader query-ref="employment"/>
    		<sql-insert>
 			INSERT INTO EMPLOYMENT 
@@ -165,12 +167,10 @@
 
 	<sql-query name="organizationCurrentEmployments">
 		<return alias="emp" class="Employment">		    
-			<return-property name="salary"> 
-		      <!-- as multi column properties are not supported via the
-		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+		    <!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
 			<return-property name="endDate" column="myEndDate"/>
 		</return>
@@ -209,12 +209,10 @@
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
 			<return-property name="id" column="EMPID"/>						
-			<return-property name="salary">
-				<!-- as multi column properties are not supported via the
-				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="`VALUE`"/>
-				<return-column name="CURRENCY"/>
-			</return-property>
+			<!-- as multi column properties are not supported via the
+			{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 		{ call selectAllEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/mysql/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/mysql/Mappings.hbm.xml
@@ -57,10 +57,12 @@
 		<property name="startDate" not-null="true" update="false" insert="false"/>
 		<property name="endDate" insert="false"/>
 		<property name="regionCode" update="false"/>
-	  <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="`VALUE`" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="`VALUE`">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 		<loader query-ref="employment"/>
    		<sql-insert>
 			INSERT INTO Employment 
@@ -163,12 +165,10 @@
 
 	<sql-query name="organizationCurrentEmployments">
 		<return alias="emp" class="Employment">		    
-			<return-property name="salary"> 
-		      <!-- as multi column properties are not supported via the
-		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+		    <!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
 			<return-property name="endDate" column="myEndDate"/>
 		</return>
@@ -206,13 +206,10 @@
 			<return-property name="startDate" column="STARTDATE"/>
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
-			<return-property name="id" column="EMPID"/>						
-			<return-property name="salary"> 
-				<!-- as multi column properties are not supported via the
-				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="`VALUE`"/>
-				<return-column name="CURRENCY"/>			
-			</return-property>
+			<return-property name="id" column="EMPID"/>						<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 		{ call selectAllEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/mysql/MySQLCustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/mysql/MySQLCustomSQLTest.java
@@ -7,11 +7,11 @@
 package org.hibernate.orm.test.sql.hand.custom.mysql;
 
 import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * Custom SQL tests for MySQL
@@ -19,9 +19,7 @@ import org.junit.Ignore;
  * @author Gavin King
  */
 @RequiresDialect( MySQLDialect.class )
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
+@SkipForDialect(value = TiDBDialect.class, comment = "TiDB doesn't support stored procedures")
 public class MySQLCustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] { "sql/hand/custom/mysql/Mappings.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/Mappings.hbm.xml
@@ -57,10 +57,12 @@
         <property name="startDate" not-null="true" update="false" insert="false"/>
         <property name="endDate" insert="false"/>
         <property name="regionCode" update="false"/>
-        <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-            <column name="`VALUE`" sql-type="float"/>
-            <column name="CURRENCY"/>
-        </property>
+        <component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+            <property name="value" column="`VALUE`">
+                <type name="float"/>
+            </property>
+            <property name="currency" column="CURRENCY"/>
+        </component>
         <loader query-ref="employment"/>
         <sql-insert>
             INSERT INTO EMPLOYMENT
@@ -157,13 +159,10 @@
 
 
     <sql-query name="organizationCurrentEmployments">
-        <return alias="emp" class="Employment">
-            <return-property name="salary">
-                <!-- as multi column properties are not supported via the
-                              {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-                <return-column name="`VALUE`"/>
-                <return-column name="CURRENCY"/>
-            </return-property>
+        <return alias="emp" class="Employment"><!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+            <return-property name="salary.value" column="`VALUE`"/>
+            <return-property name="salary.currency" column="CURRENCY"/>
             <!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
             <return-property name="endDate" column="myEndDate"/>
         </return>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/OracleCustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/OracleCustomSQLTest.java
@@ -10,8 +10,6 @@ import org.hibernate.dialect.OracleDialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
 
 /**
  * Custom SQL tests for Oracle
@@ -19,9 +17,6 @@ import org.junit.Ignore;
  * @author Gavin King
  */
 @RequiresDialect( OracleDialect.class )
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
 public class OracleCustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] { "sql/hand/custom/oracle/Mappings.hbm.xml", "sql/hand/custom/oracle/StoredProcedures.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/StoredProcedures.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/oracle/StoredProcedures.hbm.xml
@@ -40,10 +40,8 @@
             <return-property name="endDate" column="ENDDATE"/>
             <return-property name="regionCode" column="REGIONCODE"/>
             <return-property name="employmentId" column="EMPID"/>
-            <return-property name="salary">
-                <return-column name="`VALUE`"/>
-                <return-column name="CURRENCY"/>
-            </return-property>
+            <return-property name="salary.value" column="`VALUE`"/>
+            <return-property name="salary.currency" column="CURRENCY"/>
         </return>
         { ? = call allEmployments() }
     </sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sqlserver/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sqlserver/Mappings.hbm.xml
@@ -56,10 +56,12 @@
 		<property name="startDate" column="STARTDATE" not-null="true" update="false" insert="false"/>
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
-        <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="VALUE" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="`VALUE`">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 		<loader query-ref="employment"/>
    		<sql-insert>
 			INSERT INTO EMPLOYMENT 
@@ -70,11 +72,11 @@
 		<sql-delete>DELETE FROM EMPLOYMENT WHERE EMPID=?</sql-delete> 
 	</class>
 
-    <class name="TextHolder">
-        <id name="id" column="id">
+    <class name="TextHolder" table="TEXTHOLDER">
+        <id name="id" column="ID">
             <generator class="increment"/>
         </id>
-        <property name="description" type="text" length="15000"/>
+        <property name="description" column="DESCRIPTION" type="text" length="15000"/>
         <loader query-ref="textholder"/>
         <sql-insert>
             INSERT INTO TEXTHOLDER
@@ -85,11 +87,11 @@
         <sql-delete>DELETE FROM TEXTHOLDER WHERE ID=?</sql-delete>
     </class>
 
-    <class name="ImageHolder">
-        <id name="id" column="id">
+    <class name="ImageHolder" table="IMAGEHOLDER">
+        <id name="id" column="ID">
             <generator class="increment"/>
         </id>
-        <property name="photo" type="image" length="15000"/>
+        <property name="photo" column="PHOTO" type="image" length="15000"/>
         <loader query-ref="imageholder"/>
         <sql-insert>
             INSERT INTO IMAGEHOLDER
@@ -163,13 +165,11 @@
 
 
 	<sql-query name="organizationCurrentEmployments">
-		<return alias="emp" class="Employment">		    
-			<return-property name="salary"> 
-		      <!-- as multi column properties are not supported via the
-		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+		<return alias="emp" class="Employment">
+			<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
 			<return-property name="endDate" column="myEndDate"/>
 		</return>
@@ -207,13 +207,11 @@
 			<return-property name="startDate" column="STARTDATE"/>
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
-			<return-property name="id" column="EMPID"/>						
-			<return-property name="salary"> 
-				<!-- as multi column properties are not supported via the
-				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="`VALUE`"/>
-				<return-column name="CURRENCY"/>			
-			</return-property>
+			<return-property name="id" column="EMPID"/>
+			<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 		{ call selectAllEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sqlserver/SQLServerCustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sqlserver/SQLServerCustomSQLTest.java
@@ -10,8 +10,6 @@ import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
 
 /**
  * Custom SQL tests for SQLServer
@@ -19,9 +17,6 @@ import org.junit.Ignore;
  * @author Gail Badner
  */
 @RequiresDialect( SQLServerDialect.class )
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
 public class SQLServerCustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] { "sql/hand/custom/sqlserver/Mappings.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sybase/Mappings.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sybase/Mappings.hbm.xml
@@ -56,10 +56,12 @@
 		<property name="startDate" column="STARTDATE" not-null="true" update="false" insert="false"/>
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
-        <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="`VALUE`" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="`VALUE`">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 		<loader query-ref="employment"/>
    		<sql-insert>
 			INSERT INTO EMPLOYMENT 
@@ -70,11 +72,11 @@
 		<sql-delete>DELETE FROM EMPLOYMENT WHERE EMPID=?</sql-delete> 
 	</class>
 
-    <class name="TextHolder">
-        <id name="id" column="id">
+    <class name="TextHolder" table="TEXTHOLDER">
+        <id name="id" column="ID">
             <generator class="increment"/>
         </id>
-        <property name="description" type="text" length="15000"/>
+        <property name="description" column="DESCRIPTION" type="text" length="15000"/>
         <loader query-ref="textholder"/>
         <sql-insert>
             INSERT INTO TEXTHOLDER
@@ -85,11 +87,11 @@
         <sql-delete>DELETE FROM TEXTHOLDER WHERE ID=?</sql-delete>
     </class>
 
-    <class name="ImageHolder">
-        <id name="id" column="id">
+    <class name="ImageHolder" table="IMAGEHOLDER">
+        <id name="id" column="ID">
             <generator class="increment"/>
         </id>
-        <property name="photo" type="image" length="15000"/>
+        <property name="photo" column="PHOTO" type="image" length="15000"/>
         <loader query-ref="imageholder"/>
         <sql-insert>
             INSERT INTO IMAGEHOLDER
@@ -163,13 +165,11 @@
 
 
 	<sql-query name="organizationCurrentEmployments">
-		<return alias="emp" class="Employment">		    
-			<return-property name="salary"> 
-		      <!-- as multi column properties are not supported via the
-		      {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-  			  <return-column name="`VALUE`"/>
-			  <return-column name="CURRENCY"/>			
-			</return-property>
+		<return alias="emp" class="Employment">
+			<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 			<!-- Here we are remapping endDate. Notice that we can still use {emp.endDate} in the SQL. -->
 			<return-property name="endDate" column="myEndDate"/>
 		</return>
@@ -207,13 +207,11 @@
 			<return-property name="startDate" column="STARTDATE"/>
 			<return-property name="endDate" column="ENDDATE"/>			
 			<return-property name="regionCode" column="REGIONCODE"/>			
-			<return-property name="id" column="EMPID"/>						
-			<return-property name="salary"> 
-				<!-- as multi column properties are not supported via the
-				{}-syntax, we need to provide an explicit column list for salary via <return-property> -->
-				<return-column name="`VALUE`"/>
-				<return-column name="CURRENCY"/>			
-			</return-property>
+			<return-property name="id" column="EMPID"/>
+			<!-- as multi column properties are not supported via the
+		    {}-syntax, we need to provide an explicit column list for salary via <return-property> -->
+			<return-property name="salary.value" column="`VALUE`"/>
+			<return-property name="salary.currency" column="CURRENCY"/>
 		</return>
 		{ call selectAllEmployments() }
 	</sql-query>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sybase/SybaseCustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/custom/sybase/SybaseCustomSQLTest.java
@@ -10,8 +10,6 @@ import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.orm.test.sql.hand.custom.CustomStoredProcTestSupport;
 
 import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
-import org.junit.Ignore;
 
 /**
  * Custom SQL tests for Sybase dialects
@@ -19,9 +17,6 @@ import org.junit.Ignore;
  * @author Gavin King
  */
 @RequiresDialect( { SybaseDialect.class })
-// todo (6.0): needs a composite user type mechanism e.g. by providing a custom embeddable strategy or istantiator
-@Ignore( "Missing support for composite user types" )
-@NotImplementedYet
 public class SybaseCustomSQLTest extends CustomStoredProcTestSupport {
 	public String[] getMappings() {
 		return new String[] { "sql/hand/custom/sybase/Mappings.hbm.xml" };

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueries.hbm.xml
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueries.hbm.xml
@@ -58,12 +58,12 @@
 		<property name="startDate" column="STARTDATE" not-null="false"/>
 		<property name="endDate" column="ENDDATE" insert="false"/>
 		<property name="regionCode" column="REGIONCODE" update="false"/>
-<!--
-	    <property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<column name="AMOUNT" sql-type="float"/>
-			<column name="CURRENCY"/>			
-		</property>
--->
+		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+			<property name="value" column="AMOUNT">
+				<type name="float"/>
+			</property>
+			<property name="currency" column="CURRENCY"/>
+		</component>
 	</class>
 	
 	<class name="Order" table="TBL_ORDER">
@@ -129,14 +129,14 @@
         <id name="id" column="id">
             <generator class="increment"/>
         </id>
-        <property name="description" type="text" length="15000"/>
+        <property name="description" column="DESCRIPTION" type="text" length="15000"/>
     </class>
 
     <class name="ImageHolder" table="IMAGE_HOLDER">
         <id name="id" column="id">
             <generator class="increment"/>
         </id>
-        <property name="photo" type="image" length="15000"/>
+        <property name="photo" column="PHOTO" type="image" length="15000"/>
     </class>    
 
     <resultset name="org-emp-regionCode">
@@ -221,13 +221,13 @@
 	</sql-query>
 
 	<sql-query name="AllEmploymentAsMapped">
-		<return class="Employment"/>
+		<return alias="emp" class="Employment"/>
 		SELECT * FROM EMPLOYMENT
 	</sql-query>
 
 	<sql-query name="EmploymentAndPerson">
-		<return class="Employment"/>
-		<return class="Person"/>
+		<return alias="emp" class="Employment"/>
+		<return alias="pers" class="Person"/>
 		SELECT * FROM EMPLOYMENT, PERSON
 	</sql-query>
 
@@ -253,24 +253,22 @@
 			<return-property name="element.endDate" column="ENDDATE"/>			
 			<return-property name="element.regionCode" column="REGIONCODE"/>			
 			<return-property name="element.employmentId" column="EMPID"/>						
-			<return-property name="element.salary">
-                <return-column name="AMOUNT"/>
-                <return-column name="CURRENCY"/>
-			</return-property>
+			<return-property name="element.salary.value" column="AMOUNT1"/>
+			<return-property name="element.salary.currency" column="CURRENCY"/>
 		</return-join>
 		SELECT org.ORGID as orgid,
             org.NAME as name,
-            emp.EMPLOYER as employer,
             emp.EMPID as empid,
             emp.EMPLOYEE as employee,
             emp.EMPLOYER as employer,
             emp.STARTDATE as xstartDate,
             emp.ENDDATE as endDate,
             emp.REGIONCODE as regionCode,
-            emp.AMOUNT as AMOUNT,
+            emp.AMOUNT as AMOUNT1,
             emp.CURRENCY as CURRENCY
         FROM ORGANIZATION org
 			LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER
+		ORDER BY org.NAME DESC
 	</sql-query>
 
     
@@ -278,7 +276,6 @@
 	<!--  equal to "organizationpropertyreturn" but since no {} nor return-property are used hibernate will fallback to use the columns directly from the mapping -->
         SELECT org.ORGID as orgid,
             org.NAME as name,
-            emp.EMPLOYER as employer,
             emp.EMPID as empid,
             emp.EMPLOYEE as employee,
             emp.EMPLOYER as employer,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AbstractCollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AbstractCollectionMetadataGenerator.java
@@ -335,6 +335,7 @@ public abstract class AbstractCollectionMetadataGenerator extends AbstractMetada
 			valueMetadataGenerator.addValue(
 					entity,
 					component.getProperty( auditedPropertyName ).getValue(),
+					component.getProperty( auditedPropertyName ).getPropertyAccessStrategy(),
 					componentMapper,
 					prefix,
 					context.getEntityMappingData(),
@@ -351,6 +352,7 @@ public abstract class AbstractCollectionMetadataGenerator extends AbstractMetada
 			valueMetadataGenerator.addValue(
 					entity,
 					component.getProperty( auditedPropertyName ).getValue(),
+					component.getProperty( auditedPropertyName ).getPropertyAccessStrategy(),
 					componentMapper,
 					context.getReferencingEntityName(),
 					context.getEntityMappingData(),

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
@@ -105,6 +105,7 @@ public final class AuditMetadataGenerator extends AbstractMetadataGenerator {
 				valueMetadataGenerator.addValue(
 						attributeContainer,
 						property.getValue(),
+						property.getPropertyAccessStrategy(),
 						currentMapper,
 						entityName,
 						mappingData,
@@ -370,6 +371,7 @@ public final class AuditMetadataGenerator extends AbstractMetadataGenerator {
 			valueMetadataGenerator.addValue(
 					entity,
 					propertyAuditingData.getValue(),
+					null,
 					currentMapper,
 					entityName,
 					mappingData,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ValueMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ValueMetadataGenerator.java
@@ -18,6 +18,7 @@ import org.hibernate.envers.internal.tools.MappingTools;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.Value;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.ComponentType;
@@ -52,6 +53,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 	public void addValue(
 			AttributeContainer attributeContainer,
 			Value value,
+			PropertyAccessStrategy propertyAccessStrategy,
 			CompositeMapperBuilder currentMapper,
 			String entityName,
 			EntityMappingData mappingData,
@@ -63,6 +65,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 			addValueInFirstPass(
 					attributeContainer,
 					value,
+					propertyAccessStrategy,
 					currentMapper,
 					entityName,
 					mappingData,
@@ -75,6 +78,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 			addValueInSecondPass(
 					attributeContainer,
 					value,
+					propertyAccessStrategy,
 					currentMapper,
 					entityName,
 					mappingData,
@@ -88,6 +92,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 	private void addValueInFirstPass(
 			AttributeContainer attributeContainer,
 			Value value,
+			PropertyAccessStrategy propertyAccessStrategy,
 			CompositeMapperBuilder currentMapper,
 			String entityName,
 			EntityMappingData mappingData,
@@ -95,6 +100,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 			boolean insertable,
 			boolean processModifiedFlag) {
 		final Type type = value.getType();
+		propertyAuditingData.setPropertyAccessStrategy( propertyAccessStrategy );
 
 		if ( type instanceof BasicType ) {
 			basicMetadataGenerator.addBasic(
@@ -134,6 +140,7 @@ public class ValueMetadataGenerator extends AbstractMetadataGenerator {
 	private void addValueInSecondPass(
 			AttributeContainer attributeContainer,
 			Value value,
+			PropertyAccessStrategy propertyAccessStrategy,
 			CompositeMapperBuilder currentMapper,
 			String entityName,
 			EntityMappingData mappingData,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/PersistentPropertiesSource.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/PersistentPropertiesSource.java
@@ -32,6 +32,8 @@ public interface PersistentPropertiesSource {
 
 	boolean isDynamicComponent();
 
+	boolean hasCompositeUserType();
+
 	/**
 	 * Get a persistent properties source for a persistent class.
 	 *
@@ -58,6 +60,11 @@ public interface PersistentPropertiesSource {
 
 			@Override
 			public boolean isDynamicComponent() {
+				return false;
+			}
+
+			@Override
+			public boolean hasCompositeUserType() {
 				return false;
 			}
 		};
@@ -114,6 +121,11 @@ public interface PersistentPropertiesSource {
 			@Override
 			public boolean isDynamicComponent() {
 				return dynamic;
+			}
+
+			@Override
+			public boolean hasCompositeUserType() {
+				return component.getTypeName() != null;
 			}
 		};
 	}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/PropertyAuditingData.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/reader/PropertyAuditingData.java
@@ -20,6 +20,7 @@ import org.hibernate.envers.RelationTargetNotFoundAction;
 import org.hibernate.envers.internal.entities.PropertyData;
 import org.hibernate.envers.internal.tools.StringTools;
 import org.hibernate.mapping.Value;
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.type.Type;
 
 /**
@@ -50,6 +51,7 @@ public class PropertyAuditingData {
 	private Value value;
 	private Type propertyType;
 	private Type virtualPropertyType;
+	private PropertyAccessStrategy propertyAccessStrategy;
 	// Synthetic properties are ones which are not part of the actual java model.
 	// They're properties used for bookkeeping by Hibernate
 	private boolean synthetic;
@@ -323,6 +325,14 @@ public class PropertyAuditingData {
 		this.propertyType = propertyType;
 	}
 
+	public PropertyAccessStrategy getPropertyAccessStrategy() {
+		return propertyAccessStrategy;
+	}
+
+	public void setPropertyAccessStrategy(PropertyAccessStrategy propertyAccessStrategy) {
+		this.propertyAccessStrategy = propertyAccessStrategy;
+	}
+
 	public Type getVirtualPropertyType() {
 		return virtualPropertyType;
 	}
@@ -349,7 +359,8 @@ public class PropertyAuditingData {
 					modifiedFlagName,
 					synthetic,
 					propertyType,
-					virtualPropertyType.getReturnedClass()
+					virtualPropertyType.getReturnedClass(),
+					propertyAccessStrategy
 			);
 		}
 		else if ( propertyType != null ) {
@@ -360,7 +371,8 @@ public class PropertyAuditingData {
 					usingModifiedFlag,
 					modifiedFlagName,
 					synthetic,
-					propertyType
+					propertyType,
+					propertyAccessStrategy
 			);
 		}
 		return new PropertyData(
@@ -370,7 +382,8 @@ public class PropertyAuditingData {
 				usingModifiedFlag,
 				modifiedFlagName,
 				synthetic,
-				null
+				null,
+				propertyAccessStrategy
 		);
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/PropertyData.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/PropertyData.java
@@ -8,6 +8,7 @@ package org.hibernate.envers.internal.entities;
 
 import java.util.Objects;
 
+import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.type.Type;
 
 /**
@@ -30,6 +31,7 @@ public class PropertyData {
 	private boolean synthetic;
 	private Type propertyType;
 	private Class<?> virtualReturnClass;
+	private PropertyAccessStrategy propertyAccessStrategy;
 
 	/**
 	 * Copies the given property data, except the name.
@@ -91,8 +93,9 @@ public class PropertyData {
 			boolean usingModifiedFlag,
 			String modifiedFlagName,
 			boolean synthetic,
-			Type propertyType) {
-		this( name, beanName, accessType, usingModifiedFlag, modifiedFlagName, synthetic, propertyType, null );
+			Type propertyType,
+			PropertyAccessStrategy propertyAccessStrategy) {
+		this( name, beanName, accessType, usingModifiedFlag, modifiedFlagName, synthetic, propertyType, null, propertyAccessStrategy );
 	}
 
 	public PropertyData(
@@ -103,10 +106,12 @@ public class PropertyData {
 			String modifiedFlagName,
 			boolean synthetic,
 			Type propertyType,
-			Class<?> virtualReturnClass) {
+			Class<?> virtualReturnClass,
+			PropertyAccessStrategy propertyAccessStrategy) {
 		this( name, beanName, accessType, usingModifiedFlag, modifiedFlagName, synthetic );
 		this.propertyType = propertyType;
 		this.virtualReturnClass = virtualReturnClass;
+		this.propertyAccessStrategy = propertyAccessStrategy;
 	}
 
 	public String getName() {
@@ -139,6 +144,10 @@ public class PropertyData {
 
 	public Class<?> getVirtualReturnClass() {
 		return virtualReturnClass;
+	}
+
+	public PropertyAccessStrategy getPropertyAccessStrategy() {
+		return propertyAccessStrategy;
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/CompositeMapperBuilder.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/CompositeMapperBuilder.java
@@ -9,12 +9,15 @@ package org.hibernate.envers.internal.entities.mapper;
 import java.util.Map;
 
 import org.hibernate.envers.internal.entities.PropertyData;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 
 /**
  * @author Adam Warski (adam at warski dot org)
  */
 public interface CompositeMapperBuilder extends SimpleMapperBuilder {
-	CompositeMapperBuilder addComponent(PropertyData propertyData, Class componentClass);
+	CompositeMapperBuilder addComponent(
+			PropertyData propertyData,
+			Class componentClass, EmbeddableInstantiator instantiator);
 
 	void addComposite(PropertyData propertyData, PropertyMapper propertyMapper);
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiDynamicComponentMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiDynamicComponentMapper.java
@@ -122,4 +122,14 @@ public class MultiDynamicComponentMapper extends MultiPropertyMapper {
 			mapper.mapToEntityFromMap( enversService, obj, data, primaryKey, versionsReader, revision );
 		}
 	}
+
+	@Override
+	public Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
+		return null;
+	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiPropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/MultiPropertyMapper.java
@@ -19,6 +19,7 @@ import org.hibernate.envers.internal.tools.MappingTools;
 import org.hibernate.envers.internal.tools.ReflectionTools;
 import org.hibernate.envers.internal.tools.Tools;
 import org.hibernate.envers.tools.Pair;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 import org.hibernate.property.access.spi.Getter;
 
 /**
@@ -45,7 +46,9 @@ public class MultiPropertyMapper extends AbstractPropertyMapper implements Exten
 	}
 
 	@Override
-	public CompositeMapperBuilder addComponent(PropertyData propertyData, Class componentClass) {
+	public CompositeMapperBuilder addComponent(
+			PropertyData propertyData,
+			Class componentClass, EmbeddableInstantiator instantiator) {
 		if ( properties.get( propertyData ) != null ) {
 			// This is needed for second pass to work properly in the components mapper
 			return (CompositeMapperBuilder) properties.get( propertyData );
@@ -53,7 +56,8 @@ public class MultiPropertyMapper extends AbstractPropertyMapper implements Exten
 
 		final ComponentPropertyMapper componentMapperBuilder = new ComponentPropertyMapper(
 				propertyData,
-				componentClass
+				componentClass,
+				instantiator
 		);
 		addComposite( propertyData, componentMapperBuilder );
 
@@ -196,6 +200,16 @@ public class MultiPropertyMapper extends AbstractPropertyMapper implements Exten
 		for ( PropertyMapper mapper : properties.values() ) {
 			mapper.mapToEntityFromMap( enversService, obj, data, primaryKey, versionsReader, revision );
 		}
+	}
+
+	@Override
+	public Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
+		return null;
 	}
 
 	private Pair<PropertyMapper, String> getMapperAndDelegatePropName(String referencingPropertyName) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/PropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/PropertyMapper.java
@@ -51,6 +51,13 @@ public interface PropertyMapper extends ModifiedFlagMapperSupport, DynamicCompon
 			AuditReaderImplementor versionsReader,
 			Number revision);
 
+	Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision);
+
 	/**
 	 * Maps collection changes.
 	 *

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SinglePropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SinglePropertyMapper.java
@@ -120,6 +120,21 @@ public class SinglePropertyMapper extends AbstractPropertyMapper implements Simp
 		}
 	}
 
+	@Override
+	public Object mapToEntityFromMap(
+			final EnversService enversService,
+			final Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
+		// synthetic properties are not part of the entity model; therefore they should be ignored.
+		if ( data == null || propertyData.isSynthetic() ) {
+			return null;
+		}
+
+		return data.get( propertyData.getName() );
+	}
+
 	private boolean isPrimitive(Setter setter, PropertyData propertyData, Class<?> cls) {
 		if ( cls == null ) {
 			throw new HibernateException( "No field found for property: " + propertyData.getName() );

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SubclassPropertyMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/SubclassPropertyMapper.java
@@ -16,6 +16,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.internal.entities.PropertyData;
 import org.hibernate.envers.internal.reader.AuditReaderImplementor;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 
 /**
  * A mapper which maps from a parent mapper and a "main" one, but adds only to the "main". The "main" mapper
@@ -88,6 +89,16 @@ public class SubclassPropertyMapper extends AbstractPropertyMapper implements Ex
 	}
 
 	@Override
+	public Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
+		return null;
+	}
+
+	@Override
 	public List<PersistentCollectionChangeData> mapCollectionChanges(
 			SessionImplementor session, String referencingPropertyName,
 			PersistentCollection newColl,
@@ -120,8 +131,10 @@ public class SubclassPropertyMapper extends AbstractPropertyMapper implements Ex
 	}
 
 	@Override
-	public CompositeMapperBuilder addComponent(PropertyData propertyData, Class componentClass) {
-		return main.addComponent( propertyData, componentClass );
+	public CompositeMapperBuilder addComponent(
+			PropertyData propertyData,
+			Class componentClass, EmbeddableInstantiator instantiator) {
+		return main.addComponent( propertyData, componentClass, instantiator );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractCollectionMapper.java
@@ -276,6 +276,25 @@ public abstract class AbstractCollectionMapper<T> extends AbstractPropertyMapper
 			final Object primaryKey,
 			final AuditReaderImplementor versionsReader,
 			final Number revision) {
+		final Object collectionProxy = mapToEntityFromMap( enversService, data, primaryKey, versionsReader, revision );
+		final PropertyData collectionPropertyData = commonCollectionMapperData.getCollectionReferencingPropertyData();
+
+		if ( isDynamicComponentMap() ) {
+			final Map<String, Object> map = (Map<String, Object>) obj;
+			map.put( collectionPropertyData.getBeanName(), collectionProxy );
+		}
+		else {
+			setValueOnObject( collectionPropertyData, obj, collectionProxy, enversService.getServiceRegistry() );
+		}
+	}
+
+	@Override
+	public Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
 		final String revisionTypePropertyName = enversService.getConfig().getRevisionTypePropertyName();
 
 		// construct the collection proxy
@@ -294,16 +313,7 @@ public abstract class AbstractCollectionMapper<T> extends AbstractPropertyMapper
 		catch ( Exception e ) {
 			throw new AuditException( "Failed to construct collection proxy", e );
 		}
-
-		final PropertyData collectionPropertyData = commonCollectionMapperData.getCollectionReferencingPropertyData();
-
-		if ( isDynamicComponentMap() ) {
-			final Map<String, Object> map = (Map<String, Object>) obj;
-			map.put( collectionPropertyData.getBeanName(), collectionProxy );
-		}
-		else {
-			setValueOnObject( collectionPropertyData, obj, collectionProxy, enversService.getServiceRegistry() );
-		}
+		return collectionProxy;
 	}
 
 	/**

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractOneToOneMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractOneToOneMapper.java
@@ -45,6 +45,17 @@ public abstract class AbstractOneToOneMapper extends AbstractToOneMapper {
 			Object primaryKey,
 			AuditReaderImplementor versionsReader,
 			Number revision) {
+		Object value = nullSafeMapToEntityFromMap( enversService, data, primaryKey, versionsReader, revision );
+		setPropertyValue( obj, value );
+	}
+
+	@Override
+	public Object nullSafeMapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
 		final EntityInfo referencedEntity = getEntityInfo( enversService, referencedEntityName );
 
 		Object value;
@@ -60,8 +71,7 @@ public abstract class AbstractOneToOneMapper extends AbstractToOneMapper {
 							"." + getPropertyData().getBeanName() + ".", e
 			);
 		}
-
-		setPropertyValue( obj, value );
+		return value;
 	}
 
 	/**

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractToOneMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/AbstractToOneMapper.java
@@ -59,6 +59,16 @@ public abstract class AbstractToOneMapper extends AbstractPropertyMapper {
 	}
 
 	@Override
+	public Object mapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
+		return nullSafeMapToEntityFromMap( enversService, data, primaryKey, versionsReader, revision );
+	}
+
+	@Override
 	public List<PersistentCollectionChangeData> mapCollectionChanges(
 			SessionImplementor session,
 			String referencingPropertyName,
@@ -110,6 +120,13 @@ public abstract class AbstractToOneMapper extends AbstractPropertyMapper {
 	public abstract void nullSafeMapToEntityFromMap(
 			EnversService enversService,
 			Object obj,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision);
+
+	public abstract Object nullSafeMapToEntityFromMap(
+			EnversService enversService,
 			Map data,
 			Object primaryKey,
 			AuditReaderImplementor versionsReader,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/ToOneIdMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/ToOneIdMapper.java
@@ -149,6 +149,17 @@ public class ToOneIdMapper extends AbstractToOneMapper {
 			Object primaryKey,
 			AuditReaderImplementor versionsReader,
 			Number revision) {
+		Object value = nullSafeMapToEntityFromMap( enversService, data, primaryKey, versionsReader, revision );
+		setPropertyValue( obj, value );
+	}
+
+	@Override
+	public Object nullSafeMapToEntityFromMap(
+			EnversService enversService,
+			Map data,
+			Object primaryKey,
+			AuditReaderImplementor versionsReader,
+			Number revision) {
 		final Object entityId = delegate.mapToIdFromMap( data );
 		Object value = null;
 		if ( entityId != null ) {
@@ -183,8 +194,7 @@ public class ToOneIdMapper extends AbstractToOneMapper {
 				}
 			}
 		}
-
-		setPropertyValue( obj, value );
+		return value;
 	}
 
 	public void addMiddleEqualToQuery(

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/component/MiddleEmbeddableComponentMapper.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mapper/relation/component/MiddleEmbeddableComponentMapper.java
@@ -17,6 +17,7 @@ import org.hibernate.envers.internal.entities.mapper.MultiPropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.PropertyMapper;
 import org.hibernate.envers.internal.entities.mapper.relation.ToOneIdMapper;
 import org.hibernate.envers.internal.tools.query.Parameters;
+import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 
 /**
  * @author Kristoffer Lundberg (kristoffer at cambio dot se)
@@ -125,8 +126,10 @@ public class MiddleEmbeddableComponentMapper extends AbstractMiddleComponentMapp
 	}
 
 	@Override
-	public CompositeMapperBuilder addComponent(PropertyData propertyData, Class componentClass) {
-		return delegate.addComponent( propertyData, componentClass );
+	public CompositeMapperBuilder addComponent(
+			PropertyData propertyData,
+			Class componentClass, EmbeddableInstantiator instantiator) {
+		return delegate.addComponent( propertyData, componentClass, instantiator );
 	}
 
 	@Override

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
@@ -47,7 +47,23 @@ public abstract class ReflectionTools {
 	}
 
 	public static Getter getGetter(Class cls, PropertyData propertyData, ServiceRegistry serviceRegistry) {
-		return getGetter( cls, propertyData.getBeanName(), propertyData.getAccessType(), serviceRegistry );
+		if ( propertyData.getPropertyAccessStrategy() == null ) {
+			return getGetter( cls, propertyData.getBeanName(), propertyData.getAccessType(), serviceRegistry );
+		}
+		else {
+			final String propertyName = propertyData.getName();
+			final Pair<Class, String> key = Pair.make( cls, propertyName );
+			Getter value = GETTER_CACHE.get( key );
+			if ( value == null ) {
+				value = propertyData.getPropertyAccessStrategy().buildPropertyAccess(
+						cls,
+						propertyData.getBeanName(), false
+				).getGetter();
+				// It's ok if two getters are generated concurrently
+				GETTER_CACHE.put( key, value );
+			}
+			return value;
+		}
 	}
 
 	public static Getter getGetter(Class cls, String propertyName, String accessorType, ServiceRegistry serviceRegistry) {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserType.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserType.java
@@ -6,23 +6,14 @@
  */
 package org.hibernate.envers.test.integration.customtype;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.util.function.Supplier;
 
 import org.hibernate.HibernateException;
-import org.hibernate.NotYetImplementedFor6Exception;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.usertype.UserType;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.usertype.CompositeUserType;
+
+import jakarta.persistence.Lob;
 
 /**
  * Custom type used to persist binary representation of Java object in the database.
@@ -31,16 +22,31 @@ import org.hibernate.usertype.UserType;
  *
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
-public class ObjectUserType implements UserType {
-	private static final int[] TYPES = new int[] {Types.VARCHAR, Types.BLOB};
+public class ObjectUserType implements CompositeUserType<Object> {
 
 	@Override
-	public int[] sqlTypes() {
-		return TYPES;
+	public Object getPropertyValue(Object component, int property) throws HibernateException {
+		switch ( property ) {
+			case 0:
+				return component;
+			case 1:
+				return component.getClass().getName();
+		}
+		return null;
 	}
 
 	@Override
-	public Class returnedClass() {
+	public Object instantiate(Supplier<Object[]> values, SessionFactoryImplementor sessionFactory) {
+		return values.get()[0];
+	}
+
+	@Override
+	public Class<?> embeddable() {
+		return TaggedObject.class;
+	}
+
+	@Override
+	public Class<Object> returnedClass() {
 		return Object.class;
 	}
 
@@ -58,77 +64,6 @@ public class ObjectUserType implements UserType {
 	@Override
 	public int hashCode(Object x) throws HibernateException {
 		return x.hashCode();
-	}
-
-	@Override
-	public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
-		throw new NotYetImplementedFor6Exception(
-				"See https://github.com/hibernate/hibernate-orm/discussions/3960"
-		);
-	}
-
-	@Override
-	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
-		if ( value == null ) {
-			st.setNull( index, TYPES[0] );
-			st.setNull( index + 1, TYPES[1] );
-		}
-		else {
-			st.setString( index, value.getClass().getName() );
-			st.setBinaryStream( index + 1, convertObjectToInputStream( value ) );
-		}
-	}
-
-	private InputStream convertObjectToInputStream(Object value) {
-		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-		ObjectOutputStream objectOutputStream = null;
-		try {
-			objectOutputStream = new ObjectOutputStream( byteArrayOutputStream );
-			objectOutputStream.writeObject( value );
-			objectOutputStream.flush();
-			return new ByteArrayInputStream( byteArrayOutputStream.toByteArray() );
-		}
-		catch (IOException e) {
-			throw new RuntimeException( e );
-		}
-		finally {
-			closeQuietly( objectOutputStream );
-		}
-	}
-
-	private Object convertInputStreamToObject(InputStream inputStream) {
-		ObjectInputStream objectInputStream = null;
-		try {
-			objectInputStream = new ObjectInputStream( inputStream );
-			return objectInputStream.readObject();
-		}
-		catch (Exception e) {
-			throw new RuntimeException( e );
-		}
-		finally {
-			closeQuietly( objectInputStream );
-		}
-	}
-
-	private void closeQuietly(OutputStream stream) {
-		if ( stream != null ) {
-			try {
-				stream.close();
-			}
-			catch (IOException e) {
-			}
-		}
-	}
-
-	private void closeQuietly(InputStream stream) {
-		if ( stream != null ) {
-			try {
-				stream.close();
-			}
-			catch (IOException e) {
-			}
-		}
 	}
 
 	@Override
@@ -154,5 +89,11 @@ public class ObjectUserType implements UserType {
 	@Override
 	public Object replace(Object original, Object target, Object owner) throws HibernateException {
 		return original;
+	}
+
+	public static class TaggedObject {
+		String type;
+		@Lob
+		Serializable object;
 	}
 }

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserTypeEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserTypeEntity.java
@@ -7,13 +7,15 @@
 package org.hibernate.envers.test.integration.customtype;
 
 import java.io.Serializable;
+
+import org.hibernate.annotations.CompositeType;
+import org.hibernate.envers.Audited;
+
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-
-import org.hibernate.annotations.Columns;
-import org.hibernate.envers.Audited;
 
 /**
  * Entity encapsulating {@link Object} property which concrete type may change during subsequent updates.
@@ -29,8 +31,10 @@ public class ObjectUserTypeEntity implements Serializable {
 
 	private String buildInType;
 
-//	@Type(type = "org.hibernate.envers.test.integration.customtype.ObjectUserType")
-	@Columns(columns = {@Column(name = "OBJ_TYPE"), @Column(name = "OBJ_VALUE")})
+	@Audited
+	@CompositeType(ObjectUserType.class)
+	@AttributeOverride( name = "type", column = @Column(name = "OBJ_TYPE"))
+	@AttributeOverride( name = "object", column = @Column(name = "OBJ_VALUE"))
 	private Object userType;
 
 	public ObjectUserTypeEntity() {

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserTypeTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/customtype/ObjectUserTypeTest.java
@@ -10,12 +10,10 @@ import java.util.Arrays;
 import java.util.Map;
 import jakarta.persistence.EntityManager;
 
-import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.envers.configuration.EnversSettings;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
 
-import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,7 +22,6 @@ import org.junit.Test;
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 @TestForIssue(jiraKey = "HHH-7870")
-@RequiresDialect(Oracle8iDialect.class)
 public class ObjectUserTypeTest extends BaseEnversJPAFunctionalTestCase {
 	private int id;
 

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -198,6 +198,32 @@ identifiers cannot use constructor injection.
 
 See https://docs.jboss.org/hibernate/orm/6.0/userguide/html_single/Hibernate_User_Guide.html#embeddable-instantiator for details.
 
+==== CompositeUserType changes
+
+The `CompositeUserType` interface was re-implemented to be able to model user types as proper embeddable types.
+A major difference to 5.x is the introduction of an "embeddable projection" that is used to determine the mapping structure.
+
+Previously, a `CompositeUserType` had to provide property names and types through dedicated accessor methods,
+but this was complicated for non-basic mappings and required quite some knowledge about Hibernate internals.
+With 6.0 these methods are replaced with a method that returns an "embeddable projection" class.
+The class is like a regular `@Embeddable` class and is used to determine the mapping structure for the `CompositeUserType`.
+
+Component values of a user type object are accessed by property index. The property index is 0-based and can be determined
+by sorting the persistent attribute names lexicographically ascending and using the 0-based position as property index.
+
+For example, the following component:
+
+```java
+public class MonetaryAmountEmbeddable {
+	BigDecimal value;
+	Currency currency;
+}
+```
+
+will assign property index 0 to `currency` and index 1 to `value`.
+
+Note that it is not possible anymore to use `@Columns` to specify the names of columns of a composite user type mapping.
+Since a `CompositeUserType` now constructs a proper component, it is necessary to use the `@AttributeOverride` annotation.
 
 === Plural attributes
 
@@ -758,3 +784,53 @@ when loaded by-id i.e. through `Session#get`/`EntityManager#find`, even though f
 
 Starting with Hibernate 6.0, the laziness of such associations is properly respected, regardless of the fetch mechanism.
 Backwards compatibility can be achieved by specifying `lazy="false"` or `@ManyToOne(fetch = EAGER)`/`@OneToOne(fetch = EAGER)`/`@OneToMany(fetch = EAGER)`/`@ManyToMany(fetch = EAGER)`.
+
+== hbm.xml <return-join/> behavior change
+
+As of Hibernate 6.0, a `<return-join/>` will cause a fetch of an association, rather than adding a selection item.
+Consider the following example:
+
+```xml
+<sql-query name="organizationreturnproperty">
+    <return alias="org" class="Organization">
+        <return-property name="id" column="ORGID"/>
+        <return-property name="name" column="NAME"/>
+    </return>
+    <return-join alias="emp" property="org.employments">
+        <return-property name="key" column="EMPLOYER"/>
+        <return-property name="element" column="EMPID"/>
+        <return-property name="element.employee" column="EMPLOYEE"/>
+    </return-join>
+    ...
+</sql-query>
+```
+
+Prior to 6.0, a query would return a list of tuples [`Organization`, `Employee`],
+but now this will return a list of `Organization` with an initialized `employments` collection.
+
+== hbm.xml multiple <column/> now disallowed
+
+In 6.0 the support for basic property mappings with multiple columns was removed. The only use case for that was when a
+`CompositeUserType` was in use, which was reworked to now work on top of components.
+
+Uses like:
+
+```xml
+<property name="salary" type="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+    <column name="CURRENCY"/>
+    <column name="AMOUNT" sql-type="float"/>
+</property>
+```
+
+have to be migrated to proper components:
+
+```xml
+<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
+    <property name="value" column="AMOUNT">
+        <type name="float"/>
+    </property>
+    <property name="currency" column="CURRENCY"/>
+</component>
+```
+
+The component class attribute now supports interpreting a `CompositeUserType` class properly.


### PR DESCRIPTION
See https://github.com/hibernate/hibernate-orm/discussions/3960

Citing from the migration guide:

The `CompositeUserType` interface was re-implemented to be able to model user types as proper embeddable types.
A major difference to 5.x is the introduction of an "embeddable projection" that is used to determine the mapping structure.

Previously, a `CompositeUserType` had to provide property names and types through dedicated accessor methods,
but this was complicated for non-basic mappings and required quite some knowledge about Hibernate internals.
With 6.0 these methods are replaced with a method that returns an "embeddable projection" class.
The class is like a regular `@Embeddable` class and is used to determine the mapping structure for the `CompositeUserType`.

Component values of a user type object are accessed by property index. The property index is 0-based and can be determined
by sorting the persistent attribute names lexicographically ascending and using the 0-based position as property index.

For example, the following component:

```java
public class MonetaryAmountEmbeddable {
	BigDecimal value;
	Currency currency;
}
```

will assign property index 0 to `currency` and index 1 to `value`.

Note that it is not possible anymore to use `@Columns` to specify the names of columns of a composite user type mapping.
Since a `CompositeUserType` now constructs a proper component, it is necessary to use the `@AttributeOverride` annotation.