### PR TITLE
HHH-13135 Use FOR NO KEY UPDATE when locking in PostgreSQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLSqlAstTranslator.java
@@ -66,7 +66,13 @@ public class PostgreSQLSqlAstTranslator<T extends JdbcOperation> extends Abstrac
 	}
 
 	@Override
+	protected String getForUpdate() {
+		return getDialect().getVersion().isSameOrAfter( 9, 3 ) ? " for no key update" : " for update";
+	}
+
+	@Override
 	protected String getForShare(int timeoutMillis) {
+		// Note that `for key share` is inappropriate as that only means "prevent PK changes"
 		return " for share";
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockReference.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockReference.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+//$Id$
+package org.hibernate.orm.test.jpa.lock;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.Version;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+public class LockReference {
+	private Integer id;
+	private String name;
+	private Lock lock;
+
+	public LockReference() {
+	}
+
+	public LockReference(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	@Id
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@ManyToOne
+	public Lock getLock() {
+		return lock;
+	}
+
+	public void setLock(Lock lock) {
+		this.lock = lock;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13135

As can be seen from the test runs, most databases implement the semantics that PostgreSQL introduced with `FOR NO KEY UPDATE`. I don't know if it makes sense to introduce new `LockMode` entries, but if so, we need the following:

* `WRITE_KEY` or `WRITE_ALL` which will block inserts for FKs pointing to the locked row
* `READ_KEY` which will prevent row deletions or changes of the PK pointed to through FKs

We could also implement the `FOR NO KEY UPDATE` locking for HANA by using `... for update of col1, col2, ...` i.e. by listing all non-primary key columns. Maybe it's even enough to list just a single non-PK column. Also see https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.06/en-US/20fcf24075191014a89e9dc7b8408b26.html#loio20fcf24075191014a89e9dc7b8408b26__sql_select_1sql_select_for_update

Wdyt about new `LockMode` entries? And support for this in HANA?