### PR TITLE
HHH-15317 DeepCopy fields when marking an entity non-readonly

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -33,6 +33,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.UniqueKeyLoadable;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.type.TypeHelper;
 
 /**
  * A base implementation of EntityEntry
@@ -434,6 +435,13 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 			}
 			setStatus( Status.MANAGED );
 			loadedState = getPersister().getPropertyValues( entity );
+			TypeHelper.deepCopy(
+					loadedState,
+					persister.getPropertyTypes(),
+					persister.getPropertyCheckability(),
+					loadedState,
+					getPersistenceContext().getSession()
+			);
 			getPersistenceContext().getNaturalIdHelper().manageLocalNaturalIdCrossReference(
 					persister,
 					id,


### PR DESCRIPTION
Otherwise a modification might get unnoticed in the next flush.

This is a draft PR for now as it doesn't yet contain a test case, and I'm not sure which branch to submit this one to.

I'd be happy for some advice: 
* if submitting the PR for 5.6 is ok, as I'd like to see a fix for 5.6 - or should I rather submit it for 6.0?
* could you point me to a test case example I could extend that already uses some custom types?
* could the test cases be more minimized?
* between 6.0 and 5.6 some classes about user defined types changed - see migration guide. Should I eventually submit two PRs? 

Thanks!