### PR TITLE
[HHH-15259] Explicitly add JavaDoc to make @deprecated hint visible in Eclipse

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1310,9 +1310,19 @@ public interface Session extends SharedSessionContract, EntityManager {
 	@Override
 	<R> Query<R> createQuery(CriteriaQuery<R> criteriaQuery);
 
-	@Override @Deprecated @SuppressWarnings("rawtypes")
+	/**
+	 * Create a {@link MutationQuery} for the given JPA {@link CriteriaDelete}
+	 *
+	 * @deprecated use {@link #createMutationQuery(CriteriaDelete)}
+	 */
+	@Override @Deprecated(since = "6.0") @SuppressWarnings("rawtypes")
 	Query createQuery(CriteriaDelete deleteQuery);
 
-	@Override @Deprecated @SuppressWarnings("rawtypes")
+	/**
+	 * Create a {@link MutationQuery} for the given JPA {@link CriteriaUpdate}
+	 *
+	 * @deprecated use {@link #createMutationQuery(CriteriaUpdate)}
+	 */
+	@Override @Deprecated(since = "6.0") @SuppressWarnings("rawtypes")
 	Query createQuery(CriteriaUpdate updateQuery);
 }


### PR DESCRIPTION
The newly added method overrides (i.e., https://github.com/hibernate/hibernate-orm/commit/aa08c90b52c4de2c86f33f31b0d5d27b461d1afc) "hide" the JavaDoc from QueryProducer (at least in Eclipse 2022-03). Explicitly add the javadoc here to provide users the @deprecated JavaDoc hint on how to resolve the deprecation warnings in Eclipse.