### PR TITLE
Backport HHH-15265 + HHH-15270 to branch 6.0 - Default catalog/schema fixes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -2971,7 +2971,7 @@ public class ModelBinder {
 			return database.toIdentifier( tableSpecSource.getExplicitCatalogName() );
 		}
 		else {
-			return database.toIdentifier( metadataBuildingContext.getMappingDefaults().getImplicitCatalogName() );
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/qualfiedTableNaming/DefaultCatalogAndSchemaTest.java
@@ -197,6 +197,8 @@ public class DefaultCatalogAndSchemaTest {
 		final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.orm.xml" ) );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "implicit-file-level-catalog-and-schema.hbm.xml" ) );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "no-file-level-catalog-and-schema.orm.xml" ) );
+		metadataSources.addInputStream( getClass().getResourceAsStream( "no-file-level-catalog-and-schema.hbm.xml" ) );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "database-object-using-catalog-placeholder.hbm.xml" ) );
 		metadataSources.addInputStream( getClass().getResourceAsStream( "database-object-using-schema-placeholder.hbm.xml" ) );
 		if ( configuredXmlMappingPath != null ) {
@@ -317,6 +319,8 @@ public class DefaultCatalogAndSchemaTest {
 		verifyEntityPersisterQualifiers( EntityWithExplicitQualifiers.class, expectedExplicitQualifier() );
 		verifyEntityPersisterQualifiers( EntityWithOrmXmlImplicitFileLevelQualifiers.class, expectedImplicitFileLevelQualifier() );
 		verifyEntityPersisterQualifiers( EntityWithHbmXmlImplicitFileLevelQualifiers.class, expectedImplicitFileLevelQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithOrmXmlNoFileLevelQualifiers.class, expectedDefaultQualifier() );
+		verifyEntityPersisterQualifiers( EntityWithHbmXmlNoFileLevelQualifiers.class, expectedDefaultQualifier() );
 
 		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithDefaultQualifiers.class, expectedDefaultQualifier() );
 		verifyEntityPersisterQualifiers( EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.class, expectedDefaultQualifier() );
@@ -491,6 +495,8 @@ public class DefaultCatalogAndSchemaTest {
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithDefaultQualifiers.NAME, expectedDefaultQualifier() );
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithOrmXmlImplicitFileLevelQualifiers.NAME, expectedImplicitFileLevelQualifier() );
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithHbmXmlImplicitFileLevelQualifiers.NAME, expectedImplicitFileLevelQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithOrmXmlNoFileLevelQualifiers.NAME, expectedDefaultQualifier() );
+		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithHbmXmlNoFileLevelQualifiers.NAME, expectedDefaultQualifier() );
 
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithDefaultQualifiers.NAME, expectedDefaultQualifier() );
 		verifyOnlyQualifier( sql, SqlType.DDL, EntityWithJoinedInheritanceWithDefaultQualifiersSubclass.NAME, expectedDefaultQualifier() );
