### PR TITLE
Use default Locale for lowercasing.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/criterion/LikeExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/LikeExpression.java
@@ -78,7 +78,7 @@ public class LikeExpression implements Criterion {
 
 	@Override
 	public TypedValue[] getTypedValues(Criteria criteria, CriteriaQuery criteriaQuery) {
-		final String matchValue = ignoreCase ? value.toString().toLowerCase(Locale.ROOT) : value.toString();
+		final String matchValue = ignoreCase ? value.toString().toLowerCase() : value.toString();
 
 		return new TypedValue[] { criteriaQuery.getTypedValue( criteria, propertyName, matchValue ) };
 	}


### PR DESCRIPTION
For i18n, the default Locale should be used for lowercasing.  Locale.ROOT will not correctly lowercase Turkish "I"s.