### PR TITLE
HHH-15102 Processing of annotation recognition in BasicFormatterImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -97,6 +97,19 @@ public class BasicFormatterImpl implements Formatter {
 						lcToken = token;
 						misc();
 						break;
+					case "-":
+						if (lcToken.equals("-"))
+						{
+							String ttt;
+							do {
+								ttt = tokens.nextToken();
+								token += ttt;
+							}
+							while (tokens.hasMoreTokens());
+							lcToken = token;
+							misc();
+						}
+						break;
 
 					case ",":
 						if ( afterByOrSetOrFromOrSelect && inFunction==0 ) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15102

I use making SQL statements pretty in BasicFormatterImpl.
However, if there is a comma behind the annotation, the column behind the annotation is sent to the next line to recognize the column that should not be recognized.
So I customized the class.
The result was successful. I hope that the full request will be reflected based on the successful results.


Below is the situation I went through.
The left side is raw SQL, and the right side is the result of formatting using the class. You can see that the column behind the annotation went to the next line.
![image](https://user-images.githubusercontent.com/54926902/156699346-3e4be530-69f4-45ab-bdaf-1251396f7ea9.png)

Normal results after processing it.
![image](https://user-images.githubusercontent.com/54926902/156699636-8ae690aa-effa-4f44-899e-a1ac7114f57f.png)

