### PR TITLE
HHH-14614 - Better support for JUnit 5 on-failure handling 

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/hql/SelectionQueryExampleTests.java
+++ b/documentation/src/test/java/org/hibernate/userguide/hql/SelectionQueryExampleTests.java
@@ -8,7 +8,6 @@ package org.hibernate.userguide.hql;
 
 import org.hibernate.query.Query;
 import org.hibernate.query.SelectionQuery;
-import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.userguide.model.Account;
 import org.hibernate.userguide.model.Call;
 import org.hibernate.userguide.model.CreditCardPayment;
@@ -18,6 +17,7 @@ import org.hibernate.userguide.model.WireTransferPayment;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.FailureExpectedCallback;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -46,6 +46,13 @@ public class SelectionQueryExampleTests {
 			// can be validated while creating the SelectionQuery
 			SelectionQuery<?> badQuery = session.createSelectionQuery( "delete Person" );
 			//end::example-hql-selection-query[]
+		} );
+	}
+
+	@FailureExpectedCallback
+	public void cleanTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete Person" ).executeUpdate();
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/enhanced/auto/AutoGenerationTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/enhanced/auto/AutoGenerationTypeTests.java
@@ -29,9 +29,7 @@ import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 
-import org.hibernate.testing.orm.junit.FailureExpectedExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -51,7 +49,6 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Steve Ebersole
  */
-@ExtendWith( FailureExpectedExtension.class )
 public class AutoGenerationTypeTests {
 	@Test
 	public void testAutoDefaults() {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ExpectedExceptionCallback.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ExpectedExceptionCallback.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.orm.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Steve Ebersole
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith( ExpectedExceptionExtension.class )
+public @interface ExpectedExceptionCallback {
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpected.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpected.java
@@ -13,13 +13,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Marks a test method or class as being expected to fail.
  *
  * @see FailureExpectedExtension
+ * @see FailureExpectedCallback
  *
  * @author Steve Ebersole
  */

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpectedCallback.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpectedCallback.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.orm.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Used to mark a method to be executed when an expected failure happens.
+ *
+ * @see FailureExpected
+ * @see ExecutableInvoker
+ *
+ * @author Steve Ebersole
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+
+@ExtendWith( FailureExpectedExtension.class )
+public @interface FailureExpectedCallback {
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/NotImplementedYetCallback.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/NotImplementedYetCallback.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.orm.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Steve Ebersole
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith( NotImplementedYetExtension.class )
+public @interface NotImplementedYetCallback {
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/TestingUtil.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/TestingUtil.java
@@ -28,10 +28,32 @@ public class TestingUtil {
 	private TestingUtil() {
 	}
 
+	public static List<Method> findAnnotatedMethods(
+			ExtensionContext context,
+			Class<? extends Annotation> annotationType) {
+		if ( context.getElement().isEmpty() ) {
+			return Collections.emptyList();
+		}
+
+		final Method[] methods = context.getRequiredTestClass().getMethods();
+		if ( methods.length <= 0 ) {
+			return Collections.emptyList();
+		}
+
+		final ArrayList<Method> results = new ArrayList<>();
+		for ( int i = 0; i < methods.length; i++ ) {
+			if ( methods[i].isAnnotationPresent( annotationType ) ) {
+				results.add( methods[i] );
+			}
+		}
+
+		return results;
+	}
+
 	public static <A extends Annotation> Optional<A> findEffectiveAnnotation(
 			ExtensionContext context,
 			Class<A> annotationType) {
-		if ( !context.getElement().isPresent() ) {
+		if ( context.getElement().isEmpty() ) {
 			return Optional.empty();
 		}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -122,7 +122,7 @@ dependencyResolutionManagement {
         }
         testLibs {
             version( "junit4", "4.13.2" )
-            version( "junit5", "5.8.2" )
+            version( "junit5", "5.9.0-M1" )
             version( "assertj", "3.14.0" )
             version( "mockito", "4.3.1" )
             version( "byteman", "4.0.16" )


### PR DESCRIPTION
HHH-14614 - Better support for JUnit 5 on-failure handling

- this commit is just the "infrastructure" piece.
- still need to come back and use it.  

The benefit is this allows us to perform some action when tests fail.  E.g., atm we are forced to create and drop test data for each test method - `@BeforeEach` and `@AfterEach`.  This support allows us to use `@BeforeAll` and `@AfterAll`.  Previously this would be a potential problem when tests fail.  This support though let's us hook into the "failure process" to rebuild the SessionFactory when we have these failures