### PR TITLE
Add sql type name and size information to BasicType

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdSqlAstTranslator.java
@@ -247,11 +247,7 @@ public class FirebirdSqlAstTranslator<T extends JdbcOperation> extends AbstractS
 				// Firebird cannot determine the datatype of a parameter as passed to a function,
 				// resulting in a "Datatype unknown" error when the statement is compiled.
 				// This adds an explicit cast so Firebird can infer the type
-				final JdbcMapping jdbcMapping = jdbcParameter.getExpressionType().getJdbcMappings().get( 0 );
-				final List<SqlAstNode> arguments = new ArrayList<>( 2 );
-				arguments.add( jdbcParameter );
-				arguments.add( new CastTarget( jdbcMapping ) );
-				castFunction().render( this, arguments, this );
+				renderCasted( jdbcParameter );
 			}
 			finally {
 				inFunction = true;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MimerSQLDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MimerSQLDialect.java
@@ -98,6 +98,21 @@ public class MimerSQLDialect extends Dialect {
 //	}
 
 	@Override
+	public int getMaxVarbinaryLength() {
+		return 15000;
+	}
+
+	@Override
+	public int getMaxVarcharLength() {
+		return 15000;
+	}
+
+	@Override
+	public int getMaxNVarcharLength() {
+		return 5000;
+	}
+
+	@Override
 	public DatabaseVersion getVersion() {
 		return ZERO_VERSION;
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -54,8 +54,10 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 
 import jakarta.persistence.TemporalType;
@@ -70,6 +72,14 @@ import static org.hibernate.query.sqm.produce.function.FunctionParameterType.INT
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.NUMERIC;
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.STRING;
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.TEMPORAL;
+import static org.hibernate.type.SqlTypes.CHAR;
+import static org.hibernate.type.SqlTypes.LONG32NVARCHAR;
+import static org.hibernate.type.SqlTypes.LONG32VARCHAR;
+import static org.hibernate.type.SqlTypes.LONGNVARCHAR;
+import static org.hibernate.type.SqlTypes.LONGVARCHAR;
+import static org.hibernate.type.SqlTypes.NCHAR;
+import static org.hibernate.type.SqlTypes.NVARCHAR;
+import static org.hibernate.type.SqlTypes.VARCHAR;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsDate;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTime;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithMicros;
@@ -114,6 +124,22 @@ public class SQLiteDialect extends Dialect {
 		registerColumnType( Types.BINARY, "blob" );
 		registerColumnType( Types.VARBINARY, "blob" );
 		uniqueDelegate = new SQLiteUniqueDelegate( this );
+	}
+
+	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "text";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
@@ -7,12 +7,10 @@
 package org.hibernate.boot.model.process.internal;
 
 import java.util.function.Function;
-import jakarta.persistence.AttributeConverter;
 
 import org.hibernate.boot.model.convert.internal.ClassBasedConverterDescriptor;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.model.convert.spi.JpaAttributeConverterCreationContext;
-import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.BasicValue;
@@ -40,6 +38,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 			Function<TypeConfiguration, JdbcType> explicitStdAccess,
 			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
 			JdbcTypeIndicators sqlTypeIndicators,
+			String columnDefinition,
+			Integer lengthOrPrecision,
+			Integer scale,
 			JpaAttributeConverterCreationContext converterCreationContext,
 			MetadataBuildingContext context) {
 		return fromInternal(
@@ -48,6 +49,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 				explicitMutabilityPlanAccess,
 				converter( converterCreationContext, converterDescriptor ),
 				sqlTypeIndicators,
+				columnDefinition,
+				lengthOrPrecision,
+				scale,
 				context
 		);
 	}
@@ -58,6 +62,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 			Function<TypeConfiguration, JdbcType> explicitStdAccess,
 			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
 			JdbcTypeIndicators sqlTypeIndicators,
+			String columnDefinition,
+			Integer lengthOrPrecision,
+			Integer scale,
 			JpaAttributeConverterCreationContext converterCreationContext,
 			MetadataBuildingContext context) {
 		assert name.startsWith( ConverterDescriptor.TYPE_NAME_PREFIX );
@@ -76,6 +83,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 				explicitMutabilityPlanAccess,
 				converter( converterCreationContext, converterDescriptor ),
 				sqlTypeIndicators,
+				columnDefinition,
+				lengthOrPrecision,
+				scale,
 				context
 		);
 	}
