### PR TITLE
Add missing blank in Dialect.cast SQL expression

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -437,7 +437,7 @@ public abstract class Dialect implements ConversionContext {
 			return "cast(" + value + " as char(" + length + "))";
 		}
 		else {
-			return "cast(" + value + "as " + getTypeName( jdbcTypeCode, length, precision, scale ) + ")";
+			return "cast(" + value + " as " + getTypeName( jdbcTypeCode, length, precision, scale ) + ")";
 		}
 	}
 


### PR DESCRIPTION
The missing blank before 'as' resultet in an invalid SQL expression.