### PR TITLE
HHH-15045 avoid dirty-flush for OneToOne type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EntityType.java
@@ -385,7 +385,7 @@ public abstract class EntityType extends AbstractType implements AssociationType
 	/**
 	 * Resolve an identifier or unique key value
 	 */
-	private Object resolve(Object value, SharedSessionContractImplementor session, Object owner) {
+	protected Object resolve(Object value, SharedSessionContractImplementor session, Object owner) {
 		if ( value != null && !isNull( owner, session ) ) {
 			if ( isReferenceToPrimaryKey() ) {
 				return resolveIdentifier( value, session, null );

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -106,17 +106,12 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	public boolean isDirty(Object old, Object current, SharedSessionContractImplementor session) {
-		if ( isSame( old, current ) ) {
-			return false;
-		}
-
-		return getIdentifierType( session )
-				.isDirty( getIdentifier( old, session ), getIdentifier( current, session ), session );
+		return false;
 	}
 
 	@Override
 	public boolean isDirty(Object old, Object current, boolean[] checkable, SharedSessionContractImplementor session) {
-		return isDirty(old, current, session);
+		return false;
 	}
 
 	@Override
@@ -159,6 +154,12 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	public Object assemble(Serializable oid, SharedSessionContractImplementor session, Object owner) throws HibernateException {
+		if ( oid == null ) {
+			if ( uniqueKeyPropertyName != null ) {
+				return resolve( session.getContextEntityIdentifier( owner ), session, owner );
+			}
+			return null;
+		}
 
 		//the owner of the association is not the owner of the id
 		Object id = getIdentifierType( session ).assemble( oid, session, null );
@@ -169,9 +170,14 @@ public class OneToOneType extends EntityType {
 
 		return resolveIdentifier( id, session );
 	}
-	
+
+	/**
+	 * We don't need to dirty check one-to-one because of how
+	 * assemble/disassemble is implemented and because a one-to-one
+	 * association is never dirty
+	 */
 	@Override
 	public boolean isAlwaysDirtyChecked() {
-		return true;
+		return false;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/flush/DirtyFlushTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/flush/DirtyFlushTest.java
@@ -1,0 +1,136 @@
+package org.hibernate.orm.test.onetoone.flush;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.CallbackException;
+import org.hibernate.Interceptor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.boot.spi.Bootstrap;
+import org.hibernate.orm.test.jpa.SettingsGenerator;
+import org.hibernate.type.Type;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.jpa.PersistenceUnitDescriptorAdapter;
+import org.hibernate.testing.orm.junit.DialectContext;
+import org.hibernate.testing.orm.transaction.TransactionUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+ * @author Nathan Xu
+ */
+@TestForIssue( jiraKey = "HHH-15045" )
+class DirtyFlushTest {
+
+	List<Class> getAnnotatedClasses() {
+		return List.of( User.class, Profile.class );
+	}
+
+	Map basicSettings() {
+		return SettingsGenerator.generateSettings(
+				AvailableSettings.HBM2DDL_AUTO, "create-drop",
+				AvailableSettings.DIALECT, DialectContext.getDialect().getClass().getName(),
+				AvailableSettings.LOADED_CLASSES, getAnnotatedClasses(),
+				AvailableSettings.GLOBALLY_QUOTED_IDENTIFIERS, "true"
+		);
+	}
+
+	EntityManagerFactory buildEntityManagerFactory(Map settings) {
+		return Bootstrap
+				.getEntityManagerFactoryBuilder( new PersistenceUnitDescriptorAdapter(), settings )
+				.build();
+	}
+
+	EntityManagerFactory entityManagerFactory;
+
+	@BeforeEach
+	void setUp() {
+		DirtyFlushInterceptor.dirtyFlushedForUser = false;
+	}
+
+	@Test
+	void testDirtyFlushNotHappened() {
+		var settings = basicSettings();
+		settings.put( AvailableSettings.INTERCEPTOR, new DirtyFlushInterceptor() );
+		entityManagerFactory = buildEntityManagerFactory( settings );
+		var em = entityManagerFactory.createEntityManager();
+
+		TransactionUtil.inTransaction( em, entityManager -> {
+			var user = new User();
+			user.id = 1;
+			entityManager.persist( user );
+		} );
+
+		try {
+			TransactionUtil.inTransaction( em, entityManager -> {
+				var user = entityManager.find( User.class, 1 );
+				var profile = new Profile();
+				profile.id = 1;
+				profile.user = user;
+				user.profile = profile;
+				entityManager.persist( profile );
+			} );
+
+			Assertions.assertFalse( DirtyFlushInterceptor.dirtyFlushedForUser, "User should not be dirty-flushed when only Profile changes!" );
+
+		} finally {
+			TransactionUtil.inTransaction( em, entityManager -> {
+				entityManager.createQuery( "delete from Profile " ).executeUpdate();
+				entityManager.createQuery( "delete from User" ).executeUpdate();
+			} );
+		}
+	}
+
+	@AfterEach
+	void releaseResources() {
+		if ( entityManagerFactory != null ) {
+			entityManagerFactory.close();
+		}
+	}
+
+
+	@Entity(name = "User")
+	static class User {
+		@Id int id;
+
+		@OneToOne(mappedBy = "user")
+		Profile profile;
+	}
+
+	@Entity(name = "Profile")
+	static class Profile {
+		@Id int id;
+
+		@OneToOne // internally Hibernate will use `@ManyToOne` for this field
+		User user;
+	}
+
+	static class DirtyFlushInterceptor implements Interceptor {
+		static boolean dirtyFlushedForUser;
+
+		@Override
+		public boolean onFlushDirty(
+				Object entity,
+				Object id,
+				Object[] currentState,
+				Object[] previousState,
+				String[] propertyNames,
+				Type[] types) throws CallbackException {
+
+			System.out.println( "onFlushDirty invoked on entity: " + entity.getClass().getSimpleName() );
+
+			dirtyFlushedForUser = entity instanceof DirtyFlushTest.User;
+
+			return false;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15045

For the following simple OneToOne case:
```
@Entity
class User {
  @Id int id;

  @OneToOne(mappedBy = "user")
  Profile profile;
}

@Entity
class Profile {
  @Id int id;

  @OneToOne
  User user;
}
```
Internally the 'user' field in `Profile` would be treated as `@ManyToOne`, not `@OneToOne`. the `mappedBy` side is treated as the only `@OneToOne` type. For this reason, OneToOneType is always clean, never **dirty**.

This is a regression issue after https://github.com/hibernate/hibernate-orm/pull/3590 (for https://hibernate.atlassian.net/browse/HHH-14216). After reverting back the changes in `OneToOneType` class, the testing case is still fine in that PR.