@@ -93,6 +103,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 			Function<TypeConfiguration, MutabilityPlan> explicitMutabilityPlanAccess,
 			JpaAttributeConverter<T,?> converter,
 			JdbcTypeIndicators sqlTypeIndicators,
+			String columnDefinition,
+			Integer lengthOrPrecision,
+			Integer scale,
 			MetadataBuildingContext context) {
 		final TypeConfiguration typeConfiguration = context.getBootstrapContext().getTypeConfiguration();
 
@@ -136,6 +149,9 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 				jdbcType,
 				converter,
 				mutabilityPlan,
+				columnDefinition,
+				lengthOrPrecision,
+				scale,
 				context.getBootstrapContext().getTypeConfiguration()
 		);
 	}
@@ -156,8 +172,11 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 			JavaType<J> domainJtd,
 			JavaType<?> relationalJtd,
 			JdbcType jdbcType,
-			JpaAttributeConverter<J,?> valueConverter,
+			JpaAttributeConverter<J, ?> valueConverter,
 			MutabilityPlan<J> mutabilityPlan,
+			String columnDefinition,
+			Integer lengthOrPrecision,
+			Integer scale,
 			TypeConfiguration typeConfiguration) {
 		assert domainJtd != null;
 		this.domainJtd = domainJtd;
@@ -177,40 +196,7 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 		this.jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
 				relationalJtd,
 				jdbcType
-		);
-//		this.jdbcMapping = new JdbcMapping() {
-//			private final ValueExtractor extractor = relationalStd.getExtractor( relationalJtd );
-//			private final ValueBinder binder = relationalStd.getBinder( relationalJtd );
-//
-//			@Override
-//			public JavaType getJavaType() {
-//				return relationalJtd;
-//			}
-//
-//			@Override
-//			public JdbcType getJdbcType() {
-//				return relationalStd;
-//			}
-//
-//			@Override
-//			public ValueExtractor getJdbcValueExtractor() {
-//				return extractor;
-//			}
-//
-//			@Override
-//			public ValueBinder getJdbcValueBinder() {
-//				return binder;
-//			}
-//		};
-
-//		this.jdbcMapping = new ConverterJdbcMappingImpl(
-//				domainJtd,
-//				relationalJtd,
-//				relationalStd,
-//				valueConverter,
-//				mutabilityPlan,
-//				typeConfiguration
-//		);
+		).withSqlType( columnDefinition, lengthOrPrecision, scale );
 
 		this.legacyResolvedType = new AttributeConverterTypeAdapter<>(
 				ConverterDescriptor.TYPE_NAME_PREFIX

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.process.internal;
 
+import java.lang.reflect.Type;
 import java.util.function.Function;
 import jakarta.persistence.TemporalType;
 
@@ -35,11 +36,14 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public static <E> VersionResolution<E> from(
-			Function<TypeConfiguration, java.lang.reflect.Type> implicitJavaTypeAccess,
+			Function<TypeConfiguration, Type> implicitJavaTypeAccess,
 			Function<TypeConfiguration, BasicJavaType> explicitJtdAccess,
 			Function<TypeConfiguration, JdbcType> explicitStdAccess,
 			TimeZoneStorageType timeZoneStorageType,
 			TypeConfiguration typeConfiguration,
+			String columnDefinition,
+			Integer lengthOrPrecision,
+			Integer scale,
 			@SuppressWarnings("unused") MetadataBuildingContext context) {
 
 		// todo (6.0) : add support for Dialect-specific interpretation?
@@ -76,7 +80,8 @@ public class VersionResolution<E> implements BasicValue.Resolution<E> {
 				}
 		);
 
-		final BasicType<?> basicType = typeConfiguration.getBasicTypeRegistry().resolve( jtd, recommendedJdbcType );
+		final BasicType<?> basicType = typeConfiguration.getBasicTypeRegistry().resolve( jtd, recommendedJdbcType )
+				.withSqlType( columnDefinition, lengthOrPrecision, scale );
 		final BasicType legacyType = typeConfiguration.getBasicTypeRegistry().getRegisteredType( jtd.getJavaType() );
 
 		assert legacyType.getJdbcType().equals( recommendedJdbcType );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -273,6 +273,21 @@ public abstract class AbstractHANADialect extends Dialect {
 	}
 
 	@Override
+	public int getMaxVarcharLength() {
+		return 5000;
+	}
+
+	@Override
+	public int getMaxNVarcharLength() {
+		return 5000;
+	}
+
+	@Override
+	public int getMaxVarbinaryLength() {
+		return 5000;
+	}
+
+	@Override
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		super.initializeFunctionRegistry( queryEngine );
 		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -157,6 +157,7 @@ public abstract class AbstractTransactSQLDialect extends Dialect {
 				new CastingConcatFunction(
 						this,
 						"+",
+						false,
 						SqlAstNodeRenderingMode.DEFAULT,
 						queryEngine.getTypeConfiguration()
 				)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -48,6 +48,7 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
@@ -139,6 +140,27 @@ public class CockroachDialect extends Dialect {
 			default:
 				return super.columnType(jdbcTypeCode);
 		}
+	}
+
+	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "string";
+			case BINARY:
+			case VARBINARY:
+			case LONGVARBINARY:
+			case LONG32VARBINARY:
+				return "bytes";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -61,6 +61,7 @@ import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLe
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
@@ -69,13 +70,22 @@ import jakarta.persistence.TemporalType;
 
 import static org.hibernate.query.sqm.TemporalUnit.SECOND;
 import static org.hibernate.type.SqlTypes.ARRAY;
+import static org.hibernate.type.SqlTypes.BINARY;
+import static org.hibernate.type.SqlTypes.CHAR;
 import static org.hibernate.type.SqlTypes.DECIMAL;
 import static org.hibernate.type.SqlTypes.DOUBLE;
 import static org.hibernate.type.SqlTypes.FLOAT;
 import static org.hibernate.type.SqlTypes.LONG32NVARCHAR;
 import static org.hibernate.type.SqlTypes.LONG32VARBINARY;
 import static org.hibernate.type.SqlTypes.LONG32VARCHAR;
+import static org.hibernate.type.SqlTypes.LONGNVARCHAR;
+import static org.hibernate.type.SqlTypes.LONGVARBINARY;
+import static org.hibernate.type.SqlTypes.LONGVARCHAR;
+import static org.hibernate.type.SqlTypes.NCHAR;
 import static org.hibernate.type.SqlTypes.NUMERIC;
+import static org.hibernate.type.SqlTypes.NVARCHAR;
+import static org.hibernate.type.SqlTypes.VARBINARY;
+import static org.hibernate.type.SqlTypes.VARCHAR;
 
 /**
  * A {@linkplain Dialect SQL dialect} for H2.
@@ -188,6 +198,28 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+				return "char";
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "varchar";
+			case BINARY:
+			case VARBINARY:
+			case LONGVARBINARY:
+			case LONG32VARBINARY:
+				return "varbinary";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
+	}
+
+	@Override
 	protected List<Integer> getSupportedJdbcTypeCodes() {
 		List<Integer> typeCodes = new ArrayList<>( super.getSupportedJdbcTypeCodes() );
 		typeCodes.add(ARRAY);
@@ -226,7 +258,7 @@ public class H2Dialect extends Dialect {
 		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
 
 		// H2 needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
-		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER, "||", null );
+		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -849,30 +849,41 @@ public class MySQLDialect extends Dialect {
 			case Types.VARBINARY:
 			case Types.LONGVARBINARY:
 				//MySQL doesn't let you cast to BLOB/TINYBLOB/LONGBLOB
-				//we could just return 'binary' here but that would be
-				//inconsistent with other Dialects which need a length
-				return String.format(
-						"binary(%d)",
-						length != null ? length : javaType.getDefaultSqlLength(
-								this,
-								jdbcType
-						)
-				);
+				if ( length == null ) {
+					return "binary";
+				}
+				return String.format( "binary(%d)", length );
 			case Types.VARCHAR:
 			case Types.LONGVARCHAR:
 				//MySQL doesn't let you cast to TEXT/LONGTEXT
-				//we could just return 'char' here but that would be
-				//inconsistent with other Dialects which need a length
-				return String.format(
-						"char(%d)",
-						length != null ? length : javaType.getDefaultSqlLength(
-								this,
-								jdbcType
-						)
-				);
+				if ( length == null ) {
+					return "char";
+				}
+				return String.format( "char(%d)", length );
 			default:
 				return super.getCastTypeName( type, length, precision, scale );
 		}
+	}
+
+	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "char";
+			case BINARY:
+			case VARBINARY:
+			case LONGVARBINARY:
+			case LONG32VARBINARY:
+				return "binary";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -67,6 +67,7 @@ import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.type.JavaObjectType;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
@@ -173,6 +174,27 @@ public class PostgreSQLDialect extends Dialect {
 			default:
 				return super.columnType(jdbcTypeCode);
 		}
+	}
+
+	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "text";
+			case BINARY:
+			case VARBINARY:
+			case LONGVARBINARY:
+			case LONG32VARBINARY:
+				return "bytea";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -48,6 +48,8 @@ import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 import jakarta.persistence.TemporalType;
 
@@ -125,6 +127,27 @@ public class SpannerDialect extends Dialect {
 			default:
 				return super.columnType(jdbcTypeCode);
 		}
+	}
+
+	@Override
+	public String getUnboundedTypeName(JdbcType jdbcType, JavaType<?> javaType) {
+		switch ( jdbcType.getDefaultSqlTypeCode() ) {
+			case CHAR:
+			case NCHAR:
+			case VARCHAR:
+			case NVARCHAR:
+			case LONGVARCHAR:
+			case LONGNVARCHAR:
+			case LONG32VARCHAR:
+			case LONG32NVARCHAR:
+				return "string";
+			case BINARY:
+			case VARBINARY:
+			case LONGVARBINARY:
+			case LONG32VARBINARY:
+				return "bytes";
+		}
+		return super.getUnboundedTypeName( jdbcType, javaType );
 	}
 
 	@Override
@@ -805,6 +828,13 @@ public class SpannerDialect extends Dialect {
 
 	@Override
 	public String getCastTypeName(SqlExpressible type, Long length, Integer precision, Integer scale) {
+		switch ( type.getJdbcMapping().getJdbcType().getDefaultSqlTypeCode() ) {
+			case VARCHAR:
+			case NVARCHAR:
+				return "string";
+			case VARBINARY:
+				return "bytes";
+		}
 		//Spanner doesn't let you specify a length in cast() types
 		return super.getRawTypeName( type.getJdbcMapping().getJdbcType() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.dialect;
 import org.hibernate.NotYetImplementedFor6Exception;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
+import org.hibernate.dialect.function.CountFunction;
 import org.hibernate.dialect.function.IntegralTimestampaddFunction;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.spi.IdentifierCaseStrategy;
@@ -209,7 +210,17 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
 
 		// For SQL-Server we need to cast certain arguments to varchar(16384) to be able to concat them
-		functionFactory.aggregates( this, SqlAstNodeRenderingMode.DEFAULT, "+", "varchar(16384)" );
+		queryEngine.getSqmFunctionRegistry().register(
+				"count",
+				new CountFunction(
+						this,
+						queryEngine.getTypeConfiguration(),
+						SqlAstNodeRenderingMode.DEFAULT,
+						"+",
+						"varchar(16384)",
+						false
+				)
+		);
 
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.DEFAULT );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -1713,11 +1713,7 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
-	public void aggregates(
-			Dialect dialect,
-			SqlAstNodeRenderingMode inferenceArgumentRenderingMode,
-			String concatOperator,
-			String concatArgumentCastType) {
+	public void aggregates(Dialect dialect, SqlAstNodeRenderingMode inferenceArgumentRenderingMode) {
 		functionRegistry.namedAggregateDescriptorBuilder( "max" )
 				.setArgumentRenderingMode( inferenceArgumentRenderingMode )
 				.setExactArgumentCount( 1 )
@@ -1751,8 +1747,7 @@ public class CommonFunctionFactory {
 						dialect,
 						typeConfiguration,
 						inferenceArgumentRenderingMode,
-						concatOperator,
-						concatArgumentCastType
+						"||"
 				)
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
@@ -38,8 +38,8 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 	private final QueryParameterImplementor<?> queryParameter;
 	private final MappingModelExpressible<?> valueMapping;
 	private final Function<QueryParameterImplementor<?>, QueryParameterBinding<?>> queryParameterBindingResolver;
-
-	private final Expression resolvedExpression;
+	private final List<JdbcParameter> jdbcParameters;
+	private Expression resolvedExpression;
 
 	public SqmParameterInterpretation(
 			SqmParameter<?> sqmParameter,
@@ -61,7 +61,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 		assert jdbcParameters != null;
 		assert jdbcParameters.size() > 0;
 
-		this.resolvedExpression = determineResolvedExpression( jdbcParameters, this.valueMapping );
+		this.jdbcParameters = jdbcParameters;
 	}
 
 	private Expression determineResolvedExpression(List<JdbcParameter> jdbcParameters, MappingModelExpressible<?> valueMapping) {
@@ -75,12 +75,16 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 	}
 
 	public Expression getResolvedExpression() {
+		// We need to defer the resolution because the JdbcParameter might be replaced in BaseSqmToSqlAstConverter#replaceJdbcParametersType
+		if ( resolvedExpression == null ) {
+			return this.resolvedExpression = determineResolvedExpression( jdbcParameters, this.valueMapping );
+		}
 		return resolvedExpression;
 	}
 
 	@Override
 	public void accept(SqlAstWalker sqlTreeWalker) {
-		resolvedExpression.accept( sqlTreeWalker );
+		getResolvedExpression().accept( sqlTreeWalker );
 	}
 
 	@Override
@@ -92,6 +96,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 	public DomainResult<?> createDomainResult(
 			String resultVariable,
 			DomainResultCreationState creationState) {
+		final Expression resolvedExpression = getResolvedExpression();
 		if ( resolvedExpression instanceof SqlTuple ) {
 			throw new SemanticException( "Composite query parameter cannot be used in select" );
 		}
@@ -122,6 +127,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 
 	@Override
 	public SqlTuple getSqlTuple() {
+		final Expression resolvedExpression = getResolvedExpression();
 		return resolvedExpression instanceof SqlTuple
 				? (SqlTuple) resolvedExpression
 				: null;
@@ -133,6 +139,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 	}
 
 	public SqlSelection resolveSqlSelection(DomainResultCreationState creationState) {
+		final Expression resolvedExpression = getResolvedExpression();
 		if ( resolvedExpression instanceof SqlTuple ) {
 			throw new SemanticException( "Composite query parameter cannot be used in select" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -3574,10 +3574,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 
 			final LiteralAsParameter<Object> jdbcParameter = new LiteralAsParameter<>( literal );
 			if ( castParameter ) {
-				final List<SqlAstNode> arguments = new ArrayList<>( 2 );
-				arguments.add( jdbcParameter );
-				arguments.add( new CastTarget( jdbcMapping ) );
-				castFunction().render( this, arguments, this );
+				renderCasted( jdbcParameter );
 			}
 			else {
 				appendSql( PARAM_MARKER );
@@ -4235,14 +4232,19 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 
 	@Override
 	public void visitCastTarget(CastTarget castTarget) {
-		appendSql(
-				getDialect().getCastTypeName(
-						(SqlExpressible) castTarget.getExpressionType(),
-						castTarget.getLength(),
-						castTarget.getPrecision(),
-						castTarget.getScale()
-				)
-		);
+		if ( castTarget.getSqlType() != null ) {
+			appendSql( castTarget.getSqlType() );
+		}
+		else {
+			appendSql(
+					getDialect().getCastTypeName(
+							(SqlExpressible) castTarget.getExpressionType(),
+							castTarget.getLength(),
+							castTarget.getPrecision(),
+							castTarget.getScale()
+					)
+			);
+		}
 	}
 
 	@Override
@@ -4274,10 +4276,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	public void visitParameter(JdbcParameter jdbcParameter) {
 		switch ( parameterRenderingMode ) {
 			case NO_PLAIN_PARAMETER:
-				final List<SqlAstNode> arguments = new ArrayList<>( 2 );
-				arguments.add( jdbcParameter );
-				arguments.add( new CastTarget( jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ) ) );
-				castFunction().render( this, arguments, this );
+				renderCasted( jdbcParameter );
 				break;
 			case INLINE_PARAMETERS:
 			case INLINE_ALL_PARAMETERS:

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CastTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CastTarget.java
@@ -10,25 +10,46 @@ import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicType;
 
 /**
  * @author Gavin King
  */
 public class CastTarget implements Expression, SqlAstNode {
 	private final JdbcMapping type;
+	private final String sqlType;
 	private final Long length;
 	private final Integer precision;
 	private final Integer scale;
 
 	public CastTarget(JdbcMapping type) {
-		this( type, null, null, null );
+		this(
+				type,
+				type instanceof BasicType<?> ? ( (BasicType<?>) type ).getSqlType() : null,
+				type instanceof BasicType<?> ? asLong( ( (BasicType<?>) type ).getLength() ) : null,
+				type instanceof BasicType<?> ? ( (BasicType<?>) type ).getPrecision() : null,
+				type instanceof BasicType<?> ? ( (BasicType<?>) type ).getScale() : null
+		);
 	}
 
 	public CastTarget(JdbcMapping type, Long length, Integer precision, Integer scale) {
+		this( type, null, length, precision, scale );
+	}
+
+	public CastTarget(JdbcMapping type, String sqlType, Long length, Integer precision, Integer scale) {
 		this.type = type;
+		this.sqlType = sqlType;
 		this.length = length;
 		this.precision = precision;
 		this.scale = scale;
+	}
+
+	private static Long asLong(Integer length) {
+		return length == null ? null : Long.valueOf( length );
+	}
+
+	public String getSqlType() {
+		return sqlType;
 	}
 
 	public Long getLength() {

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractSingleColumnStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractSingleColumnStandardBasicType.java
@@ -27,6 +27,15 @@ public abstract class AbstractSingleColumnStandardBasicType<T>
 		super( jdbcType, javaType );
 	}
 
+	public AbstractSingleColumnStandardBasicType(
+			JdbcType jdbcType,
+			JavaType<T> javaType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale) {
+		super( jdbcType, javaType, sqlType, lengthOrPrecision, scale );
+	}
+
 	@Override
 	public final void nullSafeSet(PreparedStatement st, Object value, int index, boolean[] settable, SharedSessionContractImplementor session)
 			throws HibernateException, SQLException {

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -44,14 +44,49 @@ public abstract class AbstractStandardBasicType<T>
 	private final int[] sqlTypes;
 	private final ValueBinder<T> jdbcValueBinder;
 	private final ValueExtractor<T> jdbcValueExtractor;
+	private final String sqlType;
+	private final Integer lengthOrPrecision;
+	private final Integer scale;
 
 	public AbstractStandardBasicType(JdbcType jdbcType, JavaType<T> javaType) {
+		this( jdbcType, javaType, null, null, null );
+	}
+
+	public AbstractStandardBasicType(
+			JdbcType jdbcType,
+			JavaType<T> javaType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale) {
 		this.jdbcType = jdbcType;
 		this.sqlTypes = new int[] { jdbcType.getDefaultSqlTypeCode() };
 		this.javaType = javaType;
 
 		this.jdbcValueBinder = jdbcType.getBinder( javaType );
 		this.jdbcValueExtractor = jdbcType.getExtractor( javaType );
+		this.sqlType = sqlType;
+		this.lengthOrPrecision = lengthOrPrecision;
+		this.scale = scale;
+	}
+
+	@Override
+	public String getSqlType() {
+		return sqlType;
+	}
+
+	@Override
+	public Integer getLength() {
+		return scale == null ? lengthOrPrecision : null;
+	}
+
+	@Override
+	public Integer getPrecision() {
+		return scale == null ? null: lengthOrPrecision;
+	}
+
+	@Override
+	public Integer getScale() {
+		return scale;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
@@ -33,6 +33,26 @@ public interface BasicType<T> extends Type, BasicDomainType<T>, MappingType, Bas
 	 */
 	String[] getRegistrationKeys();
 
+	default BasicType<T> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return this;
+	}
+
+	default String getSqlType() {
+		return null;
+	}
+
+	default Integer getLength() {
+		return null;
+	}
+
+	default Integer getPrecision() {
+		return null;
+	}
+
+	default Integer getScale() {
+		return null;
+	}
+
 	@Override
 	default MappingType getMappedType() {
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/type/SerializableType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SerializableType.java
@@ -37,9 +37,24 @@ public class SerializableType<T extends Serializable> extends AbstractSingleColu
 		this.serializableClass = serializableClass;
 	}
 
-	public SerializableType(JavaType<T> jtd) {
-		super( VarbinaryJdbcType.INSTANCE, jtd  );
-		this.serializableClass = jtd.getJavaTypeClass();
+	public SerializableType(JavaType<T> javaType) {
+		super( VarbinaryJdbcType.INSTANCE, javaType  );
+		this.serializableClass = javaType.getJavaTypeClass();
+	}
+
+	public SerializableType(JavaType<T> javaType, String sqlType, Integer lengthOrPrecision, Integer scale) {
+		super( VarbinaryJdbcType.INSTANCE, javaType, sqlType, lengthOrPrecision, scale  );
+		this.serializableClass = javaType.getJavaTypeClass();
+	}
+
+	@Override
+	public BasicType<T> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new SerializableType<>(
+				getJavaTypeDescriptor(),
+				sqlType,
+				lengthOrPrecision,
+				scale
+		);
 	}
 
 	public String getName() {

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/BasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/BasicTypeImpl.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.AdjustableBasicType;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -25,15 +26,35 @@ public class BasicTypeImpl<J> extends AbstractSingleColumnStandardBasicType<J> i
 
 	private final String name;
 
-	public BasicTypeImpl(JavaType<J> jtd, JdbcType std) {
-		super( std, jtd );
+	public BasicTypeImpl(JavaType<J> javaType, JdbcType jdbcType) {
+		this( javaType, jdbcType, null, null, null );
+	}
+
+	public BasicTypeImpl(
+			JavaType<J> javaType,
+			JdbcType jdbcType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale) {
+		super( jdbcType, javaType, sqlType, lengthOrPrecision, scale );
 		name = String.format(
 				Locale.ROOT,
 				"%s@%s(%s,%s)",
 				EXTERNALIZED_PREFIX,
 				++count,
-				jtd.getJavaTypeClass().getName(),
-				std.getDefaultSqlTypeCode()
+				javaType.getJavaTypeClass().getName(),
+				jdbcType.getDefaultSqlTypeCode()
+		);
+	}
+
+	@Override
+	public BasicType<J> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new BasicTypeImpl<>(
+				getJavaTypeDescriptor(),
+				getJdbcType(),
+				sqlType,
+				lengthOrPrecision,
+				scale
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.type.internal;
 
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.ConvertedBasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -25,6 +26,30 @@ public class ConvertedBasicTypeImpl<J> extends NamedBasicTypeImpl<J> implements 
 			BasicValueConverter<J, ?> converter) {
 		super( jtd, std, name );
 		this.converter = converter;
+	}
+
+	public ConvertedBasicTypeImpl(
+			JavaType<J> javaType,
+			JdbcType jdbcType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale, String name,
+			BasicValueConverter<J, ?> converter) {
+		super( javaType, jdbcType, sqlType, lengthOrPrecision, scale, name );
+		this.converter = converter;
+	}
+
+	@Override
+	public BasicType<J> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new ConvertedBasicTypeImpl<>(
+				getJavaTypeDescriptor(),
+				getJdbcType(),
+				sqlType,
+				lengthOrPrecision,
+				scale,
+				getName(),
+				converter
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ImmutableConvertedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ImmutableConvertedBasicTypeImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.type.internal;
 
 import org.hibernate.metamodel.model.convert.spi.BasicValueConverter;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
@@ -23,6 +24,29 @@ public class ImmutableConvertedBasicTypeImpl<J> extends ConvertedBasicTypeImpl<J
 			String name,
 			BasicValueConverter<J, ?> converter) {
 		super( jtd, std, name, converter );
+	}
+
+	public ImmutableConvertedBasicTypeImpl(
+			JavaType<J> javaType,
+			JdbcType jdbcType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale, String name,
+			BasicValueConverter<J, ?> converter) {
+		super( javaType, jdbcType, sqlType, lengthOrPrecision, scale, name, converter);
+	}
+
+	@Override
+	public BasicType<J> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new ImmutableConvertedBasicTypeImpl<>(
+				getJavaTypeDescriptor(),
+				getJdbcType(),
+				sqlType,
+				lengthOrPrecision,
+				scale,
+				getName(),
+				getValueConverter()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ImmutableNamedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ImmutableNamedBasicTypeImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.internal;
 
+import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
@@ -21,6 +22,28 @@ public class ImmutableNamedBasicTypeImpl<J> extends NamedBasicTypeImpl<J> {
 			JdbcType std,
 			String name) {
 		super( jtd, std, name );
+	}
+
+	public ImmutableNamedBasicTypeImpl(
+			JavaType<J> javaType,
+			JdbcType jdbcType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale,
+			String name) {
+		super( javaType, jdbcType, sqlType, lengthOrPrecision, scale, name );
+	}
+
+	@Override
+	public BasicType<J> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new ImmutableNamedBasicTypeImpl<>(
+				getJavaTypeDescriptor(),
+				getJdbcType(),
+				sqlType,
+				lengthOrPrecision,
+				scale,
+				getName()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/NamedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/NamedBasicTypeImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.internal;
 
+import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -19,6 +20,29 @@ public class NamedBasicTypeImpl<J> extends BasicTypeImpl<J> {
 	public NamedBasicTypeImpl(JavaType<J> jtd, JdbcType std, String name) {
 		super( jtd, std );
 		this.name = name;
+	}
+
+	public NamedBasicTypeImpl(
+			JavaType<J> javaType,
+			JdbcType jdbcType,
+			String sqlType,
+			Integer lengthOrPrecision,
+			Integer scale,
+			String name) {
+		super( javaType, jdbcType, sqlType, lengthOrPrecision, scale );
+		this.name = name;
+	}
+
+	@Override
+	public BasicType<J> withSqlType(String sqlType, Integer lengthOrPrecision, Integer scale) {
+		return lengthOrPrecision == null && scale == null ? this : new NamedBasicTypeImpl<>(
+				getJavaTypeDescriptor(),
+				getJdbcType(),
+				sqlType,
+				lengthOrPrecision,
+				scale,
+				name
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/CriteriaToBigDecimalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/CriteriaToBigDecimalTest.java
@@ -73,6 +73,34 @@ public class CriteriaToBigDecimalTest {
 		);
 	}
 
+	@Test
+	public void testToBigDecimal2(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+
+					final CriteriaQuery<BigDecimal> query = criteriaBuilder.createQuery( BigDecimal.class );
+
+					final Root<Person> person = query.from( Person.class );
+
+					final Path<BigDecimal> ageAttribute = person.get( "age" );
+
+					final Expression<BigDecimal> prod = criteriaBuilder.prod(
+							ageAttribute,
+							new BigDecimal( "5.501" )
+					);
+
+					query.select( criteriaBuilder.toBigDecimal( prod ) );
+
+					query.where( criteriaBuilder.equal( ageAttribute, 20 ) );
+
+					BigDecimal result = entityManager.createQuery( query ).getSingleResult();
+
+					assertEquals( new BigDecimal( "110.02" ).stripTrailingZeros(), result.stripTrailingZeros() );
+				}
+		);
+	}
+
 	@Entity(name = "Person")
 	public static class Person {
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/literal/AbstractCriteriaLiteralHandlingModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/literal/AbstractCriteriaLiteralHandlingModeTest.java
@@ -99,16 +99,9 @@ public abstract class AbstractCriteriaLiteralHandlingModeTest extends BaseEntity
 		return getDialect().castPattern( CastType.OTHER, castType )
 				.replace(
 						"?2",
-						getDialect().getTypeName(
-								SqlTypes.VARCHAR,
-								getDialect().getSizeStrategy().resolveSize(
-										typeConfiguration.getJdbcTypeRegistry()
-												.getDescriptor(SqlTypes.VARCHAR ),
-										typeConfiguration.getJavaTypeRegistry().getDescriptor( String.class ),
-										null,
-										null,
-										null
-								)
+						getDialect().getUnboundedTypeName(
+								typeConfiguration.getJdbcTypeRegistry().getDescriptor( SqlTypes.VARCHAR ),
+								typeConfiguration.getJavaTypeRegistry().getDescriptor( String.class )
 						)
 				)
 				.replace( "?1", expression );


### PR DESCRIPTION
The main purpose of this is to have information about the column sql type and size available at runtime which helps to generate casts that work in more situations. See the added tests for scenarios that would fail if we didn't have the proper size available.

This is also a preliminary step to support array types and maybe also beneficial for supporting struct types. Also see the discussion https://github.com/hibernate/hibernate-orm/discussions/3810 related to this.