### PR TITLE
HHH-15141 + HHH-15209 Upgrade to bytebuddy 1.12.9

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -27,7 +27,7 @@ ext {
     weldVersion = '3.1.5.Final'
     jakartaWeldVersion = '4.0.1.SP1'
 
-    byteBuddyVersion = '1.12.8'
+    byteBuddyVersion = '1.12.9'
 
     agroalVersion = '1.14'
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/CrossPackageMappedSuperclassWithEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/CrossPackageMappedSuperclassWithEmbeddableTest.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.base.EmbeddableType;
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.derived.TestEntity;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(lazyLoading = true, inlineDirtyChecking = true)
+public class CrossPackageMappedSuperclassWithEmbeddableTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { TestEntity.class };
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-15141")
+	public void testIt() {
+		// Just a smoke test; the original failure happened during bytecode enhancement.
+		Long id = fromTransaction( s -> {
+			TestEntity testEntity = new TestEntity();
+			EmbeddableType embedded = new EmbeddableType();
+			embedded.setField( "someValue" );
+			testEntity.setEmbeddedField( embedded );
+			s.persist( testEntity );
+			return testEntity.getId();
+		} );
+		inTransaction( s -> {
+			TestEntity testEntity = s.find( TestEntity.class, id );
+			assertThat( testEntity.getEmbeddedField().getField() ).isEqualTo( "someValue" );
+		} );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/base/BaseEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/base/BaseEntity.java
@@ -1,0 +1,33 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.base;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Embedded
+    protected EmbeddableType embeddedField;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public EmbeddableType getEmbeddedField() {
+        return embeddedField;
+    }
+
+    public void setEmbeddedField(final EmbeddableType embeddedField) {
+        this.embeddedField = embeddedField;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/base/EmbeddableType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/base/EmbeddableType.java
@@ -1,0 +1,19 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class EmbeddableType {
+
+    @Column
+    private String field;
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(final String field) {
+        this.field = field;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/derived/TestEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/crosspackage/derived/TestEntity.java
@@ -1,0 +1,10 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.derived;
+
+import jakarta.persistence.Entity;
+
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.base.BaseEntity;
+
+@Entity
+public class TestEntity extends BaseEntity {
+
+}


### PR DESCRIPTION
* [HHH-15209](https://hibernate.atlassian.net/browse/HHH-15209): Upgrade to bytebuddy 1.12.9
* [HHH-15141](https://hibernate.atlassian.net/browse/HHH-15141): Bytecode enhancement fails for a protected, embedded field in a MappedSuperclass from a different package than the entity

