### PR TITLE
HHH-15216 Cannot change MetadataProvider implementation because JPAXMLOverriddenMetadataProvider is final and precisely expected by a cast operator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -31,7 +31,7 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenMetadataProvider;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenMetadataProvider;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.jpa.internal.MutableJpaComplianceImpl;
 import org.hibernate.jpa.spi.MutableJpaCompliance;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -29,7 +29,7 @@ import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.AnnotationBinder;
 import org.hibernate.cfg.InheritanceState;
 import org.hibernate.cfg.annotations.reflection.AttributeConverterDefinitionCollector;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenMetadataProvider;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenMetadataProvider;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenAnnotationReader.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.beans.Introspector;
 import java.lang.annotation.Annotation;
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.hibernate.AnnotationException;
+import org.hibernate.Internal;
 import org.hibernate.annotations.Any;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -98,7 +99,7 @@ import org.hibernate.boot.jaxb.mapping.ManagedType;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
-import org.hibernate.cfg.annotations.reflection.PersistentAttributeFilter;
+import org.hibernate.cfg.annotations.reflection.internal.PropertyMappingElementCollector;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
@@ -209,6 +210,7 @@ import static org.hibernate.cfg.annotations.reflection.internal.PropertyMappingE
  */
 // FIXME HHH-14529 Change this class to use JaxbEntityMappings instead of Document.
 //   I'm delaying this change in order to keep the commits simpler and easier to review.
+@Internal
 @SuppressWarnings("unchecked")
 public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( JPAXMLOverriddenAnnotationReader.class );

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenMetadataProvider.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.Internal;
 import org.hibernate.annotations.common.reflection.AnnotationReader;
 import org.hibernate.annotations.common.reflection.MetadataProvider;
 import org.hibernate.annotations.common.reflection.java.JavaMetadataProvider;
@@ -36,8 +37,9 @@ import jakarta.persistence.TableGenerator;
  *
  * @author Emmanuel Bernard
  */
+@Internal
 @SuppressWarnings("unchecked")
-public final class JPAXMLOverriddenMetadataProvider implements MetadataProvider {
+public class JPAXMLOverriddenMetadataProvider implements MetadataProvider {
 
 	private static final MetadataProvider STATELESS_BASE_DELEGATE = new JavaMetadataProvider();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.AnnotationException;
+import org.hibernate.Internal;
 import org.hibernate.boot.internal.ClassmateContext;
 import org.hibernate.boot.jaxb.mapping.JaxbConverter;
 import org.hibernate.boot.jaxb.mapping.JaxbEntity;
@@ -28,7 +29,6 @@ import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
-import org.hibernate.cfg.annotations.reflection.AttributeConverterDefinitionCollector;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
@@ -42,6 +42,7 @@ import jakarta.persistence.AttributeConverter;
  * @author Emmanuel Bernard
  * @author Brett Meyer
  */
+@Internal
 public class XMLContext implements Serializable {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( XMLContext.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/PropertyMappingElementCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/PropertyMappingElementCollector.java
@@ -34,6 +34,7 @@ import org.hibernate.boot.jaxb.mapping.JaxbVersion;
 import org.hibernate.boot.jaxb.mapping.LifecycleCallback;
 import org.hibernate.boot.jaxb.mapping.LifecycleCallbackContainer;
 import org.hibernate.boot.jaxb.mapping.PersistentAttribute;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
 
 
 /**
@@ -44,9 +45,9 @@ import org.hibernate.boot.jaxb.mapping.PersistentAttribute;
  *     <li>Only create lists if we actually have elements (most lists should be empty in most cases)</li>
  * </ul>
  */
-final class PropertyMappingElementCollector {
-	static final Function<PersistentAttribute, String> PERSISTENT_ATTRIBUTE_NAME = PersistentAttribute::getName;
-	static final Function<JaxbTransient, String> JAXB_TRANSIENT_NAME = JaxbTransient::getName;
+public final class PropertyMappingElementCollector {
+	public static final Function<PersistentAttribute, String> PERSISTENT_ATTRIBUTE_NAME = PersistentAttribute::getName;
+	public static final Function<JaxbTransient, String> JAXB_TRANSIENT_NAME = JaxbTransient::getName;
 	static final Function<LifecycleCallback, String> LIFECYCLE_CALLBACK_NAME = LifecycleCallback::getMethodName;
 
 	private final String propertyName;
@@ -71,7 +72,7 @@ final class PropertyMappingElementCollector {
 	private List<JaxbPostUpdate> postUpdate;
 	private List<JaxbPostLoad> postLoad;
 
-	PropertyMappingElementCollector(String propertyName) {
+	public PropertyMappingElementCollector(String propertyName) {
 		this.propertyName = propertyName;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
@@ -12,8 +12,8 @@ import java.lang.reflect.Method;
 
 import org.hibernate.annotations.Columns;
 import org.hibernate.boot.jaxb.mapping.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.orm.test.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.TestForIssue;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/XMLContextTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/reflection/XMLContextTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.orm.test.annotations.reflection;
 
 import org.hibernate.boot.jaxb.mapping.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.orm.test.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.TestForIssue;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
@@ -11,8 +11,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 
 import org.hibernate.boot.jaxb.mapping.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.orm.test.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.boot.BootstrapContextImpl;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15216

This PR moves `JPAXMLOverriddenMetadataProvider` out of package `internal` and makes it non final.