### PR TITLE
HHH-15253 Enable JMH performance benchmark

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -8,6 +8,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'org.hibernate.build.xjc-jakarta'
+    id "me.champeau.jmh" version "0.6.6"
 }
 
 description = 'Hibernate\'s core ORM functionality'
@@ -78,6 +79,9 @@ dependencies {
     xjc jakartaLibs.xjc
     xjc jakartaLibs.jaxb
     xjc rootProject.fileTree(dir: 'patched-libs/jaxb2-basics', include: '*.jar')
+
+    jmh libs.jmh
+    jmh libs.jmhAnnotations
 }
 
 jar {
@@ -129,6 +133,13 @@ xjc {
             xjcExtensions += ['inheritance']
         }
     }
+}
+
+jmh {
+    warmupIterations = 2
+    iterations = 5
+    fork = 1
+    includeTests = true // add @Benchmark to any existing testing method to benchmark it
 }
 
 

--- a/hibernate-core/src/jmh/java/org/hibernate/jmh/SampleJMHTest.java
+++ b/hibernate-core/src/jmh/java/org/hibernate/jmh/SampleJMHTest.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jmh;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class SampleJMHTest {
+
+	@Benchmark
+	public void wellHelloThere() {
+		// this method was intentionally left blank.
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include(SampleJMHTest.class.getSimpleName())
+				.forks(1)
+				.build();
+
+		new Runner( opt).run();
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,6 +67,7 @@ dependencyResolutionManagement {
             version( "proxool", "0.8.3" )
             version( "vibur", "25.0" )
             version( "micrometer", "1.6.1" )
+            version( "jmh", "0.9" )
 
             alias( "antlr" ).to( "org.antlr", "antlr4" ).versionRef( "antlr")
             alias( "antlrRuntime" ).to( "org.antlr", "antlr4-runtime" ).versionRef( "antlr")
@@ -100,6 +101,9 @@ dependencyResolutionManagement {
             alias( "vibur" ).to( "org.vibur", "vibur-dbcp" ).versionRef( "vibur" )
 
             alias( "micrometer" ).to ( "io.micrometer", "micrometer-core" ).versionRef( "micrometer" )
+
+            alias( "jmh" ).to( "org.openjdk.jmh", "jmh-core" ).versionRef( "jmh" )
+            alias( "jmhAnnotations" ).to( "org.openjdk.jmh", "jmh-generator-annprocess" ).versionRef( "jmh" )
         }
         jakartaLibs {
             version( "jaxbRuntime", "3.0.2" )


### PR DESCRIPTION
A performance benchmark capability is needed to verify various performance improvement, and JMH is an obvious choice in this regard. Without such tool, we might fall prey of wishful thinking, tunnel vision and missing the performance bottleneck.

Might provide some interesting use cases to showcase the usage of such tool, maybe on some of my previous PRs.