@@ -751,6 +757,21 @@ public class DefaultCatalogAndSchemaTest {
 
 	public static class EntityWithHbmXmlImplicitFileLevelQualifiers {
 		public static final String NAME = "EntityWithHbmXmlImplicitFileLevelQualifiers";
+		private Long id;
+		private String basic;
+	}
+
+	public static class EntityWithOrmXmlNoFileLevelQualifiers {
+		public static final String NAME = "EntityWithOrmXmlNoFileLevelQualifiers";
+		private Long id;
+		private String basic;
+		private List<EntityWithDefaultQualifiers> oneToMany;
+		private List<EntityWithDefaultQualifiers> manyToMany;
+		private List<String> elementCollection;
+	}
+
+	public static class EntityWithHbmXmlNoFileLevelQualifiers {
+		public static final String NAME = "EntityWithHbmXmlNoFileLevelQualifiers";
 		private Long id;
 		private String basic;
 	}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/implicit-file-level-catalog-and-schema.hbm.xml
@@ -11,7 +11,16 @@
 				   package="org.hibernate.orm.test.boot.database.qualfiedTableNaming"
 				   catalog="someImplicitFileLevelCatalog" schema="someImplicitFileLevelSchema" default-access="field">
 	<class name="DefaultCatalogAndSchemaTest$EntityWithHbmXmlImplicitFileLevelQualifiers" entity-name="EntityWithHbmXmlImplicitFileLevelQualifiers">
-		<id name="id" />
-		<property name="basic" />
+		<comment>Some entity-level comment</comment>
+		<id name="id">
+			<column name="id">
+				<comment>Some column-level comment for "id"</comment>
+			</column>
+		</id>
+		<property name="basic">
+			<column name="basic">
+				<comment>Some column-level comment for "property"</comment>
+			</column>
+		</property>
 	</class>
 </hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.hibernate.org/xsd/hibernate-mapping http://www.hibernate.org/xsd/hibernate-mapping/hibernate-mapping-4.0.xsd"
+				   package="org.hibernate.orm.test.boot.database.qualfiedTableNaming"
+				   default-access="field">
+	<class name="DefaultCatalogAndSchemaTest$EntityWithHbmXmlNoFileLevelQualifiers" entity-name="EntityWithHbmXmlNoFileLevelQualifiers">
+		<id name="id" />
+		<property name="basic" />
+	</class>
+</hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.hbm.xml
@@ -11,7 +11,16 @@
 				   package="org.hibernate.orm.test.boot.database.qualfiedTableNaming"
 				   default-access="field">
 	<class name="DefaultCatalogAndSchemaTest$EntityWithHbmXmlNoFileLevelQualifiers" entity-name="EntityWithHbmXmlNoFileLevelQualifiers">
-		<id name="id" />
-		<property name="basic" />
+		<comment>Some entity-level comment</comment>
+		<id name="id">
+			<column name="id">
+				<comment>Some column-level comment for "id"</comment>
+			</column>
+		</id>
+		<property name="basic">
+			<column name="basic">
+				<comment>Some column-level comment for "property"</comment>
+			</column>
+		</property>
 	</class>
 </hibernate-mapping>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/boot/database/qualfiedTableNaming/no-file-level-catalog-and-schema.orm.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
+                 http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+				 version="2.1">
+	<package>org.hibernate.orm.test.boot.database.qualfiedTableNaming</package>
+	<entity class="DefaultCatalogAndSchemaTest$EntityWithOrmXmlNoFileLevelQualifiers" name="EntityWithOrmXmlNoFileLevelQualifiers"
+			access="FIELD">
+		<attributes>
+			<id name="id"/>
+			<basic name="basic"/>
+			<one-to-many name="oneToMany">
+				<join-table name="EntityWithOrmXmlNoFileLevelQualifiers_oneToMany">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_oneToMany" />
+					<inverse-join-column name="inverse" />
+				</join-table>
+			</one-to-many>
+			<many-to-many name="manyToMany">
+				<join-table name="EntityWithOrmXmlNoFileLevelQualifiers_manyToMany">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_oneToMany" />
+					<inverse-join-column name="inverse" />
+				</join-table>
+			</many-to-many>
+			<element-collection name="elementCollection">
+				<collection-table name="EntityWithOrmXmlNoFileLevelQualifiers_elementCollection">
+					<!-- Custom names to avoid false positive in assertions -->
+					<join-column name="forward" />
+					<foreign-key name="FK_elementCollection" />
+				</collection-table>
+			</element-collection>
+		</attributes>
+	</entity>
+</entity-mappings>


### PR DESCRIPTION
* [HHH-15270](https://hibernate.atlassian.net/browse/HHH-15270): Inconsistent precedence of orm.xml implicit catalog over "default_catalog" in XML-mapped entities
* [HHH-15265](https://hibernate.atlassian.net/browse/HHH-15265): SchemaExport.execute does not add the configured schema to comments

Backport of #5046 to branch 6.0.

