### PR TITLE
HHH-15258 Orphan removal for OneToMany relations is broken when used with GenerationType.IDENTITY

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -281,6 +281,18 @@ public class ActionQueue {
 			executeInserts();
 			LOG.debug( "Executing identity-insert immediately" );
 			execute( insert );
+
+			addAction(	// HHH-15258
+					OrphanRemovalAction.class,
+					new OrphanRemovalAction( insert.getId(),
+											 insert.getState(),
+											 null,
+											 insert.getInstance(),
+											 insert.getPersister(),
+											 false,
+											 (SessionImplementor) insert.getSession()
+					)
+			);
 		}
 		else {
 			LOG.trace( "Adding resolved non-early insert action." );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/DeleteOneToManyOrphanWithIdentityIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/DeleteOneToManyOrphanWithIdentityIdTest.java
@@ -1,0 +1,70 @@
+package org.hibernate.orm.test.jpa.orphan.onetomany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Jpa(
+		annotatedClasses = {
+			DeleteOneToManyOrphanWithIdentityIdTest.Parent.class,
+			DeleteOneToManyOrphanWithIdentityIdTest.Child.class
+		}
+)
+class DeleteOneToManyOrphanWithIdentityIdTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-15258")
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
+	void testNoExceptionThrown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent();
+					session.persist( parent );
+					session.createQuery( "from Parent" ).getResultList();
+					assertDoesNotThrow(
+							() -> session.createQuery( "from Parent" ).getResultList(),
+							"without fixing, an exception would be thrown for the second getResultList() invocation"
+					);
+				}
+		);
+	}
+
+	@Entity(name = "Parent")
+	static class Parent {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Long id;
+
+		@OneToMany(mappedBy = "parent", orphanRemoval = true)
+		List<Child> children = new ArrayList<>();
+
+	}
+
+	@Entity(name = "Child")
+	static class Child {
+
+		@Id
+		Long id;
+
+		@ManyToOne
+		Parent parent;
+
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15258