### PR TITLE
HHH-15094 Handle http://hibernate.org and https://* for all DTDs in LocalXmlResourceResolver

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -47,6 +47,9 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 				// JPA 2.1 and 2.2 share the same namespace URI
 				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( MappingXsdSupport.jpa21.getLocalResourceName() ) );
 			}
+			else if ( MappingXsdSupport.jpa30.getNamespaceUri().matches( namespace ) ) {
+				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( MappingXsdSupport.jpa30.getLocalResourceName() ) );
+			}
 			else if ( ConfigXsdSupport.getJPA10().getNamespaceUri().matches( namespace ) ) {
 				// JPA 1.0 and 2.0 share the same namespace URI
 				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( ConfigXsdSupport.getJPA10().getLocalResourceName() ) );
@@ -54,6 +57,9 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 			else if ( ConfigXsdSupport.getJPA21().getNamespaceUri().matches( namespace ) ) {
 				// JPA 2.1 and 2.2 share the same namespace URI
 				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( ConfigXsdSupport.getJPA21().getLocalResourceName() ) );
+			}
+			else if ( ConfigXsdSupport.getJPA30().getNamespaceUri().matches( namespace ) ) {
+				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( ConfigXsdSupport.getJPA30().getLocalResourceName() ) );
 			}
 			else if ( MappingXsdSupport.hibernateMappingXml.getNamespaceUri().matches( namespace ) ) {
 				return openUrlStream( LocalSchemaLocator.resolveLocalSchemaUrl( MappingXsdSupport.hibernateMappingXml.getLocalResourceName() ) );

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -84,11 +84,6 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 				return openUrlStream( MAPPING_DTD.localSchemaUrl );
 			}
 
-			if ( LEGACY2_MAPPING_DTD.matches( publicID, systemID ) ) {
-				DEPRECATION_LOGGER.recognizedObsoleteHibernateNamespace( LEGACY2_MAPPING_DTD.getIdentifierBase(), MAPPING_DTD.getIdentifierBase() );
-				return openUrlStream( MAPPING_DTD.localSchemaUrl );
-			}
-
 			if ( CFG_DTD.matches( publicID, systemID ) ) {
 				return openUrlStream( CFG_DTD.localSchemaUrl );
 			}
@@ -143,11 +138,6 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 	);
 
 	public static final DtdDescriptor LEGACY_MAPPING_DTD = new DtdDescriptor(
-			"www.hibernate.org/dtd/hibernate-mapping",
-			"org/hibernate/hibernate-mapping-3.0.dtd"
-	);
-
-	public static final DtdDescriptor LEGACY2_MAPPING_DTD = new DtdDescriptor(
 			"hibernate.sourceforge.net/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -79,6 +79,10 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 				return openUrlStream( MAPPING_DTD.localSchemaUrl );
 			}
 
