### PR TITLE
HHH-15060  - Associations with @NotFound should always be left joined when de-referenced in HQL/Criteria

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/FetchNotFoundException.java
+++ b/hibernate-core/src/main/java/org/hibernate/FetchNotFoundException.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate;
+
+import java.util.Locale;
+import javax.persistence.EntityNotFoundException;
+
+/**
+ * Exception for {@link org.hibernate.annotations.NotFoundAction#EXCEPTION}
+ *
+ * @see org.hibernate.annotations.NotFound
+ *
+ * @author Steve Ebersole
+ */
+public class FetchNotFoundException extends EntityNotFoundException {
+	private final String entityName;
+	private final Object identifier;
+
+	public FetchNotFoundException(String entityName, Object identifier) {
+		super(
+				String.format(
+						Locale.ROOT,
+						"Entity `%s` with identifier value `%s` does not exist",
+						entityName,
+						identifier
+				)
+		);
+		this.entityName = entityName;
+		this.identifier = identifier;
+	}
+
+	public String getEntityName() {
+		return entityName;
+	}
+
+	public Object getIdentifier() {
+		return identifier;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
@@ -7,8 +7,8 @@
 package org.hibernate.annotations;
 
 /**
- * Fetch options on associations.  Defines more of the "how" of fetching, whereas JPA {@link javax.persistence.FetchType}
- * focuses on the "when".
+ * Defines how the association should be fetched, compared to
+ * {@link javax.persistence.FetchType} which defines when it should be fetched
  *
  * @author Emmanuel Bernard
  */

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FetchMode.java
@@ -16,13 +16,27 @@ public enum FetchMode {
 	/**
 	 * Use a secondary select for each individual entity, collection, or join load.
 	 */
-	SELECT,
+	SELECT( org.hibernate.FetchMode.SELECT ),
 	/**
 	 * Use an outer join to load the related entities, collections or joins.
 	 */
-	JOIN,
+	JOIN( org.hibernate.FetchMode.JOIN ),
 	/**
-	 * Available for collections only.  When accessing a non-initialized collection, this fetch mode will trigger loading all elements of all collections of the same role for all owners associated with the persistence context using a single secondary select.
+	 * Available for collections only.
+	 *
+	 * When accessing a non-initialized collection, this fetch mode will trigger
+	 * loading all elements of all collections of the same role for all owners
+	 * associated with the persistence context using a single secondary select.
 	 */
-	SUBSELECT
+	SUBSELECT( org.hibernate.FetchMode.SELECT );
+
+	private final org.hibernate.FetchMode hibernateFetchMode;
+
+	FetchMode(org.hibernate.FetchMode hibernateFetchMode) {
+		this.hibernateFetchMode = hibernateFetchMode;
+	}
+
+	public org.hibernate.FetchMode getHibernateFetchMode() {
+		return hibernateFetchMode;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NotFoundAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NotFoundAction.java
@@ -6,20 +6,36 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.FetchNotFoundException;
 
 /**
- * Possible actions when an associated entity is not found in the database.  Often seen with "legacy" foreign-key
- * schemes which do not use {@code NULL} to indicate a missing reference, instead using a "magic value".
+ * Possible actions when the database contains a non-null fk with no
+ * matching target. This also implies that there are no physical
+ * foreign-key constraints on the database.
  *
+ * As an example, consider a typical Customer/Order model.  These actions apply
+ * when a non-null `orders.customer_fk` value does not have a corresponding value
+ * in `customers.id`.
+ *
+ * Generally this will occur in 2 scenarios:<ul>
+ *     <li>the associated data has been deleted</li>
+ *     <li>the model uses special "magic" values to indicate null</li>
+ * </ul>
+ *
+ * @author Steve Ebersole
  * @author Emmanuel Bernard
  */
 public enum NotFoundAction {
 	/**
-	 * Raise an exception when an element is not found (default and recommended).
+	 * Throw an exception when the association is not found (default and recommended).
+	 *
+	 * @see FetchNotFoundException
 	 */
 	EXCEPTION,
+
 	/**
-	 * Ignore the element when not found in database.
+	 * Ignore the association when not found in database.  Effectively treats the
+	 * association as null, despite the non-null foreign-key value.
 	 */
 	IGNORE
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -3401,8 +3401,20 @@ public final class AnnotationBinder {
 			javax.persistence.ForeignKey fkOverride,
 			JoinColumn joinColumn,
 			JoinColumns joinColumns) {
-		if ( ( joinColumn != null && joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT )
-				|| ( joinColumns != null && joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT ) ) {
+
+		final NotFound notFoundAnn= property.getAnnotation( NotFound.class );
+		if ( notFoundAnn != null ) {
+			// supersedes all others
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumn != null && (
+				joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT) ) ) {
+			value.setForeignKeyName( "none" );
+		}
+		else if ( joinColumns != null && (
+				joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
+						|| ( joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT) ) ) {
 			value.setForeignKeyName( "none" );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AnnotationBinder.java
@@ -3417,20 +3417,8 @@ public final class AnnotationBinder {
 			javax.persistence.ForeignKey fkOverride,
 			JoinColumn joinColumn,
 			JoinColumns joinColumns) {
-
-		final NotFound notFoundAnn= property.getAnnotation( NotFound.class );
-		if ( notFoundAnn != null ) {
-			// supersedes all others
-			value.setForeignKeyName( "none" );
-		}
-		else if ( joinColumn != null && (
-				joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-						|| ( joinColumn.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT) ) ) {
-			value.setForeignKeyName( "none" );
-		}
-		else if ( joinColumns != null && (
-				joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT
-						|| ( joinColumns.foreignKey().value() == ConstraintMode.PROVIDER_DEFAULT) ) ) {
+		if ( ( joinColumn != null && joinColumn.foreignKey().value() == ConstraintMode.NO_CONSTRAINT )
+				|| ( joinColumns != null && joinColumns.foreignKey().value() == ConstraintMode.NO_CONSTRAINT ) ) {
 			value.setForeignKeyName( "none" );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/CollectionSecondPass.java
@@ -16,6 +16,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.IndexedCollection;
 import org.hibernate.mapping.OneToMany;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Value;
 
@@ -69,8 +70,7 @@ public abstract class CollectionSecondPass implements SecondPass {
 		}
 	}
 
-	abstract public void secondPass(java.util.Map persistentClasses, java.util.Map inheritedMetas)
-			throws MappingException;
+	abstract public void secondPass(java.util.Map persistentClasses, java.util.Map inheritedMetas);
 
 	private static String columns(Value val) {
 		StringBuilder columns = new StringBuilder();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -8,13 +8,13 @@ package org.hibernate.cfg;
 
 import java.util.Iterator;
 import java.util.Map;
-
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.MappingException;
 import org.hibernate.annotations.LazyGroup;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.cfg.annotations.PropertyBinder;
@@ -40,7 +40,7 @@ public class OneToOneSecondPass implements SecondPass {
 	private String ownerEntity;
 	private String ownerProperty;
 	private PropertyHolder propertyHolder;
-	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 	private PropertyData inferredData;
 	private XClass targetEntity;
 	private boolean cascadeOnDelete;
@@ -56,7 +56,7 @@ public class OneToOneSecondPass implements SecondPass {
 			PropertyHolder propertyHolder,
 			PropertyData inferredData,
 			XClass targetEntity,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean cascadeOnDelete,
 			boolean optional,
 			String cascadeStrategy,
@@ -67,7 +67,7 @@ public class OneToOneSecondPass implements SecondPass {
 		this.mappedBy = mappedBy;
 		this.propertyHolder = propertyHolder;
 		this.buildingContext = buildingContext;
-		this.ignoreNotFound = ignoreNotFound;
+		this.notFoundAction = notFoundAction;
 		this.inferredData = inferredData;
 		this.targetEntity = targetEntity;
 		this.cascadeOnDelete = cascadeOnDelete;
@@ -189,7 +189,7 @@ public class OneToOneSecondPass implements SecondPass {
 					);
 					ManyToOne manyToOne = new ManyToOne( buildingContext, mappedByJoin.getTable() );
 					//FIXME use ignore not found here
-					manyToOne.setIgnoreNotFound( ignoreNotFound );
+					manyToOne.setNotFoundAction( notFoundAction );
 					manyToOne.setCascadeDeleteEnabled( value.isCascadeDeleteEnabled() );
 					manyToOne.setFetchMode( value.getFetchMode() );
 					manyToOne.setLazy( value.isLazy() );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ToOneFkSecondPass.java
@@ -103,7 +103,9 @@ public class ToOneFkSecondPass extends FkSecondPass {
 			/*
 			 * HbmMetadataSourceProcessorImpl does this only when property-ref != null, but IMO, it makes sense event if it is null
 			 */
-			if ( !manyToOne.isIgnoreNotFound() ) manyToOne.createPropertyRefConstraints( persistentClasses );
+			if ( manyToOne.getNotFoundAction() == null ) {
+				manyToOne.createPropertyRefConstraints( persistentClasses );
+			}
 		}
 		else if ( value instanceof OneToOne ) {
 			value.createForeignKey();

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/IdBagBinder.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.annotations.CollectionId;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
@@ -50,11 +51,11 @@ public class IdBagBinder extends BagBinder {
 			XProperty property,
 			boolean unique,
 			TableBinder associationTableBinder,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			MetadataBuildingContext buildingContext) {
 		boolean result = super.bindStarToManySecondPass(
 				persistentClasses, collType, fkJoinColumns, keyColumns, inverseColumns, elementColumns, isEmbedded,
-				property, unique, associationTableBinder, ignoreNotFound, getBuildingContext()
+				property, unique, associationTableBinder, notFoundAction, getBuildingContext()
 		);
 		CollectionId collectionIdAnn = property.getAnnotation( CollectionId.class );
 		if ( collectionIdAnn != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/ListBinder.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.OrderBy;
 import org.hibernate.annotations.Sort;
 import org.hibernate.annotations.common.reflection.XClass;
@@ -76,14 +77,13 @@ public class ListBinder extends CollectionBinder {
 			final boolean isEmbedded,
 			final XProperty property,
 			final XClass collType,
-			final boolean ignoreNotFound,
+			final NotFoundAction notFoundAction,
 			final boolean unique,
 			final TableBinder assocTableBinder,
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( getBuildingContext(), ListBinder.this.collection ) {
 			@Override
-            public void secondPass(Map persistentClasses, Map inheritedMetas)
-					throws MappingException {
+            public void secondPass(Map persistentClasses, Map inheritedMetas) {
 				bindStarToManySecondPass(
 						persistentClasses,
 						collType,
@@ -95,7 +95,7 @@ public class ListBinder extends CollectionBinder {
 						property,
 						unique,
 						assocTableBinder,
-						ignoreNotFound,
+						notFoundAction,
 						buildingContext
 				);
 				bindIndex( buildingContext );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/MapBinder.java
@@ -23,7 +23,7 @@ import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
-import org.hibernate.annotations.common.reflection.ClassLoadingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -87,16 +87,15 @@ public class MapBinder extends CollectionBinder {
 			final boolean isEmbedded,
 			final XProperty property,
 			final XClass collType,
-			final boolean ignoreNotFound,
+			final NotFoundAction notFoundAction,
 			final boolean unique,
 			final TableBinder assocTableBinder,
 			final MetadataBuildingContext buildingContext) {
 		return new CollectionSecondPass( buildingContext, MapBinder.this.collection ) {
-			public void secondPass(Map persistentClasses, Map inheritedMetas)
-					throws MappingException {
+			public void secondPass(Map persistentClasses, Map inheritedMetas) {
 				bindStarToManySecondPass(
 						persistentClasses, collType, fkJoinColumns, keyColumns, inverseColumns, elementColumns,
-						isEmbedded, property, unique, assocTableBinder, ignoreNotFound, buildingContext
+						isEmbedded, property, unique, assocTableBinder, notFoundAction, buildingContext
 				);
 				bindKeyFromAssociationTable(
 						collType, persistentClasses, mapKeyPropertyName, property, isEmbedded, buildingContext,

--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/tree/DotNode.java
@@ -389,6 +389,7 @@ public class DotNode extends FromReferenceNode implements DisplayableNode, Selec
 		String property = propertyName;
 		final boolean joinIsNeeded;
 
+
 		if ( isDotNode( parent ) ) {
 			// our parent is another dot node, meaning we are being further dereferenced.
 			// thus we need to generate a join unless the association is non-nullable and
@@ -397,8 +398,14 @@ public class DotNode extends FromReferenceNode implements DisplayableNode, Selec
 			property = parentAsDotNode.propertyName;
 			joinIsNeeded = generateJoin && (
 					entityType.isNullable() ||
-							!isReferenceToPrimaryKey( parentAsDotNode.propertyName, entityType )
+							!isPropertyEmbeddedInJoinProperties( parentAsDotNode.propertyName )
 			);
+			if ( generateJoin
+					&& implicitJoin
+					&& entityType.isNullable()
+					&& isReferenceToPrimaryKey( parentAsDotNode.propertyName, entityType ) ) {
+				joinType = JoinType.LEFT_OUTER_JOIN;
+			}
 		}
 		else if ( !getWalker().isSelectStatement() ) {
 			// in non-select queries, the only time we should need to join is if we are in a subquery from clause
@@ -425,7 +432,43 @@ public class DotNode extends FromReferenceNode implements DisplayableNode, Selec
 
 	}
 
-	private boolean isDotNode(AST n) {
+	/**
+	 * Is the given property name a reference to the primary key of the associated
+	 * entity construed by the given entity type?
+	 * <p/>
+	 * For example, consider a fragment like order.customer.id
+	 * (where order is a from-element alias).  Here, we'd have:
+	 * propertyName = "id" AND
+	 * owningType = ManyToOneType(Customer)
+	 * and are being asked to determine whether "customer.id" is a reference
+	 * to customer's PK...
+	 *
+	 * @param propertyName The name of the property to check.
+	 * @param owningType The type represeting the entity "owning" the property
+	 *
+	 * @return True if propertyName references the entity's (owningType->associatedEntity)
+	 *         primary key; false otherwise.
+	 */
+	private boolean isPropertyEmbeddedInJoinProperties(String propertyName, EntityType owningType) {
+		EntityPersister persister = getSessionFactoryHelper()
+				.getFactory().getMetamodel().entityPersister( owningType.getAssociatedEntityName() );
+		if ( persister.getEntityMetamodel().hasNonIdentifierPropertyNamedId() ) {
+			// only the identifier property field name can be a reference to the associated entity's PK...
+			return propertyName.equals( persister.getIdentifierPropertyName() ) && owningType.isReferenceToPrimaryKey();
+		}
+		// here, we have two possibilities:
+		// 1) the property-name matches the expliciHEtly identifier property name
+		// 2) the property-name matches the implicit 'id' property name
+		// the referenced node text is the special 'id'
+		if ( EntityPersister.ENTITY_ID.equals( propertyName ) ) {
+			return owningType.isReferenceToPrimaryKey();
+		}
+		String keyPropertyName = getSessionFactoryHelper().getIdentifierOrUniqueKeyPropertyName( owningType );
+		return keyPropertyName != null && keyPropertyName.equals( propertyName ) && owningType.isReferenceToPrimaryKey();
+	}
+
+
+	private static boolean isDotNode(AST n) {
 		return n != null && n.getType() == SqlTokenTypes.DOT;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ManyToOne.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.type.EntityType;
@@ -22,6 +23,7 @@ import org.hibernate.type.Type;
  */
 public class ManyToOne extends ToOne {
 	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 	private boolean isLogicalOneToOne;
 
 	/**
@@ -44,7 +46,7 @@ public class ManyToOne extends ToOne {
 				getPropertyName(),
 				isLazy(),
 				isUnwrapProxy(),
-				isIgnoreNotFound(),
+				getNotFoundAction(),
 				isLogicalOneToOne
 		);
 	}
@@ -97,12 +99,25 @@ public class ManyToOne extends ToOne {
 		return visitor.accept(this);
 	}
 
+	public NotFoundAction getNotFoundAction() {
+		return notFoundAction;
+	}
+
+	public void setNotFoundAction(NotFoundAction notFoundAction) {
+		this.notFoundAction = notFoundAction;
+	}
+
 	public boolean isIgnoreNotFound() {
-		return ignoreNotFound;
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	public void setIgnoreNotFound(boolean ignoreNotFound) {
-		this.ignoreNotFound = ignoreNotFound;
+		if ( ignoreNotFound ) {
+			notFoundAction = NotFoundAction.IGNORE;
+		}
+		else {
+			notFoundAction = null;
+		}
 	}
 
 	public void markAsLogicalOneToOne() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.engine.spi.Mapping;
@@ -29,7 +30,7 @@ public class OneToMany implements Value {
 
 	private String referencedEntityName;
 	private PersistentClass associatedClass;
-	private boolean ignoreNotFound;
+	private NotFoundAction notFoundAction;
 
 	/**
 	 * @deprecated Use {@link OneToMany#OneToMany(MetadataBuildingContext, PersistentClass)} instead.
@@ -57,7 +58,7 @@ public class OneToMany implements Value {
 				null,
 				false,
 				false,
-				isIgnoreNotFound(),
+				notFoundAction,
 				false
 		);
 	}
@@ -162,12 +163,25 @@ public class OneToMany implements Value {
 		throw new UnsupportedOperationException();
 	}
 
+	public NotFoundAction getNotFoundAction() {
+		return notFoundAction;
+	}
+
+	public void setNotFoundAction(NotFoundAction notFoundAction) {
+		this.notFoundAction = notFoundAction;
+	}
+
 	public boolean isIgnoreNotFound() {
-		return ignoreNotFound;
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	public void setIgnoreNotFound(boolean ignoreNotFound) {
-		this.ignoreNotFound = ignoreNotFound;
+		if ( ignoreNotFound ) {
+			notFoundAction = NotFoundAction.IGNORE;
+		}
+		else {
+			notFoundAction = null;
+		}
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
@@ -19,7 +19,12 @@ import org.hibernate.ObjectNotFoundException;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.jdbc.Size;
-import org.hibernate.engine.spi.*;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.EntityUniqueKey;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.Loadable;
 
@@ -30,6 +35,7 @@ import org.hibernate.persister.entity.Loadable;
  */
 public class ManyToOneType extends EntityType {
 	private final String propertyName;
+	private final boolean nullable;
 	private final NotFoundAction notFoundAction;
 	private boolean isLogicalOneToOne;
 
@@ -57,7 +63,7 @@ public class ManyToOneType extends EntityType {
 
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -73,7 +79,7 @@ public class ManyToOneType extends EntityType {
 	}
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -85,7 +91,18 @@ public class ManyToOneType extends EntityType {
 			boolean unwrapProxy,
 			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
-		this( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, null, lazy, unwrapProxy, notFoundAction, isLogicalOneToOne );
+		this(
+				scope,
+				referencedEntityName,
+				referenceToPrimaryKey,
+				uniqueKeyPropertyName,
+				null,
+				notFoundAction != null,
+				lazy,
+				unwrapProxy,
+				notFoundAction,
+				isLogicalOneToOne
+		);
 	}
 
 	public ManyToOneType(
@@ -94,6 +111,7 @@ public class ManyToOneType extends EntityType {
 			boolean referenceToPrimaryKey,
 			String uniqueKeyPropertyName,
 			String propertyName,
+			boolean nullable,
 			boolean lazy,
 			boolean unwrapProxy,
 			NotFoundAction notFoundAction,
@@ -101,6 +119,7 @@ public class ManyToOneType extends EntityType {
 		super( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, !lazy, unwrapProxy );
 		this.propertyName = propertyName;
 		this.notFoundAction = notFoundAction;
+		this.nullable = nullable;
 		this.isLogicalOneToOne = isLogicalOneToOne;
 	}
 
@@ -109,12 +128,12 @@ public class ManyToOneType extends EntityType {
 		this.propertyName = original.propertyName;
 		this.notFoundAction = original.notFoundAction;
 		this.isLogicalOneToOne = original.isLogicalOneToOne;
+		this.nullable = original.nullable;
 	}
 
 	@Override
 	public boolean isNullable() {
-		// this matches the original check, but this seems wrong.
-		return notFoundAction == NotFoundAction.IGNORE;
+		return notFoundAction != null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
@@ -12,8 +12,11 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.FetchNotFoundException;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.*;
@@ -27,7 +30,7 @@ import org.hibernate.persister.entity.Loadable;
  */
 public class ManyToOneType extends EntityType {
 	private final String propertyName;
-	private final boolean ignoreNotFound;
+	private final NotFoundAction notFoundAction;
 	private boolean isLogicalOneToOne;
 
 	/**
@@ -49,12 +52,12 @@ public class ManyToOneType extends EntityType {
 	 * @param lazy Should the association be handled lazily
 	 */
 	public ManyToOneType(TypeFactory.TypeScope scope, String referencedEntityName, boolean lazy) {
-		this( scope, referencedEntityName, true, null, lazy, true, false, false );
+		this( scope, referencedEntityName, true, null, lazy, true, null, false );
 	}
 
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -64,13 +67,13 @@ public class ManyToOneType extends EntityType {
 			boolean lazy,
 			boolean unwrapProxy,
 			boolean isEmbeddedInXML,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
-		this( scope, referencedEntityName, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, ignoreNotFound, isLogicalOneToOne );
+		this( scope, referencedEntityName, uniqueKeyPropertyName == null, uniqueKeyPropertyName, lazy, unwrapProxy, notFoundAction, isLogicalOneToOne );
 	}
 
 	/**
-	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, boolean, boolean ) } instead.
+	 * @deprecated Use {@link #ManyToOneType(TypeFactory.TypeScope, String, boolean, String, String, boolean, boolean, NotFoundAction, boolean ) } instead.
 	 */
 	@Deprecated
 	public ManyToOneType(
@@ -80,9 +83,9 @@ public class ManyToOneType extends EntityType {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
-		this( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, null, lazy, unwrapProxy, ignoreNotFound, isLogicalOneToOne );
+		this( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, null, lazy, unwrapProxy, notFoundAction, isLogicalOneToOne );
 	}
 
 	public ManyToOneType(
@@ -93,24 +96,25 @@ public class ManyToOneType extends EntityType {
 			String propertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		super( scope, referencedEntityName, referenceToPrimaryKey, uniqueKeyPropertyName, !lazy, unwrapProxy );
 		this.propertyName = propertyName;
-		this.ignoreNotFound = ignoreNotFound;
+		this.notFoundAction = notFoundAction;
 		this.isLogicalOneToOne = isLogicalOneToOne;
 	}
 
 	public ManyToOneType(ManyToOneType original, String superTypeEntityName) {
 		super( original, superTypeEntityName );
 		this.propertyName = original.propertyName;
-		this.ignoreNotFound = original.ignoreNotFound;
+		this.notFoundAction = original.notFoundAction;
 		this.isLogicalOneToOne = original.isLogicalOneToOne;
 	}
 
 	@Override
 	public boolean isNullable() {
-		return ignoreNotFound;
+		// this matches the original check, but this seems wrong.
+		return notFoundAction == NotFoundAction.IGNORE;
 	}
 
 	@Override
@@ -236,7 +240,14 @@ public class ManyToOneType extends EntityType {
 
 	@Override
 	public Object resolve(Object value, SharedSessionContractImplementor session, Object owner, Boolean overridingEager) throws HibernateException {
-		Object resolvedValue = super.resolve(value, session, owner, overridingEager);
+		final Object resolvedValue;
+		try {
+			resolvedValue = super.resolve( value, session, owner, overridingEager );
+		}
+		catch (ObjectNotFoundException e) {
+			throw new FetchNotFoundException( getAssociatedEntityName(), value );
+		}
+
 		if ( isLogicalOneToOne && value != null && getPropertyName() != null ) {
 			EntityEntry entry = session.getPersistenceContext().getEntry( owner );
 			if ( entry != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.Properties;
 
 import org.hibernate.MappingException;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.classic.Lifecycle;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.CoreMessageLogger;
@@ -42,7 +43,7 @@ public final class TypeFactory implements Serializable {
 	private static final CoreMessageLogger LOG = messageLogger( TypeFactory.class );
 
 	/**
-	 * @deprecated Use {@link TypeConfiguration}/{@link TypeConfiguration.Scope} instead
+	 * @deprecated Use {@link TypeConfiguration}
 	 */
 	@Deprecated
 	public interface TypeScope extends Serializable {
@@ -279,7 +280,7 @@ public final class TypeFactory implements Serializable {
 	}
 
 	/**
-	 * @deprecated Use {@link #manyToOne(String, boolean, String, boolean, boolean, boolean, boolean)} instead.
+	 * @deprecated Use {@link #manyToOne(String, boolean, String, boolean, boolean, NotFoundAction, boolean)} instead.
 	 */
 	@Deprecated
 	public EntityType manyToOne(
@@ -287,7 +288,7 @@ public final class TypeFactory implements Serializable {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return manyToOne(
 				persistentClass,
@@ -295,13 +296,13 @@ public final class TypeFactory implements Serializable {
 				uniqueKeyPropertyName,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}
 
 	/**
-	 * @deprecated Use {@link #manyToOne(String, boolean, String, String, boolean, boolean, boolean, boolean)} instead.
+	 * @deprecated Use {@link #manyToOne(String, boolean, String, String, boolean, boolean, NotFoundAction, boolean)} instead.
 	 */
 	@Deprecated
 	public EntityType manyToOne(
@@ -310,7 +311,7 @@ public final class TypeFactory implements Serializable {
 			String uniqueKeyPropertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return manyToOne(
 				persistentClass,
@@ -319,7 +320,7 @@ public final class TypeFactory implements Serializable {
 				null,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}
@@ -331,7 +332,7 @@ public final class TypeFactory implements Serializable {
 			String propertyName,
 			boolean lazy,
 			boolean unwrapProxy,
-			boolean ignoreNotFound,
+			NotFoundAction notFoundAction,
 			boolean isLogicalOneToOne) {
 		return new ManyToOneType(
 				typeScope,
@@ -341,7 +342,7 @@ public final class TypeFactory implements Serializable {
 				propertyName,
 				lazy,
 				unwrapProxy,
-				ignoreNotFound,
+				notFoundAction,
 				isLogicalOneToOne
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeFactory.java
@@ -340,6 +340,31 @@ public final class TypeFactory implements Serializable {
 				referenceToPrimaryKey,
 				uniqueKeyPropertyName,
 				propertyName,
+				notFoundAction != null,
+				lazy,
+				unwrapProxy,
+				notFoundAction,
+				isLogicalOneToOne
+		);
+	}
+
+	public EntityType manyToOne(
+			String persistentClass,
+			boolean referenceToPrimaryKey,
+			String uniqueKeyPropertyName,
+			String propertyName,
+			boolean nullable,
+			boolean lazy,
+			boolean unwrapProxy,
+			NotFoundAction notFoundAction,
+			boolean isLogicalOneToOne) {
+		return new ManyToOneType(
+				typeScope,
+				persistentClass,
+				referenceToPrimaryKey,
+				uniqueKeyPropertyName,
+				propertyName,
+				nullable,
 				lazy,
 				unwrapProxy,
 				notFoundAction,

--- a/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/cfg/annotations/CollectionBinderTest.java
@@ -65,7 +65,7 @@ public class CollectionBinderTest extends BaseUnitTestCase {
 
 		String expectMessage = "Association [abc] for entity [CollectionBinderTest] references unmapped class [List]";
 		try {
-			collectionBinder.bindOneToManySecondPass(collection, new HashMap(), null, collectionType, false, false, buildingContext, null);
+			collectionBinder.bindOneToManySecondPass(collection, new HashMap(), null, collectionType, false, null, buildingContext, null);
 		} catch (MappingException e) {
 			assertEquals(expectMessage, e.getMessage());
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionLogicalOneToOneTest.java
@@ -1,0 +1,221 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@OneToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>When loading the `Coin#currency`, `EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundExceptionLogicalOneToOneTest extends BaseCoreFunctionalTestCase {
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testGet() {
+		inTransaction( (session) -> {
+			try {
+				session.get( Coin.class, 1 );
+				fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "We return a proxy here for `Coin#currency`, which violates NOTE #1.  The exception happens " +
+					"when we reference the proxy, but thats not correct"
+	)
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/exception/NotFoundExceptionManyToOneTest.java
@@ -1,0 +1,281 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.exception;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@ManyToOne @NotFound(EXCEPTION)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`EXCEPTION` should trigger an exception since the particular `Coin#currency` fk is broken</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundExceptionManyToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+			try {
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "ObjectNotFoundException is thrown but caught and null is returned - see " +
+					"org.hibernate.internal.SessionImpl.IdentifierLoadAccessImpl#doLoad"
+	)
+	public void testGet() {
+		inTransaction( (session) -> {
+			try {
+				final Coin coin = session.get( Coin.class, 1 );
+				coin.getCurrency().getName();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "EntityNotFoundException thrown rather than ObjectNotFoundException; " +
+					"ObjectNotFoundException is thrown but caught and then converted to EntityNotFoundException"
+	)
+	public void testQueryOwnerSelection() {
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			try {
+				session.createQuery( hql, Coin.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "This one is somewhat debatable.  Is this selecting the association?  Or simply matching Currencies?"
+	)
+	public void testQueryAssociationSelection() {
+		// NOTE: this one is not obvious
+		//		- we are selecting the association so from that perspective, throwing the ObjectNotFoundException is nice
+		//		- the other way to look at it is that there are simply no matching results, so nothing to return
+		statementInspector.clear();
+
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			try {
+				session.createQuery( hql, Currency.class ).getResultList();
+				fail( "Expecting ObjectNotFoundException for broken fk" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).isEqualTo( Currency.class.getName() );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	public static class CollectionStatementInspector implements StatementInspector {
+		private List<String> queries = new ArrayList<>();
+
+		@Override
+		public String inspect(String sql) {
+			queries.add( sql );
+			return sql;
+		}
+
+		public void clear() {
+			queries.clear();
+		}
+
+		public List<String> getQueries() {
+			return queries;
+		}
+	}
+
+	private final CollectionStatementInspector statementInspector = new CollectionStatementInspector();
+
+	@Override
+	protected void configure(Configuration configuration) {
+		super.configure( configuration );
+		configuration.getProperties().put( AvailableSettings.STATEMENT_INSPECTOR, statementInspector );
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
@@ -14,24 +14,25 @@ import org.hibernate.ObjectNotFoundException;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 
-import org.hibernate.testing.jdbc.SQLStatementInspector;
-import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.FailureExpected;
-import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.orm.test.notfound.exception.NotFoundExceptionManyToOneTest;
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SQLStatementInterceptor;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Tuple;
-import org.assertj.core.api.Assertions;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for `@ManyToOne @NotFound(IGNORE)`
@@ -43,37 +44,47 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Steve Ebersole
  */
-@DomainModel( annotatedClasses = { NotFoundIgnoreManyToOneTest.Coin.class, NotFoundIgnoreManyToOneTest.Currency.class } )
-@SessionFactory( useCollectingStatementInspector = true )
-public class NotFoundIgnoreManyToOneTest {
+public class NotFoundIgnoreManyToOneTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private SQLStatementInterceptor statementInspector;
+
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{NotFoundExceptionManyToOneTest.Coin.class, NotFoundExceptionManyToOneTest.Currency.class};
+	}
+
+	@Override
+	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+		statementInspector = new SQLStatementInterceptor( sfb );
+	}
 
 	@Test
-	@JiraKey( "HHH-15060" )
-	public void testProxy(SessionFactoryScope scope) {
-		scope.inTransaction( (session) -> {
+	@TestForIssue(jiraKey = "HHH-15060")
+	public void testProxy() {
+		inTransaction( (session) -> {
 			// the non-existent Child
 			// 	- this is the one valid deviation from treating the broken fk as null
 			final Currency proxy = session.byId( Currency.class ).getReference( 1 );
 			try {
 				Hibernate.initialize( proxy );
-				Assertions.fail( "Expecting ObjectNotFoundException" );
+				fail( "Expecting ObjectNotFoundException" );
 			}
 			catch (ObjectNotFoundException expected) {
-				assertThat( expected.getEntityName() ).endsWith( "Currency" );
-				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+				assertThat( expected.getEntityName(), endsWith( "Currency" ));
+				assertThat( expected.getIdentifier(), equalTo( 1 ));
 			}
 		} );
 	}
 
 	@Test
-	@JiraKey( "HHH-15060" )
-	public void testGet(SessionFactoryScope scope) {
-		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+	@TestForIssue(jiraKey = "HHH-15060")
+	public void testGet() {
 		statementInspector.clear();
 
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			final Coin coin = session.get( Coin.class, 1 );
-			assertThat( coin.getCurrency() ).isNull();
+			assertThat( coin.getCurrency(), nullValue());
 
 			// atm, 5.x generates 2 selects here; which wouldn't be bad, except that
 			// the first one contains a join
@@ -83,96 +94,93 @@ public class NotFoundIgnoreManyToOneTest {
 //				assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
 //				assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
 			// what actually happens
-			assertThat( statementInspector.getSqlQueries() ).hasSize( 2 );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " Coin " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " Currency " );
-			assertThat( statementInspector.getSqlQueries().get( 1 ) ).doesNotContain( " Coin " );
+			assertThat( statementInspector.getSqlQueries().size(), is( 2 ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " Coin " ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " join " ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " Currency " ));
+			assertThat( statementInspector.getSqlQueries().get( 1 ), not(containsString(" coin ")));
 		} );
 	}
 
 	@Test
-	@JiraKey( "HHH-15060" )
-	public void testQueryImplicitPathDereferencePredicate(SessionFactoryScope scope) {
-		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+	@TestForIssue(jiraKey = "HHH-15060")
+	public void testQueryImplicitPathDereferencePredicate() {
 		statementInspector.clear();
 
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			final String hql = "select c from Coin c where c.currency.id = 1";
 			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
-			assertThat( coins ).isEmpty();
+			assertThat( coins.size(), is(0));
 
 			// technically we could use a subsequent-select rather than a join...
-			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+			assertThat( statementInspector.getSqlQueries().size(), is(1));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString(" join " ));
+			assertThat( statementInspector.getSqlQueries().get( 1 ), containsString(" inner " ));
 		} );
 	}
 
 	@Test
-	@JiraKey( "HHH-15060" )
-	public void testQueryOwnerSelection(SessionFactoryScope scope) {
-		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+	@TestForIssue(jiraKey = "HHH-15060")
+	public void testQueryOwnerSelection() {
 		statementInspector.clear();
 
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			final String hql = "select c from Coin c";
 			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
-			assertThat( coins ).hasSize( 1 );
-			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+			assertThat( coins.size(), is( 1 ));
+			assertThat( coins.get( 0 ).getCurrency(), nullValue());
 
 			// at the moment this uses a subsequent-select.  on the bright side, it is at least eagerly fetched.
-			assertThat( statementInspector.getSqlQueries() ).hasSize( 2 );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " Coin " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " Currency " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " join " );
-			assertThat( statementInspector.getSqlQueries().get( 1 ) ).doesNotContain( " Coin " );
-			assertThat( statementInspector.getSqlQueries().get( 1 ) ).contains( " Currency " );
-			assertThat( statementInspector.getSqlQueries().get( 1 ) ).doesNotContain( " join " );
+			assertThat( statementInspector.getSqlQueries().size(), is( 2 ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " Coin " ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), not(containsString(" Currency " )));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), not(containsString(" join " )));
+			assertThat( statementInspector.getSqlQueries().get( 1 ), not(containsString(" Coin " )));
+			assertThat( statementInspector.getSqlQueries().get( 1 ), containsString( " Currency " ));
+			assertThat( statementInspector.getSqlQueries().get( 1 ), not(containsString(" join " )));
+
 		} );
 	}
 
 	@Test
-	@JiraKey( "HHH-15060" )
-	@FailureExpected(
-			reason = "Has zero results because of inner-join; & the select w/ inner-join is executed twice for some odd reason"
+	@FailureExpected(jiraKey = "HHH-15060",
+			message = "Has zero results because of inner-join; & the select w/ inner-join is executed twice for some odd reason"
 	)
-	public void testQueryAssociationSelection(SessionFactoryScope scope) {
-		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+	public void testQueryAssociationSelection() {
 		statementInspector.clear();
 
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			final String hql = "select c.id, c.currency from Coin c";
 			final List<Tuple> tuples = session.createQuery( hql, Tuple.class ).getResultList();
-			assertThat( tuples ).hasSize( 1 );
+			assertThat( tuples.size(), is( 1 ));
 			final Tuple tuple = tuples.get( 0 );
-			assertThat( tuple.get( 0 ) ).isEqualTo( 1 );
-			assertThat( tuple.get( 1 ) ).isNull();
+			assertThat( tuple.get( 0 ), equalTo( 1 ));
+			assertThat( tuple.get( 1 ), nullValue());
 
-			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+			assertThat( statementInspector.getSqlQueries().size(), is( 1 ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " join " ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), not(containsString(" inner " )));
 		} );
 
 		statementInspector.clear();
 
 		// I guess this one is somewhat debatable, but for consistency I think this makes the most sense
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			final String hql = "select c.currency from Coin c";
 			session.createQuery( hql, Currency.class ).getResultList();
 			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
-			assertThat( currencies ).hasSize( 1 );
-			assertThat( currencies.get( 0 ) ).isNull();
+			assertThat( currencies.size(), is( 1 ));
+			assertThat( currencies.get( 0 ), nullValue());
 
-			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).contains( " join " );
-			assertThat( statementInspector.getSqlQueries().get( 0 ) ).doesNotContain( " inner " );
+			assertThat( statementInspector.getSqlQueries().size(), is( 1 ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), containsString( " join " ));
+			assertThat( statementInspector.getSqlQueries().get( 0 ), not(containsString(" inner " )));
 		} );
 	}
 
-	@BeforeEach
-	protected void prepareTestData(SessionFactoryScope scope) {
-		scope.inTransaction( (session) -> {
+	@Before
+	protected void prepareTestData() {
+		inTransaction( (session) -> {
 			Currency euro = new Currency( 1, "Euro" );
 			Coin fiveC = new Coin( 1, "Five cents", euro );
 
@@ -180,14 +188,14 @@ public class NotFoundIgnoreManyToOneTest {
 			session.persist( fiveC );
 		} );
 
-		scope.inTransaction( (session) -> {
+		inTransaction( (session) -> {
 			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
 		} );
 	}
 
-	@AfterEach
-	protected void dropTestData(SessionFactoryScope scope) throws Exception {
-		scope.inTransaction( (session) -> {
+	@After
+	protected void dropTestData(){
+		inTransaction( (session) -> {
 			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
 		} );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreManyToOneTest.java
@@ -1,0 +1,215 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for `@ManyToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundIgnoreManyToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			try {
+				final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	public void testGet() {
+		inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Bad results due to cross-join"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Has zero results because of inner-join - the select w/ inner-join is executed twice for some odd reason"
+	)
+	public void testQueryAssociationSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@ManyToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/ignore/NotFoundIgnoreOneToOneTest.java
@@ -1,0 +1,210 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.notfound.ignore;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.Hibernate;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+
+import org.hibernate.testing.FailureExpected;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for `@ManyToOne @NotFound(IGNORE)`
+ *
+ * NOTES:<ol>
+ *     <li>`@NotFound` should force the association to be eager - `Coin#currency` should be loaded immediately</li>
+ *     <li>`IGNORE` says to treat the broken fk as null</li>
+ * </ol>
+ *
+ * @author Steve Ebersole
+ */
+public class NotFoundIgnoreOneToOneTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void testProxy() {
+		inTransaction( (session) -> {
+			// the non-existent Child
+			// 	- this is the one valid deviation from treating the broken fk as null
+			try {
+				final Currency proxy = session.byId( Currency.class ).getReference( 1 );
+				Hibernate.initialize( proxy );
+				Assertions.fail( "Expecting ObjectNotFoundException" );
+			}
+			catch (ObjectNotFoundException expected) {
+				assertThat( expected.getEntityName() ).endsWith( "Currency" );
+				assertThat( expected.getIdentifier() ).isEqualTo( 1 );
+			}
+		} );
+	}
+
+	@Test
+	public void testGet() {
+		inTransaction( (session) -> {
+			final Coin coin = session.get( Coin.class, 1 );
+			assertThat( coin.getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Bad results due to cross-join"
+	)
+	public void testQueryImplicitPathDereferencePredicate() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c where c.currency.id = 1";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	public void testQueryOwnerSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c from Coin c";
+			final List<Coin> coins = session.createQuery( hql, Coin.class ).getResultList();
+			assertThat( coins ).hasSize( 1 );
+			assertThat( coins.get( 0 ).getCurrency() ).isNull();
+		} );
+	}
+
+	@Test
+	@FailureExpected(
+			jiraKey = "HHH-15060",
+			message = "Has zero results because of inner-join - the select w/ inner-join is executed twice for some odd reason"
+	)
+	public void testQueryAssociationSelection() {
+		inTransaction( (session) -> {
+			final String hql = "select c.currency from Coin c";
+			session.createQuery( hql, Currency.class ).getResultList();
+			final List<Currency> currencies = session.createQuery( hql, Currency.class ).getResultList();
+			assertThat( currencies ).hasSize( 1 );
+			assertThat( currencies.get( 0 ) ).isNull();
+		} );
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { Coin.class, Currency.class };
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		super.prepareTest();
+
+		inTransaction( (session) -> {
+			Currency euro = new Currency( 1, "Euro" );
+			Coin fiveC = new Coin( 1, "Five cents", euro );
+
+			session.persist( euro );
+			session.persist( fiveC );
+		} );
+
+		inTransaction( (session) -> {
+			session.createQuery( "delete Currency where id = 1" ).executeUpdate();
+		} );
+	}
+
+	@Override
+	protected void cleanupTest() throws Exception {
+		inTransaction( (session) -> {
+			session.createQuery( "delete Coin where id = 1" ).executeUpdate();
+		} );
+
+		super.cleanupTest();
+	}
+
+	@Entity(name = "Coin")
+	public static class Coin {
+		private Integer id;
+		private String name;
+		private Currency currency;
+
+		public Coin() {
+		}
+
+		public Coin(Integer id, String name, Currency currency) {
+			this.id = id;
+			this.name = name;
+			this.currency = currency;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@OneToOne(fetch = FetchType.EAGER)
+		@NotFound(action = NotFoundAction.IGNORE)
+		public Currency getCurrency() {
+			return currency;
+		}
+
+		public void setCurrency(Currency currency) {
+			this.currency = currency;
+		}
+	}
+
+	@Entity(name = "Currency")
+	public static class Currency implements Serializable {
+		private Integer id;
+		private String name;
+
+		public Currency() {
+		}
+
+		public Currency(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@Id
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/JoinFormulaOneToManyNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/formula/JoinFormulaOneToManyNotIgnoreLazyFetchingTest.java
@@ -1,0 +1,175 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.annotations.formula;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.Hibernate;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.cfg.AnnotationBinder;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.logger.LoggerInspectionRule;
+import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.hibernate.testing.transaction.TransactionUtil2;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.jboss.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@TestForIssue(jiraKey = "HHH-12770")
+public class JoinFormulaOneToManyNotIgnoreLazyFetchingTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Rule
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
+			Logger.getMessageLogger( CoreMessageLogger.class, AnnotationBinder.class.getName() )
+	);
+
+	private Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );
+
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				Stock.class,
+				StockCode.class,
+		};
+	}
+
+	@Override
+	protected void afterEntityManagerFactoryBuilt() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			StockCode code = new StockCode();
+			code.setId( 1L );
+			code.setCopeType( CodeType.TYPE_A );
+			code.setRefNumber( "ABC" );
+			entityManager.persist( code );
+
+			Stock stock1 = new Stock();
+			stock1.setId( 1L );
+			stock1.getCodes().add( code );
+			entityManager.persist( stock1 );
+
+			Stock stock2 = new Stock();
+			stock2.setId( 2L );
+			entityManager.persist( stock2 );
+		} );
+	}
+
+	@Test
+	public void testLoading() {
+
+		assertFalse( triggerable.wasTriggered() );
+
+		List<Stock> stocks = TransactionUtil2.fromTransaction( entityManagerFactory().unwrap( SessionFactoryImplementor.class ), (session) -> {
+			return session.createQuery("SELECT s FROM Stock s order by id", Stock.class ).getResultList();
+		} );
+
+		assertThat( stocks ).hasSize( 2 );
+
+		final Stock firstStock = stocks.get( 0 );
+		final Stock secondStock = stocks.get( 1 );
+
+		assertThat( firstStock.getCodes() ).hasSize( 1 );
+		assertThat( secondStock.getCodes() ).hasSize( 0 );
+	}
+
+	@Entity(name = "Stock")
+	public static class Stock implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@OneToMany
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumn(name = "CODE_ID", referencedColumnName = "ID")
+		private List<StockCode> codes = new ArrayList<>(  );
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<StockCode> getCodes() {
+			return codes;
+		}
+	}
+
+	@Entity(name = "StockCode")
+	public static class StockCode implements Serializable {
+
+		@Id
+		@Column(name = "ID")
+		private Long id;
+
+		@Id
+		@Enumerated(EnumType.STRING)
+		@Column(name = "TYPE")
+		private CodeType copeType;
+
+		private String refNumber;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public CodeType getCopeType() {
+			return copeType;
+		}
+
+		public void setCopeType(CodeType copeType) {
+			this.copeType = copeType;
+		}
+
+		public String getRefNumber() {
+			return refNumber;
+		}
+
+		public void setRefNumber(String refNumber) {
+			this.refNumber = refNumber;
+		}
+	}
+
+	public enum CodeType {
+		TYPE_A, TYPE_B;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
@@ -91,7 +91,7 @@ public class NotFoundLogicalOneToOneTest extends BaseCoreFunctionalTestCase {
 		}
 
 		@OneToOne(fetch = FetchType.LAZY)
-		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+//		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 		@NotFound(action = NotFoundAction.IGNORE)
 		public Currency getCurrency() {
 			return currency;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/NotFoundLogicalOneToOneTest.java
@@ -91,7 +91,7 @@ public class NotFoundLogicalOneToOneTest extends BaseCoreFunctionalTestCase {
 		}
 
 		@OneToOne(fetch = FetchType.LAZY)
-//		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 		@NotFound(action = NotFoundAction.IGNORE)
 		public Currency getCurrency() {
 			return currency;

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
@@ -32,9 +32,8 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 
 @TestForIssue( jiraKey = "HHH-12226")
 @RunWith( BytecodeEnhancerRunner.class )
@@ -71,8 +70,12 @@ public class LazyNotFoundManyToOneNonUpdatableNonInsertableTest extends BaseCore
 		doInHibernate(
 				this::sessionFactory, session -> {
 					User user = session.find( User.class, ID );
-					assertFalse( Hibernate.isPropertyInitialized( user, "lazy" ) );
-					assertNull( user.getLazy() );
+					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) )
+							.describedAs( "Expecting `User#lazy to be (bytecode) initialized due to `@NotFound`" )
+							.isTrue();
+					assertThat( user.getLazy() )
+							.describedAs( "Expecting `User#lazy to null due to `NotFoundAction#IGNORE`" )
+							.isNull();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneNonUpdatableNonInsertableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneNonUpdatableNonInsertableTest.java
@@ -32,6 +32,7 @@ import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -72,9 +73,14 @@ public class LazyNotFoundOneToOneNonUpdatableNonInsertableTest extends BaseCoreF
 		doInHibernate(
 				this::sessionFactory, session -> {
 					User user = session.find( User.class, ID );
-					assertFalse( Hibernate.isPropertyInitialized( user, "lazy" ) );
-					assertNull( user.getLazy() );
-					assertTrue( Hibernate.isPropertyInitialized( user, "lazy" ) );
+
+					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) )
+							.describedAs( "Expecting `User#lazy to be (bytecode) initialized due to `@NotFound`" )
+							.isTrue();
+					assertThat( user.getLazy() )
+							.describedAs( "Expecting `User#lazy to null due to `NotFoundAction#IGNORE`" )
+							.isNull();
+
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/notfound/LazyNotFoundOneToOneTest.java
@@ -27,7 +27,7 @@ import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
-
+import org.hibernate.cfg.Configuration;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -1,0 +1,401 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.orm.junit;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.Interceptor;
+import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatelessSession;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.hibernate.tool.schema.Action;
+import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
+import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator.ActionGrouping;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.transaction.TransactionUtil;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import org.jboss.logging.Logger;
+
+/**
+ * hibernate-testing implementation of a few JUnit5 contracts to support SessionFactory-based testing,
+ * including argument injection (or see {@link SessionFactoryScopeAware})
+ *
+ * @see SessionFactoryScope
+ * @see DomainModelExtension
+ *
+ * @author Steve Ebersole
+ */
+public class SessionFactoryExtension
+		implements TestInstancePostProcessor, AfterAllCallback, TestExecutionExceptionHandler {
+
+	private static final Logger log = Logger.getLogger( SessionFactoryExtension.class );
+	private static final String SESSION_FACTORY_KEY = SessionFactoryScope.class.getName();
+
+	private static ExtensionContext.Store locateExtensionStore(Object testInstance, ExtensionContext context) {
+		return JUnitHelper.locateExtensionStore( SessionFactoryExtension.class, context, testInstance );
+	}
+
+	public static SessionFactoryScope findSessionFactoryScope(Object testInstance, ExtensionContext context) {
+		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
+		final SessionFactoryScope existing = (SessionFactoryScope) store.get( SESSION_FACTORY_KEY );
+		if ( existing != null ) {
+			return existing;
+		}
+
+		SessionFactoryProducer producer = null;
+
+		final DomainModelScope domainModelScope = DomainModelExtension.findDomainModelScope( testInstance, context );
+
+		if ( testInstance instanceof SessionFactoryProducer ) {
+			producer = (SessionFactoryProducer) testInstance;
+		}
+		else if ( ! context.getElement().isPresent() ) {
+			throw new RuntimeException( "Unable to determine how to handle given ExtensionContext : " + context.getDisplayName() );
+		}
+		else {
+			final Optional<SessionFactory> sfAnnWrappper = AnnotationSupport.findAnnotation(
+					context.getElement().get(),
+					SessionFactory.class
+			);
+
+			if ( sfAnnWrappper.isPresent() ) {
+				final SessionFactory sessionFactoryConfig = sfAnnWrappper.get();
+
+				producer = model -> {
+					try {
+						final SessionFactoryBuilder sessionFactoryBuilder = model.getSessionFactoryBuilder();
+						if ( StringHelper.isNotEmpty( sessionFactoryConfig.sessionFactoryName() ) ) {
+							sessionFactoryBuilder.applyName( sessionFactoryConfig.sessionFactoryName() );
+						}
+
+						if ( sessionFactoryConfig.generateStatistics() ) {
+							sessionFactoryBuilder.applyStatisticsSupport( true );
+						}
+
+						if ( ! sessionFactoryConfig.interceptorClass().equals( Interceptor.class ) ) {
+							sessionFactoryBuilder.applyInterceptor( sessionFactoryConfig.interceptorClass().newInstance() );
+						}
+
+						final Class<? extends StatementInspector> explicitInspectorClass = sessionFactoryConfig.statementInspectorClass();
+						if ( sessionFactoryConfig.useCollectingStatementInspector() ) {
+							sessionFactoryBuilder.applyStatementInspector( new SQLStatementInspector() );
+						}
+						else if ( ! explicitInspectorClass.equals( StatementInspector.class ) ) {
+							sessionFactoryBuilder.applyStatementInspector( explicitInspectorClass.getConstructor().newInstance() );
+						}
+
+						final SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) sessionFactoryBuilder.build();
+
+						if ( sessionFactoryConfig.exportSchema() ) {
+							prepareSchemaExport( sessionFactory, model, sessionFactoryConfig.createSecondarySchemas() );
+						}
+
+						return sessionFactory;
+					}
+					catch (Exception e) {
+						throw new RuntimeException( "Could not build SessionFactory", e );
+					}
+				};
+			}
+		}
+
+		if ( producer == null ) {
+			throw new IllegalStateException( "Could not determine SessionFactory producer" );
+		}
+
+		final SessionFactoryScopeImpl sfScope = new SessionFactoryScopeImpl(
+				domainModelScope,
+				producer
+		);
+
+		locateExtensionStore( testInstance, context ).put( SESSION_FACTORY_KEY, sfScope );
+
+		if ( testInstance instanceof SessionFactoryScopeAware ) {
+			( (SessionFactoryScopeAware) testInstance ).injectSessionFactoryScope( sfScope );
+		}
+
+		return sfScope;
+	}
+
+	private static void prepareSchemaExport(
+			SessionFactoryImplementor sessionFactory,
+			MetadataImplementor model,
+			boolean createSecondarySchemas) {
+		final ActionGrouping grouping = ActionGrouping.interpret( sessionFactory.getProperties() );
+		if ( grouping.getDatabaseAction() != Action.NONE || grouping.getScriptAction() != Action.NONE ) {
+			// the properties contained explicit settings for auto schema tooling; skip here as part of
+			// @SessionFactory handling
+			return;
+		}
+
+		final HashMap<String,Object> settings = new HashMap<>( sessionFactory.getProperties() );
+		settings.put( AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION, Action.CREATE_DROP );
+		if ( createSecondarySchemas ) {
+			if ( !( model.getDatabase().getDialect().canCreateSchema() ) ) {
+				throw new UnsupportedOperationException(
+						model.getDatabase().getDialect() + " does not support schema creation" );
+			}
+			settings.put( AvailableSettings.JAKARTA_HBM2DDL_CREATE_SCHEMAS, true );
+		}
+
+		final StandardServiceRegistry serviceRegistry = model.getMetadataBuildingOptions().getServiceRegistry();
+
+		SchemaManagementToolCoordinator.process(
+				model,
+				serviceRegistry,
+				settings,
+				action -> sessionFactory.addObserver(
+						new SessionFactoryObserver() {
+							@Override
+							public void sessionFactoryClosing(org.hibernate.SessionFactory factory) {
+								action.perform( serviceRegistry );
+							}
+						}
+				)
+		);
+	}
+
+	@Override
+	public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+		log.tracef( "#postProcessTestInstance(%s, %s)", testInstance, context.getDisplayName() );
+
+		findSessionFactoryScope( testInstance, context );
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		log.tracef( "#afterAll(%s)", context.getDisplayName() );
+
+		final Object testInstance = context.getRequiredTestInstance();
+
+		if ( testInstance instanceof SessionFactoryScopeAware ) {
+			( (SessionFactoryScopeAware) testInstance ).injectSessionFactoryScope( null );
+		}
+
+		final SessionFactoryScopeImpl removed = (SessionFactoryScopeImpl) locateExtensionStore( testInstance, context ).remove( SESSION_FACTORY_KEY );
+		if ( removed != null ) {
+			removed.close();
+		}
+
+		if ( testInstance instanceof SessionFactoryScopeAware ) {
+			( (SessionFactoryScopeAware) testInstance ).injectSessionFactoryScope( null );
+		}
+	}
+
+	@Override
+	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+		log.tracef( "#handleTestExecutionException(%s, %s)", context.getDisplayName(), throwable );
+
+		try {
+			final Object testInstance = context.getRequiredTestInstance();
+			final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
+			final SessionFactoryScopeImpl scope = (SessionFactoryScopeImpl) store.get( SESSION_FACTORY_KEY );
+			scope.releaseSessionFactory();
+		}
+		catch (Exception ignore) {
+		}
+
+		throw throwable;
+	}
+
+	private static class SessionFactoryScopeImpl implements SessionFactoryScope, ExtensionContext.Store.CloseableResource {
+		private final DomainModelScope modelScope;
+		private final SessionFactoryProducer producer;
+
+		private SessionFactoryImplementor sessionFactory;
+		private boolean active = true;
+
+		private SessionFactoryScopeImpl(
+				DomainModelScope modelScope,
+				SessionFactoryProducer producer) {
+			this.modelScope = modelScope;
+			this.producer = producer;
+		}
+
+		@Override
+		public SessionFactoryImplementor getSessionFactory() {
+			if ( sessionFactory == null ) {
+				sessionFactory = createSessionFactory();
+			}
+
+			return sessionFactory;
+		}
+
+		@Override
+		public MetadataImplementor getMetadataImplementor() {
+			return modelScope.getDomainModel();
+		}
+
+		@Override
+		public StatementInspector getStatementInspector() {
+			return getSessionFactory().getSessionFactoryOptions().getStatementInspector();
+		}
+
+		@Override
+		public <T extends StatementInspector> T getStatementInspector(Class<T> type) {
+			//noinspection unchecked
+			return (T) getStatementInspector();
+		}
+
+		@Override
+		public SQLStatementInspector getCollectingStatementInspector() {
+			return getStatementInspector( SQLStatementInspector.class );
+		}
+
+		@Override
+		public void close() {
+			if ( !active ) {
+				return;
+			}
+
+			log.debug( "Closing SessionFactoryScope" );
+
+			active = false;
+			releaseSessionFactory();
+		}
+
+		public void releaseSessionFactory() {
+			if ( sessionFactory != null ) {
+				log.debug( "Releasing SessionFactory" );
+
+				try {
+					sessionFactory.close();
+				}
+				catch (Exception e) {
+					log.warn( "Error closing SF", e );
+				}
+				finally {
+					sessionFactory = null;
+				}
+			}
+		}
+
+		private SessionFactoryImplementor createSessionFactory() {
+			if ( !active ) {
+				throw new IllegalStateException( "SessionFactoryScope is no longer active" );
+			}
+
+			log.debug( "Creating SessionFactory" );
+
+			return producer.produceSessionFactory( modelScope.getDomainModel() );
+		}
+
+		public void inSession(Consumer<SessionImplementor> action) {
+			log.trace( "#inSession(Consumer)" );
+
+			try (SessionImplementor session = (SessionImplementor) getSessionFactory().openSession()) {
+				log.trace( "Session opened, calling action" );
+				action.accept( session );
+			}
+			finally {
+				log.trace( "Session close - auto-close block" );
+			}
+		}
+
+		@Override
+		public <T> T fromSession(Function<SessionImplementor, T> action) {
+			log.trace( "#fromSession(Function)" );
+
+			try (SessionImplementor session = (SessionImplementor) getSessionFactory().openSession()) {
+				log.trace( "Session opened, calling action" );
+				return action.apply( session );
+			}
+			finally {
+				log.trace( "Session close - auto-close block" );
+			}
+		}
+
+		@Override
+		public void inTransaction(Consumer<SessionImplementor> action) {
+			log.trace( "#inTransaction(Consumer)" );
+
+			try (SessionImplementor session = (SessionImplementor) getSessionFactory().openSession()) {
+				log.trace( "Session opened, calling action" );
+				inTransaction( session, action );
+			}
+			finally {
+				log.trace( "Session close - auto-close block" );
+			}
+		}
+
+		@Override
+		public <T> T fromTransaction(Function<SessionImplementor, T> action) {
+			log.trace( "#fromTransaction(Function)" );
+
+			try (SessionImplementor session = (SessionImplementor) getSessionFactory().openSession()) {
+				log.trace( "Session opened, calling action" );
+				return fromTransaction( session, action );
+			}
+			finally {
+				log.trace( "Session close - auto-close block" );
+			}
+		}
+
+		@Override
+		public void inTransaction(SessionImplementor session, Consumer<SessionImplementor> action) {
+			log.trace( "inTransaction(Session,Consumer)" );
+			TransactionUtil.inTransaction( session, action );
+		}
+
+		@Override
+		public <T> T fromTransaction(SessionImplementor session, Function<SessionImplementor, T> action) {
+			log.trace( "fromTransaction(Session,Function)" );
+			return TransactionUtil.fromTransaction( session, action );
+		}
+
+		@Override
+		public void inStatelessSession(Consumer<StatelessSession> action) {
+			log.trace( "#inStatelessSession(Consumer)" );
+
+			try ( final StatelessSession statelessSession = getSessionFactory().openStatelessSession() ) {
+				log.trace( "StatelessSession opened, calling action" );
+				action.accept( statelessSession );
+			}
+			finally {
+				log.trace( "StatelessSession close - auto-close block" );
+			}
+		}
+
+		@Override
+		public void inStatelessTransaction(Consumer<StatelessSession> action) {
+			log.trace( "#inStatelessTransaction(Consumer)" );
+
+			try ( final StatelessSession statelessSession = getSessionFactory().openStatelessSession() ) {
+				log.trace( "StatelessSession opened, calling action" );
+				inStatelessTransaction( statelessSession, action );
+			}
+			finally {
+				log.trace( "StatelessSession close - auto-close block" );
+			}
+		}
+
+		@Override
+		public void inStatelessTransaction(StatelessSession session, Consumer<StatelessSession> action) {
+			log.trace( "inStatelessTransaction(StatelessSession,Consumer)" );
+
+			TransactionUtil.inTransaction( session, action );
+		}
+	}
+}


### PR DESCRIPTION
Issue: https://hibernate.atlassian.net/browse/HHH-15060
Backporting this issue in 5.3 version.
Issue: https://issues.redhat.com/browse/JBEAP-23147
