### PR TITLE
Support return of interval type from timestampdiff function

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/tutorials/annotations/src/test/resources/hibernate.cfg.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/annotations/src/test/resources/hibernate.cfg.xml
@@ -15,7 +15,7 @@
 
         <!-- Database connection settings -->
         <property name="connection.driver_class">org.h2.Driver</property>
-        <property name="connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE</property>
+        <property name="connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1</property>
         <property name="connection.username">sa</property>
         <property name="connection.password"></property>
 

--- a/documentation/src/main/asciidoc/quickstart/tutorials/basic/src/test/resources/hibernate.cfg.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/basic/src/test/resources/hibernate.cfg.xml
@@ -15,7 +15,7 @@
 
         <!-- Database connection settings -->
         <property name="connection.driver_class">org.h2.Driver</property>
-        <property name="connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE</property>
+        <property name="connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1</property>
         <property name="connection.username">sa</property>
         <property name="connection.password"/>
 

--- a/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/src/test/resources/META-INF/persistence.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/src/test/resources/META-INF/persistence.xml
@@ -18,7 +18,7 @@
 
         <properties>
             <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver" />
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE" />
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1" />
             <property name="jakarta.persistence.jdbc.user" value="sa" />
             <property name="jakarta.persistence.jdbc.password" value="" />
 

--- a/documentation/src/main/asciidoc/quickstart/tutorials/envers/src/test/resources/META-INF/persistence.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/envers/src/test/resources/META-INF/persistence.xml
@@ -18,7 +18,7 @@
 
         <properties>
             <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver" />
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE" />
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1" />
             <property name="jakarta.persistence.jdbc.user" value="sa" />
             <property name="jakarta.persistence.jdbc.password" value="" />
 

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -383,6 +383,9 @@ This setting applies to Oracle Dialect only, and it specifies whether `byte[]` o
 `*hibernate.type.preferred_boolean_jdbc_type_code*` (e.g. `-7` for `java.sql.Types.BIT`)::
 Global setting identifying the preferred JDBC type code for storing boolean values. The fallback is to ask the Dialect.
 
+`*hibernate.type.preferred_duration_jdbc_type_code*` (e.g. `2` for `java.sql.Types.NUMERIC` or `3` for `java.sql.Types.DECIMAL`)::
+Global setting identifying the preferred JDBC type code for storing duration values. The fallback is `3100` for `org.hibernate.types.SqlTypes.INTERVAL_SECOND`.
+
 ==== Bean Validation options
 `*jakarta.persistence.validation.factory*` (e.g. `jakarta.validation.ValidationFactory` implementation)::
 Specify the  `javax.validation.ValidationFactory` implementation to use for Bean Validation.

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -383,8 +383,8 @@ This setting applies to Oracle Dialect only, and it specifies whether `byte[]` o
 `*hibernate.type.preferred_boolean_jdbc_type_code*` (e.g. `-7` for `java.sql.Types.BIT`)::
 Global setting identifying the preferred JDBC type code for storing boolean values. The fallback is to ask the Dialect.
 
-`*hibernate.type.preferred_duration_jdbc_type_code*` (e.g. `2` for `java.sql.Types.NUMERIC` or `3` for `java.sql.Types.DECIMAL`)::
-Global setting identifying the preferred JDBC type code for storing duration values. The fallback is `3100` for `org.hibernate.types.SqlTypes.INTERVAL_SECOND`.
+`*hibernate.type.preferred_duration_jdbc_type_code*` (e.g. `2` for `java.sql.Types.NUMERIC` or `3100` for `org.hibernate.types.SqlTypes.INTERVAL_SECOND` (default value))::
+Global setting identifying the preferred JDBC type code for storing duration values.
 
 ==== Bean Validation options
 `*jakarta.persistence.validation.factory*` (e.g. `jakarta.validation.ValidationFactory` implementation)::

--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/extras/persistence-external.xml
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/extras/persistence-external.xml
@@ -18,7 +18,7 @@
                       value="org.h2.Driver" />
 
             <property name="jakarta.persistence.jdbc.url"
-                      value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE" />
+                      value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1" />
 
             <property name="jakarta.persistence.jdbc.user"
                       value="sa" />

