### PR TITLE
HHH-15149 add a new 'SelectionQuery#uniqueList()' method

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -80,6 +80,17 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	List<R> list();
 
 	/**
+	 * Execute the query and return the query results as a {@link List} after deduplication.
+	 * The first candidate will be retained in face of duplication as per the original order.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the list is packaged in an array of type
+	 * {@code Object[]}.
+	 *
+	 * @return the result list only containing unique values
+	 */
+	List<R> uniqueList();
+
+	/**
 	 * Execute the query and return the query results as a {@link List}.
 	 * If the query contains multiple items in the selection list, then
 	 * by default each result in the list is packaged in an array of type

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -51,6 +51,17 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	List<R> list();
 
 	/**
+	 * Execute the query and return the query results as a {@link List} after deduplication.
+	 * The first candidate will be retained in face of duplication as per the original order.
+	 * If the query contains multiple items in the selection list, then
+	 * by default each result in the list is packaged in an array of type
+	 * {@code Object[]}.
+	 *
+	 * @return the result list containing only unique values
+	 */
+	List<R> uniqueList();
+
+	/**
 	 * Execute the query and return the query results as a {@link List}.
 	 * If the query contains multiple items in the selection list, then
 	 * by default each result in the list is packaged in an array of type

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -8,6 +8,7 @@ package org.hibernate.query.spi;
 
 import java.sql.Types;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -15,6 +16,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -39,6 +41,7 @@ import org.hibernate.TypeMismatchException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.spi.AppliedGraph;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.metamodel.model.domain.DomainType;
@@ -376,6 +379,22 @@ public abstract class AbstractSelectionQuery<R>
 		finally {
 			afterQuery( success );
 		}
+	}
+
+	@Override
+	public List<R> uniqueList() {
+		final List<R> list = list();
+		if ( list.isEmpty() ) {
+			return list;
+		}
+		Set<R> dict = CollectionHelper.linkedSetOfSize( list.size() );
+		List<R> uniqueList = new ArrayList<>( list.size() );
+		for ( R listElement : list ) {
+			if ( dict.add( listElement ) ) {
+				uniqueList.add( listElement );
+			}
+		}
+		return uniqueList;
 	}
 
 	protected void beforeQuery() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -986,6 +986,12 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
+	public List<R> uniqueList() {
+		//noinspection unchecked
+		return super.uniqueList();
+	}
+
+	@Override
 	public ScrollableResultsImplementor<R> scroll() {
 		//noinspection unchecked
 		return super.scroll();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/returns/ResultUniqueListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/returns/ResultUniqueListTest.java
@@ -1,0 +1,54 @@
+package org.hibernate.orm.test.query.returns;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.internal.util.MutableInteger;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.domain.gambit.BasicEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.assertj.core.api.Assertions;
+
+/**
+ * @author Nathan Xu
+ */
+@DomainModel(annotatedClasses = BasicEntity.class)
+@SessionFactory
+@TestForIssue(jiraKey = "HHH-15149")
+class ResultUniqueListTest {
+
+	private final List<String> values = Arrays.asList( "v1", "v1", "v2", null, "v3", null, "v3", "v4", "v4" );
+	private final List<String> expectedUniqueValues = Arrays.asList( "v1", "v2", null, "v3", "v4" );
+
+	@BeforeEach
+	void setUpTestData(SessionFactoryScope scope) {
+		final MutableInteger id = new MutableInteger();
+		final List<BasicEntity> entities = values.stream().map( v -> new BasicEntity( id.incrementAndGet(), v ) ).collect( Collectors.toList() );
+		scope.inTransaction( session -> entities.forEach( session::persist ) );
+	}
+
+	@Test
+	void testUniqueList(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<String> uniqueValues = session.createQuery( "SELECT data FROM BasicEntity", String.class )
+					.uniqueList();
+			Assertions.assertThat( uniqueValues ).isEqualTo( expectedUniqueValues );
+		} );
+	}
+
+	@AfterEach
+	void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.createQuery( "delete BasicEntity" ).executeUpdate()
+		);
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15149

straightforward implementation. The subtleties include:
* uniqueList() should be based directly on top of list() result, as opposed to some common internal method shared by both (so overriden list() would take care of uniqueList() automatically)
* null value
* retain the first element in face of duplication as per the original order in list() result
* avoid the common trap to use `new HashSet<>(expectedSize)` (as in both ANTR and byteBuddy libraries, but we have corresponding CollectionHelper method already).