### PR TITLE
HHH-15275 CoordinatingEntityNameResolver should avoid using getEntityNameResolvers() after initialization

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -196,6 +196,11 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 
 	CustomEntityDirtinessStrategy getCustomEntityDirtinessStrategy();
+
+	/**
+	 * @deprecated as this is not the most efficient way to get the EntityNameResolver(s) list.
+	 */
+	@Deprecated
 	EntityNameResolver[] getEntityNameResolvers();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -181,7 +181,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			sessionEventsManager = new SessionEventListenerManagerImpl( customSessionEventListener.toArray( new SessionEventListener[0] ) );
 		}
 
-		this.entityNameResolver = new CoordinatingEntityNameResolver( factory, interceptor );
+		this.entityNameResolver = fastSessionServices.buildSessionScopedEntityNameResolver( interceptor );
 
 		final StatementInspector statementInspector = interpret( options.getStatementInspector() );
 		if ( options instanceof SharedSessionCreationOptions && ( (SharedSessionCreationOptions) options ).isTransactionCoordinatorShared() ) {
@@ -1390,7 +1390,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				.getService( TransactionCoordinatorBuilder.class )
 				.buildTransactionCoordinator( jdbcCoordinator, this );
 
-		entityNameResolver = new CoordinatingEntityNameResolver( factory, interceptor );
+		entityNameResolver = fastSessionServices.buildSessionScopedEntityNameResolver( interceptor );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
@@ -15,7 +15,9 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.PessimisticLockScope;
 
 import org.hibernate.CacheMode;
+import org.hibernate.EntityNameResolver;
 import org.hibernate.FlushMode;
+import org.hibernate.Interceptor;
 import org.hibernate.LockOptions;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -170,6 +172,7 @@ public final class FastSessionServices {
 	private final ConnectionObserverStatsBridge defaultJdbcObservers;
 	private final FormatMapper jsonFormatMapper;
 	private final FormatMapper xmlFormatMapper;
+	private final CoordinatingEntityNameResolver coordinatingEntityNameResolver;
 
 	FastSessionServices(SessionFactoryImpl sf) {
 		Objects.requireNonNull( sf );
@@ -245,6 +248,7 @@ public final class FastSessionServices {
 		this.initialSessionFlushMode = initializeDefaultFlushMode( defaultSessionProperties );
 		this.jsonFormatMapper = sessionFactoryOptions.getJsonFormatMapper();
 		this.xmlFormatMapper = sessionFactoryOptions.getXmlFormatMapper();
+		this.coordinatingEntityNameResolver = sf.getEntityNameResolver();
 	}
 
 	private static FlushMode initializeDefaultFlushMode(Map<String, Object> defaultSessionProperties) {
@@ -380,4 +384,9 @@ public final class FastSessionServices {
 	public FormatMapper getXmlFormatMapper() {
 		return xmlFormatMapper;
 	}
+
+	public EntityNameResolver buildSessionScopedEntityNameResolver(Interceptor sessionInterceptor) {
+		return this.coordinatingEntityNameResolver.createSessionScopedEntityNameResolver( sessionInterceptor );
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -188,7 +188,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	private final transient SessionBuilder defaultSessionOpenOptions;
 	private final transient SessionBuilder temporarySessionOpenOptions;
 	private final transient StatelessSessionBuilder defaultStatelessOptions;
-	private final transient EntityNameResolver entityNameResolver;
+	private final transient CoordinatingEntityNameResolver entityNameResolver;
 
 	public SessionFactoryImpl(
 			final MetadataImplementor bootMetamodel,
@@ -375,6 +375,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			this.defaultSessionOpenOptions = createDefaultSessionOpenOptionsIfPossible();
 			this.temporarySessionOpenOptions = this.defaultSessionOpenOptions == null ? null : buildTemporarySessionOpenOptions();
 			this.defaultStatelessOptions = this.defaultSessionOpenOptions == null ? null : withStatelessOptions();
+			this.entityNameResolver = new CoordinatingEntityNameResolver( this, getInterceptor() );
 			this.fastSessionServices = new FastSessionServices( this );
 			this.wrapperOptions = new SessionFactoryBasedWrapperOptions( this );
 
@@ -391,8 +392,6 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			//As last operation, delete all caches from ReflectionManager
 			//(not modelled as a listener as we want this to be last)
 			bootstrapContext.getReflectionManager().reset();
-
-			this.entityNameResolver = new CoordinatingEntityNameResolver( this, getInterceptor() );
 		}
 		catch (Exception e) {
 			for ( Integrator integrator : serviceRegistry.getService( IntegratorService.class ).getIntegrators() ) {
@@ -1562,6 +1561,15 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	@Override
 	public FastSessionServices getFastSessionServices() {
 		return this.fastSessionServices;
+	}
+
+	/**
+	 * @return the global CoordinatingEntityNameResolver for this SessionFactory.
+	 * Intentionally exposed to package-private only as this should only be used
+	 * by FastSessionServices.
+	 */
+	CoordinatingEntityNameResolver getEntityNameResolver() {
+		return this.entityNameResolver;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionScopedEntityNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionScopedEntityNameResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal;
+
+import org.hibernate.EntityNameResolver;
+import org.hibernate.Interceptor;
+
+/**
+ * The EntityNameResolver used by default by each Session, when a Session scoped Interceptor
+ * is present.
+ * When there is no Interceptor the Session might use directly the global CoordinatingEntityNameResolver
+ * from the SessionFactory.
+ */
+final class SessionScopedEntityNameResolver implements EntityNameResolver {
+
+	private final CoordinatingEntityNameResolver coordinatingEntityNameResolver;
+	private final Interceptor sessionInterceptor;
+
+	public SessionScopedEntityNameResolver(
+			CoordinatingEntityNameResolver coordinatingEntityNameResolver,
+			Interceptor sessionInterceptor) {
+		this.coordinatingEntityNameResolver = coordinatingEntityNameResolver;
+		this.sessionInterceptor = sessionInterceptor;
+	}
+
+	@Override
+	public String resolveEntityName(final Object entity) {
+		String entityName = sessionInterceptor.getEntityName( entity );
+		if ( entityName != null ) {
+			return entityName;
+		}
+		return coordinatingEntityNameResolver.resolveEntityName( entity );
+	}
+
+}


### PR DESCRIPTION

Some small optimisations thatwere highlighted during the last round of benchmarking

 - https://hibernate.atlassian.net/browse/HHH-15275