--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/extras/persistence.xml
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/extras/persistence.xml
@@ -18,7 +18,7 @@
                       value="org.h2.Driver" />
 
             <property name="jakarta.persistence.jdbc.url"
-                      value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE" />
+                      value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1" />
 
             <property name="jakarta.persistence.jdbc.user"
                       value="sa" />

--- a/documentation/src/test/java/org/hibernate/userguide/mapping/basic/DurationMappingLegacyTests.java
+++ b/documentation/src/test/java/org/hibernate/userguide/mapping/basic/DurationMappingLegacyTests.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.userguide.mapping.basic;
+
+import java.time.Duration;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.jdbc.AdjustableJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel(annotatedClasses = DurationMappingLegacyTests.EntityWithDuration.class)
+@SessionFactory
+// 2 stands for the type code Types.NUMERIC
+@ServiceRegistry(settings = @Setting(name = AvailableSettings.PREFERRED_DURATION_JDBC_TYPE_CODE, value = "2"))
+public class DurationMappingLegacyTests {
+
+	@Test
+	public void verifyMappings(SessionFactoryScope scope) {
+		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
+				.getRuntimeMetamodels()
+				.getMappingMetamodel();
+		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor(EntityWithDuration.class);
+		final JdbcTypeRegistry jdbcTypeRegistry = mappingMetamodel.getTypeConfiguration().getJdbcTypeRegistry();
+
+		final BasicAttributeMapping duration = (BasicAttributeMapping) entityDescriptor.findAttributeMapping("duration");
+		final JdbcMapping jdbcMapping = duration.getJdbcMapping();
+		assertThat(jdbcMapping.getJavaTypeDescriptor().getJavaTypeClass(), equalTo(Duration.class));
+		final JdbcType intervalType = jdbcTypeRegistry.getDescriptor(SqlTypes.NUMERIC);
+		final JdbcType realType;
+		if (intervalType instanceof AdjustableJdbcType) {
+			realType = ((AdjustableJdbcType) intervalType).resolveIndicatedType(
+					() -> mappingMetamodel.getTypeConfiguration(),
+					jdbcMapping.getJavaTypeDescriptor()
+			);
+		}
+		else {
+			realType = intervalType;
+		}
+		assertThat( jdbcMapping.getJdbcType(), is( realType));
+
+		scope.inTransaction(
+				(session) -> {
+					session.persist(new EntityWithDuration(1, Duration.ofHours(3)));
+				}
+		);
+
+		scope.inTransaction(
+				(session) -> session.find(EntityWithDuration.class, 1)
+		);
+	}
+
+	@Entity(name = "EntityWithDuration")
+	@Table(name = "EntityWithDuration")
+	public static class EntityWithDuration {
+		@Id
+		private Integer id;
+
+		//tag::basic-duration-example[]
+		private Duration duration;
+		//end::basic-duration-example[]
+
+		public EntityWithDuration() {
+		}
+
+		public EntityWithDuration(Integer id, Duration duration) {
+			this.id = id;
+			this.duration = duration;
+		}
+	}
+}

