### PR TITLE
HHH-15293 BYTES column type in CockroachDB does not support a length

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -127,7 +127,6 @@ public class CockroachDialect extends Dialect {
 
 			case BINARY:
 			case VARBINARY:
-				return "bytes($l)";
 			case BLOB:
 				return "bytes";
 


### PR DESCRIPTION
Fix for CockroachDB dialect