### PR TITLE
Backport HHH-15094 to branch 5.6 - Handle http://hibernate.org and https://* for all DTDs in LocalXmlResourceResolver

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -67,6 +67,12 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 				);
 				return openUrlStream( HBM_DTD_MAPPING.getMappedLocalUrl() );
 			}
+			else if ( ALTERNATE_MAPPING_DTD.matches( publicID, systemID ) ) {
+				log.debug(
+						"Recognized alternate hibernate-mapping identifier; attempting to resolve on classpath under org/hibernate/"
+				);
+				return openUrlStream( ALTERNATE_MAPPING_DTD.getMappedLocalUrl() );
+			}
 			else if ( LEGACY_HBM_DTD_MAPPING.matches( publicID, systemID ) ) {
 				DeprecationLogger.DEPRECATION_LOGGER.recognizedObsoleteHibernateNamespace(
 						LEGACY_HBM_DTD_MAPPING.getIdentifierBase(),
@@ -82,6 +88,12 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 						"Recognized hibernate-configuration identifier; attempting to resolve on classpath under org/hibernate/"
 				);
 				return openUrlStream( CFG_DTD_MAPPING.getMappedLocalUrl() );
+			}
+			else if ( ALTERNATE_CFG_DTD.matches( publicID, systemID ) ) {
+				log.debug(
+						"Recognized alternate hibernate-configuration identifier; attempting to resolve on classpath under org/hibernate/"
+				);
+				return openUrlStream( ALTERNATE_CFG_DTD.getMappedLocalUrl() );
 			}
 			else if ( LEGACY_CFG_DTD_MAPPING.matches( publicID, systemID ) ) {
 				DeprecationLogger.DEPRECATION_LOGGER.recognizedObsoleteHibernateNamespace(
@@ -185,6 +197,11 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);
 
+	public static final DtdMapping ALTERNATE_MAPPING_DTD = new DtdMapping(
+			"hibernate.org/dtd/hibernate-mapping",
+			"org/hibernate/hibernate-mapping-3.0.dtd"
+	);
+
 	public static final DtdMapping LEGACY_HBM_DTD_MAPPING = new DtdMapping(
 			"hibernate.sourceforge.net/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
@@ -192,6 +209,11 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 
 	public static final DtdMapping CFG_DTD_MAPPING = new DtdMapping(
 			"www.hibernate.org/dtd/hibernate-configuration",
+			"org/hibernate/hibernate-configuration-3.0.dtd"
+	);
+
+	public static final DtdMapping ALTERNATE_CFG_DTD = new DtdMapping(
+			"hibernate.org/dtd/hibernate-configuration",
 			"org/hibernate/hibernate-configuration-3.0.dtd"
 	);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -77,16 +77,6 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 				);
 				return openUrlStream( HBM_DTD_MAPPING.getMappedLocalUrl() );
 			}
-			else if ( LEGACY2_HBM_DTD_MAPPING.matches( publicID, systemID ) ) {
-				DeprecationLogger.DEPRECATION_LOGGER.recognizedObsoleteHibernateNamespace(
-						LEGACY2_HBM_DTD_MAPPING.getIdentifierBase(),
-						HBM_DTD_MAPPING.getIdentifierBase()
-				);
-				log.debug(
-						"Recognized legacy hibernate-mapping identifier; attempting to resolve on classpath under org/hibernate/"
-				);
-				return openUrlStream( HBM_DTD_MAPPING.getMappedLocalUrl() );
-			}
 			else if ( CFG_DTD_MAPPING.matches( publicID, systemID ) ) {
 				log.debug(
 						"Recognized hibernate-configuration identifier; attempting to resolve on classpath under org/hibernate/"
@@ -158,7 +148,7 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 			"http://xmlns.jcp.org/xml/ns/persistence/orm",
 			"org/hibernate/jpa/orm_2_1.xsd"
 	);
-	
+
 	/**
 	 * Maps the namespace for the orm.xml xsd for Jakarta Persistence 2.2
 	 */
@@ -174,7 +164,7 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 			"https://jakarta.ee/xml/ns/persistence/orm",
 			"org/hibernate/jpa/orm_3_0.xsd"
 	);
