### PR TITLE
HHH-15325 Avoid allocations from BitSet.stream() in AbstractEntityPersister

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2542,7 +2542,7 @@ public abstract class AbstractEntityPersister
 			// We have to check the state for "mutable" properties as dirty tracking isn't aware of mutable types
 			final Type[] propertyTypes = entityMetamodel.getPropertyTypes();
 			final boolean[] propertyCheckability = entityMetamodel.getPropertyCheckability();
-			mutablePropertiesIndexes.stream().forEach( i -> {
+			for ( int i = mutablePropertiesIndexes.nextSetBit(0); i >= 0; i = mutablePropertiesIndexes.nextSetBit(i + 1) ) {
 				// This is kindly borrowed from org.hibernate.type.TypeHelper.findDirty
 				final boolean dirty = currentState[i] != LazyPropertyInitializer.UNFETCHED_PROPERTY &&
 						// Consider mutable properties as dirty if we don't have a previous state
@@ -2557,7 +2557,7 @@ public abstract class AbstractEntityPersister
 				if ( dirty ) {
 					fields.add( i );
 				}
-			} );
+			}
 		}
 
 		if ( attributeNames.length != 0 ) {


### PR DESCRIPTION
See https://hibernate.atlassian.net/browse/HHH-15325 for more info.

If accepted, a backport to 5.x would be highly appreciated.

Cheers,
Christoph