### PR TITLE
HHH-15146 + HHH-15147 Fix jpamodelgen-jakarta annotation processor processing javax.* annotations instead of jakarta.* annotations

### DIFF
--- a/tooling/metamodel-generator-jakarta/hibernate-jpamodelgen-jakarta.gradle
+++ b/tooling/metamodel-generator-jakarta/hibernate-jpamodelgen-jakarta.gradle
@@ -168,7 +168,7 @@ abstract class JakartaJarTransformation extends DefaultTask {
 						"-q",
 						"-tr", getProject().getRootProject().file( "rules/jakarta-renames.properties" ).getAbsolutePath(),
 						"-tv", getProject().getRootProject().file( "rules/jakarta-versions.properties" ).getAbsolutePath(),
-						"-td", getProject().getRootProject().file( "rules/jakarta-direct.properties" ).getAbsolutePath()
+						"-td", getProject().getRootProject().file( "rules/jakarta-direct-modelgen.properties" ).getAbsolutePath()
 				);
 			}
 		});

--- a/tooling/metamodel-generator-jakarta/hibernate-jpamodelgen-jakarta.gradle
+++ b/tooling/metamodel-generator-jakarta/hibernate-jpamodelgen-jakarta.gradle
@@ -18,11 +18,18 @@ configurations {
 // we do not want the much of the normal java plugin's behavior
 compileJava.enabled false
 processResources.enabled false
-compileTestJava.enabled false
-processTestResources.enabled false
 jar.enabled false
 javadocJar.enabled false
 sourcesJar.enabled false
+
+ext {
+	transformedJarName = project(':hibernate-jpamodelgen').tasks.jar.archiveFileName.get().
+			replaceAll( 'hibernate-jpamodelgen', 'hibernate-jpamodelgen-jakarta' )
+
+	originalTestSrcDir = "${project(':hibernate-jpamodelgen').projectDir}/src/test"
+	transformedTestSrcDirRelative = 'generated-src/test'
+	transformedTestSrcDir = "${buildDir}/${transformedTestSrcDirRelative}"
+}
 
 dependencies {
 	// JAXB
@@ -35,7 +42,18 @@ dependencies {
 			'org.slf4j:slf4j-api:1.7.26',
 			'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
 			'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
+
+	testCompile project(':hibernate-testing-jakarta')
 	testCompile fileTree(dir: 'libs', include: '*.jar')
+	testCompile libraries.junit
+	testCompile libraries.jakarta_jpa
+	testCompile libraries.jakarta_validation
+}
+
+//
+sourceSets.test {
+	java.srcDir "${project.transformedTestSrcDir}/java"
+	resources.srcDir "${project.transformedTestSrcDir}/resources"
 }
 
 jar {
@@ -108,6 +126,18 @@ task transformJavadocJar(type: JakartaJarTransformation) {
 	targetJar tasks.javadocJar.archiveFile.get().asFile
 }
 
+// jpamodelgen tests need access to test sources, so we transform test sources instead of the test JAR.
+task transformTestSources(type: JakartaSourcesTransformation) {
+	description 'Transforms the hibernate-jpamodelgen test sources using the JakartaTransformer tool'
+
+	// Only run this if JavaEE tests compile
+	dependsOn project(':hibernate-jpamodelgen').tasks.compileTestJava
+	mustRunAfter project(':hibernate-jpamodelgen').tasks.compileTestJava
+
+	sourceDir project.originalTestSrcDir
+	targetDir project.transformedTestSrcDir
+}
+
 configurations {
 	[apiElements, runtimeElements].each {
 		it.outgoing.artifacts.removeIf {
@@ -121,6 +151,48 @@ configurations {
 		}
 		it.outgoing.artifact(tasks.transformJavadocJar.targetJar) {
 			builtBy tasks.transformJavadocJar
+		}
+		it.outgoing.artifact(tasks.transformTestSources.targetDir) {
+			builtBy tasks.transformTestSources
+		}
+	}
+}
+
+compileTestJava {
+	dependsOn tasks.transformJar
+	dependsOn tasks.transformTestSources
+
+	mustRunAfter tasks.transformJar
+	mustRunAfter tasks.transformTestSources
+
+	classpath += files(
+			"${buildDir}/libs/${project.transformedJarName}"
+	)
+
+	options.compilerArgs += [
+			"-proc:none"
+	]
+}
+
+test {
+	classpath += files(
+			"${buildDir}/libs/${project.transformedJarName}"
+	)
+
+	systemProperty 'file.encoding', 'utf-8'
+	systemProperty 'sourceBaseDir', "${project.transformedTestSrcDir}/java"
+
+	if ( gradle.ext.javaVersions.test.launcher.asInt() >= 9 ) {
+		// Weld needs this to generate proxies
+		jvmArgs( ['--add-opens', 'java.base/java.security=ALL-UNNAMED'] )
+		jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
+	}
+
+	maxHeapSize = '3G'
+	// Allow to exclude specific tests
+	if (project.hasProperty('excludeTests')) {
+		filter {
+			excludeTestsMatching project.property('excludeTests').toString()
 		}
 	}
 }
@@ -165,6 +237,59 @@ abstract class JakartaJarTransformation extends DefaultTask {
 				javaExecSpec.args(
 						sourceJar.get().getAsFile().getAbsolutePath(),
 						targetJar.get().getAsFile().getAbsolutePath(),
+						"-q",
+						"-tr", getProject().getRootProject().file( "rules/jakarta-renames.properties" ).getAbsolutePath(),
+						"-tv", getProject().getRootProject().file( "rules/jakarta-versions.properties" ).getAbsolutePath(),
+						"-td", getProject().getRootProject().file( "rules/jakarta-direct-modelgen.properties" ).getAbsolutePath()
+				);
+			}
+		});
+	}
+}
+
+@CacheableTask
+abstract class JakartaSourcesTransformation extends DefaultTask {
+	private final DirectoryProperty sourceDir;
+	private final DirectoryProperty targetDir;
+
+	@Inject
+	JakartaSourcesTransformation(ObjectFactory objectFactory) {
+		sourceDir = objectFactory.directoryProperty();
+		targetDir = objectFactory.directoryProperty();
+	}
+
+	@InputDirectory
+	@PathSensitive( PathSensitivity.RELATIVE )
+	DirectoryProperty getSourceDir() {
+		return sourceDir;
+	}
+
+	void sourceDir(Object directoryReference) {
+		sourceDir.set( project.file( directoryReference ) )
+	}
+
+	@OutputDirectory
+	DirectoryProperty getTargetDir() {
+		return targetDir;
+	}
+
+	void targetDir(Object directoryReference) {
+		targetDir.set( project.file( directoryReference ) )
+	}
+
+	@TaskAction
+	void transform() {
+		project.javaexec( new Action<JavaExecSpec>() {
+			@Override
+			void execute(JavaExecSpec javaExecSpec) {
+				javaExecSpec.classpath( getProject().getConfigurations().getByName( "jakartaeeTransformTool" ) );
+				javaExecSpec.setMain( "org.eclipse.transformer.jakarta.JakartaTransformer" );
+				javaExecSpec.args(
+						sourceDir.get().getAsFile().getAbsolutePath(),
+						targetDir.get().getAsFile().getAbsolutePath(),
+						// The transformer won't run if the target directory exist,
+						// except if we allow it to overwrite the target directory through this option.
+						'-o',
 						"-q",
 						"-tr", getProject().getRootProject().file( "rules/jakarta-renames.properties" ).getAbsolutePath(),
 						"-tv", getProject().getRootProject().file( "rules/jakarta-versions.properties" ).getAbsolutePath(),


### PR DESCRIPTION
* [HHH-15147](https://hibernate.atlassian.net/browse/HHH-15147): hibernate-jpamodelgen-jakarta annotation processor ignores jakarta.* annotations
* [HHH-15146](https://hibernate.atlassian.net/browse/HHH-15146): Run tests against hibernate-jpamodelgen-jakarta

See also https://hibernate.zulipchat.com/#narrow/stream/132096-hibernate-user/topic/Hibernate.20jpamodegen.205.2E6.2E7.2EFinal.20does.20not.20work , https://github.com/spring-projects/spring-boot/issues/30445