-	
+
 	public static final NamespaceSchemaMapping HBM_XSD_MAPPING = new NamespaceSchemaMapping(
 			"http://www.hibernate.org/xsd/orm/hbm",
 			"org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd"
@@ -196,11 +186,6 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 	);
 
 	public static final DtdMapping LEGACY_HBM_DTD_MAPPING = new DtdMapping(
-			"http://www.hibernate.org/dtd/hibernate-mapping",
-			"org/hibernate/hibernate-mapping-3.0.dtd"
-	);
-
-	public static final DtdMapping LEGACY2_HBM_DTD_MAPPING = new DtdMapping(
 			"http://hibernate.sourceforge.net/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -181,22 +181,22 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 	);
 
 	public static final DtdMapping HBM_DTD_MAPPING = new DtdMapping(
-			"http://www.hibernate.org/dtd/hibernate-mapping",
+			"www.hibernate.org/dtd/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);
 
 	public static final DtdMapping LEGACY_HBM_DTD_MAPPING = new DtdMapping(
-			"http://hibernate.sourceforge.net/hibernate-mapping",
+			"hibernate.sourceforge.net/hibernate-mapping",
 			"org/hibernate/hibernate-mapping-3.0.dtd"
 	);
 
 	public static final DtdMapping CFG_DTD_MAPPING = new DtdMapping(
-			"http://www.hibernate.org/dtd/hibernate-configuration",
+			"www.hibernate.org/dtd/hibernate-configuration",
 			"org/hibernate/hibernate-configuration-3.0.dtd"
 	);
 
 	public static final DtdMapping LEGACY_CFG_DTD_MAPPING = new DtdMapping(
-			"http://hibernate.sourceforge.net/hibernate-configuration",
+			"hibernate.sourceforge.net/hibernate-configuration",
 			"org/hibernate/hibernate-configuration-3.0.dtd"
 	);
 
@@ -220,27 +220,31 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 	}
 
 	public static class DtdMapping {
-		private final String identifierBase;
+		private final String httpBase;
+		private final String httpsBase;
 		private final URL localSchemaUrl;
 
 		public DtdMapping(String identifierBase, String resourceName) {
-			this.identifierBase = identifierBase;
+			this.httpBase = "http://" + identifierBase;
+			this.httpsBase = "https://" + identifierBase;
 			this.localSchemaUrl = LocalSchemaLocator.resolveLocalSchemaUrl( resourceName );
 		}
 
 		public String getIdentifierBase() {
-			return identifierBase;
+			return httpBase;
 		}
 
 		public boolean matches(String publicId, String systemId) {
 			if ( publicId != null ) {
-				if ( publicId.startsWith( identifierBase ) ) {
+				if ( publicId.startsWith( httpBase )
+						|| publicId.matches( httpsBase ) ) {
 					return true;
 				}
 			}
 
 			if ( systemId != null ) {
-				if ( systemId.startsWith( identifierBase ) ) {
+				if ( systemId.startsWith( httpBase )
+						|| systemId.matches( httpsBase ) ) {
 					return true;
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -59,11 +59,17 @@ public class LocalXmlResourceResolverTest {
 			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 			"https://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 
+			"http://hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 			"https://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
 
 			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 			"https://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+
+			"http://hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"https://hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 
 			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -57,9 +57,16 @@ public class LocalXmlResourceResolverTest {
 	@ParameterizedTest
 	@CsvSource({
 			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+
 			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
-			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
+			"https://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+
+			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
 	})
 	void resolve_dtd_localResource(String id, String expectedLocalResource) throws XMLStreamException {
 		// publicId

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.boot.jaxb.internal.stax;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.hibernate.testing.boot.ClassLoaderServiceTestingImpl;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+
+/**
+ * Test the resolution of known XML schemas/DTDs to local resources.
+ * <p>
+ * Note that when it comes to XML schemas,
+ * LocalXmlResourceResolver doesn't seem to be actually invoked;
+ * which makes sense since we set the XML schema ourselves when configuring the parser.
+ * So this test is probably only relevant for DTDs, but we keep tests about XML schemas too just in case.
+ */
+public class LocalXmlResourceResolverTest {
+
+	private final LocalXmlResourceResolver resolver;
+
+	public LocalXmlResourceResolverTest() {
+		this.resolver = new LocalXmlResourceResolver( ClassLoaderServiceTestingImpl.INSTANCE );
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			// JPA 1.0 and 2.0 share the same namespace URI
+			// NOTE: Behavior differs from Hibernate ORM 6, which resolves to org/hibernate/jpa/orm_1_0.xsd
+			"http://java.sun.com/xml/ns/persistence/orm,org/hibernate/jpa/orm_2_0.xsd",
+			// JPA 2.1 and 2.2 share the same namespace URI
+			"http://xmlns.jcp.org/xml/ns/persistence/orm,org/hibernate/jpa/orm_2_1.xsd",
+			"https://jakarta.ee/xml/ns/persistence/orm,org/hibernate/jpa/orm_3_0.xsd",
+
+			// NOTE: Hibernate ORM 5 doesn't resolve persistence.xml XSDs to local resources
+			//       so we don't test them here.
+
+			"http://www.hibernate.org/xsd/orm/hbm,org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd",
+			"http://www.hibernate.org/xsd/hibernate-mapping,org/hibernate/hibernate-mapping-4.0.xsd",
+			"http://www.hibernate.org/xsd/orm/cfg,org/hibernate/xsd/cfg/legacy-configuration-4.0.xsd",
+	})
+	void resolve_namespace_localResource(String namespace, String expectedLocalResource) throws XMLStreamException {
+		assertThat( resolver.resolveEntity( null, null, null, namespace ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"http://www.hibernate.org/dtd/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"http://hibernate.sourceforge.net/hibernate-mapping,org/hibernate/hibernate-mapping-3.0.dtd",
+			"http://www.hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
+	})
+	void resolve_dtd_localResource(String id, String expectedLocalResource) throws XMLStreamException {
+		// publicId
+		assertThat( resolver.resolveEntity( id, null, null, null ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+
+		// systemId
+		assertThat( resolver.resolveEntity( null, id, null, null ) )
+				.asInstanceOf( InstanceOfAssertFactories.INPUT_STREAM )
+				.hasSameContentAs( getClass().getClassLoader().getResourceAsStream( expectedLocalResource ) );
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15094

Backport of  #4841 to branch 5.6.