### PR TITLE
HHH-15219 Re-introduce the ability to stop and then reactivate a ServiceRegistry

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/service/internal/AbstractServiceRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/AbstractServiceRegistryImpl.java
@@ -416,7 +416,8 @@ public abstract class AbstractServiceRegistryImpl
 	}
 
 	/**
-	 * Very advanced and tricky to handle: not designed for this. Intended for experiments only!
+	 * Not intended for general use. We need the ability to stop and "reactivate" a registry to allow
+	 * experimentation with technologies such as GraalVM, Quarkus and Cri-O.
 	 */
 	public synchronized void resetParent(BootstrapServiceRegistry newParent) {
 		if ( this.parent != null ) {
@@ -434,6 +435,10 @@ public abstract class AbstractServiceRegistryImpl
 		}
 	}
 
+	/**
+	 * Not intended for general use. We need the ability to stop and "reactivate" a registry to allow
+	 * experimentation with technologies such as GraalVM, Quarkus and Cri-O.
+	 */
 	public synchronized void reactivate() {
 		if ( !active.compareAndSet(false, true) ) {
 			throw new IllegalStateException( "Was not inactive, could not reactivate!" );


### PR DESCRIPTION

https://hibernate.atlassian.net/browse/HHH-15219

This is essentially re-introducing a method which has been "cleaned up" during ORM 6 refactorings. We still need this method to integrate with Quarkus, I'd appreciate simply restoring it as-is.
Clarified the related comments a bit.