### PR TITLE
HHH-15267 Make ParameterBindingsMemento extend Serializable so that cache keys can be serialized

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/QueryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/QueryKey.java
@@ -26,7 +26,7 @@ public class QueryKey implements Serializable {
 	/**
 	 * todo (6.0) : integrate work from original 6.0 branch
 	 */
-	public interface ParameterBindingsMemento {
+	public interface ParameterBindingsMemento extends Serializable {
 	}
 
 	public static QueryKey from(


### PR DESCRIPTION
[…](https://hibernate.atlassian.net/browse/HHH-15267)