### PR TITLE
Timestampdiff interval support

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -516,6 +516,9 @@ public class CockroachDialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		switch (unit) {
 			case YEAR:
 				return "(extract(year from ?3)-extract(year from ?2))";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -398,6 +398,9 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		return "datediff(?1,?2,?3)";
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -330,6 +330,9 @@ public class PostgreSQLDialect extends Dialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		if ( unit == null ) {
+			return "(?3-?2)";
+		}
 		if ( toTemporalType != TemporalType.TIMESTAMP && fromTemporalType != TemporalType.TIMESTAMP && unit == DAY ) {
 			// special case: subtraction of two dates
 			// results in an integer number of days

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/TimestampdiffFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/TimestampdiffFunction.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.query.ReturnableType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
@@ -79,7 +80,7 @@ public class TimestampdiffFunction
 		final Expression from = (Expression) arguments.get( 1 );
 		final Expression to = (Expression) arguments.get( 2 );
 
-		patternRenderer( field.getUnit(), from, to ).render( sqlAppender, arguments, walker );
+		patternRenderer( field == null ? null : field.getUnit(), from, to ).render( sqlAppender, arguments, walker );
 	}
 
 	private PatternRenderer patternRenderer(TemporalUnit unit, Expression from, Expression to) {
@@ -99,7 +100,9 @@ public class TimestampdiffFunction
 				impliedResultType != null
 						? impliedResultType
 						: (ReturnableType<?>) field.getExpressionType().getJdbcMapping(),
-				field.getExpressionType()
+				field != null
+						? field.getExpressionType()
+						: (JdbcMappingContainer) impliedResultType
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -5453,10 +5453,20 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			// the diff, and then the subsequent add
 
 			DurationUnit unit = new DurationUnit( baseUnit, diffResultType );
-			Expression magnitude = applyScale( timestampdiff().expression( null, unit, right, left ) );
+			BasicValuedMapping durationType = (BasicValuedMapping) expression.getNodeType();
+			Expression scaledMagnitude = applyScale(
+					timestampdiff().expression(
+							(ReturnableType<?>) expression.getNodeType(),
+							durationType.getJdbcMapping().getJdbcType().isInterval() ? null : unit,
+							right,
+							left
+					)
+			);
 			return timestampadd().expression(
 					(ReturnableType<?>) adjustedTimestampType, //TODO should be adjustedTimestamp.getType()
-					unit, magnitude, adjustedTimestamp
+					unit,
+					scaledMagnitude,
+					adjustedTimestamp
 			);
 		}
 		else if ( appliedByUnit != null ) {
@@ -5470,10 +5480,14 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			// a plain "bare" Duration
 			DurationUnit unit = new DurationUnit( baseUnit, diffResultType );
 			BasicValuedMapping durationType = (BasicValuedMapping) expression.getNodeType();
-			Expression scaledMagnitude = applyScale( timestampdiff().expression(
-					(ReturnableType<?>) expression.getNodeType(),
-					unit, right, left
-			) );
+			Expression scaledMagnitude = applyScale(
+					timestampdiff().expression(
+							(ReturnableType<?>) expression.getNodeType(),
+							durationType.getJdbcMapping().getJdbcType().isInterval() ? null : unit,
+							right,
+							left
+					)
+			);
 			return new Duration( scaledMagnitude, baseUnit, durationType );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -4439,10 +4439,12 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	@Override
 	public void visitDuration(Duration duration) {
 		duration.getMagnitude().accept( this );
-		// Convert to NANOSECOND because DurationJavaType requires values in that unit
-		appendSql(
-				duration.getUnit().conversionFactor( NANOSECOND, getDialect() )
-		);
+		if ( !duration.getExpressionType().getJdbcMapping().getJdbcType().isInterval() ) {
+			// Convert to NANOSECOND because DurationJavaType requires values in that unit
+			appendSql(
+					duration.getUnit().conversionFactor( NANOSECOND, getDialect() )
+			);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Builds on top of https://github.com/hibernate/hibernate-orm/pull/4901

The main change is to allow `timestampdiff` to return an interval as result when a null duration unit is passed to avoid extra SQL for extracting nanoseconds