### PR TITLE
HHH-15239 add 5.6 link in user guide after v6 became the new "current"

### DIFF
--- a/documentation/src/main/style/asciidoctor/js/toc.js
+++ b/documentation/src/main/style/asciidoctor/js/toc.js
@@ -1,5 +1,6 @@
 var versions = {
     'current' : '/current/userguide/html_single/Hibernate_User_Guide.html',
+    '5.6' : '/5.6/userguide/html_single/Hibernate_User_Guide.html',
     '5.5' : '/5.5/userguide/html_single/Hibernate_User_Guide.html',
     '5.4' : '/5.4/userguide/html_single/Hibernate_User_Guide.html',
     '5.3' : '/5.3/userguide/html_single/Hibernate_User_Guide.html',


### PR DESCRIPTION
So I added the missing "previous current" or v5.5 link when v5.6 became the new "current" (see https://github.com/hibernate/hibernate-orm/pull/4370); now we need to do similar thing when v6 became the new "current".

It would be great to keep that in mind when new version got released: the previous "current" needs to be added explicitly in documentation/src/main/style/js/toc.js

Or could we make it automatic so there is zero delay before the "previous version" doc was added?