### PR TITLE
Copy only the content of the documentation staging directory

### DIFF
--- a/local-build-plugins/src/main/java/org/hibernate/orm/docs/PublishTask.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/docs/PublishTask.java
@@ -54,11 +54,12 @@ public abstract class PublishTask extends DefaultTask {
 		final String url = normalizedBase + releaseFamily;
 
 		final String stagingDirPath = stagingDirectory.get().getAsFile().getAbsolutePath();
+		final String stagingDirPathContent =  stagingDirPath.endsWith( "/" ) ? stagingDirPath : stagingDirPath + "/";
 
 		getProject().getLogger().lifecycle( "Uploading documentation `{}` -> `{}`", stagingDirPath, url );
 		final ExecResult result = getProject().exec( (exec) -> {
 			exec.executable( "rsync" );
-			exec.args("--port=2222", "-avz", "--links", "--delete", stagingDirPath, url );
+			exec.args("--port=2222", "-avz", "--links", "--delete", stagingDirPathContent, url );
 		} );
 		getProject().getLogger().lifecycle( "Done uploading documentation - {}", result.getExitValue() == 0 ? "success" : "failure" );
 	}


### PR DESCRIPTION
By adding "/"  at the end of the stagingDirPath only the content of the stagingDirPath is copied,
so on the server it will be created the following dir structure :

```
hibernate /
	orm/
		${releaseFamily}/
			incubating/
			integrationguide/
			...
			userguide/
```

without the dir structure would be :

```
hibernate/
	orm/
		${releaseFamily}/
			documentation/
				incubating/
				integrationguide/
				...
				userguide/
```

see 
https://docs.jboss.org/hibernate/orm/6.0/
or 
https://docs.jboss.org/hibernate/orm/5.5/
created by the previous releases
and the wrong
https://docs.jboss.org/hibernate/orm/6.0/documentation/
created during the last release