### PR TITLE
Jandex, Classmate and commons annotations shouldn't be listed as API

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -27,9 +27,10 @@ configurations {
 dependencies {
     api libraries.jakarta_jpa
     api libraries.jakarta_jta
-    api libraries.jandex
-    api libraries.classmate
-    api libraries.commons_annotations
+
+    implementation libraries.jandex
+    implementation libraries.classmate
+    implementation libraries.commons_annotations
 
     implementation libraries.byteBuddy
     implementation libraries.jakarta_activation

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -15,6 +15,8 @@ dependencies {
 
     implementation libraries.jakarta_jaxb_api
     implementation libraries.jakarta_jaxb_runtime
+    implementation libraries.commons_annotations
+    implementation libraries.jandex
 
     compileOnly libraries.ant
 

--- a/hibernate-testing/hibernate-testing.gradle
+++ b/hibernate-testing/hibernate-testing.gradle
@@ -12,6 +12,9 @@ apply from: rootProject.file( 'gradle/published-java-module.gradle' )
 dependencies {
     api project( ':hibernate-core' )
 
+    implementation libraries.commons_annotations
+    implementation libraries.jandex
+
     api libraries.junit
     api libraries.junit5_api
     api libraries.junit5_params
@@ -45,7 +48,3 @@ dependencies {
 tasks.checkstyleMain {
     exclude '**/org/hibernate/orm/test/legacy/**'
 }
-
-
-
-


### PR DESCRIPTION
A little cleanup of the dependency metadata: let's treat Jandex, Classmate and HCANN as internal dependencies.