### PR TITLE
HHH-15258 Orphan removal for OneToMany relations is broken when used with GenerationType.IDENTITY

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1614,7 +1614,7 @@ public abstract class AbstractEntityPersister
 
 	}
 
-	protected Object getCollectionKey(
+	public Object getCollectionKey(
 			CollectionPersister persister,
 			Object owner,
 			EntityEntry ownerEntry,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/DelayedCollectionInitializer.java
@@ -6,18 +6,11 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import org.hibernate.collection.spi.CollectionSemantics;
-import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.log.LoggingHelper;
-import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.collection.LoadingCollectionEntry;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 
 /**
@@ -35,49 +28,7 @@ public class DelayedCollectionInitializer extends AbstractCollectionInitializer 
 
 	@Override
 	public void resolveInstance(RowProcessingState rowProcessingState) {
-		if ( collectionKey != null ) {
-			final SharedSessionContractImplementor session = rowProcessingState.getSession();
-			final PersistenceContext persistenceContext = session.getPersistenceContext();
-
-			final LoadingCollectionEntry loadingEntry = persistenceContext.getLoadContexts()
-					.findLoadingCollectionEntry( collectionKey );
-
-			if ( loadingEntry != null ) {
-				collectionInstance = loadingEntry.getCollectionInstance();
-				return;
-			}
-
-			final PersistentCollection<?> existing = persistenceContext.getCollection( collectionKey );
-
-			if ( existing != null ) {
-				collectionInstance = existing;
-				return;
-			}
-
-			final CollectionPersister collectionDescriptor = collectionAttributeMapping.getCollectionDescriptor();
-			final CollectionSemantics<?, ?> collectionSemantics = collectionDescriptor.getCollectionSemantics();
-			final Object key = collectionKey.getKey();
-
-			collectionInstance = collectionSemantics.instantiateWrapper(
-					key,
-					collectionDescriptor,
-					session
-			);
-
-			parentAccess.registerResolutionListener(
-					owner -> collectionInstance.setOwner( owner )
-			);
-
-			persistenceContext.addUninitializedCollection(
-					collectionDescriptor,
-					collectionInstance,
-					key
-			);
-
-			if ( collectionSemantics.getCollectionClassification() == CollectionClassification.ARRAY ) {
-				session.getPersistenceContext().addCollectionHolder( collectionInstance );
-			}
-		}
+		resolveInstance( rowProcessingState, false );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/SelectEagerCollectionInitializer.java
@@ -6,18 +6,11 @@
  */
 package org.hibernate.sql.results.graph.collection.internal;
 
-import org.hibernate.collection.spi.CollectionSemantics;
-import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.log.LoggingHelper;
-import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.FetchParentAccess;
-import org.hibernate.sql.results.graph.collection.LoadingCollectionEntry;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 
 /**
@@ -35,51 +28,7 @@ public class SelectEagerCollectionInitializer extends AbstractCollectionInitiali
 
 	@Override
 	public void resolveInstance(RowProcessingState rowProcessingState) {
-		if ( collectionKey != null ) {
-			final SharedSessionContractImplementor session = rowProcessingState.getSession();
-			final PersistenceContext persistenceContext = session.getPersistenceContext();
-
-			final LoadingCollectionEntry loadingEntry = persistenceContext.getLoadContexts()
-					.findLoadingCollectionEntry( collectionKey );
-
-			if ( loadingEntry != null ) {
-				collectionInstance = loadingEntry.getCollectionInstance();
-				return;
-			}
-
-			final PersistentCollection<?> existing = persistenceContext.getCollection( collectionKey );
-
-			if ( existing != null ) {
-				collectionInstance = existing;
-				return;
-			}
-
-			final CollectionPersister collectionDescriptor = collectionAttributeMapping.getCollectionDescriptor();
-			final CollectionSemantics<?, ?> collectionSemantics = collectionDescriptor.getCollectionSemantics();
-			final Object key = collectionKey.getKey();
-
-			collectionInstance = collectionSemantics.instantiateWrapper(
-					key,
-					collectionDescriptor,
-					session
-			);
-
-			parentAccess.registerResolutionListener(
-					owner -> collectionInstance.setOwner( owner )
-			);
-
-			persistenceContext.addUninitializedCollection(
-					collectionDescriptor,
-					collectionInstance,
-					key
-			);
-
-			persistenceContext.addNonLazyCollection( collectionInstance );
-
-			if ( collectionSemantics.getCollectionClassification() == CollectionClassification.ARRAY ) {
-				session.getPersistenceContext().addCollectionHolder( collectionInstance );
-			}
-		}
+		resolveInstance( rowProcessingState, true );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/EagerOneToManyOrphanWithIdentityIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/EagerOneToManyOrphanWithIdentityIdTest.java
@@ -1,0 +1,149 @@
+package org.hibernate.orm.test.jpa.orphan.onetomany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Jpa(
+		annotatedClasses = {
+				EagerOneToManyOrphanWithIdentityIdTest.Parent.class,
+				EagerOneToManyOrphanWithIdentityIdTest.Child.class
+		}
+)
+@TestForIssue(jiraKey = "HHH-15258")
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
+public class EagerOneToManyOrphanWithIdentityIdTest {
+
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					entityManager.createQuery( "delete from Child" ).executeUpdate();
+					entityManager.createQuery( "delete from Parent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testPersistParentAndQueryInTheSameSession(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Parent parent = new Parent();
+					entityManager.persist( parent );
+
+					List result = entityManager.createQuery( "from Parent" ).getResultList();
+
+					Parent p = (Parent) result.get( 0 );
+
+					assertTrue( Hibernate.isInitialized( p.getChildren() ) );
+					assertThat( p.getChildren().size(), is( 0 ) );
+
+					entityManager.createQuery( "from Parent" ).getResultList();
+				}
+		);
+	}
+
+	@Test
+	public void testPersistParentWithChildAndQueryInTheSameSession(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Parent parent = new Parent();
+					Child child = new Child();
+					parent.addChild( child );
+					entityManager.persist( child );
+					entityManager.persist( parent );
+
+					List result = entityManager.createQuery( "from Parent" ).getResultList();
+
+					Parent p = (Parent) result.get( 0 );
+
+					assertTrue( Hibernate.isInitialized( p.getChildren() ) );
+					assertThat( p.getChildren().size(), is( 1 ) );
+					assertSame( child, parent.getChildren().get( 0 ) );
+					entityManager.createQuery( "from Parent" ).getResultList();
+				}
+		);
+	}
+
+	@Entity(name = "Parent")
+	static class Parent {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Long id;
+
+		@OneToMany(mappedBy = "parent", orphanRemoval = true, fetch = FetchType.EAGER)
+		List<Child> children = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(List<Child> children) {
+			this.children = children;
+		}
+
+		public void addChild(Child child) {
+			children.add( child );
+			child.setParent( this );
+		}
+	}
+
+	@Entity(name = "Child")
+	static class Child {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Long id;
+
+		@ManyToOne
+		Parent parent;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/LazyOneToManyOrphanWithIdentityIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/LazyOneToManyOrphanWithIdentityIdTest.java
@@ -1,0 +1,148 @@
+package org.hibernate.orm.test.jpa.orphan.onetomany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Jpa(
+		annotatedClasses = {
+				LazyOneToManyOrphanWithIdentityIdTest.Parent.class,
+				LazyOneToManyOrphanWithIdentityIdTest.Child.class
+		}
+)
+@TestForIssue(jiraKey = "HHH-15258")
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
+public class LazyOneToManyOrphanWithIdentityIdTest {
+
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					entityManager.createQuery( "delete from Child" ).executeUpdate();
+					entityManager.createQuery( "delete from Parent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testPersistParentAndLoadInTheSameSession(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Parent parent = new Parent();
+					entityManager.persist( parent );
+
+					List result = entityManager.createQuery( "from Parent" ).getResultList();
+
+					Parent p = (Parent) result.get( 0 );
+
+					assertTrue( Hibernate.isInitialized( p.getChildren() ) );
+					assertThat( p.getChildren().size(), is( 0 ) );
+
+					entityManager.createQuery( "from Parent" ).getResultList();
+				}
+		);
+	}
+
+	@Test
+	public void testPersistParentWithChildAndLoadInTheSameSession(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Parent parent = new Parent();
+					Child child = new Child();
+					parent.addChild( child );
+					entityManager.persist( child );
+					entityManager.persist( parent );
+
+					List result = entityManager.createQuery( "from Parent" ).getResultList();
+
+					Parent p = (Parent) result.get( 0 );
+
+					assertTrue( Hibernate.isInitialized( p.getChildren() ) );
+					assertThat( p.getChildren().size(), is( 1 ) );
+					assertSame( child, parent.getChildren().get( 0 ) );
+					entityManager.createQuery( "from Parent" ).getResultList();
+				}
+		);
+	}
+
+	@Entity(name = "Parent")
+	static class Parent {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Long id;
+
+		@OneToMany(mappedBy = "parent", orphanRemoval = true)
+		List<Child> children = new ArrayList<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public List<Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(List<Child> children) {
+			this.children = children;
+		}
+
+		public void addChild(Child child) {
+			children.add( child );
+			child.setParent( this );
+		}
+	}
+
+	@Entity(name = "Child")
+	static class Child {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		Long id;
+
+		@ManyToOne
+		Parent parent;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15258

The issue is fixed by this https://github.com/hibernate/hibernate-orm/compare/main...dreab8:HHH-15258?expand=1#diff-68e234b1b90c3573e2efd14e73cb756666049314c0f886884a8f0b88dee704f8R118

The `persistentCollection` is added by the persist of the `Parent` that happpens in the same Session of the query.

then I just refactored the common code of the `DelayedCollectionInitializer#resolveInstance` and `SelectEagerCollectionInitializer#resolveInstance` methods into the `AbstractCollectionInitializer`.
 