### PR TITLE
HHH-15300 - Lazy evaluation to statement.toString() when logging a slow query

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/spi/SqlStatementLoggerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/spi/SqlStatementLoggerTest.java
@@ -1,0 +1,58 @@
+package org.hibernate.engine.jdbc.spi;
+
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.stubbing.Answer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Kyuhee Cho
+ */
+@TestForIssue(jiraKey = "HHH-15300")
+class SqlStatementLoggerTest {
+
+	@Test
+	public void testLogSlowQueryFromStatementWhenLoggingDisabled() {
+		SqlStatementLogger sqlStatementLogger = new SqlStatementLogger( false, false, false, 0L );
+		AtomicInteger callCounterToString = new AtomicInteger();
+		Statement statement = mockStatementForCountingToString( callCounterToString );
+
+		sqlStatementLogger.logSlowQuery( statement, System.nanoTime() );
+		assertEquals( 0, callCounterToString.get() );
+	}
+
+	@Test
+	public void testLogSlowQueryFromStatementWhenLoggingEnabled() {
+		long logSlowQueryThresholdMillis = 300L;
+		SqlStatementLogger sqlStatementLogger = new SqlStatementLogger(
+				false,
+				false,
+				false,
+				logSlowQueryThresholdMillis
+		);
+		AtomicInteger callCounterToString = new AtomicInteger();
+		Statement statement = mockStatementForCountingToString( callCounterToString );
+
+		long startTimeNanos = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos( logSlowQueryThresholdMillis + 1 );
+		sqlStatementLogger.logSlowQuery( statement, startTimeNanos );
+		assertEquals( 1, callCounterToString.get() );
+	}
+
+	private Statement mockStatementForCountingToString(AtomicInteger callCounter) {
+		Statement statement = mock( Statement.class );
+		when( statement.toString() ).then( (Answer<String>) invocation -> {
+			callCounter.incrementAndGet();
+			return (String) invocation.callRealMethod();
+		} );
+		return statement;
+	}
+
+}


### PR DESCRIPTION
Enabling logging of slow queries increases memory usage.
As a result of checking, statement.toString() is called even though the slow query threshold is not exceeded, and it seems to waste resources.
It would be good to change to call toString() only when the slow query threshold is exceeded.


[hibernate-orm/SqlStatementLogger.java at 6.0.2 · hibernate/hibernate-orm](https://github.com/hibernate/hibernate-orm/blob/6.0.2/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlStatementLogger.java#L144)

Jira Ticket : https://hibernate.atlassian.net/browse/HHH-15300