### PR TITLE
remove a deprecation that was probably an accident

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractPreDatabaseOperationEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractPreDatabaseOperationEvent.java
@@ -47,11 +47,8 @@ public abstract class AbstractPreDatabaseOperationEvent
 	 * Retrieves the entity involved in the database operation.
 	 *
 	 * @return The entity.
-	 *
-	 * @deprecated Support for JACC will be removed in 6.0
 	 */
 	@Override
-	@Deprecated
 	public Object getEntity() {
 		return entity;
 	}


### PR DESCRIPTION
Based on 6.0 change:
https://github.com/hibernate/hibernate-orm/commit/5f1358633d368605e76da20f93d19f25ceb06055