### PR TITLE
HHH-15292 escape html chars in JavaDoc

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1311,7 +1311,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	<R> Query<R> createQuery(CriteriaQuery<R> criteriaQuery);
 
 	/**
-	 * Create a {@link MutationQuery} for the given JPA {@link CriteriaDelete}
+	 * Create a {@link Query} for the given JPA {@link CriteriaDelete}
 	 *
 	 * @deprecated use {@link #createMutationQuery(CriteriaDelete)}
 	 */
@@ -1319,7 +1319,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	Query createQuery(CriteriaDelete deleteQuery);
 
 	/**
-	 * Create a {@link MutationQuery} for the given JPA {@link CriteriaUpdate}
+	 * Create a {@link Query} for the given JPA {@link CriteriaUpdate}
 	 *
 	 * @deprecated use {@link #createMutationQuery(CriteriaUpdate)}
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/AbstractScannerImpl.java
@@ -76,7 +76,7 @@ public abstract class AbstractScannerImpl implements Scanner {
 	}
 
 	/**
-	 * Handle <jar-file/> references from a persistence.xml file.
+	 * Handle &lt;jar-file/&gt; references from a persistence.xml file.
 	 *
 	 * JPA allows for  to be specific
 	 * @return The resolved non-root URL

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/PluralAttributeMapKeySource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/PluralAttributeMapKeySource.java
@@ -8,7 +8,7 @@ package org.hibernate.boot.model.source.spi;
 
 /**
  * Describes source information about the key of a persistent map.  At high
- * level this broken down further into 2 categories:<ul>
+ * level this is broken down further into 2 categories:<ul>
  *     <li>{@link PluralAttributeMapKeySourceEntityAttribute}</li>
  *     <li>
  *         <ul>

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
@@ -207,7 +207,7 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 
 
 	/**
-	 * Constructor for an implicit resultset mapping defined inline as part of a `<sql-query/>`
+	 * Constructor for an implicit resultset mapping defined inline as part of a `&lt;sql-query/&gt;`
 	 * stanza
 	 */
 	public HbmResultSetMappingDescriptor(

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AbstractPropertyHolder.java
@@ -217,7 +217,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 
 	/**
 	 * Get column overriding, property first, then parent, then holder
-	 * replace the placeholder 'collection&&element' with nothing
+	 * replace the placeholder 'collection&amp;&amp;element' with nothing
 	 *
 	 * These rules are here to support both JPA 2 and legacy overriding rules.
 	 */
@@ -300,7 +300,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 
 	/**
 	 * Get column overriding, property first, then parent, then holder
-	 * replace the placeholder 'collection&&element' with nothing
+	 * replace the placeholder 'collection&amp;&amp;element' with nothing
 	 *
 	 * These rules are here to support both JPA 2 and legacy overriding rules.
 	 */
@@ -358,7 +358,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 
 	/**
 	 * Get column overriding, property first, then parent, then holder
-	 * replace the placeholder 'collection&&element' with nothing
+	 * replace the placeholder 'collection&amp;&amp;element' with nothing
 	 *
 	 * These rules are here to support both JPA 2 and legacy overriding rules.
 	 */
@@ -374,7 +374,7 @@ public abstract class AbstractPropertyHolder implements PropertyHolder {
 
 	/**
 	 * Get column overriding, property first, then parent, then holder
-	 * replace the placeholder 'collection&&element' with nothing
+	 * replace the placeholder 'collection&amp;&amp;element' with nothing
 	 *
 	 * These rules are here to support both JPA 2 and legacy overriding rules.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -464,7 +464,7 @@ public interface PersistentCollection<E> {
 	}
 
 	/**
-	 * Like {@link #toString()} but without the silliness of rendering the elements
+	 * Like {@link Object#toString()} but without the silliness of rendering the elements
 	 */
 	default String render() {
 		return getRole() + "#" + getKey() + "(initialized: " + wasInitialized() + ")";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2005LimitHandler.java
@@ -67,7 +67,7 @@ public class SQLServer2005LimitHandler extends AbstractLimitHandler {
 	 *     from ( [original-query] ) row_
 	 * )
 	 * select [alias-list] from query_
-	 * where rownumber_ >= ? and rownumber_ < ?
+	 * where rownumber_ &gt;= ? and rownumber_ &lt; ?
 	 * </pre>
 	 *
 	 * Where {@code [original-query]} is the original SQL query, with a

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/UniqueDelegate.java
@@ -28,7 +28,7 @@ import org.hibernate.mapping.UniqueKey;
  *     </li>
  * </ol>
  *
- * #1 & #2 are preferred, if possible; #3 should be solely a fall-back.
+ * #1 &amp; #2 are preferred, if possible; #3 should be solely a fall-back.
  * 
  * See HHH-7797.
  * 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/JdbcServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/JdbcServices.java
@@ -67,7 +67,7 @@ public interface JdbcServices extends Service {
 
 	/**
 	 * Create an instance of a {@link LobCreator} appropriate for the current environment, mainly meant to account for
-	 * variance between JDBC 4 (<= JDK 1.6) and JDBC3 (>= JDK 1.5).
+	 * variance between JDBC 4 (&lt;= JDK 1.6) and JDBC3 (&gt;= JDK 1.5).
 	 *
 	 * @param lobCreationContext The context in which the LOB is being created
 	 * @return The LOB creator.

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -370,7 +370,7 @@ public class Component extends SimpleValue implements MetaAttributable, Sortable
 	 *
 	 * @param index index of the {@link Property} to return
 	 * @return {@link Property}
-	 * @throws IndexOutOfBoundsException - if the index is out of range(index < 0 || index >=
+	 * @throws IndexOutOfBoundsException - if the index is out of range(index &lt; 0 || index &gt;=
 	 * {@link #getPropertySpan()})
 	 */
 	public Property getProperty(int index) {

--- a/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/pretty/MessageHelper.java
@@ -147,7 +147,7 @@ public final class MessageHelper {
 	 * @param persister The persister for the entities
 	 * @param ids The entity id values
 	 * @param factory The session factory
-	 * @return An info string, in the form [FooBar#<1,2,3>]
+	 * @return An info string, in the form [FooBar#&lt;1,2,3&gt;]
 	 */
 	public static String infoString(
 			EntityPersister persister,
@@ -279,7 +279,7 @@ public final class MessageHelper {
 	 * @param persister The persister for the collections
 	 * @param ids The id values of the owners
 	 * @param factory The session factory
-	 * @return An info string, in the form [Foo.bars#<1,2,3>]
+	 * @return An info string, in the form [Foo.bars#&lt;1,2,3&gt;]
 	 */
 	public static String collectionInfoString(
 			CollectionPersister persister,

--- a/hibernate-core/src/main/java/org/hibernate/proxy/ProxyFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/ProxyFactory.java
@@ -39,7 +39,7 @@ public interface ProxyFactory {
 	 * @param componentIdType For composite identifier types, a reference to
 	 * the {@linkplain CompositeType type} of the identifier
 	 * property; again accessing the id should generally not cause
-	 * initialization - but need to bear in mind <key-many-to-one/>
+	 * initialization - but need to bear in mind &lt;key-many-to-one/&gt;
 	 * mappings.
 	 * @throws HibernateException Indicates a problem completing post
 	 * instantiation initialization.

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
@@ -32,7 +32,7 @@ import static org.hibernate.query.results.ResultsHelper.impl;
 /**
  * ResultBuilder for scalar results defined via:<ul>
  *     <li>JPA {@link jakarta.persistence.ColumnResult}</li>
- *     <li>`<return-scalar/>` as part of a `<resultset/>` stanza in `hbm.xml`</li>
+ *     <li>`&lt;return-scalar/&gt;` as part of a `&lt;resultset/&gt;` stanza in `hbm.xml`</li>
  * </ul>
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
@@ -27,7 +27,7 @@ import static org.hibernate.query.results.ResultsHelper.impl;
 /**
  * ResultBuilder for scalar results defined via:<ul>
  *     <li>JPA {@link jakarta.persistence.ColumnResult}</li>
- *     <li>`<return-scalar/>` as part of a `<resultset/>` stanza in `hbm.xml`</li>
+ *     <li>`&lt;return-scalar/&gt;` as part of a `&lt;resultset/&gt;` stanza in `hbm.xml`</li>
  * </ul>
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -169,7 +169,7 @@ public class OneToOneType extends EntityType {
 
 		return resolveIdentifier( id, session );
 	}
-	
+
 	@Override
 	public boolean isAlwaysDirtyChecked() {
 		return true;

--- a/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
@@ -34,8 +34,8 @@ import org.hibernate.metamodel.spi.ValueAccess;
  * <br>
  * Properties are ordered by the order of their names
  * i.e. they are alphabetically ordered, such that
- * <code>properties[i].name < properties[i + 1].name</code>
- * for all <code>i >= 0</code>.
+ * <code>properties[i].name &lt; properties[i + 1].name</code>
+ * for all <code>i &gt;= 0</code>.
  */
 @Incubating
 public interface CompositeUserType<J> extends EmbeddableInstantiator {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15292

An example overlooking of html char escaping leads to wrong JavaDoc:
![screenshot](https://user-images.githubusercontent.com/8211458/169623367-737310ac-4736-4a11-9f9d-a247f3cd9e0d.png)

The corresponding JavaDoc is:
```
 * ResultBuilder for scalar results defined via:<ul>
 *     <li>JPA {@link jakarta.persistence.ColumnResult}</li>
 *     <li>`<return-scalar/>` as part of a `<resultset/>` stanza in `hbm.xml`</li>
 * </ul>
```

After html char (most of time, only '<', '>' and '&' are needed to escape in JavaDoc), the warning number in gradle's javadoc task drops from 100 to 37.

Also fixed some obvious other JavaDoc issues along the way.