### PR TITLE
Backport HHH-15212 to branch 5.6 - SchemaExport.execute does not replace the ${schema}-placeholder in HBM database-object with configured schema

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/AuxiliaryDatabaseObject.java
@@ -56,7 +56,9 @@ public interface AuxiliaryDatabaseObject extends Exportable, Serializable {
 	 * @param dialect The dialect for which to generate the SQL creation strings
 	 *
 	 * @return the SQL strings for creating the database object.
-	 * @deprecated Implement {@link #sqlCreateStrings(SqlStringGenerationContext)} instead.
+	 * @deprecated Hibernate ORM may never call this method,
+	 * and implementations cannot properly handle default catalogs/schemas.
+	 * Call/implement {@link #sqlCreateStrings(SqlStringGenerationContext)} instead.
 	 */
 	@Deprecated
 	default String[] sqlCreateStrings(Dialect dialect) {
@@ -80,7 +82,9 @@ public interface AuxiliaryDatabaseObject extends Exportable, Serializable {
 	 * @param dialect The dialect for which to generate the SQL drop strings
 	 *
 	 * @return the SQL strings for dropping the database object.
-	 * @deprecated Implement {@link #sqlDropStrings(SqlStringGenerationContext)} instead.
+	 * @deprecated Hibernate ORM may never call this method,
+	 * and implementations cannot properly handle default catalogs/schemas.
+	 * Call/implement {@link #sqlDropStrings(SqlStringGenerationContext)} instead.
 	 */
 	@Deprecated
 	default String[] sqlDropStrings(Dialect dialect) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SqlStringGenerationContext.java
@@ -25,8 +25,24 @@ public interface SqlStringGenerationContext {
 	 * @return The helper for dealing with identifiers in the current JDBC environment.
 	 * <p>
 	 * Note that the Identifiers returned from this helper already account for auto-quoting.
+	 *
+	 * @deprecated Use {@link #toIdentifier(String)} instead.
 	 */
+	@Deprecated
 	IdentifierHelper getIdentifierHelper();
+
+	/**
+	 * Generate an Identifier instance from its simple name as obtained from mapping
+	 * information.
+	 * <p/>
+	 * Note that Identifiers returned from here may be implicitly quoted based on
+	 * 'globally quoted identifiers' or based on reserved words.
+	 *
+	 * @param text The text form of a name as obtained from mapping information.
+	 *
+	 * @return The identifier form of the name.
+	 */
+	Identifier toIdentifier(String text);
 
 	/**
 	 * @return The default catalog, used for table/sequence names that do not explicitly mention a catalog.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/internal/SqlStringGenerationContextImpl.java
@@ -150,6 +150,11 @@ public class SqlStringGenerationContextImpl
 	}
 
 	@Override
+	public Identifier toIdentifier(String text) {
+		return identifierHelper != null ? identifierHelper.toIdentifier( text ) : Identifier.toIdentifier( text );
+	}
+
+	@Override
 	public Identifier getDefaultCatalog() {
 		return defaultCatalog;
 	}

--- a/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/database-object-using-catalog-placeholder.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/database-object-using-catalog-placeholder.hbm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.test.boot.database.qualfiedTableNaming"
+				   default-access="field">
+	<database-object>
+		<!-- Note this code does not actually get executed.
+		     We just generate the script and check that ${catalog} gets replaced correctly.
+		     So the actual language used here does not need to be compatible with the DB dialect under test.
+		 -->
+		<create>
+			CREATE OR REPLACE FUNCTION ${catalog}.catalogPrefixedAuxObject()
+			RETURNS varchar AS
+			$BODY$
+			BEGIN
+			SELECT 'test';
+			END;
+			$BODY$
+			LANGUAGE plpgsql
+		</create>
+		<drop>DROP FUNCTION ${catalog}.catalogPrefixedAuxObject()</drop>
+	</database-object>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/database-object-using-schema-placeholder.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/test/boot/database/qualfiedTableNaming/database-object-using-schema-placeholder.hbm.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.test.boot.database.qualfiedTableNaming"
+				   default-access="field">
+	<database-object>
+		<!-- Note this code does not actually get executed.
+		     We just generate the script and check that ${schema} gets replaced correctly.
+		     So the actual language used here does not need to be compatible with the DB dialect under test.
+		 -->
+		<create>
+			CREATE OR REPLACE FUNCTION ${schema}.schemaPrefixedAuxObject()
+			RETURNS varchar AS
+			$BODY$
+			BEGIN
+			SELECT 'test';
+			END;
+			$BODY$
+			LANGUAGE plpgsql
+		</create>
+		<drop>DROP FUNCTION ${schema}.schemaPrefixedAuxObject()</drop>
+	</database-object>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15212

Backport of #4989 to branch 5.6.