### PR TITLE
HHH-15060 - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/SqlGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/SqlGenerator.java
@@ -378,7 +378,7 @@ public class SqlGenerator extends SqlGeneratorBase implements ErrorReporter {
 				writeCrossJoinSeparator();
 			}
 			else {
-				out( " " );
+				out( " left join " );
 			}
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TypedQueryResultListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/jpa/test/query/TypedQueryResultListTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.jpa.test.query;
 
 import java.util.List;
+import java.util.Map;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,7 +15,12 @@ import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
+import org.hibernate.testing.jdbc.SQLStatementInterceptor;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,18 +28,40 @@ import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
 public class TypedQueryResultListTest extends BaseEntityManagerFunctionalTestCase {
 
+	private SQLStatementInterceptor statementInspector;
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		statementInspector = new SQLStatementInterceptor( options );
+	}
+
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Parent.class };
 	}
 
-	@Test
-	public void testIt() {
+	@Before
+	public void setUp() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			Parent parent1 = new Parent( 1, "usr1", null );
 			Parent parent2 = new Parent( 1, "usr2", null );
 			entityManager.persist( parent1 );
 			entityManager.persist( parent2 );
+		} );
+	}
+
+	@After
+	public void tearDown() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+					 entityManager.createQuery( "delete from Parent" ).executeUpdate();
+				 }
+		);
+	}
+
+	@Test
+	public void testIt() {
+		statementInspector.clear();
+		doInJPA( this::entityManagerFactory, entityManager -> {
 
 			TypedQuery<Parent> query = entityManager.createQuery(
 					"select parent " +
@@ -47,18 +75,19 @@ public class TypedQueryResultListTest extends BaseEntityManagerFunctionalTestCas
 			query.setParameter( "name", "usr1" );
 			List<Parent> entityList = query.getResultList();
 			assertThat( entityList.size(), is( 2 ) );
+
+			Assertions.assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			Assertions.assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
+			Assertions.assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " left " );
+			Assertions.assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+			Assertions.assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " cross " );
 		} );
-
-
 	}
 
 	@Test
 	public void testIt2() {
+		statementInspector.clear();
 		doInJPA( this::entityManagerFactory, entityManager -> {
-			Parent parent1 = new Parent( 1, "usr1", null );
-			Parent parent2 = new Parent( 1, "usr2", null );
-			entityManager.persist( parent1 );
-			entityManager.persist( parent2 );
 
 			TypedQuery<Parent> query = entityManager.createQuery(
 					"select parent " +
@@ -72,9 +101,10 @@ public class TypedQueryResultListTest extends BaseEntityManagerFunctionalTestCas
 			query.setParameter( "name", "usr1" );
 			List<Parent> entityList = query.getResultList();
 			assertThat( entityList.size(), is( 2 ) );
+
+			Assertions.assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			Assertions.assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " join " );
 		} );
-
-
 	}
 
 	@Entity(name = "Parent")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/IsNullAndNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/IsNullAndNotFoundTest.java
@@ -1,0 +1,159 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class IsNullAndNotFoundTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Account.class, Person.class };
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+					Account account1 = new Account( 1, null, null );
+					Account account2 = new Account( 2, "Fab", null );
+
+					Person person1 = new Person( 1, "Luigi", account1 );
+					Person person2 = new Person( 2, "Andrea", account2 );
+					Person person3 = new Person( 3, "Max", null );
+
+					session.persist( account1 );
+					session.persist( account2 );
+					session.persist( person1 );
+					session.persist( person2 );
+					session.persist( person3 );
+				}
+		);
+	}
+
+	@After
+	public void tearDown() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from Person" ).executeUpdate();
+					session.createQuery( "delete from Account" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testIsNullInWhereClause() {
+		inTransaction(
+				session -> {
+					final List<Integer> ids = session.createQuery(
+							"select p.id from Person p where p.account.code is null" ).getResultList();
+
+					assertEquals( 1, ids.size() );
+					assertEquals( 1, (int) ids.get( 0 ) );
+
+				}
+		);
+	}
+
+	@Test
+	public void testIsNullInWhereClause2() {
+		inTransaction(
+				session -> {
+					final List<Integer> ids = session.createQuery(
+							"select distinct p.id from Person p where p.account is null" ).getResultList();
+
+					assertEquals( 1, ids.size() );
+					assertEquals( 3, (int) ids.get( 0 ) );
+
+				}
+		);
+	}
+
+	@Test
+	public void testIsNullInWhereClause3() {
+		inTransaction(
+				session -> {
+					final List<Integer> ids = session.createQuery(
+							"select distinct p.id from Person p where p.account is null").getResultList();
+
+					assertEquals( 1, ids.size() );
+					assertEquals( 3, (int) ids.get( 0 ) );
+
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@OneToOne
+		@NotFound(action = NotFoundAction.IGNORE)
+		private Account account;
+
+		Person() {
+		}
+
+		public Person(Integer id, String name, Account account) {
+			this.id = id;
+			this.name = name;
+			this.account = account;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Account getAccount() {
+			return account;
+		}
+	}
+
+	@Entity(name = "Account")
+	@Table(name = "ACCOUNT_TABLE")
+	public static class Account {
+		@Id
+		private Integer id;
+
+		private String code;
+
+		private Double amount;
+
+		public Account() {
+		}
+
+		public Account(Integer id, String code, Double amount) {
+			this.id = id;
+			this.code = code;
+			this.amount = amount;
+		}
+
+	}
+}


### PR DESCRIPTION
@sebersole this changes the cross join into a left one for associations with `@NotFound` 