### PR TITLE
HHH-15070 - fix NPE for NamedNativeQuery + SqlResultSetMapping with columns only

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
@@ -60,7 +60,7 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 
 	@Override
 	public Class<?> getJavaType() {
-		return explicitJavaType.getJavaTypeClass();
+		return explicitJavaType == null ? null : explicitJavaType.getJavaTypeClass();
 	}
 
 	@Override
@@ -160,20 +160,13 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 
 		CompleteResultBuilderBasicValuedStandard that = (CompleteResultBuilderBasicValuedStandard) o;
 
-		if ( !Objects.equals( explicitColumnName, that.explicitColumnName ) ) {
-			return false;
-		}
-		if ( !Objects.equals( explicitType, that.explicitType ) ) {
-			return false;
-		}
-		return explicitJavaType.equals( that.explicitJavaType );
+		return Objects.equals( explicitColumnName, that.explicitColumnName )
+				&& Objects.equals( explicitType, that.explicitType )
+				&& Objects.equals( explicitJavaType, that.explicitJavaType );
 	}
 
 	@Override
 	public int hashCode() {
-		int result = explicitColumnName != null ? explicitColumnName.hashCode() : 0;
-		result = 31 * result + ( explicitType != null ? explicitType.hashCode() : 0 );
-		result = 31 * result + explicitJavaType.hashCode();
-		return result;
+		return Objects.hash( explicitColumnName, explicitType, explicitJavaType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -278,7 +278,7 @@ public class NativeQueryImpl<R>
 					throw new IllegalArgumentException( "Named query exists but its result type is not compatible" );
 				case 1:
 					final Class<?> actualResultJavaType = resultSetMapping.getResultBuilders().get( 0 ).getJavaType();
-					if ( !resultJavaType.isAssignableFrom( actualResultJavaType ) ) {
+					if ( actualResultJavaType != null && !resultJavaType.isAssignableFrom( actualResultJavaType ) ) {
 						throw buildIncompatibleException( resultJavaType, actualResultJavaType );
 					}
 					break;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -817,14 +817,14 @@ public class QuerySqmImpl<R>
 
 	@Override
 	public SqmQueryImplementor<R> setLockOptions(LockOptions lockOptions) {
-		verifySelect();
+		// No verifySelect call, because in Hibernate we support locking in subqueries
 		getQueryOptions().getLockOptions().overlay( lockOptions );
 		return this;
 	}
 
 	@Override
 	public SqmQueryImplementor<R> setLockMode(String alias, LockMode lockMode) {
-		verifySelect();
+		// No verifySelect call, because in Hibernate we support locking in subqueries
 		getQueryOptions().getLockOptions().setAliasSpecificLockMode( alias, lockMode );
 		return this;
 	}
@@ -869,6 +869,7 @@ public class QuerySqmImpl<R>
 	@Override
 	public SqmQueryImplementor<R> setLockMode(LockModeType lockMode) {
 		if ( lockMode != LockModeType.NONE ) {
+			// JPA requires an exception to be thrown when this is not a select statement
 			verifySelect();
 		}
 		getSession().checkOpen( false );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/NamedNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/resultmapping/NamedNativeQueryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query.resultmapping;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.SqlResultSetMapping;
+
+/**
+ * @author Nathan Xu
+ */
+@Jpa(annotatedClasses = NamedNativeQueryTest.Sample.class)
+@TestForIssue(jiraKey = "HHH-15070")
+class NamedNativeQueryTest {
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em ->
+			Assertions.assertDoesNotThrow(
+				() -> em.createNamedQuery( "sample.count", Long.class ),
+				"without fixing, NullPointerException would be thrown"
+			)
+		);
+	}
+
+	@SqlResultSetMapping(
+		name = "mapping",
+		columns = @ColumnResult( name = "cnt" )
+	)
+	@NamedNativeQuery(
+		name = "sample.count",
+		resultSetMapping = "mapping",
+		query = "SELECT count(*) AS cnt FROM Sample"
+	)
+	@Entity(name = "Sample")
+	static class Sample {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15070

One of the issues reported in this suite ticket. Will create more in future.
Just our old friend - NullPointerException. In this specific case both following fields of `CompleteResultBuilderBasicValuedStandard` are null:

- private final BasicValuedMapping explicitType;
- private final JavaType<?> explicitJavaType;

Seems previously we assume `explicitJavaType` is non-null.