### PR TITLE
HHH-15210 Increase Oracle Dialect MaxIdentifierLength to 128 for 12.2+

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1013,13 +1013,15 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public int getMaxAliasLength() {
-		// Max identifier length is 30, but Hibernate needs to add "uniqueing info" so we account for that
-		return 20;
+		// Max identifier length is 30 for pre 12.2 versions, and 128 for 12.2+
+		// but Hibernate needs to add "uniqueing info" so we account for that
+		return getVersion().isSameOrAfter( 12, 2 ) ? 118 : 20;
 	}
 
 	@Override
 	public int getMaxIdentifierLength() {
-		return 30;
+		// Since 12.2 version, maximum identifier length is 128
+		return getVersion().isSameOrAfter( 12, 2 ) ? 128 : 30;
 	}
 
 	@Override


### PR DESCRIPTION
This pull request enhances OracleDialect by supporting 128 bytes for maximum identifier length starting from 12.2 database version.

This new feature is described [here](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/newft/new-features.html#GUID-64283AD6-0939-47B0-856E-5E9255D7246B).

Thanks
Loïc