### PR TITLE
HHH-15212 SchemaExport.execute does not replace the ${schema}-placeholder in HBM database-object with configured schema

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
@@ -78,7 +78,7 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 	public String[] sqlCreateStrings(SqlStringGenerationContext context) {
 		final String[] copy = new String[createStrings.length];
 		for ( int i = 0, max =createStrings.length; i<max; i++ ) {
-			copy[i] = injectCatalogAndSchema( createStrings[i] );
+			copy[i] = injectCatalogAndSchema( createStrings[i], context );
 		}
 		return copy;
 	}
@@ -87,7 +87,7 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 	public String[] sqlDropStrings(SqlStringGenerationContext context) {
 		final String[] copy = new String[dropStrings.length];
 		for ( int i = 0, max = dropStrings.length; i<max; i++ ) {
-			copy[i] = injectCatalogAndSchema( dropStrings[i] );
+			copy[i] = injectCatalogAndSchema( dropStrings[i], context );
 		}
 		return copy;
 	}
@@ -100,9 +100,11 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 		return schemaName;
 	}
 
-	private String injectCatalogAndSchema(String ddlString) {
-		String rtn = StringHelper.replace( ddlString, CATALOG_NAME_PLACEHOLDER, catalogName == null ? "" : catalogName );
-		rtn = StringHelper.replace( rtn, SCHEMA_NAME_PLACEHOLDER, schemaName == null ? "" : schemaName );
+	private String injectCatalogAndSchema(String ddlString, SqlStringGenerationContext context) {
+		Identifier defaultedCatalogName = context.catalogWithDefault( catalogName == null ? null : context.toIdentifier( catalogName ) );
+		Identifier defaultedSchemaName = context.schemaWithDefault( schemaName == null ? null : context.toIdentifier( schemaName ) );
+		String rtn = StringHelper.replace( ddlString, CATALOG_NAME_PLACEHOLDER, defaultedCatalogName == null ? "" : defaultedCatalogName.getText() );
+		rtn = StringHelper.replace( rtn, SCHEMA_NAME_PLACEHOLDER, defaultedSchemaName == null ? "" : defaultedSchemaName.getText() );
 		return rtn;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -25,8 +25,24 @@ public interface SqlStringGenerationContext {
 	 * @return The helper for dealing with identifiers in the current JDBC environment.
 	 * <p>
 	 * Note that the Identifiers returned from this helper already account for auto-quoting.
+	 *
+	 * @deprecated Use {@link #toIdentifier(String)} instead.
 	 */
+	@Deprecated
 	IdentifierHelper getIdentifierHelper();
+
+	/**
+	 * Generate an Identifier instance from its simple name as obtained from mapping
+	 * information.
+	 * <p/>
+	 * Note that Identifiers returned from here may be implicitly quoted based on
+	 * 'globally quoted identifiers' or based on reserved words.
+	 *
+	 * @param text The text form of a name as obtained from mapping information.
+	 *
+	 * @return The identifier form of the name.
+	 */
+	Identifier toIdentifier(String text);
 
 	/**
 	 * @return The default catalog, used for table/sequence names that do not explicitly mention a catalog.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -115,6 +115,11 @@ public class SqlStringGenerationContextImpl
 	}
 
 	@Override
+	public Identifier toIdentifier(String text) {
+		return identifierHelper != null ? identifierHelper.toIdentifier( text ) : Identifier.toIdentifier( text );
+	}
+
+	@Override
 	public Identifier getDefaultCatalog() {
 		return defaultCatalog;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -80,7 +80,7 @@ import jakarta.persistence.TableGenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(CustomParameterized.class)
-@TestForIssue(jiraKey = { "HHH-14921", "HHH-14922" })
+@TestForIssue(jiraKey = { "HHH-14921", "HHH-14922", "HHH-15212" })
 public class DefaultCatalogAndSchemaTest {
 
 	private static final String SQL_QUOTE_CHARACTER_CLASS = "([`\"]|\\[|\\])";
@@ -197,6 +197,8 @@ public class DefaultCatalogAndSchemaTest {
 		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.orm.xml" ) );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.hbm.xml" ) );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "database-object-using-catalog-placeholder.hbm.xml" ) );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "database-object-using-schema-placeholder.hbm.xml" ) );
 		if ( configuredXmlMappingPath != null ) {
 			metadataSources.addInputStream( getClass().getResourceAsStream( configuredXmlMappingPath ) );
 		}
@@ -512,6 +514,15 @@ public class DefaultCatalogAndSchemaTest {
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithIncrementGenerator.NAME, expectedExplicitQualifier() );
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiersWithEnhancedSequenceGenerator.NAME, expectedDefaultQualifier() );
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithExplicitQualifiersWithEnhancedSequenceGenerator.NAME, expectedExplicitQualifier() );
+
+		if ( dbSupportsCatalogs && expectedDefaultCatalog != null ) {
+			verifyOnlyQualifier( sql, SqlType.DDL, "catalogPrefixedAuxObject",
+					expectedQualifier( expectedDefaultCatalog, null ) );
+		}
+		if ( dbSupportsSchemas && expectedDefaultSchema != null ) {
+			verifyOnlyQualifier( sql, SqlType.DDL, "schemaPrefixedAuxObject",
+					expectedQualifier( null, expectedDefaultSchema ) );
+		}
 	}
 
 	private enum SqlType {

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/database-object-using-catalog-placeholder.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/database-object-using-catalog-placeholder.hbm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.test.boot.database.qualfiedTableNaming"
+				   default-access="field">
+	<database-object>
+		<!-- Note this code does not actually get executed.
+		     We just generate the script and check that ${catalog} gets replaced correctly.
+		     So the actual language used here does not need to be compatible with the DB dialect under test.
+		 -->
+		<create>
+			CREATE OR REPLACE FUNCTION ${catalog}.catalogPrefixedAuxObject()
+			RETURNS varchar AS
+			$BODY$
+			BEGIN
+			SELECT 'test';
+			END;
+			$BODY$
+			LANGUAGE plpgsql
+		</create>
+		<drop>DROP FUNCTION ${catalog}.catalogPrefixedAuxObject()</drop>
+	</database-object>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/database-object-using-schema-placeholder.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/database-object-using-schema-placeholder.hbm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.test.boot.database.qualfiedTableNaming"
+				   default-access="field">
+	<database-object>
+		<!-- Note this code does not actually get executed.
+		     We just generate the script and check that ${schema} gets replaced correctly.
+		     So the actual language used here does not need to be compatible with the DB dialect under test.
+		 -->
+		<create>
+			CREATE OR REPLACE FUNCTION ${schema}.schemaPrefixedAuxObject()
+			RETURNS varchar AS
+			$BODY$
+			BEGIN
+			SELECT 'test';
+			END;
+			$BODY$
+			LANGUAGE plpgsql
+		</create>
+		<drop>DROP FUNCTION ${schema}.schemaPrefixedAuxObject()</drop>
+	</database-object>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15212

cc @NathanQingyangXu 

Backport to branch 5.6: #4990