--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -13,7 +13,10 @@ ext {
     junitVintageVersion = '5.8.2'
     junit5Version = '5.8.2'
 
-    h2Version = '1.4.197'
+    h2Version = '2.1.210'
+    h2GisVersion = '2.0.0'
+//    h2Version = '1.4.197'
+//    h2GisVersion = '1.5.0'
     bytemanVersion = '4.0.16' //Compatible with JDK16
     jnpVersion = '5.0.6.CR1'
 
@@ -151,8 +154,8 @@ ext {
             byteman_install: "org.jboss.byteman:byteman-install:${bytemanVersion}",
             byteman_bmunit:  "org.jboss.byteman:byteman-bmunit:${bytemanVersion}",
             h2:              "com.h2database:h2:${h2Version}",
-            h2gis:           "org.orbisgis:h2gis:1.5.0",
-            hsqldb:          "org.hsqldb:hsqldb:2.3.6",
+            h2gis:           "org.orbisgis:h2gis:${h2GisVersion}",
+            hsqldb:          "org.hsqldb:hsqldb:2.6.1",
             derby:           "org.apache.derby:derby:10.14.2.0",
             postgresql:      'org.postgresql:postgresql:42.2.16',
             mysql:           'mysql:mysql-connector-java:8.0.27',

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -212,6 +212,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private Boolean useOfJdbcNamedParametersEnabled;
 	private boolean namedQueryStartupCheckingEnabled;
 	private final int preferredSqlTypeCodeForBoolean;
+	private final int preferredSqlTypeCodeForDuration;
 	private final TimeZoneStorageStrategy defaultTimeZoneStorageStrategy;
 
 	// Caching
@@ -415,6 +416,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 		this.namedQueryStartupCheckingEnabled = cfgService.getSetting( QUERY_STARTUP_CHECKING, BOOLEAN, true );
 		this.preferredSqlTypeCodeForBoolean = ConfigurationHelper.getPreferredSqlTypeCodeForBoolean( serviceRegistry );
+		this.preferredSqlTypeCodeForDuration = ConfigurationHelper.getPreferredSqlTypeCodeForDuration( serviceRegistry );
 		this.defaultTimeZoneStorageStrategy = context.getMetadataBuildingOptions().getDefaultTimeZoneStorage();
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
@@ -1186,6 +1188,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public int getPreferredSqlTypeCodeForBoolean() {
 		return preferredSqlTypeCodeForBoolean;
+	}
+
+	@Override
+	public int getPreferredSqlTypeCodeForDuration() {
+		return preferredSqlTypeCodeForDuration;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -42,6 +42,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.SqlTypes;
@@ -377,7 +378,13 @@ public class MetadataBuildingProcess {
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.UUID, SqlTypes.BINARY );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.JSON, SqlTypes.VARBINARY );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.INET, SqlTypes.VARBINARY );
-		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.INTERVAL_SECOND, SqlTypes.NUMERIC );
+		final int preferredSqlTypeCodeForDuration = ConfigurationHelper.getPreferredSqlTypeCodeForDuration( bootstrapContext.getServiceRegistry() );
+		if ( preferredSqlTypeCodeForDuration != SqlTypes.INTERVAL_SECOND ) {
+			jdbcTypeRegistry.addDescriptor( SqlTypes.INTERVAL_SECOND, jdbcTypeRegistry.getDescriptor( preferredSqlTypeCodeForDuration ) );
+		}
+		else {
+			addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.INTERVAL_SECOND, SqlTypes.NUMERIC );
+		}
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.GEOMETRY, SqlTypes.VARBINARY );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.POINT, SqlTypes.VARBINARY );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -438,6 +438,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForDuration() {
+		return delegate.getPreferredSqlTypeCodeForDuration();
+	}
+
+	@Override
 	public TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy() {
 		return delegate.getDefaultTimeZoneStorageStrategy();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingContext.java
@@ -55,6 +55,10 @@ public interface MetadataBuildingContext {
 		return ConfigurationHelper.getPreferredSqlTypeCodeForBoolean( getBootstrapContext().getServiceRegistry() );
 	}
 
+	default int getPreferredSqlTypeCodeForDuration() {
+		return ConfigurationHelper.getPreferredSqlTypeCodeForDuration( getBootstrapContext().getServiceRegistry() );
+	}
+
 	TypeDefinitionRegistry getTypeDefinitionRegistry();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -300,6 +300,8 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	int getPreferredSqlTypeCodeForBoolean();
 
+	int getPreferredSqlTypeCodeForDuration();
+
 	TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy();
 
 	FormatMapper getJsonFormatMapper();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2484,6 +2484,14 @@ public interface AvailableSettings {
 	String PREFERRED_BOOLEAN_JDBC_TYPE_CODE = "hibernate.type.preferred_boolean_jdbc_type_code";
 
 	/**
+	 * Specifies the preferred JDBC type code for storing duration values. When no
+	 * type code is explicitly specified, {@link org.hibernate.type.SqlTypes#INTERVAL_SECOND} is used.
+	 *
+	 * @since 6.0
+	 */
+	String PREFERRED_DURATION_JDBC_TYPE_CODE = "hibernate.type.preferred_duration_jdbc_type_code";
+
+	/**
 	 * Specifies a {@link org.hibernate.type.FormatMapper} used for for JSON serialization
 	 * and deserialization, either:
 	 * <ul>

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/BasicValueBinder.java
@@ -215,6 +215,11 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForDuration() {
+		return buildingContext.getPreferredSqlTypeCodeForDuration();
+	}
+
+	@Override
 	public boolean isNationalized() {
 		return isNationalized;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -1100,6 +1100,11 @@ public abstract class AbstractHANADialect extends Dialect {
 	}
 
 	@Override
+	public long getFractionalSecondPrecisionInNanos() {
+		return 100;
+	}
+
+	@Override
 	public String timestampaddPattern(TemporalUnit unit, TemporalType temporalType, IntervalType intervalType) {
 		switch (unit) {
 			case NANOSECOND:

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -516,6 +516,9 @@ public class CockroachDialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		switch (unit) {
 			case YEAR:
 				return "(extract(year from ?3)-extract(year from ?2))";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -178,11 +178,7 @@ public class H2Dialect extends Dialect {
 			case NCHAR:
 				return columnType( CHAR );
 			case NVARCHAR:
-			case LONG32NVARCHAR:
-			case LONG32VARCHAR:
 				return columnType( VARCHAR );
-			case LONG32VARBINARY:
-				return columnType( VARBINARY );
 		}
 		return super.columnType( sqlTypeCode );
 	}
@@ -235,7 +231,7 @@ public class H2Dialect extends Dialect {
 			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
 		}
 		if ( getVersion().isSameOrAfter( 1, 4, 198 ) ) {
-			jdbcTypeRegistry.addDescriptorIfAbsent( DurationIntervalSecondJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( H2DurationIntervalSecondJdbcType.INSTANCE );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -394,6 +394,9 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		return "datediff(?1,?2,?3)";
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2DurationIntervalSecondJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2DurationIntervalSecondJdbcType.java
@@ -26,9 +26,9 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 /**
  * @author Christian Beikov
  */
-public class DurationIntervalSecondJdbcType implements JdbcType {
+public class H2DurationIntervalSecondJdbcType implements JdbcType {
 
-	public static final DurationIntervalSecondJdbcType INSTANCE = new DurationIntervalSecondJdbcType();
+	public static final H2DurationIntervalSecondJdbcType INSTANCE = new H2DurationIntervalSecondJdbcType();
 
 	@Override
 	public int getJdbcTypeCode() {
@@ -74,17 +74,32 @@ public class DurationIntervalSecondJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				// Handle the fact that a duration could also come decimal of seconds
+				final Object nativeValue = rs.getObject( paramIndex );
+				if ( nativeValue instanceof Number ) {
+					return javaType.wrap( nativeValue, options );
+				}
 				return javaType.wrap( rs.getObject( paramIndex, Duration.class ), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				// Handle the fact that a duration could also come decimal of seconds
+				final Object nativeValue = statement.getObject( index );
+				if ( nativeValue instanceof Number ) {
+					return javaType.wrap( nativeValue, options );
+				}
 				return javaType.wrap( statement.getObject( index, Duration.class ), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 					throws SQLException {
+				// Handle the fact that a duration could also come decimal of seconds
+				final Object nativeValue = statement.getObject( name );
+				if ( nativeValue instanceof Number ) {
+					return javaType.wrap( nativeValue, options );
+				}
 				return javaType.wrap( statement.getObject( name, Duration.class ), options );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -330,6 +330,9 @@ public class PostgreSQLDialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		if ( toTemporalType != TemporalType.TIMESTAMP && fromTemporalType != TemporalType.TIMESTAMP && unit == DAY ) {
 			// special case: subtraction of two dates
 			// results in an integer number of days

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/TimestampdiffFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/TimestampdiffFunction.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.query.ReturnableType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
@@ -79,7 +80,7 @@ public class TimestampdiffFunction
 		final Expression from = (Expression) arguments.get( 1 );
 		final Expression to = (Expression) arguments.get( 2 );
 
-		patternRenderer( field.getUnit(), from, to ).render( sqlAppender, arguments, walker );
+		patternRenderer( field == null ? null : field.getUnit(), from, to ).render( sqlAppender, arguments, walker );
 	}
 
 	private PatternRenderer patternRenderer(TemporalUnit unit, Expression from, Expression to) {
@@ -99,7 +100,9 @@ public class TimestampdiffFunction
 				impliedResultType != null
 						? impliedResultType
 						: (ReturnableType<?>) field.getExpressionType().getJdbcMapping(),
-				field.getExpressionType()
+				field != null
+						? field.getExpressionType()
+						: (JdbcMappingContainer) impliedResultType
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/config/ConfigurationHelper.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.type.SqlTypes;
 
 /**
  * Collection of helper methods for dealing with configuration settings.
@@ -526,6 +527,14 @@ public final class ConfigurationHelper {
 				.getJdbcEnvironment()
 				.getDialect()
 				.getPreferredSqlTypeCodeForBoolean();
+	}
+
+	public static synchronized int getPreferredSqlTypeCodeForDuration(StandardServiceRegistry serviceRegistry) {
+		return serviceRegistry.getService( ConfigurationService.class ).getSetting(
+				AvailableSettings.PREFERRED_DURATION_JDBC_TYPE_CODE,
+				StandardConverters.INTEGER,
+				SqlTypes.INTERVAL_SECOND
+		);
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -680,6 +680,11 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 	}
 
 	@Override
+	public int getPreferredSqlTypeCodeForDuration() {
+		return getBuildingContext().getPreferredSqlTypeCodeForDuration();
+	}
+
+	@Override
 	public TimeZoneStorageStrategy getDefaultTimeZoneStorageStrategy() {
 		if ( timeZoneStorageType != null ) {
 			switch ( timeZoneStorageType ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Supplier;
 
+import org.hibernate.Internal;
 import org.hibernate.QueryException;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
@@ -119,7 +120,8 @@ public class StandardFunctionReturnTypeResolvers {
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Internal helpers
 
-	private static boolean isAssignableTo(
+	@Internal
+	public static boolean isAssignableTo(
 			ReturnableType<?> defined, ReturnableType<?> implied) {
 		if ( implied == null ) {
 			return false;
@@ -144,7 +146,8 @@ public class StandardFunctionReturnTypeResolvers {
 				|| isNumeric( impliedTypeCode ) && isNumeric( definedTypeCode );
 	}
 
-	private static BasicValuedMapping useImpliedTypeIfPossible(
+	@Internal
+	public static BasicValuedMapping useImpliedTypeIfPossible(
 			BasicValuedMapping defined,
 			BasicValuedMapping implied) {
 		if ( defined == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -5431,17 +5431,9 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		Expression left = getActualExpression( cleanly( () -> toSqlExpression( lhs.accept( this ) ) ) );
 		Expression right = getActualExpression( cleanly( () -> toSqlExpression( rhs.accept( this ) ) ) );
 
-		TypeConfiguration typeConfiguration = getCreationContext().getMappingMetamodel().getTypeConfiguration();
-		TemporalType leftTimestamp = typeConfiguration.getSqlTemporalType( expression.getLeftHandOperand().getNodeType() );
-		TemporalType rightTimestamp = typeConfiguration.getSqlTemporalType( expression.getRightHandOperand().getNodeType() );
-
-		// when we're dealing with Dates, we use
-		// DAY as the smallest unit, otherwise we
-		// use SECOND granularity with fractions as that is what the DurationJavaType expects
-
-		TemporalUnit baseUnit = ( rightTimestamp == TemporalType.TIMESTAMP || leftTimestamp == TemporalType.TIMESTAMP ) ?
-				SECOND :
-				DAY;
+		// The result of timestamp subtraction is always a `Duration`, unless a unit is applied
+		// So use SECOND granularity with fractions as that is what the `DurationJavaType` expects
+		final TemporalUnit baseUnit = SECOND; // todo: alternatively repurpose NATIVE to mean "INTERVAL SECOND"
 
 		if ( adjustedTimestamp != null ) {
 			if ( appliedByUnit != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -387,8 +387,8 @@ import static org.hibernate.internal.util.NullnessHelper.coalesceSuppliedValues;
 import static org.hibernate.query.sqm.BinaryArithmeticOperator.ADD;
 import static org.hibernate.query.sqm.BinaryArithmeticOperator.MULTIPLY;
 import static org.hibernate.query.sqm.BinaryArithmeticOperator.SUBTRACT;
-import static org.hibernate.query.sqm.TemporalUnit.DAY;
 import static org.hibernate.query.sqm.TemporalUnit.EPOCH;
+import static org.hibernate.query.sqm.TemporalUnit.NATIVE;
 import static org.hibernate.query.sqm.TemporalUnit.SECOND;
 import static org.hibernate.query.sqm.UnaryArithmeticOperator.UNARY_MINUS;
 import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnReferenceKey;
@@ -5438,9 +5438,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 		// The result of timestamp subtraction is always a `Duration`, unless a unit is applied
 		// So use SECOND granularity with fractions as that is what the `DurationJavaType` expects
-		final TemporalUnit baseUnit = SECOND;
-		// For SECOND, the expected result type is Double
-		final BasicType<Double> diffResultType = basicType( Double.class );
+		final TemporalUnit baseUnit = NATIVE;
+		final BasicType<Long> diffResultType = basicType( Long.class );
 
 		if ( adjustedTimestamp != null ) {
 			if ( appliedByUnit != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -584,7 +584,12 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		return creationContext.getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
 	}
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	@Override
+	public int getPreferredSqlTypeCodeForDuration() {
+		return creationContext.getSessionFactory().getSessionFactoryOptions().getPreferredSqlTypeCodeForDuration();
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// FromClauseAccess
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -177,7 +177,7 @@ import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 
-import static org.hibernate.query.sqm.TemporalUnit.SECOND;
+import static org.hibernate.query.sqm.TemporalUnit.NANOSECOND;
 import static org.hibernate.sql.ast.SqlTreePrinter.logSqlAst;
 import static org.hibernate.sql.results.graph.DomainResultGraphPrinter.logDomainResultGraph;
 
@@ -4439,9 +4439,12 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	@Override
 	public void visitDuration(Duration duration) {
 		duration.getMagnitude().accept( this );
-		appendSql(
-				duration.getUnit().conversionFactor( SECOND, getDialect() )
-		);
+		if ( !duration.getExpressionType().getJdbcMapping().getJdbcType().isInterval() ) {
+			// Convert to NANOSECOND because DurationJavaType requires values in that unit
+			appendSql(
+					duration.getUnit().conversionFactor( NANOSECOND, getDialect() )
+			);
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
@@ -347,7 +347,8 @@ public final class StandardBasicTypes {
 	// Date / time data
 
 	/**
-	 * The standard Hibernate type for mapping {@link Duration} to JDBC {@link org.hibernate.type.SqlTypes#NUMERIC NUMERIC}.
+	 * The standard Hibernate type for mapping {@link Duration} to JDBC {@link org.hibernate.type.SqlTypes#INTERVAL_SECOND INTERVAL_SECOND}
+	 * or {@link org.hibernate.type.SqlTypes#NUMERIC NUMERIC} as a fallback.
 	 */
 	public static final BasicTypeReference<Duration> DURATION = new BasicTypeReference<>(
 			"Duration",

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaType.java
@@ -54,7 +54,7 @@ public class DurationJavaType extends AbstractClassJavaType<Duration> {
 
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
-		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.INTERVAL_SECOND );
+		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( context.getPreferredSqlTypeCodeForDuration() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DurationJavaType.java
@@ -103,7 +103,7 @@ public class DurationJavaType extends AbstractClassJavaType<Duration> {
 		}
 
 		if ( Long.class.isAssignableFrom( type ) ) {
-			return (X) Long.valueOf( duration.toNanos() );
+			return (X) Long.valueOf( duration.toSeconds() );
 		}
 
 		throw unknownUnwrap( type );
@@ -128,7 +128,7 @@ public class DurationJavaType extends AbstractClassJavaType<Duration> {
 		}
 
 		if (value instanceof Long) {
-			return Duration.ofNanos( (Long) value );
+			return Duration.ofSeconds( (Long) value );
 		}
 
 		if (value instanceof String) {
@@ -141,7 +141,7 @@ public class DurationJavaType extends AbstractClassJavaType<Duration> {
 	private Duration fromDecimal(Object number) {
 		final String formatted = DECIMAL_FORMAT.get().format( number );
 		final int dotIndex = formatted.indexOf( '.' );
-		if (dotIndex == -1) {
+		if ( dotIndex == -1 ) {
 			return Duration.ofSeconds( Long.parseLong( formatted ) );
 		}
 		return Duration.ofSeconds(

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -70,6 +71,16 @@ public interface JdbcTypeIndicators {
 	 */
 	default int getPreferredSqlTypeCodeForBoolean() {
 		return Types.BOOLEAN;
+	}
+
+	/**
+	 * When mapping a duration type to the database what is the preferred SQL type code to use?
+	 * <p/>
+	 * Specifically names the key into the
+	 * {@link JdbcTypeRegistry}.
+	 */
+	default int getPreferredSqlTypeCodeForDuration() {
+		return SqlTypes.INTERVAL_SECOND;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -351,11 +351,6 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 			public TypeConfiguration getTypeConfiguration() {
 				return typeConfiguration;
 			}
-
-			@Override
-			public int getPreferredSqlTypeCodeForBoolean() {
-				return SqlTypes.BOOLEAN;
-			}
 		};
 
 		public Scope(TypeConfiguration typeConfiguration) {

--- a/hibernate-envers/src/demo/resources/META-INF/persistence.xml
+++ b/hibernate-envers/src/demo/resources/META-INF/persistence.xml
@@ -13,7 +13,7 @@
         <exclude-unlisted-classes />
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
             <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>

--- a/hibernate-integrationtest-java-modules/src/test/resources/META-INF/persistence.xml
+++ b/hibernate-integrationtest-java-modules/src/test/resources/META-INF/persistence.xml
@@ -14,7 +14,7 @@
         <properties>
             <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>

--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
@@ -33,7 +33,7 @@ import org.hibernate.testing.DialectCheck;
 public class ConnectionProviderBuilder implements DialectCheck {
 	public static final String DRIVER = "org.h2.Driver";
 	public static final String DATA_SOURCE = "org.h2.jdbcx.JdbcDataSource";
-//	public static final String URL = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;MVCC=TRUE";
+//	public static final String URL = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1";
 	public static final String URL_FORMAT = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1";
 	public static final String URL = URL_FORMAT;
 	public static final String USER = "sa";

--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/TestingDatabaseInfo.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/TestingDatabaseInfo.java
@@ -16,7 +16,7 @@ import org.hibernate.dialect.H2Dialect;
  */
 public final class TestingDatabaseInfo {
 	public static volatile String DRIVER = "org.h2.Driver";
-	public static volatile String URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE";
+	public static volatile String URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
 	public static volatile String USER = "sa";
 	public static volatile String PASS = "";
 

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -256,10 +256,17 @@ plural attribute classification
 See https://docs.jboss.org/hibernate/orm/6.0/userguide/html_single/Hibernate_User_Guide.html#collection-type-reg-ann
 for details of using `@CollectionTypeRegistration`
 
-=== Misc
+=== Duration mapping changes
 
-* The default type for `Duration` was changed to `NUMERIC` which could lead to schema validation errors
+Duration now maps to the type code `SqlType.INTERVAL_SECOND` by default, which maps to the SQL type `interval second`
+if possible, and falls back to `numeric(21)`.
+In either case, schema validation errors could occur as 5.x used the type code `Types.BIGINT`.
 
+Migration to `numeric(21)` should be easy. The migration to `interval second` might require a migration expression like
+`cast(cast(old as numeric(21,9) / 1000000000) as interval second(9))`.
+
+To retain backwards compatibility, configure the setting `hibernate.type.preferred_duration_jdbc_type_code` to `2`
+which stands for `Types.NUMERIC`.
 
 [[query]]
 == Query


### PR DESCRIPTION
Work on top of https://github.com/hibernate/hibernate-orm/pull/4888 for discussion. The last commit models the request for timestampdiff to return an interval by passing a null duration unit.