### PR TITLE
Avoid using deprecated CDI API that is removed from CDI 4.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
@@ -128,7 +128,7 @@ public class JpaCompliantLifecycleStrategy implements BeanLifecycleStrategy {
 			}
 
 			try {
-				this.injectionTarget = beanManager.createInjectionTarget( annotatedType );
+				this.injectionTarget = beanManager.getInjectionTargetFactory( annotatedType ).createInjectionTarget( null );
 				this.creationalContext = beanManager.createCreationalContext( null );
 
 				this.beanInstance = this.injectionTarget.produce( creationalContext );


### PR DESCRIPTION
This came up in an EE 10 effort for WFLY 10, see also https://github.com/wildfly/wildfly/pull/15252

`BeanManager#createInjectionTarget` method was deprecated and in CDI 4 is removed.

I also quickly checked on other deprecations that happened for CDI 4 but didn't see any other usages in this repo.
The list of removals can be seen here - https://github.com/eclipse-ee4j/cdi/issues/472