+			if ( ALTERNATE_MAPPING_DTD.matches( publicID, systemID ) ) {
+				return openUrlStream( ALTERNATE_MAPPING_DTD.localSchemaUrl );
+			}
+
 			if ( LEGACY_MAPPING_DTD.matches( publicID, systemID ) ) {
 				DEPRECATION_LOGGER.recognizedObsoleteHibernateNamespace( LEGACY_MAPPING_DTD.getIdentifierBase(), MAPPING_DTD.getIdentifierBase() );
 				return openUrlStream( MAPPING_DTD.localSchemaUrl );
@@ -86,6 +90,10 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 
 			if ( CFG_DTD.matches( publicID, systemID ) ) {
 				return openUrlStream( CFG_DTD.localSchemaUrl );
+			}
+
+			if ( ALTERNATE_CFG_DTD.matches( publicID, systemID ) ) {
+				return openUrlStream( ALTERNATE_CFG_DTD.localSchemaUrl );
 			}
 
 			if ( LEGACY_CFG_DTD.matches( publicID, systemID ) ) {
@@ -137,6 +145,11 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);
 
+	public static final DtdDescriptor ALTERNATE_MAPPING_DTD = new DtdDescriptor(
+			"hibernate.org/dtd/hibernate-mapping",
+			"org/hibernate/hibernate-mapping-3.0.dtd"
+	);
+
 	public static final DtdDescriptor LEGACY_MAPPING_DTD = new DtdDescriptor(
 			"hibernate.sourceforge.net/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
@@ -144,6 +157,11 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 
 	public static final DtdDescriptor CFG_DTD = new DtdDescriptor(
 			"www.hibernate.org/dtd/hibernate-configuration",
+			"org/hibernate/hibernate-configuration-3.0.dtd"
+	);
+
+	public static final DtdDescriptor ALTERNATE_CFG_DTD = new DtdDescriptor(
+			"hibernate.org/dtd/hibernate-configuration",
 			"org/hibernate/hibernate-configuration-3.0.dtd"
 	);
 

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -64,11 +64,17 @@ public class LocalXmlResourceResolverTest {
 			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 			"https://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 
+			"http://hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 			"https://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 
 			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 			"https://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+
+			"http://hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"https://hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 
 			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.jaxb.internal.stax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.hibernate.testing.boot.ClassLoaderServiceTestingImpl;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+
+/**
+ * Test the resolution of known XML schemas/DTDs to local resources.
+ * <p>
+ * Note that when it comes to XML schemas,
+ * LocalXmlResourceResolver doesn't seem to be actually invoked;
+ * which makes sense since we set the XML schema ourselves when configuring the parser.
+ * So this test is probably only relevant for DTDs, but we keep tests about XML schemas too just in case.
+ */
+public class LocalXmlResourceResolverTest {
+
+	private final LocalXmlResourceResolver resolver;
+
+	public LocalXmlResourceResolverTest() {
+		this.resolver = new LocalXmlResourceResolver( ClassLoaderServiceTestingImpl.INSTANCE );
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			// JPA 1.0 and 2.0 share the same namespace URI
+			// NOTE: Behavior differs from Hibernate ORM 5, which resolves to org/hibernate/jpa/orm_2_0.xsd
+			"http://java.sun.com/xml/ns/persistence/orm,org/hibernate/jpa/orm_1_0.xsd",
+			// JPA 2.1 and 2.2 share the same namespace URI
+			"http://xmlns.jcp.org/xml/ns/persistence/orm,org/hibernate/jpa/orm_2_1.xsd",
+			"https://jakarta.ee/xml/ns/persistence/orm,org/hibernate/jpa/orm_3_0.xsd",
+
+			// NOTE: Hibernate ORM 5 doesn't resolve persistence.xml XSDs to local resources,
+			//       but Hibernate ORM 6+ does.
+			// JPA 1.0 and 2.0 share the same namespace URI
+			"http://java.sun.com/xml/ns/persistence,org/hibernate/jpa/persistence_1_0.xsd",
+			// JPA 2.1 and 2.2 share the same namespace URI
+			"http://xmlns.jcp.org/xml/ns/persistence,org/hibernate/jpa/persistence_2_1.xsd",
+			"https://jakarta.ee/xml/ns/persistence,org/hibernate/jpa/persistence_3_0.xsd",
+
+			"http://www.hibernate.org/xsd/orm/hbm,org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd",
+			"http://www.hibernate.org/xsd/hibernate-mapping,org/hibernate/hibernate-mapping-4.0.xsd",
+			"http://www.hibernate.org/xsd/orm/cfg,org/hibernate/xsd/cfg/legacy-configuration-4.0.xsd",
+	})
+	void resolve_namespace_localResource(String namespace, String expectedLocalResource) throws XMLStreamException {
+		assertThat( resolver.resolveEntity( null, null, null, namespace ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
+	})
+	void resolve_dtd_localResource(String id, String expectedLocalResource) throws XMLStreamException {
+		// publicId
+		assertThat( resolver.resolveEntity( id, null, null, null ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+
+		// systemId
+		assertThat( resolver.resolveEntity( null, id, null, null ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -62,9 +62,16 @@ public class LocalXmlResourceResolverTest {
 	@ParameterizedTest
 	@CsvSource({
 			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
-			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
+			"https://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+
+			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
 	})
 	void resolve_dtd_localResource(String id, String expectedLocalResource) throws XMLStreamException {
 		// publicId


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15094

Turns out the HTTPS part was already implemented in 6, so I just had to add a test for that part. That was not the case in 5.x though, so the backport PR (#4842) includes a bit more code.

This also fixes a few problems I noticed in passing.